### PR TITLE
Load google ADC before init AnthropicVertex

### DIFF
--- a/litellm/llms/vertex_ai_anthropic.py
+++ b/litellm/llms/vertex_ai_anthropic.py
@@ -123,7 +123,7 @@ class VertexAIAnthropicConfig:
 
 
 """
-- Run client init 
+- Run client init
 - Support async completion, streaming
 """
 
@@ -236,15 +236,17 @@ def completion(
         if client is None:
             if vertex_credentials is not None and isinstance(vertex_credentials, str):
                 import google.oauth2.service_account
-
-                json_obj = json.loads(vertex_credentials)
-
                 creds = (
                     google.oauth2.service_account.Credentials.from_service_account_info(
-                        json_obj,
+                        json.loads(vertex_credentials),
                         scopes=["https://www.googleapis.com/auth/cloud-platform"],
                     )
                 )
+                ### CHECK IF ACCESS
+                access_token = refresh_auth(credentials=creds)
+            else:
+                import google.auth
+                creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
                 ### CHECK IF ACCESS
                 access_token = refresh_auth(credentials=creds)
 


### PR DESCRIPTION
This is the continuation for #3150 with the fix.

---

`anthropic-python-sdk` somehow forces the credential to have a `project_id`, otherwise, it aborts and complains:
```
{
    "error": {
        "message": "Could not resolve project_id",
        "type": null,
        "param": null,
        "code": 500
    }
}
```

This is problematic when serving Vertex AI models from multiple different GCP projects. `vertex_ai_project` set in the config should always take precedence instead of the `project_id` associated with the credential.

A fix was also sent to upstream `anthropic-python-sdk`: https://github.com/anthropics/anthropic-sdk-python/pull/468