### PR TITLE
docs: fix llmcord.py side bar link

### DIFF
--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -255,7 +255,7 @@ const sidebars = {
             "projects/GPT Migrate",
             "projects/YiVal",
             "projects/LiteLLM Proxy",
-            "projects/llmcord.py (Discord LLM Chatbot)",
+            "projects/llmcord.py Discord LLM Chatbot",
           ],
         },
       ],


### PR DESCRIPTION
sorry for so many PRs...

I realized that my last attempt (https://github.com/BerriAI/litellm/pull/4101) was incorrect and leads to an invalid page:
![image](https://github.com/BerriAI/litellm/assets/38699060/5b1eb3d4-9d52-4a61-a9e7-17b951a11c4d)

The correct URL has no parenthesis:
![image](https://github.com/BerriAI/litellm/assets/38699060/812d17da-faf5-4a73-8457-1a3d9b09c34a)
