### PR TITLE
router - use verbose logger when using litellm.Router

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -417,14 +417,15 @@ class Router:
             litellm.failure_callback.append(self.deployment_callback_on_failure)
         else:
             litellm.failure_callback = [self.deployment_callback_on_failure]
-        print(  # noqa
+        verbose_router_logger.info(
             f"Intialized router with Routing strategy: {self.routing_strategy}\n\n"
             f"Routing enable_pre_call_checks: {self.enable_pre_call_checks}\n\n"
             f"Routing fallbacks: {self.fallbacks}\n\n"
             f"Routing content fallbacks: {self.content_policy_fallbacks}\n\n"
             f"Routing context window fallbacks: {self.context_window_fallbacks}\n\n"
             f"Router Redis Caching={self.cache.redis_cache}\n"
-        )  # noqa
+        )
+
         self.routing_strategy_args = routing_strategy_args
         self.retry_policy: Optional[RetryPolicy] = retry_policy
         self.model_group_retry_policy: Optional[Dict[str, RetryPolicy]] = (


### PR DESCRIPTION
## Addressing user request - allow user to switch off default router prints 


> We’re generally happy. There’s a small thing, we’d love to have a general off switch for stdout output, for example I couldn’t find a way to turn off the Router initial messages:
> Intialized router with Routing strategy: simple-shuffle
> 
> Routing enable_pre_call_checks: False
> 
> Routing fallbacks: None
> 
> Routing content fallbacks: None
> 
> Routing context window fallbacks: None
> 
> Router Redis Caching=None
> 
> Intialized router with Routing strategy: simple-shuffle
> 
> Routing enable_pre_call_checks: False
> 
> Routing fallbacks: None
> 
> Routing content fallbacks: None
> 
> Routing context window fallbacks: None
> 
> Router Redis Caching=None

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

