### PR TITLE
Make `argon2-cffi` optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ click = "*"
 jinja2 = "^3.1.2"
 aiohttp = "*"
 requests = "^2.31.0"
-argon2-cffi = "^23.1.0"
 
 uvicorn = {version = "^0.22.0", optional = true}
 gunicorn = {version = "^21.2.0", optional = true}
@@ -36,6 +35,7 @@ streamlit = {version = "^1.29.0", optional = true}
 fastapi-sso = { version = "^0.10.0", optional = true }
 PyJWT = { version = "^2.8.0", optional = true }
 python-multipart = { version = "^0.0.6", optional = true }
+argon2-cffi = { version = "^23.1.0", optional = true }
 
 [tool.poetry.extras]
 proxy = [
@@ -50,6 +50,7 @@ proxy = [
     "fastapi-sso",
     "PyJWT",
     "python-multipart",
+    "argon2-cffi",
 ]
 
 extra_proxy = [


### PR DESCRIPTION
The change I made in https://github.com/BerriAI/litellm/pull/2443 wasn't accurate, as it made `argon2-cffi` a required dependency instead of an optional one for the proxy server.