### PR TITLE
fix slack_alerting.py - timedelta should be a valid float

### DIFF
--- a/litellm/integrations/slack_alerting.py
+++ b/litellm/integrations/slack_alerting.py
@@ -1466,6 +1466,9 @@ Model Info:
                             response_s.total_seconds() / completion_tokens
                         )
 
+                if isinstance(final_value, timedelta):
+                    final_value = final_value.total_seconds()
+
                 await self.async_update_daily_reports(
                     DeploymentMetrics(
                         id=model_id,


### PR DESCRIPTION
## Title

Fix timedelta should be a valid float.

```python
Message: '[Non-Blocking Error] Slack Alerting: Got error in logging LLM deployment latency: ' Arguments: (1 validation error for DeploymentMetrics latency_per_output_token
  Input should be a valid number [type=float_type, input_value=datetime.timedelta(microseconds=286456), input_type=timedelta]
    For further information visit https://errors.pydantic.dev/2.7/v/float_type,)
```

## Type

🐛 Bug Fix

## Changes

just changing the type of the variable from timedelta to float.
