### PR TITLE
(feat) admin UI show model avg latency, num requests

### DIFF
--- a/ui/litellm-dashboard/src/components/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard.tsx
@@ -208,13 +208,26 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
           </Table>
         </Card>
         <Card>
-          <Title>Model Statistics (Number Requests, Latency)</Title>
+          <Title>Model Statistics (Number Requests)</Title>
               <BarChart
                 data={modelMetrics}
                 index="model"
-                categories={["num_requests", "avg_latency_seconds"]}
-                colors={["blue", "red"]}
-                yAxisWidth={100}
+                categories={["num_requests"]}
+                colors={["blue"]}
+                yAxisWidth={400}
+                layout="vertical"
+                tickGap={5}
+              />
+        </Card>
+        <Card>
+          <Title>Model Statistics (Latency)</Title>
+              <BarChart
+                data={modelMetrics}
+                index="model"
+                categories={["avg_latency_seconds"]}
+                colors={["red"]}
+                yAxisWidth={400}
+                layout="vertical"
                 tickGap={5}
               />
         </Card>


### PR DESCRIPTION
## Admin UI - View Avg Latency, Num Requests Per Model 

<img width="1250" alt="Screenshot 2024-03-06 at 1 00 08 PM" src="https://github.com/BerriAI/litellm/assets/29436595/9c601216-0e3c-40d5-9bea-2da18440b217">
