### PR TITLE
[Feat] Semantic Caching - Track Cost of using embedding, Use Langfuse Trace ID

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -427,10 +427,16 @@ class RedisSemanticCache(BaseCache):
             else []
         )
         if llm_router is not None and self.embedding_model in router_model_names:
+            user_api_key = kwargs.get("metadata", {}).get("user_api_key", "")
             embedding_response = await llm_router.aembedding(
                 model=self.embedding_model,
                 input=prompt,
                 cache={"no-store": True, "no-cache": True},
+                metadata={
+                    "user_api_key": user_api_key,
+                    "semantic-cache-embedding": True,
+                    "trace_id": kwargs.get("metadata", {}).get("trace_id", None),
+                },
             )
         else:
             # convert to embedding
@@ -476,13 +482,20 @@ class RedisSemanticCache(BaseCache):
             else []
         )
         if llm_router is not None and self.embedding_model in router_model_names:
+            user_api_key = kwargs.get("metadata", {}).get("user_api_key", "")
             embedding_response = await llm_router.aembedding(
                 model=self.embedding_model,
                 input=prompt,
                 cache={"no-store": True, "no-cache": True},
+                metadata={
+                    "user_api_key": user_api_key,
+                    "semantic-cache-embedding": True,
+                    "trace_id": kwargs.get("metadata", {}).get("trace_id", None),
+                },
             )
         else:
             # convert to embedding
+            user_api_key = kwargs["litellm_params"]["metadata"].get("user_api_key", "")
             embedding_response = await litellm.aembedding(
                 model=self.embedding_model,
                 input=prompt,

--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -495,7 +495,6 @@ class RedisSemanticCache(BaseCache):
             )
         else:
             # convert to embedding
-            user_api_key = kwargs["litellm_params"]["metadata"].get("user_api_key", "")
             embedding_response = await litellm.aembedding(
                 model=self.embedding_model,
                 input=prompt,


### PR DESCRIPTION
- If a `trace_id` is passed we'll place the semantic cache embedding call in the same trace 
- We now track cost for the API key that will make the embedding call for semantic caching 

<img width="1002" alt="Screenshot 2024-02-07 at 7 18 57 PM" src="https://github.com/BerriAI/litellm/assets/29436595/203e2d12-9d1e-4411-a1dd-4219de83a2b7">
