### PR TITLE
(fix) curl example on proxy/quick_start

### DIFF
--- a/docs/my-website/docs/proxy/quick_start.md
+++ b/docs/my-website/docs/proxy/quick_start.md
@@ -58,7 +58,7 @@ curl --location 'http://0.0.0.0:8000/chat/completions' \
           "role": "user",
           "content": "what llm are you"
         }
-      ],
+      ]
     }
 '
 ```


### PR DESCRIPTION
Remove unnecessary `,` from curl example.
This cause an error: "json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 9 column 5 (char 152)" when execute request.