### PR TITLE
feat: add langfuse metadata via proxy request headers

### DIFF
--- a/docs/my-website/docs/observability/langfuse_integration.md
+++ b/docs/my-website/docs/observability/langfuse_integration.md
@@ -151,7 +151,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
     --header 'Content-Type: application/json' \    
     --header 'langfuse_trace_id: trace-id22' \
     --header 'langfuse_trace_user_id: user-id2' \
-    --header 'langfuse_trace_metadata: {"key":"value"}'
+    --header 'langfuse_trace_metadata: {"key":"value"}' \
     --data '{
     "model": "gpt-3.5-turbo",
     "messages": [

--- a/docs/my-website/docs/observability/langfuse_integration.md
+++ b/docs/my-website/docs/observability/langfuse_integration.md
@@ -144,6 +144,26 @@ print(response)
 
 ```
 
+You can also pass `metadata` as part of the request header with a `langfuse_*` prefix:
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \    
+    --header 'langfuse_trace_id: trace-id22' \
+    --header 'langfuse_trace_user_id: user-id2' \
+    --header 'langfuse_trace_metadata: {"key":"value"}'
+    --data '{
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+
 ### Trace & Generation Parameters
 
 #### Trace Specific Parameters

--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -69,6 +69,27 @@ class LangFuseLogger:
         else:
             self.upstream_langfuse = None
 
+    @staticmethod
+    def add_metadata_from_header(litellm_params) -> dict:
+        """
+        Adds metadata from proxy request headers to Langfuse logging if keys start with "trace_" 
+        and overwrites if already exists in litellm_params.metadata
+        """
+        metadata = litellm_params.get("metadata", {})
+        proxy_headers = litellm_params.get("proxy_server_request", {}).get("headers", {})
+
+        # Update the following keys for this trace
+        for metadata_param_key in proxy_headers:
+            if metadata_param_key.startswith("trace_"):
+                trace_param_key = metadata_param_key.replace("trace_", "", 1)
+                if trace_param_key in metadata:
+                    verbose_logger.warning(f"Overwriting Langfuse `{trace_param_key}` from request header")
+                else:
+                    verbose_logger.debug(f"Found Langfuse `{trace_param_key}` in request header")
+                metadata[trace_param_key] = proxy_headers.get(metadata_param_key)
+
+        return metadata
+
     # def log_error(kwargs, response_obj, start_time, end_time):
     #     generation = trace.generation(
     #         level ="ERROR" # can be any of DEBUG, DEFAULT, WARNING or ERROR
@@ -94,9 +115,7 @@ class LangFuseLogger:
 
             litellm_params = kwargs.get("litellm_params", {})
             litellm_call_id = kwargs.get("litellm_call_id", None)
-            metadata = (
-                litellm_params.get("metadata", {}) or {}
-            )  # if litellm_params['metadata'] == None
+            metadata = self.add_metadata_from_header(litellm_params)
             optional_params = copy.deepcopy(kwargs.get("optional_params", {}))
 
             prompt = {"messages": kwargs.get("messages")}


### PR DESCRIPTION
Hey all,

I am missing a small feature when using LiteLLM Proxy together with Langfuse. I am using the Vercel AI SDK and want to pass additional metadata to the proxy completion call. However, the `createOpenAi()` from [AI-SDK](https://sdk.vercel.ai/providers/ai-sdk-providers/openai) only supports custom metadata via headers out of the box.

For example, I initialize my trace via `const trace = langfuse.trace()` and pass the existing traceId to Langfuse via
```javascript
  const openai = createOpenAI({
    apiKey: process.env.OPENAI_API_KEY,
    baseURL: process.env.OPENAI_BASE_URL,
    headers: {
      "langfuse_trace_id": trace.id
    }
  });
```
because the traceId response from LiteLLM is also not easily accesible.

That's why I extended the Langfuse logger to accept `langfuse_*` key in header and pass it over as `metadata` to the Langfuse logger.

Apparently I am not 100% familiar with all corner cases when extending the logger, but wanted to contribute this functionality back. I am open to adjust my changes to comply with your guidelines and to catch any corner cases.

Thanks a lot for this amazing library.

Cheers, Andreas ✌️