### PR TITLE
fix(factory.py): handle missing 'content' in cohere assistant messages

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -1781,7 +1781,7 @@ def cohere_messages_pt_v2(
         assistant_tool_calls: List[ToolCallObject] = []
         ## MERGE CONSECUTIVE ASSISTANT CONTENT ##
         while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
-            if isinstance(messages[msg_i]["content"], list):
+            if messages[msg_i].get("content", None) is not None and  isinstance(messages[msg_i]["content"], list):
                 for m in messages[msg_i]["content"]:
                     if m.get("type", "") == "text":
                         assistant_content += m["text"]


### PR DESCRIPTION
I'll fill out the template based on the information we've discussed:

## Title
Handle missing 'content' in assistant messages for Cohere's command-r-plus model

## Relevant issues


## Type
🐛 Bug Fix

## Changes
- Update cohere_messages_pt_v2 function to check for 'content' existence
Fixes #5382 
## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
