### PR TITLE
feat: Upgrade all httpx clients to use http2 (unit test me plz?)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             pip install traceloop-sdk==0.21.1
             pip install openai
             pip install prisma            
-            pip install "httpx==0.24.1"
+            pip install "httpx[http2]==0.27.0"
             pip install fastapi
             pip install "gunicorn==21.2.0"
             pip install "anyio==3.7.1"
@@ -177,7 +177,7 @@ jobs:
             pip install numpydoc
             pip install prisma            
             pip install fastapi            
-            pip install "httpx==0.24.1"
+            pip install "httpx[http2]==0.27.0"
             pip install "gunicorn==21.2.0"
             pip install "anyio==3.7.1"
             pip install "aiodynamo==23.10.1"

--- a/litellm/llms/azure.py
+++ b/litellm/llms/azure.py
@@ -730,6 +730,7 @@ class AzureChatCompletion(BaseLLM):
             if client is None:
                 client_session = litellm.aclient_session or httpx.AsyncClient(
                     transport=AsyncCustomHTTPTransport(),
+                    http2=True,
                 )
                 azure_client = AsyncAzureOpenAI(
                     http_client=client_session, **azure_client_params
@@ -834,6 +835,7 @@ class AzureChatCompletion(BaseLLM):
             if client is None:
                 client_session = litellm.client_session or httpx.Client(
                     transport=CustomHTTPTransport(),
+                    http2=True,
                 )
                 azure_client = AzureOpenAI(http_client=client_session, **azure_client_params)  # type: ignore
             else:
@@ -1038,6 +1040,7 @@ class AzureChatCompletion(BaseLLM):
     ) -> dict:
         client_session = litellm.client_session or httpx.Client(
             transport=CustomHTTPTransport(),  # handle dall-e-2 calls
+            http2=True,
         )
         if "gateway.ai.cloudflare.com" in api_base:
             ## build base url - assume api base includes resource name
@@ -1113,6 +1116,7 @@ class AzureChatCompletion(BaseLLM):
     ) -> dict:
         client_session = litellm.aclient_session or httpx.AsyncClient(
             transport=AsyncCustomHTTPTransport(),  # handle dall-e-2 calls
+            http2=True,
         )
         if "gateway.ai.cloudflare.com" in api_base:
             ## build base url - assume api base includes resource name

--- a/litellm/llms/base.py
+++ b/litellm/llms/base.py
@@ -31,7 +31,7 @@ class BaseLLM:
         if litellm.client_session:
             _client_session = litellm.client_session
         else:
-            _client_session = httpx.Client()
+            _client_session = httpx.Client(http2=True)
 
         return _client_session
 
@@ -39,7 +39,7 @@ class BaseLLM:
         if litellm.aclient_session:
             _aclient_session = litellm.aclient_session
         else:
-            _aclient_session = httpx.AsyncClient()
+            _aclient_session = httpx.AsyncClient(http2=True)
 
         return _aclient_session
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -20,6 +20,7 @@ class AsyncHTTPHandler:
                 max_connections=concurrent_limit,
                 max_keepalive_connections=concurrent_limit,
             ),
+            http2=True,
         )
 
     async def close(self):
@@ -85,6 +86,7 @@ class HTTPHandler:
                     max_connections=concurrent_limit,
                     max_keepalive_connections=concurrent_limit,
                 ),
+                http2=True,
             )
         else:
             self.client = client

--- a/litellm/llms/custom_httpx/httpx_handler.py
+++ b/litellm/llms/custom_httpx/httpx_handler.py
@@ -9,7 +9,8 @@ class HTTPHandler:
             limits=httpx.Limits(
                 max_connections=concurrent_limit,
                 max_keepalive_connections=concurrent_limit,
-            )
+            ),
+            http2=True,
         )
 
     async def close(self):

--- a/litellm/llms/huggingface_restapi.py
+++ b/litellm/llms/huggingface_restapi.py
@@ -651,7 +651,7 @@ class Huggingface(BaseLLM):
     ):
         response = None
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
                 response = await client.post(url=api_base, json=data, headers=headers)
                 response_json = response.json()
                 if response.status_code != 200:
@@ -703,7 +703,7 @@ class Huggingface(BaseLLM):
         model: str,
         timeout: float,
     ):
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
             response = client.stream(
                 "POST", url=f"{api_base}", json=data, headers=headers
             )

--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -341,7 +341,7 @@ def ollama_completion_stream(url, data, logging_obj):
 
 async def ollama_async_streaming(url, data, model_response, encoding, logging_obj):
     try:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(http2=True)
         async with client.stream(
             url=f"{url}", json=data, method="POST", timeout=litellm.request_timeout
         ) as response:

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -381,7 +381,7 @@ async def ollama_async_streaming(
     url, api_key, data, model_response, encoding, logging_obj
 ):
     try:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(http2=True)
         _request = {
             "url": f"{url}",
             "json": data,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2862,6 +2862,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=async_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -2887,6 +2888,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=sync_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -2912,6 +2914,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=async_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -2937,6 +2940,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=sync_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -2980,6 +2984,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=async_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -3002,6 +3007,7 @@ class Router:
                                 ),
                             ),
                             mounts=sync_proxy_mounts,
+                            http2=True,
                         ),  # type: ignore
                     )
                     self.cache.set_cache(
@@ -3025,6 +3031,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=async_proxy_mounts,
+                            http2=True,
                         ),
                     )
                     self.cache.set_cache(
@@ -3047,6 +3054,7 @@ class Router:
                                 verify=litellm.ssl_verify,
                             ),
                             mounts=sync_proxy_mounts,
+                            http2=True,
                         ),
                     )
                     self.cache.set_cache(
@@ -3079,6 +3087,7 @@ class Router:
                             verify=litellm.ssl_verify,
                         ),
                         mounts=async_proxy_mounts,
+                        http2=True,
                     ),  # type: ignore
                 )
                 self.cache.set_cache(
@@ -3103,6 +3112,7 @@ class Router:
                             verify=litellm.ssl_verify,
                         ),
                         mounts=sync_proxy_mounts,
+                        http2=True,
                     ),  # type: ignore
                 )
                 self.cache.set_cache(
@@ -3128,6 +3138,7 @@ class Router:
                             verify=litellm.ssl_verify,
                         ),
                         mounts=async_proxy_mounts,
+                        http2=True,
                     ),  # type: ignore
                 )
                 self.cache.set_cache(
@@ -3153,6 +3164,7 @@ class Router:
                             verify=litellm.ssl_verify,
                         ),
                         mounts=sync_proxy_mounts,
+                        http2=True,
                     ),  # type: ignore
                 )
                 self.cache.set_cache(

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,5 @@ aiohttp==3.9.0 # for network calls
 aioboto3==12.3.0 # for async sagemaker calls
 tenacity==8.2.3  # for retrying requests, when litellm.num_retries set
 pydantic==2.7.1 # openai req. 
+httpx[http2]==0.27.0
 ####


### PR DESCRIPTION
## Title

This enables using HTTP 2.0 for upstream requests.

## Relevant issues

Resolves #3533.

## Type

🆕 New Feature

## Changes

I upgraded all the httpx clients to use HTTP/2 by default. If HTTP/2 isn't supported by the LLM API, httpx should automatically fallback to HTTP/1.1. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Running all the CircleCI unit tests should show pretty quickly if this broke anything. I don't think it should, it's working fine locally.