### PR TITLE
(edge case) fix IndexError vulnerability with Anthropic models

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -693,12 +693,12 @@ def anthropic_messages_pt(messages: list):
         if assistant_content:
             new_messages.append({"role": "assistant", "content": assistant_content})
 
-    if new_messages[0]["role"] != "user":
+    if len(new_messages) > 0 and new_messages[0]["role"] != "user":
         new_messages.insert(
             0, {"role": "user", "content": [{"type": "text", "text": "."}]}
         )
 
-    if new_messages[-1]["role"] == "assistant":
+    if len(new_messages) > 0 and new_messages[-1]["role"] == "assistant":
         for content in new_messages[-1]["content"]:
             if isinstance(content, dict) and content["type"] == "text":
                 content["text"] = content[


### PR DESCRIPTION
The following error occurs with Anthropic models:
```
Traceback (most recent call last):
  File "/home/jakobdylanc/.local/lib/python3.11/site-packages/litellm/llms/prompt_templates/factory.py", line 696, in anthropic_messages_pt
    if new_messages[0]["role"] != "user":
       ~~~~~~~~~~~~^^^
IndexError: list index out of range
```
When passing a message object with "content" as an empty list:
```
{"role": "user", "content": []}
```