### PR TITLE
fix: fix bug for the case --model is not specified

### DIFF
--- a/litellm_server/main.py
+++ b/litellm_server/main.py
@@ -106,11 +106,8 @@ async def chat_completion(request: Request, model: Optional[str] = None):
     try:
         data = await request.json()
         print(f"data: {data}")
-        data["model"] = (
-            server_settings.get("completion_model", None) # server default
-            or model # model passed in url 
-            or data["model"] # default passed in
-        )
+        server_model = server_settings.get("completion_model", None) if server_settings else None
+        data["model"] = server_model or model or data["model"]
         ## CHECK KEYS ## 
         # default to always using the "ENV" variables, only if AUTH_STRATEGY==DYNAMIC then reads headers
         # env_validation = litellm.validate_environment(model=data["model"])


### PR DESCRIPTION
When you following [instruction](https://github.com/BerriAI/litellm/tree/main/litellm_server) to use a config.yaml file, you will not specify --model when you launch the server, and you will get error even with config file detected:

```
CONFIG FILE DETECTED
data: {'model': 'huggingface/some_model', 'messages': [{'role': 'user', 'content': 'How are you?'}], 'max_tokens': 150}
Traceback (most recent call last):
  File "/app/main.py", line 110, in chat_completion
    server_settings.get("completion_model", None) # server default
AttributeError: 'NoneType' object has no attribute 'get'
```

Not sure whether we should always specify server_settings in config.yaml.