### PR TITLE
(fix) Unable to override max_retries for Azure and Groq

### DIFF
--- a/litellm/llms/AzureOpenAI/azure.py
+++ b/litellm/llms/AzureOpenAI/azure.py
@@ -372,7 +372,7 @@ class AzureChatCompletion(BaseLLM):
                     status_code=422, message="Missing model or messages"
                 )
 
-            max_retries = optional_params.pop("max_retries", 2)
+            max_retries = optional_params.get("max_retries", 2)
             json_mode: Optional[bool] = optional_params.pop("json_mode", False)
 
             ### CHECK IF CLOUDFLARE AI GATEWAY ###
@@ -406,6 +406,8 @@ class AzureChatCompletion(BaseLLM):
                     else:
                         client = AzureOpenAI(**azure_client_params)
 
+                # Already included azure_client_params
+                optional_params.pop('max_retries', None)
                 data = {"model": None, "messages": messages, **optional_params}
             else:
                 data = litellm.AzureOpenAIConfig.transform_request(
@@ -512,6 +514,9 @@ class AzureChatCompletion(BaseLLM):
                         status_code=500,
                         message="azure_client is not an instance of AzureOpenAI",
                     )
+
+                # Already included in azure_client_params
+                data.pop("max_retries", None)
 
                 headers, response = self.make_sync_azure_openai_chat_completion_request(
                     azure_client=azure_client, data=data, timeout=timeout

--- a/litellm/llms/AzureOpenAI/chat/gpt_transformation.py
+++ b/litellm/llms/AzureOpenAI/chat/gpt_transformation.py
@@ -85,6 +85,7 @@ class AzureOpenAIConfig:
             "stream_options",
             "stop",
             "max_tokens",
+            "max_retries",
             "max_completion_tokens",
             "tools",
             "tool_choice",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3449,6 +3449,8 @@ def get_optional_params(
             optional_params["temperature"] = temperature
         if max_tokens is not None:
             optional_params["max_tokens"] = max_tokens
+        if max_retries is not None:
+            optional_params["max_retries"] = max_retries
         if top_p is not None:
             optional_params["top_p"] = top_p
         if stream is not None:

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -322,6 +322,36 @@ def test_openai_extra_headers():
 
 
 @pytest.mark.parametrize(
+    "provider",
+    [
+        "openai",
+        "groq",
+        "azure",
+    ]
+)
+def test_max_retries(provider):
+    optional_params = litellm.utils.get_optional_params(
+        model="",
+        custom_llm_provider=provider,
+        max_retries=0,
+    )
+    assert optional_params["max_retries"] == 0
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "openai",
+        "groq",
+        "azure",
+    ]
+)
+def test_supported_open_ai_params_max_retries(provider):
+    supported_params = litellm.utils.get_supported_openai_params("", provider)
+    assert "max_retries" in supported_params
+
+
+@pytest.mark.parametrize(
     "api_version",
     [
         "2024-02-01",

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -1900,11 +1900,11 @@ async def test_vertexai_embedding(sync_mode):
         assert len(response.data) == len(input_text)
 
         # Assert that each embedding is a non-empty list of floats
-        for embedding in response.data:
-            assert "embedding" in embedding
-            assert isinstance(embedding["embedding"], list)
-            assert len(embedding["embedding"]) > 0
-            assert all(isinstance(x, float) for x in embedding["embedding"])
+        for item in response.data:
+            assert "embedding" in item
+            assert isinstance(item["embedding"], list)
+            assert len(item["embedding"]) > 0
+            assert all(isinstance(x, float) for x in item["embedding"])
 
     except litellm.RateLimitError as e:
         pass


### PR DESCRIPTION
## Title

(fix) Unable to override max_retries for Azure and Groq

## Relevant issues

Fixes #6129

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

- Fixed propagation of max_retries argument to Azure and Groq providers
- Added tests for Azure, Groq and OpenAI

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<img width="1073" alt="375031044-565d77d1-0262-4e75-ab20-ea9575617c1e" src="https://github.com/user-attachments/assets/c81f0727-ca25-41b1-a970-c7bda73b781c">


