### PR TITLE
fix -  Raise `BadRequestError` when passing the wrong role 

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -876,6 +876,7 @@ from .exceptions import (
     InternalServerError,
     JSONSchemaValidationError,
     LITELLM_EXCEPTION_TYPES,
+    MockException,
 )
 from .budget_manager import BudgetManager
 from .proxy.proxy_cli import run_server

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -723,3 +723,28 @@ class InvalidRequestError(openai.BadRequestError):  # type: ignore
         super().__init__(
             self.message, f"{self.model}"
         )  # Call the base class constructor with the parameters it needs
+
+
+class MockException(openai.APIError):
+    # used for testing
+    def __init__(
+        self,
+        status_code,
+        message,
+        llm_provider,
+        model,
+        request: Optional[httpx.Request] = None,
+        litellm_debug_info: Optional[str] = None,
+        max_retries: Optional[int] = None,
+        num_retries: Optional[int] = None,
+    ):
+        self.status_code = status_code
+        self.message = "litellm.MockException: {}".format(message)
+        self.llm_provider = llm_provider
+        self.model = model
+        self.litellm_debug_info = litellm_debug_info
+        self.max_retries = max_retries
+        self.num_retries = num_retries
+        if request is None:
+            request = httpx.Request(method="POST", url="https://api.openai.com/v1")
+        super().__init__(self.message, request=request, body=None)  # type: ignore

--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -1845,7 +1845,9 @@ class BedrockConverseLLM(BaseLLM):
             inference_params.pop(key, None)
 
         bedrock_messages: List[MessageBlock] = _bedrock_converse_messages_pt(
-            messages=messages
+            messages=messages,
+            model=model,
+            llm_provider="bedrock_converse",
         )
         bedrock_tools: List[ToolBlock] = _bedrock_tools_pt(
             inference_params.pop("tools", [])

--- a/litellm/llms/cohere_chat.py
+++ b/litellm/llms/cohere_chat.py
@@ -212,7 +212,9 @@ def completion(
     headers = validate_environment(api_key)
     completion_url = api_base
     model = model
-    most_recent_message, chat_history = cohere_messages_pt_v2(messages=messages)
+    most_recent_message, chat_history = cohere_messages_pt_v2(
+        messages=messages, model=model, llm_provider="cohere_chat"
+    )
 
     ## Load Config
     config = litellm.CohereConfig.get_config()

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -479,7 +479,7 @@ def mock_completion(
         if isinstance(mock_response, Exception):
             if isinstance(mock_response, openai.APIError):
                 raise mock_response
-            raise litellm.APIError(
+            raise litellm.MockException(
                 status_code=getattr(mock_response, "status_code", 500),  # type: ignore
                 message=getattr(mock_response, "text", str(mock_response)),
                 llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),  # type: ignore

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -3265,7 +3265,9 @@ def test_completion_anthropic_hanging():
         {"role": "function", "name": "get_capital", "content": "Kokoko"},
     ]
 
-    converted_messages = anthropic_messages_pt(messages)
+    converted_messages = anthropic_messages_pt(
+        messages, model="claude-3-sonnet-20240229", llm_provider="anthropic"
+    )
 
     print(f"converted_messages: {converted_messages}")
 

--- a/litellm/tests/test_exceptions.py
+++ b/litellm/tests/test_exceptions.py
@@ -414,6 +414,35 @@ def test_completion_mistral_exception():
 # test_completion_mistral_exception()
 
 
+def test_completion_bedrock_invalid_role_exception():
+    """
+    Test if litellm raises a BadRequestError for an invalid role on Bedrock
+    """
+    try:
+        litellm.set_verbose = True
+        response = completion(
+            model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "very-bad-role", "content": "hello"}],
+        )
+        print(f"response: {response}")
+        print(response)
+
+    except Exception as e:
+        assert isinstance(
+            e, litellm.BadRequestError
+        ), "Expected BadRequestError but got {}".format(type(e))
+        print("str(e) = {}".format(str(e)))
+
+        # This is important - We we previously returning a poorly formatted error string. Which was
+        #  litellm.BadRequestError: litellm.BadRequestError: Invalid Message passed in {'role': 'very-bad-role', 'content': 'hello'}
+
+        # IMPORTANT ASSERTION
+        assert (
+            (str(e))
+            == "litellm.BadRequestError: Invalid Message passed in {'role': 'very-bad-role', 'content': 'hello'}"
+        )
+
+
 def test_content_policy_exceptionimage_generation_openai():
     try:
         # this is ony a test - we needed some way to invoke the exception :(

--- a/litellm/tests/test_prompt_factory.py
+++ b/litellm/tests/test_prompt_factory.py
@@ -121,13 +121,20 @@ def test_anthropic_messages_pt():
     litellm.modify_params = True
     messages = []
     expected_messages = [{"role": "user", "content": [{"type": "text", "text": "."}]}]
-    assert anthropic_messages_pt(messages) == expected_messages
+    assert (
+        anthropic_messages_pt(
+            messages, model="claude-3-sonnet-20240229", llm_provider="anthropic"
+        )
+        == expected_messages
+    )
 
     # Test case: No messages (filtered system messages only) when modify_params is False should raise error
     litellm.modify_params = False
     messages = []
     with pytest.raises(Exception) as err:
-        anthropic_messages_pt(messages)
+        anthropic_messages_pt(
+            messages, model="claude-3-sonnet-20240229", llm_provider="anthropic"
+        )
     assert "Invalid first message" in str(err.value)
 
 

--- a/litellm/tests/test_rules.py
+++ b/litellm/tests/test_rules.py
@@ -1,14 +1,18 @@
 #### What this tests ####
 #    This tests setting rules before / after making llm api calls
-import sys, os, time
-import traceback, asyncio
+import asyncio
+import os
+import sys
+import time
+import traceback
+
 import pytest
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import litellm
-from litellm import completion, acompletion
+from litellm import acompletion, completion
 
 
 def my_pre_call_rule(input: str):
@@ -126,10 +130,7 @@ def test_post_call_rule_streaming():
         print("Got exception", e)
         print(type(e))
         print(vars(e))
-        assert (
-            "OpenAIException - This violates LiteLLM Proxy Rules. Response too short"
-            in e.message
-        )
+        assert "This violates LiteLLM Proxy Rules. Response too short" in e.message
 
 
 @pytest.mark.asyncio

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5961,6 +5961,12 @@ def exception_type(
     extra_kwargs={},
 ):
     global user_logger_fn, liteDebuggerClient
+
+    if any(
+        isinstance(original_exception, exc_type)
+        for exc_type in litellm.LITELLM_EXCEPTION_TYPES
+    ):
+        return original_exception
     exception_mapping_worked = False
     if litellm.suppress_debug_info is False:
         print()  # noqa
@@ -6131,7 +6137,7 @@ def exception_type(
                 ):
                     exception_mapping_worked = True
                     raise BadRequestError(
-                        message=f"BadRequestError: {exception_provider} - {message}",
+                        message=f"{exception_provider} - {message}",
                         llm_provider=custom_llm_provider,
                         model=model,
                         response=original_exception.response,
@@ -6218,7 +6224,7 @@ def exception_type(
                     elif original_exception.status_code == 422:
                         exception_mapping_worked = True
                         raise BadRequestError(
-                            message=f"BadRequestError: {exception_provider} - {message}",
+                            message=f"{exception_provider} - {message}",
                             model=model,
                             llm_provider=custom_llm_provider,
                             response=original_exception.response,


### PR DESCRIPTION
## Title

Raise the following exception when a bad role is passed
```
raise litellm.BadRequestError(
    message=BAD_MESSAGE_ERROR_STR + f"passed in {messages[msg_i]}",
    model=model,
    llm_provider=llm_provider,
)
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

