### PR TITLE
Use patch instead of apatch for instructor

### DIFF
--- a/docs/my-website/docs/tutorials/instructor.md
+++ b/docs/my-website/docs/tutorials/instructor.md
@@ -57,7 +57,7 @@ from litellm import Router
 import instructor, asyncio
 from pydantic import BaseModel
 
-aclient = instructor.apatch(
+aclient = instructor.patch(
     Router(
         model_list=[
             {


### PR DESCRIPTION
## Use patch instead of apatch for instructor

`apatch` is deprecated, see [this](https://github.com/jxnl/instructor/blob/main/instructor/patch.py#L179-L182) 

## Type

📖 Documentation

