### PR TITLE
Print each model only once on startup

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1765,12 +1765,16 @@ class ProxyConfig:
             print(  # noqa
                 f"\033[32mLiteLLM: Proxy initialized with Config, Set models:\033[0m"
             )  # noqa
+            printed_model_names = set()
             for model in model_list:
                 ### LOAD FROM os.environ/ ###
                 for k, v in model["litellm_params"].items():
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = litellm.get_secret(v)
-                print(f"\033[32m    {model.get('model_name', '')}\033[0m")  # noqa
+                model_name = model.get("model_name", '')
+                if model_name not in printed_model_names:
+                    print(f"\033[32m    {model_name}\033[0m")  # noqa
+                    printed_model_names.add(model_name)
                 litellm_model_name = model["litellm_params"]["model"]
                 litellm_model_api_base = model["litellm_params"].get("api_base", None)
                 if "ollama" in litellm_model_name and litellm_model_api_base is None:


### PR DESCRIPTION
Currently each model name can be printed several times if you have multiple endpoints for that model. If we're not showing the endpoint info, then it seems noisy for no good reason.

Before:

```
LiteLLM: Proxy initialized with Config, Set models:
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-0125
    gpt-35-turbo-1106
    gpt-35-turbo-1106
    gpt-35-turbo-16k
    gpt-3.5-turbo-16k
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    gpt-4-0125-preview
    text-embedding-ada-002
    text-embedding-3-small
    text-embedding-3-large
```

After:

```
LiteLLM: Proxy initialized with Config, Set models:
    gpt-35-turbo-0125
    gpt-35-turbo-1106
    gpt-35-turbo-16k
    gpt-3.5-turbo-16k
    gpt-4-0125-preview
    text-embedding-ada-002
    text-embedding-3-small
    text-embedding-3-large
```