### PR TITLE
litellm-helm: fix missing resource definitions in initContainer and missing DBname value for envVars in deployment.yaml

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: DATABASE_HOST
               value: {{ .Values.db.endpoint }}
             - name: DATABASE_NAME
-              value: litellm
+              value: {{ .Values.db.database }}
             {{- end }}
           command:
             - sh
@@ -89,6 +89,8 @@ spec:
               else
                 echo "Database failed to become ready before we gave up waiting."
               fi
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.securityContext.readOnlyRootFilesystem }}
           volumeMounts:
             - name: tmp

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
                 echo "Database failed to become ready before we gave up waiting."
               fi
           resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.securityContext.readOnlyRootFilesystem }}
           volumeMounts:
             - name: tmp


### PR DESCRIPTION
## Title

I fixed two minor issues with the deployment.yaml in the litellm-helm chart.

## Relevant issues

Not created, because they would be too small.

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

All changes took place in `deploy/charts/litellhm-helm/templates/deployment.yaml`

1. Line 70: added the missing template value for the DATABASE_NAME key-value pair, so that the init container connects to the correct database like the original litellm container.
2. New line 92+93: Also added resource definitions for the initContainer. This is needed because there are clusters that have resourceQuotas in place. Therefore all workloads need to have resource requests and limits to be set. So do have initContainers.

This is very small fix, so would be nice to be accepted soonish :-)