### PR TITLE
Fix exception handling gemini

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -811,6 +811,8 @@ models_by_provider: dict = {
     "fireworks_ai": fireworks_ai_models + fireworks_ai_embedding_models,
 }
 
+provider_by_model = {}  # This will initialized by get_provider_from_model()
+
 # mapping for those models which have larger equivalents
 longer_context_model_fallback_dict: dict = {
     # openai chat completion models

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2071,6 +2071,9 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         elif value.get("litellm_provider") == "bedrock":
             if key not in litellm.bedrock_models:
                 litellm.bedrock_models.append(key)
+        elif value.get("litellm_provider") == "gemini":
+            if key not in litellm.gemini_models:
+                litellm.gemini_models.append(key)
     return model_cost
 
 
@@ -8390,6 +8393,31 @@ def get_valid_models() -> List[str]:
     except Exception:
         return []  # NON-Blocking
 
+def get_provider_from_model(model_or_model_name):
+    """
+    Returns a provider(llm_provider) from litellm.models_by_provider(provider_by_model)
+
+    Args:
+        model_or_model_name (str): The name. like "openai/gpt-3.5-turbo" or "gpt-3.5-turbo".
+
+    Returns:
+        llm_provider(str): provider or None
+    """
+    if len(litellm.provider_by_model) == 0:
+        # models_by_provider: provider -> list[provider/model_name]
+        for provider, models in litellm.models_by_provider.items():
+            for model in models:
+                # provider_by_model : provider/model_name -> provider
+                #                     model_name -> provider
+                model_name = model.replace(provider + "/", "")
+                litellm.provider_by_model[model] = provider
+                if model_name:
+                    litellm.provider_by_model[model_name] = provider
+
+    if model_or_model_name in litellm.provider_by_model:
+        return litellm.provider_by_model[model_or_model_name]
+
+    return None
 
 def print_args_passed_to_litellm(original_function, args, kwargs):
     try:


### PR DESCRIPTION
## Fix exception handling gemini

Add get_provider_from_model() for handling 429 Exception from gemini.

## Relevant issues

This error is the target problem to resolved in PR.
From some case, model is not include llm_provider name.
It causes ERROR in get_llm_provider().

"""
09:26:06 - LiteLLM:ERROR: utils.py:5873 - Error occurred in getting api base - GetLLMProvider Exception - name 'get_provider_from_model' is not defined

original model: gemini-1.5-pro-latest
"""

## Type

🧹 Refactoring

## Changes

- Add get_provider_from_model()
- Call get_provider_from_model() from get_llm_provider() before exception.
- The dict provider_by_model manages full model(provider/model_name ) and model_name  only. 

## Testing

Works fine with this condition.

- MODEL_NAME="gemini/gemini-1.5-pro-latest"
- GEMINI_API_KEY=XXXX
- LITELLM_LOCAL_MODEL_COST_MAP="True"

Finaly 
```
Error in chat: 429 Resource has been exhausted (e.g. check quota).
```

## Notes

Retlated with https://github.com/BerriAI/litellm/pull/3473.
This PR may help to reproduce the condition.
"gemini/gemini-1.5-pro-latest" soon 429 exception.

## Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
