### PR TITLE
(fix) bump uvicorn on proxy docker builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ fastapi>=0.109.1 # server dep
 pydantic>=2.5 # openai req. 
 backoff==2.2.1 # server dep
 pyyaml>=6.0.1 # server dep
-uvicorn==0.22.0 # server dep
+uvicorn==0.29.0 # server dep
 gunicorn==21.2.0 # server dep
 boto3==1.34.34 # aws bedrock/sagemaker calls
 redis==5.0.0 # caching


### PR DESCRIPTION
seeing `100ms` faster response times with uvicorn on proxy