### PR TITLE
feat: clarify slack alerting message

### DIFF
--- a/litellm/integrations/slack_alerting.py
+++ b/litellm/integrations/slack_alerting.py
@@ -537,7 +537,7 @@ class SlackAlerting(CustomLogger):
             cache_list=combined_metrics_cache_keys
         )
 
-        message += f"\n\nNext Run is in: `{time.time() + self.alerting_args.daily_report_frequency}`s"
+        message += f"\n\nNext Run is at: `{time.time() + self.alerting_args.daily_report_frequency}`s"
 
         # send alert
         await self.send_alert(message=message, level="Low", alert_type="daily_reports")


### PR DESCRIPTION
Specify the time of the next run, not the interval

## Title

feat: clarify slack alerting message
Specify the time of the next run, not the interval

## Relevant issues

n/a

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


📖 Documentation


## Changes

<!-- List of changes -->

Specify the time of the next run, not the interval

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

