### PR TITLE
Fix Docs Formatting in Website

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -129,10 +129,10 @@ spec:
             name: litellm-config-file
 ```
 
-</TabItem>
-
 > [!TIP]
 > To avoid issues with predictability, difficulties in rollback, and inconsistent environments, use versioning or SHA digests (for example, `litellm:main-v1.30.3` or `litellm@sha256:12345abcdef...`) instead of `litellm:main-latest`.
+
+</TabItem>
 
 </Tabs>
 


### PR DESCRIPTION
- [+] docs(deploy.md): move tip about versioning inside the tab item


@ishaan-jaff @krrishdholakia this should be correct in https://docs.litellm.ai/docs/proxy/deploy