### PR TITLE
chore: update NLP Cloud model pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -965,15 +965,15 @@
     },
     "dolphin": {
         "max_tokens": 4096,
-        "input_cost_per_token": 0.00002,
-        "output_cost_per_token": 0.00002,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000005,
         "litellm_provider": "nlp_cloud",
         "mode": "completion"
     },
     "chatdolphin": {
         "max_tokens": 4096,
-        "input_cost_per_token": 0.00002,
-        "output_cost_per_token": 0.00002,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000005,
         "litellm_provider": "nlp_cloud",
         "mode": "chat"
     },


### PR DESCRIPTION
The price for NLP cloud inference decreased dramatically from $0.02/1k tokens to $0.0005/1k tokens.

- Updated the `model_prices_and_context_window.json` file.