### PR TITLE
Make it possible to set safety_settings when using the Gemini provider

### DIFF
--- a/litellm/llms/gemini.py
+++ b/litellm/llms/gemini.py
@@ -121,7 +121,7 @@ def completion(
     ## Load Config
     inference_params = copy.deepcopy(optional_params)
     stream = inference_params.pop("stream", None)
-    safety_settings = optional_params.pop("safety_settings", None)
+    safety_settings = inference_params.pop("safety_settings", None)
     config = litellm.GeminiConfig.get_config()
     for k, v in config.items():
         if (

--- a/litellm/llms/gemini.py
+++ b/litellm/llms/gemini.py
@@ -163,7 +163,7 @@ def completion(
         input=prompt,
         api_key="",
         original_response=response,
-        additional_args={"complete_input_dict": {}},
+        additional_args={"complete_input_dict": {}, "safety_settings": safety_settings},
     )
     print_verbose(f"raw model_response: {response}")
     ## RESPONSE OBJECT

--- a/litellm/llms/gemini.py
+++ b/litellm/llms/gemini.py
@@ -121,6 +121,7 @@ def completion(
     ## Load Config
     inference_params = copy.deepcopy(optional_params)
     stream = inference_params.pop("stream", None)
+    safety_settings = optional_params.pop("safety_settings", None)
     config = litellm.GeminiConfig.get_config()
     for k, v in config.items():
         if (
@@ -141,11 +142,13 @@ def completion(
             response = _model.generate_content(
                 contents=prompt,
                 generation_config=genai.types.GenerationConfig(**inference_params),
+                safety_settings=safety_settings,
             )
         else:
             response = _model.generate_content(
                 contents=prompt,
                 generation_config=genai.types.GenerationConfig(**inference_params),
+                safety_settings=safety_settings,
                 stream=True,
             )
             return response

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -1911,6 +1911,42 @@ def test_completion_gemini():
 # test_completion_gemini()
 
 
+def test_completion_gemini_with_safety_settings():
+    litellm.set_verbose = True
+    model_name = "gemini/gemini-pro"
+    messages = [{"role": "user", "content": "Hey, how's it going?"}]
+
+    from google import generativeai
+    safety_settings = [
+        {
+            "category": generativeai.types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+            "threshold": generativeai.types.HarmBlockThreshold.BLOCK_NONE,
+        },
+        {
+            "category": generativeai.types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+            "threshold": generativeai.types.HarmBlockThreshold.BLOCK_NONE,
+        },
+        {
+            "category": generativeai.types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+            "threshold": generativeai.types.HarmBlockThreshold.BLOCK_NONE,
+        },
+        {
+            "category": generativeai.types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+            "threshold": generativeai.types.HarmBlockThreshold.BLOCK_NONE,
+        },
+    ]
+
+    try:
+        response = completion(model=model_name, messages=messages, safety_settings=safety_settings)
+        # Add any assertions here to check the response
+        print(response)
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
+# test_completion_gemini_with_safety_settings()
+
+
 # Palm tests
 def test_completion_palm():
     litellm.set_verbose = True


### PR DESCRIPTION
This is a more lightweight implementation than [the one recently submitted for the Vertex AI provider](https://github.com/BerriAI/litellm/pull/1190), and it is less dynamic than [the solution for the Palm provider](https://github.com/BerriAI/litellm/blob/d90e04b531692dcb8672909f526c234d0f828595/litellm/llms/palm.py#L119), but it does make it possible to easily specify safety_settings when using the Gemini provider.