### PR TITLE
[New Feature] Add mock_tool_calls to `main.py`

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -41,6 +41,7 @@ from litellm.utils import (
     get_optional_params_embeddings,
     get_optional_params_image_gen,
     supports_httpx_timeout,
+    ChatCompletionMessageToolCall,
 )
 from .llms import (
     anthropic_text,
@@ -398,6 +399,7 @@ def mock_completion(
     messages: List,
     stream: Optional[bool] = False,
     mock_response: Union[str, Exception] = "This is a mock request",
+    mock_tool_calls: Optional[List] = None,
     logging=None,
     **kwargs,
 ):
@@ -464,6 +466,11 @@ def mock_completion(
         model_response["choices"][0]["message"]["content"] = mock_response
         model_response["created"] = int(time.time())
         model_response["model"] = model
+
+        if mock_tool_calls:
+            model_response["choices"][0]["message"]["tool_calls"] = [
+                ChatCompletionMessageToolCall(**tool_call) for tool_call in mock_tool_calls
+            ]
 
         setattr(
             model_response,
@@ -578,6 +585,7 @@ def completion(
     args = locals()
     api_base = kwargs.get("api_base", None)
     mock_response = kwargs.get("mock_response", None)
+    mock_tool_calls = kwargs.get("mock_tool_calls", None)
     force_timeout = kwargs.get("force_timeout", 600)  ## deprecated
     logger_fn = kwargs.get("logger_fn", None)
     verbose = kwargs.get("verbose", False)
@@ -896,12 +904,13 @@ def completion(
             litellm_params=litellm_params,
             custom_llm_provider=custom_llm_provider,
         )
-        if mock_response:
+        if mock_response or mock_tool_calls:
             return mock_completion(
                 model,
                 messages,
                 stream=stream,
                 mock_response=mock_response,
+                mock_tool_calls=mock_tool_calls,
                 logging=logging,
                 acompletion=acompletion,
                 mock_delay=kwargs.get("mock_delay", None),


### PR DESCRIPTION
## Add mock tool calls

Add the ability to mock tool calls the same way we can mock response.

This feature allows to test calls that leverage function calling.

It works with `instructor` function calling using Pydantic Models.

## Type

🆕 New Feature

## Changes

- Add `ChatCompletionMessageToolCall` import in `main.py`
- Add `mock_tool_calls: Optional[List]` argument to `completion` and `mock_completion`
- `mock_completion` is now called when either `mock_response` or `mock_tool_calls` is not `None`
- Add the following block in `mock_completion`:
  ```python
   if mock_tool_calls:
       model_response["choices"][0]["message"]["tool_calls"] = [
           ChatCompletionMessageToolCall(**tool_call) for tool_call in mock_tool_calls
       ] 
  ```

## Testing

I did not extensively test this feature, but running `poetry run pytest .` yields the same result before and after the changes.

You can test this feature with the following code blocks:

```python
from litellm import completion 

model = "gpt-3.5-turbo"
messages = [{"role":"user", "content":"This is a test request"}]

mock_tool_calls = [{
    "id": "call_9gRXccBmyi1fIDkngrlB9Ikc",
    "function": {
        "arguments": {"reasoning": "Let's think step by step in order to solve this problem. Actually, there is no problem.", "answer": 42},
        "name": "OutputModel",    
    },
    "type": "function",
}]


completion(model=model, messages=messages, mock_response="It's simple to use and easy to get started", mock_tool_calls=mock_tool_calls)

```

With a Router, async and `instructor`:

```python
import os

import instructor
from litellm import Router

OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")

model_list = [
    {
        "model_name": "gpt-3.5-turbo",
        "litellm_params": {
            "model": "gpt-3.5-turbo",
            "api_key": OPENAI_API_KEY,
        },
    },
]

client = instructor.patch(Router(model_list=model_list, default_litellm_params={"acompletion": True}))

mock_tool_calls = [{
    "id": "call_9gRXccBmyi1fIDkngrlB9Ikc",
    "function": {
        "arguments": {"reasoning": "Let's think step by step in order to solve this problem. Actually, there is no problem.", "answer": 42},
        "name": "OutputModel",    
    },
    "type": "function",
}]

await client.chat.completions.create(model=model, messages=messages, mock_tool_calls=mock_tool_calls)
```



