### PR TITLE
Update Docs for Kubernetes

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -131,6 +131,9 @@ spec:
 
 </TabItem>
 
+> [!TIP]
+> To avoid issues with predictability, difficulties in rollback, and inconsistent environments, use versioning or SHA digests (for example, `litellm:main-v1.30.3` or `litellm@sha256:12345abcdef...`) instead of `litellm:main-latest`.
+
 </Tabs>
 
 ## Deploy with Database


### PR DESCRIPTION
- [+] docs(deploy.md): add tip about using versioning or SHA digests instead of latest tag