### PR TITLE
Add deepseek-coder-v2(-lite), mistral-large, codegeex4 to ollama

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4038,6 +4038,66 @@
         "litellm_provider": "ollama",
         "mode": "completion"
     },
+    "ollama/codegeex4": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat", 
+        "supports_function_calling": false
+    },
+    "ollama/deepseek-coder-v2-instruct": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat", 
+        "supports_function_calling": true
+    },
+    "ollama/deepseek-coder-v2-base": {
+        "max_tokens": 8192,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "completion", 
+        "supports_function_calling": true
+    },
+    "ollama/deepseek-coder-v2-lite-instruct": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat", 
+        "supports_function_calling": true
+    },
+    "ollama/deepseek-coder-v2-lite-base": {
+        "max_tokens": 8192,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "completion", 
+        "supports_function_calling": true
+    },
+    "ollama/internlm2_5-20b-chat": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat", 
+        "supports_function_calling": true
+    },
     "ollama/llama2": {
         "max_tokens": 4096, 
         "max_input_tokens": 4096, 
@@ -4093,7 +4153,7 @@
         "mode": "chat"
     },
     "ollama/llama3.1": {
-        "max_tokens": 8192,
+        "max_tokens": 32768,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "input_cost_per_token": 0.0,
@@ -4101,6 +4161,15 @@
         "litellm_provider": "ollama",
         "mode": "chat", 
         "supports_function_calling": true
+    },
+    "ollama/mistral-large-instruct-2407": {
+        "max_tokens": 65536,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat"
     },
     "ollama/mistral": {
         "max_tokens": 8192,


### PR DESCRIPTION
## Title

Update Ollama models

## Relevant issues

n/a

## Type

🆕 New Feature

## Changes

- Add deepseek-coder-v2(-lite), mistral-large, codegeex4 to ollama
- Increase llama3.1 max context size (it's actually a lot higher, but this is a well performing default)