### PR TITLE
[Fix] OTEL - Don't log messages when callback settings disable message logging 

### DIFF
--- a/litellm/_service_logger.py
+++ b/litellm/_service_logger.py
@@ -196,20 +196,27 @@ class ServiceLogging(CustomLogger):
                     end_time=end_time,
                     event_metadata=event_metadata,
                 )
+            elif callback == "otel":
+                from litellm.integrations.opentelemetry import OpenTelemetry
+                from litellm.proxy.proxy_server import open_telemetry_logger
 
-        from litellm.proxy.proxy_server import open_telemetry_logger
+                await self.init_otel_logger_if_none()
 
-        if not isinstance(error, str):
-            error = str(error)
-        if open_telemetry_logger is not None:
-            await self.otel_logger.async_service_failure_hook(
-                payload=payload,
-                parent_otel_span=parent_otel_span,
-                start_time=start_time,
-                end_time=end_time,
-                event_metadata=event_metadata,
-                error=error,
-            )
+                if not isinstance(error, str):
+                    error = str(error)
+
+                if (
+                    parent_otel_span is not None
+                    and open_telemetry_logger is not None
+                    and isinstance(open_telemetry_logger, OpenTelemetry)
+                ):
+                    await self.otel_logger.async_service_success_hook(
+                        payload=payload,
+                        parent_otel_span=parent_otel_span,
+                        start_time=start_time,
+                        end_time=end_time,
+                        event_metadata=event_metadata,
+                    )
 
     async def async_post_call_failure_hook(
         self,

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -409,12 +409,50 @@ class OpenTelemetry(CustomLogger):
                 str(optional_params.get("stream", False)),
             )
 
+            if optional_params.get("user"):
+                span.set_attribute(SpanAttributes.LLM_USER, optional_params.get("user"))
+
+            # The unique identifier for the completion.
+            if response_obj.get("id"):
+                span.set_attribute("gen_ai.response.id", response_obj.get("id"))
+
+            # The model used to generate the response.
+            if response_obj.get("model"):
+                span.set_attribute(
+                    SpanAttributes.LLM_RESPONSE_MODEL, response_obj.get("model")
+                )
+
+            usage = response_obj.get("usage")
+            if usage:
+                span.set_attribute(
+                    SpanAttributes.LLM_USAGE_TOTAL_TOKENS,
+                    usage.get("total_tokens"),
+                )
+
+                # The number of tokens used in the LLM response (completion).
+                span.set_attribute(
+                    SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
+                    usage.get("completion_tokens"),
+                )
+
+                # The number of tokens used in the LLM prompt.
+                span.set_attribute(
+                    SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
+                    usage.get("prompt_tokens"),
+                )
+
+            ########################################################################
+            ########## LLM Request Medssages / tools / content Attributes ###########
+            #########################################################################
+
+            if litellm.turn_off_message_logging is True:
+                return
+            if self.message_logging is not True:
+                return
+
             if optional_params.get("tools"):
                 tools = optional_params["tools"]
                 self.set_tools_attributes(span, tools)
-
-            if optional_params.get("user"):
-                span.set_attribute(SpanAttributes.LLM_USER, optional_params.get("user"))
 
             if kwargs.get("messages"):
                 for idx, prompt in enumerate(kwargs.get("messages")):
@@ -472,34 +510,6 @@ class OpenTelemetry(CustomLogger):
                                     tool_calls[0].get("function").get("arguments"),
                                 )
 
-                # The unique identifier for the completion.
-                if response_obj.get("id"):
-                    span.set_attribute("gen_ai.response.id", response_obj.get("id"))
-
-                # The model used to generate the response.
-                if response_obj.get("model"):
-                    span.set_attribute(
-                        SpanAttributes.LLM_RESPONSE_MODEL, response_obj.get("model")
-                    )
-
-                usage = response_obj.get("usage")
-                if usage:
-                    span.set_attribute(
-                        SpanAttributes.LLM_USAGE_TOTAL_TOKENS,
-                        usage.get("total_tokens"),
-                    )
-
-                    # The number of tokens used in the LLM response (completion).
-                    span.set_attribute(
-                        SpanAttributes.LLM_USAGE_COMPLETION_TOKENS,
-                        usage.get("completion_tokens"),
-                    )
-
-                    # The number of tokens used in the LLM prompt.
-                    span.set_attribute(
-                        SpanAttributes.LLM_USAGE_PROMPT_TOKENS,
-                        usage.get("prompt_tokens"),
-                    )
         except Exception as e:
             verbose_logger.error(
                 "OpenTelemetry logging error in set_attributes %s", str(e)


### PR DESCRIPTION
## Title

When message logging is off don't log messages / responses 

```
callback_settings:
    otel:
      message_logging: False
```

Logged Otel attributes:

```
{
  "metadata.user_api_key": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
  "metadata.litellm_api_version": "1.42.9",
  "metadata.user_api_key_user_id": "default_user_id",
  "metadata.user_api_key_spend": 0,
  "metadata.endpoint": "http://localhost:4000/v1/chat/completions",
  "metadata.requester_ip_address": "127.0.0.1",
  "metadata.model_group": "gpt-3.5-turbo",
  "metadata.model_group_size": 1,
  "metadata.deployment": "openai/gpt-3.5-turbo",
  "metadata.api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
  "gen_ai.request.model": "gpt-3.5-turbo",
  "gen_ai.system": "openai",
  "llm.is_streaming": "False",
  "gen_ai.response.id": "chatcmpl-ae280c48999c4cf6893f681a85a43519",
  "gen_ai.response.model": "gpt-3.5-turbo-0125",
  "llm.usage.total_tokens": 21,
  "gen_ai.usage.completion_tokens": 12,
  "gen_ai.usage.prompt_tokens": 9
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

