### PR TITLE
fix Llama models messages to prompt conversion for AWS Bedrock

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -653,6 +653,10 @@ def convert_messages_to_prompt(model, messages, provider, custom_prompt_dict):
         prompt = prompt_factory(
             model=model, messages=messages, custom_llm_provider="bedrock"
         )
+    elif provider == "meta":
+        prompt = prompt_factory(
+            model=model, messages=messages, custom_llm_provider="bedrock"
+        )
     else:
         prompt = ""
         for message in messages:

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -1346,6 +1346,16 @@ def prompt_factory(
                 return anthropic_pt(messages=messages)
         elif "mistral." in model:
             return mistral_instruct_pt(messages=messages)
+        elif "llama2" in model:
+            return llama_2_chat_pt(messages=messages)
+        elif "llama3" in model:
+            return hf_chat_template(
+                model=model,
+                messages=messages,
+                chat_template=known_tokenizer_config[  # type: ignore
+                    "meta-llama/Meta-Llama-3-8B-Instruct"
+                ]["tokenizer"]["chat_template"],
+            )
     elif custom_llm_provider == "perplexity":
         for message in messages:
             message.pop("name", None)

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -1346,9 +1346,9 @@ def prompt_factory(
                 return anthropic_pt(messages=messages)
         elif "mistral." in model:
             return mistral_instruct_pt(messages=messages)
-        elif "llama2" in model:
+        elif "llama2" in model and "chat" in model:
             return llama_2_chat_pt(messages=messages)
-        elif "llama3" in model:
+        elif "llama3" in model and "instruct" in model:
             return hf_chat_template(
                 model=model,
                 messages=messages,


### PR DESCRIPTION
Fix: #3297

----
@krrishdholakia I saw that you added support for Llama-3 recently in commit [df7db2b](https://github.com/BerriAI/litellm/commit/df7db2b870d2e1201888bb625c446e4473759ffb) but that didn't cover Llama Bedrock models.

Please let me know if this looks good otherwise.