### PR TITLE
Allow optional usage of the tls encryption for SMTP

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1022,7 +1022,8 @@ async def send_email(sender_name, sender_email, receiver_email, subject, html):
         print_verbose(f"SMTP Connection Init")
         # Establish a secure connection with the SMTP server
         with smtplib.SMTP(smtp_host, smtp_port) as server:
-            server.starttls()
+            if os.getenv("SMTP_TLS", 'True') != "False":
+                server.starttls()
 
             # Login to your email account
             server.login(smtp_username, smtp_password)


### PR DESCRIPTION
For local dev, a local SMTP server like mailhog is useful and allow to manually manage user creation


if the SMTP_TLS env variable is 'False' , we bypass that step