### PR TITLE
fix: adding missing redis cluster kwargs

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -69,6 +69,8 @@ def _get_redis_cluster_kwargs(client=None):
 
     available_args = [x for x in arg_spec.args if x not in exclude_args]
     available_args.append("password")
+    available_args.append("username")
+    available_args.append("ssl")
 
     return available_args
 


### PR DESCRIPTION
`inspect.getfullargspec(redis.RedisCluster)` doesn't return a complete list of available kwargs. For example `username` and `ssl` are missing. We faced this issue in our deployment, connecting to MemroyDB on AWS. This PR adds these two kwargs.

Following is the returned args, missing `username` and `ssl`, before the change:
```
FullArgSpec(args=['self', 'host', 'port', 'startup_nodes', 'cluster_error_retry_attempts', 'retry', 'require_full_coverage', 'reinitialize_steps', 'read_from_replicas', 'dynamic_startup_nodes', 'url', 'address_remap', 'cache', 'cache_config'], varargs=None, varkw='kwargs', defaults=(None, 6379, None, 3, None, False, 5, False, True, None, None, None, None), kwonlyargs=[], kwonlydefaults=None, annotations={'host': typing.Optional[str], 'port': <class 'int'>, 'startup_nodes': typing.Optional[typing.List[ForwardRef('ClusterNode')]], 'cluster_error_retry_attempts': <class 'int'>, 'retry': typing.Optional[ForwardRef('Retry')], 'require_full_coverage': <class 'bool'>, 'reinitialize_steps': <class 'int'>, 'read_from_replicas': <class 'bool'>, 'dynamic_startup_nodes': <class 'bool'>, 'url': typing.Optional[str], 'address_remap': typing.Optional[typing.Callable[[typing.Tuple[str, int]], typing.Tuple[str, int]]], 'cache': typing.Optional[redis.cache.CacheInterface], 'cache_config': typing.Optional[redis.cache.CacheConfig]})
```

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->


