### PR TITLE
Fix link to providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ LiteLLM manages:
 - Set Budgets & Rate limits per project, api key, model [OpenAI Proxy Server](https://docs.litellm.ai/docs/simple_proxy)
 
 [**Jump to OpenAI Proxy Docs**](https://github.com/BerriAI/litellm?tab=readme-ov-file#openai-proxy---docs) <br>
-[**Jump to Supported LLM Providers**](https://github.com/BerriAI/litellm?tab=readme-ov-file#supported-provider-docs)
+[**Jump to Supported LLM Providers**](https://github.com/BerriAI/litellm?tab=readme-ov-file#supported-providers-docs)
 
 🚨 **Stable Release:** v1.34.1 
 


### PR DESCRIPTION
The link to supported providers is wrong, this fixes it.

PS.  I didn't check if there was already a PR for it.

Many thanks for the great work!