### PR TITLE
support qwen in openai compatible mode

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5849,6 +5849,7 @@ def get_optional_params(
         for k in passed_params.keys():
             if k not in default_params.keys():
                 optional_params[k] = passed_params[k]
+    if custom_llm_provider == "openai" and "qwen" in model: optional_params.pop("user", None)
     print_verbose(f"Final returned optional params: {optional_params}")
     return optional_params
 


### PR DESCRIPTION
as [dashscope developer-reference](https://help.aliyun.com/zh/dashscope/developer-reference/compatibility-of-openai-with-dashscope/?spm=a2c4g.11186623.0.0.5ab04bb0SFbKjC) says, DashScope provides an OpenAI-compatible interface `https://dashscope.aliyuncs.com/compatible-mode/v1` for many qwen models but it can't support the optional 'user' paramater and litellm always add this paramater

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Remove the optional 'user' paramater for model  whose name is started with 'qwen' 
## Pre-Submission Checklist (optional but appreciated):

## OS Tests (optional but appreciated):

- [x] Tested on Linux
