### PR TITLE
fix(anthropic): tool calling detection

### DIFF
--- a/litellm/llms/anthropic.py
+++ b/litellm/llms/anthropic.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 from litellm.utils import ModelResponse, Usage, map_finish_reason, CustomStreamWrapper
 import litellm
 from .prompt_templates.factory import (
+    contains_tag,
     prompt_factory,
     custom_prompt,
     construct_tool_use_system_prompt,
@@ -235,7 +236,7 @@ def completion(
         else:
             text_content = completion_response["content"][0].get("text", None)
             ## TOOL CALLING - OUTPUT PARSE
-            if text_content is not None and "invoke" in text_content:
+            if text_content is not None and contains_tag("invoke", text_content):
                 function_name = extract_between_tags("tool_name", text_content)[0]
                 function_arguments_str = extract_between_tags("invoke", text_content)[
                     0

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -714,6 +714,8 @@ def extract_between_tags(tag: str, string: str, strip: bool = False) -> List[str
         ext_list = [e.strip() for e in ext_list]
     return ext_list
 
+def contains_tag(tag: str, string: str) -> bool:
+    return bool(re.search(f"<{tag}>(.+?)</{tag}>", string, re.DOTALL))
 
 def parse_xml_params(xml_content):
     root = ET.fromstring(xml_content)


### PR DESCRIPTION
Fix error when Claude response with the word "invokes".

```
raw model_response: {"id":"msg_01HV4RHeGL1bv3noFGJDa6Fc","type":"message","role":"assistant","content":[{"type":"text","text":"(...) **invokes** (...)"}],"model":"claude-3-opus-20240229","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":352,"output_tokens":188}}
```

Error:
```
File "/usr/local/lib/python3.11/site-packages/litellm/main.py", line 1133, in completion
  response = anthropic.completion(
              ^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/litellm/llms/anthropic.py", line 239, in completion
  function_name = extract_between_tags("tool_name", text_content)[0]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```