### PR TITLE
Fix app_version in helm build

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -194,6 +194,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_hash }}
+          fetch-depth: 0
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -205,12 +206,17 @@ jobs:
       - name: lowercase github.repository_owner
         run: |
           echo "REPO_OWNER=`echo ${{github.repository_owner}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
-
+    
       - name: Get LiteLLM Latest Tag
         id: current_app_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
-        env:
-          CHART_NAME: ${{ env.APP_NAME }}
+        shell: bash
+        run: |
+          LATEST_TAG=$(git describe --tags --exclude "*dev*" --abbrev=0)
+          if [ -z "${LATEST_TAG}" ]; then
+            echo "latest_tag=latest" | tee -a $GITHUB_OUTPUT
+          else
+            echo "latest_tag=${LATEST_TAG}" | tee -a $GITHUB_OUTPUT
+          fi
 
       - name: Get last published chart version
         id: current_version
@@ -238,7 +244,7 @@ jobs:
           name: ${{ env.CHART_NAME }}
           repository: ${{ env.REPO_OWNER }}
           tag: ${{ github.event.inputs.chartVersion || steps.bump_version.outputs.next-version || '0.1.0' }}
-          app_version: ${{ steps.current_app_tag.outputs.tag || 'latest' }}
+          app_version: ${{ steps.current_app_tag.outputs.latest_tag || 'latest' }}
           path: deploy/charts/${{ env.CHART_NAME }}
           registry: ${{ env.REGISTRY }}
           registry_username: ${{ github.actor }}

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -18,6 +18,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   CHART_NAME: litellm-helm
+  APP_NAME: litellm
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
@@ -186,6 +187,7 @@ jobs:
           platforms: local,linux/amd64,linux/arm64,linux/arm64/v8
 
   build-and-push-helm-chart:
+    needs: [docker-hub-deploy, build-and-push-image, build-and-push-image-database]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -203,9 +205,12 @@ jobs:
       - name: lowercase github.repository_owner
         run: |
           echo "REPO_OWNER=`echo ${{github.repository_owner}} | tr '[:upper:]' '[:lower:]'`" >>${GITHUB_ENV}
+
       - name: Get LiteLLM Latest Tag
         id: current_app_tag
         uses: WyriHaximus/github-action-get-previous-tag@v1.3.0
+        env:
+          CHART_NAME: ${{ env.APP_NAME }}
 
       - name: Get last published chart version
         id: current_version

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -18,7 +18,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   CHART_NAME: litellm-helm
-  APP_NAME: litellm
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -194,7 +194,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_hash }}
-          fetch-depth: 0
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -244,7 +243,7 @@ jobs:
           name: ${{ env.CHART_NAME }}
           repository: ${{ env.REPO_OWNER }}
           tag: ${{ github.event.inputs.chartVersion || steps.bump_version.outputs.next-version || '0.1.0' }}
-          app_version: ${{ steps.current_app_tag.outputs.latest_tag || 'latest' }}
+          app_version: ${{ steps.current_app_tag.outputs.latest_tag }}
           path: deploy/charts/${{ env.CHART_NAME }}
           registry: ${{ env.REGISTRY }}
           registry_username: ${{ github.actor }}

--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -187,6 +187,7 @@ jobs:
           platforms: local,linux/amd64,linux/arm64,linux/arm64/v8
 
   build-and-push-helm-chart:
+    if: github.event.inputs.release_type  != 'dev'
     needs: [docker-hub-deploy, build-and-push-image, build-and-push-image-database]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Title
Fix population of the `app_version` in `build-and-push-helm-chart` job

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

🚄 Infrastructure

## Changes

I'm not sure if it is intentional, but [this](https://github.com/BerriAI/litellm/actions/runs/9879768264/workflow#L206-L208) step is trying to retrieve the latest tag from the helm chart instead of the actual app. It doesn't look like the helm chart gets tagged, which results in it always being set to the default value of `latest`.  

Added a `needs` to the `build-and-push-helm-chart` job since it will be looking for the most recently build image to set as the `app_version`.
Added the env var of `CHART_NAME=litellm` to the `Get LiteLLM Latest Tag` step to override the workflow env var.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

