### PR TITLE
fix: wrong order of arguments for ollama

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -601,12 +601,13 @@ def ollama_embeddings(
 ):
     return asyncio.run(
         ollama_aembeddings(
-            api_base,
-            model,
-            prompts,
-            optional_params,
-            logging_obj,
-            model_response,
-            encoding,
+            api_base=api_base,
+            model=model,
+            prompts=prompts,
+            model_response=model_response,
+            optional_params=optional_params,
+            logging_obj=logging_obj,
+            encoding=encoding,
         )
+
     )


### PR DESCRIPTION
## Title

Fix: Ollama embeddings were called with positional arguments that were in the wrong order. The fix uses keywords arguments. The embeddings were unusable (crashing litellm).

## Relevant issues

I fixed it instead of creating an issue.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Used keyword arguments instead of positional arguments

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

Before the fix:
> >>> from litellm import embedding ; embedding(model="ollama/bge-m3", input=["this is a test"], api_base="http://localhost:11434")

``` python
APIConnectionError: litellm.APIConnectionError: 'EmbeddingResponse' object has no attribute 'pre_call'
Traceback (most recent call last):
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/site-packages/litellm/main.py", line 3520, in embedding
    response = ollama_embeddings_fn(  # type: ignore
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/site-packages/litellm/llms/ollama.py", line 602, in ollama_embeddings
    return asyncio.run(
           ^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/site-packages/litellm/llms/ollama.py", line 542, in ollama_aembeddings
    logging_obj.pre_call(
    ^^^^^^^^^^^^^^^^^^^^
  File "$HOME/.pyenv/versions/3.11.7/lib/python3.11/site-packages/pydantic/main.py", line 828, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'EmbeddingResponse' object has no attribute 'pre_call'

```

After the fix it works fine.
