### PR TITLE
make the HOST variable configurable

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST
-              value: "{{ .Values.listen | default ":" }}"
+              value: "{{ .Values.listen | default "::" }}"
             - name: PORT
               value: {{ .Values.service.port | quote}}
             {{- if .Values.db.deployStandalone }}

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HOST
-              value: "::"
+              value: "{{ .Values.listen | default ":" }}"
             - name: PORT
               value: {{ .Values.service.port | quote}}
             {{- if .Values.db.deployStandalone }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -74,6 +74,10 @@ ingress:
 
 # masterkey: changeit
 
+# Define on which stack the unicorn process will listen, it can be ":" or "0.0.0.0"
+# This can be used if your cluster is for instance on a single stack (IPV4)
+# listen: ""
+
 # The elements within proxy_config are rendered as config.yaml for the proxy
 #  Examples: https://github.com/BerriAI/litellm/tree/main/litellm/proxy/example_config_yaml
 #  Reference: https://docs.litellm.ai/docs/proxy/configs


### PR DESCRIPTION
## make the HOST variable configurable

Kubernetes clusters can be single stack or dual stack. This change address the recent change where dual stack cluster is set to be the default.

Setting can now be configurable in the chart

## Relevant issues
Fixes #5517

## Type
🐛 Bug Fix

## Changes

Add a value for the HOST env variable in order to make the helm chart less restrictive on the environment where it is deployed

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
helm template . --set listen="0.0.0.0"
```
      containers:
        - name: litellm
          securityContext:
            {}
          image: "ghcr.io/berriai/litellm-database:main-v1.43.18"
          imagePullPolicy: IfNotPresent
          env:
            - name: HOST
              value: "0.0.0.0"
            - name: PORT
              value: "4000"
```

helm template .
```
      containers:
        - name: litellm
          securityContext:
            {}
          image: "ghcr.io/berriai/litellm-database:main-v1.43.18"
          imagePullPolicy: IfNotPresent
          env:
            - name: HOST
              value: ":"
            - name: PORT
              value: "4000"
```

