### PR TITLE
[Fix] Redacting messages from OTEL + Refactor `utils.py` to use `litellm_core_utils`

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -61,3 +61,5 @@ def redact_message_input_output_from_logging(
                             choice.message.content = "redacted-by-litellm"
                         elif isinstance(choice, litellm.utils.StreamingChoices):
                             choice.delta.content = "redacted-by-litellm"
+
+    return _result

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -1,0 +1,63 @@
+# +-----------------------------------------------+
+# |                                               |
+# |           Give Feedback / Get Help            |
+# | https://github.com/BerriAI/litellm/issues/new |
+# |                                               |
+# +-----------------------------------------------+
+#
+#  Thank you users! We ❤️ you! - Krrish & Ishaan
+
+import copy
+from typing import TYPE_CHECKING, Any
+import litellm
+
+if TYPE_CHECKING:
+    from litellm.utils import Logging as _LiteLLMLoggingObject
+
+    LiteLLMLoggingObject = _LiteLLMLoggingObject
+else:
+    LiteLLMLoggingObject = Any
+
+
+def redact_message_input_output_from_logging(
+    litellm_logging_obj: LiteLLMLoggingObject, result
+):
+    """
+    Removes messages, prompts, input, response from logging. This modifies the data in-place
+    only redacts when litellm.turn_off_message_logging == True
+    """
+    # check if user opted out of logging message/response to callbacks
+    if litellm.turn_off_message_logging is not True:
+        return result
+
+    _result = copy.deepcopy(result)
+    # remove messages, prompts, input, response from logging
+    litellm_logging_obj.model_call_details["messages"] = [
+        {"role": "user", "content": "redacted-by-litellm"}
+    ]
+    litellm_logging_obj.model_call_details["prompt"] = ""
+    litellm_logging_obj.model_call_details["input"] = ""
+
+    # response cleaning
+    # ChatCompletion Responses
+    if (
+        litellm_logging_obj.stream
+        and "complete_streaming_response" in litellm_logging_obj.model_call_details
+    ):
+        _streaming_response = litellm_logging_obj.model_call_details[
+            "complete_streaming_response"
+        ]
+        for choice in _streaming_response.choices:
+            if isinstance(choice, litellm.Choices):
+                choice.message.content = "redacted-by-litellm"
+            elif isinstance(choice, litellm.utils.StreamingChoices):
+                choice.delta.content = "redacted-by-litellm"
+    else:
+        if _result is not None:
+            if isinstance(_result, litellm.ModelResponse):
+                if hasattr(_result, "choices") and _result.choices is not None:
+                    for choice in _result.choices:
+                        if isinstance(choice, litellm.Choices):
+                            choice.message.content = "redacted-by-litellm"
+                        elif isinstance(choice, litellm.utils.StreamingChoices):
+                            choice.delta.content = "redacted-by-litellm"

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -41,7 +41,7 @@ def redact_message_input_output_from_logging(
     # response cleaning
     # ChatCompletion Responses
     if (
-        litellm_logging_obj.stream
+        litellm_logging_obj.stream is True
         and "complete_streaming_response" in litellm_logging_obj.model_call_details
     ):
         _streaming_response = litellm_logging_obj.model_call_details[

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -24,6 +24,7 @@ general_settings:
 litellm_settings:
   callbacks: ["otel"]
   store_audit_logs: true
+  turn_off_message_logging: true
   redact_messages_in_exceptions: True
   enforced_params:  
     - user


### PR DESCRIPTION
## Title

- when turn_off_message logging was enabled - the returned client side response also got modified 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

