### PR TITLE
Add in Bedrock Mistral Streaming fix for litellm proxy

### DIFF
--- a/litellm/proxy/openapi.json
+++ b/litellm/proxy/openapi.json
@@ -2,13 +2,13 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
-    "title": "Frontend API",
-    "description": "Frontend LLM API"
+    "title": "LiteLLM API",
+    "description": "API for LiteLLM"
   },
   "paths": {
    "/chat/completions": {
   "post": {
-    "summary": "Create chat completion for LLM APIs",
+    "summary": "Create chat completion for 100+ LLM APIs",
     "requestBody": {
       "required": true,
       "content": {

--- a/litellm/proxy/openapi.json
+++ b/litellm/proxy/openapi.json
@@ -2,13 +2,13 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
-    "title": "LiteLLM API",
-    "description": "API for LiteLLM"
+    "title": "Frontend API",
+    "description": "Frontend LLM API"
   },
   "paths": {
    "/chat/completions": {
   "post": {
-    "summary": "Create chat completion for 100+ LLM APIs",
+    "summary": "Create chat completion for LLM APIs",
     "requestBody": {
       "required": true,
       "content": {

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8602,6 +8602,9 @@ class CustomStreamWrapper:
             # cohere mapping
             elif "text" in chunk_data:
                 text = chunk_data["text"]  # bedrock.cohere
+            # mistral mapping
+            elif "outputs" in chunk_data:
+                text = chunk_data['outputs'][0]['text']
             # cohere mapping for finish reason
             elif "finish_reason" in chunk_data:
                 finish_reason = chunk_data["finish_reason"]


### PR DESCRIPTION
With V1.30.3, the internal litellm response operations supported streaming, however doing any OpenAI API calls for streaming returned empty responses with the litellm proxy. Upon further inspection, it shows that the response being sent by Bedrock for the mistral models is found in `chunk_data['outputs'][0]['text']`. In the utils, for handling the bedrock stream, this PR adds in a condition for Bedrock Mistral formatted streaming.