### PR TITLE
fix least_busy router by updating min_traffic

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1177,6 +1177,7 @@ class Router:
             min_deployment = None
             for k, v in deployments.items(): 
                 if v < min_traffic:
+                    min_traffic = v
                     min_deployment = k
             ############## No Available Deployments passed, we do a random pick #################
             if min_deployment is None: 


### PR DESCRIPTION
Seemed a bug when getting the least-busy `api_base`