### PR TITLE
Issue-3707-ModelResponse-have-no-key-ended

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3844,18 +3844,14 @@ def get_model_params_and_category(model_name):
     return None
 
 
-def get_replicate_completion_pricing(completion_response=None, total_time=0.0):
+def get_replicate_completion_pricing(total_time: float = 0.0) -> float:
     # see https://replicate.com/pricing
     a100_40gb_price_per_second_public = 0.001150
     # for all litellm currently supported LLMs, almost all requests go to a100_80gb
+    # todo: The pricing is to be extracted from `model_prices_and_context_window.json` ??
     a100_80gb_price_per_second_public = (
         0.001400  # assume all calls sent to A100 80GB for now
     )
-    if total_time == 0.0:  # total time is in ms
-        start_time = completion_response["created"]
-        end_time = completion_response["ended"]
-        total_time = end_time - start_time
-
     return a100_80gb_price_per_second_public * total_time / 1000
 
 
@@ -4540,7 +4536,7 @@ def completion_cost(
             model in litellm.replicate_models or "replicate" in model
         ) and model not in litellm.model_cost:
             # for unmapped replicate model, default to replicate's time tracking logic
-            return get_replicate_completion_pricing(completion_response, total_time)
+            return get_replicate_completion_pricing(total_time)
 
         (
             prompt_tokens_cost_usd_dollar,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3203,6 +3203,15 @@ def client(original_function):
             # MODEL CALL
             result = original_function(*args, **kwargs)
             end_time = datetime.datetime.now()
+            if (
+                isinstance(result, ModelResponse)
+                or isinstance(result, EmbeddingResponse)
+                or isinstance(result, TranscriptionResponse)
+            ):
+                result._response_ms = (
+                    end_time - start_time
+                ).total_seconds() * 1000  # return response latency in ms like openai
+
             if "stream" in kwargs and kwargs["stream"] == True:
                 if (
                     "complete_response" in kwargs
@@ -3250,9 +3259,6 @@ def client(original_function):
                     model=model,
                     optional_params=getattr(logging_obj, "optional_params", {}),
                 )
-            result._response_ms = (
-                end_time - start_time
-            ).total_seconds() * 1000  # return response latency in ms like openai
             return result
         except Exception as e:
             call_type = original_function.__name__
@@ -3623,6 +3629,15 @@ def client(original_function):
             # MODEL CALL
             result = await original_function(*args, **kwargs)
             end_time = datetime.datetime.now()
+            if (
+                isinstance(result, ModelResponse)
+                or isinstance(result, EmbeddingResponse)
+                or isinstance(result, TranscriptionResponse)
+            ):
+                result._response_ms = (
+                    end_time - start_time
+                ).total_seconds() * 1000  # return response latency in ms like openai
+
             if "stream" in kwargs and kwargs["stream"] == True:
                 if (
                     "complete_response" in kwargs
@@ -3646,14 +3661,6 @@ def client(original_function):
                     model=model,
                     optional_params=kwargs,
                 )
-            if (
-                isinstance(result, ModelResponse)
-                or isinstance(result, EmbeddingResponse)
-                or isinstance(result, TranscriptionResponse)
-            ):
-                result._response_ms = (
-                    end_time - start_time
-                ).total_seconds() * 1000  # return response latency in ms like openai
 
             ### POST-CALL RULES ###
             post_call_processing(original_response=result, model=model)


### PR DESCRIPTION
## Replicate Model -> fix use of old key

fix in response time calculation

## Relevant issues

https://github.com/BerriAI/litellm/issues/3707

## Type

🐛 Bug Fix

## Changes

* Change the computation of `_response_ms` before calling the callback functions
* Remove old time calculation to price for replicate model.