### PR TITLE
Fix: Output Structure of Ollama chat

### DIFF
--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -501,8 +501,10 @@ async def ollama_acompletion(
                         {
                             "id": f"call_{str(uuid.uuid4())}",
                             "function": {
-                                "name": function_call["name"],
-                                "arguments": json.dumps(function_call["arguments"]),
+                                "name": function_call.get("name", function_name),
+                                "arguments": json.dumps(
+                                    function_call.get("arguments", function_call)
+                                ),
                             },
                             "type": "function",
                         }


### PR DESCRIPTION
## Title

Ollama response fix for function calling

## Relevant issues

https://github.com/BerriAI/litellm/issues/3912

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

Resolve the key error by the use of  `dict.get` method

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local
Ollama requires local testing
testing the example from https://microsoft.github.io/autogen/docs/topics/non-openai-models/local-litellm-ollama/

program response
```text
user_proxy (to chatbot):

How much is 123.45 EUR in USD?

--------------------------------------------------------------------------------
chatbot (to user_proxy):

***** Suggested tool call (call_b2eb58bd-5ff4-4332-9566-147fb17d4b76): currency_calculator *****
Arguments: 
{"base_amount": 123.45, "quote_currency": "USD"}
************************************************************************************************

--------------------------------------------------------------------------------

>>>>>>>> EXECUTING FUNCTION currency_calculator...
user_proxy (to chatbot):

user_proxy (to chatbot):

***** Response from calling tool (call_b2eb58bd-5ff4-4332-9566-147fb17d4b76) *****
123.45 USD
**********************************************************************************

--------------------------------------------------------------------------------
chatbot (to user_proxy):

***** Suggested tool call (call_8d3ca275-0b00-4bd1-8734-3f2d9f1e438a): currency_calculator *****
Arguments: 
{"parameter_1_name": "base_amount", "parameter_2_name": "quote_currency"}
************************************************************************************************

--------------------------------------------------------------------------------

Process finished with exit code 0
```

