### PR TITLE
modified docs proxy->logging->langfuse

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -42,6 +42,7 @@ litellm_settings:
 ```shell
 export LANGFUSE_PUBLIC_KEY="pk_kk"
 export LANGFUSE_SECRET_KEY="sk_ss"
+# Optional, defaults to https://cloud.langfuse.com
 export LANGFUSE_HOST="https://xxx.langfuse.com"
 ```
 

--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -41,7 +41,8 @@ litellm_settings:
 **Step 3**: Set required env variables for logging to langfuse
 ```shell
 export LANGFUSE_PUBLIC_KEY="pk_kk"
-export LANGFUSE_SECRET_KEY="sk_ss
+export LANGFUSE_SECRET_KEY="sk_ss"
+export LANGFUSE_HOST="https://xxx.langfuse.com"
 ```
 
 **Step 4**: Start the proxy, make a test request


### PR DESCRIPTION
## Title

Modify the logging section of the documentation on using langfuse.

## Relevant issues

https://github.com/BerriAI/litellm/issues/4034

## Type

📖 Documentation

## Changes

- [Optional] add the environment variable LANGFUSE_HOST in the logging section of the documentation


