### PR TITLE
Add custom_openai type in provider list

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -224,6 +224,7 @@ model_list = (
 
 provider_list: List = [
     "openai",
+    "custom_openai",
     "cohere",
     "anthropic",
     "replicate",


### PR DESCRIPTION
According to this [line](https://github.com/BerriAI/litellm/blob/7add88a8b0d3d5894092446099a02f4232285672/litellm/main.py#L355), the `custom_llm_provider` can be `custom_openai`, but it's not in the provider list, so the model with `custom_openai/` prefix can NOT be properly catch in this [line](https://github.com/BerriAI/litellm/blob/7add88a8b0d3d5894092446099a02f4232285672/litellm/utils.py#L1356)