### PR TITLE
Add OIDC to bedrock httpx

### DIFF
--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -208,6 +208,7 @@ class BedrockLLM(BaseLLM):
         aws_session_name: Optional[str] = None,
         aws_profile_name: Optional[str] = None,
         aws_role_name: Optional[str] = None,
+        aws_web_identity_token: Optional[str] = None,
     ):
         """
         Return a boto3.Credentials object
@@ -222,6 +223,7 @@ class BedrockLLM(BaseLLM):
             aws_session_name,
             aws_profile_name,
             aws_role_name,
+            aws_web_identity_token,
         ]
 
         # Iterate over parameters and update if needed
@@ -238,10 +240,34 @@ class BedrockLLM(BaseLLM):
             aws_session_name,
             aws_profile_name,
             aws_role_name,
+            aws_web_identity_token,
         ) = params_to_check
 
         ### CHECK STS ###
-        if aws_role_name is not None and aws_session_name is not None:
+        if aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None:
+            oidc_token = get_secret(aws_web_identity_token)
+
+            if oidc_token is None:
+                raise BedrockError(
+                    message="OIDC token could not be retrieved from secret manager.",
+                    status_code=401,
+                )
+
+            sts_client = boto3.client(
+                "sts"
+            )
+
+            # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role_with_web_identity.html
+            sts_response = sts_client.assume_role_with_web_identity(
+                RoleArn=aws_role_name,
+                RoleSessionName=aws_session_name,
+                WebIdentityToken=oidc_token,
+                DurationSeconds=3600,
+            )
+
+            return sts_response["Credentials"]
+        elif aws_role_name is not None and aws_session_name is not None:
             sts_client = boto3.client(
                 "sts",
                 aws_access_key_id=aws_access_key_id,  # [OPTIONAL]
@@ -371,6 +397,7 @@ class BedrockLLM(BaseLLM):
         aws_bedrock_runtime_endpoint = optional_params.pop(
             "aws_bedrock_runtime_endpoint", None
         )  # https://bedrock-runtime.{region_name}.amazonaws.com
+        aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -398,6 +425,7 @@ class BedrockLLM(BaseLLM):
             aws_session_name=aws_session_name,
             aws_profile_name=aws_profile_name,
             aws_role_name=aws_role_name,
+            aws_web_identity_token=aws_web_identity_token,
         )
 
         ### SET RUNTIME ENDPOINT ###

--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -266,7 +266,14 @@ class BedrockLLM(BaseLLM):
                 DurationSeconds=3600,
             )
 
-            return sts_response["Credentials"]
+            session = boto3.Session(
+                aws_access_key_id=sts_response["Credentials"]["AccessKeyId"],
+                aws_secret_access_key=sts_response["Credentials"]["SecretAccessKey"],
+                aws_session_token=sts_response["Credentials"]["SessionToken"],
+                region_name=aws_region_name,
+            )
+
+            return session.get_credentials()
         elif aws_role_name is not None and aws_session_name is not None:
             sts_client = boto3.client(
                 "sts",


### PR DESCRIPTION
## Title

OIDC Support for Bedrock HTTPX

## Relevant issues

Resolves #3674

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

This adds OIDC support to the bedrock httpx client.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

I don't have any AWS_SECRET_ACCESS_KEY set in my deployment, so the only way this can work is if OIDC is working. :) 

<img width="704" alt="image" src="https://github.com/BerriAI/litellm/assets/7232674/3fa2e8fc-4e16-4447-a6c2-3d666e76cbec">

```yaml
model_list:
  - model_name: command-r
    litellm_params:
      model: bedrock/cohere.command-r-v1:0
      aws_region_name: us-east-1
      max_tokens: 4000
      seed: 1337
      aws_session_name: "test"
      aws_role_name: "arn:aws:iam::REMOVED:role/litellm-demo-example-run"
      aws_web_identity_token: "oidc/google/https://example.com"
```
