### PR TITLE
[Feat-Proxy] Add Oauth 2.0 Support 

### DIFF
--- a/docs/my-website/docs/proxy/oauth2.md
+++ b/docs/my-website/docs/proxy/oauth2.md
@@ -2,6 +2,12 @@
 
 Use this if you want to use an Oauth2.0 token to make `/chat`, `/embeddings` requests to the LiteLLM Proxy
 
+:::info
+
+This is an Enterprise Feature - [get in touch with us if you want a free trial to test if this feature meets your needs]((https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat))
+
+:::
+
 ## Usage 
 
 1. Set env vars:

--- a/docs/my-website/docs/proxy/oauth2.md
+++ b/docs/my-website/docs/proxy/oauth2.md
@@ -1,0 +1,57 @@
+# Oauth 2.0 Authentication
+
+Use this if you want to use an Oauth2.0 token to make `/chat`, `/embeddings` requests to the LiteLLM Proxy
+
+## Usage 
+
+1. Set env vars:
+
+```bash
+export OAUTH_TOKEN_INFO_ENDPOINT="https://your-provider.com/token/info"
+export OAUTH_USER_ID_FIELD_NAME="sub"
+export OAUTH_USER_ROLE_FIELD_NAME="role"
+export OAUTH_USER_TEAM_ID_FIELD_NAME="team_id"
+```
+
+- `OAUTH_TOKEN_INFO_ENDPOINT`: URL to validate OAuth tokens
+- `OAUTH_USER_ID_FIELD_NAME`: Field in token info response containing user ID
+- `OAUTH_USER_ROLE_FIELD_NAME`: Field in token info for user's role
+- `OAUTH_USER_TEAM_ID_FIELD_NAME`: Field in token info for user's team ID
+
+2. Enable on litellm config.yaml
+
+Set this on your config.yaml
+
+```yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: openai/fake
+      api_key: fake-key
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+
+general_settings: 
+  master_key: sk-1234
+  enable_oauth2_auth: true
+```
+
+3. Use token in requests to LiteLLM 
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --data '{
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+## Debugging 
+
+Start the LiteLLM Proxy with [`--detailed_debug` mode and you should see more verbose logs](cli.md#detailed_debug)
+

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -66,6 +66,7 @@ const sidebars = {
         "proxy/customers",
         "proxy/billing",
         "proxy/token_auth",
+        "proxy/oauth2",
         "proxy/alerting",
         "proxy/ui",
         "proxy/prometheus",

--- a/litellm/proxy/auth/oauth2_check.py
+++ b/litellm/proxy/auth/oauth2_check.py
@@ -1,9 +1,3 @@
-import os
-from typing import Literal
-
-import httpx
-
-from litellm.llms.custom_httpx.http_handler import _get_async_httpx_client
 from litellm.proxy._types import UserAPIKeyAuth
 
 
@@ -20,6 +14,15 @@ async def check_oauth2_token(token: str) -> UserAPIKeyAuth:
     Raises:
     ValueError: If the token is invalid, the request fails, or the token info endpoint is not set.
     """
+    import os
+    from typing import Literal
+
+    import httpx
+
+    from litellm._logging import verbose_proxy_logger
+    from litellm.llms.custom_httpx.http_handler import _get_async_httpx_client
+
+    verbose_proxy_logger.debug("Oauth2 token validation for token=%s", token)
     # Get the token info endpoint from environment variable
     token_info_endpoint = os.getenv("OAUTH_TOKEN_INFO_ENDPOINT")
     user_id_field_name = os.environ.get("OAUTH_USER_ID_FIELD_NAME", "sub")
@@ -30,7 +33,6 @@ async def check_oauth2_token(token: str) -> UserAPIKeyAuth:
         raise ValueError("OAUTH_TOKEN_INFO_ENDPOINT environment variable is not set")
 
     client = _get_async_httpx_client()
-
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
     try:
@@ -41,6 +43,12 @@ async def check_oauth2_token(token: str) -> UserAPIKeyAuth:
 
         # If we get here, the request was successful
         data = response.json()
+
+        verbose_proxy_logger.debug(
+            "Oauth2 token validation for token=%s, response from /token/info=%s",
+            token,
+            data,
+        )
 
         # You might want to add additional checks here based on the response
         # For example, checking if the token is expired or has the correct scope

--- a/litellm/proxy/auth/oauth2_check.py
+++ b/litellm/proxy/auth/oauth2_check.py
@@ -1,0 +1,55 @@
+import os
+from typing import Literal
+
+import httpx
+
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    HTTPHandler,
+    _get_async_httpx_client,
+    _get_httpx_client,
+)
+
+
+async def check_oauth2_token(token: str) -> Literal[True]:
+    """
+    Makes a request to the token info endpoint to validate the OAuth2 token.
+
+    Args:
+    token (str): The OAuth2 token to validate.
+
+    Returns:
+    Literal[True]: If the token is valid.
+
+    Raises:
+    ValueError: If the token is invalid, the request fails, or the token info endpoint is not set.
+    """
+    # Get the token info endpoint from environment variable
+    token_info_endpoint = os.getenv("OAUTH_TOKEN_INFO_ENDPOINT")
+
+    if not token_info_endpoint:
+        raise ValueError("OAUTH_TOKEN_INFO_ENDPOINT environment variable is not set")
+
+    client = _get_async_httpx_client()
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    try:
+        response = await client.get(token_info_endpoint, headers=headers)
+
+        # if it's a bad token we expect it to raise an HTTPStatusError
+        response.raise_for_status()
+
+        # If we get here, the request was successful
+        data = response.json()
+
+        # You might want to add additional checks here based on the response
+        # For example, checking if the token is expired or has the correct scope
+
+        return True
+    except httpx.HTTPStatusError as e:
+        # This will catch any 4xx or 5xx errors
+        raise ValueError(f"Token validation failed: {e}")
+    except Exception as e:
+        # This will catch any other errors (like network issues)
+        raise ValueError(f"An error occurred during token validation: {e}")

--- a/litellm/proxy/auth/oauth2_check.py
+++ b/litellm/proxy/auth/oauth2_check.py
@@ -21,6 +21,14 @@ async def check_oauth2_token(token: str) -> UserAPIKeyAuth:
 
     from litellm._logging import verbose_proxy_logger
     from litellm.llms.custom_httpx.http_handler import _get_async_httpx_client
+    from litellm.proxy._types import CommonProxyErrors
+    from litellm.proxy.proxy_server import premium_user
+
+    if premium_user is not True:
+        raise ValueError(
+            "Oauth2 token validation is only available for premium users"
+            + CommonProxyErrors.not_premium_user.value
+        )
 
     verbose_proxy_logger.debug("Oauth2 token validation for token=%s", token)
     # Get the token info endpoint from environment variable

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -62,6 +62,7 @@ from litellm.proxy.auth.auth_utils import (
     is_llm_api_route,
     route_in_additonal_public_routes,
 )
+from litellm.proxy.auth.oauth2_check import check_oauth2_token
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.utils import _to_ns
 
@@ -196,6 +197,11 @@ async def user_api_key_auth(
         ):
             # check if public endpoint
             return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY)
+
+        if general_settings.get("enable_oauth2_auth", False) is True:
+            # return UserAPIKeyAuth object
+            # helper to check if the api_key is a valid oauth2 token
+            return await check_oauth2_token(token=api_key)
 
         if general_settings.get("enable_jwt_auth", False) is True:
             is_jwt = jwt_handler.is_jwt(token=api_key)

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -201,6 +201,14 @@ async def user_api_key_auth(
         if general_settings.get("enable_oauth2_auth", False) is True:
             # return UserAPIKeyAuth object
             # helper to check if the api_key is a valid oauth2 token
+            from litellm.proxy.proxy_server import premium_user
+
+            if premium_user is not True:
+                raise ValueError(
+                    "Oauth2 token validation is only available for premium users"
+                    + CommonProxyErrors.not_premium_user.value
+                )
+
             return await check_oauth2_token(token=api_key)
 
         if general_settings.get("enable_jwt_auth", False) is True:


### PR DESCRIPTION
## [Feat-Proxy] Add Oauth 2.0 Support

# Oauth 2.0 Authentication

Use this if you want to use an Oauth2.0 token to make `/chat`, `/embeddings` requests to the LiteLLM Proxy


## Usage 

1. Set env vars:

```bash
export OAUTH_TOKEN_INFO_ENDPOINT="https://your-provider.com/token/info"
export OAUTH_USER_ID_FIELD_NAME="sub"
export OAUTH_USER_ROLE_FIELD_NAME="role"
export OAUTH_USER_TEAM_ID_FIELD_NAME="team_id"
```

- `OAUTH_TOKEN_INFO_ENDPOINT`: URL to validate OAuth tokens
- `OAUTH_USER_ID_FIELD_NAME`: Field in token info response containing user ID
- `OAUTH_USER_ROLE_FIELD_NAME`: Field in token info for user's role
- `OAUTH_USER_TEAM_ID_FIELD_NAME`: Field in token info for user's team ID

2. Enable on litellm config.yaml

Set this on your config.yaml

```yaml
model_list:
  - model_name: gpt-4
    litellm_params:
      model: openai/fake
      api_key: fake-key
      api_base: https://exampleopenaiendpoint-production.up.railway.app/

general_settings: 
  master_key: sk-1234
  enable_oauth2_auth: true
```

3. Use token in requests to LiteLLM 

```shell
curl --location 'http://0.0.0.0:4000/chat/completions' \
    --header 'Content-Type: application/json' \
    --data '{
    "model": "gpt-3.5-turbo",
    "messages": [
        {
        "role": "user",
        "content": "what llm are you"
        }
    ]
}'
```

## Debugging 

Start the LiteLLM Proxy with [`--detailed_debug` mode and you should see more verbose logs](cli.md#detailed_debug)



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

