### PR TITLE
fix/docs: was missing a beta model from openrouter of claude sonnet

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2795,6 +2795,18 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
+    "openrouter/anthropic/claude-3.5-sonnet:beta": {
+        "max_tokens": 4096,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159
+    },
     "openrouter/anthropic/claude-3-sonnet": {
         "max_tokens": 200000,
         "input_cost_per_token": 0.000003,


### PR DESCRIPTION
## Title

Hi,
A model was missing from openrouter : https://openrouter.ai/models/anthropic/claude-3.5-sonnet:beta/api

It was causing all kinds of issue because the vision is by default set to False if no model is found.

Pinging @krrishdholakia because I know you're super fast :D

Have a nice day everyone, litellm rocks!

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation

## Changes

Add missing model in the model_prices_and_context_window.json

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
Irrelevant
