### PR TITLE
(fix) /health/readiness return success callback names as (str)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7298,6 +7298,17 @@ async def health_readiness():
     Unprotected endpoint for checking if worker can receive requests
     """
     try:
+        # get success callback
+        success_callback_names = []
+        try:
+            # this was returning a JSON of the values in some of the callbacks
+            # all we need is the callback name, hence we do str(callback)
+            success_callback_names = [str(x) for x in litellm.success_callback]
+        except:
+            # don't let this block the /health/readiness response, if we can't convert to str -> return litellm.success_callback
+            success_callback_names = litellm.success_callback
+
+        # check Cache
         cache_type = None
         if litellm.cache is not None:
             from litellm.caching import RedisSemanticCache
@@ -7313,6 +7324,7 @@ async def health_readiness():
                     index_info = "index does not exist - error: " + str(e)
                 cache_type = {"type": cache_type, "index_info": index_info}
 
+        # check DB
         if prisma_client is not None:  # if db passed in, check if it's connected
             db_health_status = _db_health_readiness_check()
 
@@ -7321,7 +7333,7 @@ async def health_readiness():
                 "db": "connected",
                 "cache": cache_type,
                 "litellm_version": version,
-                "success_callbacks": litellm.success_callback,
+                "success_callbacks": success_callback_names,
                 **db_health_status,
             }
         else:
@@ -7330,7 +7342,7 @@ async def health_readiness():
                 "db": "Not connected",
                 "cache": cache_type,
                 "litellm_version": version,
-                "success_callbacks": litellm.success_callback,
+                "success_callbacks": success_callback_names,
             }
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Service Unhealthy ({str(e)})")


### PR DESCRIPTION
Problem - /health/readiness was returning elements of user_api_key_cache since it's used in one of the callbacks. This was making the response extremely long 
```json
{
  "status": "healthy",
  "db": "connected",
  "cache": null,
  "litellm_version": "1.31.15.dev2",
  "success_callbacks": [
    {
      "user_api_key_cache": {
        "in_memory_cache": {
          "cache_dict": {
            
            },
            "None::2024-03-16-15-59::request_count": {
              "current_requests": 2,
              "current_tpm": 0,
              "current_rpm": 0
            },
            "sk-1234::2024-03-16-15-59::request_count": {
              "current_requests": 0,
              "current_tpm": 0,
              "current_rpm": 0
            },
            "sk-1234::2024-03-16-16-00::request_count": {
              "current_requests": 0,
              "current_tpm": 0,
              "current_rpm": 0
            }
          },
          "ttl_dict": {
            "sk-1234::2024-03-16-15-59::request_count": 1710630053.5264692,
            "sk-1234::2024-03-16-16-00::request_count": 1710630060.335871
          }
        },
        "redis_cache": null
      }
    },
    {},
    {}
  ]
}

```


Fix after this PR
```json
{
  "status": "connected",
  "db": "connected",
  "cache": null,
  "litellm_version": "1.31.15.dev2",
  "success_callbacks": [
    "<litellm.proxy.hooks.parallel_request_limiter._PROXY_MaxParallelRequestsHandler object at 0x12451a170>",
    "<litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x12451a1a0>",
    "<litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x12451a1d0>"
  ],
  "last_updated": "2024-03-16T15:57:43.798413"
}

```