### PR TITLE
(feat) langfuse set generation_id to chatcmpl-response ID

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -207,6 +207,7 @@ class LangFuseLogger:
         if generation_name is None:
             # just log `litellm-{call_type}` as the generation name
             generation_name = f"litellm-{kwargs.get('call_type', 'completion')}"
+        response_id = response_obj.get("id", None)
         trace_params = {
             "name": generation_name,
             "input": input,
@@ -226,7 +227,7 @@ class LangFuseLogger:
         trace = self.Langfuse.trace(**trace_params)
         trace.generation(
             name=generation_name,
-            id=metadata.get("generation_id", None),
+            id=metadata.get("generation_id", response_id),
             startTime=start_time,
             endTime=end_time,
             model=kwargs["model"],


### PR DESCRIPTION
By default litellm will set the generation ID to be the response ID from the LLM API Call. this should allow better lookup 

![image](https://github.com/BerriAI/litellm/assets/29436595/b7b2b557-9563-4058-aba4-e9ea024929f2)
