### PR TITLE
[FIX] s3 cache proxy - fix notImplemented error

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -675,6 +675,9 @@ class S3Cache(BaseCache):
     def flush_cache(self):
         pass
 
+    async def disconnect(self):
+        pass
+
 
 class DualCache(BaseCache):
     """


### PR DESCRIPTION
there's no concept of disconnecting from an S3 cache, don't flood user logs 