### PR TITLE
[Fix] Reduce Mem Usage - only set ttl for requests to 2 mins 

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -282,7 +282,7 @@ class ProxyLogging:
             key="request_status:{}".format(litellm_call_id),
             value=status,
             local_only=True,
-            ttl=3600,
+            ttl=120,
         )
 
     # The actual implementation of the function


### PR DESCRIPTION
## Fix memory usage 

This line `key=\"request_status:{}\".format(litellm_call_id),']` had `851.72265625 KiB` mem usage when load testing 



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

