### PR TITLE
fixed an issue with tool use of claude models with anthropic and bedrock

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -273,7 +273,11 @@ class AnthropicConfig:
                     anthropic_tools.append(tool)
                 else:  # assume openai tool call
                     new_tool = tool["function"]
-                    new_tool["input_schema"] = new_tool.pop("parameters")  # rename key
+                    parameters = new_tool.pop("parameters", {
+                        "type": "object",
+                        "properties": {},
+                    })
+                    new_tool["input_schema"] = parameters  # rename key
                     if "cache_control" in tool:
                         new_tool["cache_control"] = tool["cache_control"]
                     anthropic_tools.append(new_tool)

--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -2554,7 +2554,10 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
     """
     tool_block_list: List[BedrockToolBlock] = []
     for tool in tools:
-        parameters = tool.get("function", {}).get("parameters", None)
+        parameters = tool.get("function", {}).get("parameters", {
+            "type": "object",
+            "properties": {}
+        })
         name = tool.get("function", {}).get("name", "")
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007


### PR DESCRIPTION
## Title

Fixed claude tool use without "parameters" in anthropic and bedrock

## Relevant issues

Fixes #6012

## Type

🐛 Bug Fix

## Changes

Added a default value for the `"parameters"` in the `anthropic`'s `_transform_request` and the `_bedrock_tools_pt`

