### PR TITLE
Allowing inference of LLM provider in `get_supported_openai_params`

### DIFF
--- a/litellm/tests/test_utils.py
+++ b/litellm/tests/test_utils.py
@@ -23,6 +23,7 @@ from litellm.utils import (
     create_pretrained_tokenizer,
     create_tokenizer,
     get_max_tokens,
+    get_supported_openai_params,
 )
 
 # Assuming your trim_messages, shorten_message_to_fit_limit, and get_token_count functions are all in a module named 'message_utils'
@@ -386,3 +387,7 @@ def test_get_max_token_unit_test():
     )  # Returns a number instead of throwing an Exception
 
     assert isinstance(max_tokens, int)
+
+
+def test_get_supported_openai_params() -> None:
+    assert isinstance(get_supported_openai_params("gpt-4"), list)

--- a/litellm/tests/test_utils.py
+++ b/litellm/tests/test_utils.py
@@ -390,4 +390,8 @@ def test_get_max_token_unit_test():
 
 
 def test_get_supported_openai_params() -> None:
+    # Mapped provider
     assert isinstance(get_supported_openai_params("gpt-4"), list)
+
+    # Unmapped provider
+    assert get_supported_openai_params("nonexistent") is None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6226,7 +6226,7 @@ def get_first_chars_messages(kwargs: dict) -> str:
 
 def get_supported_openai_params(
     model: str,
-    custom_llm_provider: str,
+    custom_llm_provider: Optional[str] = None,
     request_type: Literal["chat_completion", "embeddings"] = "chat_completion",
 ) -> Optional[list]:
     """
@@ -6241,6 +6241,8 @@ def get_supported_openai_params(
     - List if custom_llm_provider is mapped
     - None if unmapped
     """
+    if not custom_llm_provider:
+        custom_llm_provider = litellm.get_llm_provider(model=model)[1]
     if custom_llm_provider == "bedrock":
         return litellm.AmazonConverseConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "ollama":

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6242,7 +6242,10 @@ def get_supported_openai_params(
     - None if unmapped
     """
     if not custom_llm_provider:
-        custom_llm_provider = litellm.get_llm_provider(model=model)[1]
+        try:
+            custom_llm_provider = litellm.get_llm_provider(model=model)[1]
+        except BadRequestError:
+            return None
     if custom_llm_provider == "bedrock":
         return litellm.AmazonConverseConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "ollama":


### PR DESCRIPTION
## Title

Allowing inference of LLM provider in `get_supported_openai_params`

## Relevant issues

- Related: https://github.com/BerriAI/litellm/issues/4100#issuecomment-2159276091

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

<!-- List of changes -->

- Allowing inference of LLM provider in `get_supported_openai_params`

<!-- Test procedure -->

