### PR TITLE
Work with custom `LANGSMITH_BASE_URL`

### DIFF
--- a/docs/my-website/docs/observability/langsmith_integration.md
+++ b/docs/my-website/docs/observability/langsmith_integration.md
@@ -71,6 +71,23 @@ response = litellm.completion(
 )
 print(response)
 ```
+
+### Make LiteLLM Proxy use Custom `LANGSMITH_BASE_URL`
+
+If you're using a custom LangSmith instance, you can set the
+`LANGSMITH_BASE_URL` environment variable to point to your instance.
+For example, you can make LiteLLM Proxy log to a local LangSmith instance with
+this config:
+
+```yaml
+litellm_settings:
+  success_callback: ["langsmith"]
+
+environment_variables:
+  LANGSMITH_BASE_URL: "http://localhost:1984"
+  LANGSMITH_PROJECT: "litellm-proxy"
+```
+
 ## Support & Talk to Founders
 
 - [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -44,6 +44,8 @@ class LangsmithLogger:
         print_verbose(
             f"Langsmith Logging - project_name: {project_name}, run_name {run_name}"
         )
+        langsmith_base_url = os.getenv("LANGSMITH_BASE_URL", "https://api.smith.langchain.com")
+
         try:
             print_verbose(
                 f"Langsmith Logging - Enters logging function for model {kwargs}"
@@ -86,8 +88,12 @@ class LangsmithLogger:
                 "end_time": end_time,
             }
 
+            url = f"{langsmith_base_url}/runs"
+            print_verbose(
+                f"Langsmith Logging - About to send data to {url} ..."
+            )
             response = requests.post(
-                "https://api.smith.langchain.com/runs",
+                url=url,
                 json=data,
                 headers={"x-api-key": self.langsmith_api_key},
             )


### PR DESCRIPTION
This allows working with a custom`LANGSMITH_BASE_URL`.

For example, I can use this to test against a local LangSmith instance, running on my laptop with Docker by adding this to the proxy config:

```yaml
litellm_settings:
  success_callback: ["langsmith"]

environment_variables:
  LANGSMITH_BASE_URL: "http://localhost:1984"
  LANGSMITH_PROJECT: "litellm-proxy"
```

![Screenshot 2024-05-16 at 5 07 46 PM](https://github.com/BerriAI/litellm/assets/305268/f2b99237-425d-4178-a700-dad01a9417eb)