### PR TITLE
fix tool usage null content using vertexai

### DIFF
--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -642,9 +642,9 @@ def completion(
 
         prompt = " ".join(
             [
-                message["content"]
+                message.get("content", "")
                 for message in messages
-                if isinstance(message["content"], str)
+                if isinstance(message.get("content", ""), str)
             ]
         )
 

--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -642,9 +642,9 @@ def completion(
 
         prompt = " ".join(
             [
-                message.get("content", "")
+                message.get("content")
                 for message in messages
-                if isinstance(message.get("content", ""), str)
+                if isinstance(message.get("content", None), str)
             ]
         )
 


### PR DESCRIPTION
Sometimes, when the model proposes a function, the content key is not present. This gives error like:
```

  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_ai.py", line 647, in <listcomp>
    if isinstance(message["content"], str)
                  ~~~~~~~^^^^^^^^^^^
KeyError: 'content'
```

This PR avoids this error while maintaning compatibility
