### PR TITLE
(fix) disable Openrouter.ai's automatic 'transform' on the prompts.

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1001,7 +1001,8 @@ def completion(
 
             data = {
                 "model": model, 
-                "messages": messages,  
+                "messages": messages,
+                "transforms": [],
                 **optional_params
             }
             ## LOGGING


### PR DESCRIPTION
By default Openrouter transforms the prompt messages with the so called middle-out transform.
https://openrouter.ai/docs#transforms

That is especially dangerous for longer coding tasks because effectively removes parts of the code.

I would recommend to disable it by default, and leave this kind of transformations for higher layers,
ie. before litellm is called. 

(I may have misunderstood how liteLLM calls openrouter, correct me if I am wrong.)