### PR TITLE
proxy /models endpoint with the results of get_valid_models()

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -248,7 +248,6 @@ provider_list: List = [
     "bedrock",
     "vllm",
     "nlp_cloud",
-    "bedrock",
     "petals",
     "oobabooga",
     "ollama",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -485,7 +485,7 @@ def model_list():
             object="list",
         )
     else:
-        all_models = litellm.model_list
+        all_models = litellm.utils.get_valid_models()
         return dict(
             data = [{"id": model, "object": "model", "created": 1677610602, "owned_by": "openai"} for model in all_models],
             object="list",


### PR DESCRIPTION
updated `proxy_server.py` to respond with `litellm.utils.get_valid_models()` on the `/models` endpoint instead of responding with all models.