### PR TITLE
[Fix] Bug - Clear user_id from cache when /user/update is called 

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -1668,6 +1668,9 @@ class DualCache(BaseCache):
             self.redis_cache.flush_cache()
 
     def delete_cache(self, key):
+        """
+        Delete a key from the cache
+        """
         if self.in_memory_cache is not None:
             self.in_memory_cache.delete_cache(key)
         if self.redis_cache is not None:

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -29,6 +29,10 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     generate_key_helper_fn,
 )
+from litellm.proxy.management_helpers.utils import (
+    add_new_member,
+    management_endpoint_wrapper,
+)
 
 router = APIRouter()
 
@@ -39,7 +43,10 @@ router = APIRouter()
     dependencies=[Depends(user_api_key_auth)],
     response_model=NewUserResponse,
 )
-async def new_user(data: NewUserRequest):
+@management_endpoint_wrapper
+async def new_user(
+    data: NewUserRequest,
+):
     """
     Use this to create a new INTERNAL user with a budget.
     Internal Users can access LiteLLM Admin UI to make keys, request access to models.
@@ -254,6 +261,7 @@ async def ui_get_available_role(
     tags=["Internal User management"],
     dependencies=[Depends(user_api_key_auth)],
 )
+@management_endpoint_wrapper
 async def user_info(
     user_id: Optional[str] = fastapi.Query(
         default=None, description="User ID in the request parameters"
@@ -441,7 +449,10 @@ async def user_info(
     tags=["Internal User management"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def user_update(data: UpdateUserRequest):
+@management_endpoint_wrapper
+async def user_update(
+    data: UpdateUserRequest,
+):
     """
     Example curl 
 
@@ -683,6 +694,7 @@ async def get_users(
     tags=["Internal User management"],
     dependencies=[Depends(user_api_key_auth)],
 )
+@management_endpoint_wrapper
 async def delete_user(
     data: DeleteUserRequest,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -191,6 +191,8 @@ def management_endpoint_wrapper(func):
                                 logging_payload=logging_payload,
                                 parent_otel_span=parent_otel_span,
                             )
+
+                # Delete updated/deleted info from cache
                 _delete_api_key_from_cache(kwargs=kwargs)
                 _delete_user_id_from_cache(kwargs=kwargs)
                 _delete_team_id_from_cache(kwargs=kwargs)

--- a/litellm/tests/test_key_generate_prisma.py
+++ b/litellm/tests/test_key_generate_prisma.py
@@ -76,6 +76,7 @@ from litellm.proxy.proxy_server import (
     user_api_key_auth,
 )
 from litellm.proxy.spend_tracking.spend_management_endpoints import (
+    global_spend,
     spend_key_fn,
     spend_user_fn,
     view_spend_logs,
@@ -99,6 +100,7 @@ from litellm.proxy._types import (
     ProxyException,
     UpdateKeyRequest,
     UpdateTeamRequest,
+    UpdateUserRequest,
     UserAPIKeyAuth,
 )
 from litellm.proxy.utils import DBClient
@@ -2488,3 +2490,58 @@ async def test_enforced_params(prisma_client):
             in e.message
         )
     general_settings.pop("enforced_params")
+
+
+@pytest.mark.asyncio()
+async def test_update_user_role(prisma_client):
+    """
+    Tests if we update user role, incorrect values are not stored in cache
+    -> create a user with role == INTERNAL_USER
+    -> access an Admin only route -> expect to fail
+
+    -> update user role to == PROXY_ADMIN
+    -> access an Admin only route -> expect to succeed
+    """
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    await litellm.proxy.proxy_server.prisma_client.connect()
+    key = await new_user(
+        data=NewUserRequest(
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+    )
+
+    print(key)
+    api_key = "Bearer " + key.key
+
+    api_route = APIRoute(path="/global/spend", endpoint=global_spend)
+    request = Request(
+        {
+            "type": "http",
+            "route": api_route,
+            "path": "/global/spend",
+            "headers": [("Authorization", api_key)],
+        }
+    )
+
+    request._url = URL(url="/global/spend")
+
+    # use generated key to auth in
+    try:
+        result = await user_api_key_auth(request=request, api_key=api_key)
+        print("result from user auth with new key", result)
+    except Exception as e:
+        print(e)
+        pass
+
+    await user_update(
+        data=UpdateUserRequest(
+            user_id=key.user_id, user_role=LitellmUserRoles.PROXY_ADMIN
+        )
+    )
+
+    await asyncio.sleep(2)
+
+    # use generated key to auth in
+    result = await user_api_key_auth(request=request, api_key=api_key)
+    print("result from user auth with new key", result)


### PR DESCRIPTION
## When /update /delete called for Key, User, Team -> delete that specific key from user_api_key cache


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

