### PR TITLE
Pydantic warning conflict with protected namespace

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -65,6 +65,9 @@ class UpdateRouterConfig(BaseModel):
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
 
+    class Config:
+        protected_namespaces = ()
+
 
 class ModelInfo(BaseModel):
     id: Optional[


### PR DESCRIPTION
Previous PR: https://github.com/BerriAI/litellm/pull/3334
It looks like another warning snuck in.
```UserWarning: Field "model_group_retry_policy" has conflict with protected namespace "model_".```

I found a bizarre behavior with the pytest.
When I run the pytest in a separate folder, it picked up the warning and fails.
But when I run the exact same pytest file from inside the repository tests folder, it lets it pass.
I'm not sure what causes the difference in behavior, if theres a pytest config file or something.
This is the relevant pytest file: https://github.com/BerriAI/litellm/blob/main/litellm/tests/test_pydantic_namespaces.py

Separate folder:
![image](https://github.com/BerriAI/litellm/assets/6693226/91d50bcd-875e-412b-ae14-938e87807734)

Repository tests folder:
![image](https://github.com/BerriAI/litellm/assets/6693226/7fa6001d-e457-4ff4-a38c-3f35897d8470)

