### PR TITLE
Incorrect boto3 parameter name

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -61,7 +61,7 @@ bedrock = boto3.client(
             service_name="bedrock-runtime",
             region_name="us-east-1",
             aws_access_key_id="",
-            aws_secret_access_key_id="",
+            aws_secret_access_key="",
             aws_session_token="",
 )
 


### PR DESCRIPTION
The LiteLLM documentation contains incorrect parameter name to set boto3 client.
    Currently displayed parameter name= aws_secret_access_key_id
    Correct parameter name= aws_secret_access_key

https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html