### PR TITLE
fix: typo in vision docs

### DIFF
--- a/docs/my-website/docs/completion/vision.md
+++ b/docs/my-website/docs/completion/vision.md
@@ -39,7 +39,7 @@ Use `litellm.supports_vision(model="")` -> returns `True` if model supports `vis
 
 ```python
 assert litellm.supports_vision(model="gpt-4-vision-preview") == True
-assert litellm.supports_vision(model="gemini-1.0-pro-visionn") == True
+assert litellm.supports_vision(model="gemini-1.0-pro-vision") == True
 assert litellm.supports_vision(model="gpt-3.5-turbo") == False
 ```
 


### PR DESCRIPTION
## Title

Fixed small typo in vision docs.
```python
litellm.supports_vision(model="gemini-1.0-pro-visionn")
```
evaluates to `False`
it should be:
```python
litellm.supports_vision(model="gemini-1.0-pro-vision")
```
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

Change is very small, and trivial.
- Typo fix.

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
I believe this is not necessary.
