### PR TITLE
Remove dockerfile port override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl 
 
 RUN chmod +x entrypoint.sh
 
-EXPOSE 4000/tcp
+EXPOSE 8000/tcp
 
 ENTRYPOINT ["litellm"]
-CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--detailed_debug", "--run_gunicorn"]
+CMD ["--config", "./proxy_server_config.yaml", "--detailed_debug", "--run_gunicorn"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -45,8 +45,7 @@ COPY --from=builder /wheels/ /wheels/
 # Install the built wheel using pip; again using a wildcard if it's the only file
 RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl && rm -rf /wheels
 
-EXPOSE 4000/tcp
+EXPOSE 8000/tcp
 
 # Set your entrypoint and command
 ENTRYPOINT ["litellm"]
-CMD ["--port", "4000"]

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -60,9 +60,9 @@ RUN chmod +x build_admin_ui.sh && ./build_admin_ui.sh
 RUN prisma generate
 RUN chmod +x entrypoint.sh
 
-EXPOSE 4000/tcp
+EXPOSE 8000/tcp
 
 # # Set your entrypoint and command
 
 ENTRYPOINT ["litellm"]
-CMD ["--port", "4000", "--run_gunicorn"]
+CMD ["--run_gunicorn"]

--- a/deploy/Dockerfile.ghcr_base
+++ b/deploy/Dockerfile.ghcr_base
@@ -11,7 +11,7 @@ COPY config.yaml .
 RUN chmod +x entrypoint.sh
 
 # Expose the necessary port
-EXPOSE 4000/tcp
+EXPOSE 8000/tcp
 
 # Override the CMD instruction with your desired command and arguments
-CMD ["--port", "4000", "--config", "config.yaml", "--detailed_debug", "--run_gunicorn"]
+CMD ["--config", "config.yaml", "--detailed_debug", "--run_gunicorn"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
     volumes:
       - ./proxy_server_config.yaml:/app/proxy_server_config.yaml # mount your litellm config.yaml
     ports:
-      - "4000:4000"
+      - "8000:8000"
     environment:
       - AZURE_API_KEY=sk-123

--- a/docs/my-website/docs/proxy/budget_alerts.md
+++ b/docs/my-website/docs/proxy/budget_alerts.md
@@ -42,7 +42,7 @@ $ litellm --config /path/to/config.yaml
 
 
 ### 2. Create API Key on Proxy Admin UI
-The Admin UI is found on `your-litellm-proxy-endpoint/ui`, example `http://localhost:4000/ui/` 
+The Admin UI is found on `your-litellm-proxy-endpoint/ui`, example `http://localhost:8000/ui/` 
 
 - Set a key name 
 - Set a Soft Budget on when to get alerted 

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -134,8 +134,8 @@ spec:
     app: litellm
   ports:
     - protocol: TCP
-      port: 4000
-      targetPort: 4000
+      port: 8000
+      targetPort: 8000
   type: NodePort
 ```
 
@@ -146,10 +146,10 @@ kubectl apply -f /path/to/service.yaml
 ### Step 3. Start server
 
 ```
-kubectl port-forward service/litellm-service 4000:4000
+kubectl port-forward service/litellm-service 8000:8000
 ```
 
-Your OpenAI proxy server is now running on `http://0.0.0.0:4000`.
+Your OpenAI proxy server is now running on `http://0.0.0.0:8000`.
 
 </TabItem>
 <TabItem value="helm-deploy" label="Helm">

--- a/docs/my-website/docs/proxy/enterprise.md
+++ b/docs/my-website/docs/proxy/enterprise.md
@@ -319,7 +319,7 @@ print(response)
 
 #### `/spend/tags` Request Format 
 ```shell
-curl -X GET "http://0.0.0.0:4000/spend/tags" \
+curl -X GET "http://0.0.0.0:8000/spend/tags" \
 -H "Authorization: Bearer sk-1234"
 ```
 

--- a/docs/my-website/docs/proxy/metrics.md
+++ b/docs/my-website/docs/proxy/metrics.md
@@ -2,7 +2,7 @@
 
 ## Request Format
 ```shell
-curl -X GET "http://0.0.0.0:4000/daily_metrics" -H "Authorization: Bearer sk-1234"
+curl -X GET "http://0.0.0.0:8000/daily_metrics" -H "Authorization: Bearer sk-1234"
 ```
 
 ## Response format 

--- a/docs/my-website/docs/proxy/ui.md
+++ b/docs/my-website/docs/proxy/ui.md
@@ -38,7 +38,7 @@ http://0.0.0.0:8000/ui # <proxy_base_url>/ui
 
 
 ### 3. Get Admin UI Link on Swagger 
-Your Proxy Swagger is available on the root of the Proxy: e.g.: `http://localhost:4000/`
+Your Proxy Swagger is available on the root of the Proxy: e.g.: `http://localhost:8000/`
 
 <Image img={require('../../img/ui_link.png')} />
 
@@ -107,7 +107,7 @@ MICROSOFT_TENANT="5a39737
 - Set Redirect URI on your App Registration on https://portal.azure.com/
     - Set a redirect url = `<your proxy base url>/sso/callback`
     ```shell
-    http://localhost:4000/sso/callback
+    http://localhost:8000/sso/callback
     ```
 
 </TabItem>
@@ -242,5 +242,3 @@ Set your colors to any of the following colors: https://www.tremor.so/docs/layou
 
 ```
 - Deploy LiteLLM Proxy Server
-
-

--- a/docs/my-website/docs/proxy/user_keys.md
+++ b/docs/my-website/docs/proxy/user_keys.md
@@ -63,14 +63,14 @@ from llama_index import VectorStoreIndex, SimpleDirectoryReader, ServiceContext
 llm = AzureOpenAI(
     engine="azure-gpt-3.5",               # model_name on litellm proxy
     temperature=0.0,
-    azure_endpoint="http://0.0.0.0:4000", # litellm proxy endpoint
+    azure_endpoint="http://0.0.0.0:8000", # litellm proxy endpoint
     api_key="sk-1234",                    # litellm proxy API Key
     api_version="2023-07-01-preview",
 )
 
 embed_model = AzureOpenAIEmbedding(
     deployment_name="azure-embedding-model",
-    azure_endpoint="http://0.0.0.0:4000",
+    azure_endpoint="http://0.0.0.0:8000",
     api_key="sk-1234",
     api_version="2023-07-01-preview",
 )

--- a/docs/my-website/docs/proxy/users.md
+++ b/docs/my-website/docs/proxy/users.md
@@ -182,7 +182,7 @@ litellm_settings:
 
 2. Make a /chat/completions call, pass 'user' - First call Works 
 ```shell
-curl --location 'http://0.0.0.0:4000/chat/completions' \
+curl --location 'http://0.0.0.0:8000/chat/completions' \
         --header 'Content-Type: application/json' \
         --header 'Authorization: Bearer sk-zi5onDRdHGD24v0Zdn7VBA' \
         --data ' {
@@ -199,7 +199,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 3. Make a /chat/completions call, pass 'user' - Call Fails, since 'ishaan3' over budget
 ```shell
-curl --location 'http://0.0.0.0:4000/chat/completions' \
+curl --location 'http://0.0.0.0:8000/chat/completions' \
         --header 'Content-Type: application/json' \
         --header 'Authorization: Bearer sk-zi5onDRdHGD24v0Zdn7VBA' \
         --data ' {

--- a/docs/my-website/docs/proxy/virtual_keys.md
+++ b/docs/my-website/docs/proxy/virtual_keys.md
@@ -291,7 +291,7 @@ Request Params:
 
 All [key/generate params supported](#keygenerate) for creating a user
 ```shell
-curl 'http://0.0.0.0:4000/user/new' \
+curl 'http://0.0.0.0:8000/user/new' \
 --header 'Authorization: Bearer sk-1234' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -358,12 +358,12 @@ If you're trying to view all users, we recommend using pagination with the follo
 - `page=0` Optional(int) min = 0, default=0
 - `page_size=25` Optional(int) min = 1, default = 25
 ```shell
-curl -X GET "http://0.0.0.0:4000/user/info?view_all=true&page=0&page_size=25" -H "Authorization: Bearer sk-1234"
+curl -X GET "http://0.0.0.0:8000/user/info?view_all=true&page=0&page_size=25" -H "Authorization: Bearer sk-1234"
 ```
 
 #### View specific user_id
 ```shell
-curl -X GET "http://0.0.0.0:4000/user/info?user_id=228da235-eef0-4c30-bf53-5d6ac0d278c2" -H "Authorization: Bearer sk-1234"
+curl -X GET "http://0.0.0.0:8000/user/info?user_id=228da235-eef0-4c30-bf53-5d6ac0d278c2" -H "Authorization: Bearer sk-1234"
 ```
 
 ### Response
@@ -469,7 +469,7 @@ litellm_settings:
 
 #### Create key with team_id="litellm-dev"
 ```shell
-curl --location 'http://localhost:4000/key/generate' \
+curl --location 'http://localhost:8000/key/generate' \
 --header 'Authorization: Bearer sk-1234' \
 --header 'Content-Type: application/json' \
 --data-raw '{"team_id": "litellm-dev"}'
@@ -477,7 +477,7 @@ curl --location 'http://localhost:4000/key/generate' \
 
 #### Use Key to call invalid model - Fails 
 ```shell
-curl --location 'http://0.0.0.0:4000/chat/completions' \
+curl --location 'http://0.0.0.0:8000/chat/completions' \
     --header 'Content-Type: application/json' \
     --header 'Authorization: Bearer sk-qo992IjKOC2CHKZGRoJIGA' \
     --data '{


### PR DESCRIPTION
This PR removes the port 4000 override from the project Dockerfiles. The default Uvicorn webapp for the LiteLLM proxy runs at port 8000, codified in:
https://docs.litellm.ai/docs/proxy/cli#--port
https://github.com/BerriAI/litellm/blob/688b903d195bd0c33d87617f2e899069c136993b/litellm/proxy/proxy_cli.py#L57

The override causes a bit of confusion when reading the Dockerfile as port 8000 is clearly intended to be the default. Since I am not too familiar with the project, I did not change the port override as specified in the CircleCI testing. If it is intended that we move permanently to port 8000, it is best that the project maintainer remedy that as well.

# How to reproduce

Use this `docker-compose.yml`:
```
name: litellm
services:
  litellm:
    container_name: litellm-proxy
    image: ghcr.io/berriai/litellm:main-v1.29.1
    restart: unless-stopped
    ports:
      - "8000:8000"
    command: "--num_workers $LITELLM_WORKERS_NUM"
    environment:
      - OPENAI_API_KEY=$OPENAI_API_KEY
````

`docker ps` shows unnecessary port 4000:
```
❯ docker ps
CONTAINER ID   IMAGE                                  COMMAND                  CREATED          STATUS         PORTS                                                 NAMES
6ffee5bdfe42   ghcr.io/berriai/litellm:main-v1.29.1   "litellm --num_workers…"   10 seconds ago   Up 9 seconds   4000/tcp, 0.0.0.0:8000->8000/tcp, :::8000->8000/tcp   litellm-proxy
```