### PR TITLE
[FIX] Verbose Logger - don't double print CURL command 

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -866,7 +866,11 @@ class Logging:
                 curl_command += additional_args.get("request_str", None)
             elif api_base == "":
                 curl_command = self.model_call_details
-            print_verbose(f"\033[92m{curl_command}\033[0m\n")
+
+            # only print verbose if verbose logger is not set
+            if verbose_logger.level == 0:
+                # this means verbose logger was not switched on - user is in litellm.set_verbose=True
+                print_verbose(f"\033[92m{curl_command}\033[0m\n")
             verbose_logger.info(f"\033[92m{curl_command}\033[0m\n")
             if self.logger_fn and callable(self.logger_fn):
                 try:


### PR DESCRIPTION
Fix - our debug logs would print the CURL command sent to the LLM twice, this fixes it 