### PR TITLE
Solving budget info update if the budget id exists

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6226,15 +6226,38 @@ async def new_budget(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
-    response = await prisma_client.db.litellm_budgettable.create(
-        data={
-            **budget_obj.model_dump(exclude_none=True),  # type: ignore
-            "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-            "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-        }  # type: ignore
-    )
+    try:
+        # Check if the budget already exists
+        existing_budget = await prisma_client.db.litellm_budgettable.find_unique(
+            where={"budget_id": budget_obj.budget_id}
+        )
+    
+        if existing_budget:
+            # Update the existing budget
+            response = await prisma_client.db.litellm_budgettable.update(
+                where={"budget_id": budget_obj.budget_id},
+                data={
+                    **budget_obj.model_dump(exclude_none=True),  # type: ignore
+                    "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                }
+            )
+        else:
+            # Create a new budget
+            response = await prisma_client.db.litellm_budgettable.create(
+                data={
+                    **budget_obj.model_dump(exclude_none=True),  # type: ignore
+                    "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                    "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                }  # type: ignore
+            )
 
-    return response
+        return response
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to create or update budget: {str(e)}"},
+        )
 
 
 @router.post(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6227,32 +6227,20 @@ async def new_budget(
         )
 
     try:
-        # Check if the budget already exists
-        existing_budget = await prisma_client.db.litellm_budgettable.find_unique(
-            where={"budget_id": budget_obj.budget_id}
-        )
-    
-        if existing_budget:
-            # Update the existing budget
-            response = await prisma_client.db.litellm_budgettable.update(
-                where={"budget_id": budget_obj.budget_id},
-                data={
-                    **budget_obj.model_dump(exclude_none=True),  # type: ignore
-                    "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                }
-            )
-        else:
-            # Create a new budget
-            response = await prisma_client.db.litellm_budgettable.create(
-                data={
-                    **budget_obj.model_dump(exclude_none=True),  # type: ignore
-                    "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                    "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                }  # type: ignore
-            )
-
+        
+        response = await prisma_client.db.litellm_budgettable.upsert(
+            where={"budget_id": budget_obj.budget_id},
+            data = {
+            "create": {
+                **budget_obj.model_dump(exclude_none=True),  # type: ignore
+                "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,},
+            "update": {
+                **budget_obj.model_dump(exclude_none=True),  # type: ignore
+                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,}}
+           )
         return response
-
+        
     except Exception as e:
         raise HTTPException(
             status_code=500,


### PR DESCRIPTION
## Title
Solving Budget Information Update If the Budget ID Exists

## Relevant Issues
N/A

## Type
🐛 Bug Fix

## Changes
- **Added existence check for the budget ID**: The function now checks if a budget entry with the provided `budget_id` already exists in the database.
  - **Logic Added**: The function uses `prisma_client.db.litellm_budgettable.find_unique()` to determine if a budget with the given `budget_id` exists.
- **Updated or created budget entry**:
  - If the budget ID exists, the entry is updated with the new data using `prisma_client.db.litellm_budgettable.update()`.
  - If the budget ID does not exist, a new budget entry is created using `prisma_client.db.litellm_budgettable.create()`.
- **Improved error handling**: Wrapped the database operations in a try-except block to catch potential exceptions, ensuring that any failure during the creation or update process results in a descriptive HTTP exception with a 500 status code.

## [REQUIRED] Testing
- **Screenshot**: The attached video shows the updated function behavior
- **Testing Procedure**:
  1. **Check for existing budget**: Ensure that an update is performed if the budget ID already exists in the database.
  2. **Create a new budget**: Validate that a new budget entry is created when the budget ID does not exist.
  3. **Error Handling**: Verify that appropriate error messages are returned if an exception occurs during the process.
[litellm_budget_update.webm](https://github.com/user-attachments/assets/e7ab6d65-4795-473c-afff-3260310db6e9)

No UI changes are involved, so no additional screenshots or GIFs are provided.
