### PR TITLE
Properly use `allowed_fails_policy` when it has fields with a value of 0

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3690,7 +3690,7 @@ class Router:
             exception=original_exception,
         )
 
-        allowed_fails = _allowed_fails or self.allowed_fails
+        allowed_fails = _allowed_fails if _allowed_fails is not None else self.allowed_fails
 
         dt = get_utc_datetime()
         current_minute = dt.strftime("%H-%M")


### PR DESCRIPTION
## Properly use `allowed_fails_policy` when it has fields with a value of 0

When using `AllowedFailsPolicy` ([docs](https://docs.litellm.ai/docs/routing#advanced-custom-retries-cooldowns-based-on-error-type)) and one of the fields has an "allowed fails" of 0, it will be properly used and won't revert to the value of `Router.allowed_fails`.
```python
_allowed_fails = 0
self.allowed_fails = 100

print(_allowed_fails or self.allowed_fails)
# 100 (The code before the PR)

print(_allowed_fails if _allowed_fails is not None else self.allowed_fails)
# 0 (The code after the PR)
```


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

