### PR TITLE
[Feat-Proxy] Add failure logging for GCS bucket 

### DIFF
--- a/litellm/integrations/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket.py
@@ -129,13 +129,20 @@ class GCSBucketLogger(CustomLogger):
             )
             logging_payload["log_event_type"] = "failed_api_call"
 
+            _litellm_params = kwargs.get("litellm_params") or {}
+            metadata = _litellm_params.get("metadata") or {}
+
             json_logged_payload = json.dumps(logging_payload)
 
             # Get the current date
             current_date = datetime.now().strftime("%Y-%m-%d")
 
             # Modify the object_name to include the date-based folder
-            object_name = f"{current_date}/{uuid.uuid4().hex}"
+            object_name = f"{current_date}/failure-{uuid.uuid4().hex}"
+
+            if "gcs_log_id" in metadata:
+                object_name = metadata["gcs_log_id"]
+
             response = await self.async_httpx_client.post(
                 headers=headers,
                 url=f"https://storage.googleapis.com/upload/storage/v1/b/{self.BUCKET_NAME}/o?uploadType=media&name={object_name}",

--- a/litellm/integrations/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional, TypedDict, Union
 
@@ -29,6 +30,8 @@ class GCSBucketPayload(TypedDict):
     end_time: str
     response_cost: Optional[float]
     spend_log_metadata: str
+    exception: Optional[str]
+    log_event_type: Optional[str]
 
 
 class GCSBucketLogger(CustomLogger):
@@ -79,6 +82,7 @@ class GCSBucketLogger(CustomLogger):
             logging_payload: GCSBucketPayload = await self.get_gcs_payload(
                 kwargs, response_obj, start_time_str, end_time_str
             )
+            logging_payload["log_event_type"] = "successful_api_call"
 
             json_logged_payload = json.dumps(logging_payload)
 
@@ -103,7 +107,49 @@ class GCSBucketLogger(CustomLogger):
             verbose_logger.error("GCS Bucket logging error: %s", str(e))
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
-        pass
+        from litellm.proxy.proxy_server import premium_user
+
+        if premium_user is not True:
+            raise ValueError(
+                f"GCS Bucket logging is a premium feature. Please upgrade to use it. {CommonProxyErrors.not_premium_user.value}"
+            )
+        try:
+            verbose_logger.debug(
+                "GCS Logger: async_log_failure_event logging kwargs: %s, response_obj: %s",
+                kwargs,
+                response_obj,
+            )
+
+            start_time_str = start_time.strftime("%Y-%m-%d %H:%M:%S")
+            end_time_str = end_time.strftime("%Y-%m-%d %H:%M:%S")
+            headers = await self.construct_request_headers()
+
+            logging_payload: GCSBucketPayload = await self.get_gcs_payload(
+                kwargs, response_obj, start_time_str, end_time_str
+            )
+            logging_payload["log_event_type"] = "failed_api_call"
+
+            json_logged_payload = json.dumps(logging_payload)
+
+            # Get the current date
+            current_date = datetime.now().strftime("%Y-%m-%d")
+
+            # Modify the object_name to include the date-based folder
+            object_name = f"{current_date}/{uuid.uuid4().hex}"
+            response = await self.async_httpx_client.post(
+                headers=headers,
+                url=f"https://storage.googleapis.com/upload/storage/v1/b/{self.BUCKET_NAME}/o?uploadType=media&name={object_name}",
+                data=json_logged_payload,
+            )
+
+            if response.status_code != 200:
+                verbose_logger.error("GCS Bucket logging error: %s", str(response.text))
+
+            verbose_logger.debug("GCS Bucket response %s", response)
+            verbose_logger.debug("GCS Bucket status code %s", response.status_code)
+            verbose_logger.debug("GCS Bucket response.text %s", response.text)
+        except Exception as e:
+            verbose_logger.error("GCS Bucket logging error: %s", str(e))
 
     async def construct_request_headers(self) -> Dict[str, str]:
         from litellm import vertex_chat_completion
@@ -139,9 +185,18 @@ class GCSBucketLogger(CustomLogger):
             optional_params=kwargs.get("optional_params", None),
         )
         response_dict = {}
-        response_dict = convert_litellm_response_object_to_dict(
-            response_obj=response_obj
-        )
+        if response_obj:
+            response_dict = convert_litellm_response_object_to_dict(
+                response_obj=response_obj
+            )
+
+        exception_str = None
+
+        # Handle logging exception attributes
+        if "exception" in kwargs:
+            exception_str = kwargs.get("exception", "")
+            if not isinstance(exception_str, str):
+                exception_str = str(exception_str)
 
         _spend_log_payload: SpendLogsPayload = get_logging_payload(
             kwargs=kwargs,
@@ -156,8 +211,10 @@ class GCSBucketLogger(CustomLogger):
             response_obj=response_dict,
             start_time=start_time,
             end_time=end_time,
-            spend_log_metadata=_spend_log_payload["metadata"],
+            spend_log_metadata=_spend_log_payload.get("metadata", ""),
             response_cost=kwargs.get("response_cost", None),
+            exception=exception_str,
+            log_event_type=None,
         )
 
         return gcs_payload

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -39,7 +39,4 @@ general_settings:
 
 litellm_settings:
   fallbacks: [{"gemini-1.5-pro-001": ["gpt-4o"]}]
-  success_callback: ["langfuse", "prometheus"]
-  langfuse_default_tags: ["cache_hit", "cache_key", "proxy_base_url", "user_api_key_alias", "user_api_key_user_id", "user_api_key_user_email", "user_api_key_team_alias", "semantic-similarity", "proxy_base_url"]
-  failure_callback: ["prometheus"]
-  cache: True
+  callbacks: ["gcs_bucket"]

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -21,6 +21,8 @@ def get_logging_payload(
 
     if kwargs is None:
         kwargs = {}
+    if response_obj is None:
+        response_obj = {}
     # standardize this function to be used across, s3, dynamoDB, langfuse logging
     litellm_params = kwargs.get("litellm_params", {})
     metadata = (

--- a/litellm/tests/test_gcs_bucket.py
+++ b/litellm/tests/test_gcs_bucket.py
@@ -147,6 +147,7 @@ async def test_basic_gcs_logger():
 
     assert gcs_payload["response_cost"] > 0.0
 
+    assert gcs_payload["log_event_type"] == "successful_api_call"
     gcs_payload["spend_log_metadata"] = json.loads(gcs_payload["spend_log_metadata"])
 
     assert (

--- a/litellm/tests/test_gcs_bucket.py
+++ b/litellm/tests/test_gcs_bucket.py
@@ -162,3 +162,113 @@ async def test_basic_gcs_logger():
     # Delete Object from GCS
     print("deleting object from GCS")
     await gcs_logger.delete_gcs_object(object_name=object_name)
+
+
+@pytest.mark.asyncio
+async def test_basic_gcs_logger_failure():
+    load_vertex_ai_credentials()
+    gcs_logger = GCSBucketLogger()
+    print("GCSBucketLogger", gcs_logger)
+
+    gcs_log_id = f"failure-test-{uuid.uuid4().hex}"
+
+    litellm.callbacks = [gcs_logger]
+
+    try:
+        response = await litellm.acompletion(
+            model="gpt-3.5-turbo",
+            temperature=0.7,
+            messages=[{"role": "user", "content": "This is a test"}],
+            max_tokens=10,
+            user="ishaan-2",
+            mock_response=litellm.BadRequestError(
+                model="gpt-3.5-turbo",
+                message="Error: 400: Bad Request: Invalid API key, please check your API key and try again.",
+                llm_provider="openai",
+            ),
+            metadata={
+                "gcs_log_id": gcs_log_id,
+                "tags": ["model-anthropic-claude-v2.1", "app-ishaan-prod"],
+                "user_api_key": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
+                "user_api_key_alias": None,
+                "user_api_end_user_max_budget": None,
+                "litellm_api_version": "0.0.0",
+                "global_max_parallel_requests": None,
+                "user_api_key_user_id": "116544810872468347480",
+                "user_api_key_org_id": None,
+                "user_api_key_team_id": None,
+                "user_api_key_team_alias": None,
+                "user_api_key_metadata": {},
+                "requester_ip_address": "127.0.0.1",
+                "spend_logs_metadata": {"hello": "world"},
+                "headers": {
+                    "content-type": "application/json",
+                    "user-agent": "PostmanRuntime/7.32.3",
+                    "accept": "*/*",
+                    "postman-token": "92300061-eeaa-423b-a420-0b44896ecdc4",
+                    "host": "localhost:4000",
+                    "accept-encoding": "gzip, deflate, br",
+                    "connection": "keep-alive",
+                    "content-length": "163",
+                },
+                "endpoint": "http://localhost:4000/chat/completions",
+                "model_group": "gpt-3.5-turbo",
+                "deployment": "azure/chatgpt-v-2",
+                "model_info": {
+                    "id": "4bad40a1eb6bebd1682800f16f44b9f06c52a6703444c99c7f9f32e9de3693b4",
+                    "db_model": False,
+                },
+                "api_base": "https://openai-gpt-4-test-v-1.openai.azure.com/",
+                "caching_groups": None,
+                "raw_request": "\n\nPOST Request Sent from LiteLLM:\ncurl -X POST \\\nhttps://openai-gpt-4-test-v-1.openai.azure.com//openai/ \\\n-H 'Authorization: *****' \\\n-d '{'model': 'chatgpt-v-2', 'messages': [{'role': 'system', 'content': 'you are a helpful assistant.\\n'}, {'role': 'user', 'content': 'bom dia'}], 'stream': False, 'max_tokens': 10, 'user': '116544810872468347480', 'extra_body': {}}'\n",
+            },
+        )
+    except:
+        pass
+
+    await asyncio.sleep(5)
+
+    # Get the current date
+    # Get the current date
+    current_date = datetime.now().strftime("%Y-%m-%d")
+
+    # Modify the object_name to include the date-based folder
+    object_name = gcs_log_id
+
+    print("object_name", object_name)
+
+    # Check if object landed on GCS
+    object_from_gcs = await gcs_logger.download_gcs_object(object_name=object_name)
+    print("object from gcs=", object_from_gcs)
+    # convert object_from_gcs from bytes to DICT
+    parsed_data = json.loads(object_from_gcs)
+    print("object_from_gcs as dict", parsed_data)
+
+    print("type of object_from_gcs", type(parsed_data))
+
+    gcs_payload = GCSBucketPayload(**parsed_data)
+
+    print("gcs_payload", gcs_payload)
+
+    assert gcs_payload["request_kwargs"]["model"] == "gpt-3.5-turbo"
+    assert gcs_payload["request_kwargs"]["messages"] == [
+        {"role": "user", "content": "This is a test"}
+    ]
+
+    assert gcs_payload["response_cost"] == 0
+    assert gcs_payload["log_event_type"] == "failed_api_call"
+
+    gcs_payload["spend_log_metadata"] = json.loads(gcs_payload["spend_log_metadata"])
+
+    assert (
+        gcs_payload["spend_log_metadata"]["user_api_key"]
+        == "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b"
+    )
+    assert (
+        gcs_payload["spend_log_metadata"]["user_api_key_user_id"]
+        == "116544810872468347480"
+    )
+
+    # Delete Object from GCS
+    print("deleting object from GCS")
+    await gcs_logger.delete_gcs_object(object_name=object_name)


### PR DESCRIPTION
## Log failure event on GCS bucket 

```
{"request_kwargs": {"model": "gpt-43", "messages": [{"role": "user", "content": "Hello, Claude!sss"}], "optional_params": {}}, "response_obj": {}, "start_time": "2024-08-14 08:36:30", "end_time": "2024-08-14 08:36:30", "spend_log_metadata": "{\"user_api_key\": \"88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b\", \"user_api_key_alias\": null, \"user_api_key_team_id\": null, \"user_api_key_user_id\": \"default_user_id\", \"user_api_key_team_alias\": null, \"requester_ip_address\": \"203.0.113.195\"}", "response_cost": 0, "exception": "litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-43\n Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers", "log_event_type": "failed_api_call"}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

