### PR TITLE
add test for rate limits - Router isn't coroutine safe

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -35,7 +35,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, model_list: list, routing_args: dict = {}):
+    def __init__(
+        self, router_cache: DualCache, model_list: list, routing_args: dict = {}
+    ):
         self.router_cache = router_cache
         self.model_list = model_list
         self.routing_args = RoutingArgs(**routing_args)
@@ -48,7 +50,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
-                model_group = kwargs["litellm_params"]["metadata"].get("model_group", None)
+                model_group = kwargs["litellm_params"]["metadata"].get(
+                    "model_group", None
+                )
 
                 id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
                 if model_group is None or id is None:
@@ -128,7 +132,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
-                model_group = kwargs["litellm_params"]["metadata"].get("model_group", None)
+                model_group = kwargs["litellm_params"]["metadata"].get(
+                    "model_group", None
+                )
 
                 id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
                 if model_group is None or id is None:
@@ -281,7 +287,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 deployment = _deployment
                 break
             elif (
-                item_tpm + input_tokens > _deployment_tpm or item_rpm + 1 > _deployment_rpm
+                item_tpm + input_tokens > _deployment_tpm
+                or item_rpm + 1 > _deployment_rpm
             ):  # if user passed in tpm / rpm in the model_list
                 continue
             elif item_latency < lowest_latency:

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -35,9 +35,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(
-        self, router_cache: DualCache, model_list: list, routing_args: dict = {}
-    ):
+    def __init__(self, router_cache: DualCache, model_list: list, routing_args: dict = {}):
         self.router_cache = router_cache
         self.model_list = model_list
         self.routing_args = RoutingArgs(**routing_args)
@@ -50,9 +48,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
-                model_group = kwargs["litellm_params"]["metadata"].get(
-                    "model_group", None
-                )
+                model_group = kwargs["litellm_params"]["metadata"].get("model_group", None)
 
                 id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
                 if model_group is None or id is None:
@@ -65,8 +61,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 {
                     {model_group}_map: {
                         id: {
-                            "latency": [..]  
-                            f"{date:hour:minute}" : {"tpm": 34, "rpm": 3}      
+                            "latency": [..]
+                            f"{date:hour:minute}" : {"tpm": 34, "rpm": 3}
                         }
                     }
                 }
@@ -132,9 +128,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
-                model_group = kwargs["litellm_params"]["metadata"].get(
-                    "model_group", None
-                )
+                model_group = kwargs["litellm_params"]["metadata"].get("model_group", None)
 
                 id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
                 if model_group is None or id is None:
@@ -147,8 +141,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 {
                     {model_group}_map: {
                         id: {
-                            "latency": [..]  
-                            f"{date:hour:minute}" : {"tpm": 34, "rpm": 3}      
+                            "latency": [..]
+                            f"{date:hour:minute}" : {"tpm": 34, "rpm": 3}
                         }
                     }
                 }
@@ -287,13 +281,10 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 deployment = _deployment
                 break
             elif (
-                item_tpm + input_tokens > _deployment_tpm
-                or item_rpm + 1 > _deployment_rpm
+                item_tpm + input_tokens > _deployment_tpm or item_rpm + 1 > _deployment_rpm
             ):  # if user passed in tpm / rpm in the model_list
                 continue
             elif item_latency < lowest_latency:
                 lowest_latency = item_latency
                 deployment = _deployment
-        if deployment is None:
-            deployment = random.choice(healthy_deployments)
         return deployment

--- a/litellm/tests/test_lowest_latency_routing.py
+++ b/litellm/tests/test_lowest_latency_routing.py
@@ -230,19 +230,11 @@ def test_get_available_endpoints_tpm_rpm_check_async(ans_rpm):
     d2 = [(lowest_latency_logger, "5678", 50, 0.01)] * non_ans_rpm
     asyncio.run(_gather_deploy([*d1, *d2]))
     ## CHECK WHAT'S SELECTED ##
-    print(dir(lowest_latency_logger))
-    print(
-        "availible",
-        lowest_latency_logger.get_available_deployments(
-            model_group=model_group, healthy_deployments=model_list
-        ),
+    d_ans = lowest_latency_logger.get_available_deployments(
+        model_group=model_group, healthy_deployments=model_list
     )
-    assert (
-        lowest_latency_logger.get_available_deployments(
-            model_group=model_group, healthy_deployments=model_list
-        )["model_info"]["id"]
-        == ans
-    )
+    print(d_ans)
+    assert (d_ans and d_ans["model_info"]["id"]) == ans
 
 
 # test_get_available_endpoints_tpm_rpm_check_async()
@@ -325,17 +317,11 @@ def test_get_available_endpoints_tpm_rpm_check(ans_rpm):
         )
 
     ## CHECK WHAT'S SELECTED ##
-    print(
-        lowest_latency_logger.get_available_deployments(
-            model_group=model_group, healthy_deployments=model_list
-        )
+    d_ans = lowest_latency_logger.get_available_deployments(
+        model_group=model_group, healthy_deployments=model_list
     )
-    assert (
-        lowest_latency_logger.get_available_deployments(
-            model_group=model_group, healthy_deployments=model_list
-        )["model_info"]["id"]
-        == ans
-    )
+    print(d_ans)
+    assert (d_ans and d_ans["model_info"]["id"]) == ans
 
 
 def test_router_get_available_deployments():

--- a/litellm/tests/test_lowest_latency_routing.py
+++ b/litellm/tests/test_lowest_latency_routing.py
@@ -9,7 +9,9 @@ from dotenv import load_dotenv
 load_dotenv()
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
 import pytest
 from litellm import Router
 from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
@@ -47,7 +49,8 @@ def test_latency_updated():
     )
     latency_key = f"{model_group}_map"
     assert (
-        end_time - start_time == test_cache.get_cache(key=latency_key)[deployment_id]["latency"][0]
+        end_time - start_time
+        == test_cache.get_cache(key=latency_key)[deployment_id]["latency"][0]
     )
 
 
@@ -195,7 +198,9 @@ async def _gather_deploy(all_deploys):
     return await asyncio.gather(*[_deploy(*t) for t in all_deploys])
 
 
-@pytest.mark.parametrize("ans_rpm", [1, 5])  # 1 should produce nothing, 10 should select first
+@pytest.mark.parametrize(
+    "ans_rpm", [1, 5]
+)  # 1 should produce nothing, 10 should select first
 def test_get_available_endpoints_tpm_rpm_check_async(ans_rpm):
     """
     Pass in list of 2 valid models
@@ -240,7 +245,9 @@ def test_get_available_endpoints_tpm_rpm_check_async(ans_rpm):
 # test_get_available_endpoints_tpm_rpm_check_async()
 
 
-@pytest.mark.parametrize("ans_rpm", [1, 5])  # 1 should produce nothing, 10 should select first
+@pytest.mark.parametrize(
+    "ans_rpm", [1, 5]
+)  # 1 should produce nothing, 10 should select first
 def test_get_available_endpoints_tpm_rpm_check(ans_rpm):
     """
     Pass in list of 2 valid models
@@ -409,7 +416,9 @@ def test_router_get_available_deployments():
 
 @pytest.mark.asyncio
 async def test_router_completion_streaming():
-    messages = [{"role": "user", "content": "Hello, can you generate a 500 words poem?"}]
+    messages = [
+        {"role": "user", "content": "Hello, can you generate a 500 words poem?"}
+    ]
     model = "azure-model"
     model_list = [
         {
@@ -459,8 +468,10 @@ async def test_router_completion_streaming():
         final_response = await router.acompletion(model=model, messages=messages)
         print(f"min deployment id: {picked_deployment}")
         print(f"model id: {final_response._hidden_params['model_id']}")
-        assert final_response._hidden_params["model_id"] == picked_deployment["model_info"]["id"]
+        assert (
+            final_response._hidden_params["model_id"]
+            == picked_deployment["model_info"]["id"]
+        )
 
 
 # asyncio.run(test_router_completion_streaming())
-# %%

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -42,6 +42,9 @@ def router_factory():
 
 
 def generate_list_of_messages(num_messages):
+    """
+    create num_messages new chat conversations
+    """
     return [
         [{"role": "user", "content": f"{i}. Hey, how's it going? {random.random()}"}]
         for i in range(num_messages)
@@ -49,6 +52,9 @@ def generate_list_of_messages(num_messages):
 
 
 def calculate_limits(list_of_messages):
+    """
+    Return the min rpm and tpm level that would let all messages in list_of_messages be sent this minute
+    """
     rpm = len(list_of_messages)
     tpm = sum((utils.token_counter(messages=m) + COMPLETION_TOKENS for m in list_of_messages))
     return rpm, tpm
@@ -68,36 +74,48 @@ class ExpectNoException(Exception):
 
 
 @pytest.mark.parametrize(
-    "num_messages, num_rate_limits",
+    "num_try_send, num_allowed_send",
     [
-        # (2, 30),  # No exception expected
-        # (2, 3),  # No exception expected
         (2, 2),  # No exception expected
+        (10, 10),  # No exception expected
         (3, 2),  # Expect ValueError
-        # (6, 5),  # Expect ValueError
+        (10, 9),  # Expect ValueError
     ],
 )
 @pytest.mark.parametrize("sync_mode", [True, False])  # Use parametrization for sync/async
-def test_rate_limit(router_factory, num_messages, num_rate_limits, sync_mode):
-    expected_exception = ExpectNoException if num_messages <= num_rate_limits else ValueError
+def test_rate_limit(router_factory, num_try_send, num_allowed_send, sync_mode):
+    """
+    Check if router.completion and router.acompletion can send more messages than they've been limited to.
+    Args:
+        router_factory: makes new router object, without any shared Global state
+        num_try_send (int): number of messages to try to send
+        num_allowed_send (int): max number of messages allowed to be sent in 1 minute
+        sync_mode (bool): if making sync (router.completion) or async (router.acompletion)
+    Raises:
+        ValueError: Error router throws when it hits rate limits
+        ExpectNoException: Signfies that no other error has happened. A NOP
+    """
+    # Can send more messages then we're going to; so don't expect a rate limit error
+    expected_exception = ExpectNoException if num_try_send <= num_allowed_send else ValueError
 
-    list_of_messages = generate_list_of_messages(max(num_messages, num_rate_limits))
-    rpm, tpm = calculate_limits(list_of_messages[:num_rate_limits])
-    list_of_messages = list_of_messages[:num_messages]
+    list_of_messages = generate_list_of_messages(max(num_try_send, num_allowed_send))
+    rpm, tpm = calculate_limits(list_of_messages[:num_allowed_send])
+    list_of_messages = list_of_messages[:num_try_send]
     router = router_factory(rpm, tpm)
 
-    with pytest.raises(expected_exception) as excinfo:
+    with pytest.raises(expected_exception) as excinfo:  # asserts correct type raised
         if sync_mode:
             results = sync_call(router, list_of_messages)
         else:
             results = asyncio.run(async_call(router, list_of_messages))
-            if len([i for i in results if i is not None]) != num_messages:
-                raise ValueError(
-                    "No deployments available for selected model"
-                )  # not all results got returned
+        print(results)
+        if len([i for i in results if i is not None]) != num_try_send:
+            # since not all results got returned, raise rate limit error
+            raise ValueError("No deployments available for selected model")
         raise ExpectNoException
 
-    if expected_exception is not ExpectNoException:
+    print(expected_exception, excinfo)
+    if expected_exception is ValueError:
         assert "No deployments available for selected model" in str(excinfo.value)
     else:
-        assert len([i for i in results if i is not None]) == num_messages
+        assert len([i for i in results if i is not None]) == num_try_send

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,99 @@
+# %%
+import asyncio
+import os
+import pytest
+import random
+from typing import Any
+
+from pydantic import BaseModel
+from litellm import utils, Router
+
+COMPLETION_TOKENS = 5
+base_model_list = [
+    {
+        "model_name": "gpt-3.5-turbo",
+        "litellm_params": {
+            "model": "gpt-3.5-turbo",
+            "api_key": os.getenv("OPENAI_API_KEY"),
+            "max_tokens": COMPLETION_TOKENS,
+        },
+    }
+]
+
+
+class RouterConfig(BaseModel):
+    rpm: int
+    tpm: int
+
+
+@pytest.fixture(scope="function")
+def router_factory():
+    def create_router(rpm, tpm):
+        model_list = base_model_list.copy()
+        model_list[0]["rpm"] = rpm
+        model_list[0]["tpm"] = tpm
+        return Router(
+            model_list=model_list,
+            routing_strategy="usage-based-routing",
+            debug_level="DEBUG",
+        )
+
+    return create_router
+
+
+def generate_list_of_messages(num_messages):
+    return [
+        [{"role": "user", "content": f"{i}. Hey, how's it going? {random.random()}"}]
+        for i in range(num_messages)
+    ]
+
+
+def calculate_limits(list_of_messages):
+    rpm = len(list_of_messages)
+    tpm = sum((utils.token_counter(messages=m) + COMPLETION_TOKENS for m in list_of_messages))
+    return rpm, tpm
+
+
+async def async_call(router: Router, list_of_messages) -> Any:
+    tasks = [router.acompletion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages]
+    return await asyncio.gather(*tasks)
+
+
+def sync_call(router: Router, list_of_messages) -> Any:
+    return [router.completion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages]
+
+
+class ExpectNoException(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    "num_messages, num_rate_limits",
+    [
+        # (2, 30),  # No exception expected
+        # (2, 3),  # No exception expected
+        (2, 2),  # No exception expected
+        (3, 2),  # Expect ValueError
+        # (6, 5),  # Expect ValueError
+    ],
+)
+@pytest.mark.parametrize("sync_mode", [True, False])  # Use parametrization for sync/async
+def test_rate_limit(router_factory, num_messages, num_rate_limits, sync_mode):
+    expected_exception = ExpectNoException if num_messages <= num_rate_limits else ValueError
+
+    list_of_messages = generate_list_of_messages(max(num_messages, num_rate_limits))
+    rpm, tpm = calculate_limits(list_of_messages[:num_rate_limits])
+    list_of_messages = list_of_messages[:num_messages]
+    router = router_factory(rpm, tpm)
+
+    with pytest.raises(expected_exception) as excinfo:
+        if sync_mode:
+            results = sync_call(router, list_of_messages)
+        else:
+            results = asyncio.run(async_call(router, list_of_messages))
+        raise ExpectNoException
+
+    if expected_exception is not ExpectNoException:
+        assert "No deployments available for selected model" in str(excinfo.value)
+    else:
+        assert len([i for i in results if i is not None]) == num_messages

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -91,6 +91,10 @@ def test_rate_limit(router_factory, num_messages, num_rate_limits, sync_mode):
             results = sync_call(router, list_of_messages)
         else:
             results = asyncio.run(async_call(router, list_of_messages))
+            if len([i for i in results if i is not None]) != num_messages:
+                raise ValueError(
+                    "No deployments available for selected model"
+                )  # not all results got returned
         raise ExpectNoException
 
     if expected_exception is not ExpectNoException:

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -56,17 +56,23 @@ def calculate_limits(list_of_messages):
     Return the min rpm and tpm level that would let all messages in list_of_messages be sent this minute
     """
     rpm = len(list_of_messages)
-    tpm = sum((utils.token_counter(messages=m) + COMPLETION_TOKENS for m in list_of_messages))
+    tpm = sum(
+        (utils.token_counter(messages=m) + COMPLETION_TOKENS for m in list_of_messages)
+    )
     return rpm, tpm
 
 
 async def async_call(router: Router, list_of_messages) -> Any:
-    tasks = [router.acompletion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages]
+    tasks = [
+        router.acompletion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages
+    ]
     return await asyncio.gather(*tasks)
 
 
 def sync_call(router: Router, list_of_messages) -> Any:
-    return [router.completion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages]
+    return [
+        router.completion(model="gpt-3.5-turbo", messages=m) for m in list_of_messages
+    ]
 
 
 class ExpectNoException(Exception):
@@ -77,22 +83,26 @@ class ExpectNoException(Exception):
     "num_try_send, num_allowed_send",
     [
         (2, 2),  # sending as many as allowed, ExpectNoException
-        (10, 10),  # sending as many as allowed, ExpectNoException
+        # (10, 10),  # sending as many as allowed, ExpectNoException
         (3, 2),  # Sending more than allowed, ValueError
-        (10, 9),  # Sending more than allowed, ValueError
+        # (10, 9),  # Sending more than allowed, ValueError
     ],
 )
-@pytest.mark.parametrize("sync_mode", [True, False])  # Use parametrization for sync/async
+@pytest.mark.parametrize(
+    "sync_mode", [True, False]
+)  # Use parametrization for sync/async
 @pytest.mark.parametrize(
     "routing_strategy",
     [
         "usage-based-routing",
         # "simple-shuffle", # dont expect to rate limit
         # "least-busy", # dont expect to rate limit
-        "latency-based-routing",
+        # "latency-based-routing",
     ],
 )
-def test_rate_limit(router_factory, num_try_send, num_allowed_send, sync_mode, routing_strategy):
+def test_rate_limit(
+    router_factory, num_try_send, num_allowed_send, sync_mode, routing_strategy
+):
     """
     Check if router.completion and router.acompletion can send more messages than they've been limited to.
     Args:
@@ -105,7 +115,9 @@ def test_rate_limit(router_factory, num_try_send, num_allowed_send, sync_mode, r
         ExpectNoException: Signfies that no other error has happened. A NOP
     """
     # Can send more messages then we're going to; so don't expect a rate limit error
-    expected_exception = ExpectNoException if num_try_send <= num_allowed_send else ValueError
+    expected_exception = (
+        ExpectNoException if num_try_send <= num_allowed_send else ValueError
+    )
 
     list_of_messages = generate_list_of_messages(max(num_try_send, num_allowed_send))
     rpm, tpm = calculate_limits(list_of_messages[:num_allowed_send])

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -76,10 +76,10 @@ class ExpectNoException(Exception):
 @pytest.mark.parametrize(
     "num_try_send, num_allowed_send",
     [
-        (2, 2),  # No exception expected
-        (10, 10),  # No exception expected
-        (3, 2),  # Expect ValueError
-        (10, 9),  # Expect ValueError
+        (2, 2),  # sending as many as allowed, ExpectNoException
+        # (10, 10),  # sending as many as allowed, ExpectNoException
+        (3, 2),  # Sending more than allowed, ValueError
+        # (10, 9),  # Sending more than allowed, ValueError
     ],
 )
 @pytest.mark.parametrize("sync_mode", [True, False])  # Use parametrization for sync/async


### PR DESCRIPTION
These tests show that if the a Router(routing_strategy="usage-based-routing") is called with asyncio.run then the rate limits will be bypassed. But if it's run non-concurrently then rate limits will be respected.

You'd need another layer of concurrency control to use Router in a thread-safe manner. That may be acceptable as long as the docs are updated.

The other strategies do not respect rate limits:  https://github.com/CLARKBENHAM/litellm/blob/clark/test_ratelimit_other_routing_strategies/tests/test_ratelimit.py

In response to ask for tests: https://github.com/BerriAI/litellm/issues/2153
and Issue https://github.com/BerriAI/litellm/issues/527