### PR TITLE
fix(main.py): use model_api_key determined from get_api_key

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -775,6 +775,12 @@ def completion(
 
         if dynamic_api_key is not None:
             api_key = dynamic_api_key
+        if api_key is None:
+            # Priority order
+            #   1. dynamic_api_key of get_llm_provider()
+            #   2. api_key of Parameters
+            #   3. model_api_key of get_api_key()
+            api_key = model_api_key
         # check if user passed in any of the OpenAI optional params
         optional_params = get_optional_params(
             functions=functions,


### PR DESCRIPTION
## Title

fix(main.py): use model_api_key determined from get_api_key

## Relevant issues

None

## Type

🧹 Refactoring

## Changes

- set model_api_key as api_key

## Testing

1. export ANTHROPIC_API_KEY=XXX
2. use litellm.completion() without api_key.

```
import os
from litellm import completion

model="anthropic/claude-3-haiku-20240307"
messages = [{"role": "user", "content": "Hey! how's it going?"}]
response = completion(model=model, messages=messages)
print(response)
```

## Notes

I thought this fix made it possible to read ANTHROPIC_API_KEY, but I can no longer reproduce it.
Perhaps one of the following would have worked:
In any case, I think it is better to include processing using model_api_key.

- LITELLM_LOCAL_MODEL_COST_MAP="True"
- It depends on message length or someting.



<!-- Points to note for the reviewer, consultation content, concerns -->

## Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
