### PR TITLE
[bug] unbound variable in bedrock

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -498,6 +498,8 @@ def completion(
                     "textGenerationConfig": inference_params,
                 }
             )
+        else:
+            data = json.dumps({})
 
         ## COMPLETION CALL
         accept = "application/json"


### PR DESCRIPTION
note: the code was written as `json.dumps({})` even though it is more verbose in order to facilitate easier refactoring in the future

fixes #1428