### PR TITLE
added feedback button from feedbackrocket.io

### DIFF
--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -76,6 +76,15 @@ const config = {
     ],
   ],
 
+  scripts: [
+    {
+      async: true,
+      src: 'https://www.feedbackrocket.io/sdk/v1.2.js',
+      'data-fr-id': '<your-21-character-id>',
+      'data-fr-theme': 'dynamic',
+    }
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
@@ -99,6 +108,14 @@ const config = {
             href: 'https://discord.com/invite/wuPM9dRgDw',
             label: 'Discord',
             position: 'right',
+          },
+          {
+            type: 'html',
+            position: 'right',
+            value:
+              `<a href=# class=navbar__link data-fr-widget>
+                Feedback
+              </a>`
           },
         ],
       },


### PR DESCRIPTION
For this, I decided to go with https://www.feedbackrocket.io/ and followed these docs for implementation https://www.feedbackrocket.io/integration-guides/docusaurus

Turns out, Docusaurus is planning to add their own feedback feature, but in the meantime we can use this third party integration.

The founder of FeedbackRocket.io says its free for open source projects:
source: https://docusaurus.io/feature-requests/p/feedback-widget
<img width="791" alt="Screenshot 2023-09-26 at 12 14 01 AM" src="https://github.com/BerriAI/litellm/assets/56165694/816a53d5-a0ab-4d78-9f70-ae66273c3075">



Here's what it looks like:

https://github.com/BerriAI/litellm/assets/56165694/535ed862-7fe7-455a-9964-ee53427e5cb0


Please signup to FeedbackRocket, get the 21-character long identifier copied from your [widget setup page] and paste it in docusaurus.config.js:

````
scripts: [
    {
      async: true,
      src: 'https://www.feedbackrocket.io/sdk/v1.2.js',
      'data-fr-id': '<your-21-character-id>', \\paste it here
      'data-fr-theme': 'dynamic',
    }
  ],
````
