### PR TITLE
Decode message to string in _types.py to avoid TypeError exception when using fallbacks

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1818,7 +1818,7 @@ class ProxyException(Exception):
         code: Optional[Union[int, str]] = None,
         headers: Optional[Dict[str, str]] = None,
     ):
-        self.message = message
+        self.message = message.decode('utf-8') if isinstance(message, bytes) else message
         self.type = type
         self.param = param
 


### PR DESCRIPTION
This fix the following exception that is always triggered when a fallback is necessary:
```
 |   File "/usr/local/lib/python3.11/site-packages/litellm/proxy/_types.py", line 1836, in __init__
 |     "No healthy deployment available" in self.message
 | TypeError: a bytes-like object is required, not 'str'
```

## Title

Decode message to string in _types.py in order to avoid TypeError exception.

## Relevant issues



## Type

🐛 Bug Fix

## Changes

`self.message = message.decode('utf-8') if isinstance(message, bytes) else message`


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

1. Make a fallback request or test:

curl -X POST 'http://0.0.0.0:4000/chat/completions' \ 
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer sk-1234' \
    -d '{
      "model": "deepseek-coder",
      "messages": [
        {
          "role": "user",
          "content": "ping"
        }
      ],
      "mock_testing_fallbacks": true
    }'

2. Check the litellm docker logs: the TypeError exception is gone.