### PR TITLE
Fix: Add prisma binary_cache_dir specification to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,7 @@ version_files = [
 
 [tool.mypy]
 plugins = "pydantic.mypy"
+
+[tool.prisma]
+# cache engine binaries in a directory relative to your project
+binary_cache_dir = '.binaries'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,4 +101,6 @@ plugins = "pydantic.mypy"
 
 [tool.prisma]
 # cache engine binaries in a directory relative to your project
-binary_cache_dir = '.binaries'
+# binary_cache_dir = '.binaries'
+home_dir = '.prisma'
+nodeenv_cache_dir = '.nodeenv'


### PR DESCRIPTION
## Title

Add prisma binary_cache_dir specification to pyproject.toml

## Relevant issues

Fixes #4456

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🚄 Infrastructure

## Changes

Add additional parameter to pyproject.toml, configuring prisma to install its binaries inside the `.binaries` subfolder. 
This solves containers trying to redownload prisma binaries during runtime when run as other users than root.
This also enables containers to be run without root privileges, on e.g. RH OpenShift.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
Only infrastructure changes, see screenshot for new container structure inside /app directory.
![grafik](https://github.com/BerriAI/litellm/assets/32450519/44c3b93d-7534-4034-94c6-f1c3b5737826)