### PR TITLE
[Feat] Allow loading LiteLLM config from s3 buckets 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
             pip install tiktoken
             pip install aiohttp
             pip install click
+            pip install "boto3==1.34.34"
             pip install jinja2
             pip install tokenizers
             pip install openai
@@ -287,6 +288,7 @@ jobs:
             pip install "pytest==7.3.1"
             pip install "pytest-mock==3.12.0"
             pip install "pytest-asyncio==0.21.1"
+            pip install "boto3==1.34.34"
             pip install mypy
             pip install pyarrow
             pip install numpydoc

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -705,6 +705,29 @@ docker run ghcr.io/berriai/litellm:main-latest \
 
 Provide an ssl certificate when starting litellm proxy server 
 
+### 3. Providing LiteLLM config.yaml file as a s3 Object/url
+
+Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)
+
+LiteLLM Proxy will read your config.yaml from an s3 Bucket
+
+Set the following .env vars 
+```shell
+LITELLM_CONFIG_BUCKET_NAME = "litellm-proxy"                    # your bucket name on s3 
+LITELLM_CONFIG_BUCKET_OBJECT_KEY = "litellm_proxy_config.yaml"  # object key on s3
+```
+
+Start litellm proxy with these env vars - litellm will read your config from s3 
+
+```shell
+docker run --name litellm-proxy \
+   -e DATABASE_URL=<database_url> \
+   -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
+   -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
+   -p 4000:4000 \
+   ghcr.io/berriai/litellm-database:main-latest
+```
+
 ## Platform-specific Guide
 
 <Tabs>

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -7,6 +7,7 @@ from litellm._logging import verbose_proxy_logger
 
 
 def get_file_contents_from_s3(bucket_name, object_key):
+    # v0 rely on boto3 for authentication - allowing boto3 to handle IAM credentials etc
     s3_client = boto3.client("s3")
     try:
         verbose_proxy_logger.debug(

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -8,7 +8,19 @@ from litellm._logging import verbose_proxy_logger
 
 def get_file_contents_from_s3(bucket_name, object_key):
     # v0 rely on boto3 for authentication - allowing boto3 to handle IAM credentials etc
-    s3_client = boto3.client("s3")
+    from botocore.config import Config
+    from botocore.credentials import Credentials
+
+    from litellm.main import bedrock_converse_chat_completion
+
+    credentials: Credentials = bedrock_converse_chat_completion.get_credentials()
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id=credentials.access_key,
+        aws_secret_access_key=credentials.secret_key,
+        aws_session_token=credentials.token,  # Optional, if using temporary credentials
+    )
+
     try:
         verbose_proxy_logger.debug(
             f"Retrieving {object_key} from S3 bucket: {bucket_name}"

--- a/litellm/tests/test_completion.py
+++ b/litellm/tests/test_completion.py
@@ -23,7 +23,7 @@ from litellm import RateLimitError, Timeout, completion, completion_cost, embedd
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.prompt_templates.factory import anthropic_messages_pt
 
-# litellm.num_retries = 3
+# litellm.num_retries =3
 litellm.cache = None
 litellm.success_callback = []
 user_message = "Write a short poem about the sky"


### PR DESCRIPTION
### Providing LiteLLM config.yaml file as a s3 Object/url

Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)

LiteLLM Proxy will read your config.yaml from an s3 Bucket

Set the following .env vars 
```shell
LITELLM_CONFIG_BUCKET_NAME = "litellm-proxy"                    # your bucket name on s3 
LITELLM_CONFIG_BUCKET_OBJECT_KEY = "litellm_proxy_config.yaml"  # object key on s3
```

Start litellm proxy with these env vars - litellm will read your config from s3 

```shell
docker run --name litellm-proxy \
   -e DATABASE_URL=<database_url> \
   -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
   -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
   -p 4000:4000 \
   ghcr.io/berriai/litellm-database:main-latest
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

