### PR TITLE
ollama: vision: remove prefix info from base64 data

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -93,6 +93,11 @@ def ollama_pt(
                             prompt += element["text"]
                         elif element["type"] == "image_url":
                             image_url = element["image_url"]["url"]
+
+                            # remove prefix info from base64 data if present (ex. "data:image/jpeg;base64,")
+                            if image_url.startswith("data:") and ";base64," in image_url:
+                                image_url = image_url.split(";base64,", 1)[1]
+
                             images.append(image_url)
         return {"prompt": prompt, "images": images}
     else:


### PR DESCRIPTION
When using ollama with the llava vision model, you will get an error when including prefix info in the base64 image data (ex. `data:image/jpeg;base64,`) per the OpenAI API format. LiteLLM can remove this prefix info and prevent the error.

Solves this issue: https://github.com/BerriAI/litellm/issues/1427