### PR TITLE
Remove "ask mode" from Canary search

### DIFF
--- a/docs/my-website/src/theme/SearchBar.js
+++ b/docs/my-website/src/theme/SearchBar.js
@@ -16,8 +16,6 @@ export default function SearchBarWrapper(props) {
       import("@getcanary/web/components/canary-search-results"),
       import("@getcanary/web/components/canary-search-match-github-issue"),
       import("@getcanary/web/components/canary-search-match-github-discussion"),
-      import("@getcanary/web/components/canary-ask"),
-      import("@getcanary/web/components/canary-ask-results"),
       import("@getcanary/web/components/canary-filter-tabs-glob.js"),
       import("@getcanary/web/components/canary-filter-tags.js"),
       import("@getcanary/web/components/canary-footer.js"),
@@ -75,9 +73,6 @@ export default function SearchBarWrapper(props) {
                   ></canary-filter-tabs-glob>
                   <canary-search-results slot="body"></canary-search-results>
                 </canary-search>
-                <canary-ask slot="mode">
-                  <canary-ask-results slot="body"></canary-ask-results>
-                </canary-ask>
                 <canary-footer slot="footer"></canary-footer>
               </canary-content>
             </canary-modal>


### PR DESCRIPTION
## Title

Remove "ask mode" from Canary search

## Relevant issues

Resolves #6235 

## Type

🐛 Bug Fix

## Changes

Remove "ask mode" from Canary search for now.

`canary-ask-results` has a syntax highlighter embedded in it, and it seems to cause trouble with Docusaurus's highlighter.
