### PR TITLE
Allow calling SageMaker endpoints from different regions

### DIFF
--- a/litellm/llms/sagemaker.py
+++ b/litellm/llms/sagemaker.py
@@ -9,8 +9,6 @@ from litellm.utils import ModelResponse, EmbeddingResponse, get_secret, Usage
 import sys
 from copy import deepcopy
 import httpx  # type: ignore
-import boto3
-import aioboto3
 import io
 from .prompt_templates.factory import prompt_factory, custom_prompt
 
@@ -159,6 +157,8 @@ def completion(
     logger_fn=None,
     acompletion: bool = False,
 ):
+    import boto3
+
     # pop aws_secret_access_key, aws_access_key_id, aws_region_name from kwargs, since completion calls fail with them
     aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)
     aws_access_key_id = optional_params.pop("aws_access_key_id", None)
@@ -413,6 +413,10 @@ async def async_streaming(
     aws_access_key_id: Optional[str],
     aws_region_name: Optional[str],
 ):
+    """
+    Use aioboto3
+    """
+    import aioboto3
 
     session = aioboto3.Session()
 
@@ -477,6 +481,10 @@ async def async_completion(
     aws_access_key_id: Optional[str],
     aws_region_name: Optional[str],
 ):
+    """
+    Use aioboto3
+    """
+    import aioboto3
 
     session = aioboto3.Session()
 
@@ -628,6 +636,8 @@ def embedding(
     """
     Supports Huggingface Jumpstart embeddings like GPT-6B
     """
+    ### BOTO3 INIT
+    import boto3
 
     # pop aws_secret_access_key, aws_access_key_id, aws_region_name from kwargs, since completion calls fail with them
     aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)

--- a/litellm/llms/sagemaker.py
+++ b/litellm/llms/sagemaker.py
@@ -9,6 +9,9 @@ from litellm.utils import ModelResponse, EmbeddingResponse, get_secret, Usage
 import sys
 from copy import deepcopy
 import httpx  # type: ignore
+import boto3
+import aioboto3
+import io
 from .prompt_templates.factory import prompt_factory, custom_prompt
 
 
@@ -23,10 +26,6 @@ class SagemakerError(Exception):
         super().__init__(
             self.message
         )  # Call the base class constructor with the parameters it needs
-
-
-import io
-import json
 
 
 class TokenIterator:
@@ -160,8 +159,6 @@ def completion(
     logger_fn=None,
     acompletion: bool = False,
 ):
-    import boto3
-
     # pop aws_secret_access_key, aws_access_key_id, aws_region_name from kwargs, since completion calls fail with them
     aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)
     aws_access_key_id = optional_params.pop("aws_access_key_id", None)
@@ -416,10 +413,6 @@ async def async_streaming(
     aws_access_key_id: Optional[str],
     aws_region_name: Optional[str],
 ):
-    """
-    Use aioboto3
-    """
-    import aioboto3
 
     session = aioboto3.Session()
 
@@ -484,10 +477,6 @@ async def async_completion(
     aws_access_key_id: Optional[str],
     aws_region_name: Optional[str],
 ):
-    """
-    Use aioboto3
-    """
-    import aioboto3
 
     session = aioboto3.Session()
 
@@ -639,8 +628,6 @@ def embedding(
     """
     Supports Huggingface Jumpstart embeddings like GPT-6B
     """
-    ### BOTO3 INIT
-    import boto3
 
     # pop aws_secret_access_key, aws_access_key_id, aws_region_name from kwargs, since completion calls fail with them
     aws_secret_access_key = optional_params.pop("aws_secret_access_key", None)

--- a/litellm/llms/sagemaker.py
+++ b/litellm/llms/sagemaker.py
@@ -185,7 +185,8 @@ def completion(
         # I assume majority of users use .env for auth
         region_name = (
             get_secret("AWS_REGION_NAME")
-            or "us-west-2"  # default to us-west-2 if user not specified
+            or aws_region_name  # get region from config file if specified
+            or "us-west-2"  # default to us-west-2 if region not specified
         )
         client = boto3.client(
             service_name="sagemaker-runtime",
@@ -439,7 +440,8 @@ async def async_streaming(
         # I assume majority of users use .env for auth
         region_name = (
             get_secret("AWS_REGION_NAME")
-            or "us-west-2"  # default to us-west-2 if user not specified
+            or aws_region_name  # get region from config file if specified
+            or "us-west-2"  # default to us-west-2 if region not specified
         )
         _client = session.client(
             service_name="sagemaker-runtime",
@@ -506,7 +508,8 @@ async def async_completion(
         # I assume majority of users use .env for auth
         region_name = (
             get_secret("AWS_REGION_NAME")
-            or "us-west-2"  # default to us-west-2 if user not specified
+            or aws_region_name  # get region from config file if specified
+            or "us-west-2"  # default to us-west-2 if region not specified
         )
         _client = session.client(
             service_name="sagemaker-runtime",
@@ -661,7 +664,8 @@ def embedding(
         # I assume majority of users use .env for auth
         region_name = (
             get_secret("AWS_REGION_NAME")
-            or "us-west-2"  # default to us-west-2 if user not specified
+            or aws_region_name  # get region from config file if specified
+            or "us-west-2"  # default to us-west-2 if region not specified
         )
         client = boto3.client(
             service_name="sagemaker-runtime",

--- a/litellm/tests/test_provider_specific_config.py
+++ b/litellm/tests/test_provider_specific_config.py
@@ -517,7 +517,7 @@ def test_sagemaker_default_region(mocker):
     """
     If no regions are specified in config or in environment, the default region is us-west-2
     """
-    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    mock_client = mocker.patch("boto3.client")
     try:
         response = litellm.completion(
             model="sagemaker/mock-endpoint",
@@ -541,7 +541,7 @@ def test_sagemaker_environment_region(mocker):
     """
     expected_region = "us-east-1"
     os.environ["AWS_REGION_NAME"] = expected_region
-    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    mock_client = mocker.patch("boto3.client")
     try:
         response = litellm.completion(
             model="sagemaker/mock-endpoint",
@@ -566,7 +566,7 @@ def test_sagemaker_config_region(mocker):
     part of the config file, then use that region instead of us-west-2
     """
     expected_region = "us-east-1"
-    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    mock_client = mocker.patch("boto3.client")
     try:
         response = litellm.completion(
             model="sagemaker/mock-endpoint",
@@ -592,7 +592,7 @@ def test_sagemaker_config_and_environment_region(mocker):
     expected_region = "us-east-1"
     unexpected_region = "us-east-2"
     os.environ["AWS_REGION_NAME"] = expected_region
-    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    mock_client = mocker.patch("boto3.client")
     try:
         response = litellm.completion(
             model="sagemaker/mock-endpoint",

--- a/litellm/tests/test_provider_specific_config.py
+++ b/litellm/tests/test_provider_specific_config.py
@@ -512,6 +512,106 @@ def sagemaker_test_completion():
 
 # sagemaker_test_completion()
 
+
+def test_sagemaker_default_region(mocker):
+    """
+    If no regions are specified in config or in environment, the default region is us-west-2
+    """
+    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    try:
+        response = litellm.completion(
+            model="sagemaker/mock-endpoint",
+            messages=[
+                {
+                    "content": "Hello, world!",
+                    "role": "user"
+                }
+            ]
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    assert mock_client.call_args.kwargs["region_name"] == "us-west-2"
+
+# test_sagemaker_provided_region()
+
+
+def test_sagemaker_environment_region(mocker):
+    """
+    If a region is specified in the environment, use that region instead of us-west-2
+    """
+    expected_region = "us-east-1"
+    os.environ["AWS_REGION_NAME"] = expected_region
+    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    try:
+        response = litellm.completion(
+            model="sagemaker/mock-endpoint",
+            messages=[
+                {
+                    "content": "Hello, world!",
+                    "role": "user"
+                }
+            ]
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    del os.environ["AWS_REGION_NAME"]  # cleanup
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+# test_sagemaker_environment_region()
+
+
+def test_sagemaker_config_region(mocker):
+    """
+    If a region is specified as part of the optional parameters of the completion, including as
+    part of the config file, then use that region instead of us-west-2
+    """
+    expected_region = "us-east-1"
+    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    try:
+        response = litellm.completion(
+            model="sagemaker/mock-endpoint",
+            messages=[
+                {
+                    "content": "Hello, world!",
+                    "role": "user"
+                }
+            ],
+            aws_region_name=expected_region,
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+# test_sagemaker_config_region()
+
+
+def test_sagemaker_config_and_environment_region(mocker):
+    """
+    If both the environment and config file specify a region, the environment region is expected
+    """
+    expected_region = "us-east-1"
+    unexpected_region = "us-east-2"
+    os.environ["AWS_REGION_NAME"] = expected_region
+    mock_client = mocker.patch("litellm.llms.sagemaker.boto3.client")
+    try:
+        response = litellm.completion(
+            model="sagemaker/mock-endpoint",
+            messages=[
+                {
+                    "content": "Hello, world!",
+                    "role": "user"
+                }
+            ],
+            aws_region_name=unexpected_region,
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    del os.environ["AWS_REGION_NAME"]  # cleanup
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+# test_sagemaker_config_and_environment_region()
+
+
 #  Bedrock
 
 

--- a/litellm/tests/test_provider_specific_config.py
+++ b/litellm/tests/test_provider_specific_config.py
@@ -532,7 +532,7 @@ def test_sagemaker_default_region(mocker):
         pass  # expected serialization exception because AWS client was replaced with a Mock
     assert mock_client.call_args.kwargs["region_name"] == "us-west-2"
 
-# test_sagemaker_provided_region()
+# test_sagemaker_default_region()
 
 
 def test_sagemaker_environment_region(mocker):


### PR DESCRIPTION
## Allow calling SageMaker endpoints from different regions 

## Relevant issues

No issue I could find, but in testing SageMaker endpoints, I was unable to set a configuration in which I was able to call endpoints in multiple regions without hardcoding credentials in the configuration file. As an example, let's assume I have IAM Role credentials in my environment, which will consist of the Access Key, the Secret Access Key, and the Session Token. These credentials are valid for any region that I want to specify, including us-east-1, us-west-2, and so on.

In the current implementation, the region from the configuration file was only honored if the credentials were also specified and not coming from the environment. This set of changes allows us to set credentials without a region so that the region may come from the config file instead.

## Type

🐛 Bug Fix

## Changes

* Add region from the configuration file before the default "us-west-2"

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

### Testing Procedure

My config file:
```
model_list:
  - model_name: peter-test-us-west-2
    litellm_params:
      model: sagemaker/peter-test-us-west-2
      api_key: ignored
      aws_region_name: us-west-2
  - model_name: peter-test-us-east-1
    litellm_params:
      model: sagemaker/peter-test-us-east-1
      api_key: ignored
      aws_region_name: us-east-1
litellm_settings:
  telemetry: false
```

For both before and after my changes, I use the same config file, but get errors when outside of us-west-2 if using environmental creds. My endpoint is simply a dummy endpoint that formats responses in a format that LiteLLM can work with and repeats the input payload.

### Without changes

**NOTE** I redacted my account ID- don't be alarmed by the  '000000000000'

```
curl -s http://localhost:4000/chat/completions -d '{"model":"peter-test-us-west-2", "messages": [{"role": "user", "content": "hello"}]}'|jq
{
  "id": "chatcmpl-55de8781-2a79-42b5-8637-ebf40f1020e4",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "{'inputs': 'hello', 'parameters': {}}",
        "role": "assistant"
      }
    }
  ],
  "created": 1719875623,
  "model": "peter-test-us-west-2",
  "object": "chat.completion",
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 1,
    "completion_tokens": 11,
    "total_tokens": 12
  }
}
curl -s http://localhost:4000/chat/completions -d '{"model":"peter-test-us-east-1", "messages": [{"role": "user", "content": "hello"}]}'|jq
{
  "error": {
    "message": "litellm.APIConnectionError: An error occurred (ValidationError) when calling the InvokeEndpoint operation: Endpoint peter-test-us-east-1 of account 000000000000 not found.\nTraceback (most recent call last):\n  File \"/Users/peter/github/litellm-bugfix/litellm/llms/sagemaker.py\", line 563, in async_completion\n    response = await client.invoke_endpoint(\n  File \"/Users/peter/github/litellm-bugfix/.venv/lib/python3.10/site-packages/aiobotocore/client.py\", line 408, in _make_api_call\n    raise error_class(parsed_response, operation_name)\nbotocore.errorfactory.ValidationError: An error occurred (ValidationError) when calling the InvokeEndpoint operation: Endpoint peter-test-us-east-1 of account 000000000000 not found.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/Users/peter/github/litellm-bugfix/litellm/main.py\", line 380, in acompletion\n    response = await init_response\n  File \"/Users/peter/github/litellm-bugfix/litellm/llms/sagemaker.py\", line 573, in async_completion\n    raise SagemakerError(status_code=500, message=error_message)\nlitellm.llms.sagemaker.SagemakerError: An error occurred (ValidationError) when calling the InvokeEndpoint operation: Endpoint peter-test-us-east-1 of account 000000000000 not found.\n",
    "type": null,
    "param": null,
    "code": 500
  }
}
```

### With changes

```
curl -s http://localhost:4000/chat/completions -d '{"model":"peter-test-us-west-2", "messages": [{"role": "user", "content": "hello"}]}'|jq
{
  "id": "chatcmpl-c14f5bba-9a65-466b-8bdf-8a49d6234dfa",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "{'inputs': 'hello', 'parameters': {}}",
        "role": "assistant"
      }
    }
  ],
  "created": 1719875400,
  "model": "peter-test-us-west-2",
  "object": "chat.completion",
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 1,
    "completion_tokens": 11,
    "total_tokens": 12
  }
}

curl -s http://localhost:4000/chat/completions -d '{"model":"peter-test-us-east-1", "messages": [{"role": "user", "content": "hello"}]}'|jq
{
  "id": "chatcmpl-3a0e7ed3-d54e-4d4a-ac0a-7795550c1e84",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "{'inputs': 'hello', 'parameters': {}}",
        "role": "assistant"
      }
    }
  ],
  "created": 1719875562,
  "model": "peter-test-us-east-1",
  "object": "chat.completion",
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 1,
    "completion_tokens": 11,
    "total_tokens": 12
  }
}
```