### PR TITLE
Make helm chart listen on IPv6 (and IPv4).

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST
-              value: "0.0.0.0"
+              value: "::"
             - name: PORT
               value: {{ .Values.service.port | quote}}
             {{- if .Values.db.deployStandalone }}


### PR DESCRIPTION
This changes the listen statement from 0.0.0.0 to ::.

On any reasonably modern linux kernel, this will open a dual-stack socket and listen on all IPv4 and IPv6 sockets. Without this litellm will not run in an IPv6 only environment.

If you'd prefer I'd happily change this to just allow the HOST variable to be changed using a helm variable, instead of just changing the hardcoded value. However this should just work for everywhere and I believe this is the better default going forward, as IPv6 only kubernetes environments like ours become more and more common.

## Title

Make helm chart listen on IPv6 (and IPv4) by default.

## Relevant issues


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

<!-- List of changes -->

Change helm chart default listen parameter to use :: instead of 0.0.0.0.

<!-- Test procedure -->

