### PR TITLE
[FEAT] show langfuse logging / cache tags better through proxy

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -252,8 +252,14 @@ class LangFuseLogger:
             print_verbose(f"trace: {cost}")
             if supports_tags:
                 for key, value in metadata.items():
-                    tags.append(f"{key}:{value}")
+                    if key in [
+                        "user_api_key",
+                        "user_api_key_user_id",
+                    ]:
+                        tags.append(f"{key}:{value}")
                 if "cache_hit" in kwargs:
+                    if kwargs["cache_hit"] is None:
+                        kwargs["cache_hit"] = False
                     tags.append(f"cache_hit:{kwargs['cache_hit']}")
                 trace_params.update({"tags": tags})
 


### PR DESCRIPTION
## Show users cache_hit on langfuse logging 
(we used to have all metadata get put as a langfuse tag, now we only show user requested langfuse tags) 
(this is a hashed api_key, that is already deleted 🤠)
<img width="925" alt="Screenshot 2024-02-06 at 1 14 05 PM" src="https://github.com/BerriAI/litellm/assets/29436595/885d5e23-0787-4466-8eb3-0f89c1dbe7eb">
