### PR TITLE
Update: gpt-4-turbo-preview pricing and context.  Included in docs.

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -159,6 +159,7 @@ os.environ["OPENAI_API_BASE"] = "openaiai-api-base"     # OPTIONAL
 
 | Model Name            | Function Call                                                   |
 |-----------------------|-----------------------------------------------------------------|
+| gpt-4-turbo-preview   | `response = completion(model="gpt-4-0125-preview", messages=messages)` |
 | gpt-4-0125-preview    | `response = completion(model="gpt-4-0125-preview", messages=messages)` |
 | gpt-4-1106-preview    | `response = completion(model="gpt-4-1106-preview", messages=messages)` |
 | gpt-3.5-turbo-1106    | `response = completion(model="gpt-3.5-turbo-1106", messages=messages)` |

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10,9 +10,9 @@
         "supports_function_calling": true
     },
     "gpt-4-turbo-preview": {
-        "max_tokens": 4096, 
-        "max_input_tokens": 8192,
-        "max_output_tokens": 4096, 
+        "max_tokens": 4096,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
         "input_cost_per_token": 0.00001,
         "output_cost_per_token": 0.00003,
         "litellm_provider": "openai",


### PR DESCRIPTION
## Updated pricing and context window of gpt4-turbo-preview.  

- gpt4-turbo-preview context window is currently 128,000 tokens.
[OpenAI gpt-4-and-gpt-4-turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo)
![Screenshot from 2024-04-03 10-53-55](https://github.com/BerriAI/litellm/assets/36689148/708e551c-012b-475c-941b-babd37399ca1)
- No changes were made to the _backup version.

## Updated documentation to include gpt4-turbo-preview.
 
- gpt4-turbo-preview serves a pointer to the latest gpt-4-XXXX-preview (Currently gpt-4-0125-preview).
[OpenAI continuous models](https://platform.openai.com/docs/models/continuous-model-upgrades)

- Confirmed the response model, see provided screen shot.
![Screenshot from 2024-04-03 10-54-53](https://github.com/BerriAI/litellm/assets/36689148/61611057-85ac-4aa4-9ded-c869e2d3bd2c)
