### PR TITLE
add bedrock.anthropic support for system prompt using <admin> tag

### DIFF
--- a/litellm/llms/anthropic.py
+++ b/litellm/llms/anthropic.py
@@ -52,6 +52,10 @@ def completion(
                 prompt += (
                     f"{AnthropicConstants.HUMAN_PROMPT.value}{message['content']}"
                 )
+            elif message["role"] == "system":
+                prompt += (
+                    f"{AnthropicConstants.HUMAN_PROMPT.value}<admin>{message['content']}</admin>"
+                )
             else:
                 prompt += (
                     f"{AnthropicConstants.AI_PROMPT.value}{message['content']}"

--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -40,6 +40,11 @@ def convert_messages_to_prompt(messages, provider):
                     prompt += (
                         f"{AnthropicConstants.HUMAN_PROMPT.value}{message['content']}"
                     )
+                elif message["role"] == "system":
+                    prompt += (
+                        f"{AnthropicConstants.HUMAN_PROMPT.value}<admin>{message['content']}</admin>"
+                    )
+
                 else:
                     prompt += (
                         f"{AnthropicConstants.AI_PROMPT.value}{message['content']}"

--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -44,7 +44,6 @@ def convert_messages_to_prompt(messages, provider):
                     prompt += (
                         f"{AnthropicConstants.HUMAN_PROMPT.value}<admin>{message['content']}</admin>"
                     )
-
                 else:
                     prompt += (
                         f"{AnthropicConstants.AI_PROMPT.value}{message['content']}"


### PR DESCRIPTION
For compatibility with existing tools targetting OpenAI APIs, adding support for the system prompt concept following guidance from anthropic which was obtained and followed by LangChain [here](https://python.langchain.com/docs/integrations/platforms/anthropic).