### PR TITLE
Re-raise exception in async ollama streaming

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -267,6 +267,7 @@ async def ollama_async_streaming(url, data, model_response, encoding, logging_ob
                 yield transformed_chunk
     except Exception as e:
         traceback.print_exc()
+        raise e
 
 
 async def ollama_acompletion(url, data, model_response, encoding, logging_obj):


### PR DESCRIPTION
It was getting swallowed and an empty 200 response was given to clients.  This propagates the error if Ollama can't load a model.