### PR TITLE
fix(caching.py): pass kwargs to redis cache. Fixes #2050

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -108,7 +108,7 @@ class RedisCache(BaseCache):
         redis_kwargs.update(kwargs)
         self.redis_client = get_redis_client(**redis_kwargs)
         self.redis_kwargs = redis_kwargs
-        self.async_redis_conn_pool = get_redis_connection_pool()
+        self.async_redis_conn_pool = get_redis_connection_pool(**self.redis_kwargs)
 
     def init_async_client(self):
         from ._redis import get_redis_async_client


### PR DESCRIPTION
Fixes #2050 by passing the kwargs to the cache