### PR TITLE
[Feat] - Support Logging tags on langsmith 

### DIFF
--- a/docs/my-website/docs/observability/langsmith_integration.md
+++ b/docs/my-website/docs/observability/langsmith_integration.md
@@ -56,7 +56,7 @@ response = litellm.completion(
 ```
 
 ## Advanced
-### Set Custom Project & Run names
+### Set Langsmith fields - Custom Projec, Run names, tags
 
 ```python
 import litellm
@@ -77,6 +77,7 @@ response = litellm.completion(
     metadata={
         "run_name": "litellmRUN",               # langsmith run name
         "project_name": "litellm-completion",   # langsmith project name
+        "tags": ["model1", "prod-2"]            # tags to log on langsmith
     }
 )
 print(response)

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -79,6 +79,7 @@ class LangsmithLogger(CustomLogger):
         project_name = metadata.get("project_name", self.langsmith_project)
         run_name = metadata.get("run_name", self.langsmith_default_run_name)
         run_id = metadata.get("id", None)
+        tags = metadata.get("tags", []) or []
         verbose_logger.debug(
             f"Langsmith Logging - project_name: {project_name}, run_name {run_name}"
         )
@@ -122,6 +123,7 @@ class LangsmithLogger(CustomLogger):
             "session_name": project_name,
             "start_time": start_time,
             "end_time": end_time,
+            "tags": tags,
         }
 
         if run_id:

--- a/litellm/tests/test_langsmith.py
+++ b/litellm/tests/test_langsmith.py
@@ -36,6 +36,7 @@ async def test_async_langsmith_logging():
             temperature=0.2,
             metadata={
                 "id": run_id,
+                "tags": ["tag1", "tag2"],
                 "user_api_key": "6eb81e014497d89f3cc1aa9da7c2b37bda6b7fea68e4b710d33d94201e68970c",
                 "user_api_key_alias": "ishaans-langmsith-key",
                 "user_api_end_user_max_budget": None,


### PR DESCRIPTION
## Advanced
### Set Langsmith fields - Custom Projec, Run names, tags

```python
import litellm
import os

os.environ["LANGSMITH_API_KEY"] = ""
# LLM API Keys
os.environ['OPENAI_API_KEY']=""

# set langfuse as a callback, litellm will send the data to langfuse
litellm.success_callback = ["langsmith"] 
 
response = litellm.completion(
    model="gpt-3.5-turbo",
     messages=[
        {"role": "user", "content": "Hi 👋 - i'm openai"}
    ],
    metadata={
        "run_name": "litellmRUN",               # langsmith run name
        "project_name": "litellm-completion",   # langsmith project name
        "tags": ["model1", "prod-2"]            # tags to log on langsmith
    }
)
print(response)
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

