### PR TITLE
Fixed UserWarning: Valid config keys have changed in V2 underscore_attrs_are_private

### DIFF
--- a/litellm/rerank_api/types.py
+++ b/litellm/rerank_api/types.py
@@ -25,8 +25,9 @@ class RerankResponse(BaseModel):
     meta: dict  # Contains api_version and billed_units
     _hidden_params: dict = {}
 
-    class Config:
-        underscore_attrs_are_private = True
+    model_config = {
+        "private_attributes": {"_hidden_params"}
+    }
 
     def __getitem__(self, key):
         return self.__dict__[key]


### PR DESCRIPTION
UserWarning: Valid config keys have changed in V2:
* 'underscore_attrs_are_private' has been removed
  warnings.warn(message, UserWarning)

## Title

Fixed UserWarning for underscore_attrs_are_private

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/5596

## Type

🐛 Bug Fix

## Changes

Updated config syntax to pydantic V2

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
I haven't added any new tests, but I have verified the changes solve the warning, and still function without errors.
I'm running litellm as part of OpenInterpreter.