### PR TITLE
Allow zero temperature for Sagemaker models based on config 

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3134,6 +3134,7 @@ def get_optional_params(
             if max_tokens == 0:
                 max_tokens = 1
             optional_params["max_new_tokens"] = max_tokens
+        passed_params.pop("aws_sagemaker_allow_zero_temp", None)
     elif custom_llm_provider == "bedrock":
         supported_params = get_supported_openai_params(
             model=model, custom_llm_provider=custom_llm_provider

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3114,7 +3114,8 @@ def get_optional_params(
             if temperature == 0.0 or temperature == 0:
                 # hugging face exception raised when temp==0
                 # Failed: Error occurred: HuggingfaceException - Input validation error: `temperature` must be strictly positive
-                temperature = 0.01
+                if not passed_params.get("aws_sagemaker_allow_zero_temp", False):
+                    temperature = 0.01
             optional_params["temperature"] = temperature
         if top_p is not None:
             optional_params["top_p"] = top_p


### PR DESCRIPTION
## Title

Since Sagemaker can host any kind of model, some models allow zero temperature. However, this is not enabled by default and
only allowed based on config. The config parameter is a boolean called "aws_sagemaker_allow_zero_temp"

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
The config parameter is aws_sagemaker_allow_zero_temp which is boolean and default is False.

Tested manually with a sagemaker model and Litellm proxy
Verified that without this setting the temperature parameter is set as 0.01 even if the request has 0.0. So default behavior is not impacted
Verified that with this setting the temperature parameter sent to Sagemaker is 0.0 if the input has 0.0