### PR TITLE
Update caching.py to allow disable redis cache by set ttl <= 0

### DIFF
--- a/litellm/caching.py
+++ b/litellm/caching.py
@@ -284,6 +284,8 @@ class RedisCache(BaseCache):
 
     def set_cache(self, key, value, **kwargs):
         ttl = kwargs.get("ttl", None)
+        if ttl <= 0:
+            return
         print_verbose(
             f"Set Redis Cache: key: {key}\nValue {value}\nttl={ttl}, redis_version={self.redis_version}"
         )


### PR DESCRIPTION
## Ignore Redis cache when ttl <= 0
- This PR allow user to disable redis by set cache ttl = 0 in the config and enable per request by pass custom ttl

## Relevant issues
- No
## Type
🆕 New Feature

## Changes
- Disable caching when ttl <= 0