### PR TITLE
Add AWS Lambda Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ litellm/proxy/api_log.json
 router_config.yaml
 litellm_server/config.yaml
 litellm/proxy/_secret_config.yaml
+.aws-sam/

--- a/litellm/proxy/lambda.py
+++ b/litellm/proxy/lambda.py
@@ -1,0 +1,4 @@
+from mangum import Mangum
+from litellm.proxy.proxy_server import app
+
+handler = Mangum(app, lifespan="on")

--- a/litellm/requirements.txt
+++ b/litellm/requirements.txt
@@ -1,0 +1,1 @@
+../requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ rq
 prisma
 celery
 psutil
+mangum

--- a/template.yaml
+++ b/template.yaml
@@ -46,7 +46,7 @@ Resources:
     Properties:
       FunctionName: !Sub "${AWS::StackName}-llmlite"
       CodeUri: "./litellm"
-      Handler: proxy/lambda.lambda_handler
+      Handler: proxy/lambda.handler
       Runtime: python3.11
       AutoPublishAlias: !Ref AliasParameter
       Role: !GetAtt LambdaExecutionRole.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -35,7 +35,7 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub "${AWS::StackName}-llmlite"
+      FunctionName: !Sub "${AWS::StackName}-function"
       CodeUri: "./litellm"
       Handler: proxy/lambda.handler
       Runtime: python3.11

--- a/template.yaml
+++ b/template.yaml
@@ -47,7 +47,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-llmlite"
       CodeUri: "./"
       Handler: litellm/proxy/lambda.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.11
       AutoPublishAlias: !Ref AliasParameter
       Role: !GetAtt LambdaExecutionRole.Arn
       Architectures:
@@ -80,7 +80,7 @@ Resources:
   URL:
     Type: AWS::Lambda::Url
     DependsOn: FunctionAliaslive
-    Properties: 
+    Properties:
       AuthType: AWS_IAM
       Qualifier: live
       TargetFunctionArn: !GetAtt Function.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -10,36 +10,27 @@ Globals:
   Function:
     Timeout: 600
     MemorySize: 128
+    Environment:
+      Variables:
+        WORKER_CONFIG: !Ref WorkerConfigParameter
 
 Parameters:
   AliasParameter:
     Type: String
     Default: live
+  WorkerConfigParameter:
+    Type: String
+    Description: Sample environment variable
+    Default: '{"model": null, "alias": null, "api_base": null, "api_version": "2023-07-01-preview", "debug": false, "temperature": null, "max_tokens": null, "request_timeout": 600, "max_budget": null, "telemetry": true, "drop_params": false, "add_function_to_prompt": false, "headers": null, "save": false, "config": null, "use_queue": false}'
 
 Resources:
-  LambdaExecutionRole:
-    Type: AWS::IAM::Role
+  MyUrlFunctionPermissions:
+    Type: AWS::Lambda::Permission
     Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-                - edgelambda.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: LambdaExecutionPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: 'arn:aws:logs:*:*:*'
+      FunctionName: !Ref URL
+      Action: lambda:InvokeFunctionUrl
+      Principal: "*"
+      FunctionUrlAuthType: NONE
 
   Function:
     Type: AWS::Serverless::Function
@@ -49,7 +40,6 @@ Resources:
       Handler: proxy/lambda.handler
       Runtime: python3.11
       AutoPublishAlias: !Ref AliasParameter
-      Role: !GetAtt LambdaExecutionRole.Arn
       Architectures:
        - x86_64
       DeploymentPreference:
@@ -81,7 +71,7 @@ Resources:
     Type: AWS::Lambda::Url
     DependsOn: FunctionAliaslive
     Properties:
-      AuthType: AWS_IAM
+      AuthType: NONE
       Qualifier: live
       TargetFunctionArn: !GetAtt Function.Arn
 

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,104 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  llmlite-service
+
+  SAM Template for llmlite-service
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 600
+    MemorySize: 128
+
+Parameters:
+  AliasParameter:
+    Type: String
+    Default: live
+
+Resources:
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - edgelambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaExecutionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: 'arn:aws:logs:*:*:*'
+
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-llmlite"
+      CodeUri: "./"
+      Handler: litellm/proxy/lambda.lambda_handler
+      Runtime: python3.9
+      AutoPublishAlias: !Ref AliasParameter
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Architectures:
+       - x86_64
+      DeploymentPreference:
+        Type: AllAtOnce
+        Alarms:
+          - !Ref NewVersionErrorMetricGreaterThanZeroAlarm
+
+  NewVersionErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${Function}:live"
+        - Name: FunctionName
+          Value: !Ref Function
+        - Name: ExecutedVersion
+          Value: !GetAtt Function.Version.Version
+      EvaluationPeriods: 1
+      Unit: Count
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+
+  URL:
+    Type: AWS::Lambda::Url
+    DependsOn: FunctionAliaslive
+    Properties: 
+      AuthType: AWS_IAM
+      Qualifier: live
+      TargetFunctionArn: !GetAtt Function.Arn
+
+Outputs:
+  FunctionARN:
+    Description: "Lambda Function ARN"
+    Value: !GetAtt Function.Arn
+
+  FunctionUrl:
+    Description: "Lambda Function URL Endpoint"
+    Value:
+      Fn::GetAtt: URL.FunctionUrl
+
+  FunctionVersion:
+    Description: "Lambda Function Version"
+    Value: !GetAtt Function.Version.Version
+  
+  FunctionNewAlarmARN:
+    Description: "Lambda Function New Alarm ARN"
+    Value: !GetAtt NewVersionErrorMetricGreaterThanZeroAlarm.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -45,8 +45,8 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-llmlite"
-      CodeUri: "./"
-      Handler: litellm/proxy/lambda.lambda_handler
+      CodeUri: "./litellm"
+      Handler: proxy/lambda.lambda_handler
       Runtime: python3.11
       AutoPublishAlias: !Ref AliasParameter
       Role: !GetAtt LambdaExecutionRole.Arn


### PR DESCRIPTION
Technically this also supports Lambda@Edge, but in practice that isn't a great idea, since you're capped to 30 seconds with Lambda@Edge. https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-lambda-at-edge

Using Lambda seems to work fine in my limited testing tonight. https://q56f63qclhddf4zdmg7wksnrmq0ytyyt.lambda-url.us-east-1.on.aws/ (This URL may be offline by the time you read this in the future.)

To deploy, run:

```sh
sam build && sam deploy --guide
```