### PR TITLE
[Feat] Proxy - Track Cost Per User (Using `user` passed to requests) 

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -523,8 +523,8 @@ async def track_cost_callback(
         verbose_proxy_logger.debug(
             f"kwargs stream: {kwargs.get('stream', None)} + complete streaming response: {kwargs.get('complete_streaming_response', None)}"
         )
-        litellm_params = kwargs.get("litellm_params", {})
-        proxy_server_request = litellm_params.get("proxy_server_request")
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        proxy_server_request = litellm_params.get("proxy_server_request") or {}
         user_id = proxy_server_request.get("body", {}).get("user", None)
         if "complete_streaming_response" in kwargs:
             # for tracking streaming cost we pass the "messages" and the output_text to litellm.completion_cost

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -523,18 +523,26 @@ async def track_cost_callback(
         verbose_proxy_logger.debug(
             f"kwargs stream: {kwargs.get('stream', None)} + complete streaming response: {kwargs.get('complete_streaming_response', None)}"
         )
+        litellm_params = kwargs.get("litellm_params", {})
+        proxy_server_request = litellm_params.get("proxy_server_request")
+        user_id = proxy_server_request.get("body", {}).get("user", None)
         if "complete_streaming_response" in kwargs:
             # for tracking streaming cost we pass the "messages" and the output_text to litellm.completion_cost
             completion_response = kwargs["complete_streaming_response"]
             response_cost = litellm.completion_cost(
                 completion_response=completion_response
             )
-            verbose_proxy_logger.debug(f"streaming response_cost {response_cost}")
+
             user_api_key = kwargs["litellm_params"]["metadata"].get(
                 "user_api_key", None
             )
-            user_id = kwargs["litellm_params"]["metadata"].get(
+
+            user_id = user_id or kwargs["litellm_params"]["metadata"].get(
                 "user_api_key_user_id", None
+            )
+
+            verbose_proxy_logger.debug(
+                f"streaming response_cost {response_cost}, for user_id {user_id}"
             )
             if user_api_key and (
                 prisma_client is not None or custom_db_client is not None
@@ -555,8 +563,11 @@ async def track_cost_callback(
             user_api_key = kwargs["litellm_params"]["metadata"].get(
                 "user_api_key", None
             )
-            user_id = kwargs["litellm_params"]["metadata"].get(
+            user_id = user_id or kwargs["litellm_params"]["metadata"].get(
                 "user_api_key_user_id", None
+            )
+            verbose_proxy_logger.debug(
+                f"response_cost {response_cost}, for user_id {user_id}"
             )
             if user_api_key and (
                 prisma_client is not None or custom_db_client is not None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3305,6 +3305,8 @@ def get_optional_params(
         unsupported_params = {}
         for k in non_default_params.keys():
             if k not in supported_params:
+                if k == "user":
+                    continue
                 if k == "n" and n == 1:  # langchain sends n=1 as a default value
                     continue  # skip this param
                 if (


### PR DESCRIPTION
## What's changed 
- Proxy Server Track Cost Per User
Request:
```shell
curl --location 'http://0.0.0.0:8000/chat/completions' \
        --header 'Content-Type: application/json' \
        --header 'Authorization: Bearer sk-RwPq' \
        --data ' {
        "model": "BEDROCK_GROUP",
        "user": "litellm-is-awesome-user",
        "messages": [
            {
            "role": "user",
            "content": "what llm are you-444"
            }
        ],
        }'
```


## Cost Tracked in LiteLLM Spend Tracking DB 

<img width="419" alt="Screenshot 2024-01-18 at 5 56 17 PM" src="https://github.com/BerriAI/litellm/assets/29436595/700732e1-868a-4cec-bd17-376d7d510bab">

## Notes:
- If a `user` is passed to the request the proxy tracks cost for it 
- If the `user` does not exist in the User Table, we make a new user with the spend 

