### PR TITLE
Idea: Return Langfuse info in response

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -40,6 +40,7 @@ class LangFuseLogger:
             self.langfuse_host = "http://" + self.langfuse_host
         self.langfuse_release = os.getenv("LANGFUSE_RELEASE")
         self.langfuse_debug = os.getenv("LANGFUSE_DEBUG")
+        self.langfuse_ui_base_url = os.getenv("LANGFUSE_UI_BASE_URL")
 
         parameters = {
             "public_key": self.public_key,
@@ -232,6 +233,18 @@ class LangFuseLogger:
                 f"Langfuse Layer Logging - final response object: {response_obj}"
             )
             verbose_logger.info(f"Langfuse Layer Logging - logging success")
+
+            # response_obj.metadata["trace_id"] = trace_id
+            if "litellm" not in response_obj:
+                response_obj["litellm"] = {}
+            if "langfuse" not in response_obj["litellm"]:
+                response_obj["litellm"]["langfuse"] = {}
+            trace_url = f"{self.langfuse_ui_base_url}/trace/{trace_id}"
+            response_obj["litellm"]["langfuse"] = {
+                "trace_id": trace_id,
+                "trace_url": trace_url,
+                "generation_id": generation_id,
+            }
 
             return {"trace_id": trace_id, "generation_id": generation_id}
         except Exception as e:

--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -252,6 +252,11 @@ class LangFuseLogger:
                 "Langfuse Layer Error(): Exception occured - {}".format(str(e))
             )
             verbose_logger.debug(traceback.format_exc())
+            response_obj["litellm"]["langfuse"] = {
+                "trace_id": trace_id,
+                "trace_url": trace_url,
+                "generation_id": generation_id,
+            }
             return {"trace_id": None, "generation_id": None}
 
     async def _async_log_event(

--- a/litellm/integrations/slack_alerting.py
+++ b/litellm/integrations/slack_alerting.py
@@ -258,7 +258,7 @@ class SlackAlerting(CustomLogger):
 
             if litellm.litellm_core_utils.litellm_logging.langFuseLogger is not None:
                 base_url = (
-                    litellm.litellm_core_utils.litellm_logging.langFuseLogger.Langfuse.base_url
+                    litellm.litellm_core_utils.litellm_logging.langFuseLogger.Langfuse.langfuse_ui_base_url
                 )
                 return f"{base_url}/trace/{trace_id}"
         return None


### PR DESCRIPTION
This is more of an idea and discussion starter than a finished PR. The idea is to add the URL of the Langfuse trace to the response so that if someone wants to dig deeper, they can do so easily.

Now we could debate the field names and structure (I tried to create kind of a standard place in the response where litellm could put other stuff like this) and all that and also probably there should be a way to turn it off because some people may not want this feature.

```shell
$ curl -sSL --request POST \
  --url 'http://127.0.0.1:4000/chat/completions' \
  --header "Authorization: Bearer ${LLM_PROXY_API_KEY}" \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "gpt-35-turbo-1106",
  "messages": [{"role":"system","content":"you are a helpful assistant named Michaelangelo who answers questions about art"},{"role":"user","content":"what is your name? What can you help with?"}]
}' | jq '.'
{
  "id": "chatcmpl-9Z2m6QLTTWZyKcGiI9gdS6aUNqHVf",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "My name is Michaelangelo, and I can help you with questions about art, artists, art history, and anything else related to the world of art. Feel free to ask me anything you'd like to know!",
        "role": "assistant"
      }
    }
  ],
  "created": 1718139174,
  "model": "gpt-35-turbo",
  "object": "chat.completion",
  "system_fingerprint": "fp_811936bd4f",
  "usage": {
    "completion_tokens": 43,
    "prompt_tokens": 35,
    "total_tokens": 78
  },
  "litellm": {
    "langfuse": {
      "trace_id": "f8fe15d0-e0b0-4b27-aceb-a308f4c799a1",
      "trace_url": "https://langfuse.foo.company.com/trace/f8fe15d0-e0b0-4b27-aceb-a308f4c799a1",
      "generation_id": "time-13-52-53-429825_chatcmpl-9Z2m6QLTTWZyKcGiI9gdS6aUNqHVf"
    }
  }
}
```

Note that I can command click the `.litellm.langfuse.trace_url` URL and instantly see more about about this generation.