### PR TITLE
(fix) add azure/gpt-4o-2024-05-13 pricing 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -691,6 +691,19 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "azure/gpt-4o-2024-05-13": {
+        "max_tokens": 4096,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_prompt_caching": true
+    },
     "azure/global-standard/gpt-4o-2024-08-06": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -691,6 +691,19 @@
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
+    "azure/gpt-4o-2024-05-13": {
+        "max_tokens": 4096,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_prompt_caching": true
+    },
     "azure/global-standard/gpt-4o-2024-08-06": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Title

- looks like Azure does not list pricing for this model: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/ 
- Using the pricing listed for OpenAI for `gpt-4o-2024-05-13` 
- Confirmed this is pricing that https://artificialanalysis.ai/providers/azure#pricing also shows 
<img width="852" alt="Screenshot 2024-10-12 at 8 42 01 AM" src="https://github.com/user-attachments/assets/e574f719-cb69-46ce-b7d8-51dc40003ba2">


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

