### PR TITLE
[Fix] Load proxy models when proxy starts up 

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3186,6 +3186,11 @@ async def startup_event():
                 seconds=30,
                 args=[prisma_client, proxy_logging_obj],
             )
+
+            # this will load all existing models on proxy startup
+            await proxy_config.add_deployment(
+                prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj
+            )
         scheduler.start()
 
 


### PR DESCRIPTION
instantly load proxy models if I have my models stored in the DB. 

I don't want to wait 30 seconds for my model to get loaded in when I start the proxy 