### PR TITLE
Fix tool call without args in gemini

### DIFF
--- a/litellm/llms/prompt_templates/factory.py
+++ b/litellm/llms/prompt_templates/factory.py
@@ -991,6 +991,11 @@ def _gemini_tool_call_invoke_helper(
             name=name,
             args=_fields,
         )
+    if function_call is None:
+        function_call = litellm.types.llms.vertex_ai.FunctionCall(
+            name=name,
+            args={},
+        )
     return function_call
 
 
@@ -1076,34 +1081,24 @@ def convert_to_gemini_tool_call_invoke(
                     ] = _gemini_tool_call_invoke_helper(
                         function_call_params=tool["function"]
                     )
-                    if gemini_function_call is not None:
-                        _parts_list.append(
-                            litellm.types.llms.vertex_ai.PartType(
-                                function_call=gemini_function_call
-                            )
+                    assert gemini_function_call is not None
+                    _parts_list.append(
+                        litellm.types.llms.vertex_ai.PartType(
+                            function_call=gemini_function_call
                         )
-                    else:  # don't silently drop params. Make it clear to user what's happening.
-                        raise Exception(
-                            "function_call missing. Received tool call with 'type': 'function'. No function call in argument - {}".format(
-                                tool
-                            )
-                        )
+                    )
+
         elif function_call is not None:
             gemini_function_call = _gemini_tool_call_invoke_helper(
                 function_call_params=function_call
             )
-            if gemini_function_call is not None:
-                _parts_list.append(
-                    litellm.types.llms.vertex_ai.PartType(
-                        function_call=gemini_function_call
-                    )
+            assert gemini_function_call is not None
+            _parts_list.append(
+                litellm.types.llms.vertex_ai.PartType(
+                    function_call=gemini_function_call
                 )
-            else:  # don't silently drop params. Make it clear to user what's happening.
-                raise Exception(
-                    "function_call missing. Received tool call with 'type': 'function'. No function call in argument - {}".format(
-                        message
-                    )
-                )
+            )
+
         return _parts_list
     except Exception as e:
         raise Exception(

--- a/litellm/llms/vertex_ai_and_google_ai_studio/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai_and_google_ai_studio/gemini/vertex_and_google_ai_studio_gemini.py
@@ -211,6 +211,8 @@ class VertexAIConfig:
                         description=tool["function"].get("description", ""),
                         parameters=tool["function"].get("parameters", {}),
                     )
+                    if gtool_func_declaration["parameters"]["properties"] == {}:
+                        del gtool_func_declaration["parameters"]
                     gtool_func_declarations.append(gtool_func_declaration)
                 optional_params["tools"] = [
                     generative_models.Tool(
@@ -418,6 +420,8 @@ class VertexGeminiConfig:
                     description=openai_function_object.get("description", ""),
                     parameters=openai_function_object.get("parameters", {}),
                 )
+                if gtool_func_declaration["parameters"]["properties"] == {}:
+                    del gtool_func_declaration["parameters"]
                 gtool_func_declarations.append(gtool_func_declaration)
             else:
                 # assume it's a provider-specific param

--- a/tests/local_testing/test_gemini_no_arg_function_call.py
+++ b/tests/local_testing/test_gemini_no_arg_function_call.py
@@ -81,3 +81,65 @@ def test_gemini_function_call_without_args():
     ]
     r = litellm.completion(messages=messages, model="gemini/gemini-1.5-flash-002")
     assert len(r.choices) > 0
+def test_gemini_function_call_without_args_enabled_tool_calls():
+    messages=[
+        {
+            "role":"user",
+            "content":"invoke tool call"
+        }
+    ]
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "invoke test",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                    },
+                    "required": []
+                }
+            }
+        },
+    ]
+    r = litellm.completion(messages=messages, model="gemini/gemini-1.5-flash-002",tools=tools,temperature=0.0,tool_choice="required")
+
+    assert len(r.choices) > 0,"choices not found"
+    assert len(r.choices[0].message.tool_calls) > 0, "tool calls not found"
+    assert r.choices[0].message.tool_calls[0].function.name=="test","tool call name is not 'test'"
+    assert r.choices[0].message.tool_calls[0].function.arguments == "{}" ,"arguments is not empty"
+def test_gemini_function_call_with_args_enabled_tool_calls():
+    messages=[
+        {
+            "role":"user",
+            "content":"invoke tool call with arg1(42)"
+        }
+    ]
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "test2",
+                "description": "invoke test",
+                "parameters": {
+                    "type": "object",
+
+                    "properties": {
+                        "arg1": {
+                            "type": "string",
+                            "description": "arg1"
+                        },
+                    },
+
+                    "required": ["arg1"]
+                }
+            }
+        },
+    ]
+    r = litellm.completion(messages=messages, model="gemini/gemini-1.5-flash-002",tools=tools,temperature=0.0,tool_choice="required")
+
+    assert len(r.choices) > 0,"choices not found"
+    assert len(r.choices[0].message.tool_calls) > 0, "tool calls not found"
+    assert r.choices[0].message.tool_calls[0].function.name=="test2","tool call name is not 'test'"
+    assert r.choices[0].message.tool_calls[0].function.arguments == '{"arg1": "42"}' ,"arguments is not match"

--- a/tests/local_testing/test_gemini_no_arg_function_call.py
+++ b/tests/local_testing/test_gemini_no_arg_function_call.py
@@ -1,0 +1,83 @@
+import sys, os
+import traceback
+from dotenv import load_dotenv
+import copy
+
+load_dotenv()
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+# import asyncio
+import litellm
+import pytest
+
+def test_gemini_function_call_with_args():
+    messages=[
+        {
+            "role":"user",
+            "content":"Hi"
+        },
+        {
+            "role": "assistant",
+            "content": "hello",
+            "tool_calls":[
+                {
+                    "index": 0,
+                    "function": {
+                        "arguments": "{\"arg\": \"test\"}",
+                        "name": "test"
+                    },
+                    "id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+                    "type": "function"
+                }
+            ],
+        },
+        {
+            "tool_call_id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+            "role": "tool",
+            "name": "test",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "42"
+                }
+            ]
+        },
+    ]
+    r = litellm.completion(messages=messages, model="gemini/gemini-1.5-flash-002")
+    assert len(r.choices) > 0
+def test_gemini_function_call_without_args():
+    messages=[
+        {
+            "role":"user",
+            "content":"Hi"
+        },
+        {
+            "role": "assistant",
+            "content": "hello",
+            "tool_calls":[
+                {
+                    "index": 0,
+                    "function": {
+                        "arguments": "{}",
+                        "name": "test"
+                    },
+                    "id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+                    "type": "function"
+                }
+            ],
+        },
+        {
+            "tool_call_id": "call_597e00e6-11d4-4ed2-94b2-27edee250aec",
+            "role": "tool",
+            "name": "test",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "42"
+                }
+            ]
+        },
+    ]
+    r = litellm.completion(messages=messages, model="gemini/gemini-1.5-flash-002")
+    assert len(r.choices) > 0


### PR DESCRIPTION
## Title

Fix tool call without args

## Relevant issues

none

## Type

🐛 Bug Fix

## Changes

- Changed to delete ["parameters"] itself when ["parameters"]["properties"] is empty.
- Instead of throwing an exception when the arguments of tool_call and tool_call_response are empty, provided an empty dictionary to continue the process.

