### PR TITLE
Adds support for Vertex AI Unicorn

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -275,13 +275,20 @@
         "litellm_provider": "vertex_ai-text-models",
         "mode": "completion"
     },
+    "text-unicorn": {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000028,
+        "litellm_provider": "vertex_ai-chat-models",
+        "mode": "completion"
+    },
     "text-unicorn@001": {
         "max_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000028,
         "litellm_provider": "vertex_ai-chat-models",
         "mode": "completion"
-    }
+    },
     "chat-bison": {
         "max_tokens": 4096,
         "input_cost_per_token": 0.000000125,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -275,6 +275,13 @@
         "litellm_provider": "vertex_ai-text-models",
         "mode": "completion"
     },
+    "text-unicorn@001": {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000028,
+        "litellm_provider": "vertex_ai-chat-models",
+        "mode": "completion"
+    }
     "chat-bison": {
         "max_tokens": 4096,
         "input_cost_per_token": 0.000000125,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -277,14 +277,14 @@
     },
     "text-unicorn": {
         "max_tokens": 8192,
-        "input_cost_per_token": 0.000001,
+        "input_cost_per_token": 0.00001,
         "output_cost_per_token": 0.000028,
         "litellm_provider": "vertex_ai-chat-models",
         "mode": "completion"
     },
     "text-unicorn@001": {
         "max_tokens": 8192,
-        "input_cost_per_token": 0.000001,
+        "input_cost_per_token": 0.00001,
         "output_cost_per_token": 0.000028,
         "litellm_provider": "vertex_ai-chat-models",
         "mode": "completion"


### PR DESCRIPTION
The module was crashing for Unicorn and when I went through the stack trace, it looks like it was because the model cost map didn't have an entry for it. I calculated the price per token based off https://cloud.google.com/vertex-ai/pricing with the assumption that 4 characters is one token.

I also think the price for the other Vertex AI models is off. If you agree, I can correct them in another PR.