### PR TITLE
Fixing a bug with no _hidden_params attribute missing

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1283,8 +1283,11 @@ async def chat_completion(
             response = await llm_router.acompletion(**data, specific_deployment=True)
         else:  # router is not set
             response = await litellm.acompletion(**data)
-
-        model_id = response._hidden_params.get("model_id", None) or ""
+        
+        if not hasattr(response, '_hidden_params'):
+            model_id = ""
+        else:
+            model_id = response._hidden_params.get("model_id", None) or ""
         if (
             "stream" in data and data["stream"] == True
         ):  # use generate_responses to stream responses


### PR DESCRIPTION
This fixes an issue with a proxy that raises an error when streaming is requested from a TGI endpoint. Without the fix it crashes looking for _hidden_parameters in an object that doesn't have them.