### PR TITLE
Fix usage open in colab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ LiteLLM manages
 
 # Usage
 
-<a target="_blank" href="https://colab.research.google.com/github/BerriAI/litellm/blob/main/cookbook/liteLLM_OpenAI.ipynb">
+<a target="_blank" href="https://colab.research.google.com/github/BerriAI/litellm/blob/main/cookbook/LiteLLM_Azure_and_OpenAI_example.ipynb">
   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 


### PR DESCRIPTION
Fixed : #604

I charged the `open in colab` old dead link to https://colab.research.google.com/github/BerriAI/litellm/blob/main/cookbook/LiteLLM_Azure_and_OpenAI_example.ipynb