### PR TITLE
[Feat] Introduced team_id_default config option

### DIFF
--- a/docs/my-website/docs/proxy/token_auth.md
+++ b/docs/my-website/docs/proxy/token_auth.md
@@ -121,6 +121,7 @@ general_settings:
   litellm_jwtauth:
     admin_jwt_scope: "litellm-proxy-admin"
     team_id_jwt_field: "client_id" # 👈 CAN BE ANY FIELD
+    team_id_default: "01c2ddd5-29e6-4280-817b-81ba2b75c07d" # 👈 OPTIONAL (set to the id of an existing team)
     user_id_jwt_field: "sub" # 👈 CAN BE ANY FIELD
     org_id_jwt_field: "org_id" # 👈 CAN BE ANY FIELD
     end_user_id_jwt_field: "customer_id" # 👈 CAN BE ANY FIELD
@@ -181,6 +182,7 @@ general_settings:
   litellm_jwtauth:
     ...
     team_id_jwt_field: "litellm-team" # 👈 Set field in the JWT token that stores the team ID
+    team_id_default: "01c2ddd5-29e6-4280-817b-81ba2b75c07d" # 👈 OPTIONAL (set to the id of an existing team)
     team_allowed_routes: ["/v1/chat/completions"] # 👈 Set accepted routes
 ```
 
@@ -208,6 +210,7 @@ general_settings:
   enable_jwt_auth: True
   litellm_jwtauth:
     team_id_jwt_field: "client_id" # 👈 KEY CHANGE
+    team_id_default: "01c2ddd5-29e6-4280-817b-81ba2b75c07d" # 👈 OPTIONAL (set to the id of an existing team)
 ```
 
 ## All Params

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -204,6 +204,7 @@ class LiteLLM_JWTAuth(LiteLLMBase):
     - admin_allowed_routes: list of allowed routes for proxy admin roles.
     - team_jwt_scope: The JWT scope required for proxy team roles.
     - team_id_jwt_field: The field in the JWT token that stores the team ID. Default - `client_id`.
+    - team_id_default: Value to use when the field specified by `team_id_jwt_field` is not provided in the JWT token
     - team_allowed_routes: list of allowed routes for proxy team roles.
     - user_id_jwt_field: The field in the JWT token that stores the user id (maps to `LiteLLMUserTable`). Use this for internal employees.
     - end_user_id_jwt_field: The field in the JWT token that stores the end-user ID (maps to `LiteLLMEndUserTable`). Turn this off by setting to `None`. Enables end-user cost tracking. Use this for external customers.
@@ -229,6 +230,7 @@ class LiteLLM_JWTAuth(LiteLLMBase):
     ]
     team_jwt_scope: str = "litellm_team"
     team_id_jwt_field: str = "client_id"
+    team_id_default: Optional[str] = None
     team_allowed_routes: List[
         Literal["openai_routes", "info_routes", "management_routes"]
     ] = ["openai_routes", "info_routes"]

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -138,15 +138,15 @@ class JWTHandler:
         else:
             keys = cached_keys
 
-        public_key: Optional[dict] = None
+        # Test mode key finder
+        if kid is None and len(keys) == 1:
+            public_key = keys[0]
 
-        if len(keys) == 1:
-            if kid is None or keys["kid"] == kid:
-                public_key = keys[0]
-        elif len(keys) > 1:
-            for key in keys:
-                if kid is not None and key == kid:
-                    public_key = keys[key]
+        # Non-test key finder
+        for key in keys:
+            if kid is not None and key["kid"] == kid:
+                public_key = key
+                break
 
         if public_key is None:
             raise Exception(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -438,11 +438,12 @@ async def user_api_key_auth(
                             f"Admin not allowed to access this route. Route={route}, Allowed Routes={actual_routes}"
                         )
                 # get team id
-                team_id = jwt_handler.get_team_id(token=valid_token, default_value=None)
+                team_id = jwt_handler.get_team_id(token=valid_token, default_value=jwt_handler.litellm_jwtauth.team_id_default)
 
                 if team_id is None:
                     raise Exception(
-                        f"No team id passed in. Field checked in jwt token - '{jwt_handler.litellm_jwtauth.team_id_jwt_field}'"
+                        f"No team id passed in and no 'team_id_default' value configured. "
+                        f"Field checked in jwt token - '{jwt_handler.litellm_jwtauth.team_id_jwt_field}'"
                     )
                 # check allowed team routes
                 is_allowed = allowed_routes_check(
@@ -492,6 +493,7 @@ async def user_api_key_auth(
                     token=valid_token, default_value=None
                 )
                 if end_user_id is not None:
+                    print("sup5")
                     # get the end-user object
                     end_user_object = await get_end_user_object(
                         end_user_id=end_user_id,


### PR DESCRIPTION
## Title

[Feat] Introduced team_id_default config option

## Relevant issues

None

## Type

🆕 New Feature

## Changes

- When a value for `team_id` is not found in the `jwt` using the `team_id_jwt_field`, the value provided by `team_id_default` (if set) is used instead. This opens the gateway for `end_users` to connect using a `jwt` without a specific team included in their token.
- Added documentation to support this config

## Testing

Only local dev testing, no test suite runs.
