### PR TITLE
feature - Types for mypy - issue #360

### DIFF
--- a/litellm/py.typed
+++ b/litellm/py.typed
@@ -1,0 +1,2 @@
+# Marker file to instruct type checkers to look for inline type annotations in this package.
+# See PEP 561 for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
 readme = "README.md"
+packages = [
+    { include = "litellm" },
+    { include = "litellm/py.typed"},
+]
 
 [tool.poetry.urls]
 homepage = "https://litellm.ai"


### PR DESCRIPTION
## Title

Support distribution of type information for users of mypy and pyright.

For more information: https://peps.python.org/pep-0561/#packaging-type-information

## Relevant issues

Fixes #360, #3291, #825 

Note: This work is a duplicate subset of PR #3327   That PR is much more involved, whereas this PR is *extremely* simple and low risk.   Also, this conflicts with it, but is trivial to resolve.  You won't hurt my feelings if you don't merge this PR.

## Type

🆕 New Feature

## Changes

Add `litellm/py.typed` marker file.
 
## Testing

This doesn't change litellm functionality.  It affects linter runs within dependent projects.