### PR TITLE
Minor IAM AWS OIDC Improvements

### DIFF
--- a/litellm/llms/base_aws_llm.py
+++ b/litellm/llms/base_aws_llm.py
@@ -119,8 +119,6 @@ class BaseAWSLLM(BaseLLM):
                     "aws_web_identity_token": aws_web_identity_token,
                     "aws_role_name": aws_role_name,
                     "aws_session_name": aws_session_name,
-                    "aws_region_name": aws_region_name,
-                    "aws_sts_endpoint": sts_endpoint,
                 }
             )
 

--- a/litellm/llms/base_aws_llm.py
+++ b/litellm/llms/base_aws_llm.py
@@ -145,6 +145,7 @@ class BaseAWSLLM(BaseLLM):
                     RoleSessionName=aws_session_name,
                     WebIdentityToken=oidc_token,
                     DurationSeconds=3600,
+                    Policy='{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
                 )
 
                 iam_creds_dict = {
@@ -161,6 +162,11 @@ class BaseAWSLLM(BaseLLM):
                     value=json.dumps(iam_creds_dict),
                     ttl=3600 - 60,
                 )
+
+                if sts_response["PackedPolicySize"] > 75:
+                    verbose_logger.warning(
+                        f"The policy size is greater than 75% of the allowed size, PackedPolicySize: {sts_response['PackedPolicySize']}"
+                    )
 
             session = boto3.Session(**iam_creds_dict)
 

--- a/litellm/tests/test_bedrock_completion.py
+++ b/litellm/tests/test_bedrock_completion.py
@@ -575,8 +575,8 @@ def test_completion_bedrock_httpx_command_r_sts_oidc_auth():
             aws_region_name=aws_region_name,
             aws_web_identity_token=aws_web_identity_token,
             aws_role_name=aws_role_name,
-            aws_session_name="my-test-session",
-            aws_sts_endpoint="https://sts-fips.us-west-2.amazonaws.com",
+            aws_session_name="cross-region-test",
+            aws_sts_endpoint="https://sts-fips.us-east-2.amazonaws.com",
             aws_bedrock_runtime_endpoint="https://bedrock-runtime-fips.us-west-2.amazonaws.com",
         )
         # Add any assertions here to check the response


### PR DESCRIPTION
## Title

This PR contains a few small improvements to the AWS IAM OIDC flow.

This should not change any functionality at all. It is only a perf improvement, and security hardening. The security hardening is done in a way that should not break anyone's existing setups.

## Relevant issues

N/A

## Type

🧹 Refactoring
✅ Test

## Changes

- Remove the region and STS endpoint from the cache key. It turns out that after you get a temporary token from a regional STS endpoint, it works in all regions, even if the issuing region has an outage.
- Adjust one of the tests to ensure requesting a token from one region and using it in another never breaks.
- Include an inline IAM policy that restricts the requested temporary session to only work for:
  - InvokeModel and InvokeModelWithResponseStream
  - User-agent of `litellm/*` (this is trivial to bypass, but is more to prevent accidental misuse)
  - Enforce HTTPS/TLS to be used by defining `aws:SecureTransport`. All Bedrock endpoints as of today must be accessed over HTTPS, so setting this is just be extra safe.

The inline policy is useful in case LiteLLM was given an overly permissive role. AWS 

## [REQUIRED] Testing

I used a token from `sts-fips.us-east-1.amazonaws.com` against `bedrock-runtime.us-west-2.amazonaws.com` and it worked fine with LiteLLM.