### PR TITLE
Update SSL verification

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -111,7 +111,7 @@ common_cloud_provider_auth_params: dict = {
     "providers": ["vertex_ai", "bedrock", "watsonx", "azure", "vertex_ai_beta"],
 }
 use_client: bool = False
-ssl_verify: bool = True
+ssl_verify: Union[str, bool] = True
 ssl_certificate: Optional[str] = None
 disable_streaming_logging: bool = False
 in_memory_llm_clients_cache: dict = {}

--- a/litellm/llms/azure.py
+++ b/litellm/llms/azure.py
@@ -692,7 +692,7 @@ class AzureChatCompletion(BaseLLM):
                 "api_version": api_version,
                 "azure_endpoint": api_base,
                 "azure_deployment": model,
-                "http_client": litellm.client_session,
+                "http_client": litellm.aclient_session,
                 "max_retries": max_retries,
                 "timeout": timeout,
             }
@@ -860,7 +860,7 @@ class AzureChatCompletion(BaseLLM):
                 "api_version": api_version,
                 "azure_endpoint": api_base,
                 "azure_deployment": model,
-                "http_client": litellm.client_session,
+                "http_client": litellm.aclient_session,
                 "max_retries": data.pop("max_retries", 2),
                 "timeout": timeout,
             }
@@ -989,13 +989,16 @@ class AzureChatCompletion(BaseLLM):
                 "api_version": api_version,
                 "azure_endpoint": api_base,
                 "azure_deployment": model,
-                "http_client": litellm.client_session,
                 "max_retries": max_retries,
                 "timeout": timeout,
             }
             azure_client_params = select_azure_base_url_or_endpoint(
                 azure_client_params=azure_client_params
             )
+            if aembedding:
+                azure_client_params["http_client"] = litellm.aclient_session
+            else:
+                azure_client_params["http_client"] = litellm.client_session
             if api_key is not None:
                 azure_client_params["api_key"] = api_key
             elif azure_ad_token is not None:

--- a/litellm/llms/bedrock.py
+++ b/litellm/llms/bedrock.py
@@ -605,6 +605,9 @@ def init_bedrock_client(
         aws_web_identity_token,
     ) = params_to_check
 
+    # SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts.
+    ssl_verify = os.getenv("SSL_VERIFY", litellm.ssl_verify)
+
     ### SET REGION NAME
     if region_name:
         pass
@@ -673,6 +676,7 @@ def init_bedrock_client(
             region_name=region_name,
             endpoint_url=endpoint_url,
             config=config,
+            verify=ssl_verify,
         )
     elif aws_role_name is not None and aws_session_name is not None:
         # use sts if role name passed in
@@ -694,6 +698,7 @@ def init_bedrock_client(
             region_name=region_name,
             endpoint_url=endpoint_url,
             config=config,
+            verify=ssl_verify,
         )
     elif aws_access_key_id is not None:
         # uses auth params passed to completion
@@ -706,6 +711,7 @@ def init_bedrock_client(
             region_name=region_name,
             endpoint_url=endpoint_url,
             config=config,
+            verify=ssl_verify,
         )
     elif aws_profile_name is not None:
         # uses auth values from AWS profile usually stored in ~/.aws/credentials
@@ -715,6 +721,7 @@ def init_bedrock_client(
             region_name=region_name,
             endpoint_url=endpoint_url,
             config=config,
+            verify=ssl_verify,
         )
     else:
         # aws_access_key_id is None, assume user is trying to auth using env variables
@@ -725,6 +732,7 @@ def init_bedrock_client(
             region_name=region_name,
             endpoint_url=endpoint_url,
             config=config,
+            verify=ssl_verify,
         )
     if extra_headers:
         client.meta.events.register(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -35,11 +35,18 @@ class AsyncHTTPHandler:
         self, timeout: Optional[Union[float, httpx.Timeout]], concurrent_limit: int
     ) -> httpx.AsyncClient:
 
-        # Check if the HTTP_PROXY and HTTPS_PROXY environment variables are set and use them accordingly.
-        ssl_verify = bool(os.getenv("SSL_VERIFY", litellm.ssl_verify))
+        # SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts.
+        # /path/to/certificate.pem
+        ssl_verify = os.getenv(
+            "SSL_VERIFY",
+            litellm.ssl_verify
+        )
+        # An SSL certificate used by the requested host to authenticate the client.
+        # /path/to/client.pem
         cert = os.getenv(
-            "SSL_CERTIFICATE", litellm.ssl_certificate
-        )  # /path/to/client.pem
+            "SSL_CERTIFICATE",
+            litellm.ssl_certificate
+        )
 
         if timeout is None:
             timeout = _DEFAULT_TIMEOUT
@@ -212,11 +219,18 @@ class HTTPHandler:
         if timeout is None:
             timeout = _DEFAULT_TIMEOUT
 
-        # Check if the HTTP_PROXY and HTTPS_PROXY environment variables are set and use them accordingly.
-        ssl_verify = bool(os.getenv("SSL_VERIFY", litellm.ssl_verify))
+        # SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts.
+        # /path/to/certificate.pem
+        ssl_verify = os.getenv(
+            "SSL_VERIFY",
+            litellm.ssl_verify
+        )
+        # An SSL certificate used by the requested host to authenticate the client.
+        # /path/to/client.pem
         cert = os.getenv(
-            "SSL_CERTIFICATE", litellm.ssl_certificate
-        )  # /path/to/client.pem
+            "SSL_CERTIFICATE",
+            litellm.ssl_certificate
+        )
 
         if client is None:
             # Create a client with a connection pool


### PR DESCRIPTION
## Title
<!-- e.g. "Implement user authentication feature" -->
Update the SSL verification

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix


## Changes
<!-- List of changes -->
* Fixes the SSL verification in `AsyncHTTPHandler` or `HTTPHandler`. This fixes the SSL verification for the following providers:
    - OpenAI,
    - Azure OpenAI,
    - Azure AI Studio,
    - and others that use `AsyncHTTPHandler` or `HTTPHandler`
  
* Passes down the `verify` argument (the value is read from `SSL_VERIFY` env var or `litellm.ssl_verify`) in `requests` and `httpx` calls for the following providers:
    - AWS Bedrock
    - HuggingFace

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
**Test procedure:**

Testing was done on MacOS 14.6.1 with an M3 chip.

I've configured a proxy on my local machine that performs TLS interception, so I can test the behavior of products in an environment that emulates a customer setup where this technology is used. For this, I used [Burp Suite Community](https://portswigger.net/burp/communitydownload).

With the BurpSuite Community, I've generated the `certificate.cer` file that is converted to `certificate.pem` with the following command:
```
openssl x509 -inform der -in certificate.cer -out certificate.pem
```

After that in the Settings -> Network -> Proxies, the "Secure Web Proxy (HTTPS)" option was enabled.


### OpenAI:
```
CERTIFICATE_PATH = "/path/to/certificate.pem"

# ASYNC LLM OPENAI

litellm.aclient_session = httpx.AsyncClient(verify=CERTIFICATE_PATH)
response = await litellm.acompletion(
    model="gpt-3.5-turbo",
    messages=[{"content": "We're testing for async completion call!", "role": "user"}],
)
print("OPENAI - LLM ASYNC", response)

# SYNC LLM OPENAI
litellm.client_session = httpx.Client(verify=CERTIFICATE_PATH)
response = litellm.completion(
    model="gpt-3.5-turbo",
    messages=[{"content": "We're testing for sync completion call!", "role": "user"}],
)
print("OPENAI - LLM SYNC", response)

# ASYNC EMBEDDINGS OPENAI
litellm.aclient_session = httpx.AsyncClient(verify=CERTIFICATE_PATH)
response = await litellm.aembedding(
    model="text-embedding-3-small",
    input=["We're testing for async embedding call!"]
)
print("OPENAI - EMBEDDINGS ASYNC", response)

# SYNC EMBEDDINGS OPENAI
litellm.client_session = httpx.Client(verify=CERTIFICATE_PATH)
response = litellm.embedding(
    model="text-embedding-3-small",
    input=["We're testing for sync embedding call!"]
)
print("OPENAI - EMBEDDINGS SYNC", response)
```
Responses:
<img width="1725" alt="Screenshot 2024-08-20 at 15 18 34" src="https://github.com/user-attachments/assets/40cc1156-dfab-4d6e-b47d-ea72d4b87ba4">

### Azure OpenAI
```
CERTIFICATE_PATH = "/path/to/certificate.pem"

# ASYNC LLM AZURE OPENAI
litellm.aclient_session = httpx.AsyncClient(verify=CERTIFICATE_PATH)
response = await litellm.acompletion(
    model="azure/our-deployment",
    api_version="2023-03-15-preview",
    api_base="our-deployment-base",
    messages=[
        {
            "content": "We're testing for async completion call (Azure this time)!",
            "role": "user"
        }
    ],
)
print("AZURE OPENAI - LLM ASYNC", response)

# SYNC LLM AZURE OPENAI
litellm.client_session = httpx.Client(verify=CERTIFICATE_PATH)
response = litellm.completion(
    model="azure/our-deployment",
    api_version="2023-03-15-preview",
    api_base="our-deployment-base",
    messages=[
        {
            "content": "We're testing for sync completion call (Azure this time)!",
            "role": "user"
        }
    ],
)
print("AZURE OPENAI - LLM SYNC", response)

# ASYNC EMBEDDINGS AZURE OPENAI
litellm.aclient_session = httpx.AsyncClient(verify=CERTIFICATE_PATH)
response = await litellm.aembedding(
    model="azure/our-deployment",
    api_version="2023-05-15",
    api_base="our-deployment-base",
    input=["We're testing for async embedding call! (Azure this time)!"],
)
print("AZURE OPENAI - EMBEDDINGS ASYNC", response)

# SYNC EMBEDDINGS AZURE OPENAI
litellm.client_session = httpx.Client(verify=CERTIFICATE_PATH)
response = litellm.embedding(
    model="azure/our-deployment",
    api_version="2023-03-15-preview",
    api_base="our-deployment-base",
    input=["We're testing for sync embedding call! (Azure this time)!"],

)
print("AZURE OPENAI - EMBEDDINGS SYNC", response)
```
Responses:
<img width="1725" alt="Screenshot 2024-08-20 at 15 51 03" src="https://github.com/user-attachments/assets/13915542-c83c-47c8-83ed-1cb8fce434d2">

### Azure AI Studio

```
# ASYNC LLM
litellm.aclient_session = httpx.AsyncClient(verify=CERTIFICATE_PATH)
response = await litellm.acompletion(
    model="azure_ai/our-deployment",
    api_base="our-deployment-base",
    messages=[{"content": "We're testing for async completion call! (Azure AI Studio serverless this time)!", "role": "user"}]
)
print("AZURE AI STUDIO - LLM ASYNC", response)

# SYNC LLM
litellm.client_session = httpx.Client(verify=CERTIFICATE_PATH)
response = litellm.completion(
    model="azure_ai/our-deployment",
    api_base="our-deployment-base",
    messages=[{"content": "We're testing for sync completion call! (Azure AI Studio serverless this time)!", "role": "user"}]
)
print("AZURE AI STUDIO - LLM SYNC", response)
```
Responses:
<img width="1725" alt="Screenshot 2024-08-20 at 16 00 08" src="https://github.com/user-attachments/assets/909aaa0f-2234-48df-90e5-84b92f3032e8">


### AWS Bedrock
```
CERTIFICATE_PATH = "/path/to/certificate.pem"
litellm.ssl_verify = CERTIFICATE_PATH

# ASYNC LLM
response = await litellm.acompletion(
    model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
    messages=[{"content": "We're testing for async completion call! (Bedrock serverless this time)!", "role": "user"}],
    temperature=0.7,
    top_p=1
)
print("AWS BEDROCK - LLM ASYNC", response)

# SYNC LLM
response = litellm.completion(
    model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
    messages=[{"content": "We're testing for async completion call! (Bedrock serverless this time)!", "role": "user"}],
    temperature=0.7,
    top_p=1
)
print("AWS BEDROCK - LLM SYNC", response)

# ASYNC EMBEDDINGS
litellm.ssl_verify = CERTIFICATE_PATH
response = await litellm.aembedding(
    model="bedrock/cohere.embed-english-v3",
    input=["We're testing for async embedding call! (Bedrock serverless this time)!"],
)
print("AWS BEDROCK - EMBEDDINGS ASYNC", response)

# SYNC EMBEDDINGS
response = litellm.embedding(
    model="bedrock/cohere.embed-english-v3",
    input=["We're testing for sync embedding call! (Bedrock serverless this time)!"],
)
print("AWS BEDROCK - EMBEDDINGS SYNC", response)
```
Responses:
<img width="1725" alt="Screenshot 2024-08-20 at 16 06 18" src="https://github.com/user-attachments/assets/b65fc92e-37ea-4516-a712-0f5add6546e2">

### HuggingFace
```
response = await litellm.acompletion(
    model="huggingface/HuggingFaceH4/zephyr-7b-beta",
    api_base="our-deployment-base",
    messages=[
        {
            "content": "We're testing for sync completion call (HF dedicated this time)!",
            "role": "user"
        }
    ],
    # options={"wait_for_model": "true"}
)
print("HUGGINGFACE - LLM ASYNC", response)

# SYNC LLM
# Workaround for sync
os.environ["REQUESTS_CA_BUNDLE"] = CERTIFICATE_PATH
response = litellm.completion(
    model="huggingface/HuggingFaceH4/zephyr-7b-beta",
    api_base="our-deployment-base",
    messages=[
        {
            "content": "We're testing for sync completion call (HF dedicated this time)!",
            "role": "user"
        }
    ],
)
print("HUGGINGFACE - LLM SYNC", response)

# ASYNC EMBEDDINGS
# Workaround still applies
# os.environ["SSL_CERT_FILE"] = CERTIFICATE_PATH2
response = await litellm.aembedding(
    model="huggingface/BAAI/bge-large-en-v1.5 ",
    api_base="our-deployment-base",
    input=["We're testing for async embedding call! (HF dedicated this time)!"],
)
print("HUGGINGFACE - EMBEDDING ASYNC", response)

# SYNC EMBEDDINGS
# Workaround still applies
# os.environ["REQUESTS_CA_BUNDLE"] = CERTIFICATE_PATH
response = litellm.embedding(
    model="huggingface/BAAI/bge-large-en-v1.5 ",
    api_base="our-deployment-base",
    input=["We're testing for sync embedding call! (HF dedicated this time)!"],
)
print("HUGGINGFACE - EMBEDDING SYNC", response)
```
Response:
<img width="1725" alt="Screenshot 2024-08-20 at 16 24 03" src="https://github.com/user-attachments/assets/63ca99a5-198e-4ae6-baeb-4b3367fa1024">
