### PR TITLE
[Fix] Graceful rejection of token input for AWS Embeddings API

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -702,7 +702,7 @@ def _embedding_func_single(
     encoding=None,
     logging_obj=None,
 ):
-    if type(input) != str:
+    if isinstance(input, str) is False:
         raise BedrockError(
             message="Bedrock Embedding API input must be type str | List[str]",
             status_code=400,
@@ -800,7 +800,8 @@ def embedding(
         aws_role_name=aws_role_name,
         aws_session_name=aws_session_name,
     )
-    if type(input) == str:
+    if isinstance(input, str):
+        ## Embedding Call
         embeddings = [
             _embedding_func_single(
                 model,
@@ -810,8 +811,8 @@ def embedding(
                 logging_obj=logging_obj,
             )
         ]
-    elif type(input) == list:
-        ## Embedding Call
+    elif isinstance(input, list):
+        ## Embedding Call - assuming this is a List[str]
         embeddings = [
             _embedding_func_single(
                 model,

--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -702,6 +702,11 @@ def _embedding_func_single(
     encoding=None,
     logging_obj=None,
 ):
+    if type(input) != str:
+        raise BedrockError(
+            message="Bedrock Embedding API input must be type str | List[str]",
+            status_code=400,
+        )
     # logic for parsing in - calling - parsing out model embedding calls
     ## FORMAT EMBEDDING INPUT ##
     provider = model.split(".")[0]
@@ -805,7 +810,7 @@ def embedding(
                 logging_obj=logging_obj,
             )
         ]
-    else:
+    elif type(input) == list:
         ## Embedding Call
         embeddings = [
             _embedding_func_single(
@@ -817,6 +822,12 @@ def embedding(
             )
             for i in input
         ]  # [TODO]: make these parallel calls
+    else:
+        # enters this branch if input = int, ex. input=2
+        raise BedrockError(
+            message="Bedrock Embedding API input must be type str | List[str]",
+            status_code=400,
+        )
 
     ## Populate OpenAI compliant dictionary
     embedding_response = []

--- a/litellm/tests/test_embedding.py
+++ b/litellm/tests/test_embedding.py
@@ -302,6 +302,25 @@ def test_bedrock_embedding_cohere():
 # test_bedrock_embedding_cohere()
 
 
+def test_demo_tokens_as_input_to_embeddings_fails_for_titan():
+    litellm.set_verbose = True
+
+    with pytest.raises(
+        litellm.BadRequestError,
+        match="BedrockException - Bedrock Embedding API input must be type str | List[str]",
+    ):
+        litellm.embedding(model="amazon.titan-embed-text-v1", input=[[1]])
+
+    with pytest.raises(
+        litellm.BadRequestError,
+        match="BedrockException - Bedrock Embedding API input must be type str | List[str]",
+    ):
+        litellm.embedding(
+            model="amazon.titan-embed-text-v1",
+            input=[1],
+        )
+
+
 # comment out hf tests - since hf endpoints are unstable
 def test_hf_embedding():
     try:


### PR DESCRIPTION
 Bedrock Embeddings API for accepts only str | List[str].