### PR TITLE
feat: add gemini-experimental to vertex ai

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -960,6 +960,17 @@
         "supports_function_calling": true,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
+    "gemini-experimental": {
+        "max_tokens": 8192,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "supports_function_calling": false,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
+    },
     "gemini-pro-vision": {
         "max_tokens": 2048,
         "max_input_tokens": 16384,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -960,6 +960,17 @@
         "supports_function_calling": true,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
+    "gemini-experimental": {
+        "max_tokens": 8192,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "supports_function_calling": false,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
+    },
     "gemini-pro-vision": {
         "max_tokens": 2048,
         "max_input_tokens": 16384,


### PR DESCRIPTION
`gemini-experimental` is a public preview of the Gemini 1.5 Pro model on Vertex AI: https://cloud.google.com/vertex-ai?hl=en

<img width="811" alt="image" src="https://github.com/BerriAI/litellm/assets/818368/d783ae2c-203e-4e00-9ba6-447a2f6fab9d">
