### PR TITLE
(feat) Add sessionId for Langfuse.

### DIFF
--- a/docs/my-website/docs/observability/langfuse_integration.md
+++ b/docs/my-website/docs/observability/langfuse_integration.md
@@ -122,6 +122,7 @@ response = completion(
       "generation_id": "gen-id22",                  # set langfuse Generation ID 
       "trace_id": "trace-id22",                     # set langfuse Trace ID
       "trace_user_id": "user-id2",                  # set langfuse Trace User ID
+      "session_id": "session-1",                    # set langfuse Session ID
   },
 )
 

--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -214,6 +214,7 @@ class LangFuseLogger:
             "output": output,
             "user_id": metadata.get("trace_user_id", user_id),
             "id": metadata.get("trace_id", None),
+            "session_id": metadata.get("session_id", None),
         }
         cost = kwargs["response_cost"]
         print_verbose(f"trace: {cost}")


### PR DESCRIPTION
Usage:

```typescript
// @ts-expect-error needed
const response_json = await openai.chat.completions.create({
	model: "gpt-3.5-turbo-1106",
	messages: [
		{
			role: 'user',
			content: 'Tell me a joke now!'
		}
	],
	stream: false,
	temperature: 0.0,
	metadata: {
		generation_name: "i_am_a_pickle",
		session_id: "epic_session1"
	}
});
```