### PR TITLE
Simplify mock logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "0.1.623"
+version = "0.1.624"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT License"


### PR DESCRIPTION
Not sure if that is too much overhead, but would help me a lot. Please close if its out of scope...

Adds a shortcut and redirect to `mock_completion` to the main `completion` method.

This simplifies the integration a lot, e.g.

```python
mock_response = 'Test response' if (DEBUG or TESTING) else None

response = completion(
    model, 
    messages, 
    mock_response=mock_response,
)
```

or if you are debugging and do not want to hit the end point all the time and incur costs you can just add `mock_response='...'` without changing your code a lot.