### PR TITLE
Support LangSmith parent_run_id, trace_id, session_id

### DIFF
--- a/docs/my-website/docs/observability/callbacks.md
+++ b/docs/my-website/docs/observability/callbacks.md
@@ -8,6 +8,7 @@ liteLLM supports:
 
 - [Custom Callback Functions](https://docs.litellm.ai/docs/observability/custom_callback)
 - [Langfuse](https://langfuse.com/docs)
+- [LangSmith](https://www.langchain.com/langsmith)
 - [Helicone](https://docs.helicone.ai/introduction)
 - [Traceloop](https://traceloop.com/docs)
 - [Lunary](https://lunary.ai/docs)

--- a/docs/my-website/docs/observability/langsmith_integration.md
+++ b/docs/my-website/docs/observability/langsmith_integration.md
@@ -56,7 +56,7 @@ response = litellm.completion(
 ```
 
 ## Advanced
-### Set Langsmith fields - Custom Projec, Run names, tags
+### Set Langsmith fields
 
 ```python
 import litellm
@@ -75,9 +75,17 @@ response = litellm.completion(
         {"role": "user", "content": "Hi 👋 - i'm openai"}
     ],
     metadata={
-        "run_name": "litellmRUN",               # langsmith run name
-        "project_name": "litellm-completion",   # langsmith project name
-        "tags": ["model1", "prod-2"]            # tags to log on langsmith
+        "run_name": "litellmRUN",                                   # langsmith run name
+        "project_name": "litellm-completion",                       # langsmith project name
+        "run_id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",           # langsmith run id
+        "parent_run_id": "f8faf8c1-9778-49a4-9004-628cdb0047e5",    # langsmith run parent run id
+        "trace_id": "df570c03-5a03-4cea-8df0-c162d05127ac",         # langsmith run trace id
+        "session_id": "1ffd059c-17ea-40a8-8aef-70fd0307db82",       # langsmith run session id
+        "tags": ["model1", "prod-2"],                               # langsmith run tags
+        "metadata": {                                               # langsmith run metadata
+            "key1": "value1"
+        },
+        "dotted_order": "20240429T004912090000Z497f6eca-6276-4993-bfeb-53cbbbba6f08"
     }
 )
 print(response)

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -98,6 +98,10 @@ class LangsmithLogger(CustomLogger):
         project_name = metadata.get("project_name", self.langsmith_project)
         run_name = metadata.get("run_name", self.langsmith_default_run_name)
         run_id = metadata.get("id", None)
+        parent_run_id = metadata.get("parent_run_id", None)
+        trace_id = metadata.get("trace_id", None)
+        session_id = metadata.get("session_id", None)
+        dotted_order = metadata.get("dotted_order", None)
         tags = metadata.get("tags", []) or []
         verbose_logger.debug(
             f"Langsmith Logging - project_name: {project_name}, run_name {run_name}"
@@ -148,6 +152,18 @@ class LangsmithLogger(CustomLogger):
 
         if run_id:
             data["id"] = run_id
+
+        if parent_run_id:
+            data["parent_run_id"] = parent_run_id
+
+        if trace_id:
+            data["trace_id"] = trace_id
+
+        if session_id:
+            data["session_id"] = session_id
+
+        if dotted_order:
+            data["dotted_order"] = dotted_order
 
         verbose_logger.debug("Langsmith Logging data on langsmith: %s", data)
 


### PR DESCRIPTION
## Title

Support LangSmith parent_run_id, trace_id, session_id

## Relevant issues

#5320

## Type

🆕 New Feature

## Changes

Add support for the following LangSmith fields:
* parent_run_id
* trace_id
* session_id
* dotted_order

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

Create a function with `@langsmith.traceable` annotation that has a parameter called `run_tree`. Then use run_tree.id as the parent_run_id:
![image](https://github.com/user-attachments/assets/6922e3d4-7000-4ac6-a7e8-61ae742fbee7)

