### PR TITLE
[Feat] Support messages.name for claude-3, perplexity ai API 

### DIFF
--- a/litellm/llms/openai.py
+++ b/litellm/llms/openai.py
@@ -237,14 +237,22 @@ class OpenAIChatCompletion(BaseLLM):
                     status_code=422, message=f"Timeout needs to be a float"
                 )
 
-            if custom_llm_provider == "mistral":
-                # check if message content passed in as list, and not string
-                messages = prompt_factory(
-                    model=model,
-                    messages=messages,
-                    custom_llm_provider=custom_llm_provider,
-                )
-
+            if custom_llm_provider != "openai":
+                # process all OpenAI compatible provider logic here
+                if custom_llm_provider == "mistral":
+                    # check if message content passed in as list, and not string
+                    messages = prompt_factory(
+                        model=model,
+                        messages=messages,
+                        custom_llm_provider=custom_llm_provider,
+                    )
+                if custom_llm_provider == "perplexity" and messages is not None:
+                    # check if messages.name is passed + supported, if not supported remove
+                    messages = prompt_factory(
+                        model=model,
+                        messages=messages,
+                        custom_llm_provider=custom_llm_provider,
+                    )
             for _ in range(
                 2
             ):  # if call fails due to alternating messages, retry with reformatted message

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -83,12 +83,13 @@ def test_completion_claude():
 
 
 def test_completion_claude_3_empty_response():
+    litellm.set_verbose = True
     messages = [
         {
             "role": "system",
             "content": "You are 2twNLGfqk4GMOn3ffp4p.",
         },
-        {"role": "user", "content": "Hi gm!"},
+        {"role": "user", "content": "Hi gm!", "name": "ishaan"},
         {"role": "assistant", "content": "Good morning! How are you doing today?"},
         {
             "role": "user",


### PR DESCRIPTION
## Allow user to pass messages.name for claude-3, perplexity 
Note: Before this pr - the two providers would raise errors with the `name` param 
## LiteLLM SDK 

```python
import litellm
response = litellm.completion(
  model="claude-3-opus-20240229", 
  messages = [
    {"role": "user", "content": "Hi gm!", "name": "ishaan"},
   ]
)
``` 


## LiteLLM Proxy Server 
```python
import openai
client = openai.OpenAI(
    api_key="anything",
    base_url="http://0.0.0.0:8000"
)

response = client.chat.completions.create(
model="claude-3-opus-20240229"", 
messages = [
    {"role": "user", "content": "Hi gm!", "name": "ishaan"},
])

print(response)

```