### PR TITLE
Azure Service Principal with Secret authentication workflow.

### DIFF
--- a/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
@@ -1,9 +1,6 @@
 import os
 from typing import Callable
 
-from azure.identity import ClientSecretCredential
-from azure.identity import get_bearer_token_provider
-
 
 def get_azure_ad_token_provider() -> Callable[[], str]:
     """
@@ -17,6 +14,9 @@ def get_azure_ad_token_provider() -> Callable[[], str]:
     Returns:
         Callable that returns a temporary authentication token.
     """
+    from azure.identity import ClientSecretCredential
+    from azure.identity import get_bearer_token_provider
+
     try:
         credential = ClientSecretCredential(
             client_id=os.environ["AZURE_CLIENT_ID"],

--- a/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
@@ -1,0 +1,24 @@
+import os
+from typing import Callable
+
+from azure.identity import DefaultAzureCredential
+from azure.identity import get_bearer_token_provider
+
+
+def get_azure_ad_token_provider() -> Callable[[], str]:
+    """
+    Get Azure AD token provider based on Service Principal with Secret workflow.
+
+    Based on: https://github.com/openai/openai-python/blob/main/examples/azure_ad.py
+    See Also: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#service-principal-with-secret.
+    """
+    required_keys = {"AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_SECRET"}
+    missing_keys = required_keys.difference(os.environ)
+    if missing_keys:
+        raise ValueError(f"Missing environment variables required by Azure AD workflow: {missing_keys}.")
+    return get_bearer_token_provider(
+        # DefaultAzureCredential access environment variables:
+        # AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
+        DefaultAzureCredential(),
+        "https://cognitiveservices.azure.com/.default",
+    )

--- a/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/proxy/secret_managers/get_azure_ad_token_provider.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable
 
-from azure.identity import DefaultAzureCredential
+from azure.identity import ClientSecretCredential
 from azure.identity import get_bearer_token_provider
 
 
@@ -10,15 +10,23 @@ def get_azure_ad_token_provider() -> Callable[[], str]:
     Get Azure AD token provider based on Service Principal with Secret workflow.
 
     Based on: https://github.com/openai/openai-python/blob/main/examples/azure_ad.py
-    See Also: https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#service-principal-with-secret.
+    See Also:
+        https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#service-principal-with-secret;
+        https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.clientsecretcredential?view=azure-python.
+
+    Returns:
+        Callable that returns a temporary authentication token.
     """
-    required_keys = {"AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_SECRET"}
-    missing_keys = required_keys.difference(os.environ)
-    if missing_keys:
-        raise ValueError(f"Missing environment variables required by Azure AD workflow: {missing_keys}.")
+    try:
+        credential = ClientSecretCredential(
+            client_id=os.environ["AZURE_CLIENT_ID"],
+            client_secret=os.environ["AZURE_CLIENT_SECRET"],
+            tenant_id=os.environ["AZURE_TENANT_ID"],
+        )
+    except KeyError as e:
+        raise ValueError("Missing environment variable required by Azure AD workflow.") from e
+
     return get_bearer_token_provider(
-        # DefaultAzureCredential access environment variables:
-        # AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
-        DefaultAzureCredential(),
+        credential,
         "https://cognitiveservices.azure.com/.default",
     )

--- a/litellm/router_utils/client_initalization_utils.py
+++ b/litellm/router_utils/client_initalization_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import traceback
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
 import openai
@@ -187,7 +187,7 @@ def set_client(litellm_router_instance: LitellmRouter, model: dict):
                     f"api_base is required for Azure OpenAI. Set it on your config. Model - {_filtered_model}"
                 )
             azure_ad_token = litellm_params.get("azure_ad_token")
-            azure_ad_token_provider = None
+            azure_ad_token_provider: Callable[[], str] | None = None
             if azure_ad_token is not None:
                 if azure_ad_token.startswith("oidc/"):
                     azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)

--- a/litellm/tests/test_router_client_init.py
+++ b/litellm/tests/test_router_client_init.py
@@ -8,6 +8,7 @@ import traceback, asyncio
 from unittest.mock import patch, MagicMock, PropertyMock
 
 import pytest
+from openai.lib.azure import OpenAIError
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -77,16 +78,59 @@ async def test_router_init():
     )
 
 
+@patch("litellm.proxy.secret_managers.get_azure_ad_token_provider.os")
+def test_router_init_with_neither_api_key_nor_azure_service_principal_with_secret(mocked_os_lib: MagicMock) -> None:
+    """
+    Test router initialization with neither API key nor using Azure Service Principal with Secret authentication
+    workflow (having not provided environment variables).
+    """
+    # mock EMPTY environment variables
+    environment_variables_expected_to_use = {}
+    mocked_environ = PropertyMock(return_value=environment_variables_expected_to_use)
+    # Because of the way mock attributes are stored you can’t directly attach a PropertyMock to a mock object.
+    # https://docs.python.org/3.11/library/unittest.mock.html#unittest.mock.PropertyMock
+    type(mocked_os_lib).environ = mocked_environ
+
+    # define the model list
+    model_list = [
+        {
+            # test case for Azure Service Principal with Secret authentication
+            "model_name": "gpt-4o",
+            "litellm_params": {
+                # checkout there is no api_key here -
+                # AZURE_CLIENT_ID, AZURE_CLIENT_SECRET and AZURE_TENANT_ID environment variables should be used instead
+                "model": "gpt-4o",
+                "base_model": "gpt-4o",
+                "api_base": "test_api_base",
+                "api_version": "2024-01-01-preview",
+                "custom_llm_provider": "azure",
+            },
+            "model_info": {
+                "mode": "completion"
+            },
+        },
+    ]
+
+    # initialize the router
+    with pytest.raises(OpenAIError):
+        # it would raise an error, because environment variables were not provided => azure_ad_token_provider is None
+        Router(model_list=model_list)
+
+    # check if the mocked environment variables were reached
+    mocked_environ.assert_called()
+
+
 @patch("azure.identity.get_bearer_token_provider")
 @patch("azure.identity.ClientSecretCredential")
 @patch("litellm.proxy.secret_managers.get_azure_ad_token_provider.os")
-def test_router_init_azure_service_principal_with_secret(
+def test_router_init_azure_service_principal_with_secret_with_environment_variables(
         mocked_os_lib: MagicMock,
         mocked_credential: MagicMock,
         mocked_get_bearer_token_provider: MagicMock,
 ) -> None:
     """
-    Test router initialization and sample completion using Azure Service Principal with Secret authentication workflow.
+    Test router initialization and sample completion using Azure Service Principal with Secret authentication workflow,
+    having provided the (mocked) credentials in environment variables and not provided any API key.
 
     To allow for local testing without real credentials, first must mock Azure SDK authentication functions
     and environment variables.
@@ -95,7 +139,7 @@ def test_router_init_azure_service_principal_with_secret(
     mocked_func_generating_token = MagicMock(return_value="test_token")
     mocked_get_bearer_token_provider.return_value = mocked_func_generating_token
 
-    # mock the environment variables
+    # mock the environment variables with mocked credentials
     environment_variables_expected_to_use = {
         "AZURE_CLIENT_ID": "test_client_id",
         "AZURE_CLIENT_SECRET": "test_client_secret",


### PR DESCRIPTION
## Context

To my best knowledge (version `v1.42.12`), the only way to authentiacate using Service Principal workflow is to provide `azure_ad_token` - either hardcoded (token expires though) or providing a path that starts with `oidc/`: 

```
model_name: "azure-gpt-35"
    litellm_params:
      model: "azure/gpt-35-turbo"
      api_base: "some-url"
      azure_ad_token: "oidc/azure/api://AzureADTokenExchange"
``` 


## Why?

However, this workflow does not suit my needs, as it requires `AZURE_FEDERATED_TOKEN_FILE`. 
My goal is to use [Service Principal with Secret workflow](https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#service-principal-with-secret).


## How? 

There is a possibility in `openai` SDK to use `azure_ad_token_provider` [parameter](https://github.com/openai/openai-python/blob/646fff04dbe9458f1c46753031546ccf6415eeef/src/openai/lib/azure.py#L75), which is not used yet in the `LiteLLM Proxy`.


## Relevant issues

Related issue: https://github.com/BerriAI/litellm/issues/4417.

## Type

🆕 New Feature

## Changes

- introduced `get_azure_ad_token_provider()` function;
- modified `set_client()` so it uses `get_azure_ad_token_provider()` when necessary.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

```
❯ poetry run pytest -q --disable-warnings .
sssssssssssssssssssssssssssssssssssssssssssssssssssssssssss....ssssssssssssssssssss                                           [100%]
4 passed, 79 skipped, 143 warnings in 4.61s
```

