### PR TITLE
Fixes #3544 based on the data-type of message

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -135,7 +135,9 @@ class LangFuseLogger:
                 response_obj, litellm.ModelResponse
             ):
                 input = prompt
-                output = response_obj["choices"][0]["message"].json()
+                output = response_obj["choices"][0]["message"]
+                if isinstance(output, litellm.Message):
+                    output = output.json()
             elif response_obj is not None and isinstance(
                 response_obj, litellm.TextCompletionResponse
             ):

--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -135,9 +135,7 @@ class LangFuseLogger:
                 response_obj, litellm.ModelResponse
             ):
                 input = prompt
-                output = response_obj["choices"][0]["message"]
-                if isinstance(output, litellm.Message):
-                    output = output.json()
+                output = response_obj["choices"][0]["message"].json()
             elif response_obj is not None and isinstance(
                 response_obj, litellm.TextCompletionResponse
             ):

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -300,7 +300,7 @@ def get_ollama_response(
         model_response["choices"][0]["message"] = message
         model_response["choices"][0]["finish_reason"] = "tool_calls"
     else:
-        model_response["choices"][0]["message"] = response_json["message"]
+        model_response["choices"][0]["message"]["content"] = response_json["message"]["content"]
     model_response["created"] = int(time.time())
     model_response["model"] = "ollama/" + model
     prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))  # type: ignore
@@ -484,7 +484,7 @@ async def ollama_acompletion(
                 model_response["choices"][0]["message"] = message
                 model_response["choices"][0]["finish_reason"] = "tool_calls"
             else:
-                model_response["choices"][0]["message"] = response_json["message"]
+                model_response["choices"][0]["message"]["content"] = response_json["message"]["content"]
 
             model_response["created"] = int(time.time())
             model_response["model"] = "ollama_chat/" + data["model"]


### PR DESCRIPTION
## Fixes the error while ollama_chat use langfuse

The value of response_obj["choices"][0]["message"] is Message object and dict

Added a conditional to use .json only iff it is Message Object

## Relevant issues

Fixes #3544

## Type
🐛 Bug Fix


## Testing

Error Replicates with
```python
litellm.success_callback = ["langfuse"]
resp = completion(
    model="ollama_chat/llama3:instruct",
    messages=[
        {"role": "user", "content": "Hello"},
    ],
    base_url='http://localhost:11434'
)

print(resp["choices"][0]["message"])
```

After fix it will work for both: `ollama_chat/llama3:instruct` and `ollama/llama3:instruct`
