### PR TITLE
fix: provide only relevant args to AsyncMessage.create in AnthropicVertexClient

### DIFF
--- a/litellm/llms/vertex_ai_anthropic.py
+++ b/litellm/llms/vertex_ai_anthropic.py
@@ -302,7 +302,7 @@ def completion(
                     "complete_input_dict": optional_params,
                 },
             )
-            response = vertex_ai_client.messages.create(**data, stream=True)  # type: ignore
+            response = vertex_ai_client.messages.create(**strip_message_args(data), stream=True)  # type: ignore
             return response
 
         ## LOGGING
@@ -314,7 +314,7 @@ def completion(
             },
         )
 
-        message = vertex_ai_client.messages.create(**data)  # type: ignore
+        message = vertex_ai_client.messages.create(**strip_message_args(data))  # type: ignore
         text_content = message.content[0].text
         ## TOOL CALLING - OUTPUT PARSE
         if text_content is not None and contains_tag("invoke", text_content):
@@ -389,7 +389,7 @@ async def async_completion(
             "complete_input_dict": optional_params,
         },
     )
-    message = await vertex_ai_client.messages.create(**data)  # type: ignore
+    message = await vertex_ai_client.messages.create(**strip_message_args(data))  # type: ignore
     text_content = message.content[0].text
     ## TOOL CALLING - OUTPUT PARSE
     if text_content is not None and contains_tag("invoke", text_content):
@@ -460,7 +460,7 @@ async def async_streaming(
             "complete_input_dict": optional_params,
         },
     )
-    response = await vertex_ai_client.messages.create(**data, stream=True)  # type: ignore
+    response = await vertex_ai_client.messages.create(**strip_message_args(data), stream=True)  # type: ignore
     logging_obj.post_call(input=messages, api_key=None, original_response=response)
 
     streamwrapper = CustomStreamWrapper(
@@ -471,3 +471,8 @@ async def async_streaming(
     )
 
     return streamwrapper
+
+
+def strip_message_args(data: dict):
+    supported_param = litellm.AnthropicConfig().get_supported_openai_params()
+    return {k: v for k, v in data.items() if k in supported_param}


### PR DESCRIPTION
## Fix request body so that calling anthropic models via VertexAI is possible

## Issue
```
AsyncMessages.create() got an unexpected keyword argument 'user', 'traceback_exception': 'Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/litellm/main.py", line 348, in acompletion
    response = await init_response
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_ai_anthropic.py", line 388, in async_completion
    message = await vertex_ai_client.messages.create(**data)  # type: ignore
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/anthropic/_utils/_utils.py", line 275, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: AsyncMessages.create() got an unexpected keyword argument \'user\'
```
## Type

🐛 Bug Fix

## Changes

AnthropicVertexClient is failing on unknown attributes passed as arguments into the `vertex_ai_client.messages.create()` function. I've added a stripping function that makes sure the passed args into message are compatible with the contract expected by the create() function.