### PR TITLE
Fix `test_prompt_factory` flake8 warning

### DIFF
--- a/litellm/tests/test_prompt_factory.py
+++ b/litellm/tests/test_prompt_factory.py
@@ -212,7 +212,7 @@ def test_convert_url_to_img():
     [
         ("data:image/jpeg;base64,1234", "image/jpeg"),
         ("data:application/pdf;base64,1234", "application/pdf"),
-        ("data:image\/jpeg;base64,1234", "image/jpeg"),
+        (r"data:image\/jpeg;base64,1234", "image/jpeg"),
     ],
 )
 def test_base64_image_input(url, expected_media_type):


### PR DESCRIPTION
```shell
$ poetry run flake8 litellm/tests/test_prompt_factory.py
<unknown>:215: SyntaxWarning: invalid escape sequence '\/'
litellm/tests/test_prompt_factory.py:215:21: W605 invalid escape sequence '\/'
```

Fixed by making the string a raw string, which is equivalent:

```
$ python
Python 3.11.6 (main, Oct 25 2023, 19:49:20) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> "data:image\/jpeg;base64,1234" == r"data:image\/jpeg;base64,1234"
True
```

See: https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python

Alternative to #4850. Cc: @krrishdholakia 