### PR TITLE
Fix Requests that are incorrectly flagged as admin-only paths

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -964,10 +964,6 @@ async def user_api_key_auth(
             _user_role = _get_user_role(user_id_information=user_id_information)
 
             if not _is_user_proxy_admin(user_id_information):  # if non-admin
-                print("#### ROUTE ####")
-                print(route)
-                print(request["route"].name)
-                print()
                 if is_openai_route(route=route):
                     pass
                 elif is_openai_route(route=request["route"].name):

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -114,7 +114,11 @@ async def user_api_key_auth(
     )
 
     try:
-        route: str = request.url.path
+        route: str = (
+            request.url.path[len(request.base_url.path) - 1 :]
+            if request.url.path.startswith(request.base_url.path)
+            else request.url.path
+        )  # remove base url from path if set e.g. `/genai/chat/completions` -> `/chat/completions
 
         pass_through_endpoints: Optional[List[dict]] = general_settings.get(
             "pass_through_endpoints", None
@@ -960,6 +964,10 @@ async def user_api_key_auth(
             _user_role = _get_user_role(user_id_information=user_id_information)
 
             if not _is_user_proxy_admin(user_id_information):  # if non-admin
+                print("#### ROUTE ####")
+                print(route)
+                print(request["route"].name)
+                print()
                 if is_openai_route(route=route):
                     pass
                 elif is_openai_route(route=request["route"].name):


### PR DESCRIPTION
## Fix Requests that are incorrectly flagged as admin-only paths

Fixing an issue where path checks in `litellm/proxy/auth/user_api_key_auth.py` assume that the server is not using a `base_url` (set with `SERVER_ROOT_PATH`) so requests are incorrectly being flagged as admin-only and throwing 401 errors.

![Screenshot 2024-07-16 at 9 36 08 PM](https://github.com/user-attachments/assets/e8a600bb-4693-4785-a600-b132f482e6cc)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

🐛 Bug Fix

## Changes

* update `litellm/proxy/auth/user_api_key_auth.py` so that the `request.base_url.path` is removed from the beginning of the `request.url.path` if the url path starts with the base url path
