### PR TITLE
[FIX] -  show vertex_project, vertex_location in Vertex AI exceptions

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -341,6 +341,7 @@ async def acompletion(
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=completion_kwargs,
+            extra_kwargs=kwargs,
         )
 
 
@@ -2137,6 +2138,7 @@ def completion(
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=args,
+            extra_kwargs=kwargs,
         )
 
 
@@ -2498,6 +2500,7 @@ async def aembedding(*args, **kwargs):
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=args,
+            extra_kwargs=kwargs,
         )
 
 
@@ -2939,7 +2942,10 @@ def embedding(
         )
         ## Map to OpenAI Exception
         raise exception_type(
-            model=model, original_exception=e, custom_llm_provider=custom_llm_provider
+            model=model,
+            original_exception=e,
+            custom_llm_provider=custom_llm_provider,
+            extra_kwargs=kwargs,
         )
 
 
@@ -3033,6 +3039,7 @@ async def atext_completion(*args, **kwargs):
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=args,
+            extra_kwargs=kwargs,
         )
 
 
@@ -3370,6 +3377,7 @@ async def aimage_generation(*args, **kwargs):
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=args,
+            extra_kwargs=kwargs,
         )
 
 
@@ -3569,6 +3577,7 @@ def image_generation(
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=locals(),
+            extra_kwargs=kwargs,
         )
 
 
@@ -3618,6 +3627,7 @@ async def atranscription(*args, **kwargs):
             custom_llm_provider=custom_llm_provider,
             original_exception=e,
             completion_kwargs=args,
+            extra_kwargs=kwargs,
         )
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7800,14 +7800,22 @@ def exception_type(
                     # add model, deployment and model_group to the exception message
                     _model = completion_kwargs.get("model")
                     _kwargs = completion_kwargs.get("kwargs", {}) or {}
+                    _vertex_project = completion_kwargs.get("vertex_project")
+                    _vertex_location = completion_kwargs.get("vertex_location")
+
                     _metadata = _kwargs.get("metadata", {}) or {}
                     _model_group = _metadata.get("model_group")
                     _deployment = _metadata.get("deployment")
+
                     error_str += f"\nmodel: {_model}\n"
                     if _model_group is not None:
                         error_str += f"model_group: {_model_group}\n"
                     if _deployment is not None:
                         error_str += f"deployment: {_deployment}\n"
+                    if _vertex_project is not None:
+                        error_str += f"vertex_project: {_vertex_project}\n"
+                    if _vertex_location is not None:
+                        error_str += f"vertex_location: {_vertex_location}\n"
 
                 if (
                     "Vertex AI API has not been used in project" in error_str

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7302,6 +7302,7 @@ def exception_type(
     original_exception,
     custom_llm_provider,
     completion_kwargs={},
+    extra_kwargs={},
 ):
     global user_logger_fn, liteDebuggerClient
     exception_mapping_worked = False
@@ -7799,15 +7800,14 @@ def exception_type(
                 if completion_kwargs is not None:
                     # add model, deployment and model_group to the exception message
                     _model = completion_kwargs.get("model")
-                    _kwargs = completion_kwargs.get("kwargs", {}) or {}
-                    _vertex_project = completion_kwargs.get("vertex_project")
-                    _vertex_location = completion_kwargs.get("vertex_location")
-
-                    _metadata = _kwargs.get("metadata", {}) or {}
+                    error_str += f"\nmodel: {_model}\n"
+                if extra_kwargs is not None:
+                    _vertex_project = extra_kwargs.get("vertex_project")
+                    _vertex_location = extra_kwargs.get("vertex_location")
+                    _metadata = extra_kwargs.get("metadata", {}) or {}
                     _model_group = _metadata.get("model_group")
                     _deployment = _metadata.get("deployment")
 
-                    error_str += f"\nmodel: {_model}\n"
                     if _model_group is not None:
                         error_str += f"model_group: {_model_group}\n"
                     if _deployment is not None:


### PR DESCRIPTION
## More Detailed Vertex Exceptions 

example
```shell
Message: LLM API call failed: VertexAIException - 503 Getting metadata from plugin failed with error: Reauthentication is needed. Please run gcloud auth application-default login to reauthenticate.
model: vertex_ai/gemini-1.0-pro-vision-001
model_group: gemini
deployment: vertex_ai/gemini-1.0-pro-vision-001
vertex_project: project-id
vertex_location: us-central1
```