### PR TITLE
Added openrouter/meta-llama/llama-3-70b-instruct context and cost metrics

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1535,6 +1535,13 @@
         "litellm_provider": "openrouter",
         "mode": "chat"
     },
+    "openrouter/meta-llama/llama-3-70b-instruct": {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0.0000008,
+        "output_cost_per_token": 0.0000008,
+        "litellm_provider": "openrouter",
+        "mode": "chat"
+    },
     "j2-ultra": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,


### PR DESCRIPTION
Per https://openrouter.ai/models/meta-llama/llama-3-70b-instruct

Meta: Llama 3 70B Instruct
meta-llama/llama-3-70b-instruct

Updated Apr 18
8,192 context
$0.8/M input tkns
$0.8/M output tkns