### PR TITLE
fix(ollama_chat.py): use tiktoken as backup for prompt token counting

### DIFF
--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -220,7 +220,7 @@ def get_ollama_response(
         model_response["choices"][0]["message"] = response_json["message"]
     model_response["created"] = int(time.time())
     model_response["model"] = "ollama/" + model
-    prompt_tokens = response_json["prompt_eval_count"]  # type: ignore
+    prompt_tokens = response_json.get("prompt_eval_count", len(encoding.encode(prompt)))  # type: ignore
     completion_tokens = response_json["eval_count"]
     model_response["usage"] = litellm.Usage(
         prompt_tokens=prompt_tokens,
@@ -320,7 +320,7 @@ async def ollama_acompletion(url, data, model_response, encoding, logging_obj):
                 model_response["choices"][0]["message"] = response_json["message"]
             model_response["created"] = int(time.time())
             model_response["model"] = "ollama/" + data["model"]
-            prompt_tokens = response_json["prompt_eval_count"]  # type: ignore
+            prompt_tokens = response_json.get("prompt_eval_count", len(encoding.encode(prompt)))  # type: ignore
             completion_tokens = response_json["eval_count"]
             model_response["usage"] = litellm.Usage(
                 prompt_tokens=prompt_tokens,


### PR DESCRIPTION
The fix for ollama completions on already applied [this previous commit](https://github.com/BerriAI/litellm/commit/88d498a54a1bbff5b23d718dc1ef6686ff46400a#diff-f1fc2b8b06c0fa1a363c360b97b365d5629f0d3402d69d2554a1f7795f1f34b0) but is also required for `ollama_chat.py`.

Making a repeated request to the ollama chat endpoint produces a similar issue as before. 

This is likely due to the optional presence of these keys in the response (see the [ollama types definition](https://github.com/jmorganca/ollama/blame/d5a73533574acb02069e74f1d01f6775577391bc/api/types.go#L78))