### PR TITLE
Globally filtering pydantic conflict warnings

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1,3 +1,6 @@
+### Hide pydantic namespace conflict warnings globally ###
+import warnings
+warnings.filterwarnings("ignore", message=".*conflict with protected namespace.*")
 ### INIT VARIABLES ###
 import threading, requests, os
 from typing import Callable, List, Optional, Dict, Union, Any, Literal


### PR DESCRIPTION
Continuing from: https://github.com/BerriAI/litellm/pull/3519

It seems the reason the test was passing from inside the repo folder was that the pydantic warnings weren't showing at all.
This gave me an idea, adding a global warning filter to hide the namespace conflict warnings.
It seems to be working with no apparent issues.