### PR TITLE
fix: enables batch embedding support for triton

### DIFF
--- a/litellm/tests/test_triton.py
+++ b/litellm/tests/test_triton.py
@@ -1,0 +1,29 @@
+import pytest
+from litellm.llms.triton import TritonChatCompletion
+
+
+def test_split_embedding_by_shape_passes():
+    try:
+        triton = TritonChatCompletion()
+        data = [
+            {
+                "shape": [2, 3],
+                "data": [1, 2, 3, 4, 5, 6],
+            }
+        ]
+        split_output_data = triton.split_embedding_by_shape(data[0]["data"], data[0]["shape"])
+        assert split_output_data == [[1, 2, 3], [4, 5, 6]]
+    except Exception as e:
+        pytest.fail(f"An exception occured: {e}")
+
+
+def test_split_embedding_by_shape_fails_with_shape_value_error():
+    triton = TritonChatCompletion()
+    data = [
+        {
+            "shape": [2],
+            "data": [1, 2, 3, 4, 5, 6],
+        }
+    ]
+    with pytest.raises(ValueError):
+        triton.split_embedding_by_shape(data[0]["data"], data[0]["shape"])


### PR DESCRIPTION
## Title

Enables batch embedding support for triton. Previously if you tried to embed multiple values, litellm would throw an error.

## Relevant issues

N/a

## Type
🐛 Bug Fix


## Changes

- enables triton to support batch embeddings
- since triton does not return the embeddings split out, this PR adds logic to split the embedding result from triton based on the response's shape


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

![image](https://github.com/user-attachments/assets/7a4b386a-a1b1-4353-9169-b4fa3dbbfca6)

