### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "daily"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Title

Add a Dependabot config to auto-update GitHub action versions

## Relevant issues

n/a

## Type

🚄 Infrastructure

## Changes

Currently, deprecation warnings are being thrown due to actions using out-of-date Node versions ([recent example](https://github.com/BerriAI/litellm/actions/runs/9560233090)). Rather than submitting a PR to update them manually, this PR configures Dependabot to regularly submit PRs to update GitHub action versions as needed.

If this PR merges, you can expect Dependabot to immediately submit a PR to update actions to newer versions.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

This will resolve existing deprecation warnings due to old Node versions:

> ![image](https://github.com/BerriAI/litellm/assets/39996/6510c5f5-6375-4207-a7c9-0be3450e34c6)
