### PR TITLE
[Fix-Proxy] deal with case when check view exists returns None 

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -468,7 +468,7 @@ class ProxyLogging:
 
                     # V1 implementation - backwards compatibility
                     if callback.event_hook is None:
-                        if callback.moderation_check == "pre_call":
+                        if callback.moderation_check == "pre_call":  # type: ignore
                             return
                     else:
                         # Main - V2 Guardrails implementation
@@ -982,6 +982,11 @@ class PrismaClient:
                 """
             )
             expected_total_views = len(expected_views)
+
+            # Deal with case when ret is None
+            if ret is None:
+                ret = [{"view_count": 0, "view_names": []}]
+
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
                 return


### PR DESCRIPTION
## Fixes this stack trace 

```
    await self._router.startup()
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 709, in startup
    await handler()
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py", line 2905, in startup_event
    create_view_response = await prisma_client.check_view_exists()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/backoff/_async.py", line 151, in retry
    ret = await target(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/utils.py", line 995, in check_view_exists
    if required_view not in ret[0]["view_names"]:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

