### PR TITLE
Fix new line issue in cohere_message_pt

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -1033,7 +1033,8 @@ def cohere_message_pt(messages: list):
             tool_result = convert_openai_message_to_cohere_tool_result(message)
             tool_results.append(tool_result)
         else:
-            prompt += message["content"]
+            prompt += message["content"] + "\n\n"
+    prompt = prompt.rstrip()
     return prompt, tool_results
 
 


### PR DESCRIPTION
Fixes new line issue in cohere chat. 

Previously, LiteLLM was concatenating the messages without any spaces between them.

e.g. 
```
curl -X POST \
https://api.cohere.ai/v1/chat \
-H 'accept: application/json' -H 'content-type: application/json' -H 'Authorization: Bearer ********************' \
-d '{'model': 'command-r', 'message': 'Use the browser to answer any questionshello', 'stream': True, 'tools': [{'name': 'browser', 'description': 'searching the internet', 'parameter_definitions': {'url': {'description': '', 'type': 'string', 'required': True}}}, {'name': 'mathassistant', 'description': 'for answering math questions', 'parameter_definitions': {'input': {'description': '', 'type': 'string', 'required': True}}}]}'
```