### PR TITLE
Shorter success callbacks from `/health/readiness`

### DIFF
--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -128,9 +128,20 @@ Example Response:
 
 ```json
 {
-    "status": "healthy",
-    "db": "connected",
-    "litellm_version":"1.19.2",
+  "status": "connected",
+  "db": "connected",
+  "cache": null,
+  "litellm_version": "1.40.21",
+  "success_callbacks": [
+    "langfuse",
+    "_PROXY_track_cost_callback",
+    "response_taking_too_long_callback",
+    "_PROXY_MaxParallelRequestsHandler",
+    "_PROXY_MaxBudgetLimiter",
+    "_PROXY_CacheControlCheck",
+    "ServiceLogging"
+  ],
+  "last_updated": "2024-07-10T18:59:10.616968"
 }
 ```
 
@@ -138,9 +149,20 @@ Example Response:
 
 ```json
 {
-    "status": "healthy",
-    "db": "Not connected",
-    "litellm_version":"1.19.2",
+  "status": "connected",
+  "db": "Not connected",
+  "cache": null,
+  "litellm_version": "1.40.21",
+  "success_callbacks": [
+    "langfuse",
+    "_PROXY_track_cost_callback",
+    "response_taking_too_long_callback",
+    "_PROXY_MaxParallelRequestsHandler",
+    "_PROXY_MaxBudgetLimiter",
+    "_PROXY_CacheControlCheck",
+    "ServiceLogging"
+  ],
+  "last_updated": "2024-07-10T18:59:10.616968"
 }
 ```
 

--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -118,13 +118,11 @@ Unprotected endpoint for checking if proxy is ready to accept requests
 
 Example Request: 
 
-```bash 
-curl --location 'http://0.0.0.0:4000/health/readiness'
+```bash
+curl http://0.0.0.0:4000/health/readiness
 ```
 
 Example Response:  
-
-*If proxy connected to a database*  
 
 ```json
 {
@@ -145,26 +143,8 @@ Example Response:
 }
 ```
 
-*If proxy not connected to a database*  
-
-```json
-{
-  "status": "connected",
-  "db": "Not connected",
-  "cache": null,
-  "litellm_version": "1.40.21",
-  "success_callbacks": [
-    "langfuse",
-    "_PROXY_track_cost_callback",
-    "response_taking_too_long_callback",
-    "_PROXY_MaxParallelRequestsHandler",
-    "_PROXY_MaxBudgetLimiter",
-    "_PROXY_CacheControlCheck",
-    "ServiceLogging"
-  ],
-  "last_updated": "2024-07-10T18:59:10.616968"
-}
-```
+If the proxy is not connected to a database, then the `"db"` field will be `"Not
+connected"` instead of `"connected"` and the `"last_updated"` field will not be present.
 
 ## `/health/liveliness`
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -406,6 +406,19 @@ async def active_callbacks():
     }
 
 
+def callback_name(callback):
+    if isinstance(callback, str):
+        return callback
+
+    try:
+        return callback.__name__
+    except AttributeError:
+        try:
+            return callback.__class__.__name__
+        except AttributeError:
+            return str(callback)
+
+
 @router.get(
     "/health/readiness",
     tags=["health"],
@@ -424,8 +437,8 @@ async def health_readiness():
         try:
             # this was returning a JSON of the values in some of the callbacks
             # all we need is the callback name, hence we do str(callback)
-            success_callback_names = [str(x) for x in litellm.success_callback]
-        except:
+            success_callback_names = [callback_name(x) for x in litellm.success_callback]
+        except AttributeError:
             # don't let this block the /health/readiness response, if we can't convert to str -> return litellm.success_callback
             success_callback_names = litellm.success_callback
 


### PR DESCRIPTION
Before:

```shell
$ curl -sSL http://0.0.0.0:4000/health/readiness | jq '.success_callbacks'
[
  "langfuse",
  "<function _PROXY_track_cost_callback at 0x12fc14b80>",
  "<bound method SlackAlerting.response_taking_too_long_callback of <litellm.integrations.slack_alerting.SlackAlerting object at 0x12cedb740>>",
  "<litellm.proxy.hooks.parallel_request_limiter._PROXY_MaxParallelRequestsHandler object at 0x12cedb8f0>",
  "<litellm.proxy.hooks.max_budget_limiter._PROXY_MaxBudgetLimiter object at 0x12cedb830>",
  "<litellm.proxy.hooks.cache_control_check._PROXY_CacheControlCheck object at 0x12ca101d0>",
  "<litellm._service_logger.ServiceLogging object at 0x13a6d8c50>"
]
```

After:

```shell
$ curl -sSL http://0.0.0.0:4000/health/readiness | jq '.success_callbacks'
[
  "langfuse",
  "_PROXY_track_cost_callback",
  "response_taking_too_long_callback",
  "_PROXY_MaxParallelRequestsHandler",
  "_PROXY_MaxBudgetLimiter",
  "_PROXY_CacheControlCheck",
  "ServiceLogging"
]
```