### PR TITLE
fix: success_callback logic for cost_tracking

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -358,8 +358,6 @@ def cost_tracking():
             print("setting litellm success callback to track cost")
             if (track_cost_callback) not in litellm.success_callback: # type: ignore
                 litellm.success_callback.append(track_cost_callback) # type: ignore
-            else:
-                litellm.success_callback = track_cost_callback # type: ignore
 
 async def track_cost_callback(
     kwargs,                                       # kwargs to completion


### PR DESCRIPTION
While figuring out of litellm proxy codes, I found the logic that was mistaken on the cost_tracking method.
When `track_cost_callback` is in the `litellm.success_callback`, it changes the whole `litellm.success_call` to `track_cost_callback` which is also not a list type.

So I propose removing the else statement to handle the case when `litellm.sucess_callback` already had `track_cost_callback`.