### PR TITLE
Fix errors in the Vertex AI documentation

### DIFF
--- a/docs/my-website/docs/providers/vertex.md
+++ b/docs/my-website/docs/providers/vertex.md
@@ -509,8 +509,8 @@ response = completion(
 ## Gemini 1.5 Pro (and Vision)
 | Model Name       | Function Call                        |
 |------------------|--------------------------------------|
-| gemini-1.5-pro   | `completion('gemini-1.5-pro', messages)`, `completion('vertex_ai/gemini-pro', messages)` |
-| gemini-1.5-flash-preview-0514   | `completion('gemini-1.5-flash-preview-0514', messages)`, `completion('vertex_ai/gemini-pro', messages)` |
+| gemini-1.5-pro   | `completion('gemini-1.5-pro', messages)`, `completion('vertex_ai/gemini-1.5-pro', messages)` |
+| gemini-1.5-flash-preview-0514   | `completion('gemini-1.5-flash-preview-0514', messages)`, `completion('vertex_ai/gemini-1.5-flash-preview-0514', messages)` |
 | gemini-1.5-pro-preview-0514   | `completion('gemini-1.5-pro-preview-0514', messages)`, `completion('vertex_ai/gemini-1.5-pro-preview-0514', messages)` |
 
 


### PR DESCRIPTION
## Fixed model name typo in Vertex AI documentation


## Relevant issues


## Type

📖 Documentation

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

The model actually matches `vertex_ai/gemini-1.5-flash-preview-0514`.

<img width="1068" alt="image" src="https://github.com/BerriAI/litellm/assets/623449/95d9ea25-166f-49e4-8869-0686affd24aa">

The cutoff date for `vertex_ai/gemini-pro` is outdated and likely not Gemini 1.5 Pro.

<img width="1383" alt="image" src="https://github.com/BerriAI/litellm/assets/623449/fea56521-a419-43b9-b489-ee8c3b3a30f8">



