### PR TITLE
Include optional parameters in the request payload when using the Hugging Face REST API.

### DIFF
--- a/litellm/llms/huggingface_restapi.py
+++ b/litellm/llms/huggingface_restapi.py
@@ -578,6 +578,12 @@ class Huggingface(BaseLLM):
                         else False
                     )
                 input_text = prompt
+
+            if "options" in optional_params:
+                data["options"] = optional_params["options"]
+            if "parameters" in optional_params:
+                data["parameters"] = optional_params["parameters"]
+
             ## LOGGING
             logging_obj.pre_call(
                 input=input_text,
@@ -881,6 +887,11 @@ class Huggingface(BaseLLM):
             data = self._transform_input_on_pipeline_tag(
                 input=input, pipeline_tag=hf_task
             )
+
+        if "options" in optional_params:
+            data["options"] = optional_params["options"]
+        if "parameters" in optional_params:
+            data["parameters"] = optional_params["parameters"]
 
         return data
 


### PR DESCRIPTION
🐛 Bug Fix

## Changes

The LiteLLM client encounters an error when the inference endpoint is in a cold state, instead of waiting for the model to load. The Hugging Face API, however, provides an option to wait for the model to load by setting the `wait_for_model` parameter to `True` in the request payload, preventing the error. Currently, LiteLLM does not capture these optional parameters in the request payload. Therefore, I propose adding options and parameters to the request payload in the Hugging Face REST API client.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

