### PR TITLE
[Feat] Improve LiteLLM Verbose Logs - show args passed to litellm function 

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8282,6 +8282,26 @@ def transform_logprobs(hf_response):
 
 def print_args_passed_to_litellm(original_function, args, kwargs):
     try:
+        # we've already printed this for acompletion, don't print for completion
+        if (
+            "acompletion" in kwargs
+            and kwargs["acompletion"] == True
+            and original_function.__name__ == "completion"
+        ):
+            return
+        elif (
+            "aembedding" in kwargs
+            and kwargs["aembedding"] == True
+            and original_function.__name__ == "embedding"
+        ):
+            return
+        elif (
+            "aimg_generation" in kwargs
+            and kwargs["aimg_generation"] == True
+            and original_function.__name__ == "img_generation"
+        ):
+            return
+
         args_str = ", ".join(map(repr, args))
         kwargs_str = ", ".join(f"{key}={repr(value)}" for key, value in kwargs.items())
         print_verbose("\n")  # new line before

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1975,6 +1975,8 @@ def client(original_function):
 
     @wraps(original_function)
     def wrapper(*args, **kwargs):
+        # Prints Exactly what was passed to litellm function - don't execute any logic here - it should just print
+        print_args_passed_to_litellm(original_function, args, kwargs)
         start_time = datetime.datetime.now()
         result = None
         logging_obj = kwargs.get("litellm_logging_obj", None)
@@ -2170,6 +2172,7 @@ def client(original_function):
 
     @wraps(original_function)
     async def wrapper_async(*args, **kwargs):
+        print_args_passed_to_litellm(original_function, args, kwargs)
         start_time = datetime.datetime.now()
         result = None
         logging_obj = kwargs.get("litellm_logging_obj", None)
@@ -8275,3 +8278,29 @@ def transform_logprobs(hf_response):
         transformed_logprobs = token_info
 
     return transformed_logprobs
+
+
+def print_args_passed_to_litellm(original_function, args, kwargs):
+    try:
+        args_str = ", ".join(map(repr, args))
+        kwargs_str = ", ".join(f"{key}={repr(value)}" for key, value in kwargs.items())
+        print_verbose("\n")  # new line before
+        print_verbose("\033[92mRequest to litellm:\033[0m")
+        if args and kwargs:
+            print_verbose(
+                f"\033[92mlitellm.{original_function.__name__}({args_str}, {kwargs_str})\033[0m"
+            )
+        elif args:
+            print_verbose(
+                f"\033[92mlitellm.{original_function.__name__}({args_str})\033[0m"
+            )
+        elif kwargs:
+            print_verbose(
+                f"\033[92mlitellm.{original_function.__name__}({kwargs_str})\033[0m"
+            )
+        else:
+            print_verbose(f"\033[92mlitellm.{original_function.__name__}()\033[0m")
+        print_verbose("\n")  # new line after
+    except:
+        # This should always be non blocking
+        pass


### PR DESCRIPTION
We now show you the exact args sent to the litellm function + the curl request that was translated by LiteLLM 

<img width="1280" alt="Screenshot 2024-01-11 at 6 10 42 PM" src="https://github.com/BerriAI/litellm/assets/29436595/916a44d8-bf98-47aa-b989-9b9f5eb89bda">
