### PR TITLE
(fix) Unable to override max_retries for Azure and Groq

### DIFF
--- a/litellm/llms/AzureOpenAI/azure.py
+++ b/litellm/llms/AzureOpenAI/azure.py
@@ -138,6 +138,7 @@ class AzureOpenAIConfig:
             "stream_options",
             "stop",
             "max_tokens",
+            "max_retries",
             "max_completion_tokens",
             "tools",
             "tool_choice",
@@ -584,7 +585,7 @@ class AzureChatCompletion(BaseLLM):
                     status_code=422, message="Missing model or messages"
                 )
 
-            max_retries = optional_params.pop("max_retries", 2)
+            max_retries = optional_params.get("max_retries", 2)
             json_mode: Optional[bool] = optional_params.pop("json_mode", False)
 
             ### CHECK IF CLOUDFLARE AI GATEWAY ###

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3817,6 +3817,8 @@ def get_optional_params(
             optional_params["temperature"] = temperature
         if max_tokens is not None:
             optional_params["max_tokens"] = max_tokens
+        if max_retries is not None:
+            optional_params["max_retries"] = max_retries
         if top_p is not None:
             optional_params["top_p"] = top_p
         if stream is not None:
@@ -4450,6 +4452,7 @@ def get_supported_openai_params(
         return [
             "temperature",
             "max_tokens",
+            "max_retries",
             "top_p",
             "stream",
             "stop",

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -322,6 +322,36 @@ def test_openai_extra_headers():
 
 
 @pytest.mark.parametrize(
+    "provider",
+    [
+        "openai",
+        "groq",
+        "azure",
+    ]
+)
+def test_max_retries(provider):
+    optional_params = litellm.utils.get_optional_params(
+        model="",
+        custom_llm_provider=provider,
+        max_retries=0,
+    )
+    assert optional_params["max_retries"] == 0
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "openai",
+        "groq",
+        "azure",
+    ]
+)
+def test_supported_open_ai_params_max_retries(provider):
+    supported_params = litellm.utils.get_supported_openai_params("", provider)
+    assert "max_retries" in supported_params
+
+
+@pytest.mark.parametrize(
     "api_version",
     [
         "2024-02-01",


### PR DESCRIPTION
## Title
(fix) Unable to override max_retries for Azure and Groq

## Relevant issues
Fixes #6129

## Type
🐛 Bug Fix
✅ Test

## Changes
- Fixed propagation of max_retries argument to Azure and Groq providers
- Added tests for Azure, Groq and OpenAI

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes
<img width="1073" alt="Screenshot 2024-10-09 at 17 44 07" src="https://github.com/user-attachments/assets/565d77d1-0262-4e75-ab20-ea9575617c1e">
