### PR TITLE
When defaulting claude-3 to tiktoken, avoid failed network call in huggingface `from_pretrained`

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1590,9 +1590,12 @@ def _select_tokenizer(model: str):
         )
         return {"type": "huggingface_tokenizer", "tokenizer": cohere_tokenizer}
     # anthropic
-    elif model in litellm.anthropic_models and "claude-3" not in model:
-        claude_tokenizer = Tokenizer.from_str(claude_json_str)
-        return {"type": "huggingface_tokenizer", "tokenizer": claude_tokenizer}
+    elif model in litellm.anthropic_models:
+        if "claude-3" not in model:
+            claude_tokenizer = Tokenizer.from_str(claude_json_str)
+            return {"type": "huggingface_tokenizer", "tokenizer": claude_tokenizer}
+        else:
+            return {"type": "openai_tokenizer", "tokenizer": encoding}
     # llama2
     elif "llama-2" in model.lower() or "replicate" in model.lower():
         tokenizer = Tokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")


### PR DESCRIPTION
## Title

I noticed that every time aider calls `main_model.token_count(some_string)` where model is `'claude-3-5-sonnet-20240620'`, the logic in `_select_tokenizer` falls through to `try: tokenizer = Tokenizer.from_pretrained(model)` which always makes a failed network request and throws an exception.

It attempts to GET https://huggingface.co/claude-3-5-sonnet-20240620/resolve/main/tokenizer.json which returns a 401 Client error: Invalid username or password.  However, the error is not the problem: it's that we shouldn't make the HTTP request at all if our intent is to use tiktoken.

This has a slight performance impact on startup time, and I can't tell why it's helping if it's destined to fail, since the comments say claude should be using tiktoken anyway.

## Relevant issues


## Type

🐛 Bug Fix / enhancement / optimization

## Changes

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

