### PR TITLE
Install curl to be used for AWS ECS health check

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -39,7 +39,8 @@ RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 # Update dependencies and clean up - handles debian security issue
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/* 
+# Also install curl to be used for health checks when running in e.g. AWS ECS
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl && rm -rf /var/lib/apt/lists/* 
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app


### PR DESCRIPTION
## Install curl to be used for AWS ECS health check

Installing `curl` in the container for database, to be used for health checks in an AWS ECS cluster like [this](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html#API_HealthCheck_Contents).

## Type

🆕 New Feature

## Changes

Adding `curl` to the database dockerfile.
