### PR TITLE
[Feat] Proxy - Create Keys that can only access `/spend` routes on Admin UI 

### DIFF
--- a/docs/my-website/docs/enterprise.md
+++ b/docs/my-website/docs/enterprise.md
@@ -15,6 +15,7 @@ This covers:
 - ✅ **Custom SLAs**
 - ✅ [**Secure UI access with Single Sign-On**](../docs/proxy/ui.md#setup-ssoauth-for-ui)
 - ✅ [**JWT-Auth**](../docs/proxy/token_auth.md)
+- ✅ [**Invite Team Members to access `/spend` Routes**](../docs/proxy/cost_tracking#allowing-non-proxy-admins-to-access-spend-endpoints)
 
 
 ## [COMING SOON] AWS Marketplace Support

--- a/docs/my-website/docs/proxy/cost_tracking.md
+++ b/docs/my-website/docs/proxy/cost_tracking.md
@@ -125,6 +125,36 @@ Output from script
 
 </Tabs>
 
+## Allowing Non-Proxy Admins to access `/spend` endpoints 
+
+Use this when you want non-proxy admins to access `/spend` endpoints
+
+:::info
+
+Schedule a [meeting with us to get your Enterprise License](https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat)
+
+:::
+
+### Create Key 
+Create Key with with `permissions={"get_spend_routes": true}` 
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+        --header 'Authorization: Bearer sk-1234' \
+        --header 'Content-Type: application/json' \
+        --data '{
+            "permissions": {"get_spend_routes": true}
+    }'
+```
+
+### Use generated key on `/spend` endpoints
+
+Access spend Routes with newly generate keys
+```shell
+curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end_date=2024-06-30' \
+  -H 'Authorization: Bearer sk-H16BKvrSNConSsBYLGc_7A'
+```
+
+
 
 ## Reset Team, API Key Spend - MASTER KEY ONLY
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -157,6 +157,7 @@ class LiteLLMRoutes(enum.Enum):
         "/global/spend/end_users",
         "/global/spend/models",
         "/global/predict/spend/logs",
+        "/global/spend/report",
     ]
 
     public_routes: List = [

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -106,26 +106,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
         );
       }
 
-      if (formValues?.permissions != null) { 
-        /*
-        existing permissions = ["get_spend_logs"]
-        make this a dict like
-        {
-          "get_spend_logs": true
-        }
-        */
-
-        let permissionsForAPI: Record<string, boolean> = {};
-
-        for (let i = 0; i < formValues?.permissions?.length; i++) {
-          let permissionName: string = formValues?.permissions[i];
-          permissionsForAPI[permissionName] = true;
-        }
-        formValues.permissions = permissionsForAPI;
-        
-      } 
-
-
       message.info("Making API Call");
       setIsModalVisible(true);
       const response = await keyCreateCall(accessToken, userID, formValues);
@@ -214,7 +194,8 @@ const CreateKey: React.FC<CreateKeyProps> = ({
             <Form.Item
               label="Models"
               name="models"
-              rules={[{ message: "Please select a model" }]}
+              rules={[{ required: true, message: "Please select a model" }]}
+              help="required"
             >
               <Select
                 mode="multiple"
@@ -339,19 +320,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                   <TextInput placeholder="" />
                 </Form.Item>
 
-                <Form.Item
-                  className="mt-8"
-                  label="Allowed Routes"
-                  name="permissions"
-                  
-                  help={`Select routes this key is allowed to access`}
-                >
-                  <Select placeholder="n/a" mode="multiple" defaultValue={['get_spend_routes', 'llm_routes']} value={['get_spend_routes', 'llm_routes']}>
-                    <Select.Option value="get_spend_routes">Spend Reporting Routes (/global/spend/report, etc) </Select.Option>
-                    <Select.Option value="llm_routes">LLM routes (/chat, /completions, /embeddings)</Select.Option>
-                  </Select>
-                </Form.Item>
-                
                 <Form.Item label="Metadata" name="metadata" className="mt-8">
                   <Input.TextArea
                     rows={4}

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -319,7 +319,21 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                 >
                   <TextInput placeholder="" />
                 </Form.Item>
-                <Form.Item label="Metadata" name="metadata">
+
+                <Form.Item
+                  className="mt-8"
+                  label="Allowed Routes"
+                  name="permissions"
+                  
+                  help={`Select routes this key is allowed to access`}
+                >
+                  <Select defaultValue={null} placeholder="n/a" mode="multiple" defaultValue={['get_spend_routes', 'llm_routes']}>
+                    <Select.Option value="get_spend_routes">Spend Reporting Routes (/global/spend/report, etc) </Select.Option>
+                    <Select.Option value="llm_routes">LLM routes (/chat, /completions, /embeddings)</Select.Option>
+                  </Select>
+                </Form.Item>
+                
+                <Form.Item label="Metadata" name="metadata" className="mt-8">
                   <Input.TextArea
                     rows={4}
                     placeholder="Enter metadata as JSON"

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -106,6 +106,26 @@ const CreateKey: React.FC<CreateKeyProps> = ({
         );
       }
 
+      if (formValues?.permissions != null) { 
+        /*
+        existing permissions = ["get_spend_logs"]
+        make this a dict like
+        {
+          "get_spend_logs": true
+        }
+        */
+
+        let permissionsForAPI: Record<string, boolean> = {};
+
+        for (let i = 0; i < formValues?.permissions?.length; i++) {
+          let permissionName: string = formValues?.permissions[i];
+          permissionsForAPI[permissionName] = true;
+        }
+        formValues.permissions = permissionsForAPI;
+        
+      } 
+
+
       message.info("Making API Call");
       setIsModalVisible(true);
       const response = await keyCreateCall(accessToken, userID, formValues);
@@ -194,8 +214,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
             <Form.Item
               label="Models"
               name="models"
-              rules={[{ required: true, message: "Please select a model" }]}
-              help="required"
+              rules={[{ message: "Please select a model" }]}
             >
               <Select
                 mode="multiple"
@@ -327,7 +346,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                   
                   help={`Select routes this key is allowed to access`}
                 >
-                  <Select defaultValue={null} placeholder="n/a" mode="multiple" defaultValue={['get_spend_routes', 'llm_routes']}>
+                  <Select placeholder="n/a" mode="multiple" defaultValue={['get_spend_routes', 'llm_routes']} value={['get_spend_routes', 'llm_routes']}>
                     <Select.Option value="get_spend_routes">Spend Reporting Routes (/global/spend/report, etc) </Select.Option>
                     <Select.Option value="llm_routes">LLM routes (/chat, /completions, /embeddings)</Select.Option>
                   </Select>

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -68,6 +68,7 @@ interface ItemData {
   team_id: string;
   metadata: any;
   expires: any;
+  permissions: Record<string, any> | null;
   // Add any other properties that exist in the item data
 }
 
@@ -597,6 +598,17 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
         <Text className="my-1">{selectedToken.key_alias ? selectedToken.key_alias : selectedToken.key_name}</Text>
         <Title>Token ID</Title>
         <Text className="my-1 text-[12px]">{selectedToken.token}</Text>
+        {
+          selectedToken.permissions != null ? (
+            <div>
+                <Title>Permissions</Title>
+                <pre>{JSON.stringify(selectedToken.permissions)}</pre>
+            </div>
+          ) : (
+            <></>
+          )
+        }
+              
         <Title>Metadata</Title>
         <Text className="my-1"><pre>{JSON.stringify(selectedToken.metadata)} </pre></Text>
       </Card>

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -68,7 +68,6 @@ interface ItemData {
   team_id: string;
   metadata: any;
   expires: any;
-  permissions: Record<string, any> | null;
   // Add any other properties that exist in the item data
 }
 
@@ -597,18 +596,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
         <Title>Token Name</Title>
         <Text className="my-1">{selectedToken.key_alias ? selectedToken.key_alias : selectedToken.key_name}</Text>
         <Title>Token ID</Title>
-        <Text className="my-1 text-[12px]">{selectedToken.token}</Text>
-        {
-          selectedToken.permissions != null ? (
-            <div>
-                <Title>Permissions</Title>
-                <pre>{JSON.stringify(selectedToken.permissions)}</pre>
-            </div>
-          ) : (
-            <></>
-          )
-        }
-              
+        <Text className="my-1 text-[12px]">{selectedToken.token}</Text>              
         <Title>Metadata</Title>
         <Text className="my-1"><pre>{JSON.stringify(selectedToken.metadata)} </pre></Text>
       </Card>


### PR DESCRIPTION
## Create a Key that can access `/spend` routes

Usage 
```shell
curl --location 'http://0.0.0.0:4000/key/generate' \
        --header 'Authorization: Bearer sk-1234' \
        --header 'Content-Type: application/json' \
        --data '{
            "permissions": {"get_spend_routes": true}
    }'
```

Access spend Routes
```
curl -X GET 'http://localhost:4000/global/spend/report?start_date=2024-04-01&end_date=2024-06-30' \
  -H 'Authorization: Bearer sk-H16BKvrSNConSsBYLGc_7A'
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

