### PR TITLE
Another dictionary changed size during iteration error

### DIFF
--- a/litellm/llms/openai.py
+++ b/litellm/llms/openai.py
@@ -96,7 +96,7 @@ class MistralConfig:
         safe_prompt: Optional[bool] = None,
         response_format: Optional[dict] = None,
     ) -> None:
-        locals_ = locals()
+        locals_ = locals().copy()
         for key, value in locals_.items():
             if key != "self" and value is not None:
                 setattr(self.__class__, key, value)
@@ -211,7 +211,7 @@ class OpenAIConfig:
         temperature: Optional[int] = None,
         top_p: Optional[int] = None,
     ) -> None:
-        locals_ = locals()
+        locals_ = locals().copy()
         for key, value in locals_.items():
             if key != "self" and value is not None:
                 setattr(self.__class__, key, value)
@@ -294,7 +294,7 @@ class OpenAITextCompletionConfig:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
     ) -> None:
-        locals_ = locals()
+        locals_ = locals().copy()
         for key, value in locals_.items():
             if key != "self" and value is not None:
                 setattr(self.__class__, key, value)


### PR DESCRIPTION
```
ImportError while loading conftest '/astra-assistants-api/tests/openai-sdk/conftest.py'.
conftest.py:13: in <module>
    from impl.astra_vector import CassandraClient
../../impl/astra_vector.py:45: in <module>
    from impl.services.inference_utils import get_embeddings
../../impl/services/inference_utils.py:5: in <module>
    import litellm
.cache/pypoetry/virtualenvs/astra-assistants-api-eiSmbCzm-py3.10/lib/python3.10/site-packages/litellm/__init__.py:678: in <module>
    from .main import *  # type: ignore
.cache/pypoetry/virtualenvs/astra-assistants-api-eiSmbCzm-py3.10/lib/python3.10/site-packages/litellm/main.py:73: in <module>
    from .llms.azure_text import AzureTextCompletion
.cache/pypoetry/virtualenvs/astra-assistants-api-eiSmbCzm-py3.10/lib/python3.10/site-packages/litellm/llms/azure_text.py:23: in <module>
    openai_text_completion_config = OpenAITextCompletionConfig()
.cache/pypoetry/virtualenvs/astra-assistants-api-eiSmbCzm-py3.10/lib/python3.10/site-packages/litellm/llms/openai.py:192: in __init__
    for key, value in locals_.items():
E   RuntimeError: dictionary changed size during iteration
```

## Title

Another dictionary changed size during iteration error

## Relevant issues


## Type

🐛 Bug Fix

## Changes

>         locals_ = locals().copy()
