### PR TITLE
Always run all local_tests, even after the first failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: |
             pwd
             ls
-            python -m pytest -vv litellm/tests/ -x --junitxml=test-results/junit.xml --durations=5 -k "not test_python_38.py"
+            python -m pytest -vv litellm/tests/ --junitxml=test-results/junit.xml --durations=5 -k "not test_python_38.py"
           no_output_timeout: 120m
 
       # Store test results


### PR DESCRIPTION
This should still report a failure at the end of the run, but this way, it won't bail out so early. Right now the `-x` causes pytest to stop running any of the other unit tests.