### PR TITLE
fix: still verify kid on single pub key fetched

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -114,7 +114,8 @@ class JWTHandler:
         public_key: Optional[dict] = None
 
         if len(keys) == 1:
-            public_key = keys[0]
+            if kid is None or key["kid"] == kid:
+                public_key = keys[0]
         elif len(keys) > 1:
             for key in keys:
                 if kid is not None and key["kid"] == kid:


### PR DESCRIPTION
A minor update on get_public_key function. In case of a single public key is returned  from JWKS endpoint and kid is provided. We still need to verify if kid match.