### PR TITLE
Upgrade Traceloop to version 0.18.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             pip install "langfuse==2.27.1"
             pip install "logfire==0.29.0"
             pip install numpydoc
-            pip install traceloop-sdk==0.0.69
+            pip install traceloop-sdk==0.18.2
             pip install openai
             pip install prisma            
             pip install "httpx==0.24.1"


### PR DESCRIPTION
## Title

This PR upgrades Traceloop to version 0.18.2.

## Motivation

After merging #3444 @krrishdholakia had to revert that PR in #3637 because tests in CI/CD pipeline were failing. This is most probably caused by both Traceloop and Logfire have opentelemetry dependency, but Traceloop before this PR was pinned to 0.0.69 which is quite old (Oct 27, 2023)