### PR TITLE
Litellm GitHub action build admin UI

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -35,12 +35,20 @@ jobs:
           push: true
           tags: litellm/litellm:${{ github.event.inputs.tag || 'latest' }} 
       -
+        name: Build and push litellm-ui image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          file: ui/Dockerfile
+          tags: litellm/litellm-ui:${{ github.event.inputs.tag || 'latest' }}
+      -
         name: Build and push litellm-database image
         uses: docker/build-push-action@v5
         with:
           push: true
           file: Dockerfile.database
           tags: litellm/litellm-database:${{ github.event.inputs.tag || 'latest' }}
+      
   build-and-push-image:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -104,6 +104,36 @@ jobs:
           push: true
           tags: ${{ steps.meta-alpine.outputs.tags }}-${{ github.event.inputs.tag || 'latest' }}, ${{ steps.meta-alpine.outputs.tags }}-latest
           labels: ${{ steps.meta-alpine.outputs.labels }}
+  build-and-push-image-ui:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for UI Dockerfile
+        id: meta-ui
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ui
+
+      - name: Build and push UI Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ui/
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta-ui.outputs.tags }}-${{ github.event.inputs.tag || 'latest' }}, ${{ steps.meta-ui.outputs.tags }}-latest
+          labels: ${{ steps.meta-ui.outputs.labels }}
   build-and-push-image-database:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -130,7 +130,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ui/
-          file: Dockerfile
+          file: ui/Dockerfile
           push: true
           tags: ${{ steps.meta-ui.outputs.tags }}-${{ github.event.inputs.tag || 'latest' }}, ${{ steps.meta-ui.outputs.tags }}-latest
           labels: ${{ steps.meta-ui.outputs.labels }}


### PR DESCRIPTION
This PR updated the Github workflows to also build and push the Admin UI docker image, as requested in #1503.

I have tested that it builds OK.  The push to Docker Hub fails in my fork because I can't push to litellm/*, obviously.

I noticed that the -alpine image is being built but not pushed to Docker Hub.  I'd be happy to update this as well if you like.

Again, I don't know much about Github workflows, this PR is mostly Copy, Paste, Find and Replace. :-)