### PR TITLE
Alias  `/health/liveliness` as `/health/liveness`

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -304,6 +304,7 @@ class LiteLLMRoutes(enum.Enum):
         "/routes",
         "/",
         "/health/liveliness",
+        "/health/liveness",
         "/health/readiness",
         "/test",
         "/config/yaml",

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -482,7 +482,12 @@ async def health_readiness():
 
 
 @router.get(
-    "/health/liveliness",
+    "/health/liveliness", # Historical LiteLLM name; doesn't match k8s terminology but kept for backwards compatibility
+    tags=["health"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+@router.get(
+    "/health/liveness",   # Kubernetes has "liveness" probes (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
     tags=["health"],
     dependencies=[Depends(user_api_key_auth)],
 )
@@ -512,6 +517,11 @@ async def health_readiness_options():
 
 @router.options(
     "/health/liveliness",
+    tags=["health"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+@router.options(
+    "/health/liveness",   # Kubernetes has "liveness" probes (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
     tags=["health"],
     dependencies=[Depends(user_api_key_auth)],
 )


### PR DESCRIPTION
The latter is the more common term in Kubernetes, so it's nice to support that.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
