### PR TITLE
[FIX] Verbose Logger - don't double print CURL command 

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -29,6 +29,7 @@ model_list:
   - model_name: BEDROCK_GROUP
     litellm_params:
       model: bedrock/cohere.command-text-v14
+      timeout: 0.0001
   - model_name: tg-ai
     litellm_params:
       model: together_ai/mistralai/Mistral-7B-Instruct-v0.1

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -866,7 +866,11 @@ class Logging:
                 curl_command += additional_args.get("request_str", None)
             elif api_base == "":
                 curl_command = self.model_call_details
-            print_verbose(f"\033[92m{curl_command}\033[0m\n")
+
+            # only print verbose if verbose logger is not set
+            if verbose_logger.level == 0:
+                # this means verbose logger was not switched on - user is in litellm.set_verbose=True
+                print_verbose(f"\033[92m{curl_command}\033[0m\n")
             verbose_logger.info(f"\033[92m{curl_command}\033[0m\n")
             if self.logger_fn and callable(self.logger_fn):
                 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.23.5"
+version = "1.23.6"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -69,7 +69,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.23.5"
+version = "1.23.6"
 version_files = [
     "pyproject.toml:^version"
 ]


### PR DESCRIPTION
Fix - our debug logs would print the CURL command sent to the LLM twice, this fixes it 