### PR TITLE
:wrench: add credentials parameter to completion

### DIFF
--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -261,7 +261,6 @@ def completion(
     litellm_params=None,
     logger_fn=None,
     acompletion: bool = False,
-    credentials = None,
 ):
     try:
         import vertexai
@@ -301,8 +300,8 @@ def completion(
             f"VERTEX AI: vertex_project={vertex_project}; vertex_location={vertex_location}"
         )
 
-        creds, _ = google.auth.default(quota_project_id=vertex_project) if credentials is None else (credentials, None)
-        if credentials is None:
+        creds, _ = google.auth.default(quota_project_id=vertex_project) if optional_params.get("credentials") is None else (optional_params.get("credentials"), None)
+        if optional_params.get("credentials") is None:
             print_verbose(
                 f"VERTEX AI: creds={creds}; google application credentials: {os.getenv('GOOGLE_APPLICATION_CREDENTIALS')}"
             )

--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -261,6 +261,7 @@ def completion(
     litellm_params=None,
     logger_fn=None,
     acompletion: bool = False,
+    credentials = None,
 ):
     try:
         import vertexai
@@ -299,10 +300,12 @@ def completion(
         print_verbose(
             f"VERTEX AI: vertex_project={vertex_project}; vertex_location={vertex_location}"
         )
-        creds, _ = google.auth.default(quota_project_id=vertex_project)
-        print_verbose(
-            f"VERTEX AI: creds={creds}; google application credentials: {os.getenv('GOOGLE_APPLICATION_CREDENTIALS')}"
-        )
+
+        creds, _ = google.auth.default(quota_project_id=vertex_project) if credentials is None else (credentials, None)
+        if credentials is None:
+            print_verbose(
+                f"VERTEX AI: creds={creds}; google application credentials: {os.getenv('GOOGLE_APPLICATION_CREDENTIALS')}"
+            )
         vertexai.init(
             project=vertex_project, location=vertex_location, credentials=creds
         )


### PR DESCRIPTION
First of all, thanks for such an awesome library and OSS project. It's a life saver. Secondly, rather than post an issue and spend your time on that for such a simple change, I am just submitting this PR -- so if this is something you don't want or need to close it, zero hard feelings. 

## High-level changes

This merge adds a `credentials` input parameter to the `vertex_ai` module's `completion` method and uses the user provided `credentials` in the `vertexai.init(...)` call, if `credentials` is not `None`. 

**It should have no behavior changes for current users.**

## Motivation
Google allows the use of the `Credentials` class directly, which I use to pass service accounts in JSON format directly to client libraries. 

With vertexai here's what that looks like using Google's libraries, where the `GCP_APPLICATION_DEFAULT_CREDENTIALS` is a JSON string:

```python
import json
import os
from google.oauth2 import service_account
import vertexai
from vertexai.generative_models import GenerativeModel

service_account_info_json = json.loads(os.getenv('GCP_APPLICATION_DEFAULT_CREDENTIALS'))
credentials = service_account.Credentials.from_service_account_info(service_account_info_json)

vertexai.init(project='blah', location='us-central1', credentials=credentials)
# Load the model
multimodal_model = GenerativeModel("gemini-pro")
# Query the model
response = multimodal_model.generate_content(
    [

        # Add an example query
        "Tell me a joke about a guy named Johnny Rocket",
    ]
)
print(response)

# 'Why did Johnny Rocket never get invited to parties?\n\nBecause he was always "out of this world"!'
```

## Changes herein
Since Litellm's `vertex_ai` module uses `vertexai` from google under the hood, very little needs to change. What I've implemented should be non-breaking for current users. 

### Add parameter `credentials`

First I've added the `credentials` parameter which is default set to `None`. 

> This has been intentionally untyped since the Google libraries are loaded dynamically, as per the [litellm docs](https://litellm.vercel.app/docs/providers/vertex) requiring the installation of the `google-cloud-aiplatform` library.

### No change to existing behavior

The previous code called the `vertexai.init` method using the default application credentials. This addition does not change that behavior by default. 

If downstream users opt to create their own `credentials` they can now pass that in and it will be used internally.

If there's something different you'd like to see let me know and I'll get it fixed up.