### PR TITLE
Fix base_url for replicate's http api

### DIFF
--- a/litellm/llms/replicate.py
+++ b/litellm/llms/replicate.py
@@ -105,7 +105,7 @@ def start_prediction(
         base_url = f"https://api.replicate.com/v1/deployments/{version_id}"
         print_verbose(f"Deployment base URL: {base_url}\n")
     else:  # assume it's a model
-        base_url = f"https://api.replicate.com/v1/models/{version_id}"
+        base_url = f"https://api.replicate.com/v1"
     headers = {
         "Authorization": f"Token {api_token}",
         "Content-Type": "application/json",


### PR DESCRIPTION
Replicate's HTTP API states that Predictions are created using a POST request to https://api.replicate.com/v1/predictions.

The current implementation is failing with the following response from Replicate:
`{"detail":"Method \"POST\" not allowed."}`

For more information, Replicate's HTTP API schema located here: https://replicate.com/docs/reference/http#predictions.create