### PR TITLE
Fix openai version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.litellm.ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0, !=3.9.7"
-openai = ">=1.0.0"
+openai = "==1.14.3"
 python-dotenv = ">=0.2.0"
 tiktoken = ">=0.4.0"
 importlib-metadata = ">=6.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.litellm.ai"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0, !=3.9.7"
-openai = "==1.14.3"
+openai = "1.14.3"
 python-dotenv = ">=0.2.0"
 tiktoken = ">=0.4.0"
 importlib-metadata = ">=6.8.0"


### PR DESCRIPTION


## Title

Fix openai version in pyproject.toml

## Relevant issues

In (https://github.com/BerriAI/litellm/issues/3253) pin the openai version to 1.14.3.

## Type

🐛 Bug Fix
When `pip install litellm`, the openai version is not set as 1.14.3

## Changes

change the openai version in pyproject.toml from >= 1.0.0 to 1.14.3

## Testing

<!-- Test procedure -->

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
