### PR TITLE
add dall-e 3 required comment

### DIFF
--- a/docs/my-website/docs/image_generation.md
+++ b/docs/my-website/docs/image_generation.md
@@ -51,7 +51,7 @@ print(f"response: {response}")
 
 - `api_base`: *string (optional)* - The api endpoint you want to call the model with
 
-- `api_version`: *string (optional)* - (Azure-specific) the api version for the call
+- `api_version`: *string (optional)* - (Azure-specific) the api version for the call; required for dall-e-3 on Azure
 
 - `api_key`: *string (optional)* - The API key to authenticate and authorize requests. If not provided, the default API key is used.
 


### PR DESCRIPTION
## Title

Frustrated and confused about getting image generation to work, I figured out setting the `api_version` to the one provided by Azure ensures it uses the DALL-E 3 model as in the deployment, instead of failing with the default DALL-E 2 expected response (

Not sure if LiteLLM or Azure makes the wrong assumption here.

This small addition hopefully helps other confused image generator aficionados.

## Type

📖 Documentation

## Changes

add dall-e 3 required comment
