### PR TITLE
(fix) - update user error

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1418,6 +1418,8 @@ async def update_cache(
         try:
             for _id in user_ids:
                 # Fetch the existing cost for the given user
+                if _id is None:
+                    continue
                 existing_spend_obj = await user_api_key_cache.async_get_cache(key=_id)
                 if existing_spend_obj is None:
                     # if user does not exist in LiteLLM_UserTable, create a new user


### PR DESCRIPTION
I was seeing this error in my logs when running load tests. This PR fixes it 


```shell
updating user table for id None
<class 'NoneType'>
Traceback (most recent call last):
  File "/Users/ishaanjaffer/Github/litellm/litellm/proxy/proxy_server.py", line 1430, in _update_user_cache
    existing_spend_obj = LiteLLM_UserTable(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for LiteLLM_UserTable
user_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
19:49:13 - LiteLLM Proxy:DEBUG: proxy_server.py:1461 - An error occurred updating user cache: 1 validation error for LiteLLM_UserTable
user_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type

Traceback (most recent call last):
  File "/Users/ishaanjaffer/Github/litellm/litellm/proxy/proxy_server.py", line 1430, in _update_user_cache
    existing_spend_obj = LiteLLM_UserTable(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for LiteLLM_UserTable
user_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.6/v/string_type
```