### PR TITLE
Add return_exceptions to litellm.batch_completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ litellm/proxy/_new_secret_config.yaml
 litellm/proxy/_new_secret_config.yaml
 litellm/proxy/_super_secret_config.yaml
 litellm/proxy/_super_secret_config.yaml
+.python-version
+litellm/llms/tokenizers/9b5ad71b2ce5302211f9c61530b329a4922fc6a4

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2303,6 +2303,7 @@ def batch_completion(
         user (str, optional): The user string for generating completions. Defaults to "".
         deployment_id (optional): The deployment ID for generating completions. Defaults to None.
         request_timeout (int, optional): The request timeout for generating completions. Defaults to None.
+        return_exceptions (bool): Whether to return exceptions and partial results when exceptions occur. Defaults to False.
 
     Returns:
         list: A list of completion results.
@@ -2361,7 +2362,17 @@ def batch_completion(
                     completions.append(future)
 
         # Retrieve the results from the futures
-        results = [future.result() for future in completions]
+        # results = [future.result() for future in completions]
+        if return_exceptions:
+            results = []
+            for future in completions:
+                try:
+                    results.append(future.result())
+                except Exception as exc:
+                    results.append(exc)
+        else:
+            results = [future.result() for future in completions]
+
     return results
 
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2143,7 +2143,7 @@ def completion(
             """
             assume input to custom LLM api bases follow this format:
             resp = requests.post(
-                api_base, 
+                api_base,
                 json={
                     'model': 'meta-llama/Llama-2-13b-hf', # model name
                     'params': {
@@ -2280,6 +2280,7 @@ def batch_completion(
     deployment_id=None,
     request_timeout: Optional[int] = None,
     timeout: Optional[int] = 600,
+    return_exceptions: bool = False,
     # Optional liteLLM function params
     **kwargs,
 ):

--- a/litellm/tests/test_batch_completion_return_exceptions.py
+++ b/litellm/tests/test_batch_completion_return_exceptions.py
@@ -1,0 +1,29 @@
+"""Test batch_completion's return_exceptions."""
+import pytest
+import litellm
+
+msg1 = [{"role": "user", "content": "hi 1"}]
+msg2 = [{"role": "user", "content": "hi 2"}]
+
+
+def test_batch_completion_return_exceptions_default():
+    """Test batch_completion's return_exceptions."""
+    with pytest.raises(Exception):
+        _ = litellm.batch_completion(
+            model="gpt-3.5-turbo",
+            messages=[msg1, msg2],
+            api_key="sk_xxx",  # deliberately set invalid key
+            # return_exceptions=False,
+        )
+
+
+def test_batch_completion_return_exceptions_true():
+    """Test batch_completion's return_exceptions."""
+    res = litellm.batch_completion(
+        model="gpt-3.5-turbo",
+        messages=[msg1, msg2],
+        api_key="sk_xxx",  # deliberately set invalid key
+        return_exceptions=True,
+    )
+
+    assert isinstance(res[0], litellm.exceptions.AuthenticationError)


### PR DESCRIPTION
This PR adds a kwarg ``return_exceptions`` to litellm.batch_completion. When `return_exceptions` is set to False (default),  `batch_completion` behaves exactly as before. But when batch_completion is set to `True`, batch_completion will return exceptions and partial resuslt instead of throwing exceptions.

The idea of `return_exceptions` is borrowed from `asyncio.gather`. `batch_completion` makes use of `concurrent.futures.ProcessPoolExecutor to run multiple copies of `litellm.completion`.  However, `litellm.completion` may fail and throw exceptions. When this happens, the patched `batch_completion` will return partial results when `return_exceptions` is set to True. 

   ``return_exceptions`` can be useful in many scenarios.