### PR TITLE
Fixes priority queue comparison to work with Redis cache enabled

### DIFF
--- a/litellm/scheduler.py
+++ b/litellm/scheduler.py
@@ -49,7 +49,7 @@ class Scheduler:
         # get the queue
         queue = await self.get_queue(model_name=request.model_name)
         # update the queue
-        heapq.heappush(queue, (request.priority, request.request_id))
+        heapq.heappush(queue, [request.priority, request.request_id])
 
         # save the queue
         await self.save_queue(queue=queue, model_name=request.model_name)


### PR DESCRIPTION
## Title

Fixes priority queue comparison to work with Redis cache enabled

## Type

🐛 Bug Fix

## Changes

Changes priority queue to hold a list of the priority and request ID instead of a tuple that holds them in order to support using Redis as the backend cache.
When using Redis it uses json dumps to save the queue and it converts the tuples to list, thus failing new requests when loading the cache from Redis

<!-- List of changes -->


