### PR TITLE
[PRICING] Use specific llama2 and llama3 model names in Ollama

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3354,6 +3354,15 @@
         "litellm_provider": "ollama",
         "mode": "completion"
     },
+    "ollama/llama2:7b": {
+        "max_tokens": 4096, 
+        "max_input_tokens": 4096, 
+        "max_output_tokens": 4096, 
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "completion"
+    },
     "ollama/llama2:13b": {
         "max_tokens": 4096, 
         "max_input_tokens": 4096, 
@@ -3382,6 +3391,15 @@
         "mode": "completion"
     },
     "ollama/llama3": {
+        "max_tokens": 8192,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "ollama",
+        "mode": "chat"
+    },
+    "ollama/llama3:8b": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,


### PR DESCRIPTION
The pricing file doesn't specify the amount of params of llama2 and llama3 latest models in the model names. They default to llama2:7b and llama3:8b respectively. Added an entry for each of them.

