### PR TITLE
fix(bedrock): convert botocore credentials when role is assumed

### DIFF
--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -45,6 +45,7 @@ import httpx  # type: ignore
 from .bedrock import BedrockError, convert_messages_to_prompt, ModelResponseIterator
 from litellm.types.llms.bedrock import *
 import urllib.parse
+import botocore
 
 
 class AmazonCohereChatConfig:
@@ -261,7 +262,14 @@ class BedrockLLM(BaseLLM):
                 RoleArn=aws_role_name, RoleSessionName=aws_session_name
             )
 
-            return sts_response["Credentials"]
+            # Extract the credentials from the response and convert to Session Credentials
+            sts_credentials = sts_response["Credentials"]
+            credentials = botocore.credentials.Credentials(
+                access_key=sts_credentials["AccessKeyId"],
+                secret_key=sts_credentials["SecretAccessKey"],
+                token=sts_credentials["SessionToken"],
+            )
+            return credentials
         elif aws_profile_name is not None:  ### CHECK SESSION ###
             # uses auth values from AWS profile usually stored in ~/.aws/credentials
             client = boto3.Session(profile_name=aws_profile_name)

--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -45,7 +45,6 @@ import httpx  # type: ignore
 from .bedrock import BedrockError, convert_messages_to_prompt, ModelResponseIterator
 from litellm.types.llms.bedrock import *
 import urllib.parse
-import botocore
 
 
 class AmazonCohereChatConfig:
@@ -264,7 +263,9 @@ class BedrockLLM(BaseLLM):
 
             # Extract the credentials from the response and convert to Session Credentials
             sts_credentials = sts_response["Credentials"]
-            credentials = botocore.credentials.Credentials(
+            from botocore.credentials import Credentials
+
+            credentials = Credentials(
                 access_key=sts_credentials["AccessKeyId"],
                 secret_key=sts_credentials["SecretAccessKey"],
                 token=sts_credentials["SessionToken"],


### PR DESCRIPTION
The code changes in `bedrock_httpx.py` add functionality to extract and convert AWS STS credentials to session credentials using botocore. This fixes later error in add_auth request when token needs to be assigned.

## fix issue when assume-role is used 


```
{
    "model_name": "amazon.titan-embed-text-v1",
    "litellm_params": {
        "model": "bedrock/amazon.titan-embed-text-v1",
        "aws_role_name": "os.environ/Role-ARN",
        "aws_session_name": "dev1",
        "aws_region_name": "eu-central-1"
    }
}
```

## Relevant issues
Fixes #3878

## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
https://github.com/BerriAI/litellm/blob/deb87f71e330dcaf56574a477d9457d589754cd3/litellm/tests/test_bedrock_completion.py#L156

Sorry had issues in testing with some modules.
I do need help.

<!-- Test procedure -->

