### PR TITLE
[Fix] Router/ Proxy - Tag Based routing, raise correct error when no deployments found and tag filtering is on 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Extra, Field, Json, model_validator
 from typing_extensions import Annotated, TypedDict
 
-from litellm.types.router import UpdateRouterConfig
+from litellm.types.router import RouterErrors, UpdateRouterConfig
 from litellm.types.utils import ProviderField
 
 if TYPE_CHECKING:
@@ -1826,6 +1826,8 @@ class ProxyException(Exception):
             or "No deployments available" in self.message
         ):
             self.code = "429"
+        elif RouterErrors.no_deployments_with_tag_routing.value in self.message:
+            self.code = 401
 
     def to_dict(self) -> dict:
         """Converts the ProxyException instance to a dictionary."""

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1827,7 +1827,7 @@ class ProxyException(Exception):
         ):
             self.code = "429"
         elif RouterErrors.no_deployments_with_tag_routing.value in self.message:
-            self.code = 401
+            self.code = "401"
 
     def to_dict(self) -> dict:
         """Converts the ProxyException instance to a dictionary."""

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -19,20 +19,14 @@ model_list:
       model: openai/429
       api_key: fake-key
       api_base: https://exampleopenaiendpoint-production.up.railway.app
+      tags: ["fake"]
 
 
 general_settings: 
  master_key: sk-1234 
- alerting: ["slack"]
- alerting_threshold: 0.0001 # (Seconds) set an artifically low threshold for testing alerting
- alert_to_webhook_url: {
-    "llm_too_slow": [
-      "os.environ/SLACK_WEBHOOK_URL",
-      "os.environ/SLACK_WEBHOOK_URL_2",
-    ],
-  }
-  key_management_system: "azure_key_vault"
 
+router_settings:
+  enable_tag_filtering: true
 
 litellm_settings:
   success_callback: ["prometheus"]

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5180,6 +5180,7 @@ class Router:
             # check if user wants to do tag based routing
             healthy_deployments = await get_deployments_for_tag(  # type: ignore
                 llm_router_instance=self,
+                model=model,
                 request_kwargs=request_kwargs,
                 healthy_deployments=healthy_deployments,
             )

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -9,7 +9,7 @@ Use this to route requests between Teams
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from litellm._logging import verbose_logger
-from litellm.types.router import DeploymentTypedDict
+from litellm.types.router import DeploymentTypedDict, RouterErrors
 
 if TYPE_CHECKING:
     from litellm.router import Router as _Router
@@ -79,6 +79,11 @@ async def get_deployments_for_tag(
                         request_tags,
                     )
                     new_healthy_deployments.append(deployment)
+
+            if len(new_healthy_deployments) == 0:
+                raise ValueError(
+                    f"{RouterErrors.no_deployments_with_tag_routing.value}. Passed model={request_kwargs.get('model')}"
+                )
 
             return new_healthy_deployments
 

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -21,9 +21,15 @@ else:
 
 async def get_deployments_for_tag(
     llm_router_instance: LitellmRouter,
+    model: str,  # used to raise the correct error
     healthy_deployments: Union[List[Any], Dict[Any, Any]],
     request_kwargs: Optional[Dict[Any, Any]] = None,
 ):
+    """
+    Returns a list of deployments that match the requested model and tags in the request.
+
+    Executes tag based filtering based on the tags in request metadata and the tags on the deployments
+    """
     if llm_router_instance.enable_tag_filtering is not True:
         return healthy_deployments
 
@@ -82,7 +88,7 @@ async def get_deployments_for_tag(
 
             if len(new_healthy_deployments) == 0:
                 raise ValueError(
-                    f"{RouterErrors.no_deployments_with_tag_routing.value}. Passed model={request_kwargs.get('model')}"
+                    f"{RouterErrors.no_deployments_with_tag_routing.value}. Passed model={model} and tags={request_tags}"
                 )
 
             return new_healthy_deployments

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -414,6 +414,9 @@ class RouterErrors(enum.Enum):
 
     user_defined_ratelimit_error = "Deployment over user-defined ratelimit."
     no_deployments_available = "No deployments available for selected model"
+    no_deployments_with_tag_routing = (
+        "Not allowed to access model due to tags configuration"
+    )
 
 
 class AllowedFailsPolicy(BaseModel):


### PR DESCRIPTION
## 
- if a tag with no deployments is passed this error is raise: `Not allowed to access model due to tags configuration. Passed model=gpt-4 and tags=['paid']`


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

