### PR TITLE
(fix proxy redis) Add redis sentinel support 

### DIFF
--- a/docs/my-website/docs/proxy/caching.md
+++ b/docs/my-website/docs/proxy/caching.md
@@ -130,6 +130,7 @@ litellm_settings:
     type: "redis"
     service_name: "mymaster"
     sentinel_nodes: [["localhost", 26379]]
+    sentinel_password: "password" # [OPTIONAL]
 ```
 
 </TabItem>
@@ -143,6 +144,7 @@ You can configure redis sentinel in your .env by setting `REDIS_SENTINEL_NODES` 
 ```env
 REDIS_SENTINEL_NODES='[["localhost", 26379]]'
 REDIS_SERVICE_NAME = "mymaster"
+REDIS_SENTINEL_PASSWORD = "password"
 ```
 
 :::note

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -225,10 +225,6 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
 
-    sentinel_kwargs: Optional[Dict] = None
-    if sentinel_password:
-        sentinel_kwargs = {"password": sentinel_password}
-
     if not sentinel_nodes or not service_name:
         raise ValueError(
             "Both 'sentinel_nodes' and 'service_name' are required for Redis Sentinel."
@@ -238,7 +234,9 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
 
     # Set up the Sentinel client
     sentinel = async_redis.Sentinel(
-        sentinel_nodes, socket_timeout=0.1, sentinel_kwargs=sentinel_kwargs
+        sentinel_nodes,
+        socket_timeout=0.1,
+        password=sentinel_password,
     )
 
     # Return the master instance for the given service

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -12,7 +12,7 @@ import json
 
 # s/o [@Frank Colson](https://www.linkedin.com/in/frank-colson-422b9b183/) for this redis implementation
 import os
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import redis  # type: ignore
 import redis.asyncio as async_redis  # type: ignore
@@ -215,7 +215,12 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
 
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
+    sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+
+    sentinel_kwargs: Optional[Dict] = None
+    if sentinel_password:
+        sentinel_kwargs = {"password": sentinel_password}
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -225,7 +230,9 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     verbose_logger.debug("init_redis_sentinel: sentinel nodes are being initialized.")
 
     # Set up the Sentinel client
-    sentinel = async_redis.Sentinel(sentinel_nodes, socket_timeout=0.1)
+    sentinel = async_redis.Sentinel(
+        sentinel_nodes, socket_timeout=0.1, sentinel_kwargs=sentinel_kwargs
+    )
 
     # Return the master instance for the given service
 

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -18,7 +18,7 @@ import redis  # type: ignore
 import redis.asyncio as async_redis  # type: ignore
 
 import litellm
-from litellm import get_secret
+from litellm import get_secret, get_secret_str
 
 from ._logging import verbose_logger
 
@@ -138,6 +138,13 @@ def _get_redis_client_logic(**env_overrides):
 
     if _sentinel_nodes is not None and isinstance(_sentinel_nodes, str):
         redis_kwargs["sentinel_nodes"] = json.loads(_sentinel_nodes)
+
+    _sentinel_password: Optional[str] = redis_kwargs.get(
+        "sentinel_password", None
+    ) or get_secret_str("REDIS_SENTINEL_PASSWORD")
+
+    if _sentinel_password is not None:
+        redis_kwargs["sentinel_password"] = _sentinel_password
 
     _service_name: Optional[str] = redis_kwargs.get("service_name", None) or get_secret(  # type: ignore
         "REDIS_SERVICE_NAME"


### PR DESCRIPTION
## Add support for using `password` with Redis Sentinel 


```yaml
model_list:
  - model_name: "*"
    litellm_params:
      model: "*"


litellm_settings:
  cache: true
  cache_params:
    type: "redis"
    service_name: "mymaster"
    sentinel_nodes: [["localhost", 26379]]
    sentinel_password: "password" # [OPTIONAL]
```



Redis Py reference: https://github.com/redis/redis-py/issues/1219#issuecomment-575030772



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

