### PR TITLE
fixes #3264 and adds team_alias to /global/spend/teams

### DIFF
--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -216,7 +216,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
             // in total_spend_per_team, replace null team_id with "" and replace null total_spend with 0
 
             total_spend_per_team = total_spend_per_team.map((tspt: any) => {
-              tspt["name"] = tspt["team_id"] || "";
+              tspt["name"] = tspt["team_alias"] || "";
               tspt["value"] = tspt["total_spend"] || 0;
               return tspt;
             })


### PR DESCRIPTION
## Fix /global/spend/teams team_alias and team_id
Fixes #3264 so that team_alias is actually the team_alias and team_id is team_id.

## Relevant issues
Fixes #3264 

## Type
🐛 Bug Fix

## Changes
Modifies `proxy_server.py:global_spend_per_tea()` to select with group by team_id AND team_alias, changes `total_spend_per_team` to be keyed by `team_id`

## Testing
Verified via manual testing with the proxy UI and cURL.

## OS Tests (optional but appreciated):
- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
