### PR TITLE
Fixed DeepSeek input and output tokens

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1205,9 +1205,9 @@
         "mode": "embedding"
     },
     "deepseek-chat": {
-        "max_tokens": 4096,
-        "max_input_tokens": 32000,
-        "max_output_tokens": 4096,
+        "max_tokens": 4000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4000,
         "input_cost_per_token": 0.00000014,
         "input_cost_per_token_cache_hit": 0.000000014,
         "output_cost_per_token": 0.00000028,
@@ -1260,9 +1260,9 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "deepseek-coder": {
-        "max_tokens": 4096,
+        "max_tokens": 4000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 4000,
         "input_cost_per_token": 0.00000014,
         "input_cost_per_token_cache_hit": 0.000000014,
         "output_cost_per_token": 0.00000028,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1205,9 +1205,9 @@
         "mode": "embedding"
     },
     "deepseek-chat": {
-        "max_tokens": 4000,
+        "max_tokens": 4096,
         "max_input_tokens": 128000,
-        "max_output_tokens": 4000,
+        "max_output_tokens": 4096,
         "input_cost_per_token": 0.00000014,
         "input_cost_per_token_cache_hit": 0.000000014,
         "output_cost_per_token": 0.00000028,
@@ -1260,9 +1260,9 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "deepseek-coder": {
-        "max_tokens": 4000,
+        "max_tokens": 4096,
         "max_input_tokens": 128000,
-        "max_output_tokens": 4000,
+        "max_output_tokens": 4096,
         "input_cost_per_token": 0.00000014,
         "input_cost_per_token_cache_hit": 0.000000014,
         "output_cost_per_token": 0.00000028,


### PR DESCRIPTION
## Title

Fixed DeepSeek input and output tokens

## Relevant issues

Not found

## Type

🐛 Bug Fix

## Changes

Changed `deepseek-chat` max input tokens to `128 000` as DeepSeek platform documentation says `128K`

Based on https://platform.deepseek.com/api-docs/quick_start/pricing/
