### PR TITLE
Update utils.py: switched from pkg_resources to importlib.resources for `filename` stored in the `os.environ(TIKTOKEN_CACHE_DIR)`

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -29,9 +29,11 @@ from dataclasses import (
     dataclass,
     field,
 )  # for storing API inputs, outputs, and metadata
-import pkg_resources
+#import pkg_resources
+from importlib import resources
 
-filename = pkg_resources.resource_filename(__name__, "llms/tokenizers")
+# filename = pkg_resources.resource_filename(__name__, "llms/tokenizers")
+filename = str(resources.files().joinpath("llms/tokenizers"))
 os.environ[
     "TIKTOKEN_CACHE_DIR"
 ] = filename  # use local copy of tiktoken b/c of - https://github.com/BerriAI/litellm/issues/1071


### PR DESCRIPTION
This fixes the problem with removed pkg_resources described in this comment: https://github.com/BerriAI/litellm/issues/118#issuecomment-1918102041

Example of an error without the fix:
```
Traceback (most recent call last):
  File "/Users/sorokine/.local/bin/sgpt", line 5, in <module>
    from sgpt import cli
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/sgpt/__init__.py", line 1, in <module>
    from .app import main as main
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/sgpt/app.py", line 13, in <module>
    from sgpt.handlers.chat_handler import ChatHandler
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/sgpt/handlers/chat_handler.py", line 11, in <module>
    from .handler import Handler
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/sgpt/handlers/handler.py", line 5, in <module>
    import litellm  # type: ignore
    ^^^^^^^^^^^^^^
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/litellm/__init__.py", line 520, in <module>
    from .utils import (
  File "/Users/sorokine/.local/pipx/venvs/shell-gpt/lib/python3.12/site-packages/litellm/utils.py", line 32, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```