### PR TITLE
[FEAT] Support Generic SSO provider on Admin UI

### DIFF
--- a/docs/my-website/docs/proxy/ui.md
+++ b/docs/my-website/docs/proxy/ui.md
@@ -37,12 +37,12 @@ http://0.0.0.0:8000/ui # <proxy_base_url>/ui
 ```
 
 
-## Get Admin UI Link on Swagger 
+### 3. Get Admin UI Link on Swagger 
 Your Proxy Swagger is available on the root of the Proxy: e.g.: `http://localhost:4000/`
 
 <Image img={require('../../img/ui_link.png')} />
 
-## Change default username + password
+### 4. Change default username + password
 
 Set the following in your .env on the Proxy
 
@@ -104,6 +104,29 @@ MICROSOFT_CLIENT_SECRET="nbk8Q~"
 MICROSOFT_TENANT="5a39737
 ```
 - Set Redirect URI on your App Registration on https://portal.azure.com/
+    - Set a redirect url = `<your proxy base url>/sso/callback`
+    ```shell
+    http://localhost:4000/sso/callback
+    ```
+
+</TabItem>
+
+
+<TabItem value="Generic" label="Generic SSO Provider">
+
+A generic OAuth client that can be used to quickly create support for any OAuth provider with close to no code
+
+**Required .env variables on your Proxy**
+```shell
+
+GENERIC_CLIENT_ID = "******"
+GENERIC_CLIENT_SECRET = "G*******"
+GENERIC_AUTHORIZATION_ENDPOINT = "http://localhost:9090/auth"
+GENERIC_TOKEN_ENDPOINT = "http://localhost:9090/token"
+GENERIC_USERINFO_ENDPOINT = "http://localhost:9090/me"
+```
+
+- Set Redirect URI, if your provider requires it
     - Set a redirect url = `<your proxy base url>/sso/callback`
     ```shell
     http://localhost:4000/sso/callback

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3831,6 +3831,14 @@ async def google_login(request: Request):
                 code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+        verbose_proxy_logger.debug(
+            f"authorization_endpoint: {generic_authorization_endpoint}\ntoken_endpoint: {generic_token_endpoint}\nuserinfo_endpoint: {generic_userinfo_endpoint}"
+        )
+
+        verbose_proxy_logger.debug(
+            f"GENERIC_REDIRECT_URI: {redirect_url}\nGENERIC_CLIENT_ID: {generic_client_id}\n"
+        )
+
         discovery = DiscoveryDocument(
             authorization_endpoint=generic_authorization_endpoint,
             token_endpoint=generic_token_endpoint,


### PR DESCRIPTION
## Use Generic SSO Providers Admin UI 

## Usage 
set the following vars in your env
```shell

GENERIC_CLIENT_ID = "2***
GENERIC_CLIENT_SECRET = "****
GENERIC_AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/auth"
GENERIC_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
GENERIC_USERINFO_ENDPOINT = "https://openidconnect.googleapis.com/v1/userinfo"
```