### PR TITLE
Update langfuse in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ google-cloud-aiplatform==1.47.0 # for vertex ai calls
 anthropic[vertex]==0.21.3
 google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
-langfuse==2.7.3 # for langfuse self-hosted logging
+langfuse==2.27.1 # for langfuse self-hosted logging
 datadog-api-client==2.23.0 # for datadog logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
 orjson==3.9.15 # fast /embedding responses


### PR DESCRIPTION
df60e475e8dbfac4ffc0474f88faa48abeac900d locked the Langfuse package down to `2.7.3`. I'm not 100% sure if this is causing any issues yet.. but it's honestly just faster to update the package instead of me going through the UI and looking for several minutes to make sure everything is working as it was previously. =P 