### PR TITLE
fix(spend_tracking): `/spend/logs` with no filter

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1548,7 +1548,6 @@ async def view_spend_logs(
             raise Exception(
                 f"Database not connected. Connect a database to your proxy - https://docs.litellm.ai/docs/simple_proxy#managing-auth---virtual-keys"
             )
-        spend_logs = []
         if (
             start_date is not None
             and isinstance(start_date, str)
@@ -1667,7 +1666,7 @@ async def view_spend_logs(
             else:
                 return [spend_log]
         else:
-            spend_logs = await prisma_client.get_data(
+            spend_log = await prisma_client.get_data(
                 table_name="spend", query_type="find_all"
             )
 


### PR DESCRIPTION
## Title

Fix `/spend/logs` "cannot access local variable 'spend_log' where it is not associated with a value" error caused by a typo in implementation.

## Relevant issues

No issue. But the bug does exist.

### Steps to reproduce the bug

1. Spin up LiteLLM proxy at localhost:4000
2. `curl localhost:4000/spend/logs -H 'Authorization: Bearer <key here>'`

### Expected output
Spending logs

### Actual output
```
{"error":{"message":"/spend/logs Errorcannot access local variable 'spend_log' where it is not associated with a value","type":"internal_error","param":"None","code":"500"}}
```

## Type

🐛 Bug Fix

## Changes

- Fix typo `spend_logs` --> `spend_log` in the handling logic when no filter is set
- Remove unused variable `spend_logs` at greater scope

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

`curl localhost:4000/spend/logs -H 'Authorization: Bearer <key here>'` can now work properly.
![image](https://github.com/user-attachments/assets/2f6d7fa7-d631-49e2-b3b0-95511d32601f)

All failed tests are failing before change.
![image](https://github.com/user-attachments/assets/537b1d5d-dac1-4faf-a903-0fa096eae4a0)

<!-- Test procedure -->

