### PR TITLE
Stop throwing constant S3 spam on cache misses

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -1192,7 +1192,7 @@ class S3Cache(BaseCache):
             return cached_response
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
-                verbose_logger.error(
+                verbose_logger.debug(
                     f"S3 Cache: The specified key '{key}' does not exist in the S3 bucket."
                 )
                 return None


### PR DESCRIPTION
## Title

Stop throwing error spammy messages that aren't actually errors. 

## Relevant issues

Fixes #4146.

## Type

🐛 Bug Fix

## Changes

Change `.error` to `.debug`.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

This should be simple enough to visual see the changes.