### PR TITLE
Add quickstart deploy with k8s

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -70,8 +70,9 @@ CMD ["--port", "4000", "--config", "config.yaml", "--detailed_debug", "--run_gun
 
 <TabItem value="kubernetes" label="Kubernetes">
 
-Deploying a config file based litellm instance, just requires a simple deployment that loads
-the config.yaml file via a config map.
+Deploying a config file based litellm instance just requires a simple deployment that loads
+the config.yaml file via a config map. Also it would be a good practice to use the env var
+declaration for api keys, and attach the env vars with the api key values as an opaque secret.
 
 ```yaml
 apiVersion: v1
@@ -81,20 +82,19 @@ metadata:
 data:
   config.yaml: |
       model_list: 
-        - model_name: gpt-3.5-turbo # user-facing model alias
-          litellm_params: # all params accepted by litellm.completion() - https://docs.litellm.ai/docs/completion/input
-            model: azure/<your-deployment-name>
-            api_base: <your-azure-api-endpoint>
-            api_key: <your-azure-api-key>
         - model_name: gpt-3.5-turbo
           litellm_params:
             model: azure/gpt-turbo-small-ca
             api_base: https://my-endpoint-canada-berri992.openai.azure.com/
-            api_key: <your-azure-api-key>
-        - model_name: vllm-model
-          litellm_params:
-            model: openai/<your-model-name>
-            api_base: <your-api-base> # e.g. http://0.0.0.0:3000
+            api_key: os.environ/CA_AZURE_OPENAI_API_KEY
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: litellm-secrets
+data:
+  CA_AZURE_OPENAI_API_KEY: bWVvd19pbV9hX2NhdA== # your api key in base64
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -127,7 +127,6 @@ spec:
         - name: config-volume
           configMap:
             name: litellm-config-file
-
 ```
 
 </TabItem>


### PR DESCRIPTION
Just deployed this to some k8s clusters during today with a "static" config, i.e. just config file, no database; and thought sharing this in the quickstart would be good.

As a side comment, what I struggled the most when deploying to k8s was:
- in the docs, the docker-compose example uses the port 8000, because it overrides the command, with --port 8000. So I didn't noticed the --port 8000 and just assumed that the docker compose port mapping was ok. The default port is 4000.
- in the docs the config file is always "config.yaml" but the default name is "proxy_server_config.yaml". It took a little bit to discover. Actually I had to inspect the actual dockerfile 😅 A little bit frustrating because the config file was ok, the env vars was ok, but on start litellm complained that the azure key was missing 🤷 Anyhow, it took a little bit to figure it out.