### PR TITLE
docs: Add pricing for imagen-3 and imagen-3-fast

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2189,6 +2189,18 @@
         "mode": "image_generation",
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
+    "vertex_ai/imagen-3.0-generate-001": {
+        "cost_per_image": 0.04,
+        "litellm_provider": "vertex_ai-image-models",
+        "mode": "image_generation",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
+    },
+    "vertex_ai/imagen-3.0-fast-generate-001": {
+        "cost_per_image": 0.02,
+        "litellm_provider": "vertex_ai-image-models",
+        "mode": "image_generation",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
+    },
     "text-embedding-004": {
         "max_tokens": 3072,
         "max_input_tokens": 3072,


### PR DESCRIPTION
## Add pricing for `imagen-3` and `imagen-3-fast`

https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/imagen-3.0-generate-001
https://cloud.google.com/vertex-ai/generative-ai/pricing#imagen-models

![image](https://github.com/user-attachments/assets/04427229-33cc-4d6d-8370-4c3c5b7e9c42)

## Relevant issues

N/A

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation

## Changes

Add pricing for Google's newest image generation models to `model_prices_and_context_window.json`

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

N/A