### PR TITLE
Langsmith: Add envs for project/run names; fix bug with None metadata

### DIFF
--- a/docs/my-website/docs/observability/langsmith_integration.md
+++ b/docs/my-website/docs/observability/langsmith_integration.md
@@ -28,6 +28,8 @@ import litellm
 import os
 
 os.environ["LANGSMITH_API_KEY"] = ""
+os.environ["LANGSMITH_PROJECT"] = "" # defaults to litellm-completion
+os.environ["LANGSMITH_DEFAULT_RUN_NAME"] = "" # defaults to LLMRun
 # LLM API Keys
 os.environ['OPENAI_API_KEY']=""
 

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -21,9 +21,7 @@ class LangsmithLogger:
     def log_event(self, kwargs, response_obj, start_time, end_time, print_verbose):
         # Method definition
         # inspired by Langsmith http api here: https://github.com/langchain-ai/langsmith-cookbook/blob/main/tracing-examples/rest/rest.ipynb
-        metadata = kwargs.get('litellm_params', {}).get("metadata", {})
-        if metadata is None:
-            metadata = {}
+        metadata = kwargs.get('litellm_params', {}).get("metadata", {}) or {}  # if metadata is None
 
         # set project name and run_name for langsmith logging
         # users can pass project_name and run name to litellm.completion()

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -21,9 +21,10 @@ class LangsmithLogger:
     def log_event(self, kwargs, response_obj, start_time, end_time, print_verbose):
         # Method definition
         # inspired by Langsmith http api here: https://github.com/langchain-ai/langsmith-cookbook/blob/main/tracing-examples/rest/rest.ipynb
-        metadata = {}
-        if "litellm_params" in kwargs:
-            metadata = kwargs["litellm_params"].get("metadata", {})
+        metadata = kwargs.get('litellm_params', {}).get("metadata", {})
+        if metadata is None:
+            metadata = {}
+
         # set project name and run_name for langsmith logging
         # users can pass project_name and run name to litellm.completion()
         # Example: litellm.completion(model, messages, metadata={"project_name": "my-litellm-project", "run_name": "my-langsmith-run"})

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -13,6 +13,10 @@ class LangsmithLogger:
     # Class variables or attributes
     def __init__(self):
         self.langsmith_api_key = os.getenv("LANGSMITH_API_KEY")
+        self.langsmith_project = os.getenv("LANGSMITH_PROJECT", "litellm-completion")
+        self.langsmith_default_run_name = os.getenv(
+            "LANGSMITH_DEFAULT_RUN_NAME", "LLMRun"
+        )
 
     def log_event(self, kwargs, response_obj, start_time, end_time, print_verbose):
         # Method definition
@@ -23,9 +27,9 @@ class LangsmithLogger:
         # set project name and run_name for langsmith logging
         # users can pass project_name and run name to litellm.completion()
         # Example: litellm.completion(model, messages, metadata={"project_name": "my-litellm-project", "run_name": "my-langsmith-run"})
-        # if not set litellm will use default project_name = litellm-completion, run_name = LLMRun
-        project_name = metadata.get("project_name", "litellm-completion")
-        run_name = metadata.get("run_name", "LLMRun")
+        # if not set litellm will fallback to the environment variable LANGSMITH_PROJECT, then to the default project_name = litellm-completion, run_name = LLMRun
+        project_name = metadata.get("project_name", self.langsmith_project)
+        run_name = metadata.get("run_name", self.langsmith_default_run_name)
         print_verbose(
             f"Langsmith Logging - project_name: {project_name}, run_name {run_name}"
         )


### PR DESCRIPTION
First off - thanks for your work on this project! Been loving working with this since migrating from langchain. 

--

Ran into a problem with a fresh install and trying to integrate with an existing langsmith project, if there was no `metadata` set on the completion, the request would silently fail when logging to langsmith. 

I also added project envs for setting new project names as it's a pain to have to add metadata to every completion call.
