### PR TITLE
(proxy prometheus) track api key and team in latency metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -255,10 +255,16 @@ class PrometheusLogger(CustomLogger):
             )
 
             # Deployment Latency tracking
+            team_and_key_labels = [
+                "hashed_api_key",
+                "api_key_alias",
+                "team",
+                "team_alias",
+            ]
             self.litellm_deployment_latency_per_output_token = Histogram(
                 name="litellm_deployment_latency_per_output_token",
                 documentation="LLM Deployment Analytics - Latency per output token",
-                labelnames=_logged_llm_labels,
+                labelnames=_logged_llm_labels + team_and_key_labels,
             )
 
             self.litellm_deployment_successful_fallbacks = Counter(
@@ -760,6 +766,16 @@ class PrometheusLogger(CustomLogger):
                     model_id=model_id,
                     api_base=api_base,
                     api_provider=llm_provider,
+                    hashed_api_key=standard_logging_payload["metadata"][
+                        "user_api_key_hash"
+                    ],
+                    api_key_alias=standard_logging_payload["metadata"][
+                        "user_api_key_alias"
+                    ],
+                    team=standard_logging_payload["metadata"]["user_api_key_team_id"],
+                    team_alias=standard_logging_payload["metadata"][
+                        "user_api_key_team_alias"
+                    ],
                 ).observe(latency_per_token)
 
         except Exception as e:

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -80,6 +80,10 @@ class PrometheusLogger(CustomLogger):
                 "Total latency (seconds) for a request to LiteLLM",
                 labelnames=[
                     "model",
+                    "hashed_api_key",
+                    "api_key_alias",
+                    "team",
+                    "team_alias",
                 ],
             )
 
@@ -88,6 +92,10 @@ class PrometheusLogger(CustomLogger):
                 "Total latency (seconds) for a models LLM API call",
                 labelnames=[
                     "model",
+                    "hashed_api_key",
+                    "api_key_alias",
+                    "team",
+                    "team_alias",
                 ],
             )
 
@@ -448,14 +456,22 @@ class PrometheusLogger(CustomLogger):
                 kwargs.get("end_time") - api_call_start_time
             )
             api_call_total_time_seconds = api_call_total_time.total_seconds()
-            self.litellm_llm_api_latency_metric.labels(model).observe(
-                api_call_total_time_seconds
-            )
+            self.litellm_llm_api_latency_metric.labels(
+                model,
+                user_api_key,
+                user_api_key_alias,
+                user_api_team,
+                user_api_team_alias,
+            ).observe(api_call_total_time_seconds)
 
         # log metrics
-        self.litellm_request_total_latency_metric.labels(model).observe(
-            total_time_seconds
-        )
+        self.litellm_request_total_latency_metric.labels(
+            model,
+            user_api_key,
+            user_api_key_alias,
+            user_api_team,
+            user_api_team_alias,
+        ).observe(total_time_seconds)
 
         # set x-ratelimit headers
         self.set_llm_deployment_success_metrics(

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -102,11 +102,16 @@ async def test_proxy_success_metrics():
 
         # Check if the success metric is present and correct
         assert (
-            'litellm_request_total_latency_metric_bucket{api_key_alias="None",hashed_api_key="86902de640d82ae809119315de7eb5e0ebc7844a0924a3a611621f3f590fca3d",le="0.005",model="gpt-3.5-turbo",team="None",team_alias="None"}'
+            'litellm_request_total_latency_metric_bucket{api_key_alias="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",le="0.005",model="gpt-3.5-turbo",team="None",team_alias="None"}'
             in metrics
         )
 
         assert (
-            'litellm_llm_api_latency_metric_bucket{api_key_alias="None",hashed_api_key="86902de640d82ae809119315de7eb5e0ebc7844a0924a3a611621f3f590fca3d",le="0.005",model="gpt-3.5-turbo",team="None",team_alias="None"}'
+            'litellm_llm_api_latency_metric_bucket{api_key_alias="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",le="0.005",model="gpt-3.5-turbo",team="None",team_alias="None"}'
+            in metrics
+        )
+
+        assert (
+            'litellm_deployment_latency_per_output_token_count{api_base="https://exampleopenaiendpoint-production.up.railway.app/",api_key_alias="None",api_provider="openai",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",litellm_model_name="gpt-3.5-turbo",model_id="0ea900ab10dbf66961498e7021009040f30e843fc14920c53e51d85cef62e0fe",team="None",team_alias="None"}'
             in metrics
         )


### PR DESCRIPTION
## Title

```
litellm_llm_api_latency_metric_bucket {
  api_key_alias = "None",
  hashed_api_key = "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
  le = "2.5",
  model = "gpt-3.5-turbo",
  team = "None",
  team_alias = "None"
} 1.0
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

