### PR TITLE
fix(helm): make actual use of `image.dbReadyImage` and `image.dbReadyTag`

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: db-ready
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "docker.io/bitnami/postgresql:16.1.0-debian-11-r20"
+          image: "{{ .Values.image.dbReadyImage }}:{{ .Values.image.dbReadyTag | default "latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- if .Values.db.deployStandalone }}


### PR DESCRIPTION
## Title

currently `image.dbReadyImage` and `image.dbReadyTag` are not actually used. This enables the use.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

