### PR TITLE
VertexAI[FIX]: Fixing alternating messages breaking with empty assistant/user messages

### DIFF
--- a/litellm/llms/vertex_ai.py
+++ b/litellm/llms/vertex_ai.py
@@ -331,6 +331,14 @@ def _gemini_convert_messages_with_history(messages: list) -> List[ContentType]:
 
     last_message_with_tool_calls = None
 
+    # delete all assistant/user messages with no content or tool calls
+    # if we don't do this, then we will end up with non-alternating user and assistant messages
+    messages = [
+        message
+        for message in messages
+        if message.get("content") or message.get("tool_calls")
+    ]
+
     msg_i = 0
     try:
         while msg_i < len(messages):


### PR DESCRIPTION
## VertexAI[FIX]: Fixing alternating messages breaking with empty assistant/user messages

Previously, when sending empty assistant messages between user messages (and vice versa), google would throw a 400 due to the alternating of user/assistant messages being broken (the merging strategy missed this edge case).

To fix this, we simply filter out all assistant / user messages with no content or tool calls before merging assistant/user messages

## Relevant issues

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

