### PR TITLE
Fix XML function calling args parsing.

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -727,9 +727,13 @@ def parse_xml_params(xml_content):
     root = ET.fromstring(xml_content)
     params = {}
     for child in root.findall(".//parameters/*"):
-        params[child.tag] = child.text
+        try:
+            # Attempt to decode the element's text as JSON
+            params[child.tag] = json.loads(child.text)
+        except json.JSONDecodeError:
+            # If JSON decoding fails, use the original text
+            params[child.tag] = child.text
     return params
-
 
 ###
 


### PR DESCRIPTION
This addresses the following issues, which deal with inconsistent function call arguments being returned as a result of a slight oversight in the XML parsing of said arguments:

https://github.com/BerriAI/litellm/issues/2639
https://github.com/jackmpcollins/magentic/issues/151

I'm unfamiliar with the `litellm` codebase, so I'm unsure where to add tests for this (if necessary), or if there is perhaps a cleaner way of doing this.

Happy with any suggestions. 