### PR TITLE
(fix) run prisma generate in default dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ COPY --from=builder /wheels/ /wheels/
 # Install the built wheel using pip; again using a wildcard if it's the only file
 RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl && rm -rf /wheels
 
+# Generate prisma client
+RUN prisma generate
 RUN chmod +x entrypoint.sh
 
 EXPOSE 4000/tcp


### PR DESCRIPTION
## Fix - Run Prisma Generate 

Tested locally, able to build + run this when 
- DATABASE_URL is set
- DATABASE_URL is not set 