### PR TITLE
Added support for multiple embeddings via Bedrock

### DIFF
--- a/litellm/tests/test_embedding.py
+++ b/litellm/tests/test_embedding.py
@@ -95,7 +95,8 @@ def test_cohere_embedding3():
 def test_bedrock_embedding():
     try:
         response = embedding(
-            model="amazon.titan-embed-text-v1", input=["good morning from litellm, attempting to embed data"]
+            model="amazon.titan-embed-text-v1", input=["good morning from litellm, attempting to embed data",
+                                                       "lets test a second string for good measure"]
         )
         print(f"response:", response)
     except Exception as e:


### PR DESCRIPTION
Added support for multiple embeddings to be submitted via Bedrock API to be compliant with OpenAI API which allows >1.

Related to previous PR #765  prior to openai v1 support being added.