### PR TITLE
(feat): Add timestamp_granularities parameter to transcription API

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4789,6 +4789,7 @@ def transcription(
     response_format: Optional[
         Literal["json", "text", "srt", "verbose_json", "vtt"]
     ] = None,
+    timestamp_granularities: List[Literal["word", "segment"]] = None,
     temperature: Optional[int] = None,  # openai defaults this to 0
     ## LITELLM PARAMS ##
     user: Optional[str] = None,
@@ -4842,6 +4843,7 @@ def transcription(
         language=language,
         prompt=prompt,
         response_format=response_format,
+        timestamp_granularities=timestamp_granularities,
         temperature=temperature,
         custom_llm_provider=custom_llm_provider,
         drop_params=drop_params,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2161,6 +2161,7 @@ def get_optional_params_transcription(
     prompt: Optional[str] = None,
     response_format: Optional[str] = None,
     temperature: Optional[int] = None,
+    timestamp_granularities: Optional[List[Literal["word", "segment"]]] = None,
     custom_llm_provider: Optional[str] = None,
     drop_params: Optional[bool] = None,
     **kwargs,

--- a/tests/local_testing/test_whisper.py
+++ b/tests/local_testing/test_whisper.py
@@ -53,8 +53,9 @@ from litellm import Router
 )
 @pytest.mark.parametrize("response_format", ["json", "vtt"])
 @pytest.mark.parametrize("sync_mode", [True, False])
+@pytest.mark.parametrize("timestamp_granularities", [["word"], ["segment"]])
 @pytest.mark.asyncio
-async def test_transcription(model, api_key, api_base, response_format, sync_mode):
+async def test_transcription(model, api_key, api_base, response_format, sync_mode, timestamp_granularities):
     if sync_mode:
         transcript = litellm.transcription(
             model=model,
@@ -62,6 +63,7 @@ async def test_transcription(model, api_key, api_base, response_format, sync_mod
             api_key=api_key,
             api_base=api_base,
             response_format=response_format,
+            timestamp_granularities=timestamp_granularities,
             drop_params=True,
         )
     else:


### PR DESCRIPTION
## Title
Add timestamp_granularities parameter to transcription API

## Type

🆕 New Feature

## Changes

This PR adds support for the timestamp_granularities parameter in the transcription API, allowing users to specify the granularity level of timestamps in transcription results.

Added
- New optional parameter timestamp_granularities that accepts a list of either "word" or "segment" granularity levels
- Updated test cases to verify functionality with different timestamp granularity settings
Modified Files
- `litellm/main.py`: Added timestamp_granularities parameter to transcription function
- `litellm/utils.py`: Added timestamp_granularities to get_optional_params_transcription
- `tests/local_testing/test_whisper.py`: Added test coverage for timestamp_granularities parameter

### Testing
Added parametrized tests for both word-level and segment-level timestamp granularities
