### PR TITLE
Make contributing to docs easier

### DIFF
--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -67,6 +67,9 @@ const config = {
         },
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/BerriAI/litellm/main/editor/docs/my-website/docs/${docPath}`
+          },
         },
         blog: false, // Optional: disable the blog plugin
         theme: {


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/BerriAI/litellm/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb