### PR TITLE
Add support for `max_completion_tokens` in Azure OpenAI

### DIFF
--- a/litellm/llms/AzureOpenAI/chat/gpt_transformation.py
+++ b/litellm/llms/AzureOpenAI/chat/gpt_transformation.py
@@ -198,9 +198,6 @@ class AzureOpenAIConfig:
                     optional_params["json_mode"] = True
                 else:
                     optional_params["response_format"] = value
-            elif param == "max_completion_tokens":
-                # TODO - Azure OpenAI will probably add support for this, we should pass it through when Azure adds support
-                optional_params["max_tokens"] = value
             elif param in supported_openai_params:
                 optional_params[param] = value
 


### PR DESCRIPTION
Now that Azure supports `max_completion_tokens`, no need for special handling for this param and let it pass thru. More details: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=python-secure#api-support

## Relevant issues
Fixes #6374 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

