### PR TITLE
Docker Hub image is built for ARM64 only

### DIFF
--- a/docs/my-website/docs/providers/ollama.md
+++ b/docs/my-website/docs/providers/ollama.md
@@ -89,8 +89,8 @@ For Ollama LiteLLM Provides a Docker Image for an OpenAI API compatible server f
 
 ### Quick Start:
 Docker Hub: 
-https://hub.docker.com/repository/docker/litellm/ollama/general
-
+For ARM Processors: https://hub.docker.com/repository/docker/litellm/ollama/general
+For Intel/AMD Processors: to be added
 ```shell
 docker pull litellm/ollama
 ```


### PR DESCRIPTION
When trying to run it on a x64 Linux machine, I get the following error:

```
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
```

The Docker image was apparently built for ARM64 only.