### PR TITLE
[test] - Test /health endpoints

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -86,7 +86,12 @@ async def perform_health_check(
             return [], []
 
     if model is not None:
-        model_list = [x for x in model_list if x["litellm_params"]["model"] == model]
+        _new_model_list = [
+            x for x in model_list if x["litellm_params"]["model"] == model
+        ]
+        if _new_model_list == []:
+            _new_model_list = [x for x in model_list if x["model_name"] == model]
+        model_list = _new_model_list
 
     healthy_endpoints, unhealthy_endpoints = await _perform_health_check(model_list)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -280,7 +280,7 @@ async def test_add_model_run_health():
 
         print("calling /health?model=", model_name)
         _health_info = await get_model_health(
-            session=session, key=key, model_name="azure/chatgpt-v-2"
+            session=session, key=key, model_name=model_name
         )
         _healthy_endpooint = _health_info["healthy_endpoints"][0]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -269,7 +269,7 @@ async def test_add_model_run_health():
         model_name = f"azure-model-health-check-{model_id}"
         print("adding model", model_name)
         await add_model_for_health_checking(session=session, model_id=model_id)
-        await asyncio.sleep(10)
+        await asyncio.sleep(30)
         print("calling /model/info")
         await get_model_info(session=session, key=key)
         print("calling v2/model/info")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,7 +41,7 @@ async def get_models(session, key):
     async with session.get(url, headers=headers) as response:
         status = response.status
         response_text = await response.text()
-
+        print("response from /models")
         print(response_text)
         print()
 
@@ -207,24 +207,6 @@ async def add_model_for_health_checking(session, model_id="123"):
         response_text = await response.text()
 
         print(f"Add models {response_text}")
-        print()
-
-        if status != 200:
-            raise Exception(f"Request did not return a 200 status code: {status}")
-
-
-async def get_model_info(session, key):
-    url = "http://0.0.0.0:4000/model/info"
-    headers = {
-        "Authorization": f"Bearer {key}",
-        "Content-Type": "application/json",
-    }
-
-    async with session.get(url, headers=headers) as response:
-        status = response.status
-        response_text = await response.text()
-        print("response from /model/info")
-        print(response_text)
         print()
 
         if status != 200:


### PR DESCRIPTION
We had a bug where a user could run 
- `/model/new`
- `/model/info`
- `/health` -> `/health` was failing since `/model/info` would pop the api_key from the inmemory router 


Added testing for this scenario to ensure we don't have a regression around this 