### PR TITLE
fix replicate system prompt: forgot to add **optional_params to input data

### DIFF
--- a/litellm/llms/replicate.py
+++ b/litellm/llms/replicate.py
@@ -232,7 +232,8 @@ def completion(
     if system_prompt is not None:
         input_data = {
             "prompt": prompt,
-            "system_prompt": system_prompt
+            "system_prompt": system_prompt,
+            **optional_params
         }
     # Otherwise, use the prompt as is
     else:


### PR DESCRIPTION
In #970 , I forgot to add the **optional_params argument to input_data (see change) which prevented the user to pass other optional params to replicate (e.g. max_new_tokens)... This minimal change should fix the issue