### PR TITLE
Fix metadata being overwritten in `speech()`

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4909,7 +4909,6 @@ def speech(
     litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
     proxy_server_request = kwargs.get("proxy_server_request", None)
     model_info = kwargs.get("model_info", None)
-    metadata = kwargs.get("metadata", {})
     model, custom_llm_provider, dynamic_api_key, api_base = get_llm_provider(model=model, custom_llm_provider=custom_llm_provider, api_base=api_base)  # type: ignore
     kwargs.pop("tags", [])
 


### PR DESCRIPTION
## Title

Fix metadata being overwritten in `speech()`

## Relevant issues

The bug was introduced in: https://github.com/BerriAI/litellm/commit/aa59b2594a71201836a9e0efa3bd4893a08f8ed2


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Fix metadata being overwritten in `speech()`
