### PR TITLE
Enable setting default `model` value for `LiteLLM`, `Chat`, `Completions`

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -101,7 +101,7 @@ class Chat():
       
 class Completions():
   
-  def __init__(self, model, params):
+  def __init__(self, params):
     self.params = params
 
   def create(self, messages, model=None, **kwargs):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -103,16 +103,11 @@ class Completions():
   
   def __init__(self, model, params):
     self.params = params
-    self.model = model 
 
   def create(self, messages, model=None, **kwargs):
-    if model is None:
-        if self.model is not None:
-            model = self.model
-        else:
-            raise ValueError("a value for `model` is required)
     for k, v in kwargs.items():
         self.params[k] = v
+    model = model or self.params.get('model')
     response = completion(model=model, messages=messages, **self.params)
     return response  
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -98,17 +98,23 @@ class Chat():
   def __init__(self, params):
     self.params = params
     self.completions = Completions(self.params)
-
+      
 class Completions():
   
-  def __init__(self, params):
+  def __init__(self, model, params):
     self.params = params
+    self.model = model 
 
-  def create(self, model, messages, **kwargs):
+  def create(self, messages, model=None, **kwargs):
+    if model is None:
+        if self.model is not None:
+            model = self.model
+        else:
+            raise ValueError("a value for `model` is required)
     for k, v in kwargs.items():
         self.params[k] = v
     response = completion(model=model, messages=messages, **self.params)
-    return response
+    return response  
 
 @client
 async def acompletion(*args, **kwargs):


### PR DESCRIPTION
add `model` arg to `Completions` class; if you provide a value, it will be used when you create new completions from an instance of the class.