### PR TITLE
fix datetime json serialize error in langsmith integration

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -53,6 +53,8 @@ class LangsmithLogger:
                 value = kwargs[key]
                 if key == "start_time" or key == "end_time":
                     pass
+                elif type(value) == datetime.datetime:
+                    new_kwargs[key] = value.isoformat()
                 elif type(value) != dict:
                     new_kwargs[key] = value
 


### PR DESCRIPTION
The `kwargs` object may contains `datetime` type values, convert them to str to avoid json serialization error.