### PR TITLE
[PRICING] Add pricing for ft:gpt-3.5-turbo-*

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -286,6 +286,33 @@
         "mode": "chat"
     },
     "ft:gpt-3.5-turbo": {
+        "max_tokens": 16385,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000006,
+        "litellm_provider": "openai",
+        "mode": "chat"
+    },
+    "ft:gpt-3.5-turbo-0125": {
+        "max_tokens": 16385,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000006,
+        "litellm_provider": "openai",
+        "mode": "chat"
+    },
+    "ft:gpt-3.5-turbo-1106": {
+        "max_tokens": 16385,
+        "max_input_tokens": 16385,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000006,
+        "litellm_provider": "openai",
+        "mode": "chat"
+    },
+    "ft:gpt-3.5-turbo-0613": {
         "max_tokens": 4097,
         "max_input_tokens": 4097,
         "max_output_tokens": 4096,


### PR DESCRIPTION
Add pricing for 

- `ft:gpt-3.5-turbo-0125`
- `ft:gpt-3.5-turbo-1106`
- `ft:gpt-3.5-turbo-0613`

and fix context length for `ft:gpt-3.5-turbo` to use `ft:gpt-3.5-turbo-0125`'s context length.