### PR TITLE
[Proxy-Fix] Requests that are incorrectly flagged as admin-only paths

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -86,10 +86,16 @@ def get_request_route(request: Request) -> str:
 
     remove base url from path if set e.g. `/genai/chat/completions` -> `/chat/completions
     """
-    if request.url.path.startswith(request.base_url.path):
-        # remove base_url from path
-        return request.url.path[len(request.base_url.path) - 1 :]
-    else:
+    try:
+        if request.url.path.startswith(request.base_url.path):
+            # remove base_url from path
+            return request.url.path[len(request.base_url.path) - 1 :]
+        else:
+            return request.url.path
+    except Exception as e:
+        verbose_proxy_logger.warning(
+            f"error on get_request_route: {str(e)}, defaulting to request.url.path"
+        )
         return request.url.path
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -80,6 +80,19 @@ def is_llm_api_route(route: str) -> bool:
     return False
 
 
+def get_request_route(request: Request) -> str:
+    """
+    Helper to get the route from the request
+
+    remove base url from path if set e.g. `/genai/chat/completions` -> `/chat/completions
+    """
+    if request.url.path.startswith(request.base_url.path):
+        # remove base_url from path
+        return request.url.path[len(request.base_url.path) - 1 :]
+    else:
+        return request.url.path
+
+
 async def check_if_request_size_is_safe(request: Request) -> bool:
     """
     Enterprise Only:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -58,6 +58,7 @@ from litellm.proxy.auth.auth_checks import (
 )
 from litellm.proxy.auth.auth_utils import (
     check_if_request_size_is_safe,
+    get_request_route,
     is_llm_api_route,
     route_in_additonal_public_routes,
 )
@@ -115,7 +116,7 @@ async def user_api_key_auth(
     )
 
     try:
-        route: str = request.url.path
+        route: str = get_request_route(request=request)
 
         ### LiteLLM Enterprise Security Checks
         # Check 1. Check if request size is under max_request_size_mb


### PR DESCRIPTION
## Fix Requests that are incorrectly flagged as admin-only paths

Fixing an issue where path checks in `litellm/proxy/auth/user_api_key_auth.py` assume that the server is not using a `base_url` (set with `SERVER_ROOT_PATH`) so requests are incorrectly being flagged as admin-only and throwing 401 errors.

![Screenshot 2024-07-16 at 9 36 08 PM](https://github.com/user-attachments/assets/e8a600bb-4693-4785-a600-b132f482e6cc)

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

