### PR TITLE
[Bug]: litellm proxy cli may log db credentials

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -26,8 +26,6 @@ except:
 
 
 def append_query_params(url, params):
-    print(f"url: {url}")
-    print(f"params: {params}")
     parsed_url = urlparse.urlparse(url)
     parsed_query = urlparse.parse_qs(parsed_url.query)
     parsed_query.update(params)


### PR DESCRIPTION
Database url can contain the db user credentials. For instance: `postgresql://user:password@server:port/...`

Hence, it seems better not to log this url.