### PR TITLE
Default model_name to None in _aembedding

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1073,6 +1073,7 @@ class Router:
             raise e
 
     async def _aembedding(self, input: Union[str, List], model: str, **kwargs):
+        model_name = None
         try:
             verbose_router_logger.debug(
                 f"Inside _aembedding()- model: {model}; kwargs: {kwargs}"


### PR DESCRIPTION
If `model_name` doesn't get set before an exception happens, an exception in the exception handling itself will occur [here](https://github.com/BerriAI/litellm/pull/2981/files#diff-b0c899fae4bf607df1d0d1a3b170246a0f9d2b5dfe230c48e4539c78222ecc57L1133).

This PR fixes it by setting `model_name` to `None` as a fallback.