### PR TITLE
feat: hash prompt when caching

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -1827,6 +1827,7 @@ class Cache:
         completion_kwargs = [
             "model",
             "messages",
+            "prompt",
             "temperature",
             "top_p",
             "n",


### PR DESCRIPTION
## Title

Support hash the prompt when create cache hash

## Relevant issues

Cannot caching on /completions  endpoint

## Type


🆕 New Feature



