### PR TITLE
fix optional_params for mistral

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5413,7 +5413,8 @@ def get_optional_params(
         for k in passed_params.keys():
             if k not in default_params.keys():
                 extra_body[k] = passed_params[k]
-        optional_params["extra_body"] = extra_body
+        existing_extra_body = optional_params.get("extra_body", {})
+        optional_params["extra_body"] = {**existing_extra_body,**extra_body}
     else:
         # if user passed in non-default kwargs for specific providers/models, pass them along
         for k in passed_params.keys():

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5265,6 +5265,8 @@ def get_optional_params(
             optional_params["tools"] = tools
         if tool_choice is not None:
             optional_params["tool_choice"] = tool_choice
+        if response_format is not None:
+            optional_params["response_format"] = response_format
 
         # check safe_mode, random_seed: https://docs.mistral.ai/api/#operation/createChatCompletion
         safe_mode = passed_params.pop("safe_mode", None)


### PR DESCRIPTION
While using the mistral ai api through litellm, we noticed that some parameters are not passed correctly:

1. Even though `response_format` is listed as a parameter for mistral in `get_supported_openai_params`, it is not being transferred to `optional_params`.
2. `random_seed` is stored in `optional_params["extra_body"]`, but later `optional_params["extra_body"]` is overwritten by an empty dictionary towards the end of the function.

I am not fully familiar with the overall logic yet, but as far as I know, addressing these points should resolve both problems. If it introduces new issues, please let me know.