### PR TITLE
fix: llm_provider add openai finetune compatibility

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -375,7 +375,7 @@ def completion(
             model in litellm.open_ai_chat_completion_models
             or custom_llm_provider == "custom_openai"
             or custom_llm_provider == "openai"
-            or "ft:gpt-3.5-turbo" in model  # finetuned gpt-3.5-turbo
+            or "ft:gpt-3.5-turbo" in model  # finetune gpt-3.5-turbo
         ):  # allow user to make an openai call with a custom base
             # note: if a user sets a custom base - we should ensure this works
             # allow for the setting of dynamic and stateful api-bases

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1461,7 +1461,7 @@ def get_llm_provider(model: str, custom_llm_provider: Optional[str] = None, api_
 
         # check if model in known model provider list  -> for huggingface models, raise exception as they don't have a fixed provider (can be togetherai, anyscale, baseten, runpod, et.)
         ## openai - chatcompletion + text completion
-        if model in litellm.open_ai_chat_completion_models:
+        if model in litellm.open_ai_chat_completion_models or "ft:gpt-3.5-turbo" in model:
             custom_llm_provider = "openai"
         elif model in litellm.open_ai_text_completion_models:
             custom_llm_provider = "text-completion-openai"


### PR DESCRIPTION
llm_provider add openai finetune compatibility.

A error happens in #617 

original code:

```python
from litellm import completion

response = completion(
  model="ft:gpt-3.5-turbo-0613:xxx::xxx",
  messages=[
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Hello!"}
  ],
  custom_llm_provider="openai"
)

print(response.choices[0].message)
```

after:

```python
from litellm import completion

response = completion(
  model="ft:gpt-3.5-turbo-0613:xxx::xxx",
  messages=[
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Hello!"}
  ]
)

print(response.choices[0].message)
```