### PR TITLE
[Feat] Proxy - Improve Slack Alerting 

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -8,7 +8,7 @@ handler.setLevel(logging.DEBUG)
 
 # Create a formatter and set it for the handler
 formatter = logging.Formatter(
-    "\033[92m%(asctime)s - %(name)s - %(levelname)s\033[0m: %(message)s",
+    "\033[92m%(asctime)s - %(name)s:%(levelname)s\033[0m: %(message)s",
     datefmt="%H:%M:%S",
 )
 

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -7,8 +7,11 @@ handler = logging.StreamHandler()
 handler.setLevel(logging.DEBUG)
 
 # Create a formatter and set it for the handler
+formatter = logging.Formatter(
+    "\033[92m%(asctime)s - %(name)s - %(levelname)s\033[0m: %(message)s",
+    datefmt="%H:%M:%S",
+)
 
-formatter = logging.Formatter("\033[92m%(name)s - %(levelname)s\033[0m: %(message)s")
 
 handler.setFormatter(formatter)
 

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -67,6 +67,8 @@ litellm_settings:
 
 general_settings: 
   master_key: sk-1234
+  alerting: ["slack"]
+  alerting_threshold: 10 # sends alerts if requests hang for 2 seconds
   # database_type: "dynamo_db" 
   # database_args: { # 👈  all args - https://github.com/BerriAI/litellm/blob/befbcbb7ac8f59835ce47415c128decf37aac328/litellm/proxy/_types.py#L190
   #   "billing_mode": "PAY_PER_REQUEST", 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1863,6 +1863,8 @@ async def chat_completion(
         else:  # router is not set
             response = await litellm.acompletion(**data)
 
+        # Post Call Processing
+        data["litellm_status"] = "success"  # used for alerting
         if hasattr(response, "_hidden_params"):
             model_id = response._hidden_params.get("model_id", None) or ""
         else:
@@ -2048,6 +2050,7 @@ async def embeddings(
             response = await litellm.aembedding(**data)
 
         ### ALERTING ###
+        data["litellm_status"] = "success"  # used for alerting
         end_time = time.time()
         asyncio.create_task(
             proxy_logging_obj.response_taking_too_long(
@@ -2163,6 +2166,7 @@ async def image_generation(
             response = await litellm.aimage_generation(**data)
 
         ### ALERTING ###
+        data["litellm_status"] = "success"  # used for alerting
         end_time = time.time()
         asyncio.create_task(
             proxy_logging_obj.response_taking_too_long(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -152,6 +152,7 @@ class ProxyLogging:
             request_info = f"\nRequest Model: {model}\nMessages: {messages}"
         else:
             request_info = ""
+
         if type == "hanging_request":
             # Simulate a long-running operation that could take more than 5 minutes
             await asyncio.sleep(
@@ -193,7 +194,13 @@ class ProxyLogging:
             level: str - Low|Medium|High - if calls might fail (Medium) or are failing (High); Currently, no alerts would be 'Low'.
             message: str - what is the alert about
         """
-        formatted_message = f"Level: {level}\n\nMessage: {message}"
+        from datetime import datetime
+
+        # Get the current timestamp
+        current_time = datetime.now().strftime("%H:%M:%S")
+        formatted_message = (
+            f"Level: {level}\nTimestamp: {current_time}\n\nMessage: {message}"
+        )
         if self.alerting is None:
             return
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -158,14 +158,17 @@ class ProxyLogging:
             await asyncio.sleep(
                 self.alerting_threshold
             )  # Set it to 5 minutes - i'd imagine this might be different for streaming, non-streaming, non-completion (embedding + img) requests
-
-            alerting_message = (
-                f"Requests are hanging - {self.alerting_threshold}s+ request time"
-            )
-            await self.alerting_handler(
-                message=alerting_message + request_info,
-                level="Medium",
-            )
+            if (
+                request_data is not None
+                and request_data.get("litellm_status", "") != "success"
+            ):
+                alerting_message = (
+                    f"Requests are hanging - {self.alerting_threshold}s+ request time"
+                )
+                await self.alerting_handler(
+                    message=alerting_message + request_info,
+                    level="Medium",
+                )
 
         elif (
             type == "slow_response" and start_time is not None and end_time is not None

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -162,6 +162,7 @@ class ProxyLogging:
                 request_data is not None
                 and request_data.get("litellm_status", "") != "success"
             ):
+                # only alert hanging responses if they have not been marked as success
                 alerting_message = (
                     f"Requests are hanging - {self.alerting_threshold}s+ request time"
                 )
@@ -173,9 +174,7 @@ class ProxyLogging:
         elif (
             type == "slow_response" and start_time is not None and end_time is not None
         ):
-            slow_message = (
-                f"Responses are slow - {round(end_time-start_time,2)}s response time"
-            )
+            slow_message = f"Responses are slow - {round(end_time-start_time,2)}s response time > Alerting threshold: {self.alerting_threshold}s"
             if end_time - start_time > self.alerting_threshold:
                 await self.alerting_handler(
                     message=slow_message + request_info,


### PR DESCRIPTION
## What's Changed ?
- Fixes for Proxy Alerting, only alert hanging requests when the request does not return 
- Show Request, Timestamp in Slack Alert logs 

<img width="607" alt="Screenshot 2024-01-24 at 4 42 15 PM" src="https://github.com/BerriAI/litellm/assets/29436595/8ed28725-b97b-4a10-842d-fe29a8b29dfd">

## Notes
Tried adding current traffic stats on proxy - this led to a signifcant slowdown since tracking the proxy state required FastAPI middleware 