### PR TITLE
[Feat] v2 prometheus deployment outage, healthy, partial outage alerting 

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 # 📈 [BETA] Prometheus metrics
 
 :::info
-🚨 Prometheus Metrics will be moving to LiteLLM Enterprise on September 15th, 2024
+🚨 Prometheus metrics will be out of Beta on September 15, 2024 - as part of this release it will be on LiteLLM Enterprise starting at $250/mo
 
 [Enterprise Pricing](https://www.litellm.ai/#pricing)
 
@@ -72,9 +72,7 @@ http://localhost:4000/metrics
 
 | Metric Name          | Description                          |
 |----------------------|--------------------------------------|
-| `deployment_complete_outage`             | Value is "1" when deployment is in cooldown and has had a complete outage. This metric tracks the state of the LLM API Deployment when it's completely unavailable. |
-| `deployment_partial_outage`                | Value is "1" when deployment is experiencing a partial outage. This metric indicates when the LLM API Deployment is facing issues but is not completely down. |
-| `deployment_healthy`                | Value is "1" when deployment is in a healthy state. This metric shows when the LLM API Deployment is functioning normally without any outages. |
+| `deployment_state`             | The state of the deployment: 0 = healthy, 1 = partial outage, 2 = complete outage. |
 | `litellm_remaining_requests_metric`             | Track `x-ratelimit-remaining-requests` returned from LLM API Deployment |
 | `litellm_remaining_tokens`                | Track `x-ratelimit-remaining-tokens` return from LLM API Deployment |
 

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -37,4 +37,5 @@ general_settings:
   master_key: sk-1234
 
 litellm_settings:
-  callbacks: ["otel"] # 👈 KEY CHANGE
+  success_callback: ["prometheus"]
+  failure_callback: ["prometheus"]

--- a/litellm/router_utils/cooldown_callbacks.py
+++ b/litellm/router_utils/cooldown_callbacks.py
@@ -38,6 +38,17 @@ async def router_cooldown_handler(
     model_info = _deployment["model_info"]
     model_id = model_info.id
 
+    litellm_model_name = temp_litellm_params.get("model")
+    llm_provider = ""
+    try:
+
+        _, llm_provider, _, _ = litellm.get_llm_provider(
+            model=litellm_model_name,
+            custom_llm_provider=temp_litellm_params.get("custom_llm_provider"),
+        )
+    except:
+        pass
+
     # Trigger cooldown on Prometheus
     from litellm.litellm_core_utils.litellm_logging import prometheusLogger
 
@@ -45,7 +56,7 @@ async def router_cooldown_handler(
         prometheusLogger.set_deployment_complete_outage(
             litellm_model_name=_model_name,
             model_id=model_id,
-            api_base="",
-            llm_provider="",
+            api_base=_api_base,
+            api_provider=llm_provider,
         )
-    pass
+    return


### PR DESCRIPTION
## v2 Prometheus LLM deployment status metrics
```
# HELP deployment_state The state of the deployment: 0 = healthy, 1 = partial outage, 2 = complete outage
# TYPE deployment_state gauge
deployment_state{api_base="None", api_provider="openai", litellm_model_name="gpt-4", model_id="None"} 0
deployment_state{api_base="None", api_provider="vertex_ai", litellm_model_name="gemini-1.5-pro-001", model_id="None"} 1
deployment_state{api_base="", api_provider="", litellm_model_name="openai/gpt-4-vision-preview", model_id="3421e9bf24396ec1a6af9e79f50c9b278ffbdf139b8b922353d47fda75b4a966"} 2
```
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

