### PR TITLE
(fix) use python 3.8 on ci/cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,94 @@
 version: 2.1
 jobs:
+  local_testing:
+    docker:
+      - image: circleci/python:3.9
+    working_directory: ~/project
+
+    steps:
+      - checkout
+
+      - run:
+          name: Check if litellm dir was updated or if pyproject.toml was modified
+          command: |
+            if [ -n "$(git diff --name-only $CIRCLE_SHA1^..$CIRCLE_SHA1 | grep -E 'pyproject\.toml|litellm/')" ]; then
+              echo "litellm updated"
+            else
+              echo "No changes to litellm or pyproject.toml. Skipping tests."
+              circleci step halt
+            fi
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+      - run:
+          name: Install Dependencies
+          command: |
+            python -m pip install --upgrade pip
+            python -m pip install -r .circleci/requirements.txt
+            pip install "pytest==7.3.1"
+            pip install "pytest-asyncio==0.21.1"
+            pip install mypy
+            pip install "google-generativeai>=0.3.2"
+            pip install "google-cloud-aiplatform>=1.38.0"
+            pip install "boto3>=1.28.57"
+            pip install "aioboto3>=12.3.0"
+            pip install langchain
+            pip install "langfuse>=2.0.0"
+            pip install numpydoc
+            pip install traceloop-sdk==0.0.69
+            pip install openai
+            pip install prisma            
+            pip install "httpx==0.24.1"
+            pip install "gunicorn==21.2.0"
+            pip install "anyio==3.7.1"
+            pip install "aiodynamo==23.10.1"
+            pip install "asyncio==3.4.3"
+            pip install "apscheduler==3.10.4"
+            pip install "PyGithub==1.59.1"
+            pip install python-multipart
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
+      - run:
+          name: Run prisma ./entrypoint.sh
+          command: |
+            set +e
+            chmod +x entrypoint.sh
+            ./entrypoint.sh
+            set -e
+      - run:
+          name: Black Formatting
+          command: |
+            cd litellm
+            python -m pip install black
+            python -m black .
+            cd ..
+      - run:
+          name: Linting Testing
+          command: |
+            cd litellm
+            python -m pip install types-requests types-setuptools types-redis
+            if ! python -m mypy . --ignore-missing-imports; then
+              echo "mypy detected errors"
+              exit 1
+            fi
+            cd ..
+  
+
+      # Run pytest and generate JUnit XML report
+      - run:
+          name: Run tests
+          command: |
+            pwd
+            ls
+            python -m pytest -vv litellm/tests/ -x --junitxml=test-results/junit.xml --durations=5 
+          no_output_timeout: 120m
+
+      # Store test results
+      - store_test_results:
+          path: test-results
+
   installing_litellm_on_python:
     docker:
       - image: circleci/python:3.8
@@ -202,6 +291,12 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - local_testing:
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
       - build_and_test:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   local_testing:
     docker:
-      - image: circleci/python:3.9
+      - image: circleci/python:3.8.18
     working_directory: ~/project
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,13 @@
 version: 2.1
 jobs:
   installing_litellm_on_python:
-      local_testing:
     docker:
       - image: circleci/python:3.8
     working_directory: ~/project
 
     steps:
       - checkout
-
-       - run:
+      - run:
           name: Install Dependencies
           command: |
             python -m pip install --upgrade pip
@@ -20,7 +18,7 @@ jobs:
             pip install click
             pip install jinja2
             pip install tokenizers
-            pip install openai         
+            pip install openai
       - run:
           name: Check if litellm dir was updated or if pyproject.toml was modified
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,6 +311,7 @@ workflows:
                 - /litellm_.*/
       - publish_to_pypi:
           requires:
+            - local_testing
             - build_and_test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 jobs:
-  local_testing:
+  installing_litellm_on_python:
+      local_testing:
     docker:
       - image: circleci/python:3.8
     working_directory: ~/project
@@ -8,86 +9,24 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Check if litellm dir was updated or if pyproject.toml was modified
-          command: |
-            if [ -n "$(git diff --name-only $CIRCLE_SHA1^..$CIRCLE_SHA1 | grep -E 'pyproject\.toml|litellm/')" ]; then
-              echo "litellm updated"
-            else
-              echo "No changes to litellm or pyproject.toml. Skipping tests."
-              circleci step halt
-            fi
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
-      - run:
+       - run:
           name: Install Dependencies
           command: |
             python -m pip install --upgrade pip
             python -m pip install -r .circleci/requirements.txt
-            pip install "pytest==7.3.1"
-            pip install "pytest-asyncio==0.21.1"
-            pip install mypy
-            pip install "google-generativeai>=0.3.2"
-            pip install "google-cloud-aiplatform>=1.38.0"
-            pip install "boto3>=1.28.57"
-            pip install "aioboto3>=12.3.0"
-            pip install langchain
-            pip install "langfuse>=2.0.0"
-            pip install numpydoc
-            pip install traceloop-sdk==0.0.69
             pip install openai
             pip install prisma            
             pip install "httpx==0.24.1"
-            pip install "gunicorn==21.2.0"
-            pip install "anyio==3.7.1"
-            pip install "aiodynamo==23.10.1"
-            pip install "asyncio==3.4.3"
-            pip install "apscheduler==3.10.4"
-            pip install "PyGithub==1.59.1"
-            pip install python-multipart
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
-      - run:
-          name: Run prisma ./entrypoint.sh
-          command: |
-            set +e
-            chmod +x entrypoint.sh
-            ./entrypoint.sh
-            set -e
-      - run:
-          name: Black Formatting
-          command: |
-            cd litellm
-            python -m pip install black
-            python -m black .
-            cd ..
-      - run:
-          name: Linting Testing
-          command: |
-            cd litellm
-            python -m pip install types-requests types-setuptools types-redis
-            if ! python -m mypy . --ignore-missing-imports; then
-              echo "mypy detected errors"
-              exit 1
-            fi
-            cd ..
-  
 
-      # Run pytest and generate JUnit XML report
+      - run:
+          name: Check if litellm dir was updated or if pyproject.toml was modified
       - run:
           name: Run tests
           command: |
             pwd
             ls
-            python -m pytest -vv litellm/tests/ -x --junitxml=test-results/junit.xml --durations=5 
+            python -m pytest -vv litellm/tests/test_python_38.py
           no_output_timeout: 120m
-
-      # Store test results
-      - store_test_results:
-          path: test-results
 
   build_and_test:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,12 +202,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - local_testing:
-          filters:
-            branches:
-              only:
-                - main
-                - /litellm_.*/
       - build_and_test:
           filters:
             branches:
@@ -222,7 +216,6 @@ workflows:
                 - /litellm_.*/
       - publish_to_pypi:
           requires:
-            - local_testing
             - build_and_test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,11 @@ jobs:
             pip install tokenizers
             pip install openai
       - run:
-          name: Check if litellm dir was updated or if pyproject.toml was modified
-      - run:
           name: Run tests
           command: |
             pwd
             ls
             python -m pytest -vv litellm/tests/test_python_38.py
-          no_output_timeout: 120m
 
   build_and_test:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   local_testing:
     docker:
-      - image: circleci/python:3.8.18
+      - image: circleci/python:3.8
     working_directory: ~/project
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,12 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
+      - installing_litellm_on_python:
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
       - publish_to_pypi:
           requires:
             - local_testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,14 @@ jobs:
           name: Install Dependencies
           command: |
             python -m pip install --upgrade pip
-            python -m pip install -r .circleci/requirements.txt
-            pip install openai
-            pip install prisma            
-            pip install "httpx==0.24.1"
-
+            pip install python-dotenv
+            pip install pytest
+            pip install tiktoken
+            pip install aiohttp
+            pip install click
+            pip install jinja2
+            pip install tokenizers
+            pip install openai         
       - run:
           name: Check if litellm dir was updated or if pyproject.toml was modified
       - run:

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -4,6 +4,7 @@ import json, re, xml.etree.ElementTree as ET
 from jinja2 import Template, exceptions, Environment, meta
 from typing import Optional, Any
 import imghdr, base64
+from typing import List
 
 
 def default_pt(messages):
@@ -633,7 +634,7 @@ def anthropic_messages_pt(messages: list):
     return new_messages
 
 
-def extract_between_tags(tag: str, string: str, strip: bool = False) -> list[str]:
+def extract_between_tags(tag: str, string: str, strip: bool = False) -> List[str]:
     ext_list = re.findall(f"<{tag}>(.+?)</{tag}>", string, re.DOTALL)
     if strip:
         ext_list = [e.strip() for e in ext_list]

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -69,7 +69,7 @@ def test_completion_claude():
         response = completion(
             model="claude-instant-1", messages=messages, request_timeout=10
         )
-        # Add any assertions, here to check response args
+        # Add any assertions here to check response args
         print(response)
         print(response.usage)
         print(response.usage.completion_tokens)

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -69,7 +69,7 @@ def test_completion_claude():
         response = completion(
             model="claude-instant-1", messages=messages, request_timeout=10
         )
-        # Add any assertions here to check response args
+        # Add any assertions, here to check response args
         print(response)
         print(response.usage)
         print(response.usage.completion_tokens)

--- a/litellm/tests/test_python_38.py
+++ b/litellm/tests/test_python_38.py
@@ -1,0 +1,16 @@
+import sys, os, time
+import traceback, asyncio
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+
+
+def test_using_litellm():
+    try:
+        import litellm
+    except Exception as e:
+        pytest.fail(
+            f"Error occurred: {e}. Installing litellm on python3.8 failed please retry"
+        )

--- a/litellm/tests/test_python_38.py
+++ b/litellm/tests/test_python_38.py
@@ -10,6 +10,8 @@ sys.path.insert(
 def test_using_litellm():
     try:
         import litellm
+
+        print("litellm imported successfully")
     except Exception as e:
         pytest.fail(
             f"Error occurred: {e}. Installing litellm on python3.8 failed please retry"


### PR DESCRIPTION
## Why?
> Users complained about not being able to use python3.8 + litellm 