### PR TITLE
[Fix] Lowest Latency routing - random pick deployments when all latencies=0

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -312,6 +312,8 @@ class LowestLatencyLoggingHandler(CustomLogger):
         except:
             input_tokens = 0
 
+        all_deployments = random.sample(all_deployments.items(), len(all_deployments))
+        all_deployments = dict(all_deployments)
         for item, item_map in all_deployments.items():
             ## get the item from model list
             _deployment = None

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -312,7 +312,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
         except:
             input_tokens = 0
 
-        all_deployments = random.sample(all_deployments.items(), len(all_deployments))
+        # randomly sample from all_deployments, incase all deployments have latency=0.0
+        _items = all_deployments.items()
+        all_deployments = random.sample(list(_items), len(_items))
         all_deployments = dict(all_deployments)
         for item, item_map in all_deployments.items():
             ## get the item from model list


### PR DESCRIPTION
 When all deployments are latency=0, it should randomly pick a deployment