### PR TITLE
[Feature]#5940, add max_workers parameter for the batch_completion

### DIFF
--- a/docs/my-website/docs/data_security.md
+++ b/docs/my-website/docs/data_security.md
@@ -40,3 +40,19 @@ We value the security community's role in protecting our systems and users. To r
 - Provide any relevant additional information
 
 We'll review all reports promptly. Note that we don't currently offer a bug bounty program.
+
+### Legal/Compliance FAQs
+
+Legal Entity Name: Berrie AI Incorporated
+Company Phone Number - 7708783106 
+Number of employees in the company - 2
+Number of employees in security team - 2
+Point of contact email address for security incidents - krrish@berri.ai
+Point of contact email address for general security-related questions - krrish@berri.ai 
+Has the Vendor been audited / certified? Currently undergoing SOC-2 Certification from Drata 
+Has an information security management system been implemented? Yes - [CodeQL](https://codeql.github.com/)
+Is logging of key events - auth, creation, update changes occurring? Yes - we have [audit logs](https://docs.litellm.ai/docs/proxy/multiple_admins#1-switch-on-audit-logs)
+Does the Vendor have an established Cybersecurity incident management program? No 
+Not applicable - LiteLLM is self-hosted, this is the responsibility of the team hosting the proxy. We do provide [alerting](https://docs.litellm.ai/docs/proxy/alerting) and [monitoring](https://docs.litellm.ai/docs/proxy/prometheus) tools to help with this. 
+Does the vendor have a vulnerability disclosure policy in place? [Yes](https://github.com/BerriAI/litellm?tab=security-ov-file#security-vulnerability-reporting-guidelines)
+Does the vendor perform vulnerability scans? No 

--- a/docs/my-website/docs/data_security.md
+++ b/docs/my-website/docs/data_security.md
@@ -44,15 +44,27 @@ We'll review all reports promptly. Note that we don't currently offer a bug boun
 ### Legal/Compliance FAQs
 
 Legal Entity Name: Berrie AI Incorporated
-Company Phone Number - 7708783106 
-Number of employees in the company - 2
-Number of employees in security team - 2
-Point of contact email address for security incidents - krrish@berri.ai
-Point of contact email address for general security-related questions - krrish@berri.ai 
+
+Company Phone Number: 7708783106 
+
+Number of employees in the company: 2
+
+Number of employees in security team: 2
+
+Point of contact email address for security incidents: krrish@berri.ai
+
+Point of contact email address for general security-related questions: krrish@berri.ai 
+
 Has the Vendor been audited / certified? Currently undergoing SOC-2 Certification from Drata 
+
 Has an information security management system been implemented? Yes - [CodeQL](https://codeql.github.com/)
+
 Is logging of key events - auth, creation, update changes occurring? Yes - we have [audit logs](https://docs.litellm.ai/docs/proxy/multiple_admins#1-switch-on-audit-logs)
+
 Does the Vendor have an established Cybersecurity incident management program? No 
+
 Not applicable - LiteLLM is self-hosted, this is the responsibility of the team hosting the proxy. We do provide [alerting](https://docs.litellm.ai/docs/proxy/alerting) and [monitoring](https://docs.litellm.ai/docs/proxy/prometheus) tools to help with this. 
+
 Does the vendor have a vulnerability disclosure policy in place? [Yes](https://github.com/BerriAI/litellm?tab=security-ov-file#security-vulnerability-reporting-guidelines)
+
 Does the vendor perform vulnerability scans? No 

--- a/docs/my-website/docs/observability/langfuse_integration.md
+++ b/docs/my-website/docs/observability/langfuse_integration.md
@@ -16,7 +16,7 @@ You can integrate LiteLLM with Langfuse in three different ways:
 
 
 Example trace in Langfuse using multiple models via LiteLLM:
-<Image img={require('../../img/langfuse-example-trace-multiple-models-min')} />
+<Image img={require('../../img/langfuse-example-trace-multiple-models-min.png')} />
 
 ## 1. LiteLLM Proxy + Langfuse OpenAI SDK Wrapper
 

--- a/litellm/llms/OpenAI/openai.py
+++ b/litellm/llms/OpenAI/openai.py
@@ -1069,27 +1069,7 @@ class OpenAIChatCompletion(BaseLLM):
             except openai.UnprocessableEntityError as e:
                 ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
                 if litellm.drop_params is True or drop_params is True:
-                    invalid_params: List[str] = []
-                    if e.body is not None and isinstance(e.body, dict) and e.body.get("detail"):  # type: ignore
-                        detail = e.body.get("detail")  # type: ignore
-                        if (
-                            isinstance(detail, List)
-                            and len(detail) > 0
-                            and isinstance(detail[0], dict)
-                        ):
-                            for error_dict in detail:
-                                if (
-                                    error_dict.get("loc")
-                                    and isinstance(error_dict.get("loc"), list)
-                                    and len(error_dict.get("loc")) == 2
-                                ):
-                                    invalid_params.append(error_dict["loc"][1])
-
-                    new_data = {}
-                    for k, v in data.items():
-                        if k not in invalid_params:
-                            new_data[k] = v
-                    data = new_data
+                    data = drop_params_from_unprocessable_entity_error(e, data)
                 else:
                     raise e
             except (

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2931,6 +2931,7 @@ def batch_completion(
     deployment_id=None,
     request_timeout: Optional[int] = None,
     timeout: Optional[int] = 600,
+    max_workers:Optional[int]= 100,
     # Optional liteLLM function params
     **kwargs,
 ):
@@ -2954,6 +2955,7 @@ def batch_completion(
         user (str, optional): The user string for generating completions. Defaults to "".
         deployment_id (optional): The deployment ID for generating completions. Defaults to None.
         request_timeout (int, optional): The request timeout for generating completions. Defaults to None.
+        max_workers (int,optional): The maximum number of threads to use for parallel processing.
 
     Returns:
         list: A list of completion results.
@@ -2999,7 +3001,7 @@ def batch_completion(
             for i in range(0, len(lst), n):
                 yield lst[i : i + n]
 
-        with ThreadPoolExecutor(max_workers=100) as executor:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for sub_batch in chunks(batch_messages, 100):
                 for message_list in sub_batch:
                     kwargs_modified = args.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litellm"
-version = "1.48.2"
+version = "1.48.3"
 description = "Library to easily interface with LLM API providers"
 authors = ["BerriAI"]
 license = "MIT"
@@ -91,7 +91,7 @@ requires = ["poetry-core", "wheel"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.commitizen]
-version = "1.48.2"
+version = "1.48.3"
 version_files = [
     "pyproject.toml:^version"
 ]


### PR DESCRIPTION
## Title

add max_workers parameter for the batch_completion

### Motivation 

[!issues:#5940](https://github.com/BerriAI/litellm/issues/5940)

Various LLM providers implement different types of consumption quotas, such as Requests Per Second (RPS), Requests Per Minute (RPM), or Tokens Per Minute (TPM). In this specific instance, I attempted to send more than 50 parallel image requests to Anthropic's Claude 3.5 Sonnet model. However, the model has a quota limit of 50 requests processed per minute. The issue arose because the batch_completion function was configured to use 100 as the max_worker value, exceeding the model's quota

https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html 

## Relevant issues

[<!-- e.g. "Fixes #000" -->](https://github.com/BerriAI/litellm/issues/5940)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

Before
<img width="853" alt="image" src="https://github.com/user-attachments/assets/34e9b2e7-47b8-4229-9b35-f374a95feed2">

After 
<img width="895" alt="image" src="https://github.com/user-attachments/assets/3a3d7bb3-9844-41c4-b19c-72001042e80c">

<img width="623" alt="image" src="https://github.com/user-attachments/assets/62eb7f68-f99b-410a-99c1-dc269ad5aec8">

Add doc string

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/1c5c40ed-9a67-4834-b44c-ab125435f289">


<!-- List of changes -->

<!-- Test procedure -->

