### PR TITLE
fix: add more type hints to init methods

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -10,7 +10,7 @@ import traceback
 
 class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callback#callback-class
     # Class variables or attributes
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def log_pre_api_call(self, model, messages, kwargs):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -528,7 +528,7 @@ class ModelResponse(OpenAIObject):
         response_ms=None,
         hidden_params=None,
         **params,
-    ):
+    ) -> None:
         if stream is not None and stream is True:
             object = "chat.completion.chunk"
             if choices is not None and isinstance(choices, list):


### PR DESCRIPTION
## fix: add more type hints to init methods

This just adds a few type hints to user-facing init methods. Seems like recent additions to typing made mypy complain about unnecessary ignores, but removing that exposes more issues, e.g.:

```
tests/test_custom_callbacks.py:80: error: Call to untyped function "GeneratedCodeLogger" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:94: error: Call to untyped function "GeneratedCodeLogger" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:96: error: Call to untyped function "ModelResponse" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:152: error: Call to untyped function "ModelResponse" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:178: error: Call to untyped function "ModelResponse" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:198: error: Call to untyped function "ModelResponse" in typed context  [no-untyped-call]
tests/test_custom_callbacks.py:219: error: Call to untyped function "ModelResponse" in typed context  [no-untyped-call]
```

## Relevant issues

Related to https://github.com/BerriAI/litellm/issues/4206

## Type

🐛 Bug Fix

## Changes

Typing changes only, so no added tests.

