### PR TITLE
fix: support vertex filepath on proxy litellm_params definition

### DIFF
--- a/litellm/llms/vertex_httpx.py
+++ b/litellm/llms/vertex_httpx.py
@@ -790,7 +790,10 @@ class VertexLLM(BaseLLM):
         if credentials is not None and isinstance(credentials, str):
             import google.oauth2.service_account
 
-            json_obj = json.loads(credentials)
+            if os.path.exists(credentials):
+                json_obj = json.load(open(credentials))
+            else:
+                json_obj = json.loads(credentials)
 
             creds = google.oauth2.service_account.Credentials.from_service_account_info(
                 json_obj,


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Support vertex_credentials filepath on litellm_params vertex_ai_beta

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #4199 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes

<!-- List of changes -->
- Current implementation only support json string of value, the PR #4199 is only for `litellm/llms/vertex_ai_anthropic.py` but NOT in `litellm/llms/vertex_httpx.py` in which current vertex_ai_beta implementation is located at
- The documentation says its support filepath https://github.com/BerriAI/litellm/blob/289b468aa1a933cd5a9c22a5531f3e71123789ec/docs/my-website/docs/providers/vertex.md?plain=1#L253
-  Using the GOOGLE_APPLICATION_CREDENTIALS environment variable as a temporary solution to support file paths. However, this approach raises issue about supporting multiple credentials (e.g., work and personal credentials)

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
<img width="645" alt="Screenshot 2024-08-01 at 07 40 57" src="https://github.com/user-attachments/assets/3ee44ac9-7dfc-4d8a-881a-6053a1589a6e">
<img width="1232" alt="Screenshot 2024-08-01 at 07 20 57" src="https://github.com/user-attachments/assets/17044900-e852-4e25-8c73-e2f88f71dc2f">
<img width="1020" alt="Screenshot 2024-08-01 at 07 44 38" src="https://github.com/user-attachments/assets/ae58ef7a-3969-4681-8d2b-fec96bfb4d53">


