### PR TITLE
Update pydantic version in CI requirements.txt

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -7,6 +7,6 @@ cohere
 redis
 anthropic
 orjson
-pydantic==1.10.14
+pydantic==2.7.1
 google-cloud-aiplatform==1.43.0
 redisvl==0.0.7 # semantic caching


### PR DESCRIPTION
This fixes potential CI test failures as the pydantic version installed during CI is incorrect.

## Relevant issues

Relates to CI failure from merging #3670 
https://github.com/BerriAI/litellm/pull/3670#issuecomment-2141663869

## Type
🐛 Bug Fix

