### PR TITLE
Fix Ollama embedding

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -396,6 +396,7 @@ async def ollama_aembeddings(
 
         response_json = await response.json()
         embeddings = response_json["embedding"]
+        embeddings = [embeddings]  # Ollama currently does not support batch embedding
         ## RESPONSE OBJECT
         output_data = []
         for idx, embedding in enumerate(embeddings):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2759,6 +2759,12 @@ def embedding(
                 model_response=EmbeddingResponse(),
             )
         elif custom_llm_provider == "ollama":
+            api_base = (
+                litellm.api_base
+                or api_base
+                or get_secret("OLLAMA_API_BASE")
+                or "http://localhost:11434"
+            )
             ollama_input = None
             if isinstance(input, list) and len(input) > 1:
                 raise litellm.BadRequestError(
@@ -2779,6 +2785,7 @@ def embedding(
 
             if aembedding == True:
                 response = ollama.ollama_aembeddings(
+                    api_base=api_base,
                     model=model,
                     prompt=ollama_input,
                     encoding=encoding,


### PR DESCRIPTION
- Fix issue that api_base does not pass to `ollama_aembedding`.
  - #2674 
  - #1346 
- Fix response of `ollama_aembedding`

## Result for Python client

```python
import asyncio
from litellm import aembedding

async def test_gen_embedding():
    return await aembedding(
            model="ollama/nomic-embed-text:v1.5",
            input=["test litellm ollama nomic-embed-text v1.5"],
            api_base="http://ollama:11434",
            aembedding=True
            )

if __name__ == "__main__":
    resp = asyncio.run(test_gen_embedding())

    print(resp)
    print("-- done --")
```

output

```shell
EmbeddingResponse(model='nomic-embed-text:v1.5', data=[{'object': 'embedding', 'index': 0, 'embedding': [0.8573343753814697, -0.11661840975284576, -2.732269048690796, ... , -0.004214517772197723, -0.7543631792068481]}], object='list', usage={'prompt_tokens': 16, 'total_tokens': 16})
-- done --
```

## Result for Proxy

```shell
$ curl -X POST localhost:4000/embeddings -d '{"model": "llama2:7b", "input": ["What is my name?"]}' | jq
{
  "model": "llama2:7b",
  "data": [
    {
      "object": "embedding",
      "index": 0,
      "embedding": [
        -0.30056604743003845,
        1.0175423622131348,
        ....
        -1.1459767818450928,
        -1.0801223516464233
      ]
    }
  ],
  "object": "list",
  "usage": {
    "prompt_tokens": 5,
    "total_tokens": 5
  }
}
```

