### PR TITLE
docs: add time.sleep() between streaming calls

### DIFF
--- a/docs/my-website/docs/caching/caching_api.md
+++ b/docs/my-website/docs/caching/caching_api.md
@@ -51,8 +51,10 @@ LiteLLM can cache your streamed responses for you
 ### Usage
 ```python
 import litellm
+import time
 from litellm import completion
 from litellm.caching import Cache
+
 litellm.cache = Cache(type="hosted")
 
 # Make completion calls
@@ -64,6 +66,7 @@ response1 = completion(
 for chunk in response1:
     print(chunk)
 
+time.sleep(1) # cache is updated asynchronously
 
 response2 = completion(
     model="gpt-3.5-turbo", 


### PR DESCRIPTION
## Title

Add time.sleep() between streaming calls. LiteLLM's cache appears to be updated in the background. Without this `time.sleep()` call, both responses take `0.8s` to return, but after adding it, the second response returns in `0.006s`.


## Relevant issues

None

## Type

📖 Documentation

## Changes

- Add time.sleep() between streaming calls