### PR TITLE
fix: disabled batch by default for Traceloop

### DIFF
--- a/litellm/integrations/traceloop.py
+++ b/litellm/integrations/traceloop.py
@@ -1,6 +1,8 @@
 import sys
 
+
 class TraceloopLogger:
     def __init__(self):
         from traceloop.tracing import Tracer
-        self.tracer = Tracer.init(app_name=sys.argv[0])
+
+        self.tracer = Tracer.init(app_name=sys.argv[0], disable_batch=True)


### PR DESCRIPTION
Disabled batch by default for Traceloop so logs will be shown immediately