### PR TITLE
Fix #1119, no content when streaming.

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -221,6 +221,7 @@ async def ollama_async_streaming(url, data, model_response, encoding, logging_ob
 
 
 async def ollama_acompletion(url, data, model_response, encoding, logging_obj):
+    data["stream"] = False
     try:
         timeout = aiohttp.ClientTimeout(total=600)  # 10 minutes
         async with aiohttp.ClientSession(timeout=timeout) as session:


### PR DESCRIPTION
Workaround for #1119 , ensure we make non-streaming request.

p.s. When running under debugger the original code (without this PR) works. It looks like adding some delay makes it enough for the response to come in full. This indicates a bigger problem with the code and the way it collects response. To put it bluntly the whole ollama code looks quite messy. I even observed the current streaming code to sometimes just return a couple of tokens when repeating the same request fast in a succession.