### PR TITLE
[BUG Fix] Issue With IBM WatsonX integration for Date Format

### DIFF
--- a/litellm/llms/watsonx.py
+++ b/litellm/llms/watsonx.py
@@ -425,7 +425,7 @@ class IBMWatsonXAI(BaseLLM):
         )
         if json_resp.get("created_at"):
             model_response.created = int(
-                datetime.fromisoformat(json_resp["created_at"]).timestamp()
+                datetime.strptime(json_resp["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").timestamp()
             )
         else:
             model_response.created = int(time.time())


### PR DESCRIPTION
- Updated the parsing method for the `created_at` field in the JSON response.
- Changed from using `datetime.fromisoformat` to `datetime.strptime` for improved compatibility with the expected date format.
- The new format used is `"%Y-%m-%dT%H:%M:%S.%fZ"`, ensuring accurate timestamp conversion.
- This change enhances the robustness of the timestamp handling in the `_process_text_gen_response` function.