### PR TITLE
fix: us bedrock inference model support for function calling.

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -87,10 +87,11 @@ class AmazonConverseConfig:
             or model.startswith("mistral")
             or model.startswith("cohere")
             or model.startswith("meta.llama3-1")
+            or model.startswith("us.anthropic")
         ):
             supported_params.append("tools")
 
-        if model.startswith("anthropic") or model.startswith("mistral"):
+        if model.startswith("anthropic") or model.startswith("mistral") or model.startswith("us.anthropic"):
             # only anthropic and mistral support tool choice config. otherwise (E.g. cohere) will fail the call - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             supported_params.append("tool_choice")
 


### PR DESCRIPTION
## Title

Fixed us bedrock inference model support for function calling

## Relevant issues

[Bug]: cross-region inference anthropic models erroneously say function calling is not supported. [#6291](https://github.com/BerriAI/litellm/issues/6291)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

It works afterwards.

<!-- Test procedure -->

Manual testing inside of my pipeline.