### PR TITLE
🐛 fix: Ollama vision models call arguments (like : llava)

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -147,6 +147,7 @@ def get_ollama_response(
 
     stream = optional_params.pop("stream", False)
     format = optional_params.pop("format", None)
+    images = optional_params.pop("images", None)
     data = {
         "model": model,
         "prompt": prompt,
@@ -155,6 +156,8 @@ def get_ollama_response(
     }
     if format is not None:
         data["format"] = format
+    if images is not None:
+        data["images"] = images
 
     ## LOGGING
     logging_obj.pre_call(


### PR DESCRIPTION
When using a "vision" LLM with Ollama engine, the `images` argument is wrongly passed to the Ollama API.

Version with issue : `1.27.4`

The Goal of this PR is to correctly pass the `images` argument to the Ollama query.

## Step to reproduce

- Start Ollama engine with `llava` model (see documentation : https://ollama.com/library/llava)
- Use the following proxy config
```yaml
model_list: 
- model_name: llava
  litellm_params:
    model: ollama/llava
    api_base: "http://localhost:11434"
```
- Start the Litllm proxy :
```bash
litellm --config /tmp/config.yaml --debug --detailed_debug
```
- Call the Litellm API :
```bash
curl "http://127.0.0.1:8000/v1/chat/completions" \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "model": "ollama/llava",
    "messages": [
      { "role": "user", "content": [
        { "type": "text", "text": "Whats in this image?" },
        { "type": "image_url", "image_url": { "url": "iVBOR...QmCC" } }
      ]}
    ]
  }'
```

Here is the debug log of Litellm
```bash
curl -X POST \
http://localhost:11434/api/generate \
-d '{"model": "llava", "prompt": "Whats in this image?", "options": {"images": ["iVBOR...QmCC"]}, "stream": False}'
```
And the returned error from LiteLLm :
```json
{"error":{"message":"{\"error\":\"invalid options: images\"}","type":null,"param":null,"code":500}}
```

## With the fix proposed in the PR : 

Here is the debug log of Litellm
```bash
curl -X POST \
http://localhost:11434/api/generate \
-d '{"model": "llava", "prompt": "Whats in this image?", "options": {}, "stream": False, "images": ["iVBOR...QmCC"]}'
```
And the returned error from LiteLLm :
```json
{"id":"chatcmpl-bbe5e797-51b6-4bdd-b05f-a5a97984d4d6","choices":[{"finish_reason":"stop","index":0,"message":{"content":" The image shows a cute, cartoon-style drawing of an animated pig. It has large eyes and is giving what appears to be a thumbs up gesture with its right hand. The background is plain white, emphasizing the character in the foreground. This kind of image could be used for various purposes, such as social media posts, stickers, or even greeting cards. ","role":"assistant"}}],"created":1708966903,"model":"ollama/llava","object":"chat.completion","system_fingerprint":null,"usage":{"prompt_tokens":1,"completion_tokens":80,"total_tokens":81}}
```