### PR TITLE
Fix model name for deepseek-coder in documentation

### DIFF
--- a/docs/my-website/docs/providers/deepseek.md
+++ b/docs/my-website/docs/providers/deepseek.md
@@ -49,6 +49,6 @@ We support ALL Deepseek models, just set `deepseek/` as a prefix when sending co
 | Model Name               | Function Call                                                                                                                                                      |
 |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | deepseek-chat | `completion(model="deepseek/deepseek-chat", messages)` | 
-| deepseek-coder | `completion(model="deepseek/deepseek-chat", messages)` | 
+| deepseek-coder | `completion(model="deepseek/deepseek-coder", messages)` | 
 
 


### PR DESCRIPTION
## Title

Fix model name for deepseek-coder in documentation

## Type

📖 Documentation

## Changes

See commit message

```diff
- | deepseek-coder | `completion(model="deepseek/deepseek-chat", messages)` |
+ | deepseek-coder | `completion(model="deepseek/deepseek-coder", messages)` |
```
