### PR TITLE
need to re-attempt backoff and yaml imports if the first import attempt fails

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -39,6 +39,8 @@ except ImportError:
     import tomli as tomllib
     import appdirs
     import tomli_w
+    import backoff
+    import yaml
 
 import random
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,13 @@
 litellm
 openai
 fastapi
+tomli
+appdirs
+tomli_w
+backoff
+yaml
 uvicorn
 boto3
 litellm
 redis
+yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ tomli
 appdirs
 tomli_w
 backoff
-yaml
+pyyaml
 uvicorn
 boto3
 litellm
 redis
-yaml
+pyyaml


### PR DESCRIPTION
proxy_server has a try-import-except-pip-import block, but there were a couple of imports missing in the second block.

On running in a clean docker container for the first time from source, one of the imports fails, so it runs pip install. This succeeds, but the yaml module never got imported.

Also, one thing to be aware of is that some modules don't survive this approach - a package I maintain used the same trick, and it worked most of the time, but on some users machines / configs python would remember that a module had been unavailable and it wouldn't load it on the second import :(

https://github.com/BerriAI/litellm/issues/819
