### PR TITLE
bug fix for optional parameter passing to replicate

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3125,7 +3125,7 @@ def get_optional_params(
 
         if stream:
             optional_params["stream"] = stream
-            return optional_params
+            #return optional_params
         if max_tokens is not None:
             if "vicuna" in model or "flan" in model:
                 optional_params["max_length"] = max_tokens


### PR DESCRIPTION
## Title

Bug fix for optional parameter passing to replicate

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

Removed line 3128 which prematurely returns the `optional_params` in function `get_optional_params` in file `litellm/litellm/utils.py`. This prevents optional parameters that follow to be set appropriately.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes


<!-- Test procedure -->

