### PR TITLE
(feat) use regex pattern matching for wildcard routing 

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -375,6 +375,10 @@ model_list:
     litellm_params:
       model: "groq/*"
       api_key: os.environ/GROQ_API_KEY
+  - model_name: "fo::*:static::*" # all requests matching this pattern will be routed to this deployment, example: model="fo::hi::static::hi" will be routed to deployment: "openai/fo::*:static::*"
+    litellm_params:
+      model: "openai/fo::*:static::*"
+      api_key: os.environ/OPENAI_API_KEY
 ```
 
 Step 2 - Run litellm proxy 
@@ -405,6 +409,19 @@ curl http://localhost:4000/v1/chat/completions \
   -H "Authorization: Bearer sk-1234" \
   -d '{
     "model": "groq/llama3-8b-8192",
+    "messages": [
+      {"role": "user", "content": "Hello, Claude!"}
+    ]
+  }'
+```
+
+Test with `fo::*::static::*` - all requests matching this pattern will be routed to `openai/fo::*:static::*`
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "fo::hi::static::hi",
     "messages": [
       {"role": "user", "content": "Hello, Claude!"}
     ]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5553,7 +5553,7 @@ async def anthropic_response(
             and data["model"] not in router_model_names
             and (
                 llm_router.default_deployment is not None
-                or len(llm_router.provider_default_deployments) > 0
+                or len(llm_router.pattern_router.patterns) > 0
             )
         ):  # model in router deployments, calling a specific deployment on the router
             llm_response = asyncio.create_task(llm_router.aadapter_completion(**data))

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -109,7 +109,7 @@ async def route_request(
                 return getattr(litellm, f"{route_type}")(**data)
             elif (
                 llm_router.default_deployment is not None
-                or len(llm_router.provider_default_deployments) > 0
+                or len(llm_router.pattern_router.patterns) > 0
             ):
                 return getattr(llm_router, f"{route_type}")(**data)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4149,10 +4149,6 @@ class Router:
             ),
         )
 
-        provider_specific_deployment = re.match(
-            rf"{custom_llm_provider}/\*$", deployment.model_name
-        )
-
         # Check if user is trying to use model_name == "*"
         # this is a catch all model for their specific api key
         if deployment.model_name == "*":

--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -1,0 +1,42 @@
+"""
+Class to handle llm wildcard routing and regex pattern matching
+"""
+
+import re
+
+
+class PatternMatchRouter:
+    def __init__(self):
+        self.patterns = {}
+
+    def add_pattern(self, pattern, handler):
+        # Convert the pattern to a regex
+        regex = self._pattern_to_regex(pattern)
+        if regex not in self.patterns:
+            self.patterns[regex] = []
+        if isinstance(handler, list):
+            self.patterns[regex].extend(handler)
+        else:
+            self.patterns[regex].append(handler)
+
+    def _pattern_to_regex(self, pattern):
+        # Replace '*' with '.*' for regex matching
+        regex = pattern.replace("*", ".*")
+        # Escape other special characters
+        regex = re.escape(regex).replace(r"\.\*", ".*")
+        return f"^{regex}$"
+
+    def route(self, request):
+        for pattern, handlers in self.patterns.items():
+            if re.match(pattern, request):
+                return handlers
+        return None  # No matching pattern found
+
+
+# Example usage:
+# router = PatternRouter()
+# router.add_pattern('openai/*', ['openai_handler1', 'openai_handler2'])
+# router.add_pattern('openai/fo::*::static::*', 'openai_fo_static_handler')
+# print(router.route('openai/gpt-4'))  # Output: ['openai_handler1', 'openai_handler2']
+# print(router.route('openai/fo::hi::static::hi'))  # Output: ['openai_fo_static_handler']
+# print(router.route('something/else'))  # Output: None

--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -3,40 +3,85 @@ Class to handle llm wildcard routing and regex pattern matching
 """
 
 import re
+from typing import Dict, List, Optional
 
 
 class PatternMatchRouter:
-    def __init__(self):
-        self.patterns = {}
+    """
+    Class to handle llm wildcard routing and regex pattern matching
 
-    def add_pattern(self, pattern, handler):
+    doc: https://docs.litellm.ai/docs/proxy/configs#provider-specific-wildcard-routing
+
+    This class will store a mapping for regex pattern: List[Deployments]
+    """
+
+    def __init__(self):
+        self.patterns: Dict[str, List] = {}
+
+    def add_pattern(self, pattern: str, llm_deployment: Dict):
+        """
+        Add a regex pattern and the corresponding llm deployments to the patterns
+
+        Args:
+            pattern: str
+            llm_deployment: str or List[str]
+        """
         # Convert the pattern to a regex
         regex = self._pattern_to_regex(pattern)
         if regex not in self.patterns:
             self.patterns[regex] = []
-        if isinstance(handler, list):
-            self.patterns[regex].extend(handler)
+        if isinstance(llm_deployment, list):
+            self.patterns[regex].extend(llm_deployment)
         else:
-            self.patterns[regex].append(handler)
+            self.patterns[regex].append(llm_deployment)
 
-    def _pattern_to_regex(self, pattern):
+    def _pattern_to_regex(self, pattern: str) -> str:
+        """
+        Convert a wildcard pattern to a regex pattern
+
+        example:
+        pattern: openai/*
+        regex: openai/.*
+
+        pattern: openai/fo::*::static::*
+        regex: openai/fo::.*::static::.*
+
+        Args:
+            pattern: str
+
+        Returns:
+            str: regex pattern
+        """
         # Replace '*' with '.*' for regex matching
         regex = pattern.replace("*", ".*")
         # Escape other special characters
         regex = re.escape(regex).replace(r"\.\*", ".*")
         return f"^{regex}$"
 
-    def route(self, request):
-        for pattern, handlers in self.patterns.items():
+    def route(self, request: str) -> Optional[List[Dict]]:
+        """
+        Route a requested model to the corresponding llm deployments based on the regex pattern
+
+        loop through all the patterns and find the matching pattern
+        if a pattern is found, return the corresponding llm deployments
+        if no pattern is found, return None
+
+        Args:
+            request: str
+
+        Returns:
+            Optional[List[Deployment]]: llm deployments
+        """
+        for pattern, llm_deployments in self.patterns.items():
             if re.match(pattern, request):
-                return handlers
+                return llm_deployments
         return None  # No matching pattern found
 
 
 # Example usage:
 # router = PatternRouter()
-# router.add_pattern('openai/*', ['openai_handler1', 'openai_handler2'])
-# router.add_pattern('openai/fo::*::static::*', 'openai_fo_static_handler')
-# print(router.route('openai/gpt-4'))  # Output: ['openai_handler1', 'openai_handler2']
-# print(router.route('openai/fo::hi::static::hi'))  # Output: ['openai_fo_static_handler']
+# router.add_pattern('openai/*', [Deployment(), Deployment()])
+# router.add_pattern('openai/fo::*::static::*', Deployment())
+# print(router.route('openai/gpt-4'))  # Output: [Deployment(), Deployment()]
+# print(router.route('openai/fo::hi::static::hi'))  # Output: [Deployment()]
 # print(router.route('something/else'))  # Output: None

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -73,6 +73,7 @@ async def test_router_provider_wildcard_routing():
     Pass list of orgs in 1 model definition,
     expect a unique deployment for each to be created
     """
+    litellm.set_verbose = True
     router = litellm.Router(
         model_list=[
             {
@@ -122,6 +123,48 @@ async def test_router_provider_wildcard_routing():
     )
 
     print("response 3 = ", response3)
+
+
+@pytest.mark.asyncio()
+async def test_router_provider_wildcard_routing_regex():
+    """
+    Pass list of orgs in 1 model definition,
+    expect a unique deployment for each to be created
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai/fo::*:static::*",
+                "litellm_params": {
+                    "model": "openai/fo::*:static::*",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                },
+            },
+            {
+                "model_name": "openai/foo3::hello::*",
+                "litellm_params": {
+                    "model": "openai/foo3::hello::*",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                },
+            },
+        ]
+    )
+
+    print("router model list = ", router.get_model_list())
+
+    response1 = await router.acompletion(
+        model="openai/fo::anything-can-be-here::static::anything-can-be-here",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    print("response 1 = ", response1)
+
+    response2 = await router.acompletion(
+        model="openai/foo3::hello::static::anything-can-be-here",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    print("response 2 = ", response2)
 
 
 def test_router_specific_model_via_id():


### PR DESCRIPTION
## Provider specific wildcard routing 
**Proxy all models from a provider**

Use this if you want to **proxy all models from a specific provider without defining them on the config.yaml**

**Step 1** - define provider specific routing on config.yaml
```yaml
model_list:
  - model_name: "fo::*:static::*" # all requests matching this pattern will be routed to this deployment, example: model="fo::hi::static::hi" will be routed to deployment: "openai/fo::*:static::*"
    litellm_params:
      model: "openai/fo::*:static::*"
      api_key: os.environ/OPENAI_API_KEY
```

Step 2 - Run litellm proxy 

```shell
$ litellm --config /path/to/config.yaml
```

Step 3 Test it 

Test with `fo::*::static::*` - all requests matching this pattern will be routed to `openai/fo::*:static::*`
```shell
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "fo::hi::static::hi",
    "messages": [
      {"role": "user", "content": "Hello, Claude!"}
    ]
  }'
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

