### PR TITLE
Update model_prices_and_context_window.json - added gpt-3.5-turbo-0125

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -125,6 +125,15 @@
         "litellm_provider": "openai",
         "mode": "chat"
     },
+    "gpt-3.5-turbo-0125": {
+        "max_tokens": 16385,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000015,
+        "litellm_provider": "openai",
+        "mode": "chat"
+    },
     "gpt-3.5-turbo-16k": {
         "max_tokens": 16385,
         "max_input_tokens": 16385,


### PR DESCRIPTION
Accordingly to recent OpenAI Update:

<img width="647" alt="image" src="https://github.com/BerriAI/litellm/assets/4569866/a124b3e6-0b56-48c1-a57a-94edac2397de">
(https://openai.com/blog/new-embedding-models-and-api-updates)

This PR fixes an error otherwise appearing when I attempted to add this model in config:

```
  - model_name: gpt-3.5-turbo-0125
    litellm_params:
      model: gpt-3.5-turbo-0125
```

```
litellm.exceptions.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-3.5-turbo-0125
```