### PR TITLE
[Bug] Skip slack alert if there was no spend

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1630,7 +1630,7 @@ Model Info:
                 start_date=start_date.strftime("%Y-%m-%d"),
                 end_date=todays_date.strftime("%Y-%m-%d"),
             )
-            if _resp is None:
+            if _resp is None or _resp == ([], []):
                 return
 
             spend_per_team, spend_per_tag = _resp


### PR DESCRIPTION
## Skip spend report when there was no spend 

## Type
🐛 Bug Fix

## Changes
If `_get_spend_report_for_time_range` returns no values, it means that there was no spend for that time period and the report will be skipped.
As of now, the report is still sent but with missing info (e.g. no Tags and no Teams, spend is not set to `0.0`).

