### PR TITLE
Fix `test_prompt_factory` flake8 warning

### DIFF
--- a/litellm/tests/test_prompt_factory.py
+++ b/litellm/tests/test_prompt_factory.py
@@ -212,7 +212,7 @@ def test_convert_url_to_img():
     [
         ("data:image/jpeg;base64,1234", "image/jpeg"),
         ("data:application/pdf;base64,1234", "application/pdf"),
-        ("data:image\/jpeg;base64,1234", "image/jpeg"),
+        ("data:image/jpeg;base64,1234", "image/jpeg"),
     ],
 )
 def test_base64_image_input(url, expected_media_type):


### PR DESCRIPTION
```shell
$ poetry run flake8 litellm/tests/test_prompt_factory.py
<unknown>:215: SyntaxWarning: invalid escape sequence '\/'
litellm/tests/test_prompt_factory.py:215:21: W605 invalid escape sequence '\/'
```