### PR TITLE
s3 logger - Improve filename to allow easier sorting

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -130,11 +130,21 @@ class S3Logger:
 
             s3_object_key = (
                 (self.s3_path.rstrip("/") + "/" if self.s3_path else "")
+                + start_time.strftime('%Y-%m-%d') + "/"
+                + "time-"
+                + start_time.strftime('%H-%M-%S-%f')
+                + "_"
                 + payload["id"]
-                + "-time="
-                + str(start_time)
             )  # we need the s3 key to include the time, so we log cache hits too
             s3_object_key += ".json"
+
+            s3_object_download_filename = (
+                "time-"
+                + start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')
+                + "_"
+                + payload["id"]
+                + ".json"
+            )
 
             import json
 
@@ -148,7 +158,8 @@ class S3Logger:
                 Body=payload,
                 ContentType="application/json",
                 ContentLanguage="en",
-                ContentDisposition=f'inline; filename="{key}.json"',
+                ContentDisposition=f'inline; filename="{s3_object_download_filename}"',
+                CacheControl="private, immutable, max-age=31536000, s-maxage=0",
             )
 
             print_verbose(f"Response from s3:{str(response)}")


### PR DESCRIPTION
This puts each day into its own separate folder.

The reason we do a different filename, is so that the user will automatically get the time added to the filename when downloading the logs via an S3 presigned URL.

Logs now look like this:

```
dave@mbp ~ % rclone ls litellm-logging:litellm-logging/
     3144 2024-02-02/time-16-36-30-088793_chatcmpl-5e010e30-de74-4e79-9516-f9d668272485.json
```

And when you go to download the file, the filename is `time-2024-02-02T16-36-30-088793_chatcmpl-5e010e30-de74-4e79-9516-f9d668272485.json`. Putting the date/time first is important so it's easier to sort. =) 