### PR TITLE
feat(langfuse.py): Allow for individual call message/response redaction

### DIFF
--- a/docs/my-website/docs/observability/langfuse_integration.md
+++ b/docs/my-website/docs/observability/langfuse_integration.md
@@ -213,7 +213,19 @@ chat(messages)
 
 ## Redacting Messages, Response Content from Langfuse Logging 
 
+### Redact Messages and Responses from all Langfuse Logging
+
 Set `litellm.turn_off_message_logging=True` This will prevent the messages and responses from being logged to langfuse, but request metadata will still be logged.
+
+### Redact Messages and Responses from specific Langfuse Logging
+
+In the metadata typically passed for text completion or embedding calls you can set specific keys to mask the messages and responses for this call.
+
+Setting `mask_input` to `True` will mask the input from being logged for this call 
+
+Setting `mask_output` to `True` will make the output from being logged for this call.
+
+Be aware that if you are continuing an existing trace, and you set `update_trace_keys` to include either `input` or `output` and you set the corresponding `mask_input` or `mask_output`, then that trace will have its existing input and/or output replaced with a redacted message.
 
 ## Troubleshooting & Errors
 ### Data not getting logged to Langfuse ? 


### PR DESCRIPTION
<!-- This is just examples. You can remove all items if you want. -->
<!-- Please remove all comments. -->

## Title

Allow for individual input/output redaction in langfuse

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test

## Changes

<!-- List of changes -->

* Added new options to metadata `mask_input` and `mask_output` 
*  Uses new options to see if we should pass along true input/output to trace and generation. If set to mask then set a redacted message.

## Testing

<!-- Test procedure -->

New test written for checking individual message redaction

## Notes

Necessary change when only a single call wants to be redacted from user perspective. The current redact all message flag will not work in this case for async code as we cannot guarantee being able to turn off message redaction before other calls may execute.

For instance we may want to mask the create embedding calls in a rag pipeline, but not the rest of the calls

<!-- Test results -->

![Screenshot from 2024-05-12 22-45-41](https://github.com/BerriAI/litellm/assets/16146094/b1159003-9471-4f28-aa6c-508a0a2cbb9e)

<!-- Points to note for the reviewer, consultation content, concerns -->

## Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs/my-website)

## OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
