### PR TITLE
[Feat] Proxy - Access Key metadata in callbacks 

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1892,7 +1892,7 @@ async def image_generation(
             data["model"] = user_model
 
         if "metadata" not in data:
-            data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
+            data["metadata"] = {}
         data["metadata"]["user_api_key"] = user_api_key_dict.api_key
         data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
         data["metadata"]["headers"] = dict(request.headers)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1425,6 +1425,7 @@ async def completion(
             data["model"] = user_model
         if "metadata" in data:
             data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
             data["metadata"]["headers"] = dict(request.headers)
         else:
@@ -1432,6 +1433,7 @@ async def completion(
                 "user_api_key": user_api_key_dict.api_key,
                 "user_api_key_user_id": user_api_key_dict.user_id,
             }
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
         # override with user settings, these are params passed via cli
         if user_temperature:
@@ -1588,11 +1590,13 @@ async def chat_completion(
             verbose_proxy_logger.debug(f'received metadata: {data["metadata"]}')
             data["metadata"]["user_api_key"] = user_api_key_dict.api_key
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
         else:
             data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
 
         global user_temperature, user_request_timeout, user_max_tokens, user_api_base
         # override with user settings, these are params passed via cli
@@ -1756,10 +1760,12 @@ async def embeddings(
             data["model"] = user_model
         if "metadata" in data:
             data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
         else:
             data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
 
@@ -1897,10 +1903,12 @@ async def image_generation(
             data["model"] = user_model
         if "metadata" in data:
             data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
         else:
             data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
 
@@ -2474,10 +2482,12 @@ async def async_queue_request(
         if "metadata" in data:
             verbose_proxy_logger.debug(f'received metadata: {data["metadata"]}')
             data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
         else:
             data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
+            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
             data["metadata"]["headers"] = dict(request.headers)
             data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1423,18 +1423,14 @@ async def completion(
         )
         if user_model:
             data["model"] = user_model
-        if "metadata" in data:
-            data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-            data["metadata"]["headers"] = dict(request.headers)
-        else:
-            data["metadata"] = {
-                "user_api_key": user_api_key_dict.api_key,
-                "user_api_key_user_id": user_api_key_dict.user_id,
-            }
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["headers"] = dict(request.headers)
+        data["metadata"]["endpoint"] = str(request.url)
+
         # override with user settings, these are params passed via cli
         if user_temperature:
             data["temperature"] = user_temperature
@@ -1586,17 +1582,13 @@ async def chat_completion(
             # if users are using user_api_key_auth, set `user` in `data`
             data["user"] = user_api_key_dict.user_id
 
-        if "metadata" in data:
-            verbose_proxy_logger.debug(f'received metadata: {data["metadata"]}')
-            data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-        else:
-            data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["headers"] = dict(request.headers)
+        data["metadata"]["endpoint"] = str(request.url)
 
         global user_temperature, user_request_timeout, user_max_tokens, user_api_base
         # override with user settings, these are params passed via cli
@@ -1758,16 +1750,13 @@ async def embeddings(
         )
         if user_model:
             data["model"] = user_model
-        if "metadata" in data:
-            data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-        else:
-            data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["headers"] = dict(request.headers)
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["endpoint"] = str(request.url)
 
         router_model_names = (
             [m["model_name"] for m in llm_model_list]
@@ -1901,16 +1890,14 @@ async def image_generation(
         )
         if user_model:
             data["model"] = user_model
-        if "metadata" in data:
-            data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-        else:
+
+        if "metadata" not in data:
             data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["headers"] = dict(request.headers)
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["endpoint"] = str(request.url)
 
         router_model_names = (
             [m["model_name"] for m in llm_model_list]
@@ -2479,17 +2466,13 @@ async def async_queue_request(
             # if users are using user_api_key_auth, set `user` in `data`
             data["user"] = user_api_key_dict.user_id
 
-        if "metadata" in data:
-            verbose_proxy_logger.debug(f'received metadata: {data["metadata"]}')
-            data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
-        else:
-            data["metadata"] = {"user_api_key": user_api_key_dict.api_key}
-            data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
-            data["metadata"]["headers"] = dict(request.headers)
-            data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["headers"] = dict(request.headers)
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["endpoint"] = str(request.url)
 
         global user_temperature, user_request_timeout, user_max_tokens, user_api_base
         # override with user settings, these are params passed via cli

--- a/litellm/tests/test_proxy_custom_logger.py
+++ b/litellm/tests/test_proxy_custom_logger.py
@@ -182,6 +182,7 @@ def test_chat_completion(client):
         print("\n\n Metadata in custom logger kwargs", litellm_params.get("metadata"))
         assert metadata is not None
         assert "user_api_key" in metadata
+        assert "user_api_key_metadata" in metadata
         assert "headers" in metadata
         config_model_info = litellm_params.get("model_info")
         proxy_server_request_object = litellm_params.get("proxy_server_request")


### PR DESCRIPTION
## What's changed
- Access Proxy Key metadata in callbacks 
- Access Endpoint URL in calbacks - you can see if /chat/completions, /embeddings, /image/generation etc is called 
- Support for Langfuse Tags, We log request metadata as langfuse tags 

PS. no keys leaked - these are keys to my local proxy 
<img width="529" alt="Screenshot 2024-01-17 at 6 10 10 PM" src="https://github.com/BerriAI/litellm/assets/29436595/991744d2-2d83-49a0-bf31-c76d9d7bdaf4">

### Langfuse Tags logged:
<img width="949" alt="Screenshot 2024-01-17 at 6 11 36 PM" src="https://github.com/BerriAI/litellm/assets/29436595/a28af993-7414-405a-b5f3-63562caecd40">

