### PR TITLE
[Feat-Proxy] Load config.yaml from GCS Bucket

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -705,11 +705,36 @@ docker run ghcr.io/berriai/litellm:main-latest \
 
 Provide an ssl certificate when starting litellm proxy server 
 
-### 3. Providing LiteLLM config.yaml file as a s3 Object/url
+### 3. Providing LiteLLM config.yaml file as a s3, GCS Bucket Object/url
 
 Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)
 
-LiteLLM Proxy will read your config.yaml from an s3 Bucket
+LiteLLM Proxy will read your config.yaml from an s3 Bucket or GCS Bucket 
+
+<Tabs>
+<TabItem value="gcs" label="GCS Bucket">
+
+Set the following .env vars 
+```shell
+LITELLM_CONFIG_BUCKET_TYPE = "gcs"                              # set this to "gcs"         
+LITELLM_CONFIG_BUCKET_NAME = "litellm-proxy"                    # your bucket name on GCS
+LITELLM_CONFIG_BUCKET_OBJECT_KEY = "proxy_config.yaml"         # object key on GCS
+```
+
+Start litellm proxy with these env vars - litellm will read your config from s3 
+
+```shell
+docker run --name litellm-proxy \
+   -e DATABASE_URL=<database_url> \
+   -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
+   -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
+   -p 4000:4000 \
+   ghcr.io/berriai/litellm-database:main-latest --detailed_debug
+```
+
+</TabItem>
+
+<TabItem value="s3" label="s3">
 
 Set the following .env vars 
 ```shell
@@ -727,6 +752,8 @@ docker run --name litellm-proxy \
    -p 4000:4000 \
    ghcr.io/berriai/litellm-database:main-latest
 ```
+</TabItem>
+</Tabs>
 
 ## Platform-specific Guide
 

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -721,13 +721,14 @@ LITELLM_CONFIG_BUCKET_NAME = "litellm-proxy"                    # your bucket na
 LITELLM_CONFIG_BUCKET_OBJECT_KEY = "proxy_config.yaml"         # object key on GCS
 ```
 
-Start litellm proxy with these env vars - litellm will read your config from s3 
+Start litellm proxy with these env vars - litellm will read your config from GCS 
 
 ```shell
 docker run --name litellm-proxy \
    -e DATABASE_URL=<database_url> \
    -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
    -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
+   -e LITELLM_CONFIG_BUCKET_TYPE="gcs" \
    -p 4000:4000 \
    ghcr.io/berriai/litellm-database:main-latest --detailed_debug
 ```

--- a/litellm/integrations/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 import litellm
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.integrations.gcs_bucket_base import GCSBucketBase
 from litellm.litellm_core_utils.logging_utils import (
     convert_litellm_response_object_to_dict,
 )
@@ -34,24 +35,14 @@ class GCSBucketPayload(TypedDict):
     log_event_type: Optional[str]
 
 
-class GCSBucketLogger(CustomLogger):
-    def __init__(self) -> None:
+class GCSBucketLogger(GCSBucketBase):
+    def __init__(self, bucket_name: Optional[str] = None) -> None:
         from litellm.proxy.proxy_server import premium_user
 
+        super().__init__(bucket_name=bucket_name)
         if premium_user is not True:
             raise ValueError(
                 f"GCS Bucket logging is a premium feature. Please upgrade to use it. {CommonProxyErrors.not_premium_user.value}"
-            )
-
-        self.async_httpx_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=600.0, connect=5.0)
-        )
-        self.path_service_account_json = os.getenv("GCS_PATH_SERVICE_ACCOUNT", None)
-        self.BUCKET_NAME = os.getenv("GCS_BUCKET_NAME", None)
-
-        if self.BUCKET_NAME is None:
-            raise ValueError(
-                "GCS_BUCKET_NAME is not set in the environment, but GCS Bucket is being used as a logging callback. Please set 'GCS_BUCKET_NAME' in the environment."
             )
 
         if self.path_service_account_json is None:
@@ -158,27 +149,6 @@ class GCSBucketLogger(CustomLogger):
         except Exception as e:
             verbose_logger.error("GCS Bucket logging error: %s", str(e))
 
-    async def construct_request_headers(self) -> Dict[str, str]:
-        from litellm import vertex_chat_completion
-
-        auth_header, _ = vertex_chat_completion._get_token_and_url(
-            model="gcs-bucket",
-            vertex_credentials=self.path_service_account_json,
-            vertex_project=None,
-            vertex_location=None,
-            gemini_api_key=None,
-            stream=None,
-            custom_llm_provider="vertex_ai",
-            api_base=None,
-        )
-        verbose_logger.debug("constructed auth_header %s", auth_header)
-        headers = {
-            "Authorization": f"Bearer {auth_header}",  # auth_header
-            "Content-Type": "application/json",
-        }
-
-        return headers
-
     async def get_gcs_payload(
         self, kwargs, response_obj, start_time, end_time
     ) -> GCSBucketPayload:
@@ -225,65 +195,3 @@ class GCSBucketLogger(CustomLogger):
         )
 
         return gcs_payload
-
-    async def download_gcs_object(self, object_name):
-        """
-        Download an object from GCS.
-
-        https://cloud.google.com/storage/docs/downloading-objects#download-object-json
-        """
-        try:
-            headers = await self.construct_request_headers()
-            url = f"https://storage.googleapis.com/storage/v1/b/{self.BUCKET_NAME}/o/{object_name}?alt=media"
-
-            # Send the GET request to download the object
-            response = await self.async_httpx_client.get(url=url, headers=headers)
-
-            if response.status_code != 200:
-                verbose_logger.error(
-                    "GCS object download error: %s", str(response.text)
-                )
-                return None
-
-            verbose_logger.debug(
-                "GCS object download response status code: %s", response.status_code
-            )
-
-            # Return the content of the downloaded object
-            return response.content
-
-        except Exception as e:
-            verbose_logger.error("GCS object download error: %s", str(e))
-            return None
-
-    async def delete_gcs_object(self, object_name):
-        """
-        Delete an object from GCS.
-        """
-        try:
-            headers = await self.construct_request_headers()
-            url = f"https://storage.googleapis.com/storage/v1/b/{self.BUCKET_NAME}/o/{object_name}"
-
-            # Send the DELETE request to delete the object
-            response = await self.async_httpx_client.delete(url=url, headers=headers)
-
-            if (response.status_code != 200) or (response.status_code != 204):
-                verbose_logger.error(
-                    "GCS object delete error: %s, status code: %s",
-                    str(response.text),
-                    response.status_code,
-                )
-                return None
-
-            verbose_logger.debug(
-                "GCS object delete response status code: %s, response: %s",
-                response.status_code,
-                response.text,
-            )
-
-            # Return the content of the downloaded object
-            return response.text
-
-        except Exception as e:
-            verbose_logger.error("GCS object download error: %s", str(e))
-            return None

--- a/litellm/integrations/gcs_bucket_base.py
+++ b/litellm/integrations/gcs_bucket_base.py
@@ -1,0 +1,115 @@
+import json
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+import httpx
+from pydantic import BaseModel, Field
+
+import litellm
+from litellm._logging import verbose_logger
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.logging_utils import (
+    convert_litellm_response_object_to_dict,
+)
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+
+class GCSBucketBase(CustomLogger):
+    def __init__(self, bucket_name: Optional[str] = None) -> None:
+        from litellm.proxy.proxy_server import premium_user
+
+        self.async_httpx_client = AsyncHTTPHandler(
+            timeout=httpx.Timeout(timeout=600.0, connect=5.0)
+        )
+        self.path_service_account_json = os.getenv("GCS_PATH_SERVICE_ACCOUNT", None)
+        self.BUCKET_NAME = bucket_name or os.getenv("GCS_BUCKET_NAME", None)
+
+        if self.BUCKET_NAME is None:
+            raise ValueError(
+                "GCS_BUCKET_NAME is not set in the environment, but GCS Bucket is being used as a logging callback. Please set 'GCS_BUCKET_NAME' in the environment."
+            )
+
+    async def construct_request_headers(self) -> Dict[str, str]:
+        from litellm import vertex_chat_completion
+
+        auth_header, _ = vertex_chat_completion._get_token_and_url(
+            model="gcs-bucket",
+            vertex_credentials=self.path_service_account_json,
+            vertex_project=None,
+            vertex_location=None,
+            gemini_api_key=None,
+            stream=None,
+            custom_llm_provider="vertex_ai",
+            api_base=None,
+        )
+        verbose_logger.debug("constructed auth_header %s", auth_header)
+        headers = {
+            "Authorization": f"Bearer {auth_header}",  # auth_header
+            "Content-Type": "application/json",
+        }
+
+        return headers
+
+    async def download_gcs_object(self, object_name):
+        """
+        Download an object from GCS.
+
+        https://cloud.google.com/storage/docs/downloading-objects#download-object-json
+        """
+        try:
+            headers = await self.construct_request_headers()
+            url = f"https://storage.googleapis.com/storage/v1/b/{self.BUCKET_NAME}/o/{object_name}?alt=media"
+
+            # Send the GET request to download the object
+            response = await self.async_httpx_client.get(url=url, headers=headers)
+
+            if response.status_code != 200:
+                verbose_logger.error(
+                    "GCS object download error: %s", str(response.text)
+                )
+                return None
+
+            verbose_logger.debug(
+                "GCS object download response status code: %s", response.status_code
+            )
+
+            # Return the content of the downloaded object
+            return response.content
+
+        except Exception as e:
+            verbose_logger.error("GCS object download error: %s", str(e))
+            return None
+
+    async def delete_gcs_object(self, object_name):
+        """
+        Delete an object from GCS.
+        """
+        try:
+            headers = await self.construct_request_headers()
+            url = f"https://storage.googleapis.com/storage/v1/b/{self.BUCKET_NAME}/o/{object_name}"
+
+            # Send the DELETE request to delete the object
+            response = await self.async_httpx_client.delete(url=url, headers=headers)
+
+            if (response.status_code != 200) or (response.status_code != 204):
+                verbose_logger.error(
+                    "GCS object delete error: %s, status code: %s",
+                    str(response.text),
+                    response.status_code,
+                )
+                return None
+
+            verbose_logger.debug(
+                "GCS object delete response status code: %s, response: %s",
+                response.status_code,
+                response.text,
+            )
+
+            # Return the content of the downloaded object
+            return response.text
+
+        except Exception as e:
+            verbose_logger.error("GCS object download error: %s", str(e))
+            return None

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -42,11 +42,30 @@ def get_file_contents_from_s3(bucket_name, object_key):
             config = yaml.safe_load(yaml_file)
 
         return config
-    except ImportError:
+    except ImportError as e:
         # this is most likely if a user is not using the litellm docker container
         verbose_proxy_logger.error(f"ImportError: {str(e)}")
         pass
     except Exception as e:
+        verbose_proxy_logger.error(f"Error retrieving file contents: {str(e)}")
+        return None
+
+
+async def get_config_file_contents_from_gcs(bucket_name, object_key):
+    try:
+        from litellm.integrations.gcs_bucket import GCSBucketLogger
+
+        gcs_bucket = GCSBucketLogger(
+            bucket_name=bucket_name,
+        )
+        file_contents = await gcs_bucket.download_gcs_object(object_key)
+        # file_contentis is a bytes object, so we need to convert it to yaml
+        file_contents = file_contents.decode("utf-8")
+        # convert to yaml
+        config = yaml.safe_load(file_contents)
+        return config
+
+    except:
         verbose_proxy_logger.error(f"Error retrieving file contents: {str(e)}")
         return None
 

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -53,9 +53,9 @@ def get_file_contents_from_s3(bucket_name, object_key):
 
 async def get_config_file_contents_from_gcs(bucket_name, object_key):
     try:
-        from litellm.integrations.gcs_bucket import GCSBucketLogger
+        from litellm.integrations.gcs_bucket_base import GCSBucketBase
 
-        gcs_bucket = GCSBucketLogger(
+        gcs_bucket = GCSBucketBase(
             bucket_name=bucket_name,
         )
         file_contents = await gcs_bucket.download_gcs_object(object_key)


### PR DESCRIPTION
## Title

Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)

LiteLLM Proxy will read your config.yaml from an s3 Bucket or GCS Bucket 

<Tabs>
<TabItem value="gcs" label="GCS Bucket">

Set the following .env vars 
```shell
LITELLM_CONFIG_BUCKET_TYPE = "gcs"                              # set this to "gcs"         
LITELLM_CONFIG_BUCKET_NAME = "litellm-proxy"                    # your bucket name on GCS
LITELLM_CONFIG_BUCKET_OBJECT_KEY = "proxy_config.yaml"         # object key on GCS
```

Start litellm proxy with these env vars - litellm will read your config from GCS 

```shell
docker run --name litellm-proxy \
   -e DATABASE_URL=<database_url> \
   -e LITELLM_CONFIG_BUCKET_NAME=<bucket_name> \
   -e LITELLM_CONFIG_BUCKET_OBJECT_KEY="<object_key>> \
   -e LITELLM_CONFIG_BUCKET_TYPE="gcs" \
   -p 4000:4000 \
   ghcr.io/berriai/litellm-database:main-latest --detailed_debug
```
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

