### PR TITLE
[Feat] Show model, api base in APITimeoutError exceptions

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -82,14 +82,18 @@ class UnprocessableEntityError(UnprocessableEntityError):  # type: ignore
 
 class Timeout(APITimeoutError):  # type: ignore
     def __init__(self, message, model, llm_provider):
-        self.status_code = 408
-        self.message = message
-        self.model = model
-        self.llm_provider = llm_provider
         request = httpx.Request(method="POST", url="https://api.openai.com/v1")
         super().__init__(
             request=request
         )  # Call the base class constructor with the parameters it needs
+        self.status_code = 408
+        self.message = message
+        self.model = model
+        self.llm_provider = llm_provider
+
+    # custom function to convert to str
+    def __str__(self):
+        return str(self.message)
 
 
 class PermissionDeniedError(PermissionDeniedError):  # type:ignore

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1765,7 +1765,7 @@ class Logging:
                                     "reaches greenscale for streaming logging!"
                                 )
                                 result = kwargs["complete_streaming_response"]
-          
+
                         greenscaleLogger.log_event(
                             kwargs=kwargs,
                             response_obj=result,
@@ -7415,11 +7415,18 @@ def exception_type(
                 exception_type = type(original_exception).__name__
             else:
                 exception_type = ""
+            _api_base = ""
+            try:
+                _api_base = litellm.get_api_base(
+                    model=model, optional_params=extra_kwargs
+                )
+            except:
+                _api_base = ""
 
             if "Request Timeout Error" in error_str or "Request timed out" in error_str:
                 exception_mapping_worked = True
                 raise Timeout(
-                    message=f"APITimeoutError - Request timed out",
+                    message=f"APITimeoutError - Request timed out. \n model: {model} \n api_base: {_api_base} \n error_str: {error_str}",
                     model=model,
                     llm_provider=custom_llm_provider,
                 )


### PR DESCRIPTION
## LiteLLM APITimeoutError 
```json
{
  "error": {
    "message": "APITimeoutError - Request timed out. \n model: azure/chatgpt-v-2 \n api_base: https://openai-gpt-4-test-v-1.openai.azure.com/ \n error_str: Request timed out.",
    "type": null,
    "param": null,
    "code": 408
  }
}
```

## On slack 
<img width="504" alt="Screenshot 2024-04-24 at 2 08 44 PM" src="https://github.com/BerriAI/litellm/assets/29436595/32020fb0-7a9c-4333-83aa-ebf7bc49ac8c">

