### PR TITLE
nit: switch to valid SPDX license identifier `MIT` in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "litellm"
 version = "1.18.4"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
-license = "MIT License"
+license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
See: https://python-poetry.org/docs/pyproject/#license