### PR TITLE
added model openrouter/mistralai/mistral-7b-instruct with test

### DIFF
--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -461,6 +461,18 @@ def test_completion_openrouter2():
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
 
+def test_completion_openrouter3():
+    try:
+        response = completion(
+            model="openrouter/mistralai/mistral-7b-instruct",
+            messages=messages,
+            max_tokens=5,
+        )
+        # Add any assertions here to check the response
+        print(response)
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
 # test_completion_openrouter()
 
 def test_completion_hf_model_no_provider():

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -382,6 +382,13 @@
         "litellm_provider": "openrouter",
         "mode": "chat"
     },
+    "openrouter/mistralai/mistral-7b-instruct": {
+        "max_tokens": 4096,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "openrouter",
+        "mode": "chat"
+    },
     "j2-ultra": {
         "max_tokens": 8192,
         "input_cost_per_token": 0.000015,


### PR DESCRIPTION
Added the new openrouter/mistralai/mistral-7b-instruct model. 

The prompt template for the mistralai/mistral-7b-instruct model was added in e8ec3e8 so this works using OpenRouter with minimal edits.