### PR TITLE
Initial OIDC support (Google/GitHub/CircleCI -> Amazon Bedrock & Azure OpenAI)

### DIFF
--- a/litellm/llms/azure.py
+++ b/litellm/llms/azure.py
@@ -146,7 +146,7 @@ def get_azure_ad_token_from_oidc(azure_ad_token: str):
             message="OIDC token could not be retrieved from secret manager.",
         )
 
-    req_token = httpx.get(
+    req_token = httpx.post(
         f"https://login.microsoftonline.com/{azure_tenant}/oauth2/v2.0/token",
         data={
             "client_id": azure_client_id,

--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -550,6 +550,7 @@ def init_bedrock_client(
     aws_session_name: Optional[str] = None,
     aws_profile_name: Optional[str] = None,
     aws_role_name: Optional[str] = None,
+    aws_web_identity_token: Optional[str] = None,
     extra_headers: Optional[dict] = None,
     timeout: Optional[Union[float, httpx.Timeout]] = None,
 ):
@@ -566,6 +567,7 @@ def init_bedrock_client(
         aws_session_name,
         aws_profile_name,
         aws_role_name,
+        aws_web_identity_token,
     ]
 
     # Iterate over parameters and update if needed
@@ -581,6 +583,7 @@ def init_bedrock_client(
         aws_session_name,
         aws_profile_name,
         aws_role_name,
+        aws_web_identity_token,
     ) = params_to_check
 
     ### SET REGION NAME
@@ -619,7 +622,38 @@ def init_bedrock_client(
         config = boto3.session.Config()
 
     ### CHECK STS ###
-    if aws_role_name is not None and aws_session_name is not None:
+    if aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None:
+        oidc_token = get_secret(aws_web_identity_token)
+
+        if oidc_token is None:
+            raise BedrockError(
+                message="OIDC token could not be retrieved from secret manager.",
+                status_code=401,
+            )
+
+        sts_client = boto3.client(
+            "sts"
+        )
+
+        # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role_with_web_identity.html
+        sts_response = sts_client.assume_role_with_web_identity(
+            RoleArn=aws_role_name,
+            RoleSessionName=aws_session_name,
+            WebIdentityToken=oidc_token,
+            DurationSeconds=3600,
+        )
+
+        client = boto3.client(
+            service_name="bedrock-runtime",
+            aws_access_key_id=sts_response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=sts_response["Credentials"]["SecretAccessKey"],
+            aws_session_token=sts_response["Credentials"]["SessionToken"],
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+        )
+    elif aws_role_name is not None and aws_session_name is not None:
         # use sts if role name passed in
         sts_client = boto3.client(
             "sts",
@@ -752,6 +786,7 @@ def completion(
         aws_bedrock_runtime_endpoint = optional_params.pop(
             "aws_bedrock_runtime_endpoint", None
         )
+        aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
 
         # use passed in BedrockRuntime.Client if provided, otherwise create a new one
         client = optional_params.pop("aws_bedrock_client", None)
@@ -766,6 +801,7 @@ def completion(
                 aws_role_name=aws_role_name,
                 aws_session_name=aws_session_name,
                 aws_profile_name=aws_profile_name,
+                aws_web_identity_token=aws_web_identity_token,
                 extra_headers=extra_headers,
                 timeout=timeout,
             )
@@ -1288,6 +1324,7 @@ def embedding(
     aws_bedrock_runtime_endpoint = optional_params.pop(
         "aws_bedrock_runtime_endpoint", None
     )
+    aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
 
     # use passed in BedrockRuntime.Client if provided, otherwise create a new one
     client = init_bedrock_client(
@@ -1295,6 +1332,7 @@ def embedding(
         aws_secret_access_key=aws_secret_access_key,
         aws_region_name=aws_region_name,
         aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
+        aws_web_identity_token=aws_web_identity_token,
         aws_role_name=aws_role_name,
         aws_session_name=aws_session_name,
     )
@@ -1377,6 +1415,7 @@ def image_generation(
     aws_bedrock_runtime_endpoint = optional_params.pop(
         "aws_bedrock_runtime_endpoint", None
     )
+    aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
 
     # use passed in BedrockRuntime.Client if provided, otherwise create a new one
     client = init_bedrock_client(
@@ -1384,6 +1423,7 @@ def image_generation(
         aws_secret_access_key=aws_secret_access_key,
         aws_region_name=aws_region_name,
         aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
+        aws_web_identity_token=aws_web_identity_token,
         aws_role_name=aws_role_name,
         aws_session_name=aws_session_name,
         timeout=timeout,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -45,6 +45,7 @@ from litellm.types.router import (
     RetryPolicy,
 )
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.llms.azure import get_azure_ad_token_from_oidc
 
 
 class Router:
@@ -2089,6 +2090,10 @@ class Router:
                     raise ValueError(
                         f"api_base is required for Azure OpenAI. Set it on your config. Model - {model}"
                     )
+                azure_ad_token = litellm_params.get("azure_ad_token")
+                if azure_ad_token is not None:
+                    if azure_ad_token.startswith("oidc/"):
+                        azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)
                 if api_version is None:
                     api_version = "2023-07-01-preview"
                 if "gateway.ai.cloudflare.com" in api_base:
@@ -2099,6 +2104,7 @@ class Router:
                     cache_key = f"{model_id}_async_client"
                     _client = openai.AsyncAzureOpenAI(
                         api_key=api_key,
+                        azure_ad_token=azure_ad_token,
                         base_url=api_base,
                         api_version=api_version,
                         timeout=timeout,
@@ -2123,6 +2129,7 @@ class Router:
                     cache_key = f"{model_id}_client"
                     _client = openai.AzureOpenAI(  # type: ignore
                         api_key=api_key,
+                        azure_ad_token=azure_ad_token,
                         base_url=api_base,
                         api_version=api_version,
                         timeout=timeout,
@@ -2147,6 +2154,7 @@ class Router:
                     cache_key = f"{model_id}_stream_async_client"
                     _client = openai.AsyncAzureOpenAI(  # type: ignore
                         api_key=api_key,
+                        azure_ad_token=azure_ad_token,
                         base_url=api_base,
                         api_version=api_version,
                         timeout=stream_timeout,
@@ -2171,6 +2179,7 @@ class Router:
                     cache_key = f"{model_id}_stream_client"
                     _client = openai.AzureOpenAI(  # type: ignore
                         api_key=api_key,
+                        azure_ad_token=azure_ad_token,
                         base_url=api_base,
                         api_version=api_version,
                         timeout=stream_timeout,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2212,6 +2212,7 @@ class Router:
                         "api_key": api_key,
                         "azure_endpoint": api_base,
                         "api_version": api_version,
+                        "azure_ad_token": azure_ad_token,
                     }
                     from litellm.llms.azure import select_azure_base_url_or_endpoint
 

--- a/litellm/tests/test_bedrock_completion.py
+++ b/litellm/tests/test_bedrock_completion.py
@@ -206,6 +206,35 @@ def test_completion_bedrock_claude_sts_client_auth():
 
 # test_completion_bedrock_claude_sts_client_auth()
 
+@pytest.mark.skipif(os.environ.get('CIRCLE_OIDC_TOKEN_V2') is None, reason="CIRCLE_OIDC_TOKEN_V2 is not set")
+def test_completion_bedrock_claude_sts_oidc_auth():
+    print("\ncalling bedrock claude with oidc auth")
+    import os
+
+    aws_web_identity_token = "oidc/circleci_v2/"
+    aws_region_name = os.environ["AWS_REGION_NAME"]
+    aws_role_name = os.environ["AWS_TEMP_ROLE_NAME"]
+
+    try:
+        litellm.set_verbose = True
+
+        response = completion(
+            model="bedrock/anthropic.claude-instant-v1",
+            messages=messages,
+            max_tokens=10,
+            temperature=0.1,
+            aws_region_name=aws_region_name,
+            aws_web_identity_token=aws_web_identity_token,
+            aws_role_name=aws_role_name,
+            aws_session_name="my-test-session",
+        )
+        # Add any assertions here to check the response
+        print(response)
+    except RateLimitError:
+        pass
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
 
 def test_bedrock_extra_headers():
     try:

--- a/litellm/tests/test_secret_manager.py
+++ b/litellm/tests/test_secret_manager.py
@@ -23,3 +23,36 @@ def test_aws_secret_manager():
     print(f"secret_val: {secret_val}")
 
     assert secret_val == "sk-1234"
+
+
+def redact_oidc_signature(secret_val):
+    # remove the last part of `.` and replace it with "SIGNATURE_REMOVED"
+    return secret_val.split(".")[:-1] + ["SIGNATURE_REMOVED"]
+
+
+@pytest.mark.skipif(os.environ.get('K_SERVICE') is None, reason="Cannot run without being in GCP Cloud Run")
+def test_oidc_google():
+    secret_val = get_secret("oidc/google/https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-text-express-v1/invoke")
+
+    print(f"secret_val: {redact_oidc_signature(secret_val)}")
+
+
+@pytest.mark.skipif(os.environ.get('ACTIONS_ID_TOKEN_REQUEST_TOKEN') is None, reason="Cannot run without being in GitHub Actions")
+def test_oidc_github():
+    secret_val = get_secret("oidc/github/https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-text-express-v1/invoke")
+
+    print(f"secret_val: {redact_oidc_signature(secret_val)}")
+
+
+@pytest.mark.skipif(os.environ.get('CIRCLE_OIDC_TOKEN') is None, reason="Cannot run without being in a CircleCI Runner")
+def test_oidc_circleci():
+    secret_val = get_secret("oidc/circleci/https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-text-express-v1/invoke")
+
+    print(f"secret_val: {redact_oidc_signature(secret_val)}")
+
+
+@pytest.mark.skipif(os.environ.get('CIRCLE_OIDC_TOKEN_V2') is None, reason="Cannot run without being in a CircleCI Runner")
+def test_oidc_circleci_v2():
+    secret_val = get_secret("oidc/circleci_v2/https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.titan-text-express-v1/invoke")
+
+    print(f"secret_val: {redact_oidc_signature(secret_val)}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -33,6 +33,7 @@ from dataclasses import (
 )
 
 import litellm._service_logger  # for storing API inputs, outputs, and metadata
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 try:
     # this works in python 3.8
@@ -9287,6 +9288,59 @@ def get_secret(
     key_management_settings = litellm._key_management_settings
     if secret_name.startswith("os.environ/"):
         secret_name = secret_name.replace("os.environ/", "")
+
+    # Example: oidc/google/https://bedrock-runtime.us-east-1.amazonaws.com/model/stability.stable-diffusion-xl-v1/invoke
+    if secret_name.startswith("oidc/"):
+        secret_name = secret_name.replace("oidc/", "")
+        oidc_provider, oidc_aud = secret_name.split("/", 1)
+        # TODO: Add caching for HTTP requests
+        match oidc_provider:
+            case "google":
+                client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
+                # https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
+                response = client.get(
+                    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity",
+                    params={"audience": oidc_aud},
+                    headers={"Metadata-Flavor": "Google"},
+                )
+                if response.status_code == 200:
+                    return response.text
+                else:
+                    raise ValueError("Google OIDC provider failed")
+            case "circleci":
+                # https://circleci.com/docs/openid-connect-tokens/
+                env_secret = os.getenv("CIRCLE_OIDC_TOKEN")
+                if env_secret is None:
+                    raise ValueError("CIRCLE_OIDC_TOKEN not found in environment")
+                return env_secret
+            case "circleci_v2":
+                # https://circleci.com/docs/openid-connect-tokens/
+                env_secret = os.getenv("CIRCLE_OIDC_TOKEN_V2")
+                if env_secret is None:
+                    raise ValueError("CIRCLE_OIDC_TOKEN_V2 not found in environment")
+                return env_secret
+            case "github":
+                # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#using-custom-actions
+                actions_id_token_request_url = os.getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+                actions_id_token_request_token = os.getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+                if actions_id_token_request_url is None or actions_id_token_request_token is None:
+                    raise ValueError("ACTIONS_ID_TOKEN_REQUEST_URL or ACTIONS_ID_TOKEN_REQUEST_TOKEN not found in environment")
+                client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
+                response = client.get(
+                    actions_id_token_request_url,
+                    params={"audience": oidc_aud},
+                    headers={
+                        "Authorization": f"Bearer {actions_id_token_request_token}",
+                        "Accept": "application/json; api-version=2.0",
+                        },
+                )
+                if response.status_code == 200:
+                    return response.text['value']
+                else:
+                    raise ValueError("Github OIDC provider failed")
+            case _:
+                raise ValueError("Unsupported OIDC provider")
+
 
     try:
         if litellm.secret_manager_client is not None:


### PR DESCRIPTION
## Title

Implement OIDC for Azure OpenAI and Amazon Bedrock requests.

Currently, this supports using OIDC from:

- Google Cloud Run (tested)
- GitHub Actions (untested but pretty sure it works)
- Circle CI (untested but should work fine)

And this supports using the auth token for:

- Amazon Bedrock
- Azure OpenAI

## Relevant issues

Resolves #3505 and #3401.

## Type

🆕 New Feature
🐛 Bug Fix
💻 Development Environment
🚄 Infrastructure

## Changes

This allows using OIDC with Azure OpenAI.

## Testing

```yaml
model_list:
  - model_name: gpt-4-0125-preview
    litellm_params:
      model: azure/gpt-4-0125-preview
      azure_ad_token: "oidc/google/https://example.com"
      api_version: "2024-03-01-preview"
      api_base: "https://demo-here.openai.azure.com"
    model_info:
      base_model: azure/gpt-4-0125-preview

  - model_name: claude-3-haiku-20240307
    litellm_params:
      model: bedrock/anthropic.claude-3-haiku-20240307-v1:0
      aws_region_name: us-east-1
      aws_session_name: "litellm"
      aws_role_name: "arn:aws:iam::YOUR_THING_HERE:role/litellm-google-demo"
      aws_web_identity_token: "oidc/google/https://example.com"

```

You must set the following two env vars:

```
AZURE_CLIENT_ID=asdf
AZURE_TENANT_ID=asdf
```

And see https://github.com/BerriAI/litellm/pull/3499 for the AWS IAM info.

## Notes

Docs will be in a later PR.

## Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [X] Tested on Linux
