### PR TITLE
Fix proxy server railway deployment

### DIFF
--- a/proxy-server/main.py
+++ b/proxy-server/main.py
@@ -61,7 +61,7 @@ def get_models():
 
 if __name__ == "__main__":
   from waitress import serve
-  serve(app, host="0.0.0.0", port=5000, threads=500)
+  serve(app, host="0.0.0.0", port=os.environ.get("PORT", 5000), threads=500)
 
 ############### Advanced ##########################
 


### PR DESCRIPTION
On Railway you need to use the PORT env var for the port

Note: not 100% sure this will actually fix the railway deployment as it's using https://github.com/BerriAI/liteLLM-proxy anyway(?) Duplication here seems confusing to you so maybe delete that one and make the 1 click deploy use this? :shrug: 