### PR TITLE
fix(utils.py): change update to upsert

### DIFF
--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -29,9 +29,17 @@ async def add_new_member(
     """
     ## ADD TEAM ID, to USER TABLE IF NEW ##
     if new_member.user_id is not None:
-        await prisma_client.db.litellm_usertable.update(
+        await prisma_client.db.litellm_usertable.upsert(
             where={"user_id": new_member.user_id},
-            data={"teams": {"push": [team_id]}},
+            data={
+                "update": {
+                    "teams": {"push": [team_id]}
+                },
+                "create": {
+                    "user_id": new_member.user_id, 
+                    "teams": [team_id]
+                }
+            },
         )
     elif new_member.user_email is not None:
         user_data = {"user_id": str(uuid.uuid4()), "user_email": new_member.user_email}


### PR DESCRIPTION
## Fix: change update operation to upsert

Change current behavior to create the `user` row in `LiteLLM_UserTable` if it doesn't exist.

## Relevant issues

Fixes: #4608 

## Type

🐛 Bug Fix

## Changes

The change modifies the database operation from an `update` to an `upsert`, allowing for the creation of a new user if the user doesn't exist in the database.
