### PR TITLE
[Fix] user_custom_auth fixes when user passed bad api_keys

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -252,12 +252,13 @@ async def user_api_key_auth(
 ) -> UserAPIKeyAuth:
     global master_key, prisma_client, llm_model_list, user_custom_auth, custom_db_client
     try:
-        if isinstance(api_key, str):
-            api_key = _get_bearer_token(api_key=api_key)
-        ### USER-DEFINED AUTH FUNCTION ###
+        ### USER-DEFINED AUTH FUNCTION -> This should always be run first if a user has defined it ###
         if user_custom_auth is not None:
             response = await user_custom_auth(request=request, api_key=api_key)
             return UserAPIKeyAuth.model_validate(response)
+
+        if isinstance(api_key, str):
+            api_key = _get_bearer_token(api_key=api_key)
         ### LITELLM-DEFINED AUTH FUNCTION ###
         if master_key is None:
             if isinstance(api_key, str):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -234,8 +234,10 @@ def usage_telemetry(
 
 
 def _get_bearer_token(api_key: str):
-    assert api_key.startswith("Bearer ")  # ensure Bearer token passed in
-    api_key = api_key.replace("Bearer ", "")  # extract the token
+    if api_key.startswith("Bearer "):  # ensure Bearer token passed in
+        api_key = api_key.replace("Bearer ", "")  # extract the token
+    else:
+        api_key = ""
     return api_key
 
 
@@ -252,13 +254,21 @@ async def user_api_key_auth(
 ) -> UserAPIKeyAuth:
     global master_key, prisma_client, llm_model_list, user_custom_auth, custom_db_client
     try:
+        if isinstance(api_key, str):
+            passed_in_key = api_key
+            api_key = _get_bearer_token(api_key=api_key)
+
         ### USER-DEFINED AUTH FUNCTION -> This should always be run first if a user has defined it ###
         if user_custom_auth is not None:
             response = await user_custom_auth(request=request, api_key=api_key)
             return UserAPIKeyAuth.model_validate(response)
 
-        if isinstance(api_key, str):
-            api_key = _get_bearer_token(api_key=api_key)
+        if api_key == "":
+            # missing 'Bearer ' prefix
+            raise Exception(
+                f"Malformed API Key passed in. Ensure Key has `Bearer ` prefix. Passed in: {passed_in_key}"
+            )
+
         ### LITELLM-DEFINED AUTH FUNCTION ###
         if master_key is None:
             if isinstance(api_key, str):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2,7 +2,7 @@ import sys, os, platform, time, copy, re, asyncio, inspect
 import threading, ast
 import shutil, random, traceback, requests
 from datetime import datetime, timedelta, timezone
-from typing import Optional, List, Literal
+from typing import Optional, List
 import secrets, subprocess
 import hashlib, uuid
 import warnings

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -280,7 +280,7 @@ async def user_api_key_auth(
                 return UserAPIKeyAuth()
 
         if api_key is None:
-            raise Exception("No API Key passed in")
+            raise Exception("No API Key passed in. api_key is None")
         if secrets.compare_digest(api_key, MISSING_BEARER):
             # missing 'Bearer ' prefix
             raise Exception(
@@ -288,7 +288,7 @@ async def user_api_key_auth(
             )
         elif secrets.compare_digest(api_key, NO_API_KEY):
             # no api key passed in
-            raise Exception("No API Key passed in. Passed in: {passed_in_key}")
+            raise Exception(f"No API Key passed in. Passed in: {passed_in_key}")
 
         route: str = request.url.path
         if route == "/user/auth":

--- a/litellm/tests/test_configs/custom_auth.py
+++ b/litellm/tests/test_configs/custom_auth.py
@@ -8,10 +8,8 @@ load_dotenv()
 
 async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
     try:
-        from litellm.proxy.proxy_server import MISSING_BEARER
-
         print(f"api_key: {api_key}")
-        if api_key == MISSING_BEARER:
+        if api_key == "":
             raise Exception(
                 f"CustomAuth - Malformed API Key passed in. Ensure Key has `Bearer` prefix"
             )

--- a/litellm/tests/test_configs/custom_auth.py
+++ b/litellm/tests/test_configs/custom_auth.py
@@ -9,8 +9,14 @@ load_dotenv()
 async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
     try:
         print(f"api_key: {api_key}")
+        if api_key == "":
+            raise Exception(
+                f"CustomAuth - Malformed API Key passed in. Ensure Key has `Bearer` prefix"
+            )
         if api_key == f"{os.getenv('PROXY_MASTER_KEY')}-1234":
             return UserAPIKeyAuth(api_key=api_key)
         raise Exception
-    except:
+    except Exception as e:
+        if len(str(e)) > 0:
+            raise e
         raise Exception("Failed custom auth")

--- a/litellm/tests/test_configs/custom_auth.py
+++ b/litellm/tests/test_configs/custom_auth.py
@@ -8,8 +8,10 @@ load_dotenv()
 
 async def user_api_key_auth(request: Request, api_key: str) -> UserAPIKeyAuth:
     try:
+        from litellm.proxy.proxy_server import MISSING_BEARER
+
         print(f"api_key: {api_key}")
-        if api_key == "":
+        if api_key == MISSING_BEARER:
             raise Exception(
                 f"CustomAuth - Malformed API Key passed in. Ensure Key has `Bearer` prefix"
             )

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -1254,7 +1254,10 @@ async def test_user_api_key_auth(prisma_client):
         pytest.fail(f"This should have failed!. IT's an invalid key")
     except ProxyException as exc:
         print(exc.message)
-        assert exc.message == "Authentication Error, No API Key passed in. Passed in: "
+        assert (
+            exc.message
+            == "Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix. Passed in: "
+        )
 
 
 @pytest.mark.asyncio

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -1216,6 +1216,40 @@ async def test_default_key_params(prisma_client):
         pytest.fail(f"Got exception {e}")
 
 
+def test_get_bearer_token():
+    from litellm.proxy.proxy_server import _get_bearer_token
+
+    # Test valid Bearer token
+    api_key = "Bearer valid_token"
+    result = _get_bearer_token(api_key)
+    assert result == "valid_token", f"Expected 'valid_token', got '{result}'"
+
+    # Test empty API key
+    api_key = ""
+    result = _get_bearer_token(api_key)
+    assert result == "", f"Expected '', got '{result}'"
+
+    # Test API key without Bearer prefix
+    api_key = "invalid_token"
+    result = _get_bearer_token(api_key)
+    assert result == "", f"Expected '', got '{result}'"
+
+    # Test API key with Bearer prefix in lowercase
+    api_key = "bearer valid_token"
+    result = _get_bearer_token(api_key)
+    assert result == "", f"Expected '', got '{result}'"
+
+    # Test API key with Bearer prefix and extra spaces
+    api_key = "  Bearer   valid_token  "
+    result = _get_bearer_token(api_key)
+    assert result == "", f"Expected '', got '{result}'"
+
+    # Test API key with Bearer prefix and no token
+    api_key = "Bearer sk-1234"
+    result = _get_bearer_token(api_key)
+    assert result == "sk-1234", f"Expected 'valid_token', got '{result}'"
+
+
 @pytest.mark.asyncio
 async def test_user_api_key_auth(prisma_client):
     from litellm.proxy.proxy_server import ProxyException

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -1154,13 +1154,15 @@ async def test_key_name_null(prisma_client):
     """
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    setattr(litellm.proxy.proxy_server, "general_settings", {"allow_user_auth": False})
     await litellm.proxy.proxy_server.prisma_client.connect()
     try:
         request = GenerateKeyRequest()
         key = await generate_key_fn(request)
+        print("test_key_name_null key=", key)
         generated_key = key.key
         result = await info_key_fn(key=generated_key)
-        print("result from info_key_fn", result)
+        print("rtest_key_name_null esult from info_key_fn", result)
         assert result["info"]["key_name"] is None
     except Exception as e:
         print("Got Exception", e)

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -1159,10 +1159,9 @@ async def test_key_name_null(prisma_client):
     try:
         request = GenerateKeyRequest()
         key = await generate_key_fn(request)
-        print("test_key_name_null key=", key)
         generated_key = key.key
         result = await info_key_fn(key=generated_key)
-        print("rtest_key_name_null esult from info_key_fn", result)
+        print("result from info_key_fn", result)
         assert result["info"]["key_name"] is None
     except Exception as e:
         print("Got Exception", e)

--- a/litellm/tests/test_proxy_custom_auth.py
+++ b/litellm/tests/test_proxy_custom_auth.py
@@ -65,3 +65,30 @@ def test_custom_auth(client):
         assert e.code == 401
         assert e.message == "Authentication Error, Failed custom auth"
         pass
+
+
+def test_custom_auth_bearer(client):
+    try:
+        # Your test data
+        test_data = {
+            "model": "openai-model",
+            "messages": [
+                {"role": "user", "content": "hi"},
+            ],
+            "max_tokens": 10,
+        }
+        # Your bearer token
+        token = os.getenv("PROXY_MASTER_KEY")
+
+        headers = {"Authorization": f"WITHOUT BEAR Er  {token}"}
+        response = client.post("/chat/completions", json=test_data, headers=headers)
+        pytest.fail("LiteLLM Proxy test failed. This request should have been rejected")
+    except Exception as e:
+        print(vars(e))
+        print("got an exception")
+        assert e.code == 401
+        assert (
+            e.message
+            == "Authentication Error, CustomAuth - Malformed API Key passed in. Ensure Key has `Bearer` prefix"
+        )
+        pass


### PR DESCRIPTION
## Goal 

If a user uses `custom_auth` they want to control the exception a user sees on passing a malformed header/api_key 