### PR TITLE
Fix usage of parameter-based credentials when using vertex_ai_beta route

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2406,7 +2406,7 @@ def get_optional_params(
         elif k == "hf_model_name" and custom_llm_provider != "sagemaker":
             continue
         elif (
-            k.startswith("vertex_") and custom_llm_provider != "vertex_ai"
+            k.startswith("vertex_") and custom_llm_provider != "vertex_ai" and custom_llm_provider != "vertex_ai_beta"
         ):  # allow dynamically setting vertex ai init logic
             continue
         passed_params[k] = v


### PR DESCRIPTION
## Title

Fix usage of parameter-based credentials when using vertex_ai_beta route

## Type

🐛 Bug Fix

## Changes

One line change. Include parameters prefixd with `vertex_` when the route is `vertex_ai_beta`, not just `vertex_ai`.
