### PR TITLE
Optimize Alpine Dockerfile by removing redundant apk commands

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -11,9 +11,7 @@ FROM $LITELLM_BUILD_IMAGE AS builder
 WORKDIR /app
 
 # Install build dependencies
-RUN apk update && \
-    apk add --no-cache gcc python3-dev musl-dev && \
-    rm -rf /var/cache/apk/*
+RUN apk add --no-cache gcc python3-dev musl-dev
 
 RUN pip install --upgrade pip && \
     pip install build


### PR DESCRIPTION
## Title

Optimize Alpine Dockerfile by removing redundant apk commands

## Type

🧹 Refactoring

## Changes

Remove unnecessary `apk update` and manual cache cleanup steps in the Alpine Dockerfile. By using `apk add --no-cache`, we avoid manual cache management, making the Dockerfile simpler and easier to maintain.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

I successfully built the Docker image:
```
REPOSITORY                   TAG                  IMAGE ID       CREATED         SIZE
litellm-dockerfile           apk-cache-optimiza   ca617f454c3e   21 hours ago    1.46GB
```