### PR TITLE
fix(ci): platforms input

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-${{ github.event.inputs.tag || 'latest' }}, ${{ steps.meta.outputs.tags }}-latest # if a tag is provided, use that, otherwise use the release tag, and if neither is available, use 'latest'
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: local, linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: local,linux/amd64,linux/arm64,linux/arm64/v8
           
   build-and-push-image-database:
     runs-on: ubuntu-latest

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -75,7 +75,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-${{ github.event.inputs.tag || 'latest' }}, ${{ steps.meta.outputs.tags }}-latest # if a tag is provided, use that, otherwise use the release tag, and if neither is available, use 'latest'
           labels: ${{ steps.meta.outputs.labels }}
-          platform: local, linux/amd64,linux/arm64,linux/arm64/v8
+          platforms: local, linux/amd64,linux/arm64,linux/arm64/v8
           
   build-and-push-image-database:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hello!

As far as I can tell, [the expected input](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) is `platforms` instead of `platform`. This give the following warning for example:

In https://github.com/BerriAI/litellm/actions/runs/7946778613/job/21694888088:

```
Warning: Unexpected input(s) 'platform', valid inputs are ['add-hosts', 'allow', 'attests', 'build-args', 'build-contexts', 'builder', 'cache-from', 'cache-to', 'cgroup-parent', 'context', 'file', 'labels', 'load', 'network', 'no-cache', 'no-cache-filters', 'outputs', 'platforms', 'provenance', 'pull', 'push', 'sbom', 'secrets', 'secret-files', 'shm-size', 'ssh', 'tags', 'target', 'ulimit', 'github-token']
```

This should restore multi platform images 👍 