### PR TITLE
Updates and improvements to watsonx provider

### DIFF
--- a/cookbook/liteLLM_IBM_Watsonx.ipynb
+++ b/cookbook/liteLLM_IBM_Watsonx.ipynb
@@ -46,12 +46,8 @@
     "os.environ[\"WATSONX_URL\"] = \"\" # Your watsonx.ai base URL\n",
     "os.environ[\"WATSONX_APIKEY\"] = \"\" # Your IBM cloud API key or watsonx.ai token\n",
     "os.environ[\"WATSONX_PROJECT_ID\"] = \"\" # ID of your watsonx.ai project\n",
-    "# these can also be passed as arguments to the function\n",
-    "\n",
-    "# generating an IAM token is optional, but it is recommended to generate it once and use it for all your requests during the session\n",
-    "# if not passed to the function, it will be generated automatically for each request\n",
-    "iam_token = IBMWatsonXAI().generate_iam_token(api_key=os.environ[\"WATSONX_APIKEY\"]) \n",
-    "# you can also set os.environ[\"WATSONX_TOKEN\"] = iam_token"
+    "# you can also set the auth token manually in case you want to handle authentication yourself:\n",
+    "# os.environ[\"WATSONX_TOKEN\"] = \"<my-auth-token>\""
    ]
   },
   {
@@ -87,8 +83,7 @@
     "# see litellm.llms.watsonx.IBMWatsonXAIConfig for a list of available parameters to pass to the completion functions\n",
     "response = completion(\n",
     "        model=\"watsonx/ibm/granite-13b-chat-v2\",\n",
-    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}],\n",
-    "        token=iam_token\n",
+    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}]\n",
     ")\n",
     "print(\"Granite v2 response:\")\n",
     "print(response)\n",
@@ -96,8 +91,7 @@
     "\n",
     "response = completion(\n",
     "        model=\"watsonx/meta-llama/llama-3-8b-instruct\",\n",
-    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}],\n",
-    "        token=iam_token\n",
+    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}]\n",
     ")\n",
     "print(\"LLaMa 3 8b response:\")\n",
     "print(response)"
@@ -185,13 +179,11 @@
     "        model=\"watsonx/ibm/granite-13b-chat-v2\",\n",
     "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}],\n",
     "        max_tokens=20, # maps to watsonx.ai max_new_tokens\n",
-    "        token=iam_token\n",
     ")\n",
     "llama_3_task = acompletion(\n",
     "        model=\"watsonx/meta-llama/llama-3-8b-instruct\",\n",
     "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}],\n",
     "        max_tokens=20, # maps to watsonx.ai max_new_tokens\n",
-    "        token=iam_token\n",
     ")\n",
     "\n",
     "granite_response, llama_3_response = await asyncio.gather(granite_task, llama_3_task)\n",
@@ -223,8 +215,7 @@
     "os.environ[\"WATSONX_DEPLOYMENT_SPACE_ID\"] = \"<deployment_space_id>\" # ID of the watsonx.ai deployment space where the model is deployed\n",
     "await acompletion(\n",
     "        model=\"watsonx/deployment/<deployment_id>\",\n",
-    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}],\n",
-    "        token=iam_token\n",
+    "        messages=[{ \"content\": \"Hello, how are you?\",\"role\": \"user\"}]\n",
     ")"
    ]
   },
@@ -260,16 +251,14 @@
     "\n",
     "response = embedding(\n",
     "        model=\"watsonx/ibm/slate-30m-english-rtrvr\",\n",
-    "        input=[\"Hello, how are you?\"],\n",
-    "        token=iam_token\n",
+    "        input=[\"Hello, how are you?\"]\n",
     ")\n",
     "print(\"Slate 30m embeddings response:\")\n",
     "print(response)\n",
     "\n",
     "response = await aembedding(\n",
     "        model=\"watsonx/ibm/slate-125m-english-rtrvr\",\n",
-    "        input=[\"Hello, how are you?\"],\n",
-    "        token=iam_token\n",
+    "        input=[\"Hello, how are you?\"]\n",
     ")\n",
     "print(\"Slate 125m embeddings response:\")\n",
     "print(response)"
@@ -292,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/docs/my-website/docs/providers/watsonx.md
+++ b/docs/my-website/docs/providers/watsonx.md
@@ -247,6 +247,17 @@ response = completion(
 )
 ```
 
+### Pass a diferent auth url
+
+You can also pass a different auth url to the completion and embedding functions so that authentication is done against an endpoint other than the default one (iam.cloud.ibm.com).
+
+```python
+os.environ['WATSONX_IAM_TOKEN_URL'] = 'http://my-iam-url/token'
+response = completion(
+    model="watsonx/ibm/granite-13b-chat-v2",
+    messages=[{ "content": "What is your favorite color?","role": "user"}],
+)
+```
 
 ## Supported IBM watsonx.ai Models
 

--- a/docs/my-website/docs/providers/watsonx.md
+++ b/docs/my-website/docs/providers/watsonx.md
@@ -10,7 +10,7 @@ LiteLLM supports all IBM [watsonx.ai](https://watsonx.ai/) foundational models a
 os.environ["WATSONX_URL"] = ""  # (required) Base URL of your WatsonX instance
 # (required) either one of the following:
 os.environ["WATSONX_APIKEY"] = "" # IBM cloud API key
-os.environ["WATSONX_TOKEN"] = "" # IAM auth token
+os.environ["WATSONX_TOKEN"] = "" # IAM auth token in case you want to handle auth yourself
 # optional - can also be passed as params to completion() or embedding()
 os.environ["WATSONX_PROJECT_ID"] = "" # Project ID of your WatsonX instance
 os.environ["WATSONX_DEPLOYMENT_SPACE_ID"] = "" # ID of your deployment space to use deployed models
@@ -242,7 +242,8 @@ response = completion(
             messages=[{ "content": "What is your favorite color?","role": "user"}],
             url="",
             api_key="",
-            project_id=""
+            project_id="",
+            token=""
 )
 ```
 
@@ -251,34 +252,55 @@ response = completion(
 
 Here are some examples of models available in IBM watsonx.ai that you can use with LiteLLM:
 
-| Mode Name                          | Command                                                                                  |
-|------------------------------------|------------------------------------------------------------------------------------------|
-| Flan T5 XXL                        | `completion(model=watsonx/google/flan-t5-xxl, messages=messages)`                        |
-| Flan Ul2                           | `completion(model=watsonx/google/flan-ul2, messages=messages)`                           |
-| Mt0 XXL                            | `completion(model=watsonx/bigscience/mt0-xxl, messages=messages)`                        |
-| Gpt Neox                           | `completion(model=watsonx/eleutherai/gpt-neox-20b, messages=messages)`                   |
-| Mpt 7B Instruct2                   | `completion(model=watsonx/ibm/mpt-7b-instruct2, messages=messages)`                      |
-| Starcoder                          | `completion(model=watsonx/bigcode/starcoder, messages=messages)`                         |
-| Llama 2 70B Chat                   | `completion(model=watsonx/meta-llama/llama-2-70b-chat, messages=messages)`               |
-| Llama 2 13B Chat                   | `completion(model=watsonx/meta-llama/llama-2-13b-chat, messages=messages)`               |
-| Granite 13B Instruct               | `completion(model=watsonx/ibm/granite-13b-instruct-v1, messages=messages)`               |
-| Granite 13B Chat                   | `completion(model=watsonx/ibm/granite-13b-chat-v1, messages=messages)`                   |
-| Flan T5 XL                         | `completion(model=watsonx/google/flan-t5-xl, messages=messages)`                         |
-| Granite 13B Chat V2                | `completion(model=watsonx/ibm/granite-13b-chat-v2, messages=messages)`                   |
-| Granite 13B Instruct V2            | `completion(model=watsonx/ibm/granite-13b-instruct-v2, messages=messages)`               |
-| Elyza Japanese Llama 2 7B Instruct | `completion(model=watsonx/elyza/elyza-japanese-llama-2-7b-instruct, messages=messages)`  |
-| Mixtral 8X7B Instruct V01 Q        | `completion(model=watsonx/ibm-mistralai/mixtral-8x7b-instruct-v01-q, messages=messages)` |
+| Model Name                 | Command                                                                                |
+|:---------------------------|:---------------------------------------------------------------------------------------|
+| MT0 XXL                    | `completion(model='watsonx/bigscience/mt0-xxl', messages=messages)`                    |
+| Codellama 34B Instruct HF  | `completion(model='watsonx/codellama/codellama-34b-instruct-hf', messages=messages)`   |
+| Flan T5 XL                 | `completion(model='watsonx/google/flan-t5-xl', messages=messages)`                     |
+| Flan T5 XXL                | `completion(model='watsonx/google/flan-t5-xxl', messages=messages)`                    |
+| Flan UL2                   | `completion(model='watsonx/google/flan-ul2', messages=messages)`                       |
+| Granite 13B Chat V2        | `completion(model='watsonx/ibm/granite-13b-chat-v2', messages=messages)`               |
+| Granite 13B Instruct V2    | `completion(model='watsonx/ibm/granite-13b-instruct-v2', messages=messages)`           |
+| Granite 20B Code Instruct  | `completion(model='watsonx/ibm/granite-20b-code-instruct', messages=messages)`         |
+| Granite 20B Multilingual   | `completion(model='watsonx/ibm/granite-20b-multilingual', messages=messages)`          |
+| Granite 34B Code Instruct  | `completion(model='watsonx/ibm/granite-34b-code-instruct', messages=messages)`         |
+| Granite 3B Code Instruct   | `completion(model='watsonx/ibm/granite-3b-code-instruct', messages=messages)`          |
+| Granite 7B Lab             | `completion(model='watsonx/ibm/granite-7b-lab', messages=messages)`                    |
+| Granite 8B Code Instruct   | `completion(model='watsonx/ibm/granite-8b-code-instruct', messages=messages)`          |
+| Llama 2 13B Chat           | `completion(model='watsonx/meta-llama/llama-2-13b-chat', messages=messages)`           |
+| Llama 2 70B Chat           | `completion(model='watsonx/meta-llama/llama-2-70b-chat', messages=messages)`           |
+| Llama 3 1 70B Instruct     | `completion(model='watsonx/meta-llama/llama-3-1-70b-instruct', messages=messages)`     |
+| Llama 3 1 8B Instruct      | `completion(model='watsonx/meta-llama/llama-3-1-8b-instruct', messages=messages)`      |
+| Llama 3 405B Instruct      | `completion(model='watsonx/meta-llama/llama-3-405b-instruct', messages=messages)`      |
+| Llama 3 70B Instruct       | `completion(model='watsonx/meta-llama/llama-3-70b-instruct', messages=messages)`       |
+| Llama 3 70B Instruct Batch | `completion(model='watsonx/meta-llama/llama-3-70b-instruct-batch', messages=messages)` |
+| Llama 3 8B Instruct        | `completion(model='watsonx/meta-llama/llama-3-8b-instruct', messages=messages)`        |
+| Mistral Large              | `completion(model='watsonx/mistralai/mistral-large', messages=messages)`               |
+| Mixtral 8X7B Instruct V01  | `completion(model='watsonx/mistralai/mixtral-8x7b-instruct-v01', messages=messages)`   |
 
 
 For a list of all available models in watsonx.ai, see [here](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx&locale=en&audience=wdp).
 
+You can also get the list of available watsonx.ai models using the following code:
+
+```python
+from litellm.main import watsonxai
+
+watsonxai.get_available_models()
+# [ibm/granite-13b-chat-v2', 'ibm/granite-13b-instruct-v2', ..., meta-llama/llama-3-8b-instruct', 'mistralai/mistral-large']
+```
+
 
 ## Supported IBM watsonx.ai Embedding Models
 
-| Model Name | Function Call                                                          |
-|------------|------------------------------------------------------------------------|
-| Slate 30m  | `embedding(model="watsonx/ibm/slate-30m-english-rtrvr", input=input)`  |
-| Slate 125m | `embedding(model="watsonx/ibm/slate-125m-english-rtrvr", input=input)` |
+| Model Name                  | Command                                                                                  |
+|:----------------------------|:-----------------------------------------------------------------------------------------|
+| Slate 125M English rtrvr    | `embedding(model='watsonx/ibm/slate-125m-english-rtrvr', input=input)`            |
+| Slate 125M English rtrvr V2 | `embedding(model='watsonx/ibm/slate-125m-english-rtrvr-v2', input=input)`         |
+| Slate 30M English rtrvr     | `embedding(model='watsonx/ibm/slate-30m-english-rtrvr', input=input)`             |
+| Slate 30M English rtrvr V2  | `embedding(model='watsonx/ibm/slate-30m-english-rtrvr-v2', input=input)`          |
+| Multilingual E5 Large       | `embedding(model='watsonx/intfloat/multilingual-e5-large', input=input)`          |
+| All MiniLM L12 V2           | `embedding(model='watsonx/sentence-transformers/all-minilm-l12-v2', input=input)` |
 
 
 For a list of all available embedding models in watsonx.ai, see [here](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx).

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -2741,33 +2741,12 @@ def prompt_factory(
     elif custom_llm_provider == "azure_text":
         return azure_text_pt(messages=messages)
     elif custom_llm_provider == "watsonx":
-        if "granite" in model and "chat" in model:
-            # granite-13b-chat-v1 and granite-13b-chat-v2 use a specific prompt template
+        if "granite" in model and ("chat" in model or "lab" in model or "multilingual" in model):
+            # models like granite-13b-chat-v2, granite-20b-multilingual, and granite-7b-lab use a specific prompt template
             return ibm_granite_pt(messages=messages)
-        elif "ibm-mistral" in model and "instruct" in model:
-            # models like ibm-mistral/mixtral-8x7b-instruct-v01-q use the mistral instruct prompt template
+        elif "ibm-mistral/" in model or 'mistralai/' in model:
+            # models like ibm-mistral/mixtral-8x7b-instruct-v01 or mistralai/mistral-large use the mistral instruct prompt template
             return mistral_instruct_pt(messages=messages)
-        elif "meta-llama/llama-3" in model and "instruct" in model:
-            # https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3/
-            return custom_prompt(
-                role_dict={
-                    "system": {
-                        "pre_message": "<|start_header_id|>system<|end_header_id|>\n",
-                        "post_message": "<|eot_id|>",
-                    },
-                    "user": {
-                        "pre_message": "<|start_header_id|>user<|end_header_id|>\n",
-                        "post_message": "<|eot_id|>",
-                    },
-                    "assistant": {
-                        "pre_message": "<|start_header_id|>assistant<|end_header_id|>\n",
-                        "post_message": "<|eot_id|>",
-                    },
-                },
-                messages=messages,
-                initial_prompt_value="<|begin_of_text|>",
-                final_prompt_value="<|start_header_id|>assistant<|end_header_id|>\n",
-            )
     try:
         if "meta-llama/llama-2" in model and "chat" in model:
             return llama_2_chat_pt(messages=messages)


### PR DESCRIPTION
## Updates and improvements to watsonx provider

## Relevant issues

- handle the issue raised in #4991 (You can now pass `WATSONX_IAM_TOKEN_URL` as an env variable to override the default URL)

## Type

🆕 New Feature
🐛 Bug Fix
📖 Documentation
✅ Test

## Changes

- Better auth handling by saving the token state and only renewing it after expiration.
- Pass `WATSONX_IAM_TOKEN_URL` env variable to override the default IBM cloud auth endpoint.
- You can now generate the auth token asynchronously
- Prompt template support for MistralAI and IBM Granite Code models
- `test_watsonx_aembeddings`now mocks the `litellm.AsyncHandler` instance directly instead of `httpx.AsyncClient`
- Updated documentation to reflect the new changes and list the latest available models

##  Testing

`pytest tests/test_completion.py -k "watsonx"`

![image](https://github.com/user-attachments/assets/25cb5fd4-552e-4bb3-b9ec-fafed85d80d0)

`pytest tests/test_embedding.py -k "watsonx"`

![image](https://github.com/user-attachments/assets/b92dc733-de07-49d5-8306-930139714c29)

`python -m mypy . --ignore-missing-imports | grep watsonx`

![image](https://github.com/user-attachments/assets/1e7912a0-a4a5-48c3-8704-1d0ad46dfb8f)