### PR TITLE
fix(_redis.py): allow all supported arguments for redis cluster

### DIFF
--- a/litellm/tests/test_caching.py
+++ b/litellm/tests/test_caching.py
@@ -826,7 +826,7 @@ async def test_redis_cache_cluster_init_unit_test():
         assert isinstance(resp.redis_client, RedisCluster)
         assert isinstance(resp.init_async_client(), AsyncRedisCluster)
 
-        resp = litellm.Cache(type="redis", redis_startup_nodes=startup_nodes)
+        resp = litellm.Cache(type="redis", redis_startup_nodes=startup_nodes, password="my-cluster-password")
 
         assert isinstance(resp.cache, RedisCache)
         assert isinstance(resp.cache.redis_client, RedisCluster)


### PR DESCRIPTION
## Title

Support password protected redis clusters

## Relevant issues

Fixes #5552 

## Type

🐛 Bug Fix

## Changes

- use `cleanup_kwargs` instead of custom kwarg filtering

## [REQUIRED] Testing - Attach a screenshot of any new tests passing local
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
- adapted local test to include a password for redis cluster
