### PR TITLE
[Fix] Switch off detailed_debug in default docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,7 @@ RUN chmod +x entrypoint.sh
 EXPOSE 4000/tcp
 
 ENTRYPOINT ["litellm"]
-CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--detailed_debug", "--run_gunicorn"]
+
+# Append "--detailed_debug" to the end of CMD to view detailed debug logs 
+# CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--run_gunicorn", "--detailed_debug"]
+CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--run_gunicorn"]

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -65,4 +65,7 @@ EXPOSE 4000/tcp
 # # Set your entrypoint and command
 
 ENTRYPOINT ["litellm"]
+
+# Append "--detailed_debug" to the end of CMD to view detailed debug logs 
+# CMD ["--port", "4000","--run_gunicorn", "--detailed_debug"]
 CMD ["--port", "4000", "--run_gunicorn"]

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -183,6 +183,10 @@ Your OpenAI proxy server is now running on `http://127.0.0.1:8000`.
 </TabItem>
 </Tabs>
 
+## Best Practices for Deploying to Production
+### 1. Switch of debug logs in production 
+don't use [`--detailed-debug`, `--debug`](https://docs.litellm.ai/docs/proxy/debugging#detailed-debug) or `litellm.set_verbose=True`. We found using debug logs can add 5-10% latency per LLM API call
+
 ## Advanced Deployment Settings
 
 ### Customization of the server root path


### PR DESCRIPTION
## Switch off detailed_debug in default docker
- Using debug logs added about 5% latency when running 100 calls
- Let users know they can use debugging if required, but by default switch it off 