### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-/docs
-/cookbook
-/.circleci
-/.github
-/tests
+docs
+cookbook
+.circleci
+.github
+tests


### PR DESCRIPTION
docs, cookbook, .circleci, .github and tests do end up in the final image
```
❯ docker run --rm --entrypoint "/bin/ls" ghcr.io/berriai/litellm-database:main-v1.35.0 -a
.
..
.circleci
<omitted for brevity>
.github
<omitted for brevity>
cookbook
deploy
docker
docker-compose.yml
docs
<omitted for brevity>
tests
ui
```
Locally (on MacOs) they do not end up in the image. I suspect it is a difference in how mac and linux parse the .dockerignore file. But this should fix it (tested on MacOs).

(This showed up during a security scan, there is a known and fixable vulnerability in `loader-utils` in the docs dependencies.
From our logs: The vulnerability can be remediated by updating the library to version `2.0.3` or higher, using `yarn upgrade loader-utils`)