### PR TITLE
fix: model id in /models endpoint of the proxy server

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -444,7 +444,7 @@ def model_list():
     return dict(
         data=[
             {
-                "id": model,
+                "id": model["model_name"],
                 "object": "model",
                 "created": 1677610602,
                 "owned_by": "openai",


### PR DESCRIPTION
fix for https://github.com/BerriAI/litellm/issues/865