### PR TITLE
Router.get_available_deployment: Handle empty input edge case

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -162,9 +162,10 @@ class Router:
         current_tpm, current_rpm = self._get_deployment_usage(deployment_name=deployment["litellm_params"]["model"])
 
         # get encoding
-        if messages:
+        token_count = 0
+        if messages is not None:
             token_count = litellm.token_counter(model=deployment["model_name"], messages=messages)
-        elif input:
+        elif input is not None:
             if isinstance(input, List):
                 input_text = "".join(text for text in input)
             else:


### PR DESCRIPTION
If boolean of the `input` and `messages` evaluates to `False`, it errors out:
```
   if current_tpm + token_count > tpm or current_rpm + 1 >= rpm:
UnboundLocalError: local variable 'token_count' referenced before assignment
```