### PR TITLE
[Fix-UI] If user is already logged in using SSO, set allow_user_auth: True

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -78,7 +78,6 @@ litellm_settings:
   # callbacks: custom_callbacks.proxy_handler_instance # sets litellm.callbacks = [proxy_handler_instance]
 
 general_settings: 
-  allow_user_auth: True
   master_key: sk-1234
   alerting: ["slack"]
   alerting_threshold: 10 # sends alerts if requests hang for 2 seconds

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3171,6 +3171,9 @@ async def auth_callback(request: Request):
         + "&proxyBaseUrl="
         + os.getenv("PROXY_BASE_URL")
     )
+
+    # if a user has logged in they should be allowed to create keys - this ensures that it's set to True
+    general_settings["allow_user_auth"] = True
     return RedirectResponse(url=litellm_dashboard_ui)
 
 


### PR DESCRIPTION
If the user has already setup Google SSO, they are opting in to allow_user_auth=True. I don't see the need in requiring it to be True 