### PR TITLE
Fix response_format={'type': 'json_object'} not working for Azure models

### DIFF
--- a/litellm/llms/azure.py
+++ b/litellm/llms/azure.py
@@ -272,6 +272,8 @@ class AzureOpenAIConfig:
                     optional_params["tools"] = [_tool]
                     optional_params["tool_choice"] = _tool_choice
                     optional_params["json_mode"] = True
+                else:
+                    optional_params["response_format"] = value
             elif param in supported_openai_params:
                 optional_params[param] = value
 


### PR DESCRIPTION
## Fix `response_format={'type': 'json_object'}` not working for Azure models

## Relevant issues

Fixes #5467 

## Type

🐛 Bug Fix

## Changes

Adds an else statement to the condition in [llms.azure.map_params (line 257)](https://github.com/BerriAI/litellm/blob/main/litellm/llms/azure.py#L257) so that - when a schema is not passed - it always fallbacks to the value passed to `response_format`.

```python
def map_openai_params(...):
  for param, value in non_default_params.items():
    if param == "tool_choice":
      ...
    elif param == "response_format" and isinstance(value, dict):
        json_schema: Optional[dict] = None
        ...
        if json_schema is not None:
            ...
         # NEW CHANGES
        else: # <-
            optional_params["response_format"] = value # <-
     ...
   return optional_params
```

## Testing

`python -m mypy ./llms/azure.py --ignore-missing-imports`

![image](https://github.com/user-attachments/assets/ad80f203-902b-437f-8c43-d27e5b0c48f5)


