### PR TITLE
add checksum/config pod annotation

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "litellm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config-litellm.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "litellm.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config-litellm.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Title

Add checksum/config pod annotation

## Type

🚄 Infrastructure

## Changes

When changes are made to the config and a `helm update` is performed, the LiteLLM config map is updated, but the pods are not restarted to pick up the config changes. I followed the process outlined in the [Helm documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) to add a pod annotation with the checksum of the config file. Now, any time a change to the config is made, the checksum value will change, `helm update` will change the pod annotation value, forcing a restart of the pods.

## [REQUIRED] Testing 

```
$ helm lint                                                                                                 
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

