### PR TITLE
Fix(usage-based-routing-cache): get key is differs from set key in the cache

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -754,10 +754,17 @@ class Router:
         # ----------------------
         lowest_tpm = float("inf")
         deployment = None
+        
+        # load model context map
+        models_context_map = litellm.model_cost
 
         # return deployment with lowest tpm usage
         for item in potential_deployments:
-            item_tpm, item_rpm = self._get_deployment_usage(deployment_name=item["litellm_params"]["model"])
+            deployment_name=item["litellm_params"]["model"]
+            litellm_provider = models_context_map.get(deployment_name, {}).get("litellm_provider", None)
+            if litellm_provider is not None:
+                deployment_name = f"{litellm_provider}/{deployment_name}"
+            item_tpm, item_rpm = self._get_deployment_usage(deployment_name=deployment_name)
 
             if item_tpm == 0:
                 return item

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -761,9 +761,13 @@ class Router:
         # return deployment with lowest tpm usage
         for item in potential_deployments:
             deployment_name=item["litellm_params"]["model"]
-            litellm_provider = models_context_map.get(deployment_name, {}).get("litellm_provider", None)
-            if litellm_provider is not None:
-                deployment_name = f"{litellm_provider}/{deployment_name}"
+            custom_llm_provider = item["litellm_params"].get("custom_llm_provider", None)
+            if custom_llm_provider is not None:
+                deployment_name = f"{custom_llm_provider}/{deployment_name}"
+            else:
+                litellm_provider = models_context_map.get(deployment_name, {}).get("litellm_provider", None)
+                if litellm_provider is not None:
+                    deployment_name = f"{litellm_provider}/{deployment_name}"
             item_tpm, item_rpm = self._get_deployment_usage(deployment_name=deployment_name)
 
             if item_tpm == 0:
@@ -792,6 +796,7 @@ class Router:
         current_minute = datetime.now().strftime("%H-%M")
         tpm_key = f'{deployment_name}:tpm:{current_minute}'
         rpm_key = f'{deployment_name}:rpm:{current_minute}'
+        print("get: ", tpm_key)
 
         # ------------
         # Return usage
@@ -823,6 +828,7 @@ class Router:
         current_minute = datetime.now().strftime("%H-%M")
         tpm_key = f'{model_name}:tpm:{current_minute}'
         rpm_key = f'{model_name}:rpm:{current_minute}'
+        print("set: ", tpm_key)
 
         # ------------
         # Update usage

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -796,7 +796,6 @@ class Router:
         current_minute = datetime.now().strftime("%H-%M")
         tpm_key = f'{deployment_name}:tpm:{current_minute}'
         rpm_key = f'{deployment_name}:rpm:{current_minute}'
-        print("get: ", tpm_key)
 
         # ------------
         # Return usage
@@ -828,7 +827,6 @@ class Router:
         current_minute = datetime.now().strftime("%H-%M")
         tpm_key = f'{model_name}:tpm:{current_minute}'
         rpm_key = f'{model_name}:rpm:{current_minute}'
-        print("set: ", tpm_key)
 
         # ------------
         # Update usage


### PR DESCRIPTION
Bug Example:

get_rpm_key: `gpt-3.5-turbo-0301:rpm:19-45`
set_rpm_key: `openai/gpt-3.5-turbo-0301:rpm:19-45`