### PR TITLE
Add missing `argon2-cffi` poetry dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ click = "*"
 jinja2 = "^3.1.2"
 aiohttp = "*"
 requests = "^2.31.0"
+argon2-cffi = "^23.1.0"
 
 uvicorn = {version = "^0.22.0", optional = true}
 gunicorn = {version = "^21.2.0", optional = true}


### PR DESCRIPTION
`argon2-cffi` is included in the `proxy` extra, but is missing a poetry dependency specification.