### PR TITLE
(fix) Proxy - fix error message raised on passing invalid tokens

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -889,6 +889,9 @@ async def user_api_key_auth(
                     raise Exception(
                         f"This key is made for LiteLLM UI, Tried to access route: {route}. Not allowed"
                     )
+        if valid_token is None:
+            # No token was found when looking up in the DB
+            raise Exception("Invalid token passed")
         if valid_token_dict is not None:
             return UserAPIKeyAuth(api_key=api_key, **valid_token_dict)
         else:

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -158,7 +158,7 @@ def test_call_with_invalid_key(prisma_client):
 
         async def test():
             await litellm.proxy.proxy_server.prisma_client.connect()
-            generated_key = "bad-key"
+            generated_key = "sk-126666"
             bearer_token = "Bearer " + generated_key
 
             request = Request(scope={"type": "http"}, receive=None)
@@ -173,7 +173,7 @@ def test_call_with_invalid_key(prisma_client):
     except Exception as e:
         print("Got Exception", e)
         print(e.message)
-        assert "Authentication Error" in e.message
+        assert "Authentication Error, Invalid token passed" in e.message
         pass
 
 


### PR DESCRIPTION
## Problem - when user pass an invalid api key to proxy they see this message 
```shell
UnboundLocalError: local variable 'valid_token_dict' referenced before assignment
```

This PR shows users the correct error msg + added testing:
```shell
Authentication Error, Invalid token passed
```