### PR TITLE
fix(utils.py): fix compatibility between together_ai and openai-python

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4285,9 +4285,7 @@ def get_optional_params(
         if max_tokens is not None:
             optional_params["max_tokens"] = max_tokens
         if frequency_penalty is not None:
-            optional_params["repetition_penalty"] = (
-                frequency_penalty  # https://docs.together.ai/reference/inference
-            )
+            optional_params["frequency_penalty"] = frequency_penalty
         if stop is not None:
             optional_params["stop"] = stop
         if tools is not None:


### PR DESCRIPTION
Currently `together_ai` is implemented through the openai compatible api, so `frequency_penalty` is used instead of `repetition_penalty`, which the openai client will reject.

Closing #2192.