### PR TITLE
[Feat-Proxy] Disable Logging per Team 

### DIFF
--- a/docs/my-website/docs/proxy/team_logging.md
+++ b/docs/my-website/docs/proxy/team_logging.md
@@ -10,12 +10,14 @@ Allow each team to use their own Langfuse Project / custom callbacks
 ```
 Team 1 -> Logs to Langfuse Project 1 
 Team 2 -> Logs to Langfuse Project 2
-Team 3 -> Logs to Langsmith
+Team 3 -> Disabled Logging (for GDPR compliance)
 ```
 
-## Quick Start
+## Set Callbacks Per Team
 
-## 1. Set callback for team 
+### 1. Set callback for team 
+
+We make a request to `POST /team/{team_id}/callback` to add a callback for
 
 ```shell
 curl -X POST 'http:/localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback' \
@@ -44,7 +46,7 @@ curl -X POST 'http:/localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/cal
 | &nbsp;&nbsp;&nbsp;&nbsp;`langfuse_secret_key` | string | Required |
 | &nbsp;&nbsp;&nbsp;&nbsp;`langfuse_host` | string | Optional (defaults to https://cloud.langfuse.com) |
 
-## 2. Create key for team
+### 2. Create key for team
 
 All keys created for team `dbe2f686-a686-4896-864a-4c3924458709` will log to langfuse project specified on [Step 1. Set callback for team](#1-set-callback-for-team)
 
@@ -59,7 +61,7 @@ curl --location 'http://0.0.0.0:4000/key/generate' \
 ```
 
 
-## 3. Make `/chat/completion` request for team
+### 3. Make `/chat/completion` request for team
 
 ```shell
 curl -i http://localhost:4000/v1/chat/completions \
@@ -74,6 +76,64 @@ curl -i http://localhost:4000/v1/chat/completions \
 ```
 
 Expect this to be logged on the langfuse project specified on [Step 1. Set callback for team](#1-set-callback-for-team)
+
+
+## Disable Logging for a Team
+
+To disable logging for a specific team, you can use the following endpoint:
+
+`POST /team/{team_id}/disable_logging`
+
+This endpoint removes all success and failure callbacks for the specified team, effectively disabling logging.
+
+### Step 1. Disable logging for team
+
+```shell
+curl -X POST 'http://localhost:4000/team/YOUR_TEAM_ID/disable_logging' \
+    -H 'Authorization: Bearer YOUR_API_KEY'
+```
+Replace YOUR_TEAM_ID with the actual team ID
+
+**Response**
+A successful request will return a response similar to this:
+```json
+{
+    "status": "success",
+    "message": "Logging disabled for team YOUR_TEAM_ID",
+    "data": {
+        "team_id": "YOUR_TEAM_ID",
+        "success_callbacks": [],
+        "failure_callbacks": []
+    }
+}
+```
+
+### Step 2. Test it - `/chat/completions`
+
+Use a key generated for team = `team_id` - you should see no logs on your configured success callback (eg. Langfuse)
+
+```shell
+curl -i http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-KbUuE0WNptC0jXapyMmLBA" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {"role": "user", "content": "Hello, Claude gm!"}
+    ]
+}'
+```
+
+### Debugging / Troubleshooting
+
+- Check active callbacks for team using `GET /team/{team_id}/callback`
+
+Use this to check what success/failure callbacks are active for team=`team_id`
+
+```shell
+curl -X GET 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback' \
+        -H 'Authorization: Bearer sk-1234'
+```
 
 ## Team Logging Endpoints
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -213,6 +213,9 @@ async def add_litellm_data_to_request(
         if "callback_settings" in team_metadata:
             callback_settings = team_metadata.get("callback_settings", None) or {}
             callback_settings_obj = TeamCallbackMetadata(**callback_settings)
+            verbose_proxy_logger.debug(
+                "Team callback settings activated: %s", callback_settings_obj
+            )
             """
             callback_settings = {
               {

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -12,4 +12,4 @@ general_settings:
   master_key: sk-1234
 
 litellm_settings:
-  callbacks: ["arize"]
+  success_callback: ["langfuse"]


### PR DESCRIPTION

## Disable Logging for a Team

To disable logging for a specific team, you can use the following endpoint:

`POST /team/{team_id}/disable_logging`

This endpoint removes all success and failure callbacks for the specified team, effectively disabling logging.

### Step 1. Disable logging for team

```shell
curl -X POST 'http://localhost:4000/team/YOUR_TEAM_ID/disable_logging' \
    -H 'Authorization: Bearer YOUR_API_KEY'
```
Replace YOUR_TEAM_ID with the actual team ID

**Response**
A successful request will return a response similar to this:
```json
{
    "status": "success",
    "message": "Logging disabled for team YOUR_TEAM_ID",
    "data": {
        "team_id": "YOUR_TEAM_ID",
        "success_callbacks": [],
        "failure_callbacks": []
    }
}
```

### Step 2. Test it - `/chat/completions`

Use a key generated for team = `team_id` - you should see no logs on your configured success callback (eg. Langfuse)

```shell
curl -i http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-KbUuE0WNptC0jXapyMmLBA" \
  -d '{
    "model": "gpt-4",
    "messages": [
      {"role": "user", "content": "Hello, Claude gm!"}
    ]
}'
```

### Debugging / Troubleshooting

- Check active callbacks for team using `GET /team/{team_id}/callback`

Use this to check what success/failure callbacks are active for team=`team_id`

```shell
curl -X GET 'http://localhost:4000/team/dbe2f686-a686-4896-864a-4c3924458709/callback' \
        -H 'Authorization: Bearer sk-1234'
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

