### PR TITLE
Fix: #4942. Remove verbose logging when exception can be handled

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -413,11 +413,6 @@ async def acompletion(
             )  # sets the logging event loop if the user does sync streaming (e.g. on proxy for sagemaker calls)
         return response
     except Exception as e:
-        verbose_logger.error(
-            "litellm.acompletion(): Exception occured - {}\n{}".format(
-                str(e), traceback.format_exc()
-            )
-        )
         verbose_logger.debug(traceback.format_exc())
         custom_llm_provider = custom_llm_provider or "openai"
         raise exception_type(


### PR DESCRIPTION
## Title

Remove verbose logging when exception can be handled

## Relevant issues

Fixes #4942

## Type
🐛 Bug Fix

## Changes

Remove verbose logging when exception can be handled

## [REQUIRED] Testing

Re-ran the repro script and logs were not produced when the exception was handled

