### PR TITLE
Add aws_bedrock_runtime_endpoint support

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -327,6 +327,7 @@ def completion(
         aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)
         aws_access_key_id = optional_params.pop("aws_access_key_id", None)
         aws_region_name = optional_params.pop("aws_region_name", None)
+        aws_bedrock_runtime_endpoint = optional_params.pop("aws_bedrock_runtime_endpoint", None)
 
         # use passed in BedrockRuntime.Client if provided, otherwise create a new one
         client = optional_params.pop(
@@ -336,6 +337,7 @@ def completion(
                 aws_access_key_id=aws_access_key_id,
                 aws_secret_access_key=aws_secret_access_key,
                 aws_region_name=aws_region_name,
+                aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
             ),
         )
 
@@ -614,12 +616,14 @@ def embedding(
     aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)
     aws_access_key_id = optional_params.pop("aws_access_key_id", None)
     aws_region_name = optional_params.pop("aws_region_name", None)
+    aws_bedrock_runtime_endpoint = optional_params.pop("aws_bedrock_runtime_endpoint", None)
 
     # use passed in BedrockRuntime.Client if provided, otherwise create a new one
     client = init_bedrock_client(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_region_name=aws_region_name,
+        aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
     )   
 
     ## Embedding Call


### PR DESCRIPTION
This expands upon #717.


Future example usage (seems like Cloudflare AI Gateway has a bug atm :P ):

```yaml
model_list:
  - model_name: claude-v2.1
    litellm_params:
      model: bedrock/anthropic.claude-v2:1
      aws_region_name: us-east-1
      aws_bedrock_runtime_endpoint: https://gateway.ai.cloudflare.com/v1/1234_account_id_here/demo/aws-bedrock/bedrock-runtime/us-east-1
  - model_name: claude-v2.1
    litellm_params:
      model: bedrock/anthropic.claude-v2:1
      aws_region_name: us-west-2
      aws_bedrock_runtime_endpoint: https://gateway.ai.cloudflare.com/v1/1234_account_id_here/demo/aws-bedrock/bedrock-runtime/us-west-2
  - model_name: claude-v2.1
    litellm_params:
      model: bedrock/anthropic.claude-v2:1
      aws_region_name: eu-central-1
      aws_bedrock_runtime_endpoint: https://gateway.ai.cloudflare.com/v1/1234_account_id_here/demo/aws-bedrock/bedrock-runtime/eu-central-1
```