### PR TITLE
(proxy fix RBAC checks) Internal user viewer should not be able to create keys 

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -32,6 +32,7 @@ class RouteChecks:
         """
         Checks if Non Proxy Admin User is allowed to access the route
         """
+
         # Check user has defined custom admin routes
         RouteChecks.custom_admin_only_route_check(
             route=route,

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -32,7 +32,6 @@ class RouteChecks:
         """
         Checks if Non Proxy Admin User is allowed to access the route
         """
-
         # Check user has defined custom admin routes
         RouteChecks.custom_admin_only_route_check(
             route=route,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -105,7 +105,7 @@ def _get_bearer_token(
     return api_key
 
 
-def _is_api_route_allowed(
+def _is_route_allowed_check(
     route: str,
     request: Request,
     request_data: dict,
@@ -114,7 +114,20 @@ def _is_api_route_allowed(
     user_obj: Optional[LiteLLM_UserTable] = None,
 ) -> bool:
     """
-    - Route b/w api token check and normal token check
+    Checks if the route is allowed for the user_role
+
+    Doc LiteLLM User Roles: https://docs.litellm.ai/docs/proxy/access_control#roles
+
+    Args:
+        route: str
+        request: Request
+        request_data: dict
+        api_key: str
+        user_obj: LiteLLM_UserTable
+    Returns:
+        bool, True if the route is allowed
+    Raises:
+        Exception: If the route is not allowed
     """
     _user_role = _get_user_role(user_obj=user_obj)
 
@@ -1079,7 +1092,7 @@ async def user_api_key_auth(  # noqa: PLR0915
         # check if token is from litellm-ui, litellm ui makes keys to allow users to login with sso. These keys can only be used for LiteLLM UI functions
         # sso/login, ui/login, /key functions and /user functions
         # this will never be allowed to call /chat/completions
-        _is_route_allowed = _is_api_route_allowed(
+        _is_route_allowed = _is_route_allowed_check(
             route=route,
             user_obj=user_obj,
             request=request,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1079,7 +1079,6 @@ async def user_api_key_auth(  # noqa: PLR0915
         # check if token is from litellm-ui, litellm ui makes keys to allow users to login with sso. These keys can only be used for LiteLLM UI functions
         # sso/login, ui/login, /key functions and /user functions
         # this will never be allowed to call /chat/completions
-        token_team = getattr(valid_token, "team_id", None)
         _is_route_allowed = _is_api_route_allowed(
             route=route,
             user_obj=user_obj,

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -8,4 +8,6 @@ model_list:
 litellm_settings:
   callbacks: ["prometheus"]
   service_callback: ["prometheus_system"]
-  cache: true
+  default_internal_user_params:
+    user_role: "internal_user_viewer"
+    max_budget: 0

--- a/tests/local_testing/test_user_api_key_auth.py
+++ b/tests/local_testing/test_user_api_key_auth.py
@@ -310,8 +310,8 @@ async def test_auth_with_allowed_routes(route, should_raise_error):
         ("/organization/member_add", "internal_user", False),
     ],
 )
-def test_is_ui_route_allowed(route, user_role, expected_result):
-    from litellm.proxy.auth.user_api_key_auth import _is_ui_route_allowed
+def test_is_route_allowed_check(route, user_role, expected_result):
+    from litellm.proxy.auth.user_api_key_auth import _is_route_allowed_check
     from litellm.proxy._types import LiteLLM_UserTable
 
     user_obj = LiteLLM_UserTable(
@@ -333,7 +333,7 @@ def test_is_ui_route_allowed(route, user_role, expected_result):
         "user_obj": user_obj,
     }
     try:
-        assert _is_ui_route_allowed(**received_args) == expected_result
+        assert _is_route_allowed_check(**received_args) == expected_result
     except Exception as e:
         # If expected result is False, we expect an error
         if expected_result is False:

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -517,7 +517,7 @@ async def test_internal_user_permissions(prisma_client):
             await user_api_key_auth(request=request, api_key="Bearer " + internal_key)
             pytest.fail(f"Should not allow {method} {endpoint} for internal user")
         except ProxyException as e:
-            assert int(e.code) == 401  # Unauthorized
+            assert int(e.code) == 401 or int(e.code) == 403  # Unauthorized or Forbidden
 
 
 @pytest.mark.asyncio
@@ -596,7 +596,7 @@ async def test_internal_user_viewer_permissions(prisma_client):
                 f"Should not allow {method} {endpoint} for internal user viewer"
             )
         except Exception as e:
-            assert int(e.code) == 401  # Unauthorized
+            assert int(e.code) == 401 or int(e.code) == 403  # Unauthorized or Forbidden
 
 
 @pytest.mark.asyncio
@@ -663,7 +663,7 @@ async def test_proxy_admin_viewer_permissions(prisma_client):
             await user_api_key_auth(request=request, api_key="Bearer " + viewer_key)
             pytest.fail(f"Should not allow {method} {endpoint} for proxy admin viewer")
         except ProxyException as e:
-            assert int(e.code) == 401  # Unauthorized
+            assert int(e.code) == 401 or int(e.code) == 403  # Unauthorized or Forbidden
 
 
 @pytest.mark.asyncio

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -450,6 +450,7 @@ async def test_internal_user_permissions(prisma_client):
     """Test INTERNAL_USER permissions:
     - Can view/create/delete keys ✅
     - Can view /user/info for themselves ✅
+    - Can access llm endpoints ✅
     - Cannot add/update/delete new users ❌
     - Cannot add/update/delete teams ❌
     - Cannot add/update/delete organizations ❌
@@ -481,6 +482,7 @@ async def test_internal_user_permissions(prisma_client):
         ("/key/generate", "POST"),
         ("/key/delete", "POST"),
         ("/user/info", "GET"),
+        ("/chat/completions", "POST"),
     ]
 
     for endpoint, method in allowed_endpoints:
@@ -526,6 +528,7 @@ async def test_internal_user_viewer_permissions(prisma_client):
     - Can view own keys ✅
     - Can view /user/info for themselves ✅
     - Can view spend logs ✅
+    - Can access llm endpoints ✅ (NOTE: this is to maintain backwards compatibility)
     - Cannot create, update, delete keys ❌
     - Cannot create, update, delete users ❌
     - Cannot create, update, delete teams ❌
@@ -556,6 +559,7 @@ async def test_internal_user_viewer_permissions(prisma_client):
         ("/key/info", "GET"),
         ("/user/info", "GET"),
         ("/spend/logs", "GET"),
+        ("/chat/completions", "POST"),
     ]
 
     for endpoint, method in allowed_endpoints:
@@ -632,6 +636,7 @@ async def test_proxy_admin_viewer_permissions(prisma_client):
     allowed_endpoints = [
         ("/key/info", "GET"),
         ("/spend/logs", "GET"),
+        ("/chat/completions", "POST"),
     ]
 
     for endpoint, method in allowed_endpoints:
@@ -647,7 +652,6 @@ async def test_proxy_admin_viewer_permissions(prisma_client):
         ("/key/generate", "POST"),
         ("/key/delete", "POST"),
         ("/user/new", "POST"),
-        ("/user/update", "POST"),
         ("/user/delete", "POST"),
         ("/team/new", "POST"),
         ("/team/update", "POST"),
@@ -675,6 +679,7 @@ async def test_proxy_admin_permissions(prisma_client):
     - Can add new users ✅
     - Can manage organizations ✅
     - Can manage teams ✅
+     - Can access llm endpoints ✅ (NOTE: this is to maintain backwards compatibility)
     - Has full access to all admin endpoints ✅
     """
     import json
@@ -716,6 +721,7 @@ async def test_proxy_admin_permissions(prisma_client):
         ("/spend/logs", "GET"),
         ("/spend/key", "GET"),
         ("/spend/user", "GET"),
+        ("/chat/completions", "POST"),
     ]
 
     for endpoint, method in admin_endpoints:

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -597,7 +597,7 @@ async def test_proxy_admin_viewer_permissions(prisma_client):
 
     _new_key = await new_user(
         data=NewUserRequest(
-            user_id=user_id, user_role=LitellmUserRoles.PROXY_ADMIN_VIEWER
+            user_id=user_id, user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
         ),
         user_api_key_dict=UserAPIKeyAuth(
             user_role=LitellmUserRoles.PROXY_ADMIN,


### PR DESCRIPTION
## Fixes  internal_user_viewer can create keys on UI but shouldn't be authorized to do so 

## Details:
- Role based checks worked on the API but not on Admin UI 


## Root cause ? 
- we had a conditional branch checking if the user was on the UI or using API 
- the RBAC checks only ran when user was using API 
- there is no need for separating auth on UI vs auth on API
- lack of e2e tests for RBAC checks. `user_api_key_auth` needed to be tested here since individual components were working as expected 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

This change adds comprehensive test coverage for role-based access control (RBAC), including tests for internal users, view-only users, and admin permissions to verify proper endpoint access restrictions and authorization flows.

<!-- Test procedure -->

