### PR TITLE
Add a default for safety settings in vertex AI

### DIFF
--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -195,6 +195,7 @@ def completion(
                 optional_params[k] = v
 
         ## Process safety settings into format expected by vertex AI    
+        safety_settings = None
         if "safety_settings" in optional_params:
             safety_settings = optional_params.pop("safety_settings")
             if not isinstance(safety_settings, list):


### PR DESCRIPTION
In a previous commit (https://github.com/BerriAI/litellm/pull/1190) I added the ability to control safety settings for vertex AI. But I had forgotten to provide a default variable. This PR fixes this.

Thanks @aashiqmuhamed for pointing this out.