### PR TITLE
Print content window fallbacks on startup to help verify configuration

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -393,7 +393,11 @@ class Router:
         else:
             litellm.failure_callback = [self.deployment_callback_on_failure]
         print(  # noqa
-            f"Intialized router with Routing strategy: {self.routing_strategy}\n\nRouting fallbacks: {self.fallbacks}\n\nRouting context window fallbacks: {self.context_window_fallbacks}\n\nRouter Redis Caching={self.cache.redis_cache}"
+            f"Intialized router with Routing strategy: {self.routing_strategy}\n\n"
+            f"Routing fallbacks: {self.fallbacks}\n\n"
+            f"Routing content fallbacks: {self.content_policy_fallbacks}\n\n"
+            f"Routing context window fallbacks: {self.context_window_fallbacks}\n\n"
+            f"Router Redis Caching={self.cache.redis_cache}\n"
         )  # noqa
         self.routing_strategy_args = routing_strategy_args
         self.retry_policy: Optional[RetryPolicy] = retry_policy


### PR DESCRIPTION
## Print Content Policy Fallback config

This just prints the current content policy fallback info the same way the context window and routing fallback are being printed to confirm configuration is loaded successfully on start-up

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

![image](https://github.com/BerriAI/litellm/assets/60548/cf9b9e76-7d2b-4c21-8812-4323d4fb74bd)
