### PR TITLE
Fix Anthropic streaming tool calls with no args

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -1165,6 +1165,24 @@ def convert_function_to_anthropic_tool_invoke(
         raise e
 
 
+def convert_to_anthropic_tool_input(args: str) -> dict:
+    """
+    OpenAI tool input:
+    "{\n\"location\": \"Boston, MA\"\n}"
+
+    Anthropic tool input:
+    {
+        "location": "Boston, MA"
+    }
+    """
+
+    # With stream=True, Anthropic tool calls sometimes have "" as input instead
+    # of "{}", which causes a JSON parse error
+    if args == "":
+        args = "{}"
+    return json.loads(args)
+
+
 def convert_to_anthropic_tool_invoke(
     tool_calls: list,
 ) -> List[AnthropicMessagesToolUseParam]:
@@ -1209,7 +1227,7 @@ def convert_to_anthropic_tool_invoke(
             type="tool_use",
             id=get_attribute_or_key(tool, "id"),
             name=get_attribute_or_key(get_attribute_or_key(tool, "function"), "name"),
-            input=json.loads(
+            input=convert_to_anthropic_tool_input(
                 get_attribute_or_key(
                     get_attribute_or_key(tool, "function"), "arguments"
                 )

--- a/litellm/tests/test_anthropic_completion.py
+++ b/litellm/tests/test_anthropic_completion.py
@@ -183,3 +183,20 @@ async def test_anthropic_router_completion_e2e():
     assert isinstance(response, AnthropicResponse)
 
     assert response.model == "gpt-3.5-turbo"
+
+
+def test_anthropic_nullary_tool_call():
+    from litellm.llms.prompt_templates.factory import convert_to_anthropic_tool_invoke
+
+    convert_to_anthropic_tool_invoke(
+        [
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {
+                    "name": "perform",
+                    "arguments": "",
+                },
+            }
+        ]
+    )

--- a/litellm/tests/test_anthropic_completion.py
+++ b/litellm/tests/test_anthropic_completion.py
@@ -26,6 +26,7 @@ import pytest
 import litellm
 from litellm import AnthropicConfig, Router, adapter_completion
 from litellm.adapters.anthropic_adapter import anthropic_adapter
+from litellm.llms.prompt_templates.factory import convert_to_anthropic_tool_invoke
 from litellm.types.llms.anthropic import AnthropicResponse
 
 
@@ -186,8 +187,6 @@ async def test_anthropic_router_completion_e2e():
 
 
 def test_anthropic_nullary_tool_call():
-    from litellm.llms.prompt_templates.factory import convert_to_anthropic_tool_invoke
-
     convert_to_anthropic_tool_invoke(
         [
             {


### PR DESCRIPTION
## Title

Fix Anthropic streaming tool calls with no args

## Relevant issues

Fixes #5063

## Type

🐛 Bug Fix
✅ Test

## Changes

Messages that have tool calls with no arguments being passed are resulting in "" as the message.function.arguments. When trying to convert to Anthropic (e.g., putting the message in the next call to completion), the "" is parsed as JSON which causes an error. This fix looks for tool calls with "" arguments and replaces them with "{}" which is what you get when stream=False.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<img width="849" alt="image" src="https://github.com/user-attachments/assets/23efadbf-80b4-4082-920d-477f3200da49">

You can also run the repro in #5063, it passes.