### PR TITLE
[FEAT] Track spend per team 

### DIFF
--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -55,6 +55,7 @@ model LiteLLM_VerificationToken {
     config     Json  @default("{}")
     user_id    String?
     team_id    String?
+    permissions Json @default("{}")
     max_parallel_requests Int?
     metadata   Json  @default("{}")
     tpm_limit     BigInt?

--- a/schema.prisma
+++ b/schema.prisma
@@ -55,6 +55,7 @@ model LiteLLM_VerificationToken {
     config     Json  @default("{}")
     user_id    String?
     team_id    String?
+    permissions Json @default("{}")
     max_parallel_requests Int?
     metadata   Json  @default("{}")
     tpm_limit     BigInt?


### PR DESCRIPTION
## How to use 

### Create key with a team_id 
```shell
curl --location 'http://localhost:4000/key/generate' \
-H 'Authorization: Bearer sk-1234' \
-H 'Content-Type: application/json' \
-d '{"models": ["private"], "team_id": "data-science"}'
```

### 🤠 Enjoy 
Spend gets tracked in LiteLLM Team Table 

<img width="471" alt="Screenshot 2024-02-15 at 9 45 10 PM" src="https://github.com/BerriAI/litellm/assets/29436595/b003975a-5a16-4ee4-9ac2-8dfe5fa95021">