### PR TITLE
Fix ServiceUnavailableError super.__init__ error

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -83,13 +83,15 @@ class ContextWindowExceededError(BadRequestError):  # type: ignore
         )  # Call the base class constructor with the parameters it needs
 
 class ServiceUnavailableError(APIStatusError):  # type: ignore
-    def __init__(self, message, llm_provider, model):
+    def __init__(self, message, llm_provider, model, response: httpx.Response):
         self.status_code = 503
         self.message = message
         self.llm_provider = llm_provider
         self.model = model
         super().__init__(
-            self.message
+            self.message,
+            response=response,
+            body=None
         )  # Call the base class constructor with the parameters it needs
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3264,7 +3264,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"AnthropicException - {original_exception.message}",
                             llm_provider="anthropic",
-                            model=model
+                            model=model,
+                            response=original_exception.response
                         )
                     else:
                         exception_mapping_worked = True
@@ -3346,7 +3347,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"ReplicateException - {original_exception.message}",
                             llm_provider="replicate",
-                            model=model
+                            model=model,
+                            response=original_exception.response
                         )
                 exception_mapping_worked = True
                 raise APIError(
@@ -3395,7 +3397,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"BedrockException - {original_exception.message}",
                             llm_provider="bedrock",
-                            model=model
+                            model=model,
+                            response=original_exception.response
                         )
                     elif original_exception.status_code == 401:
                         exception_mapping_worked = True
@@ -3477,7 +3480,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"CohereException - {original_exception.message}",
                             llm_provider="cohere",
-                            model=model
+                            model=model,
+                            response=original_exception.response
                         )
                 elif (
                     "CohereConnectionError" in exception_type
@@ -3502,7 +3506,8 @@ def exception_type(
                     raise ServiceUnavailableError(
                         message=f"CohereException - {original_exception.message}",
                         llm_provider="cohere",
-                        model=model
+                        model=model,
+                        response=original_exception.response
                     )
                 else:
                     if hasattr(original_exception, "status_code"):
@@ -3710,7 +3715,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"NLPCloudException - {original_exception.message}",
                             model=model,
-                            llm_provider="nlp_cloud"
+                            llm_provider="nlp_cloud",
+                            response=original_exception.response
                         )
                     else:
                         exception_mapping_worked = True
@@ -3847,7 +3853,8 @@ def exception_type(
                         raise ServiceUnavailableError(
                             message=f"AlephAlphaException - {original_exception.message}",
                             llm_provider="aleph_alpha",
-                            model=model
+                            model=model,
+                            response=original_exception.response
                         )
                     raise original_exception
                 raise original_exception
@@ -3872,7 +3879,8 @@ def exception_type(
                     raise ServiceUnavailableError(
                         message=f"OllamaException: {original_exception}",
                         llm_provider="ollama", 
-                        model=model
+                        model=model,
+                        response=original_exception.response
                     )
                 elif "Invalid response object from API" in error_str:
                     exception_mapping_worked = True


### PR DESCRIPTION
- Add response and body to `APIStatus.__init__` call within `ServiceUnavailableError`
- Provide response to ServiceUnavailableError where needed

Addresses error

```
self = ServiceUnavailableError()
message = 'AnthropicException - Function calling is not supported by anthropic. To add it to the prompt, set `litellm.add_function_to_prompt = True`.'
llm_provider = 'anthropic', model = 'claude-2'

    def __init__(self, message, llm_provider, model):
        self.status_code = 503
        self.message = message
        self.llm_provider = llm_provider
        self.model = model
>       super().__init__(
            self.message
        )  # Call the base class constructor with the parameters it needs
E       TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'

.venv/lib/python3.10/site-packages/litellm/exceptions.py:90: TypeError
```

More context https://github.com/BerriAI/litellm/issues/774#issuecomment-1807369345

---

There are likely similar issues with other exception classes in this file.