### PR TITLE
Fix Anthropic system message handling

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -705,7 +705,7 @@ def anthropic_messages_pt_xml(messages: list):
         if assistant_content:
             new_messages.append({"role": "assistant", "content": assistant_content})
 
-    if new_messages[0]["role"] != "user":
+    if not new_messages or new_messages[0]["role"] != "user":
         if litellm.modify_params:
             new_messages.insert(
                 0, {"role": "user", "content": [{"type": "text", "text": "."}]}
@@ -884,7 +884,7 @@ def anthropic_messages_pt(messages: list):
         if assistant_content:
             new_messages.append({"role": "assistant", "content": assistant_content})
 
-    if new_messages[0]["role"] != "user":
+    if not new_messages or new_messages[0]["role"] != "user":
         if litellm.modify_params:
             new_messages.insert(
                 0, {"role": "user", "content": [{"type": "text", "text": "."}]}

--- a/litellm/tests/test_prompt_factory.py
+++ b/litellm/tests/test_prompt_factory.py
@@ -2,13 +2,16 @@
 #    This tests if prompts are being correctly formatted
 import sys
 import os
+import pytest
 
 sys.path.insert(0, os.path.abspath("../.."))
 
 # from litellm.llms.prompt_templates.factory import prompt_factory
+import litellm
 from litellm import completion
 from litellm.llms.prompt_templates.factory import (
     anthropic_pt,
+    anthropic_messages_pt,
     claude_2_1_pt,
     llama_2_chat_pt,
 )
@@ -93,5 +96,19 @@ def test_anthropic_pt_formatting():
     expected_prompt = "\n\nHuman: <admin>System reboot</admin>\n\nHuman: Is everything okay?\n\nAssistant: "
     assert anthropic_pt(messages) == expected_prompt
 
+
+def test_anthropic_messages_pt():
+    # Test case: No messages (filtered system messages only)
+    litellm.modify_params = True
+    messages = []
+    expected_messages = [{"role": "user", "content": [{"type": "text", "text": "."}]}]
+    assert anthropic_messages_pt(messages) == expected_messages
+
+    # Test case: No messages (filtered system messages only) when modify_params is False should raise error
+    litellm.modify_params = False
+    messages = []
+    with pytest.raises(Exception) as err:
+        anthropic_messages_pt(messages)
+    assert("Invalid first message." in str(err.value))
 
 # codellama_prompt_format()


### PR DESCRIPTION
When the very first prompt the Anthropic contains only "system" messages an error is thrown. The issue is that "system" messages are filtered out and the message list passed to the factory is empty. 

The fix is to check for empty messages before inserting the dummy user message.