### PR TITLE
Make `test_load_router_config` pass

### DIFF
--- a/litellm/tests/test_proxy_server.py
+++ b/litellm/tests/test_proxy_server.py
@@ -116,6 +116,7 @@ def fake_env_vars(monkeypatch):
     monkeypatch.setenv("AZURE_API_BASE", "http://fake-azure-api-base")
     monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake_azure_openai_api_key")
     monkeypatch.setenv("AZURE_SWEDEN_API_BASE", "http://fake-azure-sweden-api-base")
+    monkeypatch.setenv("REDIS_HOST", "localhost")
 
 
 @pytest.fixture(scope="function")
@@ -505,7 +506,18 @@ def test_chat_completion_optional_params(mock_acompletion, client_no_auth):
 from litellm.proxy.proxy_server import ProxyConfig
 
 
-def test_load_router_config():
+@mock.patch("litellm.proxy.proxy_server.litellm.Cache")
+def test_load_router_config(mock_cache, fake_env_vars):
+    mock_cache.return_value.cache.__dict__ = {"redis_client": None}
+    mock_cache.return_value.supported_call_types = [
+        "completion",
+        "acompletion",
+        "embedding",
+        "aembedding",
+        "atranscription",
+        "transcription",
+    ]
+
     try:
         import asyncio
 
@@ -567,6 +579,10 @@ def test_load_router_config():
         litellm.disable_cache()
 
         print("testing reading proxy config for cache with params")
+        mock_cache.return_value.supported_call_types = [
+            "embedding",
+            "aembedding",
+        ]
         asyncio.run(
             proxy_config.load_config(
                 router=None,


### PR DESCRIPTION
by mocking the necessary things in the test.

Now all the tests in `test_proxy_server.py` pass! :tada:

```shell
$ env -i PATH=$PATH poetry run pytest litellm/tests/test_proxy_server.py --disable-warnings
====================================== test session starts ======================================
platform darwin -- Python 3.12.3, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/abramowi/Code/OpenSource/litellm
plugins: anyio-4.3.0, asyncio-0.23.6, mock-3.14.0
asyncio: mode=Mode.STRICT
collected 12 items

litellm/tests/test_proxy_server.py s..........s                                           [100%]

========================== 10 passed, 2 skipped, 48 warnings in 10.70s ==========================
```