### PR TITLE
`assistants.md`: Add `user_api_end_user_max_budget` metadata to `litellm_params`

### DIFF
--- a/docs/my-website/docs/assistants.md
+++ b/docs/my-website/docs/assistants.md
@@ -136,7 +136,10 @@ assistant_settings:
   litellm_params: 
     api_key: os.environ/AZURE_API_KEY
     api_base: os.environ/AZURE_API_BASE
-    api_version: os.environ/AZURE_API_VERSION
+    api_version: 2024-03-01-preview
+    metadata:
+      user_api_end_user_max_budget: 5
+
 ```
 
 ```bash


### PR DESCRIPTION
Without this, I get:

```shell
$ curl http://0.0.0.0:4000/v1/threads \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LLM_PROXY_API_KEY" \
  -d ''
{"error":{"message":"Error code: 400 - {'error': {'message': \"Invalid type for 'metadata.user_api_end_user_max_budget': expected a string, but got null instead.\", 'type': 'invalid_request_error', 'param': 'metadata.user_api_end_user_max_budget', 'code': 'invalid_type'}}","type":null,"param":null,"code":500}}
```

With this, I get:

```shell
$ curl http://0.0.0.0:4000/v1/threads \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LLM_PROXY_API_KEY" \
  -d ''
{"id":"thread_1HZKdk9gO9vBNiiQUgpoteLo","created_at":1718066676,"metadata":{"user_api_end_user_max_budget":"5"},"object":"thread"}
```