### PR TITLE
feat - support CURL OPTIONS for `/health/readiness` endpoint

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -405,11 +405,6 @@ async def active_callbacks():
     tags=["health"],
     dependencies=[Depends(user_api_key_auth)],
 )
-@router.options(
-    "/health/readiness",
-    tags=["health"],
-    dependencies=[Depends(user_api_key_auth)],
-)
 async def health_readiness():
     """
     Unprotected endpoint for checking if worker can receive requests
@@ -477,3 +472,20 @@ async def health_liveliness():
     Unprotected endpoint for checking if worker is alive
     """
     return "I'm alive!"
+
+
+@router.options(
+    "/health/readiness",
+    tags=["health"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def health_readiness_options():
+    """
+    Options endpoint for health/readiness check.
+    """
+    response_headers = {
+        "Allow": "GET, OPTIONS",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "*",
+    }
+    return {"headers": response_headers}

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Literal, Optional
 
 import fastapi
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -488,4 +488,21 @@ async def health_readiness_options():
         "Access-Control-Allow-Methods": "GET, OPTIONS",
         "Access-Control-Allow-Headers": "*",
     }
-    return {"headers": response_headers}
+    return Response(headers=response_headers, status_code=200)
+
+
+@router.options(
+    "/health/liveliness",
+    tags=["health"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def health_liveliness_options():
+    """
+    Options endpoint for health/liveliness check.
+    """
+    response_headers = {
+        "Allow": "GET, OPTIONS",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "*",
+    }
+    return Response(headers=response_headers, status_code=200)


### PR DESCRIPTION
## Title
```
curl -i -X OPTIONS -H "Accept: application/json" -H "Authorization: Bearer sk-1234" http://localhost:4000/health/readiness
```

```
HTTP/1.1 200 OK
date: Wed, 19 Jun 2024 19:11:50 GMT
server: uvicorn
allow: GET, OPTIONS
access-control-allow-methods: GET, OPTIONS
access-control-allow-headers: *
content-length: 0
```

```
ishaanjaffer@Ishaans-MacBook-Air tests %
curl -i -X OPTIONS -H "Accept: application/json" -H "Authorization: Bearer sk-1234" http://localhost:4000/health/liveliness
```

```
HTTP/1.1 200 OK
date: Wed, 19 Jun 2024 19:12:02 GMT
server: uvicorn
allow: GET, OPTIONS
access-control-allow-methods: GET, OPTIONS
access-control-allow-headers: *
content-length: 0
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

