### PR TITLE
(bedrock): Restrict IAM policy even more

### DIFF
--- a/litellm/llms/base_aws_llm.py
+++ b/litellm/llms/base_aws_llm.py
@@ -177,7 +177,7 @@ class BaseAWSLLM(BaseLLM):
                     RoleSessionName=aws_session_name,
                     WebIdentityToken=oidc_token,
                     DurationSeconds=3600,
-                    Policy='{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":"*","Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
+                    Policy='{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],"Resource":["arn:aws:bedrock:*::foundation-model/*","arn:aws:bedrock:*:*:provisioned-model/*","arn:aws:bedrock:*:*:imported-model/*","arn:aws:bedrock:*:*:inference-profile/*"],"Condition":{"Bool":{"aws:SecureTransport":"true"},"StringLike":{"aws:UserAgent":"litellm/*"}}}]}',
                 )
 
                 iam_creds_dict = {


### PR DESCRIPTION
## Title

This restrict IAM policy even more to only allow known resource types.

## Relevant issues

N/A

## Type

🧹 Refactoring

## Changes

Adds more restrictions to the inline policy when using the OIDC flow.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

I've been running this in prod for a few days without issue. It's covered by the existing Amazon Bedrock OIDC tests.

CloudTrail success example from our prod:

```json
{
  "eventVersion": "1.08",
  "userIdentity": {
    "type": "WebIdentityUser",
    "principalId": "accounts.google.com:USER_ID_REMOVED:USER_ID_REMOVED",
    "userName": "USER_ID_REMOVED",
    "identityProvider": "accounts.google.com"
  },
  "eventTime": "2024-10-03T19:28:28Z",
  "eventSource": "sts.amazonaws.com",
  "eventName": "AssumeRoleWithWebIdentity",
  "awsRegion": "us-east-1",
  "sourceIPAddress": "IP_ADDRESS_REMOVED",
  "userAgent": "Boto3/1.34.34 md/Botocore#1.34.34 ua/2.0 os/linux#6.4.10-dirty md/arch#x86_64 lang/python#3.11.8 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.34.34",
  "requestParameters": {
    "roleArn": "arn:aws:iam::ACCOUNT_ID_REMOVED:role/ROLE_NAME_REMOVED",
    "roleSessionName": "SESSION_NAME_REMOVED",
    "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"BedrockLiteLLM\",\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":[\"arn:aws:bedrock:*::foundation-model/*\",\"arn:aws:bedrock:*:*:provisioned-model/*\",\"arn:aws:bedrock:*:*:imported-model/*\",\"arn:aws:bedrock:*:*:inference-profile/*\"],\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"true\"},\"StringLike\":{\"aws:UserAgent\":\"litellm/*\"}}}]}",
    "durationSeconds": 3600
  },
  "responseElements": {
    "credentials": {
      "accessKeyId": "ACCESS_KEY_ID_REMOVED",
      "sessionToken": "SESSION_TOKEN_REMOVED",
      "expiration": "Oct 3, 2024, 8:28:28 PM"
    },
    "subjectFromWebIdentityToken": "USER_ID_REMOVED",
    "assumedRoleUser": {
      "assumedRoleId": "ASSUMED_ROLE_ID_REMOVED",
      "arn": "arn:aws:sts::ACCOUNT_ID_REMOVED:assumed-role/ROLE_NAME_REMOVED/SESSION_NAME_REMOVED"
    },
    "packedPolicySize": 43,
    "provider": "accounts.google.com",
    "audience": "USER_ID_REMOVED"
  },
  "additionalEventData": {
    "identityProviderConnectionVerificationMethod": "IAMTrustStore"
  },
  "requestID": "REQUEST_ID_REMOVED",
  "eventID": "EVENT_ID_REMOVED",
  "readOnly": true,
  "resources": [
    {
      "accountId": "ACCOUNT_ID_REMOVED",
      "type": "AWS::IAM::Role",
      "ARN": "arn:aws:iam::ACCOUNT_ID_REMOVED:role/ROLE_NAME_REMOVED"
    }
  ],
  "eventType": "AwsApiCall",
  "managementEvent": true,
  "recipientAccountId": "ACCOUNT_ID_REMOVED",
  "eventCategory": "Management",
  "tlsDetails": {
    "tlsVersion": "TLSv1.3",
    "cipherSuite": "TLS_AES_128_GCM_SHA256",
    "clientProvidedHostHeader": "sts-fips.us-east-1.amazonaws.com"
  }
}
```