### PR TITLE
fix TypeError: 'CompletionUsage' object is not subscriptable

### DIFF
--- a/litellm/integrations/langfuse.py
+++ b/litellm/integrations/langfuse.py
@@ -300,8 +300,8 @@ class LangFuseLogger:
                 prompt=input,
                 completion=output,
                 usage={
-                    "prompt_tokens": response_obj["usage"]["prompt_tokens"],
-                    "completion_tokens": response_obj["usage"]["completion_tokens"],
+                    "prompt_tokens": response_obj.usage.prompt_tokens,
+                    "completion_tokens": response_obj.usage.completion_tokens,
                 },
                 metadata=metadata,
             )
@@ -526,8 +526,8 @@ class LangFuseLogger:
             if response_obj is not None and response_obj.get("id", None) is not None:
                 generation_id = litellm.utils.get_logging_id(start_time, response_obj)
                 usage = {
-                    "prompt_tokens": response_obj["usage"]["prompt_tokens"],
-                    "completion_tokens": response_obj["usage"]["completion_tokens"],
+                    "prompt_tokens": response_obj.usage.prompt_tokens,
+                    "completion_tokens": response_obj.usage.completion_tokens,
                     "total_cost": cost if supports_costs else None,
                 }
             generation_name = clean_metadata.pop("generation_name", None)


### PR DESCRIPTION
## Title

fix TypeError: 'CompletionUsage' object is not subscriptable

## Relevant issues

Langfuse with Litellm works well at the most time, but when I use tool call, litellm raises an error:

18:20:53 - LiteLLM:ERROR: langfuse.py:587 - Langfuse Layer Error - Traceback (most recent call last):
File "/Users/yafeilee/Library/Caches/pypoetry/virtualenvs/heracles-K5sKTMQ3-py3.11/lib/python3.11/site-packages/litellm/integrations/langfuse.py", line 530,
in _log_langfuse_v2
"prompt-tokens" response-obj ［ usage"Jr prompt-tokens"］
ypeError: 'CompletionUsage' object is not

The reason I found is that sometimes the system returns a CompletionUsage that does not support dictionary-style access, while most of the time it returns Usage that supports dictionary access. This issue is more likely to occur during streaming or function calls.



## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

