### PR TITLE
add_function_to_prompt bug fix

### DIFF
--- a/litellm/tests/test_get_optional_params_functions_not_supported.py
+++ b/litellm/tests/test_get_optional_params_functions_not_supported.py
@@ -1,0 +1,9 @@
+import litellm
+from litellm import get_optional_params
+
+litellm.add_function_to_prompt = True
+optional_params = get_optional_params(
+    tools= [{'type': 'function', 'function': {'description': 'Get the current weather in a given location', 'name': 'get_current_weather', 'parameters': {'type': 'object', 'properties': {'location': {'type': 'string', 'description': 'The city and state, e.g. San Francisco, CA'}, 'unit': {'type': 'string', 'enum': ['celsius', 'fahrenheit']}}, 'required': ['location']}}}],
+    tool_choice= 'auto',
+)
+assert optional_params is not None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5769,7 +5769,7 @@ def get_optional_params(
         optional_params["extra_body"] = extra_body
     else:
         # if user passed in non-default kwargs for specific providers/models, pass them along
-        for k in passed_params.keys():
+        for k in list(passed_params.keys()):
             if k not in default_params.keys():
                 optional_params[k] = passed_params[k]
     print_verbose(f"Final returned optional params: {optional_params}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4932,6 +4932,7 @@ def get_optional_params(
             and custom_llm_provider != "mistral"
             and custom_llm_provider != "anthropic"
             and custom_llm_provider != "cohere_chat"
+            and custom_llm_provider != "cohere"
             and custom_llm_provider != "bedrock"
             and custom_llm_provider != "ollama_chat"
         ):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4956,7 +4956,7 @@ def get_optional_params(
                 litellm.add_function_to_prompt
             ):  # if user opts to add it to prompt instead
                 optional_params["functions_unsupported_model"] = non_default_params.pop(
-                    "tools", non_default_params.pop("functions")
+                    "tools", non_default_params.pop("functions", None)
                 )
             else:
                 raise UnsupportedParamsError(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4836,7 +4836,7 @@ def get_optional_params(
     **kwargs,
 ):
     # retrieve all parameters passed to the function
-    passed_params = locals()
+    passed_params = locals().copy()
     special_params = passed_params.pop("kwargs")
     for k, v in special_params.items():
         if k.startswith("aws_") and (
@@ -5770,7 +5770,7 @@ def get_optional_params(
         optional_params["extra_body"] = extra_body
     else:
         # if user passed in non-default kwargs for specific providers/models, pass them along
-        for k in list(passed_params.keys()):
+        for k in passed_params.keys():
             if k not in default_params.keys():
                 optional_params[k] = passed_params[k]
     print_verbose(f"Final returned optional params: {optional_params}")


### PR DESCRIPTION
This blows up when there's no "functions" in the dictionary even when tools is present because the inner function executes regardless (does not short circuit).