### PR TITLE
fix(langfuse.py): Stop adding the confusing `cache_hit` tag

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -417,12 +417,12 @@ class LangFuseLogger:
             if aws_region_name:
                 clean_metadata["aws_region_name"] = aws_region_name
 
+            if "cache_hit" in kwargs:
+                if kwargs["cache_hit"] is None:
+                    kwargs["cache_hit"] = False
+                clean_metadata["cache_hit"] = kwargs["cache_hit"]
+
             if supports_tags:
-                if "cache_hit" in kwargs:
-                    if kwargs["cache_hit"] is None:
-                        kwargs["cache_hit"] = False
-                    tags.append(f"cache_hit:{kwargs['cache_hit']}")
-                    clean_metadata["cache_hit"] = kwargs["cache_hit"]
                 if existing_trace_id is None:
                     trace_params.update({"tags": tags})
 


### PR DESCRIPTION
## Title

This removes the `cache_hit` from the trace, which doesn't really make sense. A cache hit shouldn't be a modifiable tag, and it also definitely should not be tagged on the trace. Cache hits only make sense on the generation.

## Relevant issues

Fixes #3676.

## Type

🐛 Bug Fix

## Changes

Removes teh 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Just made the commit, and started sending a few requests. Langfuse works fine as expected.

<img width="1158" alt="image" src="https://github.com/BerriAI/litellm/assets/7232674/f0142f89-452c-422b-822e-efdbdc50202d">
