### PR TITLE
Removed weird replicate model from model prices list

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2255,15 +2255,6 @@
         "litellm_provider": "cohere",
         "mode": "completion"
     },
-    "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1": {
-        "max_tokens": 4096, 
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 0.0000,
-        "output_cost_per_token": 0.0000,
-        "litellm_provider": "replicate",
-        "mode": "chat"
-    },
     "replicate/meta/llama-2-13b": {
         "max_tokens": 4096,
         "max_input_tokens": 4096,


### PR DESCRIPTION
## Title
Removed weird replicate model from model prices list

## Relevant issues

## Type

🧹 Refactoring
## Changes

There's a weird model in the model_price.json that's extremely long. I don't think anyone's using it, and it seems like an anti-pattern to keep it alive.

Model in question: `"replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"`

<!-- List of changes -->

Changed model prices json

<!-- Test procedure -->

