### PR TITLE
feat(bedrock.py): Add Cloudflare AI Gateway support

### DIFF
--- a/litellm/tests/test_bedrock_completion.py
+++ b/litellm/tests/test_bedrock_completion.py
@@ -66,6 +66,41 @@ def test_completion_bedrock_claude_completion_auth():
 
 # test_completion_bedrock_claude_completion_auth()
 
+def test_completion_bedrock_cloudflare_ai_gateway():
+    print("calling bedrock with cloudflare ai gateway")
+    import os
+
+    aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+    aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+    aws_region_name = os.environ["AWS_REGION_NAME"]
+    aws_bedrock_runtime_endpoint = f"https://gateway.ai.cloudflare.com/v1/0399b10e77ac6668c80404a5ff49eb37/litellm-test/aws-bedrock/bedrock-runtime/{aws_region_name}"
+
+    os.environ.pop("AWS_ACCESS_KEY_ID", None)
+    os.environ.pop("AWS_SECRET_ACCESS_KEY", None)
+    os.environ.pop("AWS_REGION_NAME", None)
+
+    try:
+        response = completion(
+            model="bedrock/amazon.titan-text-express-v1",
+            messages=messages,
+            max_tokens=10,
+            temperature=0.1,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_region_name=aws_region_name,
+            aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint
+        )
+        # Add any assertions here to check the response
+        print(response)
+
+        os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
+        os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+        os.environ["AWS_REGION_NAME"] = aws_region_name
+    except RateLimitError:
+        pass
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
 
 def test_completion_bedrock_claude_2_1_completion_auth():
     print("calling bedrock claude 2.1 completion params auth")


### PR DESCRIPTION
## Title

This adds Cloudflare AI Gateway support for Bedrock.

## Relevant issues

Resolves #1040.

## Type

🆕 New Feature
🚄 Infrastructure

## Changes

We add a boto3 hook to modify the URL after signing, but before invoking.

## Testing

```yaml
model_list:
  - model_name: claude-3-haiku-20240307
    litellm_params:
      model: bedrock/anthropic.claude-3-haiku-20240307-v1:0
      aws_region_name: us-east-1
      max_tokens: 4096
      aws_bedrock_runtime_endpoint: https://gateway.ai.cloudflare.com/v1/ACCOUNT_ID_HERE/GATEWAY_ID_HERE/aws-bedrock/bedrock-runtime/us-east-1
```

```sh
curl -v "${OPENAI_API_BASE}/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "claude-3-haiku-20240307",
    "max_tokens": 100,
    "temperature": 1.0,
    "messages": [
      {
        "role": "user",
        "content": "Tell a joke."
      }
    ]
  }'
```

## Notes

Cloudflare AI Gateway seems to break support for streaming at the moment, not sure why.

```sh
curl -v "${OPENAI_API_BASE}/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "claude-3-haiku-20240307",
    "max_tokens": 100,
    "temperature": 1.0,
    "stream": true,
    "messages": [
      {
        "role": "user",
        "content": "Tell a joke."
      }
    ]
  }'
```

```
data: {"error": {"message": "Header length of 3216834560 exceeded the maximum of 131072\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py\", line 3159, in async_data_generator\n    async for chunk in response:\n  File \"/usr/local/lib/python3.11/site-packages/litellm/utils.py\", line 10971, in __anext__\n    raise e\n  File \"/usr/local/lib/python3.11/site-packages/litellm/utils.py\", line 10903, in __anext__\n    chunk = next(self.completion_stream)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 602, in __iter__\n    for event in self._event_generator:\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 611, in _create_raw_event_generator\n    yield from event_stream_buffer\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 544, in __next__\n    return self.next()\n           ^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 536, in next\n    self._prelude = self._parse_prelude()\n                    ^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 480, in _parse_prelude\n    self._validate_prelude(prelude)\n  File \"/usr/local/lib/python3.11/site-packages/botocore/eventstream.py\", line 471, in _validate_prelude\n    raise InvalidHeadersLength(prelude.headers_length)\nbotocore.eventstream.InvalidHeadersLength: Header length of 3216834560 exceeded the maximum of 131072\n", "type": "None", "param": "None", "code": 500}}
```

## Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [X] Tested on Linux
