### PR TITLE
Add `trace_name` in Langfuse logging

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -246,13 +246,13 @@ class LangFuseLogger:
                 metadata_tags = metadata.get("tags", [])
                 tags = metadata_tags
 
-            generation_name = metadata.get("generation_name", None)
-            if generation_name is None:
-                # just log `litellm-{call_type}` as the generation name
-                generation_name = f"litellm-{kwargs.get('call_type', 'completion')}"
+            trace_name = metadata.get("trace_name", None)
+            if trace_name is None:
+                # just log `litellm-{call_type}` as the trace name
+                trace_name = f"litellm-{kwargs.get('call_type', 'completion')}"
 
             trace_params = {
-                "name": generation_name,
+                "name": trace_name,
                 "input": input,
                 "user_id": metadata.get("trace_user_id", user_id),
                 "id": metadata.get("trace_id", None),
@@ -311,6 +311,11 @@ class LangFuseLogger:
                     "completion_tokens": response_obj["usage"]["completion_tokens"],
                     "total_cost": cost if supports_costs else None,
                 }
+            generation_name = metadata.get("generation_name", None)
+            if generation_name is None:
+                # just log `litellm-{call_type}` as the generation name
+                generation_name = f"litellm-{kwargs.get('call_type', 'completion')}"
+
             generation_params = {
                 "name": generation_name,
                 "id": metadata.get("generation_id", generation_id),


### PR DESCRIPTION
# Motivation
The Langfuse integration does not allow to specify a `trace_name`. Currently, the `generation_name` is used also as `trace_name`.

Consider for example the following code:
```python
import litellm
from litellm import completion
import os

# from https://cloud.langfuse.com/
os.environ["LANGFUSE_PUBLIC_KEY"] = ""
os.environ["LANGFUSE_SECRET_KEY"] = ""

os.environ['OPENAI_API_KEY'] = ""

# set langfuse as a callback, litellm will send the data to langfuse
litellm.success_callback = ["langfuse"]

# set custom langfuse trace params and generation params
response = completion(
  model="gpt-3.5-turbo",
  messages=[
    {"role": "user", "content": "Hi 👋 - i'm openai"}
  ],
  metadata={
      "generation_name": "test-generation",  # set langfuse Generation Name
  },
)

print(response)
```
The resulting trace will look like (the given `generation_name` _test-generation_ is used also as `trace_name`.):
![image](https://github.com/BerriAI/litellm/assets/59694427/3fe07334-565f-42e9-b440-18eda6fcbab0)

# Usage
I would like to have the possibility to specify a `trace_name` in the following way:
```python
# set custom langfuse trace params and generation params
response = completion(
  model="gpt-3.5-turbo",
  messages=[
    {"role": "user", "content": "Hi 👋 - i'm openai"}
  ],
  metadata={
      "generation_name": "test-generation",  	# set langfuse Generation Name
      "trace_name": "test-trace",  		# set langfuse Trace Name
  },
)
``` 
The result will look like:
![image](https://github.com/BerriAI/litellm/assets/59694427/773caf50-4078-4c49-8062-fa7a30ba7201)

This PR allows to specify a `trace_name` using the metadata. If no `trace_name` is specified, the default will be `f"litellm-{kwargs.get('call_type', 'completion')}"` as for the `generation_name`.