### PR TITLE
(feat proxy) [beta] add support for organization role based access controls 

### DIFF
--- a/docs/my-website/docs/proxy/access_control.md
+++ b/docs/my-website/docs/proxy/access_control.md
@@ -1,0 +1,145 @@
+# Role-based Access Controls (RBAC)
+
+Role-based access control (RBAC) is based on Organizations, Teams and Internal User Roles
+
+- `Organizations` are the top-level entities that contain Teams.
+- `Team` - A Team is a collection of multiple `Internal Users`
+- `Internal Users` - users that can create keys, make LLM API calls, view usage on LiteLLM 
+- `Roles` define the permissions of an `Internal User`
+- `Virtual Keys` - Keys are used for authentication to the LiteLLM API. Keys are tied to a `Internal User` and `Team` 
+
+## Roles
+
+**Admin Roles**
+  - `proxy_admin`: admin over the platform
+  - `proxy_admin_viewer`: can login, view all keys, view all spend. **Cannot** create/delete keys, add new users.
+
+**Organization Roles**
+  - `organization_admin`: admin over the organization. Can create teams and users within their organization
+
+**Internal User Roles**
+  - `internal_user`: can login, view/create/delete their own keys, view their spend. **Cannot** add new users.
+  - `internal_user_viewer`: can login, view their own keys, view their own spend. **Cannot** create/delete keys, add new users.
+
+
+## Managing Organizations 
+
+### 1. Creating a new Organization
+
+Any user with role=`proxy_admin` can create a new organization
+
+**Usage**
+
+[**API Reference for /organization/new**](https://litellm-api.up.railway.app/#/organization%20management/new_organization_organization_new_post)
+
+```shell
+curl --location 'http://0.0.0.0:4000/organization/new' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'Content-Type: application/json' \
+    --data '{
+        "organization_alias": "marketing_department",
+        "models": ["gpt-4"],
+        "max_budget": 20
+    }'
+```
+
+Expected Response 
+
+```json
+{
+  "organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23",
+  "organization_alias": "marketing_department",
+  "budget_id": "98754244-3a9c-4b31-b2e9-c63edc8fd7eb",
+  "metadata": {},
+  "models": [
+    "gpt-4"
+  ],
+  "created_by": "109010464461339474872",
+  "updated_by": "109010464461339474872",
+  "created_at": "2024-10-08T18:30:24.637000Z",
+  "updated_at": "2024-10-08T18:30:24.637000Z"
+}
+```
+
+
+### 2. Adding an `organization_admin` to an Organization
+
+Create a user (ishaan@berri.ai) as an `organization_admin` for the `marketing_department` Organization (from [step 1](#1-creating-a-new-organization))
+
+Users with the following roles can call `/organization/member_add`
+- `proxy_admin`
+- `organization_admin` only within their own organization
+
+```shell
+curl -X POST 'http://0.0.0.0:4000/organization/member_add' \
+    -H 'Authorization: Bearer sk-1234' \
+    -H 'Content-Type: application/json' \
+    -d '{"organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23", "member": {"role": "organization_admin", "user_id": "ishaan@berri.ai"}}'
+```
+
+Now a user with user_id = `ishaan@berri.ai` and role = `organization_admin` has been created in the `marketing_department` Organization
+
+Create a Virtual Key for user_id = `ishaan@berri.ai`. The User can then use the Virtual key for their Organization Admin Operations
+
+```shell
+curl --location 'http://0.0.0.0:4000/key/generate' \
+        --header 'Authorization: Bearer sk-1234' \
+        --header 'Content-Type: application/json' \
+        --data '{
+            "user_id": "ishaan@berri.ai"
+    }'
+```
+
+Expected Response 
+
+```json
+{
+  "models": [],
+  "user_id": "ishaan@berri.ai",
+  "key": "sk-7shH8TGMAofR4zQpAAo6kQ",
+  "key_name": "sk-...o6kQ",
+}
+```
+
+### 3. `Organization Admin` - Create a Team
+
+The organization admin will use the virtual key created in [step 2](#2-adding-an-organization_admin-to-an-organization) to create a `Team` within the `marketing_department` Organization
+
+```shell
+curl --location 'http://0.0.0.0:4000/team/new' \
+    --header 'Authorization: Bearer sk-7shH8TGMAofR4zQpAAo6kQ' \
+    --header 'Content-Type: application/json' \
+    --data '{
+        "team_alias": "engineering_team",
+        "organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23",
+    }'
+```
+
+This will create the team `engineering_team` within the `marketing_department` Organization
+
+Expected Response 
+
+```json
+{
+  "team_alias": "engineering_team",
+  "team_id": "01044ee8-441b-45f4-be7d-c70e002722d8",
+  "organization_id": "ad15e8ca-12ae-46f4-8659-d02debef1b23",
+}
+```
+
+
+### `Organization Admin` - Add an `Internal User`
+
+The organization admin will use the virtual key created in [step 2](#2-adding-an-organization_admin-to-an-organization) to add an Internal User to the `engineering_team` Team. 
+
+- We will assign role=`internal_user` so the user can create Virtual Keys for themselves
+- `team_id` is from [step 3](#3-organization-admin---create-a-team)
+
+```shell
+curl -X POST 'http://0.0.0.0:4000/team/member_add' \
+    -H 'Authorization: Bearer sk-1234' \
+    -H 'Content-Type: application/json' \
+    -d '{"team_id": "01044ee8-441b-45f4-be7d-c70e002722d8",, "member": {"role": "internal_user", "user_id": "krrish@berri.ai"}}'
+
+```
+

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -78,7 +78,12 @@ const sidebars = {
         {
           type: "category",
           label: "Admin UI",
-          items: ["proxy/ui", "proxy/self_serve", "proxy/custom_sso"],
+          items: [
+            "proxy/ui", 
+            "proxy/self_serve", 
+            "proxy/access_control",
+            "proxy/custom_sso"
+          ],
         },
         {
           type: "category",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -34,6 +34,7 @@ class LitellmUserRoles(str, enum.Enum):
     Admin Roles:
     PROXY_ADMIN: admin over the platform
     PROXY_ADMIN_VIEW_ONLY: can login, view all own keys, view all spend
+    ADMIN: admin over a specific organization, can create teams, users only within their organization
 
     Internal User Roles:
     INTERNAL_USER: can login, view/create/delete their own keys, view their spend
@@ -52,6 +53,9 @@ class LitellmUserRoles(str, enum.Enum):
     # Admin Roles
     PROXY_ADMIN = "proxy_admin"
     PROXY_ADMIN_VIEW_ONLY = "proxy_admin_viewer"
+
+    # Organization admins
+    ADMIN = "admin"
 
     # Internal User Roles
     INTERNAL_USER = "internal_user"
@@ -693,16 +697,7 @@ class NewUserRequest(_GenerateKeyRequest):
     max_budget: Optional[float] = None
     user_email: Optional[str] = None
     user_alias: Optional[str] = None
-    user_role: Optional[
-        Literal[
-            LitellmUserRoles.PROXY_ADMIN,
-            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.INTERNAL_USER,
-            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
-        ]
-    ] = None
+    user_role: Optional[LitellmUserRoles] = None
     teams: Optional[list] = None
     organization_id: Optional[str] = None
     auto_create_key: bool = (
@@ -714,16 +709,7 @@ class NewUserRequest(_GenerateKeyRequest):
 class NewUserResponse(GenerateKeyResponse):
     max_budget: Optional[float] = None
     user_email: Optional[str] = None
-    user_role: Optional[
-        Literal[
-            LitellmUserRoles.PROXY_ADMIN,
-            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.INTERNAL_USER,
-            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
-        ]
-    ] = None
+    user_role: Optional[LitellmUserRoles] = None
     teams: Optional[list] = None
     organization_id: Optional[str] = None
     user_alias: Optional[str] = None
@@ -737,16 +723,7 @@ class UpdateUserRequest(GenerateRequestBase):
     user_email: Optional[str] = None
     spend: Optional[float] = None
     metadata: Optional[dict] = None
-    user_role: Optional[
-        Literal[
-            LitellmUserRoles.PROXY_ADMIN,
-            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.INTERNAL_USER,
-            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
-        ]
-    ] = None
+    user_role: Optional[LitellmUserRoles] = None
     max_budget: Optional[float] = None
 
     @model_validator(mode="before")

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -358,9 +358,14 @@ class LiteLLMRoutes(enum.Enum):
         spend_tracking_routes + global_spend_tracking_routes + sso_only_routes
     )
 
-    org_admin_user_routes = [
+    # Routes only an Org Admin Can Access
+    org_admin_only_routes = [
+        "/organization/info",
+        "/organization/delete",
         "/organization/member_add",
-    ] + internal_user_routes
+    ]
+
+    org_admin_allowed_routes = org_admin_only_routes + internal_user_routes
 
     self_managed_routes = [
         "/team/member_add",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -276,24 +276,19 @@ class LiteLLMRoutes(enum.Enum):
         "/sso/get/ui_settings",
     ]
 
-    # Management Routes for creating new keys, users, teams, models
-    management_create_routes = [
-        "/key/generate",
-        "/user/new",
-        "/team/new",
-        "/model/new",
-    ]
-
     management_routes = [  # key
+        "/key/generate",
         "/key/update",
         "/key/delete",
         "/key/info",
         "/key/health",
         # user
+        "/user/new",
         "/user/update",
         "/user/delete",
         "/user/info",
         # team
+        "/team/new",
         "/team/update",
         "/team/delete",
         "/team/list",
@@ -301,10 +296,11 @@ class LiteLLMRoutes(enum.Enum):
         "/team/block",
         "/team/unblock",
         # model
+        "/model/new",
         "/model/update",
         "/model/delete",
         "/model/info",
-    ] + management_create_routes
+    ]
 
     spend_tracking_routes = [
         # spend
@@ -358,18 +354,30 @@ class LiteLLMRoutes(enum.Enum):
         + sso_only_routes
     )
 
-    # routes for role = ADMIN
-    # Org Admins can do all management routes within their organization
-    org_admin_user_routes = internal_user_routes + management_routes
-
     internal_user_view_only_routes = (
         spend_tracking_routes + global_spend_tracking_routes + sso_only_routes
     )
+
+    org_admin_user_routes = [
+        "/organization/member_add",
+    ] + internal_user_routes
 
     self_managed_routes = [
         "/team/member_add",
         "/team/member_delete",
     ]  # routes that manage their own allowed/disallowed logic
+
+
+# class LiteLLMAllowedRoutes(LiteLLMBase):
+#     """
+#     Defines allowed routes based on key type.
+
+#     Types = ["admin", "team", "user", "unmapped"]
+#     """
+
+#     admin_allowed_routes: List[
+#         Literal["openai_routes", "info_routes", "management_routes", "spend_tracking_routes", "global_spend_tracking_routes"]
+#     ] = ["management_routes"]
 
 
 # class LiteLLMAllowedRoutes(LiteLLMBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -272,19 +272,24 @@ class LiteLLMRoutes(enum.Enum):
         "/sso/get/ui_settings",
     ]
 
-    management_routes = [  # key
+    # Management Routes for creating new keys, users, teams, models
+    management_create_routes = [
         "/key/generate",
+        "/user/new",
+        "/team/new",
+        "/model/new",
+    ]
+
+    management_routes = [  # key
         "/key/update",
         "/key/delete",
         "/key/info",
         "/key/health",
         # user
-        "/user/new",
         "/user/update",
         "/user/delete",
         "/user/info",
         # team
-        "/team/new",
         "/team/update",
         "/team/delete",
         "/team/list",
@@ -292,11 +297,10 @@ class LiteLLMRoutes(enum.Enum):
         "/team/block",
         "/team/unblock",
         # model
-        "/model/new",
         "/model/update",
         "/model/delete",
         "/model/info",
-    ]
+    ] + management_create_routes
 
     spend_tracking_routes = [
         # spend
@@ -1444,6 +1448,26 @@ class LiteLLM_Config(LiteLLMBase):
     param_value: Dict
 
 
+class LiteLLM_OrganizationMembershipTable(LiteLLMBase):
+    """
+    This is the table that track what organizations a user belongs to and users spend within the organization
+    """
+
+    user_id: str
+    organization_id: str
+    user_role: Optional[str] = None
+    spend: float = 0.0
+    budget_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    user: Optional[Any] = (
+        None  # You might want to replace 'Any' with a more specific type if available
+    )
+    litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
+
+    model_config = ConfigDict(protected_namespaces=())
+
+
 class LiteLLM_UserTable(LiteLLMBase):
     user_id: str
     max_budget: Optional[float]
@@ -1455,6 +1479,7 @@ class LiteLLM_UserTable(LiteLLMBase):
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     user_role: Optional[str] = None
+    organization_memberships: Optional[List[LiteLLM_OrganizationMembershipTable]] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -34,7 +34,7 @@ class LitellmUserRoles(str, enum.Enum):
     Admin Roles:
     PROXY_ADMIN: admin over the platform
     PROXY_ADMIN_VIEW_ONLY: can login, view all own keys, view all spend
-    ADMIN: admin over a specific organization, can create teams, users only within their organization
+    ORG_ADMIN: admin over a specific organization, can create teams, users only within their organization
 
     Internal User Roles:
     INTERNAL_USER: can login, view/create/delete their own keys, view their spend
@@ -55,7 +55,7 @@ class LitellmUserRoles(str, enum.Enum):
     PROXY_ADMIN_VIEW_ONLY = "proxy_admin_viewer"
 
     # Organization admins
-    ADMIN = "admin"
+    ORG_ADMIN = "org_admin"
 
     # Internal User Roles
     INTERNAL_USER = "internal_user"
@@ -705,7 +705,7 @@ class NewUserRequest(_GenerateKeyRequest):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -727,7 +727,7 @@ class NewUserResponse(GenerateKeyResponse):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -751,7 +751,7 @@ class UpdateUserRequest(GenerateRequestBase):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -826,7 +826,18 @@ class DeleteCustomerRequest(LiteLLMBase):
 
 
 class Member(LiteLLMBase):
-    role: Literal["admin", "user"]
+    role: Literal[
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        LitellmUserRoles.ORG_ADMIN,
+        LitellmUserRoles.INTERNAL_USER,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+        LitellmUserRoles.TEAM,
+        LitellmUserRoles.CUSTOMER,
+        # older Member roles
+        "admin",
+        "user",
+    ]
     user_id: Optional[str] = None
     user_email: Optional[str] = None
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1931,15 +1931,14 @@ class MemberAddRequest(LiteLLMBase):
         super().__init__(**data)
 
 
-class AddMemberResponse(LiteLLM_TeamTable):
+class TeamAddMemberResponse(LiteLLM_TeamTable):
     updated_users: List[LiteLLM_UserTable]
-
-
-class TeamAddMemberResponse(AddMemberResponse):
     updated_team_memberships: List[LiteLLM_TeamMembership]
 
 
-class OrganizationAddMemberResponse(AddMemberResponse):
+class OrganizationAddMemberResponse(LiteLLMBase):
+    organization_id: str
+    updated_users: List[LiteLLM_UserTable]
     updated_organization_memberships: List[LiteLLM_OrganizationMembershipTable]
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -358,6 +358,13 @@ class LiteLLMRoutes(enum.Enum):
         spend_tracking_routes + global_spend_tracking_routes + sso_only_routes
     )
 
+    self_managed_routes = [
+        "/team/member_add",
+        "/team/member_delete",
+    ]  # routes that manage their own allowed/disallowed logic
+
+    ## Org Admin Routes ##
+
     # Routes only an Org Admin Can Access
     org_admin_only_routes = [
         "/organization/info",
@@ -365,12 +372,10 @@ class LiteLLMRoutes(enum.Enum):
         "/organization/member_add",
     ]
 
-    org_admin_allowed_routes = org_admin_only_routes + internal_user_routes
-
-    self_managed_routes = [
-        "/team/member_add",
-        "/team/member_delete",
-    ]  # routes that manage their own allowed/disallowed logic
+    # All routes accesible by an Org Admin
+    org_admin_allowed_routes = (
+        org_admin_only_routes + management_routes + self_managed_routes
+    )
 
 
 # class LiteLLMAllowedRoutes(LiteLLMBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -883,88 +883,6 @@ class GlobalEndUsersSpend(LiteLLMBase):
     endTime: Optional[datetime] = None
 
 
-#### Organization / Team Member Requests ####
-
-
-class MemberAddRequest(LiteLLMBase):
-    member: Union[List[Member], Member]
-
-    def __init__(self, **data):
-        member_data = data.get("member")
-        if isinstance(member_data, list):
-            # If member is a list of dictionaries, convert each dictionary to a Member object
-            members = [Member(**item) for item in member_data]
-            # Replace member_data with the list of Member objects
-            data["member"] = members
-        elif isinstance(member_data, dict):
-            # If member is a dictionary, convert it to a single Member object
-            member = Member(**member_data)
-            # Replace member_data with the single Member object
-            data["member"] = member
-        # Call the superclass __init__ method to initialize the object
-        super().__init__(**data)
-
-
-class MemberDeleteRequest(LiteLLMBase):
-    user_id: Optional[str] = None
-    user_email: Optional[str] = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def check_user_info(cls, values):
-        if values.get("user_id") is None and values.get("user_email") is None:
-            raise ValueError("Either user id or user email must be provided")
-        return values
-
-
-class MemberUpdateResponse(LiteLLMBase):
-    user_id: str
-    user_email: Optional[str] = None
-
-
-# Team Member Requests
-class TeamMemberAddRequest(MemberAddRequest):
-    team_id: str
-    max_budget_in_team: Optional[float] = None  # Users max budget within the team
-
-
-class TeamMemberDeleteRequest(MemberDeleteRequest):
-    team_id: str
-
-
-class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
-    max_budget_in_team: float
-
-
-class TeamMemberUpdateResponse(MemberUpdateResponse):
-    team_id: str
-    max_budget_in_team: float
-
-
-# Organization Member Requests
-class OrganizationMemberAddRequest(MemberAddRequest):
-    organization_id: str
-    max_budget_in_organization: Optional[float] = (
-        None  # Users max budget within the organization
-    )
-
-
-class OrganizationMemberDeleteRequest(MemberDeleteRequest):
-    organization_id: str
-
-
-class OrganizationMemberUpdateRequest(OrganizationMemberDeleteRequest):
-    max_budget_in_organization: float
-
-
-class OrganizationMemberUpdateResponse(MemberUpdateResponse):
-    organization_id: str
-    max_budget_in_organization: float
-
-
-##########################################
-
-
 class UpdateTeamRequest(LiteLLMBase):
     """
     UpdateTeamRequest, used by /team/update when you need to update a team
@@ -1991,9 +1909,98 @@ class LiteLLM_TeamMembership(LiteLLMBase):
     litellm_budget_table: Optional[LiteLLM_BudgetTable]
 
 
-class TeamAddMemberResponse(LiteLLM_TeamTable):
+#### Organization / Team Member Requests ####
+
+
+class MemberAddRequest(LiteLLMBase):
+    member: Union[List[Member], Member]
+
+    def __init__(self, **data):
+        member_data = data.get("member")
+        if isinstance(member_data, list):
+            # If member is a list of dictionaries, convert each dictionary to a Member object
+            members = [Member(**item) for item in member_data]
+            # Replace member_data with the list of Member objects
+            data["member"] = members
+        elif isinstance(member_data, dict):
+            # If member is a dictionary, convert it to a single Member object
+            member = Member(**member_data)
+            # Replace member_data with the single Member object
+            data["member"] = member
+        # Call the superclass __init__ method to initialize the object
+        super().__init__(**data)
+
+
+class AddMemberResponse(LiteLLM_TeamTable):
     updated_users: List[LiteLLM_UserTable]
+
+
+class TeamAddMemberResponse(AddMemberResponse):
     updated_team_memberships: List[LiteLLM_TeamMembership]
+
+
+class OrganizationAddMemberResponse(AddMemberResponse):
+    updated_organization_memberships: List[LiteLLM_OrganizationMembershipTable]
+
+
+class MemberDeleteRequest(LiteLLMBase):
+    user_id: Optional[str] = None
+    user_email: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_user_info(cls, values):
+        if values.get("user_id") is None and values.get("user_email") is None:
+            raise ValueError("Either user id or user email must be provided")
+        return values
+
+
+class MemberUpdateResponse(LiteLLMBase):
+    user_id: str
+    user_email: Optional[str] = None
+
+
+# Team Member Requests
+class TeamMemberAddRequest(MemberAddRequest):
+    team_id: str
+    max_budget_in_team: Optional[float] = None  # Users max budget within the team
+
+
+class TeamMemberDeleteRequest(MemberDeleteRequest):
+    team_id: str
+
+
+class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
+    max_budget_in_team: float
+
+
+class TeamMemberUpdateResponse(MemberUpdateResponse):
+    team_id: str
+    max_budget_in_team: float
+
+
+# Organization Member Requests
+class OrganizationMemberAddRequest(MemberAddRequest):
+    organization_id: str
+    max_budget_in_organization: Optional[float] = (
+        None  # Users max budget within the organization
+    )
+
+
+class OrganizationMemberDeleteRequest(MemberDeleteRequest):
+    organization_id: str
+
+
+class OrganizationMemberUpdateRequest(OrganizationMemberDeleteRequest):
+    max_budget_in_organization: float
+
+
+class OrganizationMemberUpdateResponse(MemberUpdateResponse):
+    organization_id: str
+    max_budget_in_organization: float
+
+
+##########################################
 
 
 class TeamInfoResponseObject(TypedDict):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -701,7 +701,6 @@ class NewUserRequest(_GenerateKeyRequest):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -723,7 +722,6 @@ class NewUserResponse(GenerateKeyResponse):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -747,7 +745,6 @@ class UpdateUserRequest(GenerateRequestBase):
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
-            LitellmUserRoles.ORG_ADMIN,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
             LitellmUserRoles.TEAM,
@@ -826,8 +823,6 @@ class Member(LiteLLMBase):
         LitellmUserRoles.ORG_ADMIN,
         LitellmUserRoles.INTERNAL_USER,
         LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-        LitellmUserRoles.TEAM,
-        LitellmUserRoles.CUSTOMER,
         # older Member roles
         "admin",
         "user",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -713,8 +713,6 @@ class NewUserRequest(_GenerateKeyRequest):
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
         ]
     ] = None
     teams: Optional[list] = None
@@ -733,8 +731,6 @@ class NewUserResponse(GenerateKeyResponse):
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
         ]
     ] = None
     teams: Optional[list] = None
@@ -755,8 +751,6 @@ class UpdateUserRequest(GenerateRequestBase):
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
-            LitellmUserRoles.TEAM,
-            LitellmUserRoles.CUSTOMER,
         ]
     ] = None
     max_budget: Optional[float] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -358,6 +358,10 @@ class LiteLLMRoutes(enum.Enum):
         + sso_only_routes
     )
 
+    # routes for role = ADMIN
+    # Org Admins can do all management routes within their organization
+    org_admin_user_routes = internal_user_routes + management_routes
+
     internal_user_view_only_routes = (
         spend_tracking_routes + global_spend_tracking_routes + sso_only_routes
     )

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -827,8 +827,6 @@ class DeleteCustomerRequest(LiteLLMBase):
 
 class Member(LiteLLMBase):
     role: Literal[
-        LitellmUserRoles.PROXY_ADMIN,
-        LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
         LitellmUserRoles.ORG_ADMIN,
         LitellmUserRoles.INTERNAL_USER,
         LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -825,7 +825,7 @@ class TeamBase(LiteLLMBase):
     max_budget: Optional[float] = None
     budget_duration: Optional[str] = None
 
-    models: list = []
+    models: Optional[List[str]] = None
     blocked: bool = False
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -380,18 +380,6 @@ class LiteLLMRoutes(enum.Enum):
 #     ] = ["management_routes"]
 
 
-# class LiteLLMAllowedRoutes(LiteLLMBase):
-#     """
-#     Defines allowed routes based on key type.
-
-#     Types = ["admin", "team", "user", "unmapped"]
-#     """
-
-#     admin_allowed_routes: List[
-#         Literal["openai_routes", "info_routes", "management_routes", "spend_tracking_routes", "global_spend_tracking_routes"]
-#     ] = ["management_routes"]
-
-
 class LiteLLM_JWTAuth(LiteLLMBase):
     """
     A class to define the roles and permissions for a LiteLLM Proxy w/ JWT Auth.

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -864,7 +864,7 @@ class TeamBase(LiteLLMBase):
     max_budget: Optional[float] = None
     budget_duration: Optional[str] = None
 
-    models: Optional[List[str]] = None
+    models: list = []
     blocked: bool = False
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -718,7 +718,6 @@ class NewUserRequest(_GenerateKeyRequest):
         ]
     ] = None
     teams: Optional[list] = None
-    organization_id: Optional[str] = None
     auto_create_key: bool = (
         True  # flag used for returning a key as part of the /user/new response
     )
@@ -739,7 +738,6 @@ class NewUserResponse(GenerateKeyResponse):
         ]
     ] = None
     teams: Optional[list] = None
-    organization_id: Optional[str] = None
     user_alias: Optional[str] = None
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -701,7 +701,17 @@ class NewUserRequest(_GenerateKeyRequest):
     max_budget: Optional[float] = None
     user_email: Optional[str] = None
     user_alias: Optional[str] = None
-    user_role: Optional[LitellmUserRoles] = None
+    user_role: Optional[
+        Literal[
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+            LitellmUserRoles.TEAM,
+            LitellmUserRoles.CUSTOMER,
+        ]
+    ] = None
     teams: Optional[list] = None
     organization_id: Optional[str] = None
     auto_create_key: bool = (
@@ -713,7 +723,17 @@ class NewUserRequest(_GenerateKeyRequest):
 class NewUserResponse(GenerateKeyResponse):
     max_budget: Optional[float] = None
     user_email: Optional[str] = None
-    user_role: Optional[LitellmUserRoles] = None
+    user_role: Optional[
+        Literal[
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+            LitellmUserRoles.TEAM,
+            LitellmUserRoles.CUSTOMER,
+        ]
+    ] = None
     teams: Optional[list] = None
     organization_id: Optional[str] = None
     user_alias: Optional[str] = None
@@ -727,7 +747,17 @@ class UpdateUserRequest(GenerateRequestBase):
     user_email: Optional[str] = None
     spend: Optional[float] = None
     metadata: Optional[dict] = None
-    user_role: Optional[LitellmUserRoles] = None
+    user_role: Optional[
+        Literal[
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+            LitellmUserRoles.ADMIN,
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+            LitellmUserRoles.TEAM,
+            LitellmUserRoles.CUSTOMER,
+        ]
+    ] = None
     max_budget: Optional[float] = None
 
     @model_validator(mode="before")

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -872,10 +872,11 @@ class GlobalEndUsersSpend(LiteLLMBase):
     endTime: Optional[datetime] = None
 
 
-class TeamMemberAddRequest(LiteLLMBase):
-    team_id: str
+#### Organization / Team Member Requests ####
+
+
+class MemberAddRequest(LiteLLMBase):
     member: Union[List[Member], Member]
-    max_budget_in_team: Optional[float] = None  # Users max budget within the team
 
     def __init__(self, **data):
         member_data = data.get("member")
@@ -893,8 +894,7 @@ class TeamMemberAddRequest(LiteLLMBase):
         super().__init__(**data)
 
 
-class TeamMemberDeleteRequest(LiteLLMBase):
-    team_id: str
+class MemberDeleteRequest(LiteLLMBase):
     user_id: Optional[str] = None
     user_email: Optional[str] = None
 
@@ -906,15 +906,52 @@ class TeamMemberDeleteRequest(LiteLLMBase):
         return values
 
 
+class MemberUpdateResponse(LiteLLMBase):
+    user_id: str
+    user_email: Optional[str] = None
+
+
+# Team Member Requests
+class TeamMemberAddRequest(MemberAddRequest):
+    team_id: str
+    max_budget_in_team: Optional[float] = None  # Users max budget within the team
+
+
+class TeamMemberDeleteRequest(MemberDeleteRequest):
+    team_id: str
+
+
 class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
     max_budget_in_team: float
 
 
-class TeamMemberUpdateResponse(LiteLLMBase):
+class TeamMemberUpdateResponse(MemberUpdateResponse):
     team_id: str
-    user_id: str
-    user_email: Optional[str] = None
     max_budget_in_team: float
+
+
+# Organization Member Requests
+class OrganizationMemberAddRequest(MemberAddRequest):
+    organization_id: str
+    max_budget_in_organization: Optional[float] = (
+        None  # Users max budget within the organization
+    )
+
+
+class OrganizationMemberDeleteRequest(MemberDeleteRequest):
+    organization_id: str
+
+
+class OrganizationMemberUpdateRequest(OrganizationMemberDeleteRequest):
+    max_budget_in_organization: float
+
+
+class OrganizationMemberUpdateResponse(MemberUpdateResponse):
+    organization_id: str
+    max_budget_in_organization: float
+
+
+##########################################
 
 
 class UpdateTeamRequest(LiteLLMBase):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -32,6 +32,8 @@ from litellm.proxy.auth.route_checks import is_llm_api_route
 from litellm.proxy.utils import PrismaClient, ProxyLogging, log_to_opentelemetry
 from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 
+from .auth_checks_organization import organization_role_based_access_check
+
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
 
@@ -203,6 +205,18 @@ def common_checks(
                     "error": "Your team does not have permission to modify guardrails."
                 },
             )
+
+    # 10 [OPTIONAL] Organization checks - is user_object.organization_memberships
+    if (
+        user_object
+        and user_object.organization_memberships is not None
+        and len(user_object.organization_memberships) > 0
+    ):
+        # check if user is in any of the organizations
+        organization_role_based_access_check(
+            user_object=user_object, route=route, request_body=request_body
+        )
+
     return True
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -430,11 +430,15 @@ async def get_user_object(
             else:
                 raise Exception
 
-        if response.organization_memberships is not None:
+        if (
+            response.organization_memberships is not None
+            and len(response.organization_memberships) > 0
+        ):
             # dump each organization membership to type LiteLLM_OrganizationMembershipTable
             _dumped_memberships = [
                 membership.model_dump()
                 for membership in response.organization_memberships
+                if membership is not None
             ]
             response.organization_memberships = _dumped_memberships
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -207,16 +207,10 @@ def common_checks(
                 },
             )
 
-    # 10 [OPTIONAL] Organization checks - is user_object.organization_memberships
-    if (
-        user_object
-        and user_object.organization_memberships is not None
-        and len(user_object.organization_memberships) > 0
-    ):
-        # check if user is in any of the organizations
-        organization_role_based_access_check(
-            user_object=user_object, route=route, request_body=request_body
-        )
+    # 10 [OPTIONAL] Organization RBAC checks
+    organization_role_based_access_check(
+        user_object=user_object, route=route, request_body=request_body
+    )
 
     return True
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -76,6 +76,7 @@ def common_checks(
     if (
         _model is not None
         and team_object is not None
+        and team_object.models is not None
         and len(team_object.models) > 0
         and _model not in team_object.models
     ):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -63,6 +63,7 @@ def common_checks(
     7. [OPTIONAL] If 'litellm.max_budget' is set (>0), is proxy under budget
     8. [OPTIONAL] If guardrails modified - is request allowed to change this
     9. Check if request body is safe
+    10. [OPTIONAL] Organization checks - is user_object.organization_id is set, run these checks
     """
     _model = request_body.get("model", None)
     if team_object is not None and team_object.blocked is True:
@@ -403,16 +404,25 @@ async def get_user_object(
     try:
 
         response = await prisma_client.db.litellm_usertable.find_unique(
-            where={"user_id": user_id}
+            where={"user_id": user_id}, include={"organization_memberships": True}
         )
 
         if response is None:
             if user_id_upsert:
                 response = await prisma_client.db.litellm_usertable.create(
-                    data={"user_id": user_id}
+                    data={"user_id": user_id},
+                    include={"organization_memberships": True},
                 )
             else:
                 raise Exception
+
+        if response.organization_memberships is not None:
+            # dump each organization membership to type LiteLLM_OrganizationMembershipTable
+            _dumped_memberships = [
+                membership.model_dump()
+                for membership in response.organization_memberships
+            ]
+            response.organization_memberships = _dumped_memberships
 
         _response = LiteLLM_UserTable(**dict(response))
         response_dict = _response.model_dump()
@@ -421,9 +431,9 @@ async def get_user_object(
         await user_api_key_cache.async_set_cache(key=user_id, value=response_dict)
 
         return _response
-    except Exception:  # if user not in db
+    except Exception as e:  # if user not in db
         raise ValueError(
-            f"User doesn't exist in db. 'user_id'={user_id}. Create user via `/user/new` call."
+            f"User doesn't exist in db. 'user_id'={user_id}. Create user via `/user/new` call. Got error - {e}"
         )
 
 

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -2,4 +2,88 @@
 Auth Checks for Organizations
 """
 
+from fastapi import status
+
 from litellm.proxy._types import *
+
+
+def organization_role_based_access_check(
+    request_body: dict,
+    user_object: Optional[LiteLLM_UserTable],
+    route: str,
+):
+    """
+    Role based access control checks only run if a user is part of an Organization
+
+
+    Organization Checks:
+    ONLY RUN IF user_object.organization_memberships is not None
+
+    1. If route is a /new or /generate route ensure organization is passed in request and user is part of it
+        1a Check UserRole in organization and ensure user has Create permissions
+
+
+    Raises Exception:
+        - when a user is part of an organization and tries creating a team / user without specifying an organization_id
+        - when a user does not have the appropriate permissions within their organization
+    """
+
+    if user_object is None:
+        return
+
+    if user_object.organization_memberships is None:
+        return
+
+    _user_organizations: List[str] = []
+    _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
+    for _membership in user_object.organization_memberships:
+        if _membership.organization_id is not None:
+            _user_organizations.append(_membership.organization_id)
+            _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
+
+    if route in LiteLLMRoutes.management_create_routes.value:
+        if "organization_id" not in request_body:
+            raise Exception(
+                "Please specify 'organization_id' in request body, you are part of multiple_organizations"
+            )
+
+        passed_organization_id = request_body["organization_id"]
+
+        if passed_organization_id not in _user_organizations:
+            raise ProxyException(
+                message=f"You are not a member of the organization specified in the request body. Passed organization_id: {passed_organization_id}",
+                type=ProxyErrorTypes.auth_error.value,
+                param="organization_id",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        user_role: Optional[LitellmUserRoles] = _user_organization_role_mapping.get(
+            passed_organization_id
+        )
+        if user_role is None:
+            raise ProxyException(
+                message=f"You are not a member of the organization specified in the request body. Passed organization_id: {passed_organization_id}",
+                type=ProxyErrorTypes.auth_error.value,
+                param="organization_id",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+        elif (
+            user_role == LitellmUserRoles.INTERNAL_USER.value
+            and route not in LiteLLMRoutes.internal_user_routes.value
+        ):
+            raise ProxyException(
+                message=f"You do not have permission to access this route. Passed organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
+                type=ProxyErrorTypes.auth_error.value,
+                param="user_role",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+        elif (
+            user_role == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value
+            and route not in LiteLLMRoutes.internal_user_view_only_routes.value
+        ):
+            raise ProxyException(
+                message=f"You do not have permission to access this route. Passed organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
+                type=ProxyErrorTypes.auth_error.value,
+                param="user_role",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -62,7 +62,7 @@ def organization_role_based_access_check(
         )
         if user_role is None:
             raise ProxyException(
-                message=f"You are not a member of the organization specified in the request body. Passed organization_id: {passed_organization_id}",
+                message=f"You do not have a role within the selected organization. Passed organization_id: {passed_organization_id}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="organization_id",
                 code=status.HTTP_401_UNAUTHORIZED,
@@ -72,7 +72,7 @@ def organization_role_based_access_check(
             and route not in LiteLLMRoutes.internal_user_routes.value
         ):
             raise ProxyException(
-                message=f"You do not have permission to access this route. Passed organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
+                message=f"You do not have the correct role to access this route in organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,
@@ -82,7 +82,7 @@ def organization_role_based_access_check(
             and route not in LiteLLMRoutes.internal_user_view_only_routes.value
         ):
             raise ProxyException(
-                message=f"You do not have permission to access this route. Passed organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
+                message=f"You do not have the correct role to access this route in organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -77,7 +77,7 @@ def organization_role_based_access_check(
 
         if user_role != LitellmUserRoles.ORG_ADMIN.value:
             raise ProxyException(
-                message=f"You do not have the required role to perform this action. Your role is {user_role} in Organization {passed_organization_id}",
+                message=f"You do not have the required role to perform {route} in Organization {passed_organization_id}. Your role is {user_role} in Organization {passed_organization_id}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,
@@ -89,7 +89,7 @@ def organization_role_based_access_check(
         )
         if (
             user_object.organization_memberships is not None
-            and len(user_object.organization_memberships) > 1
+            and len(user_object.organization_memberships) > 0
         ):
             if passed_organization_id is None:
                 raise ProxyException(

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -2,6 +2,8 @@
 Auth Checks for Organizations
 """
 
+from typing import Dict, List, Optional, Tuple
+
 from fastapi import status
 
 from litellm.proxy._types import *
@@ -18,15 +20,15 @@ def organization_role_based_access_check(
     Organization Checks:
     ONLY RUN IF user_object.organization_memberships is not None
 
-    1. Only Proxy Admins and Org Admins can access /organization/* routes
-    2. IF user_object.organization_memberships is not None /team/new is called
+    1. Only Proxy Admins can access /organization/new
+    2. IF route is a LiteLLMRoutes.org_admin_only_routes, then check if user is an Org Admin for that organization
 
     """
 
     if user_object is None:
         return
 
-    passed_organization_id: str = request_body.get("organization_id", None)
+    passed_organization_id: Optional[str] = request_body.get("organization_id", None)
 
     if route == "/organization/new":
         if user_object.user_role != LitellmUserRoles.PROXY_ADMIN.value:
@@ -39,10 +41,12 @@ def organization_role_based_access_check(
 
     if user_object.user_role == LitellmUserRoles.PROXY_ADMIN.value:
         return
+
     # Checks if route is an Org Admin Only Route
     if route in LiteLLMRoutes.org_admin_only_routes.value:
-        _user_organizations: List[str] = []
-        _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
+        _user_organizations, _user_organization_role_mapping = (
+            get_user_organization_info(user_object)
+        )
 
         if user_object.organization_memberships is None:
             raise ProxyException(
@@ -54,16 +58,11 @@ def organization_role_based_access_check(
 
         if passed_organization_id is None:
             raise ProxyException(
-                message=f"Passed organization_id is None, please pass an organization_id",
+                message="Passed organization_id is None, please pass an organization_id in your request",
                 type=ProxyErrorTypes.auth_error.value,
                 param="organization_id",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
-
-        for _membership in user_object.organization_memberships:
-            if _membership.organization_id is not None:
-                _user_organizations.append(_membership.organization_id)
-                _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
 
         user_role: Optional[LitellmUserRoles] = _user_organization_role_mapping.get(
             passed_organization_id
@@ -83,3 +82,57 @@ def organization_role_based_access_check(
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
+    elif route == "/team/new":
+        # if user is part of multiple teams, then they need to specify the organization_id
+        _user_organizations, _user_organization_role_mapping = (
+            get_user_organization_info(user_object)
+        )
+        if (
+            user_object.organization_memberships is not None
+            and len(user_object.organization_memberships) > 1
+        ):
+            if passed_organization_id is None:
+                raise ProxyException(
+                    message=f"Passed organization_id is None, please specify the organization_id in your request. You are part of multiple organizations: {_user_organizations}",
+                    type=ProxyErrorTypes.auth_error.value,
+                    param="organization_id",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+            _user_role_in_passed_org = _user_organization_role_mapping.get(
+                passed_organization_id
+            )
+            if _user_role_in_passed_org != LitellmUserRoles.ORG_ADMIN.value:
+                raise ProxyException(
+                    message=f"You do not have the required role to call {route}. Your role is {_user_role_in_passed_org} in Organization {passed_organization_id}",
+                    type=ProxyErrorTypes.auth_error.value,
+                    param="user_role",
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+
+def get_user_organization_info(
+    user_object: LiteLLM_UserTable,
+) -> Tuple[List[str], Dict[str, Optional[LitellmUserRoles]]]:
+    """
+    Helper function to extract user organization information.
+
+    Args:
+        user_object (LiteLLM_UserTable): The user object containing organization memberships.
+
+    Returns:
+        Tuple[List[str], Dict[str, Optional[LitellmUserRoles]]]: A tuple containing:
+            - List of organization IDs the user is a member of
+            - Dictionary mapping organization IDs to user roles
+    """
+    _user_organizations: List[str] = []
+    user_organizations_with_alias: List[Tuple[str, str]] = []
+    _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
+
+    if user_object.organization_memberships is not None:
+        for _membership in user_object.organization_memberships:
+            if _membership.organization_id is not None:
+                _user_organizations.append(_membership.organization_id)
+                _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
+
+    return _user_organizations, _user_organization_role_mapping

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -1,0 +1,5 @@
+"""
+Auth Checks for Organizations
+"""
+
+from litellm.proxy._types import *

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -15,77 +15,70 @@ def organization_role_based_access_check(
     """
     Role based access control checks only run if a user is part of an Organization
 
-
     Organization Checks:
     ONLY RUN IF user_object.organization_memberships is not None
 
-    1. If route is a /new or /generate route ensure organization is passed in request and user is part of it
-        1a Check UserRole in organization and ensure user has Create permissions
+    1. Only Proxy Admins and Org Admins can access /organization/* routes
+    2. IF user_object.organization_memberships is not None /team/new is called
 
-
-    Raises Exception:
-        - when a user is part of an organization and tries creating a team / user without specifying an organization_id
-        - when a user does not have the appropriate permissions within their organization
     """
 
     if user_object is None:
         return
 
-    if (
-        user_object.organization_memberships is None
-        or len(user_object.organization_memberships) == 0
-    ):
-        return
+    passed_organization_id: str = request_body.get("organization_id", None)
 
-    _user_organizations: List[str] = []
-    _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
-    for _membership in user_object.organization_memberships:
-        if _membership.organization_id is not None:
-            _user_organizations.append(_membership.organization_id)
-            _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
-
-    if route in LiteLLMRoutes.management_create_routes.value:
-        if "organization_id" not in request_body:
-            raise Exception(
-                "Please specify 'organization_id' in request body, you are part of multiple_organizations"
+    if route == "/organization/new":
+        if user_object.user_role != LitellmUserRoles.PROXY_ADMIN.value:
+            raise ProxyException(
+                message=f"Only proxy admins can create new organizations",
+                type=ProxyErrorTypes.auth_error.value,
+                param="user_role",
+                code=status.HTTP_401_UNAUTHORIZED,
             )
 
-        passed_organization_id = request_body["organization_id"]
+    if user_object.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+        return
+    # Checks if route is an Org Admin Only Route
+    if route in LiteLLMRoutes.org_admin_only_routes.value:
+        _user_organizations: List[str] = []
+        _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
 
-        if passed_organization_id not in _user_organizations:
+        if user_object.organization_memberships is None:
             raise ProxyException(
-                message=f"You are not a member of the organization specified in the request body. Passed organization_id: {passed_organization_id}",
+                message=f"Tried to access route={route} but you are not a member of any organization. Please contact the proxy admin to request access.",
                 type=ProxyErrorTypes.auth_error.value,
                 param="organization_id",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
+
+        if passed_organization_id is None:
+            raise ProxyException(
+                message=f"Passed organization_id is None, please pass an organization_id",
+                type=ProxyErrorTypes.auth_error.value,
+                param="organization_id",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        for _membership in user_object.organization_memberships:
+            if _membership.organization_id is not None:
+                _user_organizations.append(_membership.organization_id)
+                _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
 
         user_role: Optional[LitellmUserRoles] = _user_organization_role_mapping.get(
             passed_organization_id
         )
         if user_role is None:
             raise ProxyException(
-                message=f"You do not have a role within the selected organization. Passed organization_id: {passed_organization_id}",
+                message=f"You do not have a role within the selected organization. Passed organization_id: {passed_organization_id}. Please contact the organization admin to request access.",
                 type=ProxyErrorTypes.auth_error.value,
                 param="organization_id",
                 code=status.HTTP_401_UNAUTHORIZED,
             )
-        elif (
-            user_role == LitellmUserRoles.INTERNAL_USER.value
-            and route not in LiteLLMRoutes.internal_user_routes.value
-        ):
+
+        if user_role != LitellmUserRoles.ORG_ADMIN.value:
             raise ProxyException(
-                message=f"You do not have the correct role to access this route in organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
-                type=ProxyErrorTypes.auth_error.value,
-                param="user_role",
-                code=status.HTTP_401_UNAUTHORIZED,
-            )
-        elif (
-            user_role == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value
-            and route not in LiteLLMRoutes.internal_user_view_only_routes.value
-        ):
-            raise ProxyException(
-                message=f"You do not have the correct role to access this route in organization_id: {passed_organization_id}, role: {user_role}. Tried to call route: {route}",
+                message=f"You do not have the required role to perform this action. Your role is {user_role} in Organization {passed_organization_id}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -31,7 +31,10 @@ def organization_role_based_access_check(
     if user_object is None:
         return
 
-    if user_object.organization_memberships is None:
+    if (
+        user_object.organization_memberships is None
+        or len(user_object.organization_memberships) == 0
+    ):
         return
 
     _user_organizations: List[str] = []

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -136,3 +136,27 @@ def get_user_organization_info(
                 _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
 
     return _user_organizations, _user_organization_role_mapping
+
+
+def _user_is_org_admin(
+    request_data: dict,
+    user_object: Optional[LiteLLM_UserTable] = None,
+) -> bool:
+    """
+    Helper function to check if user is an org admin for the passed organization_id
+    """
+    if request_data.get("organization_id", None) is None:
+        return False
+
+    if user_object is None:
+        return False
+
+    if user_object.organization_memberships is None:
+        return False
+
+    for _membership in user_object.organization_memberships:
+        if _membership.organization_id == request_data.get("organization_id", None):
+            if _membership.user_role == LitellmUserRoles.ORG_ADMIN.value:
+                return True
+
+    return False

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -33,7 +33,7 @@ def organization_role_based_access_check(
     if route == "/organization/new":
         if user_object.user_role != LitellmUserRoles.PROXY_ADMIN.value:
             raise ProxyException(
-                message=f"Only proxy admins can create new organizations",
+                message=f"Only proxy admins can create new organizations. You are {user_object.user_role}",
                 type=ProxyErrorTypes.auth_error.value,
                 param="user_role",
                 code=status.HTTP_401_UNAUTHORIZED,
@@ -126,7 +126,6 @@ def get_user_organization_info(
             - Dictionary mapping organization IDs to user roles
     """
     _user_organizations: List[str] = []
-    user_organizations_with_alias: List[Tuple[str, str]] = []
     _user_organization_role_mapping: Dict[str, Optional[LitellmUserRoles]] = {}
 
     if user_object.organization_memberships is not None:

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -16,7 +16,7 @@ from litellm.proxy.utils import hash_token
 from .auth_utils import _has_user_setup_sso
 
 
-def non_admin_allowed_routes_check(
+def non_proxy_admin_allowed_routes_check(
     user_obj: Optional[LiteLLM_UserTable],
     _user_role: Optional[LitellmUserRoles],
     route: str,
@@ -26,7 +26,7 @@ def non_admin_allowed_routes_check(
     request_data: dict,
 ):
     """
-    Checks if Non-Admin User is allowed to access the route
+    Checks if Non Proxy Admin User is allowed to access the route
     """
 
     # Check user has defined custom admin routes
@@ -104,6 +104,11 @@ def non_admin_allowed_routes_check(
     elif (
         _user_role == LitellmUserRoles.INTERNAL_USER.value
         and route in LiteLLMRoutes.internal_user_routes.value
+    ):
+        pass
+    elif (
+        _user_role == LitellmUserRoles.ADMIN.value
+        and route in LiteLLMRoutes.org_admin_user_routes.value
     ):
         pass
     elif (

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -13,6 +13,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.utils import hash_token
 
+from .auth_checks_organization import _user_is_org_admin
 from .auth_utils import _has_user_setup_sso
 
 
@@ -107,8 +108,8 @@ def non_proxy_admin_allowed_routes_check(
     ):
         pass
     elif (
-        _user_role == LitellmUserRoles.ORG_ADMIN.value
-        and route in LiteLLMRoutes.org_admin_user_routes.value
+        _user_is_org_admin(request_data=request_data, user_object=user_obj)
+        and route in LiteLLMRoutes.org_admin_allowed_routes.value
     ):
         pass
     elif (

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -107,7 +107,7 @@ def non_proxy_admin_allowed_routes_check(
     ):
         pass
     elif (
-        _user_role == LitellmUserRoles.ADMIN.value
+        _user_role == LitellmUserRoles.ORG_ADMIN.value
         and route in LiteLLMRoutes.org_admin_user_routes.value
     ):
         pass

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -69,7 +69,7 @@ from litellm.proxy.auth.auth_utils import (
 )
 from litellm.proxy.auth.oauth2_check import check_oauth2_token
 from litellm.proxy.auth.oauth2_proxy_hook import handle_oauth2_proxy_request
-from litellm.proxy.auth.route_checks import non_admin_allowed_routes_check
+from litellm.proxy.auth.route_checks import non_proxy_admin_allowed_routes_check
 from litellm.proxy.auth.service_account_checks import service_account_checks
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.utils import _to_ns
@@ -1042,7 +1042,7 @@ async def user_api_key_auth(
             _user_role = _get_user_role(user_obj=user_obj)
 
             if not _is_user_proxy_admin(user_obj=user_obj):  # if non-admin
-                non_admin_allowed_routes_check(
+                non_proxy_admin_allowed_routes_check(
                     user_obj=user_obj,
                     _user_role=_user_role,
                     route=route,

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -63,7 +63,6 @@ async def new_user(
     - user_id: Optional[str] - Specify a user id. If not set, a unique id will be generated.
     - user_alias: Optional[str] - A descriptive name for you to know who this user id refers to.
     - teams: Optional[list] - specify a list of team id's a user belongs to.
-    - organization_id: Optional[str] - specify the org a user belongs to. when specified a user will be added to the organization.
     - user_email: Optional[str] - Specify a user email.
     - send_invite_email: Optional[bool] - Specify if an invite email should be sent.
     - user_role: Optional[str] - Specify a user role - "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer", "team", "customer". Info about each role here: `https://github.com/BerriAI/litellm/litellm/proxy/_types.py#L20`
@@ -136,17 +135,6 @@ async def new_user(
                 scope={"type": "http", "path": "/user/new"},
             ),
             user_api_key_dict=user_api_key_dict,
-        )
-
-    if data_json.get("organization_id", None) is not None:
-        # default to adding users as `INTERNAL_USER_VIEW_ONLY` if no role specified for organizations
-        _user_role: LitellmUserRoles = (
-            data_json.get("user_role", None) or LitellmUserRoles.INTERNAL_USER_VIEW_ONLY
-        )
-        await add_internal_user_to_organization(
-            user_id=data_json.get("user_id", None),
-            organization_id=data_json["organization_id"],
-            user_role=_user_role,
         )
 
     if data.send_invite_email is True:

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -238,7 +238,7 @@ async def organization_member_add(
     data: OrganizationMemberAddRequest,
     http_request: Request,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
+) -> OrganizationAddMemberResponse:
     """
     [BETA]
 

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -247,20 +247,37 @@ async def organization_member_add(
     If user doesn't exist, new user row will also be added to User Table
 
     Only proxy_admin or org_admin of organization, allowed to access this endpoint.
-    ```
 
+    # Parameters:
+
+    - organization_id: str (required)
+    - member: Union[List[Member], Member] (required)
+        - role: Literal[LitellmUserRoles] (required)
+        - user_id: Optional[str]
+        - user_email: Optional[str]
+
+    Note: Either user_id or user_email must be provided for each member.
+
+    Example:
+    ```
     curl -X POST 'http://0.0.0.0:4000/organization/member_add' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -d '{"organization_id": "45e3e396-ee08-4a61-a88e-16b3ce7e0849", "member": {"role": "internal_user", "user_id": "krrish247652@berri.ai"}}'
-
+    -d '{
+        "organization_id": "45e3e396-ee08-4a61-a88e-16b3ce7e0849",
+        "member": {
+            "role": "internal_user",
+            "user_id": "krrish247652@berri.ai"
+        },
+        "max_budget_in_organization": 100.0
+    }'
+    ```
 
     The following is executed in this function:
 
     1. Check if organization exists
     2. Creates a new Internal User if the user_id or user_email is not found in LiteLLM_UserTable
     3. Add Internal User to the `LiteLLM_OrganizationMembership` table
-    ```
     """
     try:
         from litellm.proxy.proxy_server import (

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1,0 +1,222 @@
+"""
+Endpoints for /organization operations
+
+/organization/new
+/organization/update
+/organization/delete
+/organization/info
+"""
+
+#### ORGANIZATION MANAGEMENT ####
+
+import asyncio
+import copy
+import json
+import re
+import secrets
+import traceback
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+import fastapi
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import *
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.secret_managers.main import get_secret
+
+router = APIRouter()
+
+
+@router.post(
+    "/organization/new",
+    tags=["organization management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=NewOrganizationResponse,
+)
+async def new_organization(
+    data: NewOrganizationRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Allow orgs to own teams
+
+    Set org level budgets + model access.
+
+    Only admins can create orgs.
+
+    # Parameters
+
+    - `organization_alias`: *str* = The name of the organization.
+    - `models`: *List* = The models the organization has access to.
+    - `budget_id`: *Optional[str]* = The id for a budget (tpm/rpm/max budget) for the organization.
+    ### IF NO BUDGET ID - CREATE ONE WITH THESE PARAMS ###
+    - `max_budget`: *Optional[float]* = Max budget for org
+    - `tpm_limit`: *Optional[int]* = Max tpm limit for org
+    - `rpm_limit`: *Optional[int]* = Max rpm limit for org
+    - `model_max_budget`: *Optional[dict]* = Max budget for a specific model
+    - `budget_duration`: *Optional[str]* = Frequency of reseting org budget
+
+    Case 1: Create new org **without** a budget_id
+
+    ```bash
+    curl --location 'http://0.0.0.0:4000/organization/new' \
+
+    --header 'Authorization: Bearer sk-1234' \
+
+    --header 'Content-Type: application/json' \
+
+    --data '{
+        "organization_alias": "my-secret-org",
+        "models": ["model1", "model2"],
+        "max_budget": 100
+    }'
+
+
+    ```
+
+    Case 2: Create new org **with** a budget_id
+
+    ```bash
+    curl --location 'http://0.0.0.0:4000/organization/new' \
+
+    --header 'Authorization: Bearer sk-1234' \
+
+    --header 'Content-Type: application/json' \
+
+    --data '{
+        "organization_alias": "my-secret-org",
+        "models": ["model1", "model2"],
+        "budget_id": "428eeaa8-f3ac-4e85-a8fb-7dc8d7aa8689"
+    }'
+    ```
+    """
+    from litellm.proxy.proxy_server import litellm_proxy_admin_name, prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail={"error": "No db connected"})
+
+    if (
+        user_api_key_dict.user_role is None
+        or user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error": f"Only admins can create orgs. Your role is = {user_api_key_dict.user_role}"
+            },
+        )
+
+    if data.budget_id is None:
+        """
+        Every organization needs a budget attached.
+
+        If none provided, create one based on provided values
+        """
+        budget_params = LiteLLM_BudgetTable.model_fields.keys()
+
+        # Only include Budget Params when creating an entry in litellm_budgettable
+        _json_data = data.json(exclude_none=True)
+        _budget_data = {k: v for k, v in _json_data.items() if k in budget_params}
+        budget_row = LiteLLM_BudgetTable(**_budget_data)
+
+        new_budget = prisma_client.jsonify_object(budget_row.json(exclude_none=True))
+
+        _budget = await prisma_client.db.litellm_budgettable.create(
+            data={
+                **new_budget,  # type: ignore
+                "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+            }
+        )  # type: ignore
+
+        data.budget_id = _budget.budget_id
+
+    """
+    Ensure only models that user has access to, are given to org
+    """
+    if len(user_api_key_dict.models) == 0:  # user has access to all models
+        pass
+    else:
+        if len(data.models) == 0:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "User not allowed to give access to all models. Select models you want org to have access to."
+                },
+            )
+        for m in data.models:
+            if m not in user_api_key_dict.models:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"User not allowed to give access to model={m}. Models you have access to = {user_api_key_dict.models}"
+                    },
+                )
+    organization_row = LiteLLM_OrganizationTable(
+        **data.json(exclude_none=True),
+        created_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
+        updated_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
+    )
+    new_organization_row = prisma_client.jsonify_object(
+        organization_row.json(exclude_none=True)
+    )
+    response = await prisma_client.db.litellm_organizationtable.create(
+        data={
+            **new_organization_row,  # type: ignore
+        }
+    )
+
+    return response
+
+
+@router.post(
+    "/organization/update",
+    tags=["organization management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def update_organization():
+    """[TODO] Not Implemented yet. Let us know if you need this - https://github.com/BerriAI/litellm/issues"""
+    pass
+
+
+@router.post(
+    "/organization/delete",
+    tags=["organization management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def delete_organization():
+    """[TODO] Not Implemented yet. Let us know if you need this - https://github.com/BerriAI/litellm/issues"""
+    pass
+
+
+@router.post(
+    "/organization/info",
+    tags=["organization management"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def info_organization(data: OrganizationRequest):
+    """
+    Get the org specific information
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail={"error": "No db connected"})
+
+    if len(data.organizations) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"Specify list of organization id's to query. Passed in={data.organizations}"
+            },
+        )
+    response = await prisma_client.db.litellm_organizationtable.find_many(
+        where={"organization_id": {"in": data.organizations}},
+        include={"litellm_budget_table": True},
+    )
+
+    return response

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -185,6 +185,9 @@ from litellm.proxy.management_endpoints.key_management_endpoints import (
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     router as key_management_router,
 )
+from litellm.proxy.management_endpoints.organization_endpoints import (
+    router as organization_router,
+)
 from litellm.proxy.management_endpoints.team_callback_endpoints import (
     router as team_callback_router,
 )
@@ -6029,8 +6032,7 @@ async def end_user_info(
         )
 
     user_info = await prisma_client.db.litellm_endusertable.find_first(
-        where={"user_id": end_user_id},
-        include={"litellm_budget_table": True}
+        where={"user_id": end_user_id}, include={"litellm_budget_table": True}
     )
 
     if user_info is None:
@@ -6312,200 +6314,6 @@ async def create_audit_log_for_update(request_data: LiteLLM_AuditLogs):
         verbose_proxy_logger.error(f"Failed Creating audit log {e}")
 
     return
-
-
-#### ORGANIZATION MANAGEMENT ####
-
-
-@router.post(
-    "/organization/new",
-    tags=["organization management"],
-    dependencies=[Depends(user_api_key_auth)],
-    response_model=NewOrganizationResponse,
-)
-async def new_organization(
-    data: NewOrganizationRequest,
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
-    """
-    Allow orgs to own teams
-
-    Set org level budgets + model access.
-
-    Only admins can create orgs.
-
-    # Parameters
-
-    - `organization_alias`: *str* = The name of the organization.
-    - `models`: *List* = The models the organization has access to.
-    - `budget_id`: *Optional[str]* = The id for a budget (tpm/rpm/max budget) for the organization.
-    ### IF NO BUDGET ID - CREATE ONE WITH THESE PARAMS ###
-    - `max_budget`: *Optional[float]* = Max budget for org
-    - `tpm_limit`: *Optional[int]* = Max tpm limit for org
-    - `rpm_limit`: *Optional[int]* = Max rpm limit for org
-    - `model_max_budget`: *Optional[dict]* = Max budget for a specific model
-    - `budget_duration`: *Optional[str]* = Frequency of reseting org budget
-
-    Case 1: Create new org **without** a budget_id
-
-    ```bash
-    curl --location 'http://0.0.0.0:4000/organization/new' \
-
-    --header 'Authorization: Bearer sk-1234' \
-
-    --header 'Content-Type: application/json' \
-
-    --data '{
-        "organization_alias": "my-secret-org",
-        "models": ["model1", "model2"],
-        "max_budget": 100
-    }'
-
-
-    ```
-
-    Case 2: Create new org **with** a budget_id
-
-    ```bash
-    curl --location 'http://0.0.0.0:4000/organization/new' \
-
-    --header 'Authorization: Bearer sk-1234' \
-
-    --header 'Content-Type: application/json' \
-
-    --data '{
-        "organization_alias": "my-secret-org",
-        "models": ["model1", "model2"],
-        "budget_id": "428eeaa8-f3ac-4e85-a8fb-7dc8d7aa8689"
-    }'
-    ```
-    """
-    global prisma_client
-
-    if prisma_client is None:
-        raise HTTPException(status_code=500, detail={"error": "No db connected"})
-
-    if (
-        user_api_key_dict.user_role is None
-        or user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
-    ):
-        raise HTTPException(
-            status_code=401,
-            detail={
-                "error": f"Only admins can create orgs. Your role is = {user_api_key_dict.user_role}"
-            },
-        )
-
-    if data.budget_id is None:
-        """
-        Every organization needs a budget attached.
-
-        If none provided, create one based on provided values
-        """
-        budget_params = LiteLLM_BudgetTable.model_fields.keys()
-
-        # Only include Budget Params when creating an entry in litellm_budgettable
-        _json_data = data.json(exclude_none=True)
-        _budget_data = {k: v for k, v in _json_data.items() if k in budget_params}
-        budget_row = LiteLLM_BudgetTable(**_budget_data)
-
-        new_budget = prisma_client.jsonify_object(budget_row.json(exclude_none=True))
-
-        _budget = await prisma_client.db.litellm_budgettable.create(
-            data={
-                **new_budget,  # type: ignore
-                "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-            }
-        )  # type: ignore
-
-        data.budget_id = _budget.budget_id
-
-    """
-    Ensure only models that user has access to, are given to org
-    """
-    if len(user_api_key_dict.models) == 0:  # user has access to all models
-        pass
-    else:
-        if len(data.models) == 0:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "User not allowed to give access to all models. Select models you want org to have access to."
-                },
-            )
-        for m in data.models:
-            if m not in user_api_key_dict.models:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "error": f"User not allowed to give access to model={m}. Models you have access to = {user_api_key_dict.models}"
-                    },
-                )
-    organization_row = LiteLLM_OrganizationTable(
-        **data.json(exclude_none=True),
-        created_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
-        updated_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
-    )
-    new_organization_row = prisma_client.jsonify_object(
-        organization_row.json(exclude_none=True)
-    )
-    response = await prisma_client.db.litellm_organizationtable.create(
-        data={
-            **new_organization_row,  # type: ignore
-        }
-    )
-
-    return response
-
-
-@router.post(
-    "/organization/update",
-    tags=["organization management"],
-    dependencies=[Depends(user_api_key_auth)],
-)
-async def update_organization():
-    """[TODO] Not Implemented yet. Let us know if you need this - https://github.com/BerriAI/litellm/issues"""
-    pass
-
-
-@router.post(
-    "/organization/delete",
-    tags=["organization management"],
-    dependencies=[Depends(user_api_key_auth)],
-)
-async def delete_organization():
-    """[TODO] Not Implemented yet. Let us know if you need this - https://github.com/BerriAI/litellm/issues"""
-    pass
-
-
-@router.post(
-    "/organization/info",
-    tags=["organization management"],
-    dependencies=[Depends(user_api_key_auth)],
-)
-async def info_organization(data: OrganizationRequest):
-    """
-    Get the org specific information
-    """
-    global prisma_client
-
-    if prisma_client is None:
-        raise HTTPException(status_code=500, detail={"error": "No db connected"})
-
-    if len(data.organizations) == 0:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": f"Specify list of organization id's to query. Passed in={data.organizations}"
-            },
-        )
-    response = await prisma_client.db.litellm_organizationtable.find_many(
-        where={"organization_id": {"in": data.organizations}},
-        include={"litellm_budget_table": True},
-    )
-
-    return response
 
 
 #### BUDGET TABLE MANAGEMENT ####
@@ -9655,6 +9463,7 @@ app.include_router(key_management_router)
 app.include_router(internal_user_router)
 app.include_router(team_router)
 app.include_router(ui_sso_router)
+app.include_router(organization_router)
 app.include_router(spend_management_router)
 app.include_router(caching_router)
 app.include_router(analytics_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7990,6 +7990,14 @@ async def login(request: Request):
 
     # check if we can find the `username` in the db. on the ui, users can enter username=their email
     _user_row = None
+    user_role: Optional[
+        Literal[
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+            LitellmUserRoles.INTERNAL_USER,
+            LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
+        ]
+    ] = None
     if prisma_client is not None:
         _user_row = await prisma_client.db.litellm_usertable.find_first(
             where={"user_email": {"equals": username}}

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -119,7 +119,10 @@ model LiteLLM_UserTable {
     allowed_cache_controls String[] @default([])
     model_spend      Json @default("{}")
     model_max_budget Json @default("{}")
-    litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
+
+    // relations
+    litellm_organization_table LiteLLM_OrganizationTable?                   @relation(fields: [organization_id], references: [organization_id])
+    organization_memberships LiteLLM_OrganizationMembership[]
     invitations_created LiteLLM_InvitationLink[] @relation("CreatedBy")
     invitations_updated LiteLLM_InvitationLink[] @relation("UpdatedBy")
     invitations_user    LiteLLM_InvitationLink[] @relation("UserId")
@@ -242,8 +245,13 @@ model LiteLLM_OrganizationMembership {
   budget_id String?
   created_at    DateTime               @default(now()) @map("created_at")
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+
+  // relations
+  user LiteLLM_UserTable @relation(fields: [user_id], references: [user_id])
   litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
+  
   @@id([user_id, organization_id])
+  @@unique([user_id, organization_id])
 }
 
 model LiteLLM_InvitationLink {

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -238,13 +238,13 @@ model LiteLLM_TeamMembership {
 
 model LiteLLM_OrganizationMembership {
   // Use this table to track Internal User and Organization membership. Helps tracking a users role within an Organization
-  user_id    String
-  organization_id String
-  user_role  String?
-  spend      Float    @default(0.0)
-  budget_id String?
-  created_at    DateTime               @default(now()) @map("created_at")
-  updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+  user_id         String?
+  organization_id String?
+  user_role       String?
+  spend           Float?    @default(0.0)
+  budget_id       String?
+  created_at      DateTime?               @default(now()) @map("created_at")
+  updated_at      DateTime?               @default(now()) @updatedAt @map("updated_at")
 
   // relations
   user LiteLLM_UserTable @relation(fields: [user_id], references: [user_id])

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -26,6 +26,7 @@ model LiteLLM_BudgetTable {
   keys LiteLLM_VerificationToken[] // multiple keys can have the same budget
   end_users LiteLLM_EndUserTable[] // multiple end-users can have the same budget
   team_membership LiteLLM_TeamMembership[] // budgets of Users within a Team 
+  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization 
 }
 
 // Models on proxy
@@ -230,6 +231,19 @@ model LiteLLM_TeamMembership {
   budget_id String?
   litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
   @@id([user_id, team_id])
+}
+
+model LiteLLM_OrganizationMembership {
+  // Use this table to track Internal User and Organization membership. Helps tracking a users role within an Organization
+  user_id    String
+  organization_id String
+  user_role  String?
+  spend      Float    @default(0.0)
+  budget_id String?
+  created_at    DateTime               @default(now()) @map("created_at")
+  updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+  litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
+  @@id([user_id, organization_id])
 }
 
 model LiteLLM_InvitationLink {

--- a/schema.prisma
+++ b/schema.prisma
@@ -119,7 +119,10 @@ model LiteLLM_UserTable {
     allowed_cache_controls String[] @default([])
     model_spend      Json @default("{}")
     model_max_budget Json @default("{}")
-    litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
+
+    // relations
+    litellm_organization_table LiteLLM_OrganizationTable?                   @relation(fields: [organization_id], references: [organization_id])
+    organization_memberships LiteLLM_OrganizationMembership[]
     invitations_created LiteLLM_InvitationLink[] @relation("CreatedBy")
     invitations_updated LiteLLM_InvitationLink[] @relation("UpdatedBy")
     invitations_user    LiteLLM_InvitationLink[] @relation("UserId")
@@ -242,8 +245,13 @@ model LiteLLM_OrganizationMembership {
   budget_id String?
   created_at    DateTime               @default(now()) @map("created_at")
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+
+  // relations
+  user LiteLLM_UserTable @relation(fields: [user_id], references: [user_id])
   litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
+  
   @@id([user_id, organization_id])
+  @@unique([user_id, organization_id])
 }
 
 model LiteLLM_InvitationLink {

--- a/schema.prisma
+++ b/schema.prisma
@@ -238,13 +238,13 @@ model LiteLLM_TeamMembership {
 
 model LiteLLM_OrganizationMembership {
   // Use this table to track Internal User and Organization membership. Helps tracking a users role within an Organization
-  user_id    String
-  organization_id String
-  user_role  String?
-  spend      Float    @default(0.0)
-  budget_id String?
-  created_at    DateTime               @default(now()) @map("created_at")
-  updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+  user_id         String?
+  organization_id String?
+  user_role       String?
+  spend           Float?    @default(0.0)
+  budget_id       String?
+  created_at      DateTime?               @default(now()) @map("created_at")
+  updated_at      DateTime?               @default(now()) @updatedAt @map("updated_at")
 
   // relations
   user LiteLLM_UserTable @relation(fields: [user_id], references: [user_id])

--- a/schema.prisma
+++ b/schema.prisma
@@ -26,6 +26,7 @@ model LiteLLM_BudgetTable {
   keys LiteLLM_VerificationToken[] // multiple keys can have the same budget
   end_users LiteLLM_EndUserTable[] // multiple end-users can have the same budget
   team_membership LiteLLM_TeamMembership[] // budgets of Users within a Team 
+  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization 
 }
 
 // Models on proxy
@@ -230,6 +231,19 @@ model LiteLLM_TeamMembership {
   budget_id String?
   litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
   @@id([user_id, team_id])
+}
+
+model LiteLLM_OrganizationMembership {
+  // Use this table to track Internal User and Organization membership. Helps tracking a users role within an Organization
+  user_id    String
+  organization_id String
+  user_role  String?
+  spend      Float    @default(0.0)
+  budget_id String?
+  created_at    DateTime               @default(now()) @map("created_at")
+  updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
+  litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
+  @@id([user_id, organization_id])
 }
 
 model LiteLLM_InvitationLink {

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -214,22 +214,20 @@ async def test_org_admin_create_team_permissions(prisma_client):
     )
 
     org_id = response.organization_id
-
-    response = await new_user(
-        data=NewUserRequest(
-            organization_id=org_id, user_role=LitellmUserRoles.ORG_ADMIN
-        )
+    created_user_id = f"new-user-{uuid.uuid4()}"
+    response = await organization_member_add(
+        data=OrganizationMemberAddRequest(
+            organization_id=org_id,
+            member=Member(role=LitellmUserRoles.ORG_ADMIN, user_id=created_user_id),
+        ),
+        http_request=None,
     )
 
     # create key with the response["user_id"]
-
     _new_key = await generate_key_fn(
-        data=GenerateKeyRequest(
-            user_id=response.user_id,
-        ),
+        data=GenerateKeyRequest(user_id=created_user_id),
         user_api_key_dict=UserAPIKeyAuth(
-            user_role=LitellmUserRoles.ORG_ADMIN,
-            user_id=response.user_id,
+            user_role=LitellmUserRoles.ORG_ADMIN, user_id=created_user_id
         ),
     )
 
@@ -268,7 +266,7 @@ async def test_org_admin_create_user_permissions(prisma_client):
     """
     Create a new org admin
 
-    org admin creates a new user in their org -> success
+    org admin adds a new member to their org -> success
     """
     import json
 
@@ -288,22 +286,21 @@ async def test_org_admin_create_user_permissions(prisma_client):
     )
 
     org_id = response.organization_id
-
-    response = await new_user(
-        data=NewUserRequest(
-            organization_id=org_id, user_role=LitellmUserRoles.ORG_ADMIN
-        )
+    created_user_id = f"new-user-{uuid.uuid4()}"
+    response = await organization_member_add(
+        data=OrganizationMemberAddRequest(
+            organization_id=org_id,
+            member=Member(role=LitellmUserRoles.ORG_ADMIN, user_id=created_user_id),
+        ),
+        http_request=None,
     )
 
     # create key with the response["user_id"]
 
     _new_key = await generate_key_fn(
-        data=GenerateKeyRequest(
-            user_id=response.user_id,
-        ),
+        data=GenerateKeyRequest(user_id=created_user_id),
         user_api_key_dict=UserAPIKeyAuth(
-            user_role=LitellmUserRoles.ORG_ADMIN,
-            user_id=response.user_id,
+            user_role=LitellmUserRoles.ORG_ADMIN, user_id=created_user_id
         ),
     )
 
@@ -322,7 +319,7 @@ async def test_org_admin_create_user_permissions(prisma_client):
     request.body = return_body
     response = await user_api_key_auth(request=request, api_key="Bearer " + new_key)
 
-    # after auth - actually create team now
+    # after auth - actually actually add new user to organization
     response = await new_user(
         data=NewUserRequest(
             organization_id=org_id,

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -141,7 +141,7 @@ RBAC Tests
     [
         None,
         LitellmUserRoles.PROXY_ADMIN,
-        LitellmUserRoles.ADMIN,
+        LitellmUserRoles.ORG_ADMIN,
         LitellmUserRoles.INTERNAL_USER,
         LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
     ],
@@ -224,7 +224,9 @@ async def test_org_admin_create_team_permissions(prisma_client):
     org_id = response.organization_id
 
     response = await new_user(
-        data=NewUserRequest(organization_id=org_id, user_role=LitellmUserRoles.ADMIN)
+        data=NewUserRequest(
+            organization_id=org_id, user_role=LitellmUserRoles.ORG_ADMIN
+        )
     )
 
     # create key with the response["user_id"]
@@ -234,7 +236,7 @@ async def test_org_admin_create_team_permissions(prisma_client):
             user_id=response.user_id,
         ),
         user_api_key_dict=UserAPIKeyAuth(
-            user_role=LitellmUserRoles.ADMIN,
+            user_role=LitellmUserRoles.ORG_ADMIN,
             user_id=response.user_id,
         ),
     )
@@ -262,7 +264,7 @@ async def test_org_admin_create_team_permissions(prisma_client):
         http_request=request,
         user_api_key_dict=UserAPIKeyAuth(
             user_id=response.user_id,
-            user_role=LitellmUserRoles.ADMIN,
+            user_role=LitellmUserRoles.ORG_ADMIN,
         ),
     )
 
@@ -296,7 +298,9 @@ async def test_org_admin_create_user_permissions(prisma_client):
     org_id = response.organization_id
 
     response = await new_user(
-        data=NewUserRequest(organization_id=org_id, user_role=LitellmUserRoles.ADMIN)
+        data=NewUserRequest(
+            organization_id=org_id, user_role=LitellmUserRoles.ORG_ADMIN
+        )
     )
 
     # create key with the response["user_id"]
@@ -306,7 +310,7 @@ async def test_org_admin_create_user_permissions(prisma_client):
             user_id=response.user_id,
         ),
         user_api_key_dict=UserAPIKeyAuth(
-            user_role=LitellmUserRoles.ADMIN,
+            user_role=LitellmUserRoles.ORG_ADMIN,
             user_id=response.user_id,
         ),
     )
@@ -333,7 +337,7 @@ async def test_org_admin_create_user_permissions(prisma_client):
         ),
         user_api_key_dict=UserAPIKeyAuth(
             user_id=response.user_id,
-            user_role=LitellmUserRoles.ADMIN,
+            user_role=LitellmUserRoles.ORG_ADMIN,
         ),
     )
 
@@ -378,7 +382,9 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
     org_without_admins = response2.organization_id
 
     response = await new_user(
-        data=NewUserRequest(organization_id=org_id, user_role=LitellmUserRoles.ADMIN)
+        data=NewUserRequest(
+            organization_id=org_id, user_role=LitellmUserRoles.ORG_ADMIN
+        )
     )
 
     # create key with the response["user_id"]
@@ -388,7 +394,7 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
             user_id=response.user_id,
         ),
         user_api_key_dict=UserAPIKeyAuth(
-            user_role=LitellmUserRoles.ADMIN,
+            user_role=LitellmUserRoles.ORG_ADMIN,
             user_id=response.user_id,
         ),
     )

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -145,6 +145,7 @@ RBAC Tests
     [
         None,
         LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.ADMIN,
         LitellmUserRoles.INTERNAL_USER,
         LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
     ],

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -416,7 +416,7 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
         print("got exception", e)
         print("exception.message", e.message)
         assert (
-            "You do not have permission to access this route. Passed organization_id"
+            "You are not a member of the organization specified in the request body. Passed organization_id"
             in e.message
         )
 
@@ -439,6 +439,6 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
         print("got exception", e)
         print("exception.message", e.message)
         assert (
-            "You do not have permission to access this route. Passed organization_id"
+            "You are not a member of the organization specified in the request body"
             in e.message
         )

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -1,0 +1,182 @@
+"""
+RBAC tests
+"""
+
+import os
+import sys
+import traceback
+import uuid
+from datetime import datetime
+
+from dotenv import load_dotenv
+from fastapi import Request
+from fastapi.routing import APIRoute
+
+load_dotenv()
+import io
+import os
+import time
+
+# this file is to test litellm/proxy
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+import asyncio
+import logging
+
+import pytest
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.auth.auth_checks import get_user_object
+from litellm.proxy.management_endpoints.key_management_endpoints import (
+    delete_key_fn,
+    generate_key_fn,
+    generate_key_helper_fn,
+    info_key_fn,
+    regenerate_key_fn,
+    update_key_fn,
+)
+from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+from litellm.proxy.management_endpoints.team_endpoints import (
+    new_team,
+    team_info,
+    update_team,
+)
+from litellm.proxy.proxy_server import (
+    LitellmUserRoles,
+    audio_transcriptions,
+    chat_completion,
+    completion,
+    embeddings,
+    image_generation,
+    model_list,
+    moderations,
+    new_end_user,
+    user_api_key_auth,
+    new_organization,
+)
+from litellm.proxy.spend_tracking.spend_management_endpoints import (
+    global_spend,
+    global_spend_logs,
+    global_spend_models,
+    global_spend_keys,
+    spend_key_fn,
+    spend_user_fn,
+    view_spend_logs,
+)
+
+from litellm.proxy.utils import PrismaClient, ProxyLogging, hash_token, update_spend
+
+verbose_proxy_logger.setLevel(level=logging.DEBUG)
+
+from starlette.datastructures import URL
+
+from litellm.caching import DualCache
+from litellm.proxy._types import (
+    DynamoDBArgs,
+    GenerateKeyRequest,
+    NewOrganizationRequest,
+    RegenerateKeyRequest,
+    KeyRequest,
+    LiteLLM_UpperboundKeyGenerateParams,
+    NewCustomerRequest,
+    NewTeamRequest,
+    NewUserRequest,
+    ProxyErrorTypes,
+    ProxyException,
+    UpdateKeyRequest,
+    UpdateTeamRequest,
+    UpdateUserRequest,
+    UserAPIKeyAuth,
+)
+
+proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+
+
+@pytest.fixture
+def prisma_client():
+    from litellm.proxy.proxy_cli import append_query_params
+
+    ### add connection pool + pool timeout args
+    params = {"connection_limit": 100, "pool_timeout": 60}
+    database_url = os.getenv("DATABASE_URL")
+    modified_url = append_query_params(database_url, params)
+    os.environ["DATABASE_URL"] = modified_url
+
+    # Assuming PrismaClient is a class that needs to be instantiated
+    prisma_client = PrismaClient(
+        database_url=os.environ["DATABASE_URL"], proxy_logging_obj=proxy_logging_obj
+    )
+
+    # Reset litellm.proxy.proxy_server.prisma_client to None
+    litellm.proxy.proxy_server.litellm_proxy_budget_name = (
+        f"litellm-proxy-budget-{time.time()}"
+    )
+    litellm.proxy.proxy_server.user_custom_key_generate = None
+
+    return prisma_client
+
+
+"""
+RBAC Tests
+
+1. create a new user with an organization id 
+    - test 1 - if organization_id does not exist excpect to raise an error 
+    - test 2 - if organization_id does exist expect to create a new user and user, organization relation
+
+2. Create a new user, set as Admin for the organization. As the org admin
+    2a. Create a new user without an organization id -> expect to raise an error 
+    2b. Create a new user with an organization id and Internal_USER role -> expect to create a new user and user, organization relation
+
+3. Tests run as an Admin within an Organization 
+    3a. Try creating a team without an organization_id specific -> expect to raise an error
+    3b. Try creating a team in an organization Admin is not part of ->  expect to raise an Error
+    3c. Try creating a team in an organization Admin is part of ->  expect to create a new team and team, organization relation
+    3d. Try creating a user in an organization Admin is not part of -> expect to raise an Error
+    3e. Try creating a user in an organization Admin is part of -> expect to create a new user and user, organization relation
+"""
+
+
+@pytest.mark.asyncio
+async def test_create_new_user_in_organization(prisma_client):
+    master_key = "sk-1234"
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", master_key)
+
+    await litellm.proxy.proxy_server.prisma_client.connect()
+
+    response = await new_organization(
+        data=NewOrganizationRequest(
+            organization_alias=f"new-org-{uuid.uuid4()}",
+        ),
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        ),
+    )
+
+    org_id = response.organization_id
+
+    response = await new_user(data=NewUserRequest(organization_id=org_id))
+
+    print("new user response", response)
+
+    # call get_user_object
+
+    user_object = await get_user_object(
+        user_id=response.user_id,  # type: ignore
+        prisma_client=prisma_client,
+        user_api_key_cache=DualCache(),
+        user_id_upsert=False,
+    )
+
+    print("user object", user_object)
+
+    assert user_object.organization_memberships is not None
+
+    _membership = user_object.organization_memberships[0]
+
+    assert _membership.user_id == response.user_id
+    assert _membership.organization_id == org_id

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -33,7 +33,7 @@ async def new_organization(session, i, organization_alias, max_budget=None):
 @pytest.mark.asyncio
 async def test_organization_new():
     """
-    Make 20 parallel calls to /user/new. Assert all worked.
+    Make 20 parallel calls to /organization/new. Assert all worked.
     """
     organization_alias = f"Organization: {uuid.uuid4()}"
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Title

- [x] store the role of a user within an org in DB
- [x] after calling /user/new store the user_role in OrganizationMembership
- [x] Add /organization/member_add endpoint to add a user to an organization 
- [x]  org admin creates team in his org → success 
- [x] org admin adds new internal user to his org → success (organization/member_add) 
- [x] Auth Check - if user belongs to an org ensure organization_id passed in all /new operation
- [x] if org not specified when calling /team/new then pass (org_id, alias) to orgs in exception 


## Testing 

- [x] new user created -> ensure organization membership is stored with correct role 

## Testing 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

