### PR TITLE
Fix Ollama streamed tool calls. Set finish_reason to tool_calls for all tool_calls responses

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -225,6 +225,7 @@ def get_ollama_response(
             ],
         )
         model_response["choices"][0]["message"] = message
+        model_response["choices"][0]["finish_reason"] = "tool_calls"
     else:
         model_response["choices"][0]["message"]["content"] = response_json["response"]
     model_response["created"] = int(time.time())
@@ -377,6 +378,7 @@ async def ollama_acompletion(url, data, model_response, encoding, logging_obj):
                     ],
                 )
                 model_response["choices"][0]["message"] = message
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
             else:
                 model_response["choices"][0]["message"]["content"] = response_json[
                     "response"

--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -1,3 +1,4 @@
+from itertools import chain
 import requests, types, time
 import json, uuid
 import traceback

--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -213,7 +213,7 @@ def get_ollama_response(
 
     ## RESPONSE OBJECT
     model_response["choices"][0]["finish_reason"] = "stop"
-    if optional_params.get("format", "") == "json":
+    if data.get("format", "") == "json":
         function_call = json.loads(response_json["response"])
         message = litellm.Message(
             content=None,

--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -255,8 +255,34 @@ def ollama_completion_stream(url, data, logging_obj):
                 custom_llm_provider="ollama",
                 logging_obj=logging_obj,
             )
-            for transformed_chunk in streamwrapper:
-                yield transformed_chunk
+            # If format is JSON, this was a function call
+            # Gather all chunks and return the function call as one delta to simplify parsing
+            if data.get("format", "") == "json":
+                first_chunk = next(streamwrapper)
+                response_content = "".join(
+                    chunk.choices[0].delta.content
+                    for chunk in chain([first_chunk], streamwrapper)
+                    if chunk.choices[0].delta.content
+                )
+
+                function_call = json.loads(response_content)
+                delta = litellm.utils.Delta(
+                    content=None,
+                    tool_calls=[
+                        {
+                            "id": f"call_{str(uuid.uuid4())}",
+                            "function": {"name": function_call["name"], "arguments": json.dumps(function_call["arguments"])},
+                            "type": "function",
+                        }
+                    ],
+                )
+                model_response = first_chunk
+                model_response["choices"][0]["delta"] = delta
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
+                yield model_response
+            else:
+                for transformed_chunk in streamwrapper:
+                    yield transformed_chunk
         except Exception as e:
             raise e
 
@@ -278,8 +304,36 @@ async def ollama_async_streaming(url, data, model_response, encoding, logging_ob
                 custom_llm_provider="ollama",
                 logging_obj=logging_obj,
             )
-            async for transformed_chunk in streamwrapper:
-                yield transformed_chunk
+
+            # If format is JSON, this was a function call
+            # Gather all chunks and return the function call as one delta to simplify parsing
+            if data.get("format", "") == "json":
+                first_chunk = await anext(streamwrapper)
+                first_chunk_content = first_chunk.choices[0].delta.content or ""
+                response_content = first_chunk_content + "".join(
+                    [
+                    chunk.choices[0].delta.content
+                    async for chunk in streamwrapper
+                    if chunk.choices[0].delta.content]
+                )
+                function_call = json.loads(response_content)
+                delta = litellm.utils.Delta(
+                    content=None,
+                    tool_calls=[
+                        {
+                            "id": f"call_{str(uuid.uuid4())}",
+                            "function": {"name": function_call["name"], "arguments": json.dumps(function_call["arguments"])},
+                            "type": "function",
+                        }
+                    ],
+                )
+                model_response = first_chunk
+                model_response["choices"][0]["delta"] = delta
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
+                yield model_response
+            else:
+                async for transformed_chunk in streamwrapper:
+                    yield transformed_chunk
     except Exception as e:
         traceback.print_exc()
         raise e

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -298,6 +298,7 @@ def get_ollama_response(
             ],
         )
         model_response["choices"][0]["message"] = message
+        model_response["choices"][0]["finish_reason"] = "tool_calls"
     else:
         model_response["choices"][0]["message"] = response_json["message"]
     model_response["created"] = int(time.time())
@@ -480,6 +481,7 @@ async def ollama_acompletion(
                     ],
                 )
                 model_response["choices"][0]["message"] = message
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
             else:
                 model_response["choices"][0]["message"] = response_json["message"]
 

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -395,6 +395,7 @@ async def ollama_async_streaming(
                 custom_llm_provider="ollama_chat",
                 logging_obj=logging_obj,
             )
+
             # If format is JSON, this was a function call
             # Gather all chunks and return the function call as one delta to simplify parsing
             if data.get("format", "") == "json":

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -1,3 +1,4 @@
+from itertools import chain
 import requests, types, time
 import json, uuid
 import traceback
@@ -335,8 +336,35 @@ def ollama_completion_stream(url, api_key, data, logging_obj):
                 custom_llm_provider="ollama_chat",
                 logging_obj=logging_obj,
             )
-            for transformed_chunk in streamwrapper:
-                yield transformed_chunk
+
+            # If format is JSON, this was a function call
+            # Gather all chunks and return the function call as one delta to simplify parsing
+            if data.get("format", "") == "json":
+                first_chunk = next(streamwrapper)
+                response_content = "".join(
+                    chunk.choices[0].delta.content
+                    for chunk in chain([first_chunk], streamwrapper)
+                    if chunk.choices[0].delta.content
+                )
+
+                function_call = json.loads(response_content)
+                delta = litellm.utils.Delta(
+                    content=None,
+                    tool_calls=[
+                        {
+                            "id": f"call_{str(uuid.uuid4())}",
+                            "function": {"name": function_call["name"], "arguments": json.dumps(function_call["arguments"])},
+                            "type": "function",
+                        }
+                    ],
+                )
+                model_response = first_chunk
+                model_response["choices"][0]["delta"] = delta
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
+                yield model_response
+            else:
+                for transformed_chunk in streamwrapper:
+                    yield transformed_chunk
         except Exception as e:
             raise e
 
@@ -366,8 +394,35 @@ async def ollama_async_streaming(
                 custom_llm_provider="ollama_chat",
                 logging_obj=logging_obj,
             )
-            async for transformed_chunk in streamwrapper:
-                yield transformed_chunk
+            # If format is JSON, this was a function call
+            # Gather all chunks and return the function call as one delta to simplify parsing
+            if data.get("format", "") == "json":
+                first_chunk = await anext(streamwrapper)
+                first_chunk_content = first_chunk.choices[0].delta.content or ""
+                response_content = first_chunk_content + "".join(
+                    [
+                    chunk.choices[0].delta.content
+                    async for chunk in streamwrapper
+                    if chunk.choices[0].delta.content]
+                )
+                function_call = json.loads(response_content)
+                delta = litellm.utils.Delta(
+                    content=None,
+                    tool_calls=[
+                        {
+                            "id": f"call_{str(uuid.uuid4())}",
+                            "function": {"name": function_call["name"], "arguments": json.dumps(function_call["arguments"])},
+                            "type": "function",
+                        }
+                    ],
+                )
+                model_response = first_chunk
+                model_response["choices"][0]["delta"] = delta
+                model_response["choices"][0]["finish_reason"] = "tool_calls"
+                yield model_response
+            else:
+                async for transformed_chunk in streamwrapper:
+                    yield transformed_chunk
     except Exception as e:
         traceback.print_exc()
 

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -2,6 +2,8 @@ import sys, os
 import traceback
 from dotenv import load_dotenv
 
+from litellm.utils import ModelResponse
+
 load_dotenv()
 import os, io
 
@@ -1439,6 +1441,162 @@ def test_completion_ollama_hosted():
 
 
 # test_completion_ollama_hosted()
+
+
+@pytest.mark.parametrize(("model"), [
+        "ollama/llama2",
+        "ollama_chat/llama2",
+    ]
+)
+def test_completion_ollama_function_call(model):
+    messages = [{"role": "user", "content": "What's the weather like in San Francisco?"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    try:
+        litellm.set_verbose = True
+        response = litellm.completion(model=model, messages=messages, tools=tools)
+        print(response)
+        assert response.choices[0].message.tool_calls
+        assert response.choices[0].message.tool_calls[0].function.name == "get_current_weather"
+        assert response.choices[0].finish_reason == "tool_calls"
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
+@pytest.mark.parametrize(("model"), [
+        "ollama/llama2",
+        "ollama_chat/llama2",
+    ]
+)
+def test_completion_ollama_function_call_stream(model):
+    messages = [{"role": "user", "content": "What's the weather like in San Francisco?"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    try:
+        litellm.set_verbose = True
+        response = litellm.completion(model=model, messages=messages, tools=tools, stream=True)
+        print(response)
+        first_chunk = next(response)
+        assert first_chunk.choices[0].delta.tool_calls
+        assert first_chunk.choices[0].delta.tool_calls[0].function.name == "get_current_weather"
+        assert first_chunk.choices[0].finish_reason == "tool_calls"
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
+@pytest.mark.parametrize(("model"), [
+        "ollama/llama2",
+        "ollama_chat/llama2",
+    ]
+)
+@pytest.mark.asyncio
+async def test_acompletion_ollama_function_call(model):
+    messages = [{"role": "user", "content": "What's the weather like in San Francisco?"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    try:
+        litellm.set_verbose = True
+        response = await litellm.acompletion(model=model, messages=messages, tools=tools)
+        print(response)
+        assert response.choices[0].message.tool_calls
+        assert response.choices[0].message.tool_calls[0].function.name == "get_current_weather"
+        assert response.choices[0].finish_reason == "tool_calls"
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
+@pytest.mark.parametrize(("model"), [
+        "ollama/llama2",
+        "ollama_chat/llama2",
+    ]
+)
+@pytest.mark.asyncio
+async def test_acompletion_ollama_function_call_stream(model):
+    messages = [{"role": "user", "content": "What's the weather like in San Francisco?"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    try:
+        litellm.set_verbose = True
+        response = await litellm.acompletion(model=model, messages=messages, tools=tools, stream=True)
+        print(response)
+        first_chunk = await anext(response)
+        assert first_chunk.choices[0].delta.tool_calls
+        assert first_chunk.choices[0].delta.tool_calls[0].function.name == "get_current_weather"
+        assert first_chunk.choices[0].finish_reason == "tool_calls"
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
 
 
 def test_completion_openrouter1():

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -2,8 +2,6 @@ import sys, os
 import traceback
 from dotenv import load_dotenv
 
-from litellm.utils import ModelResponse
-
 load_dotenv()
 import os, io
 


### PR DESCRIPTION
## Title

Fix Ollama streamed tool calls. Set finish_reason to tool_calls for all tool_calls responses

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/3333
Fixes https://github.com/BerriAI/litellm/issues/2209
Closes https://github.com/BerriAI/litellm/pull/2597

## Type

🐛 Bug Fix

## Changes

- Parse tool calls for streamed `ollama/` and `ollama_chat/` responses
- Set `finish_reason` to "tool_calls" for all `ollama/` and `ollama_chat/` responses
- Use `data` instead of `optional_params` so that JSON response format is correctly detected in ollama completion.

For the streamed tool calls the entire response is joined before parsing, so only one chunk/delta is yielded. This makes it much easier to parse out the function name and arguments. In future it would be nice to update this to stream the tool calls the same way openai does.

## Testing

Adapted the test cases from https://github.com/BerriAI/litellm/issues/3333

```python
import litellm

messages = [{"role": "user", "content": "What's the weather like in San Francisco, Tokyo, and Paris?"}]
tools = [
    {
        "type": "function",
        "function": {
            "name": "get_current_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "The city and state, e.g. San Francisco, CA",
                    },
                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                },
                "required": ["location"],
            },
        },
    }
]


print("\n---\n")
response = litellm.completion(model="ollama/llama2", messages=messages, tools=tools)
print(response)

print("\n---\n")
response = litellm.completion(model="ollama_chat/llama2", messages=messages, tools=tools)
print(response)

print("\n---\n")
aresponse = await litellm.acompletion(model="ollama/llama2", messages=messages, tools=tools)
print(aresponse)

print("\n---\n")
aresponse = await litellm.acompletion(model="ollama_chat/llama2", messages=messages, tools=tools)
print(aresponse)


print("\n---\n")
response = litellm.completion(model="ollama/llama2", messages=messages, tools=tools, stream=True)
for chunk in response:
    print(chunk)

print("\n---\n")
response = litellm.completion(model="ollama_chat/llama2", messages=messages, tools=tools, stream=True)
for chunk in response:
    print(chunk)

print("\n---\n")
aresponse = await litellm.acompletion(model="ollama/llama2", messages=messages, tools=tools, stream=True)
async for chunk in aresponse:
    print(chunk)

print("\n---\n")
aresponse = await litellm.acompletion(model="ollama_chat/llama2", messages=messages, tools=tools, stream=True)
async for chunk in aresponse:
    print(chunk)
```

which output

```

---

ModelResponse(id='chatcmpl-853e92fb-3da0-4852-a502-ce412381cd2a', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=None, role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"location": "San Francisco, CA", "unit": "celsius"}', name='get_current_weather'), id='call_f65b5464-9101-4bcf-a115-8ad7a263f069', type='function')]))], created=1714961534, model='ollama/llama2', object='chat.completion', system_fingerprint=None, usage=Usage(prompt_tokens=150, completion_tokens=42, total_tokens=192))

---

ModelResponse(id='chatcmpl-f07ed597-34d3-43e8-962c-2bc90582ed4e', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=None, role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), id='call_049f2949-c57e-44bf-a0bb-921fa652c56b', type='function')]))], created=1714961541, model='ollama/llama2', object='chat.completion', system_fingerprint=None, usage=Usage(prompt_tokens=314, completion_tokens=33, total_tokens=347))

---

ModelResponse(id='chatcmpl-bbcefe79-bb4e-4e1b-8037-b179dea6caf2', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=None, role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), id='call_48665cb1-2a2d-46ec-a2d5-1e9061f4d5b2', type='function')]))], created=1714961547, model='ollama/llama2', object='chat.completion', system_fingerprint=None, usage=Usage(prompt_tokens=440, completion_tokens=33, total_tokens=473))

---

ModelResponse(id='chatcmpl-8b5ad4bd-c748-4b38-b3ea-993b6b43de84', choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=None, role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), id='call_b289a5ef-4fc7-4a21-b823-f84b8ce11f75', type='function')]))], created=1714961557, model='ollama_chat/llama2', object='chat.completion', system_fingerprint=None, usage=Usage(prompt_tokens=604, completion_tokens=24, total_tokens=628))

---

ModelResponse(id='chatcmpl-16f7e445-1172-4b6a-9216-cebe9c26264e', choices=[StreamingChoices(finish_reason='tool_calls', index=0, delta=Delta(content=None, role=None, function_call=None, tool_calls=[ChatCompletionDeltaToolCall(id='call_a0c3083f-e257-4125-9fa2-73f8d09421c1', function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), type='function', index=0)]), logprobs=None)], created=1714961563, model='llama2', object='chat.completion.chunk', system_fingerprint=None)

---

ModelResponse(id='chatcmpl-497bb5e8-e950-4d7f-985e-ab25f98a4d43', choices=[StreamingChoices(finish_reason='tool_calls', index=0, delta=Delta(content=None, role=None, function_call=None, tool_calls=[ChatCompletionDeltaToolCall(id='call_b65f37f4-7c9e-488f-a80e-04147e5e4d47', function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), type='function', index=0)]), logprobs=None)], created=1714961573, model='llama2', object='chat.completion.chunk', system_fingerprint=None)

---

ModelResponse(id='chatcmpl-8c36e05d-b5b1-4522-a0fd-8658ba20305a', choices=[StreamingChoices(finish_reason='tool_calls', index=0, delta=Delta(content=None, role=None, function_call=None, tool_calls=[ChatCompletionDeltaToolCall(id='call_69d13fbf-60f7-469c-9015-af4e4aa6b1c5', function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), type='function', index=0)]), logprobs=None)], created=1714961586, model='llama2', object='chat.completion.chunk', system_fingerprint=None)

---

ModelResponse(id='chatcmpl-22648686-8618-463a-b1e5-ba23c34ea275', choices=[StreamingChoices(finish_reason='tool_calls', index=0, delta=Delta(content=None, role=None, function_call=None, tool_calls=[ChatCompletionDeltaToolCall(id='call_85bf2a5c-5c18-4d24-98d5-89a82d122d0c', function=Function(arguments='{"location": "San Francisco, CA"}', name='get_current_weather'), type='function', index=0)]), logprobs=None)], created=1714961598, model='llama2', object='chat.completion.chunk', system_fingerprint=None)
```


## Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
