### PR TITLE
Add support for Bedrock cross-region inference

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -322,7 +322,7 @@ class BedrockLLM(BaseAWSLLM):
         print_verbose,
         encoding,
     ) -> Union[ModelResponse, CustomStreamWrapper]:
-        provider = model.split(".")[0]
+        provider = self.get_provider(model=model)
         ## LOGGING
         logging_obj.post_call(
             input=messages,
@@ -574,6 +574,10 @@ class BedrockLLM(BaseAWSLLM):
         """
         return urllib.parse.quote(model_id, safe="")
 
+    def get_provider(self, model: str) -> str:
+        parts = model.split(".")
+        return parts[0] if parts[0] not in ["us", "eu"] else parts[1]
+
     def completion(
         self,
         model: str,
@@ -608,7 +612,7 @@ class BedrockLLM(BaseAWSLLM):
         else:
             modelId = model
 
-        provider = model.split(".")[0]
+        provider = self.get_provider(model=model)
 
         ## CREDENTIALS ##
         # pop aws_secret_access_key, aws_access_key_id, aws_session_token, aws_region_name from kwargs, since completion calls fail with them


### PR DESCRIPTION
While previously a Bedrock model would have id such as `anthropic.claude-3-5-sonnet-20240620-v1:0` now with cross-region inference support, it may have an id like `us.anthropic.claude-3-5-sonnet-20240620-v1:0` or `eu.anthropic.claude-3-5-sonnet-20240620-v1:0` so added the condition to check for this scenario
https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

## Add support for cross-region inference for Bedrock models

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixes #5899 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature + 🐛 Bug Fix

## Changes
Added check for if model ID starts with region like "us" or "eu" then use the next part for `provider`

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

