### PR TITLE
✨ Allow to configure scopes in generic SSO

### DIFF
--- a/docs/my-website/docs/proxy/ui.md
+++ b/docs/my-website/docs/proxy/ui.md
@@ -124,6 +124,7 @@ GENERIC_CLIENT_SECRET = "G*******"
 GENERIC_AUTHORIZATION_ENDPOINT = "http://localhost:9090/auth"
 GENERIC_TOKEN_ENDPOINT = "http://localhost:9090/token"
 GENERIC_USERINFO_ENDPOINT = "http://localhost:9090/me"
+GENERIC_SCOPE = "openid profile email"
 ```
 
 - Set Redirect URI, if your provider requires it

--- a/docs/my-website/docs/proxy/ui.md
+++ b/docs/my-website/docs/proxy/ui.md
@@ -124,6 +124,10 @@ GENERIC_CLIENT_SECRET = "G*******"
 GENERIC_AUTHORIZATION_ENDPOINT = "http://localhost:9090/auth"
 GENERIC_TOKEN_ENDPOINT = "http://localhost:9090/token"
 GENERIC_USERINFO_ENDPOINT = "http://localhost:9090/me"
+```
+
+**Additional .env variables on your Proxy**
+```shell
 GENERIC_SCOPE = "openid profile email"
 ```
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4490,6 +4490,7 @@ async def google_login(request: Request):
         from fastapi_sso.sso.generic import create_provider, DiscoveryDocument
 
         generic_client_secret = os.getenv("GENERIC_CLIENT_SECRET", None)
+        generic_scope = os.getenv("GENERIC_SCOPE", "openid email profile").split(" ")
         generic_authorization_endpoint = os.getenv(
             "GENERIC_AUTHORIZATION_ENDPOINT", None
         )
@@ -4540,6 +4541,7 @@ async def google_login(request: Request):
             client_secret=generic_client_secret,
             redirect_uri=redirect_url,
             allow_insecure_http=True,
+            scope=generic_scope,
         )
         with generic_sso:
             return await generic_sso.get_login_redirect()
@@ -4690,6 +4692,7 @@ async def auth_callback(request: Request):
         from fastapi_sso.sso.generic import create_provider, DiscoveryDocument
 
         generic_client_secret = os.getenv("GENERIC_CLIENT_SECRET", None)
+        generic_scope = os.getenv("GENERIC_SCOPE", "openid email profile").split(" ")
         generic_authorization_endpoint = os.getenv(
             "GENERIC_AUTHORIZATION_ENDPOINT", None
         )
@@ -4740,6 +4743,7 @@ async def auth_callback(request: Request):
             client_secret=generic_client_secret,
             redirect_uri=redirect_url,
             allow_insecure_http=True,
+            scope=generic_scope,
         )
         verbose_proxy_logger.debug(f"calling generic_sso.verify_and_process")
         request_body = await request.body()


### PR DESCRIPTION
In Generic SSO, default scope `openid` is sometimes not enough to retrieve basic user info like `first_name` and `last_name` located in `profile` scope. Also, user can configure specific scopes to return those attributes.

This PR : 
- Allow to configure SSO Scopes with `GENERIC_SCOPE` env vars
- Define the defaults scope to `openid profile email` (most common scopes)