### PR TITLE
[Feat] Make Proxy Auth Exceptions OpenAI compatible

### DIFF
--- a/litellm/tests/test_configs/custom_auth.py
+++ b/litellm/tests/test_configs/custom_auth.py
@@ -13,4 +13,4 @@ async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
             return UserAPIKeyAuth(api_key=api_key)
         raise Exception
     except:
-        raise Exception
+        raise Exception("Failed custom auth")

--- a/litellm/tests/test_key_generate_dynamodb.py
+++ b/litellm/tests/test_key_generate_dynamodb.py
@@ -109,8 +109,8 @@ def test_call_with_invalid_key(custom_db_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
-        assert "Authentication Error" in e.detail
+        print(e.message)
+        assert "Authentication Error" in e.message
         pass
 
 
@@ -143,7 +143,7 @@ def test_call_with_invalid_model(custom_db_client):
         asyncio.run(test())
     except Exception as e:
         assert (
-            e.detail
+            e.message
             == "Authentication Error, API Key not allowed to access model. This token can only access models=['mistral']. Tried to access gemini-pro-vision"
         )
         pass
@@ -248,7 +248,7 @@ def test_call_with_user_over_budget(custom_db_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededBudget:" in error_detail
         print(vars(e))
 
@@ -321,7 +321,7 @@ def test_call_with_user_over_budget_stream(custom_db_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededBudget:" in error_detail
         print(vars(e))
 
@@ -392,7 +392,7 @@ def test_call_with_user_key_budget(custom_db_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededTokenBudget:" in error_detail
         print(vars(e))
 
@@ -465,6 +465,6 @@ def test_call_with_key_over_budget_stream(custom_db_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededTokenBudget:" in error_detail
         print(vars(e))

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -136,8 +136,8 @@ def test_call_with_invalid_key(prisma_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
-        assert "Authentication Error" in e.detail
+        print(e.message)
+        assert "Authentication Error" in e.message
         pass
 
 
@@ -171,7 +171,7 @@ def test_call_with_invalid_model(prisma_client):
         asyncio.run(test())
     except Exception as e:
         assert (
-            e.detail
+            e.message
             == "Authentication Error, API Key not allowed to access model. This token can only access models=['mistral']. Tried to access gemini-pro-vision"
         )
         pass
@@ -274,7 +274,7 @@ def test_call_with_user_over_budget(prisma_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededBudget:" in error_detail
         print(vars(e))
 
@@ -350,7 +350,7 @@ def test_call_with_user_over_budget_stream(prisma_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededBudget:" in error_detail
         print(vars(e))
 
@@ -414,8 +414,8 @@ def test_generate_and_call_with_expired_key(prisma_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
-        assert "Authentication Error" in e.detail
+        print(e.message)
+        assert "Authentication Error" in e.message
         pass
 
 
@@ -486,8 +486,8 @@ def test_delete_key_auth(prisma_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
-        assert "Authentication Error" in e.detail
+        print(e.message)
+        assert "Authentication Error" in e.message
         pass
 
 
@@ -599,7 +599,7 @@ def test_generate_and_update_key(prisma_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
+        print(e.message)
         pytest.fail(f"An exception occurred - {str(e)}")
 
 
@@ -665,11 +665,11 @@ def test_key_generate_with_custom_auth(prisma_client):
             except Exception as e:
                 # this should fail
                 print("Got Exception", e)
-                print(e.detail)
+                print(e.message)
                 print("First request failed!. This is expected")
                 assert (
                     "This violates LiteLLM Proxy Rules. No team id provided."
-                    in e.detail
+                    in e.message
                 )
 
             request_2 = GenerateKeyRequest(
@@ -683,7 +683,7 @@ def test_key_generate_with_custom_auth(prisma_client):
         asyncio.run(test())
     except Exception as e:
         print("Got Exception", e)
-        print(e.detail)
+        print(e.message)
         pytest.fail(f"An exception occurred - {str(e)}")
 
 
@@ -752,7 +752,7 @@ def test_call_with_key_over_budget(prisma_client):
 
         asyncio.run(test())
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededTokenBudget:" in error_detail
         print(vars(e))
 
@@ -827,6 +827,6 @@ def test_call_with_key_over_budget_stream(prisma_client):
             pytest.fail(f"This should have failed!. They key crossed it's budget")
 
     except Exception as e:
-        error_detail = e.detail
+        error_detail = e.message
         assert "Authentication Error, ExceededTokenBudget:" in error_detail
         print(vars(e))

--- a/litellm/tests/test_proxy_custom_auth.py
+++ b/litellm/tests/test_proxy_custom_auth.py
@@ -58,9 +58,10 @@ def test_custom_auth(client):
 
         headers = {"Authorization": f"Bearer {token}"}
         response = client.post("/chat/completions", json=test_data, headers=headers)
-        print(f"response: {response.text}")
-        assert response.status_code == 401
-        result = response.json()
-        print(f"Received response: {result}")
+        pytest.fail("LiteLLM Proxy test failed. This request should have been rejected")
     except Exception as e:
-        pytest.fail("LiteLLM Proxy test failed. Exception", e)
+        print(vars(e))
+        print("got an exception")
+        assert e.code == 401
+        assert e.message == "Authentication Error, Failed custom auth"
+        pass


### PR DESCRIPTION
## Auth Errors Before PR -  using OpenAI JS/Python

```js
AuthenticationError: 401 status code (no body)
    at APIError.generate (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/error.js:47:20)
    at OpenAI.makeStatusError (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/core.js:255:33)
    at OpenAI.makeRequest (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/core.js:294:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async runOpenAI (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/test_openai_js.js:12:22) {
  status: 401,
  headers: {
    'content-length': '117',
    'content-type': 'application/json',
    date: 'Mon, 22 Jan 2024 21:21:14 GMT',
    server: 'uvicorn'
  },
  error: undefined,
  code: undefined,
  param: undefined,
  type: undefined
}

```

## Auth Errors  After PR - using OpenAI JS/Python

```js
AuthenticationError: 401 Authentication Error: invalid user key - token does not exist
    at APIError.generate (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/error.js:47:20)
    at OpenAI.makeStatusError (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/core.js:255:33)
    at OpenAI.makeRequest (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/node_modules/openai/core.js:294:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async runOpenAI (/Users/ishaanjaffer/Github/litellm/litellm/proxy/tests/test_openai_js.js:12:22) {
  status: 401,
  headers: {
    'content-length': '131',
    'content-type': 'application/json',
    date: 'Tue, 23 Jan 2024 00:26:52 GMT',
    server: 'uvicorn'
  },
  error: {
    message: 'Authentication Error: invalid user key - token does not exist',
    type: 'auth_error',
    param: 'None',
    code: 401
  },
  code: 401,
  param: 'None',
  type: 'auth_error'
```