### PR TITLE
(Fix) High Traffic Fix - handle litellm circular ref error

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -285,9 +285,6 @@ class LangFuseLogger:
                     if key in [
                         "headers",
                         "endpoint",
-                        "model_group",
-                        "deployment",
-                        "model_info",
                         "caching_groups",
                         "previous_models",
                     ]:

--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -265,8 +265,14 @@ class LangFuseLogger:
 
             cost = kwargs.get("response_cost", None)
             print_verbose(f"trace: {cost}")
-            if supports_tags:
+
+            # Clean Metadata before logging - never log raw metadata
+            # the raw metadata can contain circular references which leads to infinite recursion
+            # we clean out all extra litellm metadata params before logging
+            clean_metadata = {}
+            if isinstance(metadata, dict):
                 for key, value in metadata.items():
+                    # generate langfuse tags
                     if key in [
                         "user_api_key",
                         "user_api_key_user_id",
@@ -274,6 +280,22 @@ class LangFuseLogger:
                         "semantic-similarity",
                     ]:
                         tags.append(f"{key}:{value}")
+
+                    # clean litellm metadata before logging
+                    if key in [
+                        "headers",
+                        "endpoint",
+                        "model_group",
+                        "deployment",
+                        "model_info",
+                        "caching_groups",
+                        "previous_models",
+                    ]:
+                        continue
+                    else:
+                        clean_metadata[key] = value
+
+            if supports_tags:
                 if "cache_hit" in kwargs:
                     if kwargs["cache_hit"] is None:
                         kwargs["cache_hit"] = False
@@ -301,7 +323,7 @@ class LangFuseLogger:
                 "input": input,
                 "output": output,
                 "usage": usage,
-                "metadata": metadata,
+                "metadata": clean_metadata,
                 "level": level,
             }
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1669,6 +1669,7 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time):
                 "deployment",
                 "model_info",
                 "caching_groups",
+                "previous_models",
             ]:
                 continue
             else:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -507,24 +507,16 @@ class PrismaClient:
 
         return hashed_token
 
-    def handle_circular_references(obj: Any):
-        try:
-            # Try to serialize the object using default serialization
-            return json.dumps(obj)
-        except Exception as e:
-            # If a TypeError is raised, return an error message JSON
-            error_message: dict = {
-                "error": "Error converting to JSON",
-                "error_message": str(e),
-            }
-            return json.dumps(error_message)
-
     def jsonify_object(self, data: dict) -> dict:
         db_data = copy.deepcopy(data)
 
         for k, v in db_data.items():
             if isinstance(v, dict):
-                db_data[k] = json.dumps(v)
+                try:
+                    db_data[k] = json.dumps(v)
+                except:
+                    # This avoids Prisma retrying this 5 times, and making 5 clients
+                    db_data[k] = "failed-to-serialize-json"
         return db_data
 
     @backoff.on_exception(


### PR DESCRIPTION
## Proxy - High Traffic Fix 
- When a fallback occurs Prisma + Langfuse hit circular ref errors 
- This leads to Prisma retrying each request 5 times
- User hits Prisma DB limits 