### PR TITLE
🐞 fix: djl vllm support

### DIFF
--- a/litellm/llms/sagemaker.py
+++ b/litellm/llms/sagemaker.py
@@ -365,7 +365,10 @@ def completion(
     ## RESPONSE OBJECT
     completion_response = json.loads(response)
     try:
-        completion_response_choices = completion_response[0]
+        if isinstance(completion_response, list):
+            completion_response_choices = completion_response[0]
+        else:
+            completion_response_choices = completion_response
         completion_output = ""
         if "generation" in completion_response_choices:
             completion_output += completion_response_choices["generation"]
@@ -580,7 +583,10 @@ async def async_completion(
         ## RESPONSE OBJECT
         completion_response = json.loads(response)
         try:
-            completion_response_choices = completion_response[0]
+            if isinstance(completion_response, list):
+                completion_response_choices = completion_response[0]
+            else:
+                completion_response_choices = completion_response
             completion_output = ""
             if "generation" in completion_response_choices:
                 completion_output += completion_response_choices["generation"]


### PR DESCRIPTION
Using Sagemaker + Litellm for api.

Deploy llm on Sagemaker(djl-deepspeed)  from [here](https://github.com/deepjavalibrary/djl-demo/blob/master/aws/sagemaker/large-model-inference/sample-llm/vllm_deploy_llama_13b.ipynb), the predictor return format like this:

```
{"generated_text": " Tifa Lockhart: Tifa blinks twice and nods, showing", "details": {...}]}}
```
which is different from TGI response format:
```
[{"generated_text":"The diamondback terrapin was the first reptile to be protected by the..."}]
```

When using Litellm with config:

```
  - model_name: lmi-model
    litellm_params:
      model: sagemaker/lmi-model-240327-1319
      top_p: 0.97
      top_k: 20
      temperature: 0.77
```

A exception occurred when process result from sagemaker:

```
llm-provider-litellm-1  | INFO:     192.168.41.192:51666 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
llm-provider-litellm-1  | 05:37:52 - LiteLLM Router:INFO: router.py:477 - litellm.acompletion(model=sagemaker/lmi-model-240327-1319) Exception LiteLLM Error: Unable to parse sagemaker RAW RESPONSE {"generated_text": " Tifa Lockhart: Tifa blinks twice and nods, showing", "details": {...}]}}
llm-provider-litellm-1  | Traceback (most recent call last):
llm-provider-litellm-1  |   File "/usr/local/lib/python3.9/site-packages/litellm/llms/sagemaker.py", line 498, in async_completion
llm-provider-litellm-1  |     completion_response_choices = completion_response[0]
llm-provider-litellm-1  | KeyError: 0
llm-provider-litellm-1  |
llm-provider-litellm-1  |
llm-provider-litellm-1  | During handling of the above exception, another exception occurred:
llm-provider-litellm-1  |
llm-provider-litellm-1  |
llm-provider-litellm-1  | Traceback (most recent call last):
llm-provider-litellm-1  |   File "/usr/local/lib/python3.9/site-packages/litellm/main.py", line 284, in acompletion
llm-provider-litellm-1  |     response = await init_response
llm-provider-litellm-1  |   File "/usr/local/lib/python3.9/site-packages/litellm/llms/sagemaker.py", line 511, in async_completion
llm-provider-litellm-1  |     raise SagemakerError(
llm-provider-litellm-1  | litellm.llms.sagemaker.SagemakerError: LiteLLM Error: Unable to parse sagemaker RAW RESPONSE {"generated_text": " Tifa Lockhart: Tifa blinks twice and nods, showing", "details": {...}]}}
```

This pr is support vllm response format on sagemaker, which only return one choice.

