### PR TITLE
[Fix-Improve] Improve Ollama prompt input and fix Ollama function calling key error and fix Ollama function calling `can only join an iterable` error

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -126,7 +126,7 @@ class OllamaConfig:
             )
             and v is not None
         }
-    
+
     def get_required_params(self) -> List[ProviderField]:
         """For a given provider, return it's required fields with a description"""
         return [
@@ -451,7 +451,7 @@ async def ollama_acompletion(url, data, model_response, encoding, logging_obj):
                         {
                             "id": f"call_{str(uuid.uuid4())}",
                             "function": {
-                                "name": function_call["name"],
+                                "name": function_call.get("name", function_call.get("function", None)),
                                 "arguments": json.dumps(function_call["arguments"]),
                             },
                             "type": "function",

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -434,7 +434,7 @@ async def ollama_async_streaming(
                         {
                             "id": f"call_{str(uuid.uuid4())}",
                             "function": {
-                                "name": function_call["name"],
+                                "name": function_call.get("name", function_call.get("function", None)),
                                 "arguments": json.dumps(function_call["arguments"]),
                             },
                             "type": "function",

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -181,7 +181,7 @@ def ollama_pt(
                 for call in message["tool_calls"]:
                     function_name = call["function"]["name"]
                     arguments = json.loads(call["function"]["arguments"])
-                    prompt += f"### Tool Call ({call["id"]}):\nFunction: {function_name}\nArguments: {json.dumps(arguments)}\n\n"
+                    prompt += f"### Tool Call ({call["id"]}):\nName: {function_name}\nArguments: {json.dumps(arguments)}\n\n"
             elif "tool_call_id" in message:
                 prompt += f"### Tool Call Result ({message["tool_call_id"]}):\n{message["content"]}\n\n"
             elif content:

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -181,9 +181,9 @@ def ollama_pt(
                 for call in message["tool_calls"]:
                     function_name = call["function"]["name"]
                     arguments = json.loads(call["function"]["arguments"])
-                    prompt += f"### Tool Call ({call["id"]}):\nName: {function_name}\nArguments: {json.dumps(arguments)}\n\n"
+                    prompt += f"### FunctionCall ({call["id"]}):\nFunctionName: {function_name}\nArguments: {json.dumps(arguments)}\n\n"
             elif "tool_call_id" in message:
-                prompt += f"### Tool Call Result ({message["tool_call_id"]}):\n{message["content"]}\n\n"
+                prompt += f"### FunctionCall Result ({message["tool_call_id"]}):\n{message["content"]}\n\n"
             elif content:
                 prompt += f"### {role.capitalize()}:\n{content}\n\n"
 

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -135,7 +135,7 @@ def convert_to_ollama_image(openai_image_url: str):
 
 
 def ollama_pt(
-    model, messages
+        model, messages
 ):  # https://github.com/ollama/ollama/blob/af4cf55884ac54b9e637cd71dadfe9b7a5685877/docs/modelfile.md#template
     if "instruct" in model:
         prompt = custom_prompt(
@@ -178,12 +178,27 @@ def ollama_pt(
             content = message.get("content", "")
 
             if "tool_calls" in message:
+                tool_calls = []
+
                 for call in message["tool_calls"]:
-                    function_name = call["function"]["name"]
+                    call_id: str = call["id"]
+                    function_name: str = call["function"]["name"]
                     arguments = json.loads(call["function"]["arguments"])
-                    prompt += f"### FunctionCall ({call["id"]}):\nFunctionName: {function_name}\nArguments: {json.dumps(arguments)}\n\n"
+
+                    tool_calls.append({
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": function_name,
+                            "arguments": arguments
+                        }
+                    })
+
+                prompt += f"### Assistant:\nTool Calls: {json.dumps(tool_calls, indent=2)}\n\n"
+
             elif "tool_call_id" in message:
-                prompt += f"### FunctionCall Result ({message["tool_call_id"]}):\n{message["content"]}\n\n"
+                prompt += f"### User:\n{message["content"]}\n\n"
+
             elif content:
                 prompt += f"### {role.capitalize()}:\n{content}\n\n"
 


### PR DESCRIPTION
## Title

Improve Ollama prompt input

## Relevant issues

Fixes #1272
Fixes #3912
Fixes(Kinda) https://github.com/microsoft/autogen/issues/2924
RP #4089

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

- Resolve the 'name' key error by use `dict.get` method and fallback to the 'function' key if not present
- Improve Ollama prompt input
- Fix "litellm.exceptions.APIConnectionError: can only join an iterable"

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local

Ollama requires local testing
testing the example from https://microsoft.github.io/autogen/docs/topics/non-openai-models/local-litellm-ollama/

program response
```
user_proxy (to chatbot):

How much is 123.45 EUR in USD?

--------------------------------------------------------------------------------
chatbot (to user_proxy):

***** Suggested tool call (call_b2eb58bd-5ff4-4332-9566-147fb17d4b76): currency_calculator *****
Arguments: 
{"base_amount": 123.45, "quote_currency": "USD"}
************************************************************************************************

--------------------------------------------------------------------------------

>>>>>>>> EXECUTING FUNCTION currency_calculator...
user_proxy (to chatbot):

user_proxy (to chatbot):

***** Response from calling tool (call_b2eb58bd-5ff4-4332-9566-147fb17d4b76) *****
123.45 USD
**********************************************************************************

--------------------------------------------------------------------------------
chatbot (to user_proxy):

***** Suggested tool call (call_8d3ca275-0b00-4bd1-8734-3f2d9f1e438a): currency_calculator *****
Arguments: 
{"parameter_1_name": "base_amount", "parameter_2_name": "quote_currency"}
************************************************************************************************

--------------------------------------------------------------------------------

Process finished with exit code 0
```
