### PR TITLE
fix(lowest_latency.py): fix latency calc (lower better)

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -86,7 +86,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 if isinstance(response_obj, ModelResponse):
                     completion_tokens = response_obj.usage.completion_tokens
                     total_tokens = response_obj.usage.total_tokens
-                    final_value = float(completion_tokens / response_ms.total_seconds())
+                    final_value = float(response_ms.total_seconds() / completion_tokens)
 
                 # ------------
                 # Update usage


### PR DESCRIPTION
Ensures the model with the least seconds per token is prioritized in `latency-based-routing`
For example, comparing GPT4 to GPT3.5, GPT3.5 is prioritized with this change

Code to test:
```python
import os
import time

import litellm

litellm.openai_key = os.getenv("OPENAI_API_KEY")

messages = [
    {"role": "user", "content": "Recipe for a chocolate cake"},
]

model_list = [
    {
        "model_name": "OpenAI",
        "litellm_params": {
            "model": "gpt-3.5-turbo-0125",
            "api_key": litellm.openai_key
        },
        "model_info": {"id": 1}
    },
    {
        "model_name": "OpenAI",
        "litellm_params": {
            "model": "gpt-4-turbo-preview",
            "api_key": litellm.openai_key
        },
        "model_info": {"id": 2}
    }
]

router = litellm.Router(model_list=model_list, routing_strategy="latency-based-routing")

# Make 5 calls to the LLMs
for i in range(5):
    start_time = time.time()
    response = router.completion(
        model="OpenAI",
        messages=messages,
        temperature=0,
        max_tokens=200,
    )
    end_time = time.time()
    time_taken = end_time - start_time

    cache = router.cache.get_cache("OpenAI_map")
    latency = cache.get(response._hidden_params["model_id"]).get("latency")[-1]

    print(f"{i+1}. Model used: {response.model}. Latency: {latency:.4f}. Time taken: {time_taken:.4f}s")
```

Response
Old: GPT-4 is prioritised despite taking longer than GPT3.5. The "latency" here is actually speed in tokens/s so higher better.
```
1. Model used: gpt-3.5-turbo-0125. Latency: 75.9874. Time taken: 2.6329s
2. Model used: gpt-4-0125-preview. Latency: 17.7273. Time taken: 11.2831s
3. Model used: gpt-4-0125-preview. Latency: 35.6689. Time taken: 5.6084s
4. Model used: gpt-4-0125-preview. Latency: 27.8093. Time taken: 7.1928s
5. Model used: gpt-4-0125-preview. Latency: 32.1780. Time taken: 6.2159s
```

New: GPT3.5 is correctly prioritised. The "latency" here is actual seconds per token time so lower better as expected by rest of the code
```
1. Model used: gpt-3.5-turbo-0125. Latency: 0.0112. Time taken: 2.2393s
2. Model used: gpt-4-0125-preview. Latency: 0.0368. Time taken: 7.3671s
3. Model used: gpt-3.5-turbo-0125. Latency: 0.0118. Time taken: 2.3568s
4. Model used: gpt-3.5-turbo-0125. Latency: 0.0138. Time taken: 2.7592s
5. Model used: gpt-3.5-turbo-0125. Latency: 0.0132. Time taken: 2.6452s
```