### PR TITLE
fix typos & add missing names for azure models

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -335,9 +335,9 @@ baseten_models: List = [
 # used for token counting
 # Azure returns gpt-35-turbo in their responses, we need to map this to azure/gpt-3.5-turbo for token counting
 azure_llms = {
-    "gpt-35-turbo": "azure/gpt-3.5-turbo",
-    "gpt-35-turbo-16k": "azure/gpt-3.5-turbo-16k",
-    "gpt-35-turbo-instruct": "azure/gpt-3.5-turbo-instruct",
+    "gpt-35-turbo": "azure/gpt-35-turbo",
+    "gpt-35-turbo-16k": "azure/gpt-35-turbo-16k",
+    "gpt-35-turbo-instruct": "azure/gpt-35-turbo-instruct",
 }
 
 petals_models = [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -118,6 +118,13 @@
         "litellm_provider": "azure",
         "mode": "chat"
     },
+    "azure/gpt-4-0613": {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0.00003,
+        "output_cost_per_token": 0.00006,
+        "litellm_provider": "azure",
+        "mode": "chat"
+    },
     "azure/gpt-4-32k-0613": {
         "max_tokens": 32768,
         "input_cost_per_token": 0.00006,
@@ -136,6 +143,13 @@
         "max_tokens": 8192,
         "input_cost_per_token": 0.00003,
         "output_cost_per_token": 0.00006,
+        "litellm_provider": "azure",
+        "mode": "chat"
+    },
+    "azure/gpt-35-turbo-16k-0613": {
+        "max_tokens": 16385,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000004,
         "litellm_provider": "azure",
         "mode": "chat"
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -118,28 +118,42 @@
         "litellm_provider": "azure",
         "mode": "chat"
     },
+    "azure/ggpt-4-32k-0613": {
+        "max_tokens": 32768,
+        "input_cost_per_token": 0.00006,
+        "output_cost_per_token": 0.00012,
+        "litellm_provider": "azure",
+        "mode": "chat"
+    },
     "azure/gpt-4-32k": {
-        "max_tokens": 8192,
+        "max_tokens": 32768,
         "input_cost_per_token": 0.00006,
         "output_cost_per_token": 0.00012,
         "litellm_provider": "azure",
         "mode": "chat"
     },
     "azure/gpt-4": {
-        "max_tokens": 16385,
+        "max_tokens": 8192,
         "input_cost_per_token": 0.00003,
         "output_cost_per_token": 0.00006,
         "litellm_provider": "azure",
         "mode": "chat"
     },
-    "azure/gpt-3.5-turbo-16k": {
+    "azure/gpt-35-turbo-1106": {
+        "max_tokens": 16384,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.000002,
+        "litellm_provider": "azure",
+        "mode": "chat"
+    },
+    "azure/gpt-35-turbo-16k": {
         "max_tokens": 16385,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000004,
         "litellm_provider": "azure",
         "mode": "chat"
     },
-    "azure/gpt-3.5-turbo": {
+    "azure/gpt-35-turbo": {
         "max_tokens": 4097,
         "input_cost_per_token": 0.0000015,
         "output_cost_per_token": 0.000002,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -118,7 +118,7 @@
         "litellm_provider": "azure",
         "mode": "chat"
     },
-    "azure/ggpt-4-32k-0613": {
+    "azure/gpt-4-32k-0613": {
         "max_tokens": 32768,
         "input_cost_per_token": 0.00006,
         "output_cost_per_token": 0.00012,


### PR DESCRIPTION
Fixes https://github.com/BerriAI/litellm/issues/1291

Before this PR, most Azure OpenAI models used incorrect context size in LiteLMM. (For instance, `.` is not allowed in Azure deployment names, so `gpt-3.5` in Openai has to be spelled as `gpt-35` in Azure OpenAI)

This PR makes LiteLMM work perfectly fine with all available Azure OpenAI models.