### PR TITLE
Updating the default Anthropic Officlal Claude 3 max_tokens to 4096

### DIFF
--- a/litellm/llms/anthropic.py
+++ b/litellm/llms/anthropic.py
@@ -37,12 +37,12 @@ class AnthropicError(Exception):
 
 class AnthropicConfig:
     """
-    Reference: https://docs.anthropic.com/claude/reference/complete_post
+    Reference: https://docs.anthropic.com/claude/reference/messages_post
 
     to pass metadata to anthropic, it's {"user_id": "any-relevant-information"}
     """
 
-    max_tokens: Optional[int] = litellm.max_tokens  # anthropic requires a default
+    max_tokens: Optional[int] = 4096  # anthropic requires a default value (Opus, Sonnet, and Haiku have the same default) 
     stop_sequences: Optional[list] = None
     temperature: Optional[int] = None
     top_p: Optional[int] = None
@@ -52,7 +52,7 @@ class AnthropicConfig:
 
     def __init__(
         self,
-        max_tokens: Optional[int] = 256,  # anthropic requires a default
+        max_tokens: Optional[int] = None,  # You can pass in a value yourself or use the default value 4096
         stop_sequences: Optional[list] = None,
         temperature: Optional[int] = None,
         top_p: Optional[int] = None,

--- a/litellm/llms/anthropic.py
+++ b/litellm/llms/anthropic.py
@@ -52,7 +52,7 @@ class AnthropicConfig:
 
     def __init__(
         self,
-        max_tokens: Optional[int] = None,  # You can pass in a value yourself or use the default value 4096
+        max_tokens: Optional[int] = 4096,  # You can pass in a value yourself or use the default value 4096
         stop_sequences: Optional[list] = None,
         temperature: Optional[int] = None,
         top_p: Optional[int] = None,


### PR DESCRIPTION
The default value of max_tokens used to be 256. If the client does not set a larger value, the model's output may be truncated, so the default value has been changed to 4096. This value is also the maximum output value described in the official interface. 
This PR is to fix: https://github.com/BerriAI/litellm/issues/2854