### PR TITLE
Add `--config` arg to k8s Deployment example in docs

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -187,6 +187,9 @@ spec:
         image: ghcr.io/berriai/litellm:main-latest # it is recommended to fix a version generally
         ports:
         - containerPort: 4000
+        args:
+            - "--config"
+            - "/app/proxy_server_config.yaml"
         volumeMounts:
         - name: config-volume
           mountPath: /app/proxy_server_config.yaml


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


📖 Documentation


## Changes

Add `--config` argument to point to the config-volume mount point from the example. Without this, the proxy server does not load the config from the ConfigMap.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

