### PR TITLE
(feat) Allow installing proxy dependencies explicitly with `pip install litellm[proxy]`

### DIFF
--- a/docs/my-website/docs/proxy_server.md
+++ b/docs/my-website/docs/proxy_server.md
@@ -13,7 +13,7 @@ Docs outdated. New docs 👉 [here](./simple_proxy.md)
 
 ## Usage 
 ```shell
-pip install litellm
+pip install litellm[proxy]
 ```
 ```shell 
 $ litellm --model ollama/codellama 

--- a/docs/my-website/docs/simple_proxy.md
+++ b/docs/my-website/docs/simple_proxy.md
@@ -16,7 +16,7 @@ LiteLLM Server manages:
 View all the supported args for the Proxy CLI [here](https://docs.litellm.ai/docs/simple_proxy#proxy-cli-arguments)
 
 ```shell
-$ pip install litellm
+$ pip install litellm[proxy]
 ```
 
 ```shell

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17,27 +17,10 @@ try:
     import yaml
     import rq
 except ImportError:
-    import sys
-
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "uvicorn",
-            "fastapi",
-            "appdirs",
-            "backoff",
-            "pyyaml", 
-            "rq"
-        ]
+    raise ImportError(
+        "Running `litellm proxy` requires installing via `pip install litellm[proxy]`"
     )
-    import uvicorn
-    import fastapi
-    import appdirs
-    import backoff
-    import yaml
+
 
 import random
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4,6 +4,7 @@ import shutil, random, traceback, requests
 from datetime import datetime, timedelta
 from typing import Optional, List
 import secrets, subprocess
+import warnings
 messages: list = []
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -17,10 +18,31 @@ try:
     import yaml
     import rq
 except ImportError:
-    raise ImportError(
-        "Running `litellm proxy` requires installing via `pip install litellm[proxy]`"
-    )
+    import sys
 
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "uvicorn",
+            "fastapi",
+            "appdirs",
+            "backoff",
+            "pyyaml", 
+            "rq"
+        ]
+    )
+    import uvicorn
+    import fastapi
+    import appdirs
+    import backoff
+    import yaml
+
+    warnings.warn(
+        "Installed runtime dependencies for proxy server. Specify these dependencies explicitly with `pip install litellm[proxy]`"
+    )
 
 import random
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,21 @@ certifi = "^2023.7.22"
 appdirs = "^1.4.4"
 aiohttp = "*"
 
+uvicorn = {version = "^0.24.0.post1", optional = true}
+fastapi = {version = "^0.104.1", optional = true}
+backoff = {version = "*", optional = true}
+yaml = {version = "*", optional = true}
+rq = {version = "*", optional = true}
+
+[tool.poetry.extras]
+proxy = [
+    "uvicorn",
+    "fastapi",
+    "backoff",
+    "yaml",
+    "rq"
+]
+
 [tool.poetry.scripts]
 litellm = 'litellm:run_server'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ aiohttp = "*"
 uvicorn = {version = "^0.24.0.post1", optional = true}
 fastapi = {version = "^0.104.1", optional = true}
 backoff = {version = "*", optional = true}
-yaml = {version = "*", optional = true}
 rq = {version = "*", optional = true}
 
 [tool.poetry.extras]
@@ -30,7 +29,6 @@ proxy = [
     "uvicorn",
     "fastapi",
     "backoff",
-    "yaml",
     "rq"
 ]
 


### PR DESCRIPTION
Backwards compatability maintained. We warn users to install explicitly.