### PR TITLE
Proxy (health endpoints): Add `/health/db endpoint` w/ Prisma metrics

### DIFF
--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -1,12 +1,15 @@
 # Health Checks
+
 Use this to health check all LLMs defined in your config.yaml
 
-## Summary 
+## Summary
 
-The proxy exposes: 
-* a /health endpoint which returns the health of the LLM APIs  
-* a /health/readiness endpoint for returning if the proxy is ready to accept requests 
-* a /health/liveliness endpoint for returning if the proxy is alive 
+The proxy exposes:
+
+* A `/health` endpoint which returns the health of the LLM APIs  
+* A `/health/readiness` endpoint for returning if the proxy is ready to accept requests
+* A `/health/liveliness` endpoint for returning if the proxy is alive
+* A `/health/db` endpoint for returning info and metrics about the database
 
 ## `/health`
 #### Request
@@ -163,6 +166,126 @@ Example Response:
 
 ```json
 "I'm alive!"
+```
+
+## `/health/db`
+
+Unprotected endpoint for viewing info about the database, including metrics like
+the number of open connections
+
+Example Request:
+
+```shell
+curl -sSL http://0.0.0.0:4000/health/db | jq '.'
+```
+
+Example Response:
+
+```json
+{
+  "metrics": {
+    "counters": [
+      {
+        "key": "prisma_client_queries_total",
+        "value": 8,
+        "labels": {},
+        "description": "The total number of Prisma Client queries executed"
+      },
+      {
+        "key": "prisma_datasource_queries_total",
+        "value": 13,
+        "labels": {},
+        "description": "The total number of datasource queries executed"
+      },
+      {
+        "key": "prisma_pool_connections_closed_total",
+        "value": 0,
+        "labels": {},
+        "description": "The total number of pool connections closed"
+      },
+      {
+        "key": "prisma_pool_connections_opened_total",
+        "value": 2,
+        "labels": {},
+        "description": "The total number of pool connections opened"
+      }
+    ],
+    "gauges": [
+      {
+        "key": "prisma_client_queries_active",
+        "value": 0.0,
+        "labels": {},
+        "description": "The number of currently active Prisma Client queries"
+      },
+      {
+        "key": "prisma_client_queries_wait",
+        "value": 0.0,
+        "labels": {},
+        "description": "The number of datasource queries currently waiting for an free connection"
+      },
+      {
+        "key": "prisma_pool_connections_busy",
+        "value": 0.0,
+        "labels": {},
+        "description": "The number of pool connections currently executing datasource queries"
+      },
+      {
+        "key": "prisma_pool_connections_idle",
+        "value": 100.0,
+        "labels": {},
+        "description": "The number of pool connections that are not busy running a query"
+      },
+      {
+        "key": "prisma_pool_connections_open",
+        "value": 2.0,
+        "labels": {},
+        "description": "The number of pool connections currently open"
+      }
+    ],
+    "histograms": [
+      {
+        "key": "prisma_client_queries_duration_histogram_ms",
+        "value": {
+          "sum": 24731.272958,
+          "count": 8,
+          "buckets": [
+            ...
+          ]
+        },
+        "labels": {},
+        "description": "The distribution of the time Prisma Client queries took to run end to end"
+      },
+      {
+        "key": "prisma_client_queries_wait_histogram_ms",
+        "value": {
+          "sum": 0.024627,
+          "count": 9,
+          "buckets": [
+            ...
+          ]
+        },
+        "labels": {},
+        "description": "The distribution of the time all datasource queries spent waiting for a free connection"
+      },
+      {
+        "key": "prisma_datasource_queries_duration_histogram_ms",
+        "value": {
+          "sum": 24804.927917,
+          "count": 13,
+          "buckets": [
+            ...
+          ]
+        },
+        "labels": {},
+        "description": "The distribution of the time datasource queries took to run"
+      }
+    ]
+  },
+  "db_health_status": {
+    "status": "connected",
+    "last_updated": "2024-07-11T12:46:35.904744"
+  }
+}
 ```
 
 ## Advanced - Call specific models 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -355,6 +355,32 @@ def _db_health_readiness_check():
 
 
 @router.get(
+    "/health/db",
+    tags=["health"],
+)
+async def health_db():
+    """
+    Unprotected endpoint for getting info about database, and in particular
+    metrics from Prisma, like the number of open connections, etc.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    db_health_status = None
+    metrics = None
+
+    try:
+        if prisma_client is not None:
+            db_health_status = _db_health_readiness_check()
+            metrics = await prisma_client.db.get_metrics()
+        return {
+            "metrics": metrics,
+            "db_health_status": db_health_status,
+        }
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Service Unhealthy ({str(e)})")
+
+
+@router.get(
     "/active/callbacks",
     tags=["health"],
     dependencies=[Depends(user_api_key_auth)],


### PR DESCRIPTION
We recently had some issues with our LiteLLM Proxy that were caused by us exceeding the number of open connections to our Postgres server (in part because we run multiple instances of the LiteLLM Proxy and in part because we have a couple of other apps using the same Postgres server).

This PR adds a new `/health/db` endpoint to the LiteLLM Proxy that will return information about the database, including metrics from Prisma like the number of open connections. This will allow us to monitor the number of open connections to our database and take action if we exceed the limit.

```shell
$ curl -sSL 'http://0.0.0.0:4000/health/db' | jq '.'
{
  "metrics": {
    "counters": [
      {
        "key": "prisma_client_queries_total",
        "value": 8,
        "labels": {},
        "description": "The total number of Prisma Client queries executed"
      },
      {
        "key": "prisma_datasource_queries_total",
        "value": 13,
        "labels": {},
        "description": "The total number of datasource queries executed"
      },
      {
        "key": "prisma_pool_connections_closed_total",
        "value": 0,
        "labels": {},
        "description": "The total number of pool connections closed"
      },
      {
        "key": "prisma_pool_connections_opened_total",
        "value": 2,
        "labels": {},
        "description": "The total number of pool connections opened"
      }
    ],
    "gauges": [
      {
        "key": "prisma_client_queries_active",
        "value": 0.0,
        "labels": {},
        "description": "The number of currently active Prisma Client queries"
      },
      {
        "key": "prisma_client_queries_wait",
        "value": 0.0,
        "labels": {},
        "description": "The number of datasource queries currently waiting for an free connection"
      },
      {
        "key": "prisma_pool_connections_busy",
        "value": 0.0,
        "labels": {},
        "description": "The number of pool connections currently executing datasource queries"
      },
      {
        "key": "prisma_pool_connections_idle",
        "value": 100.0,
        "labels": {},
        "description": "The number of pool connections that are not busy running a query"
      },
      {
        "key": "prisma_pool_connections_open",
        "value": 2.0,
        "labels": {},
        "description": "The number of pool connections currently open"
      }
    ],
    "histograms": [
      {
        "key": "prisma_client_queries_duration_histogram_ms",
        "value": {
          "sum": 24731.272958,
          "count": 8,
          "buckets": [
            ...
          ]
        },
        "labels": {},
        "description": "The distribution of the time Prisma Client queries took to run end to end"
      },
      {
        "key": "prisma_client_queries_wait_histogram_ms",
        "value": {
          "sum": 0.024627,
          "count": 9,
          "buckets": [
            ...
          ]
        },
        "labels": {},
        "description": "The distribution of the time all datasource queries spent waiting for a free connection"
      },
      {
        "key": "prisma_datasource_queries_duration_histogram_ms",
        "value": {
          "sum": 24804.927917,
          "count": 13,
          "buckets": [
            ...
          ]
        },
        "labels": {},
        "description": "The distribution of the time datasource queries took to run"
      }
    ]
  },
  "db_health_status": {
    "status": "connected",
    "last_updated": "2024-07-11T12:46:35.904744"
  }
}
```