### PR TITLE
Respect timeouts in Anthropic

### DIFF
--- a/litellm/tests/test_timeout.py
+++ b/litellm/tests/test_timeout.py
@@ -245,3 +245,39 @@ def test_timeout_ollama():
 
 
 # test_timeout_ollama()
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.parametrize("sync_mode", [True, False])
+@pytest.mark.asyncio
+async def test_anthropic_timeout(streaming, sync_mode):
+    litellm.set_verbose = False
+
+    try:
+        if sync_mode:
+            response = litellm.completion(
+                model="claude-3-5-sonnet-20240620",
+                timeout=0.01,
+                messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
+                stream=streaming,
+            )
+            if streaming:
+                for chunk in response:
+                    pass
+        else:
+            response = await litellm.acompletion(
+                model="claude-3-5-sonnet-20240620",
+                timeout=0.01,
+                messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
+                stream=streaming,
+            )
+            if streaming:
+                async for chunk in response:
+                    pass
+        pytest.fail("Did not raise error `openai.APITimeoutError`")
+    except openai.APITimeoutError as e:
+        print(
+            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
+        )
+        print(type(e))
+        pass


### PR DESCRIPTION
## Title

Respect `timeout` parameter in completion calls to Anthropic LLMs, in all combinations of sync/async and streaming/non-streaming.

## Relevant issues

<!-- e.g. "Fixes #000" -->

Part of https://github.com/BerriAI/litellm/issues/838

## Type

🐛 Bug Fix

## Changes

- Pass `timeout` param between relevant methods
- Use `_get_httpx_client` instead of instantiating the client directly to take advantage of client caching
- Use instance HTTP client instead of `requests` to use the shared configurations (including timeouts)
- Differentiate between `litellm.Timeout` and internal server errors
- Allow `CustomStreamWrapper` callers to specify a `client` and `aclient` (and respect `None` if specified). Currently, callers may specify a `client` with a `partial` for `make_call` but this was not being respected

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

```
$ poetry run pytest litellm/tests/test_timeout.py -k 'test_anthropic_timeout'      
========================================================================================================== test session starts ===========================================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/alejandro/src/github.com/BerriAI/litellm
plugins: asyncio-0.23.8, anyio-4.3.0, mock-3.14.0
asyncio: mode=Mode.STRICT
collected 16 items / 12 deselected / 4 selected                                                                                                                                                                                          

litellm/tests/test_timeout.py ....                                                                                                                                                                                                 [100%]

============================================================================================================ warnings summary ============================================================================================================
../../../../Library/Caches/pypoetry/virtualenvs/litellm-TWDrSopJ-py3.11/lib/python3.11/site-packages/pydantic/_internal/_config.py:284
  /Users/alejandro/Library/Caches/pypoetry/virtualenvs/litellm-TWDrSopJ-py3.11/lib/python3.11/site-packages/pydantic/_internal/_config.py:284: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

litellm/utils.py:107
  /Users/alejandro/src/github.com/BerriAI/litellm/litellm/utils.py:107: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with resources.open_text("litellm.llms.tokenizers", "anthropic_tokenizer.json") as f:

litellm/tests/test_timeout.py::test_anthropic_timeout[False-True]
litellm/tests/test_timeout.py::test_anthropic_timeout[True-False]
litellm/tests/test_timeout.py::test_anthropic_timeout[True-True]
  /Users/alejandro/Library/Caches/pypoetry/virtualenvs/litellm-TWDrSopJ-py3.11/lib/python3.11/site-packages/httpx/_content.py:202: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
    warnings.warn(message, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 4 passed, 12 deselected, 5 warnings in 0.34s ==============================================================================================
```

<!-- Test procedure -->

