### PR TITLE
bug fix for calls to community models in Replicate

### DIFF
--- a/litellm/llms/replicate.py
+++ b/litellm/llms/replicate.py
@@ -127,6 +127,7 @@ def start_prediction(
             len(model_parts) > 1 and len(model_parts[1]) == 64
         ):  ## checks if model name has a 64 digit code - e.g. "meta/llama-2-70b-chat:02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3"
             initial_prediction_data["version"] = model_parts[1]
+            base_url = f"https://api.replicate.com/v1"
 
     ## LOGGING
     logging_obj.pre_call(
@@ -426,7 +427,8 @@ def completion(
     acompletion=None,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
     # Start a prediction and get the prediction URL
-    version_id = model_to_version_id(model)
+    #version_id = model_to_version_id(model)
+    version_id = model
     ## Load Config
     config = litellm.ReplicateConfig.get_config()
     for k, v in config.items():


### PR DESCRIPTION
## Title

bug fix for calls to community models in Replicate

## Relevant issues



## Type

🐛 Bug Fix

## Changes

At line 130 in `litellm/litellm/llms/replicate.py`, added:
`base_url = f"https://api.replicate.com/v1"`

The if statement starting at line 124 is testing for the presence of a version id (or as the comment calls it the 64 digit code). 
In that case, I believe the right base_url to use is `https://api.replicate.com/v1`, according to this documentation:

https://replicate.com/docs/reference/http#predictions.create

In order for this to work we need to also modify line 430, and set `version_id` to `model`. Otherwise we loose the `:` in the id and the if statement mentioned above is never exercised.


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall


Here's a test:
```
from litellm import completion

response = completion(
            model="replicate/meta/llama-2-70b-chat:02e509c789964a7ea8736978a43525956ef40397be9033abf9fd2badfe68c9e3",
            messages=[{"role": "user", "content": "Hello, "}],
            stream=True,  
        )

for chunk in response:
            msg = chunk.choices[0].delta  # pyright: ignore
            if msg.content is None:
                break
            print(msg.content)
```

Without the changes, this program throws the following RelicateException: 
```
ReplicateException - Failed to start prediction {"detail":"Method \"POST\" not allowed."}
```

Once we make the change, and "warm up" the model by going to this page and hitting `run` or `boot+run`:
https://replicate.com/meta/llama-2-70b-chat

then the Exception goes away. If we get this exception: 
```
ReplicateException - Unable to parse response. Got=None
```
it means that the model is not "warmed up" on Replicate (meaning the model isn't being served), and running something on the replicate form (https://replicate.com/meta/llama-2-70b-chat) will help. There is no exception when the green light `warm` is next to the model name (with the changes proposed in this PR).


