### PR TITLE
Add txt file type in GCS URIs as accepted file type for gemini 1.5

### DIFF
--- a/litellm/types/files.py
+++ b/litellm/types/files.py
@@ -272,6 +272,8 @@ GEMINI_1_5_ACCEPTED_FILE_TYPES: Set[FileType] = {
     FileType.THREE_GPP,
     # PDF
     FileType.PDF,
+    # TXT
+    FileType.TXT,
 }
 
 


### PR DESCRIPTION
## Title

Add txt file type to GCS URIs for Gemini 1.5 models

## Relevant issues

Since the version of **google-cloud-aiplatform** is 1.47.0, the txt file is supported in GCS URIs, this code works with txt Uris.

```python
import vertexai
from vertexai.generative_models import GenerativeModel, Part, SafetySetting

print(vertexai.__version__) # 1.47.0
def generate():
    vertexai.init(project="project-id", location="us-central1")
    model = GenerativeModel(
        "gemini-1.5-pro-002",
    )
    responses = model.generate_content(
        ["""Do a summary of the document""", document1],
        generation_config=generation_config,
        safety_settings=safety_settings,
        stream=True,
    )

    for response in responses:
        print(response.text, end="")

document1 = Part.from_uri(
    mime_type="text/plain",
    uri="gs:.....txt",
)

generation_config = {
    "max_output_tokens": 8192,
    "temperature": 1,
    "top_p": 0.95,
}

safety_settings = [
    SafetySetting(
        category=SafetySetting.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
        threshold=SafetySetting.HarmBlockThreshold.BLOCK_NONE
    ),
    SafetySetting(
        category=SafetySetting.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
        threshold=SafetySetting.HarmBlockThreshold.BLOCK_NONE
    ),
    SafetySetting(
        category=SafetySetting.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
        threshold=SafetySetting.HarmBlockThreshold.BLOCK_NONE
    ),
    SafetySetting(
        category=SafetySetting.HarmCategory.HARM_CATEGORY_HARASSMENT,
        threshold=SafetySetting.HarmBlockThreshold.BLOCK_NONE
    ),
]

generate()
```

For that reason, I propose to allow process txt for Gemini 1.5 models
## Type
🆕 New Feature

## Changes

<!-- List of changes -->

- The txt file type is added to the set **GEMINI_1_5_ACCEPTED_FILE_TYPES**
<!-- Test procedure -->
![Screenshot 2024-10-26 at 14 09 58](https://github.com/user-attachments/assets/82159099-6aee-4135-9488-529987635874)


