### PR TITLE
Fix Ollama stream handling for tool calls with None content

### DIFF
--- a/litellm/llms/ollama.py
+++ b/litellm/llms/ollama.py
@@ -347,6 +347,7 @@ def ollama_completion_stream(url, data, logging_obj):
                         isinstance(content_chunk, StreamingChoices)
                         and hasattr(content_chunk, "delta")
                         and hasattr(content_chunk.delta, "content")
+                        and content_chunk.delta.content is not None
                     ):
                         content_chunks.append(content_chunk.delta.content)
                 response_content = "".join(content_chunks)


### PR DESCRIPTION
I'm a core developer of [R2R, an opensource RAG engine](https://github.com/SciPhi-AI/R2R) that has relied on LiteLLM for many of our LLM completions.
While using our RAG Agent, which uses Ollama with tool calling, our users encountered an issue with LiteLLM's Ollama integration. Specifically, when processing JSON responses for function/tool calls, the stream occasionally contains `None` values, leading to the following error(entire trace omitted for brevity):
```
process_llm_response
    |     for chunk in stream:
    |   File "/Users/nolantremelling/Library/Caches/pypoetry/virtualenvs/r2r-giROgG2W-py3.12/lib/python3.12/site-packages/core/base/providers/llm.py", line 188, in get_completion_stream
    |     for chunk in self._execute_with_backoff_sync_stream(task):
    |   File "/Users/nolantremelling/Library/Caches/pypoetry/virtualenvs/r2r-giROgG2W-py3.12/lib/python3.12/site-packages/core/base/providers/llm.py", line 113, in _execute_with_backoff_sync_stream
    |     yield from self._execute_task_sync(task)
    |   File "/Users/nolantremelling/Library/Caches/pypoetry/virtualenvs/r2r-giROgG2W-py3.12/lib/python3.12/site-packages/litellm/llms/ollama.py", line 376, in ollama_completion_stream
    |     content=None,
```

My proposed change ensures that only non-`None` content is included in the final response, preventing a TypeError when joining the chunks.

Steps to reproduce:
- Set up an Ollama server with a model that supports function calling (e.g., llama3).
- Use LiteLLM to make a completion request with format="json" to trigger a function call.
- Occasionally, the stream will contain None values, causing this error.

I think it's important to note that this feature worked fine a few weeks ago, and your code around this hasn't seemed to change—my suspicion is that Ollama's response streams seem to be changing quite frequently still… hopefully this addition will just make your code robust to their variability. 

After applying this fix, we're able to return functionality to our application:

<img width="1512" alt="Screenshot 2024-10-10 at 12 25 48 PM" src="https://github.com/user-attachments/assets/c0f44d2a-cde2-497c-946a-d2fa1e78751a">


Your tests seem broken but I see no errors before in the file that I touched, and nothing new is throwing an error.

![Screenshot 2024-10-10 at 12 13 01 PM](https://github.com/user-attachments/assets/e3c4ec03-5d45-434e-94eb-97a9d7324a53)


