### PR TITLE
fix bug: custom prompt templates registered are never applied to vllm provider

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1780,9 +1780,11 @@ def completion(
             ## RESPONSE OBJECT
             response = response
         elif custom_llm_provider == "vllm":
+            custom_prompt_dict = custom_prompt_dict or litellm.custom_prompt_dict
             model_response = vllm.completion(
                 model=model,
                 messages=messages,
+                custom_prompt_dict=custom_prompt_dict,
                 model_response=model_response,
                 print_verbose=print_verbose,
                 optional_params=optional_params,


### PR DESCRIPTION
### Issue Description

TLDR: custom prompt templates registered for local models are never applied to vllm provider.

I was trying to use litellm to build an openai compatible API on top of vllm, with local pre-downloaded model files. The problem here is that litellm would eventually falls back to `default_pt` method in prompt_template/factory.py because the model name interpreted by litellm is `/path/to/my/model/directory`. Given my code:
```python
response = litellm.completion(
            model="vllm//path/to/my/model/directory",
            ...
```
and registering custom prompt template for model `/path/to/my/model/directory` doesn't work because parameter `custom_prompt_dict` never passed to `vllm.completion` as shown below
```python
# code snippet from litellm/main.py
elif custom_llm_provider == "vllm":
            model_response = vllm.completion(
                model=model,
                messages=messages,
                model_response=model_response,
                print_verbose=print_verbose,
                optional_params=optional_params,
                litellm_params=litellm_params,
                logger_fn=logger_fn,
                encoding=encoding,
                logging_obj=logging,
            )
```
and code used to do the register:
```python
litellm.register_prompt_template(
        model="vllm//path/to/my/model/directory",
        initial_prompt_value="<s>",
        roles={
            "system": {
                "pre_message": "[INST] ",
                "post_message": " [/INST]",
            },
            "user": {"pre_message": "[INST] ", "post_message": " [/INST]"},
            "assistant": {"pre_message": "", "post_message": "</s> "},
        }
)
```