### PR TITLE
Batch embedding for Ollama

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2795,29 +2795,19 @@ def embedding(
                 or get_secret("OLLAMA_API_BASE")
                 or "http://localhost:11434"
             )
-            ollama_input = None
-            if isinstance(input, list) and len(input) > 1:
-                raise litellm.BadRequestError(
-                    message=f"Ollama Embeddings don't support batch embeddings",
-                    model=model,  # type: ignore
-                    llm_provider="ollama",  # type: ignore
-                )
-            if isinstance(input, list) and len(input) == 1:
-                ollama_input = "".join(input[0])
-            elif isinstance(input, str):
-                ollama_input = input
-            else:
+            if isinstance(input ,str):
+                input = [input]
+            if not all(isinstance(item, str) for item in input):
                 raise litellm.BadRequestError(
                     message=f"Invalid input for ollama embeddings. input={input}",
                     model=model,  # type: ignore
                     llm_provider="ollama",  # type: ignore
                 )
-
-            if aembedding == True:
+            if aembedding:
                 response = ollama.ollama_aembeddings(
                     api_base=api_base,
                     model=model,
-                    prompt=ollama_input,
+                    prompts=input,
                     encoding=encoding,
                     logging_obj=logging,
                     optional_params=optional_params,


### PR DESCRIPTION
Enable Ollama batch embedding by calling Ollama endpoint multiple times according to the input length.

## Example

```python
import asyncio
from litellm import aembedding

async def test_gen_embedding():
    return await aembedding(
            model="ollama/nomic-embed-text:v1.5",
            input=["Hi Ollama!", "How are you?"],
            api_base="http://localhost:11434",
            )

if __name__ == "__main__":    
    resp = asyncio.run(test_gen_embedding())
    print(resp)
```

Output

```shell
EmbeddingResponse(
    model='nomic-embed-text:v1.5', 
    data=[
        {'object': 'embedding', 'index': 0, 'embedding': [0.544454038143158, 0.5679804682731628, ..., -0.18259337544441223]},
        {'object': 'embedding', 'index': 1, 'embedding': [-1.3663330078125, -1.5008107423782349, ..., 0.13399331271648407]}], 
    object='list', usage={'prompt_tokens': 9, 'total_tokens': 9}
)
```

# Related issue

#2710 