### PR TITLE
[FEAT] Set FastAPI root path

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -154,7 +154,22 @@ Your OpenAI proxy server is now running on `http://0.0.0.0:4000`.
 </TabItem>
 </Tabs>
 
-## Setting SSL Certification 
+## Advanced Deployment Settings
+
+### Customization of the server root path
+
+:::info
+
+In a Kubernetes deployment, it's possible to utilize a shared DNS to host multiple applications by modifying the virtual service
+
+:::
+
+Customize the root path to eliminate the need for employing multiple DNS configurations during deployment.
+
+👉 Set `SERVER_ROOT_PATH` in your .env and this will be set as your server root path
+
+
+### Setting SSL Certification 
 
 Use this, If you need to set ssl certificates for your on prem litellm proxy
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -143,6 +143,9 @@ app = FastAPI(
     title="LiteLLM API",
     description=f"Proxy Server to call 100+ LLMs in the OpenAI format\n\n{ui_message}",
     version=version,
+    root_path=os.environ.get(
+        "SERVER_ROOT_PATH", ""
+    ),  # check if user passed root path, FastAPI defaults this value to ""
 )
 
 


### PR DESCRIPTION
> [!IMPORTANT]
> In a Kubernetes deployment, it's possible to utilize a shared DNS to host multiple applications by modifying the virtual service

👉 Set `SERVER_ROOT_PATH` in your .env and this will be set as your server root path