### PR TITLE
Allow Bedrock to set custom STS endpoint for OIDC flow

### DIFF
--- a/litellm/llms/bedrock_httpx.py
+++ b/litellm/llms/bedrock_httpx.py
@@ -383,6 +383,7 @@ class BedrockLLM(BaseLLM):
         aws_profile_name: Optional[str] = None,
         aws_role_name: Optional[str] = None,
         aws_web_identity_token: Optional[str] = None,
+        aws_sts_endpoint: Optional[str] = None,
     ):
         """
         Return a boto3.Credentials object
@@ -403,6 +404,7 @@ class BedrockLLM(BaseLLM):
             aws_profile_name,
             aws_role_name,
             aws_web_identity_token,
+            aws_sts_endpoint,
         ]
 
         # Iterate over parameters and update if needed
@@ -421,6 +423,7 @@ class BedrockLLM(BaseLLM):
             aws_profile_name,
             aws_role_name,
             aws_web_identity_token,
+            aws_sts_endpoint,
         ) = params_to_check
 
         ### CHECK STS ###
@@ -432,12 +435,19 @@ class BedrockLLM(BaseLLM):
             print_verbose(
                 f"IN Web Identity Token: {aws_web_identity_token} | Role Name: {aws_role_name} | Session Name: {aws_session_name}"
             )
+
+            if aws_sts_endpoint is None:
+                sts_endpoint = f"https://sts.{aws_region_name}.amazonaws.com"
+            else:
+                sts_endpoint = aws_sts_endpoint
+
             iam_creds_cache_key = json.dumps(
                 {
                     "aws_web_identity_token": aws_web_identity_token,
                     "aws_role_name": aws_role_name,
                     "aws_session_name": aws_session_name,
                     "aws_region_name": aws_region_name,
+                    "aws_sts_endpoint": sts_endpoint,
                 }
             )
 
@@ -454,7 +464,7 @@ class BedrockLLM(BaseLLM):
                 sts_client = boto3.client(
                     "sts",
                     region_name=aws_region_name,
-                    endpoint_url=f"https://sts.{aws_region_name}.amazonaws.com",
+                    endpoint_url=sts_endpoint,
                 )
 
                 # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
@@ -849,6 +859,7 @@ class BedrockLLM(BaseLLM):
             "aws_bedrock_runtime_endpoint", None
         )  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
+        aws_sts_endpoint = optional_params.pop("aws_sts_endpoint", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -878,6 +889,7 @@ class BedrockLLM(BaseLLM):
             aws_profile_name=aws_profile_name,
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
+            aws_sts_endpoint=aws_sts_endpoint,
         )
 
         ### SET RUNTIME ENDPOINT ###
@@ -1536,6 +1548,7 @@ class BedrockConverseLLM(BaseLLM):
         aws_profile_name: Optional[str] = None,
         aws_role_name: Optional[str] = None,
         aws_web_identity_token: Optional[str] = None,
+        aws_sts_endpoint: Optional[str] = None,
     ):
         """
         Return a boto3.Credentials object
@@ -1552,6 +1565,7 @@ class BedrockConverseLLM(BaseLLM):
             aws_profile_name,
             aws_role_name,
             aws_web_identity_token,
+            aws_sts_endpoint,
         ]
 
         # Iterate over parameters and update if needed
@@ -1570,6 +1584,7 @@ class BedrockConverseLLM(BaseLLM):
             aws_profile_name,
             aws_role_name,
             aws_web_identity_token,
+            aws_sts_endpoint,
         ) = params_to_check
 
         ### CHECK STS ###
@@ -1578,12 +1593,22 @@ class BedrockConverseLLM(BaseLLM):
             and aws_role_name is not None
             and aws_session_name is not None
         ):
+            print_verbose(
+                f"IN Web Identity Token: {aws_web_identity_token} | Role Name: {aws_role_name} | Session Name: {aws_session_name}"
+            )
+
+            if aws_sts_endpoint is None:
+                sts_endpoint = f"https://sts.{aws_region_name}.amazonaws.com"
+            else:
+                sts_endpoint = aws_sts_endpoint
+
             iam_creds_cache_key = json.dumps(
                 {
                     "aws_web_identity_token": aws_web_identity_token,
                     "aws_role_name": aws_role_name,
                     "aws_session_name": aws_session_name,
                     "aws_region_name": aws_region_name,
+                    "aws_sts_endpoint": sts_endpoint,
                 }
             )
 
@@ -1600,7 +1625,7 @@ class BedrockConverseLLM(BaseLLM):
                 sts_client = boto3.client(
                     "sts",
                     region_name=aws_region_name,
-                    endpoint_url=f"https://sts.{aws_region_name}.amazonaws.com",
+                    endpoint_url=sts_endpoint,
                 )
 
                 # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
@@ -1815,6 +1840,7 @@ class BedrockConverseLLM(BaseLLM):
             "aws_bedrock_runtime_endpoint", None
         )  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
+        aws_sts_endpoint = optional_params.pop("aws_sts_endpoint", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -1844,6 +1870,7 @@ class BedrockConverseLLM(BaseLLM):
             aws_profile_name=aws_profile_name,
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
+            aws_sts_endpoint=aws_sts_endpoint,
         )
 
         ### SET RUNTIME ENDPOINT ###

--- a/litellm/tests/test_bedrock_completion.py
+++ b/litellm/tests/test_bedrock_completion.py
@@ -558,7 +558,7 @@ def test_completion_bedrock_httpx_command_r_sts_oidc_auth():
     import os
 
     aws_web_identity_token = "oidc/circleci_v2/"
-    aws_region_name = os.environ["AWS_REGION_NAME"]
+    aws_region_name = "us-west-2"
     # aws_role_name = os.environ["AWS_TEMP_ROLE_NAME"]
     # TODO: This is using ai.moda's IAM role, we should use LiteLLM's IAM role eventually
     aws_role_name = "arn:aws:iam::335785316107:role/litellm-github-unit-tests-circleci"
@@ -575,6 +575,8 @@ def test_completion_bedrock_httpx_command_r_sts_oidc_auth():
             aws_web_identity_token=aws_web_identity_token,
             aws_role_name=aws_role_name,
             aws_session_name="my-test-session",
+            aws_sts_endpoint="https://sts-fips.us-west-2.amazonaws.com",
+            aws_bedrock_runtime_endpoint="https://bedrock-runtime-fips.us-west-2.amazonaws.com",
         )
         # Add any assertions here to check the response
         print(response)


### PR DESCRIPTION
## Title

This adds support for setting a custom STS endpoint.


## Type

🆕 New Feature
✅ Test

## Changes

Adds a new `aws_region_name`, and also tests for it.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally


It's working, see screenshot below from Cloudtrail. I've added CI tests as well, to verify it keeps working.


<img width="622" alt="image" src="https://github.com/user-attachments/assets/807078ff-84cd-4084-a541-17e83dd2204d">

(Just one note, AWS allows using the STS FIPS endpoint to get creds, and then the non-FIPS endpoint on Bedrock using those creds.)