### PR TITLE
(fix) Update Mistral model list and prices

### DIFF
--- a/docs/my-website/docs/providers/mistral.md
+++ b/docs/my-website/docs/providers/mistral.md
@@ -42,7 +42,7 @@ for chunk in response:
 
 
 ## Supported Models
-All models listed here https://docs.mistral.ai/platform/endpoints are supported. We actively maintain the list of models, pricing, token window, etc. [here](https://github.com/BerriAI/litellm/blob/c1b25538277206b9f00de5254d80d6a83bb19a29/model_prices_and_context_window.json).
+All models listed here https://docs.mistral.ai/platform/endpoints are supported. We actively maintain the list of models, pricing, token window, etc. [here](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).
 
 | Model Name     | Function Call                                                |
 |----------------|--------------------------------------------------------------|
@@ -52,6 +52,7 @@ All models listed here https://docs.mistral.ai/platform/endpoints are supported.
 | Mistral 7B     | `completion(model="mistral/open-mistral-7b", messages)`      |
 | Mixtral 8x7B   | `completion(model="mistral/open-mixtral-8x7b", messages)`    |
 | Mixtral 8x22B  | `completion(model="mistral/open-mixtral-8x22b", messages)`   |
+| Codestral      | `completion(model="mistral/codestral-latest", messages)`     |
 
 ## Function Calling 
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -692,8 +692,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.00000015,
-        "output_cost_per_token": 0.00000046,
+        "input_cost_per_token": 0.00000025,
+        "output_cost_per_token": 0.00000025,
         "litellm_provider": "mistral",
         "mode": "chat"
     },
@@ -701,8 +701,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000002,
-        "output_cost_per_token": 0.000006,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
         "litellm_provider": "mistral",
         "supports_function_calling": true,
         "mode": "chat"
@@ -711,8 +711,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000002,
-        "output_cost_per_token": 0.000006,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
         "litellm_provider": "mistral",
         "supports_function_calling": true,
         "mode": "chat"
@@ -748,8 +748,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000008,
-        "output_cost_per_token": 0.000024,
+        "input_cost_per_token": 0.000004,
+        "output_cost_per_token": 0.000012,
         "litellm_provider": "mistral",
         "mode": "chat",
         "supports_function_calling": true
@@ -758,15 +758,34 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000008,
-        "output_cost_per_token": 0.000024,
+        "input_cost_per_token": 0.000004,
+        "output_cost_per_token": 0.000012,
         "litellm_provider": "mistral",
         "mode": "chat",
         "supports_function_calling": true
     },
+    "mistral/open-mistral-7b": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.00000025,
+        "output_cost_per_token": 0.00000025,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
     "mistral/open-mixtral-8x7b": {
         "max_tokens": 8191,
         "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.0000007,
+        "output_cost_per_token": 0.0000007,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "mistral/open-mixtral-8x22b": {
+        "max_tokens": 8191,
+        "max_input_tokens": 64000,
         "max_output_tokens": 8191,
         "input_cost_per_token": 0.000002,
         "output_cost_per_token": 0.000006,
@@ -774,10 +793,28 @@
         "mode": "chat",
         "supports_function_calling": true
     },
+    "mistral/codestral-latest": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
+    "mistral/codestral-2405": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
     "mistral/mistral-embed": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,
-        "input_cost_per_token": 0.000000111,
+        "input_cost_per_token": 0.0000001,
         "litellm_provider": "mistral",
         "mode": "embedding"
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -692,8 +692,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.00000015,
-        "output_cost_per_token": 0.00000046,
+        "input_cost_per_token": 0.00000025,
+        "output_cost_per_token": 0.00000025,
         "litellm_provider": "mistral",
         "mode": "chat"
     },
@@ -701,8 +701,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000002,
-        "output_cost_per_token": 0.000006,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
         "litellm_provider": "mistral",
         "supports_function_calling": true,
         "mode": "chat"
@@ -711,8 +711,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000002,
-        "output_cost_per_token": 0.000006,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
         "litellm_provider": "mistral",
         "supports_function_calling": true,
         "mode": "chat"
@@ -748,8 +748,8 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000008,
-        "output_cost_per_token": 0.000024,
+        "input_cost_per_token": 0.000004,
+        "output_cost_per_token": 0.000012,
         "litellm_provider": "mistral",
         "mode": "chat",
         "supports_function_calling": true
@@ -758,15 +758,34 @@
         "max_tokens": 8191,
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
-        "input_cost_per_token": 0.000008,
-        "output_cost_per_token": 0.000024,
+        "input_cost_per_token": 0.000004,
+        "output_cost_per_token": 0.000012,
         "litellm_provider": "mistral",
         "mode": "chat",
         "supports_function_calling": true
     },
+    "mistral/open-mistral-7b": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.00000025,
+        "output_cost_per_token": 0.00000025,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
     "mistral/open-mixtral-8x7b": {
         "max_tokens": 8191,
         "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.0000007,
+        "output_cost_per_token": 0.0000007,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "mistral/open-mixtral-8x22b": {
+        "max_tokens": 8191,
+        "max_input_tokens": 64000,
         "max_output_tokens": 8191,
         "input_cost_per_token": 0.000002,
         "output_cost_per_token": 0.000006,
@@ -774,10 +793,28 @@
         "mode": "chat",
         "supports_function_calling": true
     },
+    "mistral/codestral-latest": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
+    "mistral/codestral-2405": {
+        "max_tokens": 8191,
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000003,
+        "litellm_provider": "mistral",
+        "mode": "chat"
+    },
     "mistral/mistral-embed": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,
-        "input_cost_per_token": 0.000000111,
+        "input_cost_per_token": 0.0000001,
         "litellm_provider": "mistral",
         "mode": "embedding"
     },


### PR DESCRIPTION
Updates the prices of the Mistral models per the latest [pricing info](https://mistral.ai/technology/#pricing), adds [Codestral](https://mistral.ai/news/codestral/) to the model list.

## Relevant issues

Somewhat related to #3922 (although that asks for support for the new `https://codestral.mistral.ai/` endpoint, which is not addressed here)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation

## Changes

- Adds entries for `codestral-latest` and `codestral-2405`
- Adds entries for `open-mistral-7b` and `open-mistral-8x22b` (existing models which appeared to be missing)
- Updates the costs for existing Mistral models per Mistral's [pricing page](https://mistral.ai/technology/#pricing)
  - N.B. `mistral-tiny` isn't mentioned on this pricing page, but according to their [Models documentation](https://docs.mistral.ai/getting-started/models/), `mistral-tiny` now points to `open-mistral-7b`
- Adds reference to Codestral to the Mistral docs