### PR TITLE
Change quota project to the correct project being used for the call

### DIFF
--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -237,8 +237,10 @@ def completion(
             GenerationConfig,
         )
         from google.cloud.aiplatform_v1beta1.types import content as gapic_content_types
-
-        vertexai.init(project=vertex_project, location=vertex_location)
+        
+        ## Load credentials with the correct quota project ref: https://github.com/googleapis/python-aiplatform/issues/2557#issuecomment-1709284744
+        creds, _ = google.auth.default(quota_project_id=vertex_project)
+        vertexai.init(project=vertex_project, location=vertex_location, credentials=creds)
 
         ## Load Config
         config = litellm.VertexAIConfig.get_config()

--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -237,7 +237,8 @@ def completion(
             GenerationConfig,
         )
         from google.cloud.aiplatform_v1beta1.types import content as gapic_content_types
-        
+        import google.auth
+
         ## Load credentials with the correct quota project ref: https://github.com/googleapis/python-aiplatform/issues/2557#issuecomment-1709284744
         creds, _ = google.auth.default(quota_project_id=vertex_project)
         vertexai.init(project=vertex_project, location=vertex_location, credentials=creds)


### PR DESCRIPTION
if not set it will use the default project in the ADC to set that quota project which is usually different  https://github.com/googleapis/python-aiplatform/issues/2557#issuecomment-1709284744