### PR TITLE
feat(vertex_httpx.py): update usage metadata handling

### DIFF
--- a/litellm/llms/vertex_httpx.py
+++ b/litellm/llms/vertex_httpx.py
@@ -849,9 +849,9 @@ class VertexLLM(BaseLLM):
             endpoint = "generateContent"
             if stream is True:
                 endpoint = "streamGenerateContent"
-                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}?alt=sse"
+                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}?alt=sse"
             else:
-                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}"
+                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:{endpoint}"
 
         if (
             api_base is not None

--- a/litellm/llms/vertex_httpx.py
+++ b/litellm/llms/vertex_httpx.py
@@ -603,15 +603,15 @@ class VertexLLM(BaseLLM):
 
                 ## GET USAGE ##
                 usage = litellm.Usage(
-                    prompt_tokens=completion_response["usageMetadata"][
-                        "promptTokenCount"
-                    ],
+                    prompt_tokens=completion_response["usageMetadata"].get(
+                        "promptTokenCount", 0
+                    ),
                     completion_tokens=completion_response["usageMetadata"].get(
                         "candidatesTokenCount", 0
                     ),
-                    total_tokens=completion_response["usageMetadata"][
-                        "totalTokenCount"
-                    ],
+                    total_tokens=completion_response["usageMetadata"].get(
+                        "totalTokenCount", 0
+                    ),
                 )
 
                 setattr(model_response, "usage", usage)
@@ -647,15 +647,15 @@ class VertexLLM(BaseLLM):
 
                 ## GET USAGE ##
                 usage = litellm.Usage(
-                    prompt_tokens=completion_response["usageMetadata"][
-                        "promptTokenCount"
-                    ],
+                    prompt_tokens=completion_response["usageMetadata"].get(
+                        "promptTokenCount", 0
+                    ),
                     completion_tokens=completion_response["usageMetadata"].get(
                         "candidatesTokenCount", 0
                     ),
-                    total_tokens=completion_response["usageMetadata"][
-                        "totalTokenCount"
-                    ],
+                    total_tokens=completion_response["usageMetadata"].get(
+                        "totalTokenCount", 0
+                    ),
                 )
 
                 setattr(model_response, "usage", usage)
@@ -705,11 +705,15 @@ class VertexLLM(BaseLLM):
 
             ## GET USAGE ##
             usage = litellm.Usage(
-                prompt_tokens=completion_response["usageMetadata"]["promptTokenCount"],
+                prompt_tokens=completion_response["usageMetadata"].get(
+                    "promptTokenCount", 0
+                ),
                 completion_tokens=completion_response["usageMetadata"].get(
                     "candidatesTokenCount", 0
                 ),
-                total_tokens=completion_response["usageMetadata"]["totalTokenCount"],
+                total_tokens=completion_response["usageMetadata"].get(
+                    "totalTokenCount", 0
+                ),
             )
 
             setattr(model_response, "usage", usage)
@@ -1340,11 +1344,15 @@ class ModelResponseIterator:
 
             if "usageMetadata" in processed_chunk:
                 usage = ChatCompletionUsageBlock(
-                    prompt_tokens=processed_chunk["usageMetadata"]["promptTokenCount"],
+                    prompt_tokens=processed_chunk["usageMetadata"].get(
+                        "promptTokenCount", 0
+                    ),
                     completion_tokens=processed_chunk["usageMetadata"].get(
                         "candidatesTokenCount", 0
                     ),
-                    total_tokens=processed_chunk["usageMetadata"]["totalTokenCount"],
+                    total_tokens=processed_chunk["usageMetadata"].get(
+                        "totalTokenCount", 0
+                    ),
                 )
 
             returned_chunk = GenericStreamingChunk(


### PR DESCRIPTION
## Title

update usage metadata handling

## Relevant issues

Fixes #4559.

## Type

🐛 Bug Fix

## Changes

This commit updates the usage metadata handling in the `VertexLLM` and `ModelResponseIterator` classes. Instead of directly accessing the `usageMetadata` dictionary, the code now uses the `get` method to safely retrieve the values. This change ensures that the code gracefully handles cases where the `promptTokenCount`, `candidatesTokenCount`, or `totalTokenCount` keys are missing from the dictionary.


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Before commit:

```
dave@mbp hey % ./main.py
litellm.APIConnectionError: 'promptTokenCount'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/litellm/utils.py", line 9668, in __anext__
    async for chunk in self.completion_stream:
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_httpx.py", line 1416, in __anext__
    return self.chunk_parser(chunk=json_chunk)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_httpx.py", line 1346, in chunk_parser
    prompt_tokens=processed_chunk["usageMetadata"]["promptTokenCount"],
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'promptTokenCount'
```

After commit:

```
dave@mbp hey % ./main.py
Choice(delta=ChoiceDelta(content=None, function_call=None, role=None, tool_calls=None), finish_reason=None, index=0, logprobs=None)
1 + 1 = 2
```
