### PR TITLE
Do not timeout when calling HF through acomplete

### DIFF
--- a/litellm/llms/huggingface_restapi.py
+++ b/litellm/llms/huggingface_restapi.py
@@ -452,7 +452,7 @@ class Huggingface(BaseLLM):
        response = None
        try:
             async with httpx.AsyncClient() as client:
-                response = await client.post(url=api_base, json=data, headers=headers) 
+                response = await client.post(url=api_base, json=data, headers=headers, timeout=None) 
                 response_json = response.json()
                 if response.status_code != 200:
                     raise HuggingfaceError(status_code=response.status_code, message=response.text, request=response.request, response=response)


### PR DESCRIPTION
I'm trying to use litellm for a HF text-generation-inference server. When using completion everything works as expected. When using acompletion, a timeout exception occurs after 5 seconds.

This PR changes the default timeout of httpx to None.
