### PR TITLE
Add missing tool_calls and name to messages

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -145,6 +145,12 @@ def mistral_api_pt(messages):
         elif isinstance(m["content"], str):
             texts = m["content"]
         new_m = {"role": m["role"], "content": texts}
+
+        if new_m["role"] == "tool" and m.get("name"):
+            new_m["name"] = m["name"]
+        if m.get("tool_calls"):
+            new_m["tool_calls"] = m["tool_calls"]
+
         new_messages.append(new_m)
     return new_messages
 


### PR DESCRIPTION
I have added missing tool_calls and name (tool name) attributes to messages array for Mistral API. It is needed to add function calls to messages array before passing the function call result.