### PR TITLE
Add missing litellm_provider for gpt-3.5-16k-0613

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -73,6 +73,7 @@
         "max_tokens": 16385,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000004,
+        "litellm_provider": "openai",
         "mode": "chat"
     },
     "text-davinci-003": {


### PR DESCRIPTION
litellm_provider=openai was missing from this model.