### PR TITLE
fix(proxy_server.py) Check when '_hidden_params' is None

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1284,7 +1284,10 @@ async def chat_completion(
         else:  # router is not set
             response = await litellm.acompletion(**data)
 
-        model_id = response._hidden_params.get("model_id", None) or ""
+        if hasattr(response, "_hidden_params"):
+            model_id = response._hidden_params.get("model_id", None) or ""
+        else:
+            model_id = ""
         if (
             "stream" in data and data["stream"] == True
         ):  # use generate_responses to stream responses


### PR DESCRIPTION
This addresses an issue in proxy_server.py where the model_id assignment was not handling the case when _hidden_params is None. The fix ensures proper handling in such scenarios to prevent `AttributeError: 'async_generator' object has no attribute '_hidden_params'` error.

**Additional Context**
I encountered the error when using ollama + litellm proxy + gpt pilot. 
The model used was `OpenHermes-2.5-Mistral-7B`