### PR TITLE
(feat) allow users to opt out of message merge - Anthropic

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -37,6 +37,7 @@ telemetry = True
 max_tokens = 256  # OpenAI Defaults
 drop_params = False
 modify_params = False
+disable_message_merge = False
 retry = True
 api_key: Optional[str] = None
 openai_key: Optional[str] = None

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -643,6 +643,10 @@ def anthropic_messages_pt(messages: list):
     """
     # add role=tool support to allow function call result/error submission
     user_message_types = {"user", "tool"}
+
+    if litellm.disable_message_merge == True:
+        return messages
+
     # reformat messages to ensure user/assistant are alternating, if there's either 2 consecutive 'user' messages or 2 consecutive 'assistant' message, merge them.
     new_messages = []
     msg_i = 0


### PR DESCRIPTION
Addressing https://github.com/BerriAI/litellm/discussions/2664 

Problem - LiteLLM will format messages to Anthropic to ensure the call does not drop. We (LiteLLM) believe default behavior should be the call should not fail/get rejected BUT a user should be able to opt out of LiteLLM applying any type of prompt formatting

## Usage
LiteLLM will not edit / re-order the message to anthropic 

```python
litellm.disable_message_merge == True
```

```
    """
    format messages for anthropic
    1. Anthropic supports roles like "user" and "assistant", (here litellm translates system-> assistant)
    2. The first message always needs to be of role "user"
    3. Each message must alternate between "user" and "assistant" (this is not addressed as now by litellm)
    4. final assistant content cannot end with trailing whitespace (anthropic raises an error otherwise)
    5. System messages are a separate param to the Messages API (used for tool calling)
    6. Ensure we only accept role, content. (message.name is not supported)
    """
```