### PR TITLE
[Feat Proxy] Allow using hypercorn for http v2 

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -684,7 +684,27 @@ docker run ghcr.io/berriai/litellm:main-latest \
 
 Provide an ssl certificate when starting litellm proxy server 
 
-### 3. Providing LiteLLM config.yaml file as a s3, GCS Bucket Object/url
+### 3. Using Http/2 with Hypercorn
+
+Use this if you want to run the proxy with hypercorn to support http/2
+
+**Usage**
+Pass the `--run_hypercorn` flag when starting the proxy
+
+```shell
+docker run \
+    -v $(pwd)/proxy_config.yaml:/app/config.yaml \
+    -p 4000:4000 \
+    -e LITELLM_LOG="DEBUG"\
+    -e SERVER_ROOT_PATH="/api/v1"\
+    -e DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname> \
+    -e LITELLM_MASTER_KEY="sk-1234"\
+    ghcr.io/berriai/litellm:main-latest \
+    --config /app/config.yaml
+    --run_hypercorn
+```
+
+### 4. Providing LiteLLM config.yaml file as a s3, GCS Bucket Object/url
 
 Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)
 


### PR DESCRIPTION
#  Using Http/2 with Hypercorn

Use this if you want to run the proxy with hypercorn to support http/2

**Usage**
Pass the `--run_hypercorn` flag when starting the proxy

### Usage with litellm pip 

```
litellm --config proxy_config.yaml --detailed_debug --run_hypercorn
```

### Usage with litellm docker 

```shell
docker run \
    -v $(pwd)/proxy_config.yaml:/app/config.yaml \
    -p 4000:4000 \
    -e LITELLM_LOG="DEBUG"\
    -e SERVER_ROOT_PATH="/api/v1"\
    -e DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname> \
    -e LITELLM_MASTER_KEY="sk-1234"\
    ghcr.io/berriai/litellm:main-latest \
    --config /app/config.yaml
    --run_hypercorn
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

