### PR TITLE
(fix) make cohere_chat default cohere endpoint

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -449,6 +449,7 @@ provider_list: List = [
     "text-completion-openai",
     "cohere",
     "cohere_chat",
+    "cohere_text",
     "anthropic",
     "replicate",
     "huggingface",

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1253,6 +1253,46 @@ def completion(
                 )
                 return response
             response = model_response
+        elif custom_llm_provider == "cohere_text":
+            cohere_key = (
+                api_key
+                or litellm.cohere_key
+                or get_secret("COHERE_API_KEY")
+                or get_secret("CO_API_KEY")
+                or litellm.api_key
+            )
+
+            api_base = (
+                api_base
+                or litellm.api_base
+                or get_secret("COHERE_API_BASE")
+                or "https://api.cohere.ai/v1/generate"
+            )
+
+            model_response = cohere.completion(
+                model=model,
+                messages=messages,
+                api_base=api_base,
+                model_response=model_response,
+                print_verbose=print_verbose,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+                logger_fn=logger_fn,
+                encoding=encoding,
+                api_key=cohere_key,
+                logging_obj=logging,  # model call logging done inside the class as we make need to modify I/O to fit aleph alpha's requirements
+            )
+
+            if "stream" in optional_params and optional_params["stream"] == True:
+                # don't try to access stream object,
+                response = CustomStreamWrapper(
+                    model_response,
+                    model,
+                    custom_llm_provider="cohere",
+                    logging_obj=logging,
+                )
+                return response
+            response = model_response
         elif custom_llm_provider == "cohere" or custom_llm_provider == "cohere_chat":
             cohere_key = (
                 api_key

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1253,47 +1253,7 @@ def completion(
                 )
                 return response
             response = model_response
-        elif custom_llm_provider == "cohere":
-            cohere_key = (
-                api_key
-                or litellm.cohere_key
-                or get_secret("COHERE_API_KEY")
-                or get_secret("CO_API_KEY")
-                or litellm.api_key
-            )
-
-            api_base = (
-                api_base
-                or litellm.api_base
-                or get_secret("COHERE_API_BASE")
-                or "https://api.cohere.ai/v1/generate"
-            )
-
-            model_response = cohere.completion(
-                model=model,
-                messages=messages,
-                api_base=api_base,
-                model_response=model_response,
-                print_verbose=print_verbose,
-                optional_params=optional_params,
-                litellm_params=litellm_params,
-                logger_fn=logger_fn,
-                encoding=encoding,
-                api_key=cohere_key,
-                logging_obj=logging,  # model call logging done inside the class as we make need to modify I/O to fit aleph alpha's requirements
-            )
-
-            if "stream" in optional_params and optional_params["stream"] == True:
-                # don't try to access stream object,
-                response = CustomStreamWrapper(
-                    model_response,
-                    model,
-                    custom_llm_provider="cohere",
-                    logging_obj=logging,
-                )
-                return response
-            response = model_response
-        elif custom_llm_provider == "cohere_chat":
+        elif custom_llm_provider == "cohere" or custom_llm_provider == "cohere_chat":
             cohere_key = (
                 api_key
                 or litellm.cohere_key

--- a/litellm/tests/test_cohere_completion.py
+++ b/litellm/tests/test_cohere_completion.py
@@ -28,7 +28,7 @@ def test_chat_completion_cohere():
             },
         ]
         response = completion(
-            model="cohere_chat/command-r",
+            model="cohere/command-r",
             messages=messages,
             max_tokens=10,
         )
@@ -47,7 +47,7 @@ def test_chat_completion_cohere_stream():
             },
         ]
         response = completion(
-            model="cohere_chat/command-r",
+            model="cohere/command-r",
             messages=messages,
             max_tokens=10,
             stream=True,
@@ -69,7 +69,7 @@ def test_chat_completion_cohere_tool_calling():
             },
         ]
         response = completion(
-            model="cohere_chat/command-r",
+            model="cohere/command-r",
             messages=messages,
             tools=[
                 {


### PR DESCRIPTION
Use https://docs.cohere.com/reference/chat as the default endpoint for all `cohere/` calls 

All `/generate` models are compatible on `/chat` https://docs.cohere.com/reference/generate 

- Cohere no longer maintains the `/generate` endpoint according to their notice 