### PR TITLE
feat(httpx): Send litellm user-agent version upstream

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -7,6 +7,15 @@ import httpx
 
 import litellm
 
+try:
+    from litellm._version import version
+except:
+    version = "0.0.0"
+
+headers = {
+    "User-Agent": f"litellm/{version}",
+}
+
 # https://www.python-httpx.org/advanced/timeouts
 _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
 
@@ -44,6 +53,7 @@ class AsyncHTTPHandler:
             ),
             verify=ssl_verify,
             cert=cert,
+            headers=headers,
         )
 
     async def close(self):
@@ -159,6 +169,7 @@ class HTTPHandler:
                 ),
                 verify=ssl_verify,
                 cert=cert,
+                headers=headers,
             )
         else:
             self.client = client

--- a/litellm/llms/custom_httpx/httpx_handler.py
+++ b/litellm/llms/custom_httpx/httpx_handler.py
@@ -1,6 +1,14 @@
 from typing import Optional
 import httpx
 
+try:
+    from litellm._version import version
+except:
+    version = "0.0.0"
+
+headers = {
+    "User-Agent": f"litellm/{version}",
+}
 
 class HTTPHandler:
     def __init__(self, concurrent_limit=1000):
@@ -9,7 +17,8 @@ class HTTPHandler:
             limits=httpx.Limits(
                 max_connections=concurrent_limit,
                 max_keepalive_connections=concurrent_limit,
-            )
+            ),
+            headers=headers,
         )
 
     async def close(self):


### PR DESCRIPTION
## Title

This is useful for logging purposes, and also to let LLM providers know that they have a significant LiteLLM user base.

## Type

🆕 New Feature

## Changes

Sends LiteLLM's version as a `user-agent` with httpx.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

<img width="787" alt="image" src="https://github.com/BerriAI/litellm/assets/7232674/f22929b7-8def-4a43-a7a7-5cffe4e0c502">
