### PR TITLE
Fix: Langfuse prompt logging

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -317,22 +317,22 @@ class LangFuseLogger:
 
         try:
             tags = []
-            new_metadata = {}
-            for key, value in metadata.items():
-                if (
-                    isinstance(value, list)
-                    or isinstance(value, dict)
-                    or isinstance(value, str)
-                    or isinstance(value, int)
-                    or isinstance(value, float)
-                ):
-                    try:
+            try:
+                metadata = copy.deepcopy(
+                    metadata
+                )  # Avoid modifying the original metadata
+            except:
+                new_metadata = {}
+                for key, value in metadata.items():
+                    if (
+                        isinstance(value, list)
+                        or isinstance(value, dict)
+                        or isinstance(value, str)
+                        or isinstance(value, int)
+                        or isinstance(value, float)
+                    ):
                         new_metadata[key] = copy.deepcopy(value)
-                    except Exception as e:
-                        verbose_logger.error(
-                            f"Langfuse [Non-blocking error] - error copying metadata: {str(e)}"
-                        )
-            metadata = new_metadata
+                metadata = new_metadata
 
             supports_tags = Version(langfuse.version.__version__) >= Version("2.6.3")
             supports_prompt = Version(langfuse.version.__version__) >= Version("2.7.3")


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Fix Langfuse prompt logging

## Relevant issues

The following snippet does not track the `prompt` in Langfuse:

```python
import litellm
from dotenv import load_dotenv
from langfuse import Langfuse
from litellm import completion

load_dotenv()
litellm.success_callback = ["langfuse"]
litellm.failure_callback = ["langfuse"]

langfuse = Langfuse()
prompt = langfuse.get_prompt("test", label="production")

res = completion(
    model="gpt-3.5-turbo",
    messages=[{"content": prompt.compile(message="Test"), "role": "user"}],
    metadata={"prompt": prompt},
)
```

The expected result would be:
![image](https://github.com/user-attachments/assets/6d1c5f43-4776-404b-82e7-96df8f8f0e02)


While the actual result is:
![image](https://github.com/user-attachments/assets/0ca53176-2b63-402f-94dc-942689ef5364)


This is because the `prompt` parameter (that is of type `TextPromptClient` or `ChatPromptClient`) passed in the `metadata` to the `completion` function is filtered out in the `_log_langfuse_v2` function:

```python
new_metadata = {}
for key, value in metadata.items():
    if (
        isinstance(value, list)
        or isinstance(value, dict)
        or isinstance(value, str)
        or isinstance(value, int)
        or isinstance(value, float)
    ):
        try:
            new_metadata[key] = copy.deepcopy(value)
        except Exception as e:
            verbose_logger.error(
                f"Langfuse [Non-blocking error] - error copying metadata: {str(e)}"
            )
metadata = new_metadata
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

Replacing the filtering strategy, with the previous one fix the problem:

```python
try:
    metadata = copy.deepcopy(
        metadata
    )  # Avoid modifying the original metadata
except:
    new_metadata = {}
    for key, value in metadata.items():
        if (
            isinstance(value, list)
            or isinstance(value, dict)
            or isinstance(value, str)
            or isinstance(value, int)
            or isinstance(value, float)
        ):
            new_metadata[key] = copy.deepcopy(value)
    metadata = new_metadata
```

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

