### PR TITLE
Enable follow redirects in ollama_chat

### DIFF
--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -356,6 +356,7 @@ def ollama_completion_stream(url, api_key, data, logging_obj):
         "json": data,
         "method": "POST",
         "timeout": litellm.request_timeout,
+        "follow_redirects": True
     }
     if api_key is not None:
         _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}


### PR DESCRIPTION
## Title

Enable follow redirects in ollama_chat

## Relevant issues

Fixed this issue https://github.com/TheR1D/shell_gpt/discussions/503

## Type

🐛 Bug Fix

## Changes

feat: add follow_redirects parameter to ollama_completion_stream request in litellm/llms/ollama_chat.py
