### PR TITLE
(admin ui) - show created_at for virtual keys 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1371,6 +1371,8 @@ class LiteLLM_VerificationToken(LiteLLMBase):
     blocked: Optional[bool] = None
     litellm_budget_table: Optional[dict] = None
     org_id: Optional[str] = None  # org id for a given key
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -154,6 +154,8 @@ model LiteLLM_VerificationToken {
     model_spend      Json @default("{}")
     model_max_budget Json @default("{}")
     budget_id String?
+    created_at      DateTime?               @default(now()) @map("created_at")
+    updated_at      DateTime?               @default(now()) @updatedAt @map("updated_at")
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -154,6 +154,8 @@ model LiteLLM_VerificationToken {
     model_spend      Json @default("{}")
     model_max_budget Json @default("{}")
     budget_id String?
+    created_at      DateTime?               @default(now()) @map("created_at")
+    updated_at      DateTime?               @default(now()) @updatedAt @map("updated_at")
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
 }
 

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -802,6 +802,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
           <TableRow>
             <TableHeaderCell>Key Alias</TableHeaderCell>
             <TableHeaderCell>Secret Key</TableHeaderCell>
+            <TableHeaderCell>Created</TableHeaderCell>
             <TableHeaderCell>Expires</TableHeaderCell>
             <TableHeaderCell>Spend (USD)</TableHeaderCell>
             <TableHeaderCell>Budget (USD)</TableHeaderCell>
@@ -844,9 +845,18 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                   <Text>{item.key_name}</Text>
                 </TableCell>
                 <TableCell>
+                    {item.created_at != null ? (
+                      <div>
+                        <p style={{ fontSize: '0.70rem' }}>{new Date(item.created_at).toLocaleDateString()}</p>
+                      </div>
+                    ) : (
+                      <p style={{ fontSize: '0.70rem' }}>Not available</p>
+                    )}
+                  </TableCell>
+                <TableCell>
                 {item.expires != null ? (
                   <div>
-                    <p style={{ fontSize: '0.70rem' }}>{new Date(item.expires).toLocaleString()}</p>
+                    <p style={{ fontSize: '0.70rem' }}>{new Date(item.expires).toLocaleDateString()}</p>
                   </div>
                 ) : (
                   <p style={{ fontSize: '0.70rem' }}>Never</p>


### PR DESCRIPTION
## Title
<img width="1494" alt="Xnapper-2024-10-25-09 23 46" src="https://github.com/user-attachments/assets/12c20779-aebf-4111-945d-68b62fa6fef8">


Following the OpenAI UI ordering for displaying this 

<img width="1108" alt="Screenshot 2024-10-25 at 9 24 34 AM" src="https://github.com/user-attachments/assets/d7c25c9e-fad0-4d39-8857-8cfb3548f3b9">


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

