### PR TITLE
Add azure/gpt-4o-2024-08-06 pricing.

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -534,6 +534,18 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "azure/gpt-4o-2024-08-06": {
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000010,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true
+    },
     "azure/global-standard/gpt-4o-mini": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -534,6 +534,18 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "azure/gpt-4o-2024-08-06": {
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000010,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true
+    },
     "azure/global-standard/gpt-4o-mini": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,


### PR DESCRIPTION
https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/introducing-gpt-4o-2024-08-06-api-with-structured-outputs-on/ba-p/4232684

> Pricing Options: The GPT-4o-2024-08-06 API offers significant cost reductions compared to its predecessor, GPT-4o-2024-05-13. Inputs are priced at $2.50 per 1M tokens, and outputs are $10.00 per 1M tokens. For detailed pricing, please refer to the [Azure OpenAI Service pricing page](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/).

<img width="932" alt="image" src="https://github.com/user-attachments/assets/a44e6e8a-debb-4a29-919c-900877be01d3">


I am not 100% sure if there is a difference in price between the global and regional endpoint. https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/ has not been updated yet.