### PR TITLE
Use `AZURE_API_VERSION` env var as default azure openai version

### DIFF
--- a/litellm/router_utils/client_initalization_utils.py
+++ b/litellm/router_utils/client_initalization_utils.py
@@ -190,7 +190,7 @@ def set_client(litellm_router_instance: LitellmRouter, model: dict):
                 if azure_ad_token.startswith("oidc/"):
                     azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)
             if api_version is None:
-                api_version = litellm.AZURE_DEFAULT_API_VERSION
+                api_version = os.getenv("AZURE_API_VERSION", litellm.AZURE_DEFAULT_API_VERSION)
 
             if "gateway.ai.cloudflare.com" in api_base:
                 if not api_base.endswith("/"):


### PR DESCRIPTION
Without this change, the default version of the Azure OpenAI API is hardcoded in the code as an old version, `"2024-02-01"`. This change allows the user to set the default version of the Azure OpenAI API by setting the environment variable `AZURE_API_VERSION` or by using the command-line parameter `--api_version`.
