### PR TITLE
Fixing favicon path #142

### DIFF
--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'liteLLM',
   tagline: 'Simplify LLM API Calls',
-  favicon: 'static/img/favicon.ico', 
+  favicon: '/img/favicon.ico', 
 
   // Set the production url of your site here
   url: 'https://litellm.vercel.app/',


### PR DESCRIPTION
The PR fixes favicon path in docusaurus.config.js #142 
Affirmative that the favicon is visible now in docs page.
