### PR TITLE
[FEAT] Generic SSO - allow user to specify attribute names 

### DIFF
--- a/docs/my-website/docs/proxy/ui.md
+++ b/docs/my-website/docs/proxy/ui.md
@@ -126,6 +126,15 @@ GENERIC_TOKEN_ENDPOINT = "http://localhost:9090/token"
 GENERIC_USERINFO_ENDPOINT = "http://localhost:9090/me"
 ```
 
+**Optional .env variables**
+The following can be used to customize attribute names when interacting with the generic OAuth provider. We will read these attributes from the SSO Provider result
+
+```shell
+GENERIC_USER_ID_ATTRIBUTE = "given_name"
+GENERIC_USER_EMAIL_ATTRIBUTE = "family_name"
+GENERIC_USER_ROLE_ATTRIBUTE = "given_role"
+```
+
 - Set Redirect URI, if your provider requires it
     - Set a redirect url = `<your proxy base url>/sso/callback`
     ```shell

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4826,6 +4826,25 @@ async def auth_callback(request: Request):
     # User is Authe'd in - generate key for the UI to access Proxy
     user_email = getattr(result, "email", None)
     user_id = getattr(result, "id", None)
+
+    # generic client id
+    if generic_client_id is not None:
+        generic_user_id_attribute_name = os.getenv("GENERIC_USER_ID_ATTRIBUTE", "email")
+        generic_user_email_attribute_name = os.getenv(
+            "GENERIC_USER_EMAIL_ATTRIBUTE", "email"
+        )
+        generic_user_role_attribute_name = os.getenv(
+            "GENERIC_USER_ROLE_ATTRIBUTE", "role"
+        )
+
+        verbose_proxy_logger.debug(
+            f" generic_user_id_attribute_name: {generic_user_id_attribute_name}\n generic_user_email_attribute_name: {generic_user_email_attribute_name}\n generic_user_role_attribute_name: {generic_user_role_attribute_name}"
+        )
+
+        user_id = getattr(result, generic_user_id_attribute_name, None)
+        user_email = getattr(result, generic_user_email_attribute_name, None)
+        user_role = getattr(result, generic_user_role_attribute_name, None)
+
     if user_id is None:
         user_id = getattr(result, "first_name", "") + getattr(result, "last_name", "")
     response = await generate_key_helper_fn(


### PR DESCRIPTION
## Problem 
Different SSO providers return different response formats

## Solution 
Allow user to set custom attribute names when interacting with the generic SSO provider 

```shell
GENERIC_USER_ID_ATTRIBUTE = "given_name"
GENERIC_USER_EMAIL_ATTRIBUTE = "family_name"
GENERIC_USER_ROLE_ATTRIBUTE = "given_role"
```