### PR TITLE
fix: context propagation on acompletion method

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1,7 +1,7 @@
 import os, openai, sys
 from typing import Any
 from functools import partial
-import dotenv, traceback, random, asyncio, time
+import dotenv, traceback, random, asyncio, time, contextvars
 from copy import deepcopy
 import litellm
 from litellm import (  # type: ignore
@@ -49,8 +49,12 @@ async def acompletion(*args, **kwargs):
     # Use a partial function to pass your keyword arguments
     func = partial(completion, *args, **kwargs)
 
+    # Add the context to the function
+    ctx = contextvars.copy_context()
+    func_with_context = partial(ctx.run, func)
+
     # Call the synchronous function using run_in_executor
-    return await loop.run_in_executor(None, func)
+    return await loop.run_in_executor(None, func_with_context)
 
 
 @client


### PR DESCRIPTION
### Issue Description
Context variables aren't propagated to the execution of LLM calls by `acompletion` method.

### Suggested Solution
Propagating the context using `contextvars` as keyword args using a partial function.

### Alternative Solutions
In python 3.9, a method called [`asyncio.to_thread()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread) was introduced. 
This method does exactly the same thing, running a blocking code on a different thread from a thread pool while propagating the context to the method execution.

In general, it's recommended to avoid using the main loop directly.

I chose to refrain from using this method as it'll introduce a constraint on the SDK users to run python >= 3.9 while currently it requires >= 3.8