### PR TITLE
[FIX] print verbose take only one argument

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1031,7 +1031,7 @@ async def send_email(sender_name, sender_email, receiver_email, subject, html):
             server.send_message(email_message)
 
     except Exception as e:
-        print_verbose("An error occurred while sending the email:", str(e))
+        print_verbose("An error occurred while sending the email:" + str(e))
 
 
 def hash_token(token: str):


### PR DESCRIPTION
Fix that will avoid silent error in sending email failed 