### PR TITLE
fix(litellm-helm): correctly use dbReadyImage and dbReadyTag values

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: db-ready
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "docker.io/bitnami/postgresql:16.1.0-debian-11-r20"
+          image: "{{ .Values.image.dbReadyImage }}:{{ .Values.image.dbReadyTag | default("16.1.0-debian-11-r20") }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- if .Values.db.deployStandalone }}


### PR DESCRIPTION
## fix(litellm-helm): correctly use dbReadyImage and dbReadyTag values

Implement image.dbReadyImage and image.dbReadyTag values into the helm chart deployment template

## Relevant issues

Fixes #6335 

## Type


🐛 Bug Fix

## Changes

* Replaced hardcoded values for the init container image, with existing dbReadyImage and dbReadyTag values. Defaulting to the old hardcoded tag

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall


