### PR TITLE
Allow not displaying feedback box

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2184,7 +2184,8 @@ async def initialize(
     config=None,
 ):
     global user_model, user_api_base, user_debug, user_detailed_debug, user_user_max_tokens, user_request_timeout, user_temperature, user_telemetry, user_headers, experimental, llm_model_list, llm_router, general_settings, master_key, user_custom_auth, prisma_client
-    generate_feedback_box()
+    if os.getenv("LITELLM_DONT_SHOW_FEEDBACK_BOX", "").lower() != "true":
+        generate_feedback_box()
     user_model = model
     user_debug = debug
     if debug is True:  # this needs to be first, so users can see Router init debugg


### PR DESCRIPTION
by setting an env var called `LITELLM_DONT_SHOW_FEEDBACK_BOX` to `"true"`.

I liked the feedback box when I first started using LiteLLM, because it showed me that the authors care about customers. But now that I've seen it a bunch of times, I don't need to see it every time I start the server and I'd rather have less output on startup.
