### PR TITLE
Fix typo in field definition of model_config

### DIFF
--- a/litellm/tests/test_config.py
+++ b/litellm/tests/test_config.py
@@ -26,7 +26,7 @@ class DBModel(BaseModel):
     model_info: dict
     litellm_params: dict
 
-    config_dict: ConfigDict = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=())
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fix a typo in `test_config.py` that causes test to throw pydantic error

## Type
🐛 Bug Fix

## Changes

