### PR TITLE
modified the image extension to .png

### DIFF
--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -60,7 +60,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       // Replace with your project's social card
-      image: 'img/docusaurus-social-card.jpg',
+      image: 'img/docusaurus-social-card.png',
       navbar: {
         title: '🚅 LiteLLM',
         items: [


### PR DESCRIPTION
Closes #157 

After adding the change and `yarn build` 
I verified this in litellm/docs/my-website/build/index.html
The og:image and twitter:image metadata now contains .png 
<img width="648" alt="image" src="https://github.com/BerriAI/litellm/assets/56165694/2d56beba-90af-41a3-805a-41de083569af">
Verified with OGraph Previewer extension that the unfurling looks like this now
<img width="426" alt="image" src="https://github.com/BerriAI/litellm/assets/56165694/1353b96d-3a94-42b8-b56b-66d8d7a03693">

Couldn't figure out how to check the same changes on https://docs.litellm.ai/docs/ after deploying. I did deploy it on vercel but couldn't see the changes in https://docs.litellm.ai/docs/. The above verification should be sufficient though.
