### PR TITLE
Update litellm helm envconfigmap

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v1.43.18
+appVersion: v1.46.6
 
 dependencies:
   - name: "postgresql"

--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -24,6 +24,7 @@ If `db.useStackgresOperator` is used (not yet implemented):
 | `replicaCount`                                             | The number of LiteLLM Proxy pods to be deployed                                                                                                                                       | `1`  |
 | `masterkey`                                                | The Master API Key for LiteLLM.  If not specified, a random key is generated.                                                                                                         | N/A  |
 | `environmentSecrets`                                       | An optional array of Secret object names.  The keys and values in these secrets will be presented to the LiteLLM proxy pod as environment variables.  See below for an example Secret object.  | `[]`  |
+| `environmentConfigMaps`                                       | An optional array of ConfigMap object names.  The keys and values in these configmaps will be presented to the LiteLLM proxy pod as environment variables.  See below for an example Secret object.  | `[]`  |
 | `image.repository`                                         | LiteLLM Proxy image repository                                                                                                                                                        | `ghcr.io/berriai/litellm`  |
 | `image.pullPolicy`                                         | LiteLLM Proxy image pull policy                                                                                                                                                       | `IfNotPresent`  |
 | `image.tag`                                                | Overrides the image tag whose default the latest version of LiteLLM at the time this chart was published.                                                                             | `""`  |
@@ -76,6 +77,36 @@ data:
   password: <some secure password, base64 encoded>
 type: Opaque
 ```
+
+#### Examples for `environmentSecrets` and `environemntConfigMaps`
+
+```yaml
+# Use config map for not-secret configuration data
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-env-configmap
+data:
+  SOME_KEY: someValue
+  ANOTHER_KEY: anotherValue
+```
+
+```yaml
+# Use secrets for things which are actually secret like API keys, credentials, etc
+# Base64 encode the values stored in a Kubernetes Secret: $ pbpaste | base64 | pbcopy
+# The --decode flag is convenient: $ pbpaste | base64 --decode
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: litellm-env-secret
+type: Opaque
+data:
+  SOME_PASSWORD: cDZbUGVXeU5e0ZW    # base64 encoded
+  ANOTHER_PASSWORD: AAZbUGVXeU5e0ZB # base64 encoded
+```
+
+Source: [GitHub Gist from troyharvey](https://gist.github.com/troyharvey/4506472732157221e04c6b15e3b3f094)
 
 ## Accessing the Admin UI
 When browsing to the URL published per the settings in `ingress.*`, you will

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -161,6 +161,10 @@ spec:
             - secretRef:
                 name: {{ . }}
           {{- end }}
+          {{- range .Values.environmentConfigMaps }}
+            - configMapRef:
+                name: {{ . }}
+          {{- end }}
           args:
             - --config
             - /etc/litellm/config.yaml

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -50,7 +50,13 @@ securityContext: {}
 #  pod as environment variables.  These secrets can then be referenced in the
 #  configuration file (or "litellm" ConfigMap) with `os.environ/<Env Var Name>`
 environmentSecrets: []
-  # - litellm-envsecrets
+  # - litellm-env-secret
+
+# A list of Kubernetes ConfigMap objects that will be exported to the LiteLLM proxy
+#  pod as environment variables.  The ConfigMap kv-pairs can then be referenced in the
+#  configuration file (or "litellm" ConfigMap) with `os.environ/<Env Var Name>`
+environmentConfigMaps: []
+  # - litellm-env-configmap
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Title

I added the possibilitiy to use Config Maps as environment variables, so that you don't need to store non-secret variables in a secret. For them the base64 encoding is not needed.
For passwords and API-Keys the secrets approach for envVars is still valid and usable. This makes it more good practice to seperate secrets from non confidential information.

Also bumped the appVersion to v1.46.6 and raised the chart version to 0.3.0.

## Relevant issues

None.

## Type

🆕 New Feature
🚄 Infrastructure

## Changes

* deployment.yaml
* values.yaml
* litellm-helm/README.md
* chart.yaml

## [REQUIRED] Testing

`helm upgrade litellm --install --dry-run --set environmentConfigMaps[0]=test123 --set environmentConfigMaps[1]=123Test ./d
eploy/charts/litellm-helm/`

Runs properly and generates the deployment manifest with envFrom.configMapRef part in it.
