### PR TITLE
deepinfra: Add supported models

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -99,6 +99,7 @@ ai21_models: List = []
 nlp_cloud_models: List = []
 aleph_alpha_models: List = []
 bedrock_models: List = []
+deepinfra_models: List = []
 for key, value in model_cost.items():
     if value.get('litellm_provider') == 'openai':
         open_ai_chat_completion_models.append(key)
@@ -127,6 +128,8 @@ for key, value in model_cost.items():
         aleph_alpha_models.append(key)
     elif value.get('litellm_provider') == 'bedrock': 
         bedrock_models.append(key)
+    elif value.get('litellm_provider') == 'deepinfra':
+        deepinfra_models.append(key)
 
 # known openai compatible endpoints - we'll eventually move this list to the model_prices_and_context_window.json dictionary
 openai_compatible_endpoints: List = [
@@ -230,6 +233,7 @@ model_list = (
     + nlp_cloud_models
     + ollama_models
     + bedrock_models
+    + deepinfra_models
 )
 
 provider_list: List = [
@@ -271,6 +275,7 @@ models_by_provider: dict = {
     "bedrock": bedrock_models,
     "petals": petals_models,
     "ollama": ollama_models,
+    "deepinfra": deepinfra_models,
 }
 
 # mapping for those models which have larger equivalents 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -572,9 +572,9 @@
         "mode": "completion"
     },
     "deepinfra/meta-llama/Llama-2-70b-chat-hf": {
-        "max_tokens": 6144,
-        "input_cost_per_token": 0.000001875,
-        "output_cost_per_token": 0.000001875,
+        "max_tokens": 4096,
+        "input_cost_per_token": 0.000000700,
+        "output_cost_per_token": 0.000000950,
         "litellm_provider": "deepinfra",
         "mode": "chat"
     },


### PR DESCRIPTION
This is necesary when used with llama_index (for example) which checks if model is chat or not, and modifies the input accordingly.

I know the pending llama_index change that won't need the `is_chat_model` functionality: https://github.com/run-llama/llama_index/pull/7885 but then why have all models of each vendor here, either drop it or add `deepinfra` as well.