### PR TITLE
[Fix] LiteLLM Proxy - Streaming Sagemaker Support on /chat/completions 

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1658,11 +1658,16 @@ async def completion(
             "stream" in data and data["stream"] == True
         ):  # use generate_responses to stream responses
             custom_headers = {"x-litellm-model-id": model_id}
-            return StreamingResponse(
-                async_data_generator(
-                    user_api_key_dict=user_api_key_dict,
+            stream_content = async_data_generator(
+                user_api_key_dict=user_api_key_dict,
+                response=response,
+            )
+            if response.custom_llm_provider == "sagemaker":
+                stream_content = data_generator(
                     response=response,
-                ),
+                )
+            return StreamingResponse(
+                stream_content,
                 media_type="text/event-stream",
                 headers=custom_headers,
             )
@@ -1820,11 +1825,16 @@ async def chat_completion(
             "stream" in data and data["stream"] == True
         ):  # use generate_responses to stream responses
             custom_headers = {"x-litellm-model-id": model_id}
-            return StreamingResponse(
-                async_data_generator(
-                    user_api_key_dict=user_api_key_dict,
+            stream_content = async_data_generator(
+                user_api_key_dict=user_api_key_dict,
+                response=response,
+            )
+            if response.custom_llm_provider == "sagemaker":
+                stream_content = data_generator(
                     response=response,
-                ),
+                )
+            return StreamingResponse(
+                stream_content,
                 media_type="text/event-stream",
                 headers=custom_headers,
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1423,13 +1423,22 @@ async def async_data_generator(response, user_api_key_dict):
 
 
 def select_data_generator(response, user_api_key_dict):
-    # since boto3 - sagemaker does not support async calls
-    if response.custom_llm_provider == "sagemaker":
-        return data_generator(
-            response=response,
-        )
-    else:
-        # default to async_data_generator
+    try:
+        # since boto3 - sagemaker does not support async calls, we should use a sync data_generator
+        if (
+            hasattr(response, "custom_llm_provider")
+            and response.custom_llm_provider == "sagemaker"
+        ):
+            return data_generator(
+                response=response,
+            )
+        else:
+            # default to async_data_generator
+            return async_data_generator(
+                response=response, user_api_key_dict=user_api_key_dict
+            )
+    except:
+        # worst case - use async_data_generator
         return async_data_generator(
             response=response, user_api_key_dict=user_api_key_dict
         )

--- a/litellm/proxy/tests/test_openai_js.js
+++ b/litellm/proxy/tests/test_openai_js.js
@@ -4,7 +4,7 @@ const openai = require('openai');
 process.env.DEBUG=false;
 async function runOpenAI() {
   const client = new openai.OpenAI({
-    apiKey: 'sk-yPX56TDqBpr23W7ruFG3Yg',
+    apiKey: 'sk-JkKeNi6WpWDngBsghJ6B9g',
     baseURL: 'http://0.0.0.0:8000'
   });
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7732,10 +7732,8 @@ class CustomStreamWrapper:
                     ]
                     self.sent_last_chunk = True
             elif self.custom_llm_provider == "sagemaker":
-                print_verbose(f"ENTERS SAGEMAKER STREAMING")
-                new_chunk = next(self.completion_stream)
-
-                completion_obj["content"] = new_chunk
+                print_verbose(f"ENTERS SAGEMAKER STREAMING for chunk {chunk}")
+                completion_obj["content"] = chunk
             elif self.custom_llm_provider == "petals":
                 if len(self.completion_stream) == 0:
                     if self.sent_last_chunk:
@@ -7854,7 +7852,7 @@ class CustomStreamWrapper:
                             completion_obj["role"] = "assistant"
                             self.sent_first_chunk = True
                         model_response.choices[0].delta = Delta(**completion_obj)
-                    print_verbose(f"model_response: {model_response}")
+                    print_verbose(f"returning model_response: {model_response}")
                     return model_response
                 else:
                     return


### PR DESCRIPTION
## Problem - LiteLLM Proxy - Sagemaker Streaming Calls Hang on Client Side 

This is caused because we use boto3 and it is not async, we pass the response to `async_data_generator` on the litellm proxy. The proxy expects a non blocking stream but since sagemaker responses are not truly async it blocks yielding any chunks


## Fix
- If the response is from sagemaker use a sync data_generator
- We were skipping some streaming chunks for sagemaker, this PR fixes that too 

## Long Term Fix 
- Move sagemaker, boto3 calls to be truly async 