### PR TITLE
Add mistral.mistral-large-2407-v1:0 on Amazon Bedrock

### DIFF
--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -78,6 +78,7 @@ BEDROCK_CONVERSE_MODELS = [
     "ai21.jamba-instruct-v1:0",
     "meta.llama3-1-8b-instruct-v1:0",
     "meta.llama3-1-70b-instruct-v1:0",
+    "mistral.mistral-large-2407-v1:0",
 ]
 
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2996,6 +2996,15 @@
         "litellm_provider": "bedrock",
         "mode": "chat"
     },
+    "mistral.mistral-large-2407-v1:0": {
+        "max_tokens": 8191,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000009,
+        "litellm_provider": "bedrock",
+        "mode": "chat"
+    },
     "bedrock/us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
         "max_tokens": 8191,
         "max_input_tokens": 32000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2996,6 +2996,15 @@
         "litellm_provider": "bedrock",
         "mode": "chat"
     },
+    "mistral.mistral-large-2407-v1:0": {
+        "max_tokens": 8191,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000009,
+        "litellm_provider": "bedrock",
+        "mode": "chat"
+    },
     "bedrock/us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
         "max_tokens": 8191,
         "max_input_tokens": 32000,


### PR DESCRIPTION
## Title

Adds new model.

https://aws.amazon.com/blogs/machine-learning/mistral-large-2-is-now-available-in-amazon-bedrock/


## Type

🆕 New Model

## Changes

Add `mistral.mistral-large-2407-v1:0`.

<img width="987" alt="image" src="https://github.com/user-attachments/assets/648f0c8a-ec6d-46a4-96c1-5910faaf13f5">

https://aws.amazon.com/bedrock/pricing/

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

```sh
curl "${OPENAI_API_BASE}/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "mistral-large-2407",
    "messages": [
      {
        "role": "user",
        "content": "tell a short joke"
      }
    ]
  }' | jq
```

Output:
```json
{
  "id": "chatcmpl-8e1e52be-bd6e-4caf-8df2-026d28db96eb",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "What do you call fake spaghetti? An impasta",
        "role": "assistant",
        "tool_calls": [],
        "function_call": null
      }
    }
  ],
  "created": 1721938392,
  "model": "mistral.mistral-large-2407-v1:0",
  "object": "chat.completion",
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 7,
    "completion_tokens": 14,
    "total_tokens": 21
  }
}
```

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/c30ddf58-2233-4cf0-994a-d63efb5a1147">
