### PR TITLE
Create litellm user to fix issue with prisma in k8s 

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -9,6 +9,27 @@ FROM $LITELLM_BUILD_IMAGE as builder
 # Set the working directory to /app
 WORKDIR /app
 
+ARG LITELLM_USER=litellm LITELLM_UID=1729
+ARG LITELLM_GROUP=litellm LITELLM_GID=1729
+
+RUN groupadd \
+	--gid ${LITELLM_GID} \
+	${LITELLM_GROUP} \
+	&& useradd \
+	--create-home \
+	--shell /bin/sh \
+	--gid ${LITELLM_GID} \
+	--uid ${LITELLM_UID} \
+	${LITELLM_USER}
+
+# Allows user to update python install.
+# This is necessary for prisma.
+RUN chown -R ${LITELLM_USER}:${LITELLM_GROUP} /usr/local/lib/python3.11
+
+# Set the HOME var forcefully because of prisma.
+ENV HOME=/home/${LITELLM_USER}
+USER ${LITELLM_USER}
+
 # Install build dependencies
 RUN apt-get clean && apt-get update && \
     apt-get install -y gcc python3-dev && \


### PR DESCRIPTION
## Prisma in [Kubernetes](https://kubernetes.io/)

When running this Dockerfile in K8 Prisma fails when it tries to create a cache in the user home directory ~/.cache
This is because the default user is 'nobody' who has no home directory.

## Type

🐛 Bug Fix
## Changes

This creates a user / group called Litellm with a home directory.


