### PR TITLE
Fix: use Bedrock region from environment variables before other region definitions

### DIFF
--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -605,15 +605,13 @@ def init_bedrock_client(
     ) = params_to_check
 
     ### SET REGION NAME
-    if region_name:
-        pass
-    elif aws_region_name:
-        region_name = aws_region_name
-    elif litellm_aws_region_name:
-        region_name = litellm_aws_region_name
-    elif standard_aws_region_name:
-        region_name = standard_aws_region_name
-    else:
+    region_name = (
+        litellm_aws_region_name  # prefer environment variables before inline region parameters
+        or standard_aws_region_name
+        or region_name
+        or aws_region_name
+    )
+    if not region_name:
         raise BedrockError(
             message="AWS region not set: set AWS_REGION_NAME or AWS_REGION env variable or in .env file",
             status_code=401,

--- a/litellm/tests/test_provider_specific_config.py
+++ b/litellm/tests/test_provider_specific_config.py
@@ -10,7 +10,7 @@ sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import litellm
-from litellm import completion
+from litellm import completion, AuthenticationError
 from litellm import RateLimitError
 
 #  Huggingface - Expensive to deploy models and keep them running. Maybe we can try doing this via baseten??
@@ -654,6 +654,88 @@ def bedrock_test_completion():
 
 
 # bedrock_test_completion()
+
+
+def test_bedrock_embedding_default_region():
+    """
+    If no regions are specified in config or in environment, then throw an error
+    """
+    try:
+        litellm.embedding(
+            model="bedrock/amazon.titan-embed-text-v1",
+            input="Hello, world!"
+        )
+    except Exception as e:
+        assert isinstance(e, AuthenticationError)
+        assert "AWS region not set" in str(e)
+
+
+# test_bedrock_embedding_default_region()
+
+
+def test_bedrock_embedding_config_region(mocker):
+    """
+    When region is specified inline or in config, use that region
+    """
+    expected_region = "us-east-1"
+    mock_client = mocker.patch("boto3.client")
+    try:
+        litellm.embedding(
+            model="bedrock/amazon.titan-embed-text-v1",
+            input="Hello, world!",
+            aws_region_name=expected_region
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+
+# test_bedrock_embedding_config_region()
+
+
+def test_bedrock_embedding_environment_region(mocker):
+    """
+    When region is specified in an environment variable, use that region
+    """
+    expected_region = "us-east-1"
+    os.environ["AWS_REGION_NAME"] = expected_region
+    mock_client = mocker.patch("boto3.client")
+    try:
+        litellm.embedding(
+            model="bedrock/amazon.titan-embed-text-v1",
+            input="Hello, world!"
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    del os.environ["AWS_REGION_NAME"]  # cleanup
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+
+# test_bedrock_embedding_environment_region()
+
+
+def test_bedrock_embedding_config_environment_region(mocker):
+    """
+    If region is supplied in both the config and the environment variable, use the one
+    defined in the environment variable
+    """
+    expected_region = "us-east-1"
+    unexpected_region = "us-west-2"
+    os.environ["AWS_REGION_NAME"] = expected_region
+    mock_client = mocker.patch("boto3.client")
+    try:
+        litellm.embedding(
+            model="bedrock/amazon.titan-embed-text-v1",
+            input="Hello, world!",
+            aws_region_name=unexpected_region
+        )
+    except Exception:
+        pass  # expected serialization exception because AWS client was replaced with a Mock
+    del os.environ["AWS_REGION_NAME"]  # cleanup
+    assert mock_client.call_args.kwargs["region_name"] == expected_region
+
+
+# test_bedrock_embedding_config_environment_region()
 
 
 # OpenAI Chat Completion


### PR DESCRIPTION
## Use Bedrock region from environment variables before other region definitions

This set of changes standardizes the behavior of the AWS-related models, where the expectation is that environment variables are preferred over any regions that are specified in the config.yaml file or inline in an embeddings call. These changes are focused around embeddings because it looks like the completions calls use the httpx version of the Bedrock client instead.

## Relevant issues

I did not see any related issues.

## Type

🐛 Bug Fix
✅ Test

## Changes

* Update init_bedrock_client to prefer environment variable regions over others
* Add tests

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

```
Launching pytest with arguments test_provider_specific_config.py --no-header --no-summary -q in /Users/peter/github/litellm-bugfix/litellm/tests

============================= test session starts ==============================
collecting ... collected 8 items

# [test output]

========================= 8 passed, 1 warning in 1.13s =========================
```

* Additionally, I tested the behavior of the proxy by configuring the config.yaml file with different regions and then setting the AWS_REGION_NAME variable later. Setting the variable causes all versions of the model to use the same region, which is consistent with the SageMaker implementation.
```yaml
model_list:
  - model_name: titan-embed-us-east-2  # expected to fail because Bedrock isn't present in us-east-2
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v1
      api_key: ignored
      aws_region_name: us-east-2
  - model_name: titan-embed-us-west-2
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v1
      api_key: ignored
      aws_region_name: us-west-2
  - model_name: titan-embed-us-east-1
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v1
      api_key: ignored
      aws_region_name: us-east-1
```

