### PR TITLE
Proxy: include customer budget in responses

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6038,7 +6038,8 @@ async def end_user_info(
         )
 
     user_info = await prisma_client.db.litellm_endusertable.find_first(
-        where={"user_id": end_user_id}
+        where={"user_id": end_user_id},
+        include={"litellm_budget_table": True}
     )
 
     if user_info is None:
@@ -6281,7 +6282,9 @@ async def list_team(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
 
-    response = await prisma_client.db.litellm_endusertable.find_many()
+    response = await prisma_client.db.litellm_endusertable.find_many(
+        include={"litellm_budget_table": True}
+    )
 
     returned_response: List[LiteLLM_EndUserTable] = []
     for item in response:


### PR DESCRIPTION
## Title
Proxy: include customer budget in responses

## Relevant issues
Fixes #5976

## Type
🐛 Bug Fix

## Changes
* Fix property `litellm_budget_table` in methods `/customer/info` and `/customer/list`.