### PR TITLE
fix: incorrect analysis for vertex ai env vars causing confusion

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6563,7 +6563,7 @@ def validate_environment(model: Optional[str] = None) -> dict:
             if "VERTEXAI_PROJECT" in os.environ and "VERTEXAI_LOCATION" in os.environ:
                 keys_in_environment = True
             else:
-                missing_keys.extend(["VERTEXAI_PROJECT", "VERTEXAI_PROJECT"])
+                missing_keys.extend(["VERTEXAI_PROJECT", "VERTEXAI_LOCATION"])
         elif custom_llm_provider == "huggingface":
             if "HUGGINGFACE_API_KEY" in os.environ:
                 keys_in_environment = True


### PR DESCRIPTION
I was trying to use Litellm with Vertex AI, and was confused since I received the following output:

```
The following environment vars weren't found but were necessary for the model vertex_ai/gemini-1.0-pro: ['VERTEXAI_PROJECT', 'VERTEXAI_PROJECT']
```

Turns out only setting the `VERTEXAI_PROJECT` variable wasn't enough, and when I dug into the code, I noticed a minor mistake that resulted in the confusion. (I needed to set `VERTEXAI_LOCATION` too!)

I've made the fix, and I hope this helps!