### PR TITLE
[integrations/langfuse] Use packaging over deprecated pkg_resources

### DIFF
--- a/litellm/integrations/lunary.py
+++ b/litellm/integrations/lunary.py
@@ -6,6 +6,8 @@ import dotenv
 import importlib
 import sys
 
+import packaging
+
 dotenv.load_dotenv()
 
 
@@ -56,13 +58,12 @@ class LunaryLogger:
     def __init__(self):
         try:
             import lunary
-            from pkg_resources import parse_version
 
             version = importlib.metadata.version("lunary")
             # if version < 0.1.43 then raise ImportError
-            if parse_version(version) < parse_version("0.1.43"):
+            if packaging.version.Version(version) < packaging.version.Version("0.1.43"):
                 print(
-                    "Lunary version outdated. Required: > 0.1.43. Upgrade via 'pip install lunary --upgrade'"
+                    "Lunary version outdated. Required: >= 0.1.43. Upgrade via 'pip install lunary --upgrade'"
                 )
                 raise ImportError
 


### PR DESCRIPTION
Fix #2818. `packaging` is already used in `integrations/langfuse.py`. Tested locally on Mac/Python3.12.

```
% python3 -m venv env
% source env/bin/activate
% pip install git+https://github.com/BerriAI/litellm.git@fcaa452ccd6f1216d4180a8314f1eccbe1adb8b1
% python3 -c "import litellm"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/nvankempen/env/lib/python3.12/site-packages/litellm/__init__.py", line 564, in <module>
    from .utils import (
  File "/Users/nvankempen/env/lib/python3.12/site-packages/litellm/utils.py", line 62, in <module>
    from .integrations.lunary import LunaryLogger
  File "/Users/nvankempen/env/lib/python3.12/site-packages/litellm/integrations/lunary.py", line 7, in <module>
    from pkg_resources import parse_version
ModuleNotFoundError: No module named 'pkg_resources'

% python3 -m venv env
% source env/bin/activate
% pip install git+https://github.com/nicovank/litellm.git@4270337092098a45d53507eceb3621692594c4b6
% python3 -c "import litellm"
# No error.
```