### PR TITLE
added back the traceloop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ anthropic[vertex]==0.21.3
 google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
 langfuse==2.27.1 # for langfuse self-hosted logging
+traceloop-sdk==0.5.3 # for open telemetry logging
 datadog-api-client==2.23.0 # for datadog logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
 orjson==3.9.15 # fast /embedding responses


### PR DESCRIPTION
## Traceloop sdk package was missing in requirement.txt

🐛 Bug Fix

## Changes

* Added back the `traceloop-sdk==0.5.3 # for open telemetry logging` by looking into the old commit

## Relevant issues

Fixes #3421