### PR TITLE
Fix wrong model mentioned in simple proxy doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ LiteLLM manages
 # Usage ([**Docs**](https://docs.litellm.ai/docs/))
 
 > [!IMPORTANT]
-> LiteLLM v1.0.0 is now requires `openai>=1.0.0`. Migration guide [here](https://docs.litellm.ai/docs/migration)
+> LiteLLM v1.0.0 now requires `openai>=1.0.0`. Migration guide [here](https://docs.litellm.ai/docs/migration)
 
 
 <a target="_blank" href="https://colab.research.google.com/github/BerriAI/litellm/blob/main/cookbook/liteLLM_Getting_Started.ipynb">

--- a/docs/my-website/docs/simple_proxy.md
+++ b/docs/my-website/docs/simple_proxy.md
@@ -791,7 +791,7 @@ Set a model alias for your deployments.
 
 In the `config.yaml` the model_name parameter is the user-facing name to use for your deployment. 
 
-In the config below requests with `model=gpt-4` will route to `ollama/zephyr`
+In the config below requests with `model=gpt-4` will route to `ollama/llama2`
 
 ```yaml
 model_list:


### PR DESCRIPTION
I was trying to setup multiple models and model alias' in my server and I have found this discrepancy while doing that. 

```yaml
model_list:
  - model_name: text-davinci-003
    litellm_params:
        model: ollama/zephyr
  - model_name: gpt-4
    litellm_params:
        model: ollama/llama2
  - model_name: gpt-3.5-turbo
    litellm_params:
        model: ollama/llama2
```

If I start litellm proxy with above config and send a request with `model=gpt-4`, it will route to `ollama/llama2`. But the docs says `ollama/zephyr`. I have fixed it. 