### PR TITLE
fixes for langchain text clients calling the proxy

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3144,13 +3144,15 @@ def text_completion(
     # these are the params supported by Completion() but not ChatCompletion
 
     # default case, non OpenAI requests go through here
-    messages = [{"role": "system", "content": prompt}]
+    # Need to look at this more as it will need more logic to handle bigger lists as above logic do for 2d lists
+    # removed kwargs as it contains only litellm params and not compatible with the completion client here
+    messages = [{"role": "system", "content": prompt[0]}]
     kwargs.pop("prompt", None)
     response = completion(
         model=model,
         messages=messages,
         *args,
-        **kwargs,
+        # **kwargs,
         **optional_params,
     )
     if kwargs.get("acompletion", False) == True:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8114,8 +8114,8 @@ async def get_routes():
 
     return {"routes": routes}
 
-# new endpoint for the azure lang chain client for text completion
-# probably reduntant can be removed and integradet with the original /completion endpoint after fixing issue number with async completion calls
+# new endpoint for the azure langchain client for text completion
+# # After fixing the issue with async completion calls, this can likely be removed and integrated with the original completion endpoint.
 @router.post(
     "/openai/deployments/{model:path}/completions",
     dependencies=[Depends(user_api_key_auth)],
@@ -8136,7 +8136,9 @@ async def completion(
         except:
             data = json.loads(body_str)
 
-        print(data)
+        query_params = dict(request.query_params)
+        if "api_version" in query_params:
+            data["api_version"] = query_params["api_version"]
         data["user"] = data.get("user", user_api_key_dict.user_id)
         data["model"] = (
             general_settings.get("completion_model", None)  # server default

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -118,6 +118,7 @@ from litellm.proxy.auth.auth_checks import (
     get_actual_routes,
 )
 from litellm.llms.custom_httpx.httpx_handler import HTTPHandler
+from litellm.utils import TextCompletionResponse, TextChoices
 
 try:
     from litellm._version import version
@@ -3106,7 +3107,25 @@ async def completion(
             )
 
         fastapi_response.headers["x-litellm-model-id"] = model_id
-        return response
+        # Try and generate a text completion response in order to comply with tools expecting text not chat responses like langchain text clients (return whatever we got in response if we can't modify the response)
+        # todo: refactor as a function in the text completion response
+        # todo: streaming response should follow as well
+        try:
+            text_response = TextCompletionResponse()
+            text_response["id"] = response.get("id", None)
+            text_response["object"] = "text_completion"
+            text_response["created"] = response.get("created", None)
+            text_response["model"] = response.get("model", None)
+            text_choices = TextChoices()
+            text_choices["text"] = response["choices"][0]["message"]["content"]
+            text_choices["index"] = response["choices"][0]["index"]
+            text_choices["finish_reason"] = response["choices"][0]["finish_reason"]
+            text_response["choices"] = [text_choices]
+            text_response["usage"] = response.get("usage", None)
+            return text_response
+        except Exception as e:
+            verbose_proxy_logger.debug("Error occurred converting to text completion object - Error:  %s",e)
+            return response
     except Exception as e:
         verbose_proxy_logger.debug("EXCEPTION RAISED IN PROXY MAIN.PY")
         verbose_proxy_logger.debug(
@@ -8094,6 +8113,146 @@ async def get_routes():
         routes.append(route_info)
 
     return {"routes": routes}
+
+# new endpoint for the azure lang chain client for text completion
+# probably reduntant can be removed and integradet with the original /completion endpoint after fixing issue number with async completion calls
+@router.post(
+    "/openai/deployments/{model:path}/completions",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["completions"],
+)
+async def completion(
+    request: Request,
+    fastapi_response: Response,
+    model: Optional[str] = None,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    global user_temperature, user_request_timeout, user_max_tokens, user_api_base
+    try:
+        body = await request.body()
+        body_str = body.decode()
+        try:
+            data = ast.literal_eval(body_str)
+        except:
+            data = json.loads(body_str)
+
+        print(data)
+        data["user"] = data.get("user", user_api_key_dict.user_id)
+        data["model"] = (
+            general_settings.get("completion_model", None)  # server default
+            or user_model  # model name passed via cli args
+            or model  # for azure deployments
+            or data["model"]  # default passed in http request
+        )
+        if user_model:
+            data["model"] = user_model
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["user_api_key"] = user_api_key_dict.api_key
+        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["user_api_key_alias"] = getattr(
+            user_api_key_dict, "key_alias", None
+        )
+        data["metadata"]["user_api_key_user_id"] = user_api_key_dict.user_id
+        data["metadata"]["user_api_key_team_id"] = getattr(
+            user_api_key_dict, "team_id", None
+        )
+        _headers = dict(request.headers)
+        _headers.pop(
+            "authorization", None
+        )  # do not store the original `sk-..` api key in the db
+        data["metadata"]["headers"] = _headers
+        data["metadata"]["endpoint"] = str(request.url)
+
+        # override with user settings, these are params passed via cli
+        if user_temperature:
+            data["temperature"] = user_temperature
+        if user_request_timeout:
+            data["request_timeout"] = user_request_timeout
+        if user_max_tokens:
+            data["max_tokens"] = user_max_tokens
+        if user_api_base:
+            data["api_base"] = user_api_base
+
+        ### MODEL ALIAS MAPPING ###
+        # check if model name in model alias map
+        # get the actual model name
+        if data["model"] in litellm.model_alias_map:
+            data["model"] = litellm.model_alias_map[data["model"]]
+
+        ### CALL HOOKS ### - modify incoming data before calling the model
+        data = await proxy_logging_obj.pre_call_hook(
+            user_api_key_dict=user_api_key_dict, data=data, call_type="completion"
+        )
+
+        start_time = time.time()
+
+        ### ROUTE THE REQUESTs ###
+        router_model_names = llm_router.model_names if llm_router is not None else []
+        # skip router if user passed their key
+        if "api_key" in data:            
+            response = await litellm.atext_completion(**data)
+        elif (
+            llm_router is not None and data["model"] in router_model_names
+        ):  # model in router model list
+            response = llm_router.text_completion(**data)
+        elif (
+            llm_router is not None
+            and llm_router.model_group_alias is not None
+            and data["model"] in llm_router.model_group_alias
+        ):  # model set in model_group_alias
+            response = await llm_router.atext_completion(**data)
+        elif (
+            llm_router is not None and data["model"] in llm_router.deployment_names
+        ):  # model in router deployments, calling a specific deployment on the router
+            response = await llm_router.atext_completion(
+                **data, specific_deployment=True
+            )
+        elif user_model is not None:  # `litellm --model <your-model-name>`
+            response = await litellm.atext_completion(**data)
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": "Invalid model name passed in"},
+            )
+
+        if hasattr(response, "_hidden_params"):
+            model_id = response._hidden_params.get("model_id", None) or ""
+        else:
+            model_id = ""
+
+        verbose_proxy_logger.debug("final response: %s", response)
+        if (
+            "stream" in data and data["stream"] == True
+        ):  # use generate_responses to stream responses
+            custom_headers = {"x-litellm-model-id": model_id}
+            selected_data_generator = select_data_generator(
+                response=response, user_api_key_dict=user_api_key_dict
+            )
+
+            return StreamingResponse(
+                selected_data_generator,
+                media_type="text/event-stream",
+                headers=custom_headers,
+            )
+
+        fastapi_response.headers["x-litellm-model-id"] = model_id
+        return response
+    except Exception as e:
+        verbose_proxy_logger.debug("EXCEPTION RAISED IN PROXY MAIN.PY")
+        verbose_proxy_logger.debug(
+            "\033[1;31mAn error occurred: %s\n\n Debug this by setting `--debug`, e.g. `litellm --model gpt-3.5-turbo --debug`",
+            e,
+        )
+        traceback.print_exc()
+        error_traceback = traceback.format_exc()
+        error_msg = f"{str(e)}"
+        raise ProxyException(
+            message=getattr(e, "message", error_msg),
+            type=getattr(e, "type", "None"),
+            param=getattr(e, "param", "None"),
+            code=getattr(e, "status_code", 500),
+        )
 
 
 #### TEST ENDPOINTS ####

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -864,6 +864,9 @@ class Router:
                 elif k == "metadata":
                     kwargs[k].update(v)
 
+            # for some reason python overrides the model parameter in data (which is correct for litellm) with the model alias in kwargs
+            if "model" in data and "model" in kwargs:
+                kwargs.pop("model")
             # call via litellm.completion()
             return litellm.text_completion(**{**data, "prompt": prompt, "caching": self.cache_responses, **kwargs})  # type: ignore
         except Exception as e:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -864,9 +864,6 @@ class Router:
                 elif k == "metadata":
                     kwargs[k].update(v)
 
-            # The model parameter in data (correct for LittLM.text_completion) is unexpectedly overridden by the model key which is the alias in kwargs for some reason making the call fail as it can't recgonize the model name.
-            if "model" in data and "model" in kwargs:
-                kwargs.pop("model")
             # call via litellm.completion()
             return litellm.text_completion(**{**data, "prompt": prompt, "caching": self.cache_responses, **kwargs})  # type: ignore
         except Exception as e:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -864,7 +864,7 @@ class Router:
                 elif k == "metadata":
                     kwargs[k].update(v)
 
-            # for some reason python overrides the model parameter in data (which is correct for litellm) with the model alias in kwargs
+            # The model parameter in data (correct for LittLM.text_completion) is unexpectedly overridden by the model key which is the alias in kwargs for some reason making the call fail as it can't recgonize the model name.
             if "model" in data and "model" in kwargs:
                 kwargs.pop("model")
             # call via litellm.completion()


### PR DESCRIPTION
## Issue being addressed
Trying to use langchain text model clients `AzureOpenAI, OpenAI` fails
1. AzureOpenAI uses `/openai/deployments/model_name/completions` to call the models which is not present in the proxy routes
2. OpenAI client fails to respond with a text response and replies with a chat response instead
3. async text completion when talking to azure returns a coroutine instead of a model response (tried to trace what exactly is not being awaited but failed)

## How to reproduce
in order to repro these issues you can use a simple python and langchain script to invoke a message to the litellm proxy

```python
from langchain_openai import AzureOpenAI, OpenAI

azurellm = AzureOpenAI(
    azure_deployment="gpt-35-instruct",
    api_key="sk-eh0S**************2Kry",
    azure_endpoint="http://localhost:4000",
    api_version="2024-02-01"
)
openaillm = OpenAI(
    model="gpt-35-instruct",
    api_key="sk-eh0S5X********************y",
    base_url="http://localhost:4000",
)
print(azurellm.invoke("how are you?"))
print(openaillm.invoke("how are you?"))
```
the above will generate the error messages.
```bash
#from the proxy logs for the azure client
INFO:     127.0.0.1:56904 - "POST /openai/deployments/gpt-35-instruct/completions?api-version=2024-02-01 HTTP/1.1" 404 Not Found
#from proxy logs before switching to normal text_completion for the both clients (tried to track where it's not awaiting the co routine but failed :C )
    raise ValueError(errors) from e
ValueError: [TypeError("'coroutine' object is not iterable"), TypeError('vars() argument must have __dict__ attribute')]

#from proxy logs after switching to normal text_completion for the openai client but not remove kwargs from the call
    raise APIConnectionError(
litellm.exceptions.APIConnectionError: Completions.create() got an unexpected keyword argument 'original_function'

#from proxy logs after switching to normal text_completion for the openai client and remove kwargs from the call but the prompt is being sent as empty string
No logs just gibberish responses

#from langchain client logs without returning a text model response
text
  none is not an allowed value (type=type_error.none.not_allowed)
```

