### PR TITLE
"Tool calls" is None in token_counter causes error

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -910,7 +910,7 @@ def completion(
             llm_provider=custom_llm_provider, dynamic_api_key=api_key
         )  # get the api key from the environment if required for the model
 
-        if dynamic_api_key is not None:
+        if dynamic_api_key is not None and api_key is not None:
             api_key = dynamic_api_key
         # check if user passed in any of the OpenAI optional params
         optional_params = get_optional_params(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -910,7 +910,7 @@ def completion(
             llm_provider=custom_llm_provider, dynamic_api_key=api_key
         )  # get the api key from the environment if required for the model
 
-        if dynamic_api_key is not None and api_key is not None:
+        if dynamic_api_key is not None and api_key is None:
             api_key = dynamic_api_key
         # check if user passed in any of the OpenAI optional params
         optional_params = get_optional_params(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -910,7 +910,7 @@ def completion(
             llm_provider=custom_llm_provider, dynamic_api_key=api_key
         )  # get the api key from the environment if required for the model
 
-        if dynamic_api_key is not None and api_key is None:
+        if dynamic_api_key is not None:
             api_key = dynamic_api_key
         # check if user passed in any of the OpenAI optional params
         optional_params = get_optional_params(

--- a/litellm/tests/test_api_key_override_dynamic_key.py
+++ b/litellm/tests/test_api_key_override_dynamic_key.py
@@ -12,7 +12,7 @@ except Exception as e:
 
 print("==============try original===============")
 response = completion(
-    model="groq/mixtral-8x7b-32768",
+    model="gpt-3.5-turbo",
     messages=[{"role": "user", "content": "hey, how's it going?"}],
 )
 

--- a/litellm/tests/test_api_key_override_dynamic_key.py
+++ b/litellm/tests/test_api_key_override_dynamic_key.py
@@ -1,8 +1,12 @@
 from litellm import completion
 
+model = "perplexity/llama-3-sonar-large-32k-online"
+# model = "groq/mixtral-8x7b-32768"
+# model = "together_ai/Qwen/Qwen1.5-32B-Chat"
+# model = "fireworks_ai/llama-v3-8b-instruct"
 try:
     response = completion(
-        model="groq/mixtral-8x7b-32768",
+        model=model,
         messages=[{"role": "user", "content": "hey, how's it going?"}],
         api_key="invalid_key"
     )
@@ -12,7 +16,7 @@ except Exception as e:
 
 print("==============try original===============")
 response = completion(
-    model="gpt-3.5-turbo",
+    model=model,
     messages=[{"role": "user", "content": "hey, how's it going?"}],
 )
 

--- a/litellm/tests/test_api_key_override_dynamic_key.py
+++ b/litellm/tests/test_api_key_override_dynamic_key.py
@@ -1,0 +1,11 @@
+from litellm import completion
+
+try:
+    response = completion(
+        model="groq/mixtral-8x7b-32768",
+        messages=[{"role": "user", "content": "hey, how's it going?"}],
+        api_key="invalid_key"
+    )
+    
+except Exception as e:
+    print(e)

--- a/litellm/tests/test_api_key_override_dynamic_key.py
+++ b/litellm/tests/test_api_key_override_dynamic_key.py
@@ -9,3 +9,11 @@ try:
     
 except Exception as e:
     print(e)
+
+print("==============try original===============")
+response = completion(
+    model="groq/mixtral-8x7b-32768",
+    messages=[{"role": "user", "content": "hey, how's it going?"}],
+)
+
+print(response)

--- a/litellm/tests/test_empty_tool_calls.py
+++ b/litellm/tests/test_empty_tool_calls.py
@@ -4,12 +4,7 @@ messages = [
     {
         "role": "user",
         "content": "hey, how's it going?",
-        "tool_calls": [
-            {
-                "tool": "token_counter",
-                "parameters": "\{count\:5\}"
-            }
-        ]
+        "tool_calls": None
     }
 ]
 

--- a/litellm/tests/test_empty_tool_calls.py
+++ b/litellm/tests/test_empty_tool_calls.py
@@ -1,0 +1,20 @@
+from litellm import token_counter
+
+messages = [
+    {
+        "role": "user",
+        "content": "hey, how's it going?",
+        "tool_calls": [
+            {
+                "tool": "token_counter",
+                "parameters": "\{count\:5\}"
+            }
+        ]
+    }
+]
+
+result = token_counter(
+    messages=messages,
+)
+
+print(result)

--- a/litellm/tests/test_service_account.py
+++ b/litellm/tests/test_service_account.py
@@ -1,0 +1,11 @@
+import litellm
+
+model = "gpt-3.5-turbo"
+messages = [
+    {
+        "role": "user",
+        "content": "hey, how's it going?"
+    }
+]
+repsonse = litellm.completion(model=model, messages=messages)
+print(repsonse)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4376,6 +4376,7 @@ def get_llm_provider(
             model.split("/", 1)[0] in litellm.provider_list
             and model.split("/", 1)[0] not in litellm.model_list
             and len(model.split("/"))
+            and not api_key
             > 1  # handle edge case where user passes in `litellm --model mistral` https://github.com/BerriAI/litellm/issues/1351
         ):
             custom_llm_provider = model.split("/", 1)[0]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4376,14 +4376,13 @@ def get_llm_provider(
             model.split("/", 1)[0] in litellm.provider_list
             and model.split("/", 1)[0] not in litellm.model_list
             and len(model.split("/")) > 1  # handle edge case where user passes in `litellm --model mistral` https://github.com/BerriAI/litellm/issues/1351
-            and not api_key
         ):
             custom_llm_provider = model.split("/", 1)[0]
             model = model.split("/", 1)[1]
             if custom_llm_provider == "perplexity":
                 # perplexity is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.perplexity.ai
-                api_base = api_base or "https://api.perplexity.ai"
-                dynamic_api_key = get_secret("PERPLEXITYAI_API_KEY")
+                api_base = "https://api.perplexity.ai"
+                dynamic_api_key = api_key or get_secret("PERPLEXITYAI_API_KEY")
             elif custom_llm_provider == "anyscale":
                 # anyscale is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
                 api_base = api_base or "https://api.endpoints.anyscale.com/v1"
@@ -4397,8 +4396,8 @@ def get_llm_provider(
                 dynamic_api_key = get_secret("EMPOWER_API_KEY")
             elif custom_llm_provider == "groq":
                 # groq is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.groq.com/openai/v1
-                api_base = api_base or "https://api.groq.com/openai/v1"
-                dynamic_api_key = get_secret("GROQ_API_KEY")
+                api_base = "https://api.groq.com/openai/v1"
+                dynamic_api_key = api_key or get_secret("GROQ_API_KEY")
             elif custom_llm_provider == "nvidia_nim":
                 # nvidia_nim is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
                 api_base = api_base or "https://integrate.api.nvidia.com/v1"
@@ -4419,8 +4418,8 @@ def get_llm_provider(
                 # fireworks is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.fireworks.ai/inference/v1
                 if not model.startswith("accounts/fireworks/models"):
                     model = f"accounts/fireworks/models/{model}"
-                api_base = api_base or "https://api.fireworks.ai/inference/v1"
-                dynamic_api_key = (
+                api_base = "https://api.fireworks.ai/inference/v1"
+                dynamic_api_key = api_key or (
                     get_secret("FIREWORKS_API_KEY")
                     or get_secret("FIREWORKS_AI_API_KEY")
                     or get_secret("FIREWORKSAI_API_KEY")
@@ -4453,7 +4452,7 @@ def get_llm_provider(
                 dynamic_api_key = get_secret("VOYAGE_API_KEY")
             elif custom_llm_provider == "together_ai":
                 api_base = "https://api.together.xyz/v1"
-                dynamic_api_key = (
+                dynamic_api_key = api_key or (
                     get_secret("TOGETHER_API_KEY")
                     or get_secret("TOGETHER_AI_API_KEY")
                     or get_secret("TOGETHERAI_API_KEY")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4284,7 +4284,7 @@ def get_formatted_prompt(
                     for c in content:
                         if c["type"] == "text":
                             prompt += c["text"]
-            if "tool_calls" in message:
+            if message.get("tool_calls"):
                 for tool_call in message["tool_calls"]:
                     if "function" in tool_call:
                         function_arguments = tool_call["function"]["arguments"]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4375,9 +4375,8 @@ def get_llm_provider(
         if (
             model.split("/", 1)[0] in litellm.provider_list
             and model.split("/", 1)[0] not in litellm.model_list
-            and len(model.split("/"))
+            and len(model.split("/")) > 1  # handle edge case where user passes in `litellm --model mistral` https://github.com/BerriAI/litellm/issues/1351
             and not api_key
-            > 1  # handle edge case where user passes in `litellm --model mistral` https://github.com/BerriAI/litellm/issues/1351
         ):
             custom_llm_provider = model.split("/", 1)[0]
             model = model.split("/", 1)[1]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1922,7 +1922,7 @@ def token_counter(
                                     num_tokens += calculage_img_tokens(
                                         data=image_url_str, mode="auto"
                                     )
-                if "tool_calls" in message:
+                if message.get("tool_calls"):
                     is_tool_call = True
                     for tool_call in message["tool_calls"]:
                         if "function" in tool_call:


### PR DESCRIPTION
## Title

When tool_calls is None, litellm throws "NoneType" is not iterable.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type


🐛 Bug Fix


## Changes

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/a3b2e248-3822-4dcc-978d-7da1040c1b89">
In utils.py

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
<img width="551" alt="image" src="https://github.com/user-attachments/assets/4463d1bb-025b-4069-8dd8-79b2082bfe55">
Running test_empty_tool_calls.py with "tool_calls" as None in one of the messages, no error is thrown.

