### PR TITLE
Fix hardcoding of schema in view check

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -991,6 +991,11 @@ class PrismaClient:
                 """
             )
             expected_total_views = len(expected_views)
+
+            # Deal with case when ret is None
+            if ret is None:
+                ret = [{"view_count": 0, "view_names": []}]
+
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
                 return

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -991,11 +991,6 @@ class PrismaClient:
                 """
             )
             expected_total_views = len(expected_views)
-
-            # Deal with case when ret is None
-            if ret is None:
-                ret = [{"view_count": 0, "view_names": []}]
-
             if ret[0]["view_count"] == expected_total_views:
                 verbose_proxy_logger.info("All necessary views exist!")
                 return

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -975,12 +975,13 @@ class PrismaClient:
             ]
             required_view = "LiteLLM_VerificationTokenView"
             expected_views_str = ", ".join(f"'{view}'" for view in expected_views)
+            pg_schema = os.getenv("DATABASE_SCHEMA", "public")
             ret = await self.db.query_raw(
                 f"""
                 WITH existing_views AS (
                     SELECT viewname
                     FROM pg_views
-                    WHERE schemaname = 'public' AND viewname IN (
+                    WHERE schemaname = '{pg_schema}' AND viewname IN (
                         {expected_views_str}
                     )
                 )

--- a/litellm/tests/test_router_debug_logs.py
+++ b/litellm/tests/test_router_debug_logs.py
@@ -37,6 +37,7 @@ def test_async_fallbacks(caplog):
                 "api_key": os.getenv("AZURE_API_KEY"),
                 "api_version": os.getenv("AZURE_API_VERSION"),
                 "api_base": os.getenv("AZURE_API_BASE"),
+                "mock_response": "Hello world",
             },
             "tpm": 240000,
             "rpm": 1800,


### PR DESCRIPTION
## Title

## Relevant issues

## Type

🐛 Bug Fix

## Changes

Changes the hardcoding of the schema to check for view to use the `DB_SCHEMA` env variable if it exists. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

