### PR TITLE
Fix issue #2832: Add protected_namespaces to Config class within utils.py, router.py and completion.py to avoid the warning message.

### DIFF
--- a/litellm/types/completion.py
+++ b/litellm/types/completion.py
@@ -32,5 +32,5 @@ class CompletionRequest(BaseModel):
     model_list: Optional[List[str]] = None
 
     class Config:
-        # allow kwargs
         extra = "allow"
+        protected_namespaces = ()      

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -12,6 +12,9 @@ class ModelConfig(BaseModel):
     tpm: int
     rpm: int
 
+    class Config:
+        protected_namespaces = ()     
+
 
 class RouterConfig(BaseModel):
     model_list: List[ModelConfig]
@@ -144,7 +147,7 @@ class Deployment(BaseModel):
     class Config:
         extra = "allow"
         protected_namespaces = ()      
-        
+
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
         return hasattr(self, key)

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -41,6 +41,8 @@ class RouterConfig(BaseModel):
         "latency-based-routing",
     ] = "simple-shuffle"
 
+    class Config:
+        protected_namespaces = ()      
 
 class ModelInfo(BaseModel):
     id: Optional[
@@ -141,7 +143,8 @@ class Deployment(BaseModel):
 
     class Config:
         extra = "allow"
-
+        protected_namespaces = ()      
+        
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
         return hasattr(self, key)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -236,6 +236,7 @@ class HiddenParams(OpenAIObject):
 
     class Config:
         extra = "allow"
+        protected_namespaces = ()      
 
     def get(self, key, default=None):
         # Custom .get() method to access attributes with a default value if the attribute doesn't exist


### PR DESCRIPTION
Fixes #2832

## Problem
The library was using Pydantic, and some of its models had attribute names that conflicted with Pydantic's protected namespaces. This caused warning messages to be generated when using these models. The affected files were:
- `types/router.py`
- `types/completion.py`
- `utils.py`

## Solution
To resolve the namespace conflicts and suppress the warning messages, I added a configuration to the affected models to disable Pydantic's namespace protection for these specific models. This allows the use of attribute names that conflict with the protected namespaces without triggering warnings.

```python
class Config:
    protected_namespaces = ()
```
By setting `protected_namespaces` to an empty tuple `()`, Pydantic's namespace protection is disabled for these specific models. This allows the use of attribute names that conflict with the protected namespaces without triggering warnings.

The changes were made in the following files:
- `types/router.py`
- `types/completion.py`
- `utils.py`

## Testing
To ensure that the changes resolved the issue, I ran the affected code and verified that no warning messages related to Pydantic namespace conflicts were generated. 

## Additional Notes
Disabling the namespace protection should be done with caution, as it may potentially lead to naming conflicts if attribute names unintentionally match the protected namespaces. However, in this case, the attribute names causing the conflicts were intentional and necessary for the library's functionality.

Please let me know if you have any questions or feedback regarding this pull request. Thank you for considering this contribution!