### PR TITLE
[FIX] Proxy -  Set different locations per vertex ai deployment on litellm proxy 

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1467,12 +1467,12 @@ def completion(
             response = model_response
         elif custom_llm_provider == "vertex_ai":
             vertex_ai_project = (
-                optional_params.pop("vertex_ai_project", None)
+                optional_params.pop("vertex_project", None)
                 or litellm.vertex_project
                 or get_secret("VERTEXAI_PROJECT")
             )
             vertex_ai_location = (
-                optional_params.pop("vertex_ai_location", None)
+                optional_params.pop("vertex_location", None)
                 or litellm.vertex_location
                 or get_secret("VERTEXAI_LOCATION")
             )
@@ -2566,12 +2566,12 @@ def embedding(
             )
         elif custom_llm_provider == "vertex_ai":
             vertex_ai_project = (
-                optional_params.pop("vertex_ai_project", None)
+                optional_params.pop("vertex_project", None)
                 or litellm.vertex_project
                 or get_secret("VERTEXAI_PROJECT")
             )
             vertex_ai_location = (
-                optional_params.pop("vertex_ai_location", None)
+                optional_params.pop("vertex_location", None)
                 or litellm.vertex_location
                 or get_secret("VERTEXAI_LOCATION")
             )


### PR DESCRIPTION
## Set different locations per vertex ai deployment on litellm proxy 

```yaml
model_list:
  - model_name: gemini-vision
    litellm_params:
      model: vertex_ai/gemini-1.0-pro-vision-001
      vertex_project: "project-id"
      vertex_location: "us-central1"
  - model_name: gemini-vision
    litellm_params:
      model: vertex_ai/gemini-1.0-pro-vision-001
      vertex_project: "project-id2"
      vertex_location: "us-east"
```