### PR TITLE
feat(vertex_httpx.py): Add seed parameter

### DIFF
--- a/litellm/llms/vertex_httpx.py
+++ b/litellm/llms/vertex_httpx.py
@@ -265,6 +265,8 @@ class VertexGeminiConfig:
 
     - `presence_penalty` (float): This parameter is used to penalize the model from generating the same output as the input. The default value is 0.0.
 
+    - `seed` (int): The seed value is used to help generate the same output for the same input. The default value is None.
+
     Note: Please make sure to modify the default parameters as required for your use case.
     """
 
@@ -277,6 +279,7 @@ class VertexGeminiConfig:
     stop_sequences: Optional[list] = None
     frequency_penalty: Optional[float] = None
     presence_penalty: Optional[float] = None
+    seed: Optional[int] = None
 
     def __init__(
         self,
@@ -289,6 +292,7 @@ class VertexGeminiConfig:
         stop_sequences: Optional[list] = None,
         frequency_penalty: Optional[float] = None,
         presence_penalty: Optional[float] = None,
+        seed: Optional[int] = None,
     ) -> None:
         locals_ = locals()
         for key, value in locals_.items():
@@ -326,6 +330,7 @@ class VertexGeminiConfig:
             "stop",
             "frequency_penalty",
             "presence_penalty",
+            "seed",
         ]
 
     def map_tool_choice_values(
@@ -409,6 +414,8 @@ class VertexGeminiConfig:
                 )
                 if _tool_choice_value is not None:
                     optional_params["tool_choice"] = _tool_choice_value
+            if param == "seed":
+                optional_params["seed"] = value
         return optional_params
 
     def get_mapped_special_auth_params(self) -> dict:

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -145,6 +145,7 @@ class GenerationConfig(TypedDict, total=False):
     presence_penalty: float
     frequency_penalty: float
     response_mime_type: Literal["text/plain", "application/json"]
+    seed: int
 
 
 class Tools(TypedDict):


### PR DESCRIPTION
## Title

Adds `seed` as a parameter for Vertex AI.

## Relevant issues

Resolves #2973.

## Type

🆕 New Feature

## Changes

Adds `seed` as a supported parameter for Vertex AI.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

<img width="773" alt="image" src="https://github.com/BerriAI/litellm/assets/7232674/f0e8c09e-9004-4450-9eae-6dbe0ff8feb3">

