### PR TITLE
fix OpenAI completion model names

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -91,7 +91,14 @@ open_ai_chat_completion_models = [
     "gpt-3.5-turbo-16k",
     "gpt-3.5-turbo-16k-0613",
 ]
-open_ai_text_completion_models = ["text-davinci-003", "curie-001", "babbage-001", "ada-001", "babbage-002", "davinci-002"]
+open_ai_text_completion_models = [
+    "text-davinci-003", 
+    "text-curie-001", 
+    "text-babbage-001", 
+    "text-ada-001", 
+    "text-babbage-002", 
+    "text-davinci-002",
+]
 
 cohere_models = [
     "command-nightly",


### PR DESCRIPTION
The completion model names are wrong, they need to be prefixed with `text-`.

`text-ada-001`, `text-babbage-001`, etc.