### PR TITLE
(feat) add /key/health endpoint to test key based logging

### DIFF
--- a/docs/my-website/docs/proxy/team_logging.md
+++ b/docs/my-website/docs/proxy/team_logging.md
@@ -301,3 +301,53 @@ curl -X POST 'http://0.0.0.0:4000/key/generate' \
 
 Help us improve this feature, by filing a [ticket here](https://github.com/BerriAI/litellm/issues)
 
+### Check if key callbacks are configured correctly `/key/health`
+
+Call `/key/health` with the key to check if the callback settings are configured correctly
+
+Pass the key in the request header
+
+```bash
+curl -X POST "http://localhost:4000/key/health" \
+  -H "Authorization: Bearer <your-key>" \
+  -H "Content-Type: application/json"
+```
+
+<Tabs>
+<TabItem label="Response when key is configured correctly" value="Response when key is configured correctly">
+
+Response when logging callbacks are setup correctly:
+
+```json
+{
+  "key": "healthy",
+  "logging_callbacks": {
+    "callbacks": [
+      "gcs_bucket"
+    ],
+    "status": "healthy",
+    "details": "No logger exceptions triggered, system is healthy. Manually check if logs were sent to ['gcs_bucket']"
+  }
+}
+```
+
+</TabItem>
+
+<TabItem label="Response when key is configured incorrectly" value="Response when key is configured incorrectly">
+
+Response when logging callbacks are not setup correctly:
+```json
+{
+  "key": "healthy",
+  "logging_callbacks": {
+    "callbacks": [
+      "gcs_bucket"
+    ],
+    "status": "unhealthy",
+    "details": "Logger exceptions triggered, system is unhealthy: Failed to load vertex credentials. Check to see if credentials containing partial/invalid information."
+  }
+}
+```
+
+</TabItem>
+</Tabs>

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1923,3 +1923,14 @@ class CurrentItemRateLimit(TypedDict):
     current_requests: int
     current_tpm: int
     current_rpm: int
+
+
+class LoggingCallbackStatus(BaseModel):
+    callbacks: List[str]
+    status: str
+    details: Optional[str] = None
+
+
+class KeyHealthResponse(BaseModel):
+    key: str
+    logging_callbacks: Optional[LoggingCallbackStatus] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -254,6 +254,7 @@ class LiteLLMRoutes(enum.Enum):
 
     info_routes = [
         "/key/info",
+        "/key/health",
         "/team/info",
         "/team/list",
         "/user/info",
@@ -276,6 +277,7 @@ class LiteLLMRoutes(enum.Enum):
         "/key/update",
         "/key/delete",
         "/key/info",
+        "/key/health",
         # user
         "/user/new",
         "/user/update",
@@ -334,6 +336,7 @@ class LiteLLMRoutes(enum.Enum):
             "/key/generate",
             "/key/update",
             "/key/delete",
+            "/key/health",
             "/key/info",
             "/global/spend/tags",
             "/global/spend/keys",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1925,12 +1925,12 @@ class CurrentItemRateLimit(TypedDict):
     current_rpm: int
 
 
-class LoggingCallbackStatus(BaseModel):
+class LoggingCallbackStatus(TypedDict, total=False):
     callbacks: List[str]
     status: str
-    details: Optional[str] = None
+    details: Optional[str]
 
 
-class KeyHealthResponse(BaseModel):
+class KeyHealthResponse(TypedDict, total=False):
     key: str
-    logging_callbacks: Optional[LoggingCallbackStatus] = None
+    logging_callbacks: Optional[LoggingCallbackStatus]

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1569,7 +1569,7 @@ async def test_key_logging(
 
     try:
         data = {
-            "model": "litellm-key-health-test",
+            "model": "openai/litellm-key-health-test",
             "messages": [
                 {
                     "role": "user",

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1511,10 +1511,10 @@ async def key_health(
         # Get the key's metadata
         key_metadata = user_api_key_dict.metadata
 
-        health_status = {
-            "key": "healthy",
-            "logging_callbacks": None,
-        }
+        health_status: KeyHealthResponse = KeyHealthResponse(
+            key="healthy",
+            logging_callbacks=None,
+        )
 
         # Check if logging is configured in metadata
         if key_metadata and "logging" in key_metadata:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1512,7 +1512,7 @@ async def test_key_logging(
     user_api_key_dict: UserAPIKeyAuth,
     request: Request,
     key_logging: List[Dict[str, Any]],
-) -> List[LoggingCallbackStatus]:
+) -> LoggingCallbackStatus:
     """
     Test the key-based logging
 
@@ -1555,35 +1555,26 @@ async def test_key_logging(
         )
         response = await litellm.acompletion(**data)
     except Exception as e:
-        logging_statuses.append(
-            LoggingCallbackStatus(
-                callbacks=logging_callbacks,
-                status="error",
-                details=f"Logging test failed: {str(e)}",
-            )
+        return LoggingCallbackStatus(
+            callbacks=logging_callbacks,
+            status="error",
+            details=f"Logging test failed: {str(e)}",
         )
 
     await asyncio.sleep(1)
 
     # Check if any logger exceptions were triggered
     log_contents = log_capture_string.getvalue()
+    logger.removeHandler(ch)
     if log_contents:
-        logging_statuses.append(
-            LoggingCallbackStatus(
-                callbacks=logging_callbacks,
-                status="unhealthy",
-                details=f"Logger exceptions triggered, system is unhealthy: {log_contents}",
-            )
+        return LoggingCallbackStatus(
+            callbacks=logging_callbacks,
+            status="unhealthy",
+            details=f"Logger exceptions triggered, system is unhealthy: {log_contents}",
         )
     else:
-        logging_statuses.append(
-            LoggingCallbackStatus(
-                callbacks=logging_callbacks,
-                status="healthy",
-                details=f"No logger exceptions triggered, system is healthy. Manually check if logs were sent to {logging_callbacks} ",
-            )
+        return LoggingCallbackStatus(
+            callbacks=logging_callbacks,
+            status="healthy",
+            details=f"No logger exceptions triggered, system is healthy. Manually check if logs were sent to {logging_callbacks} ",
         )
-
-    logger.removeHandler(ch)
-
-    return logging_statuses

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1546,7 +1546,7 @@ async def test_key_logging(
 
     - Test that key logging is correctly formatted and all args are passed correctly
     - Make a mock completion call -> user can check if it's correctly logged
-    - Check if any logger exceptions were triggered
+    - Check if any logger.exceptions were triggered -> if they were then returns it to the user client side
     """
     import logging
     from io import StringIO
@@ -1585,7 +1585,9 @@ async def test_key_logging(
             general_settings=general_settings,
             request=request,
         )
-        response = await litellm.acompletion(**data)
+        await litellm.acompletion(
+            **data
+        )  # make mock completion call to trigger key based callbacks
     except Exception as e:
         return LoggingCallbackStatus(
             callbacks=logging_callbacks,
@@ -1593,7 +1595,7 @@ async def test_key_logging(
             details=f"Logging test failed: {str(e)}",
         )
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(1)  # wait for callbacks to run
 
     # Check if any logger exceptions were triggered
     log_contents = log_capture_string.getvalue()

--- a/tests/otel_tests/test_key_logging_callbacks.py
+++ b/tests/otel_tests/test_key_logging_callbacks.py
@@ -1,0 +1,69 @@
+"""
+Tests for Key based logging callbacks
+
+"""
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio()
+async def test_key_logging_callbacks():
+    """
+    Create virtual key with a logging callback set on the key
+    Call /key/health for the key -> it should be unhealthy
+    """
+    # Generate a key with logging callback
+    generate_url = "http://0.0.0.0:4000/key/generate"
+    generate_headers = {
+        "Authorization": "Bearer sk-1234",
+        "Content-Type": "application/json",
+    }
+    generate_payload = {
+        "metadata": {
+            "logging": [
+                {
+                    "callback_name": "gcs_bucket",
+                    "callback_type": "success_and_failure",
+                    "callback_vars": {
+                        "gcs_bucket_name": "key-logging-project1",
+                        "gcs_path_service_account": "bad-service-account",
+                    },
+                }
+            ]
+        }
+    }
+
+    async with httpx.AsyncClient() as client:
+        generate_response = await client.post(
+            generate_url, headers=generate_headers, json=generate_payload
+        )
+
+    assert generate_response.status_code == 200
+    generate_data = generate_response.json()
+    assert "key" in generate_data
+
+    _key = generate_data["key"]
+
+    # Check key health
+    health_url = "http://localhost:4000/key/health"
+    health_headers = {
+        "Authorization": f"Bearer {_key}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient() as client:
+        health_response = await client.post(health_url, headers=health_headers, json={})
+
+    assert health_response.status_code == 200
+    health_data = health_response.json()
+    print("key_health_data", health_data)
+    # Check the response format and content
+    assert "key" in health_data
+    assert "logging_callbacks" in health_data
+    assert health_data["logging_callbacks"]["callbacks"] == ["gcs_bucket"]
+    assert health_data["logging_callbacks"]["status"] == "unhealthy"
+    assert (
+        "Failed to load vertex credentials"
+        in health_data["logging_callbacks"]["details"]
+    )


### PR DESCRIPTION
## Title

Check the health of the key

  Checks:
  - If key based logging is configured correctly - sends a test log

  Usage 

  Pass the key in the request header

  ```bash
  curl -X POST "http://localhost:4000/key/health" \
   -H "Authorization: Bearer sk-1234" \
   -H "Content-Type: application/json"
  ```

  Response when logging callbacks are setup correctly:

  ```json
  {
    "key": "healthy",
    "logging_callbacks": {
      "callbacks": [
        "gcs_bucket"
      ],
      "status": "healthy",
      "details": "No logger exceptions triggered, system is healthy. Manually check if logs were sent to ['gcs_bucket']"
    }
  }
  ```


  Response when logging callbacks are not setup correctly:
  ```json
  {
    "key": "healthy",
    "logging_callbacks": {
      "callbacks": [
        "gcs_bucket"
      ],
      "status": "unhealthy",
      "details": "Logger exceptions triggered, system is unhealthy: Failed to load vertex credentials. Check to see if credentials containing partial/invalid information."
    }
  }
  ```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

