### PR TITLE
feat: read chat-template from tokenizer files for vllm

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -2514,6 +2514,12 @@ def prompt_factory(
                 initial_prompt_value="<|begin_of_text|>",
                 final_prompt_value="<|start_header_id|>assistant<|end_header_id|>\n",
             )
+    elif custom_llm_provider == "vllm":
+        from tokenizers import AutoTokenizer
+        tokenizer = AutoTokenizer.from_pretrained(model)
+        return tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
     try:
         if "meta-llama/llama-2" in model and "chat" in model:
             return llama_2_chat_pt(messages=messages)


### PR DESCRIPTION
## Title

Support reading the chat-template embedded in the tokenizer files for vllm.
We can use the transformers library directly since transformers is a dependency for vLLM, and if the `custom_llm_provider` is vLLM, the user must have it installed.

## Relevant issues

Fixes #1251

## Type
🆕 New Feature