### PR TITLE
Add `wandb` (Weights & Biases) pip package to proxy Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,10 @@ RUN pip uninstall jwt -y
 RUN pip uninstall PyJWT -y
 RUN pip install PyJWT --no-cache-dir
 
+# Install wandb package for Weights & Biases integration
+# https://docs.litellm.ai/docs/observability/wandb_integration
+RUN pip install wandb --no-cache-dir
+
 # Build Admin UI
 RUN chmod +x build_admin_ui.sh && ./build_admin_ui.sh
 


### PR DESCRIPTION
I'd like to try the [Weights & Biases integration](https://docs.litellm.ai/docs/observability/wandb_integration). I'm using the standard Docker image (e.g.: `ghcr.io/berriai/litellm:main-v1.37.9-stable`). If I add this to the proxy config:

```yaml
success_callback: ["wandb"]
```

then I get this error:

```pytb
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py", line 3342, in startup_event
    proxy_logging_obj._init_litellm_callbacks()  # INITIALIZE LITELLM CALLBACKS ON SERVER STARTUP <- do this to catch any logging errors on startup, not when calls are being made
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/utils.py", line 166, in _init_litellm_callbacks
    litellm.utils.set_callbacks(callback_list=callback_list)
  File "/usr/local/lib/python3.11/site-packages/litellm/utils.py", line 7365, in set_callbacks
    raise e
  File "/usr/local/lib/python3.11/site-packages/litellm/utils.py", line 7339, in set_callbacks
    weightsBiasesLogger = WeightsBiasesLogger()
                          ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/integrations/weights_biases.py", line 190, in __init__
    raise Exception(
Exception:  wandb not installed, try running 'pip install wandb' to fix this error

ERROR:    Application startup failed. Exiting.
```

So I propose to add `pip install wandb` to the `Dockerfile`.

It's not excessively large:

```shell
$ du -sh $VIRTUAL_ENV/lib/python3.12/site-packages/wandb
 31M	/Users/abramowi/Library/Caches/pypoetry/virtualenvs/litellm-Fe7WjZrx-py3.12/lib/python3.12/site-packages/wandb
```