### PR TITLE
Updating the default Claude3 max tokens

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -79,11 +79,13 @@ class AmazonTitanConfig:
 
 class AmazonAnthropicClaude3Config:
     """
-    Reference: https://us-west-2.console.aws.amazon.com/bedrock/home?region=us-west-2#/providers?model=claude
+    Reference:
+        https://us-west-2.console.aws.amazon.com/bedrock/home?region=us-west-2#/providers?model=claude
+        https://docs.anthropic.com/claude/docs/models-overview#model-comparison
 
     Supported Params for the Amazon / Anthropic Claude 3 models:
 
-    - `max_tokens` Required (integer) max tokens,
+    - `max_tokens` Required (integer) max tokens. Default is 4096
     - `anthropic_version` Required (string) version of anthropic for bedrock - e.g. "bedrock-2023-05-31"
     - `system` Optional (string) the system prompt, conversion from openai format to this is handled in factory.py
     - `temperature` Optional (float) The amount of randomness injected into the response
@@ -92,7 +94,7 @@ class AmazonAnthropicClaude3Config:
     - `stop_sequences` Optional (List[str]) Custom text sequences that cause the model to stop generating
     """
 
-    max_tokens: Optional[int] = litellm.max_tokens
+    max_tokens: Optional[int] = 4096  # Opus, Sonnet, and Haiku default
     anthropic_version: Optional[str] = "bedrock-2023-05-31"
     system: Optional[str] = None
     temperature: Optional[float] = None


### PR DESCRIPTION
# Summary
This change fixes LiteLLM's Bedrock Claude 3 integration so that ChatCompletion responses are not ended prematurely due to the default `max_token` value.

# About

The Bedrock Claude 3 APIs require that `max_tokens` be included in every request. LiteLLM was using the OpenAI default of 256 if `max_tokens` wasn't specified in the method call. The Claude 3 models have a max token of 4096 and the default of 256 would result in ChatCompletion responses that would prematurely end. This was often halfway through a sentence.

This PR updates the default to be equal to the max length of 4096. The 4096 matches the max tokens in the [Claude 3 documentation](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)

Note: Bedrock client actually accepts max_tokens far beyond what is in the documentation. For 'anthropic.claude-3-haiku-20240307-v1:0' the max accepted value is 204786. I don't think it's possible to generate responses this long though and the number provided in the documentation should be used by default.

# Testing

Verified that 4096 can be passed in for both Haiku and Sonnet
