### PR TITLE
added import aiohttp

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6,6 +6,7 @@ import random, uuid, requests
 import datetime, time
 import tiktoken
 import uuid
+import aiohttp
 
 encoding = tiktoken.get_encoding("cl100k_base")
 import importlib.metadata


### PR DESCRIPTION
This line in utils.py uses aiohttp but it is never imported or initialized. 

[    session = aiohttp.ClientSession()](https://github.com/BerriAI/litellm/blob/072d93696cde8a2fdf5574c470017ebe7a5d08e2/litellm/utils.py#L2174)