### PR TITLE
Fix parsing nested objects from xml

### DIFF
--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -536,6 +536,15 @@ def test_parse_xml_params():
     assert response["location"] == "Boston, MA"
     assert response["unit"] == "fahrenheit"
 
+    ## SCENARIO 3 ## - W/ ARRAY OF OBJECTS
+    xml_content = """<invoke><tool_name>User</tool_name><parameters><name>Jason</name><age>25</age><moods><Mood><name>sad</name></Mood><Mood><name>happy</name></Mood></moods></parameters></invoke>"""
+    json_schema = {'$defs': {'Mood': {'properties': {'name': {'title': 'Name', 'type': 'string'}}, 'required': ['name'], 'title': 'Mood', 'type': 'object'}}, 'properties': {'name': {'title': 'Name', 'type': 'string'}, 'age': {'title': 'Age', 'type': 'integer'}, 'moods': {'items': {'$ref': '#/$defs/Mood'}, 'title': 'Moods', 'type': 'array'}}, 'required': ['age', 'moods', 'name'], 'type': 'object'}
+
+    response = parse_xml_params(xml_content=xml_content, json_schema=json_schema)
+
+    print(f"response: {response}")
+    assert response["moods"] == [{"name": "sad"}, {"name": "happy"}]
+
 
 def test_completion_claude_3_multi_turn_conversations():
     litellm.set_verbose = True


### PR DESCRIPTION
## Title

Fix parsing nested objects from xml

## Relevant issues

https://github.com/BerriAI/litellm/issues/4004

## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->
- Changed parse_xml_params to parse objects defined in $defs
- Added a new test case to test_completion.py::test_parse_xml_params

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
<img width="916" alt="Screenshot 2024-06-04 at 17 23 16" src="https://github.com/BerriAI/litellm/assets/72855171/f4a76cf9-e844-4434-83a3-0b457b73645e">



