### PR TITLE
support cohere_chat in get_api_key

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5700,7 +5700,7 @@ def get_api_key(llm_provider: str, dynamic_api_key: Optional[str]):
     elif llm_provider == "baseten":
         api_key = api_key or litellm.baseten_key or get_secret("BASETEN_API_KEY")
     # cohere
-    elif llm_provider == "cohere":
+    elif llm_provider == "cohere" or llm_provider == "cohere_chat":
         api_key = api_key or litellm.cohere_key or get_secret("COHERE_API_KEY")
     # huggingface
     elif llm_provider == "huggingface":


### PR DESCRIPTION
I figure since get_llm_provider can return cohere_chat https://github.com/BerriAI/litellm/blob/main/litellm/utils.py#L5598 get_api_key should support it.