### PR TITLE
Support specifying exponential backoff retry strategy when calling completions()

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1315,6 +1315,7 @@ all_litellm_params = [
     "num_retries",
     "context_window_fallback_dict",
     "retry_policy",
+    "retry_strategy",
     "roles",
     "final_prompt_value",
     "bos_token",


### PR DESCRIPTION
## Title

Support specifying exponential backoff retry strategy when calling completions()

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

🆕 New Feature

## Changes

Exponential backoff is a helpful retry strategy for handling rate limiting *and* overcoming transient network failures. Currently, LiteLLM supports the former exponential backoff use case, but not the latter.

Today, users can run the following (undocumented) code to use exponential backoff for retries on rate limit *and* network failures:

```
litellm.completion(
    model="openai/gpt4o",
    messages=[{"role": "user", "content": "Test message"}],
    retry_strategy="exponential_backoff_retry",
    num_retries=10,
)
```

The `retry_strategy` argument value is respected here: 

```
https://github.com/BerriAI/litellm/blob/2c37aad1c44af9e98a0af4e36d0b89f2449bf2a9/litellm/main.py#L3020-L3027https://github.com/BerriAI/litellm/blob/2c37aad1c44af9e98a0af4e36d0b89f2449bf2a9/litellm/main.py#L3020-L3027
```

However, because `retry_strategy` is not recognized as a builtin LiteLLM parameter (https://github.com/BerriAI/litellm/blob/2c37aad1c44af9e98a0af4e36d0b89f2449bf2a9/litellm/types/utils.py#L1291), LiteLLM also passes the `retry_strategy` as part of the `optional_params` to the provider's `completion` method. This means that the first 1-2 requests fail for certain providers (like OpenAI, which throws if unrecognized args like `retry_strategy` are specified) with messages like:

```
openai.py: Received openai error - Error code: 400 - {'error': {'message': 'Unrecognized request argument supplied: retry_strategy', 'type': 'invalid_request_error', 'param': None, 'code': None}}
RAW RESPONSE:
Error code: 400 - {'error': {'message': 'Unrecognized request argument supplied: retry_strategy', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

The retry policy subsequently kicks in and drops the `retry_strategy` argument here: https://github.com/BerriAI/litellm/blob/2c37aad1c44af9e98a0af4e36d0b89f2449bf2a9/litellm/main.py#L3020

This can be addressed by adding `retry_strategy` as a recognized LLM parameter, thereby omitting it from `optional_params`.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

**UNIT TEST COVERAGE PENDING**

**MANUAL QA**

Ran the following script before the change using an Azure OpenAI endpoint with a very aggressive rate limit (1 query per minute):

```
import litellm
import uuid


litellm.set_verbose=True
for i in range(100):
    print(litellm.completion(
        model="databricks/customazureopenaideployment",
        messages=[{"role": "user", "content": "You are a helpful assistant." + uuid.uuid4().hex}],
        retry_strategy="exponential_backoff_retry",
        num_retries=10,
    ))

```

Observed the following message in the logs:

```
openai.py: Received openai error - Error code: 400 - {'error': {'message': 'Unrecognized request argument supplied: retry_strategy', 'type': 'invalid_request_error', 'param': None, 'code': None}}
RAW RESPONSE:
Error code: 400 - {'error': {'message': 'Unrecognized request argument supplied: retry_strategy', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

Reran the script after the change and did not observe the error message. Output (truncated): 

```
Request to litellm:
litellm.completion(model='databricks/customazureopenaideployment', messages=[{'role': 'user', 'content': 'You are a helpful assistant.124a94664c114bc1aed1c13b2497c68c'}], retry_strategy='exponential_backoff_retry', num_retries=10)


15:08:03 - LiteLLM:WARNING: utils.py:346 - `litellm.set_verbose` is deprecated. Please set `os.environ['LITELLM_LOG'] = 'DEBUG'` for debug logs.
SYNC kwargs[caching]: False; litellm.cache: None; kwargs.get('cache')['no-cache']: False
Final returned optional params: {}


POST Request Sent from LiteLLM:
curl -X POST \
https://e2-dogfood.staging.cloud.databricks.com/serving-endpoints/chat/completions \
-H 'Authorization: *****' -H 'Content-Type: *****' \
-d '{'model': 'customazureopenaideployment', 'messages': [{'role': 'user', 'content': 'You are a helpful assistant.124a94664c114bc1aed1c13b2497c68c'}], 'stream': False}'


Logging Details LiteLLM-Success Call: Cache_hit=None
Looking up model=gpt-4o-2024-05-13 in model_cost_map, custom_llm_provider=databricks, call_type=completion
Looking up model=gpt-4o-2024-05-13 in model_cost_map, custom_llm_provider=databricks, call_type=completion
ModelResponse(id='chatcmpl-AOB9ARIyUo1DSd6qRqMfibhitoKdT', choices=[Choices(content_filter_results={'hate': {'filtered': False, 'severity': 'safe'}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}, finish_reason='stop', index=0, message=Message(content='Thank you for sharing that information. How can I assist you today?', role='assistant', tool_calls=None, function_call=None))], created=1730326084, model='databricks/gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_67802d9a6d', usage=Usage(completion_tokens=14, prompt_tokens=31, total_tokens=45, completion_tokens_details=None, prompt_tokens_details=None))


Request to litellm:
litellm.completion(model='databricks/customazureopenaideployment', messages=[{'role': 'user', 'content': 'You are a helpful assistant.f39d32f420614dc0854c5095fb2763d8'}], retry_strategy='exponential_backoff_retry', num_retries=10)


15:08:04 - LiteLLM:WARNING: utils.py:346 - `litellm.set_verbose` is deprecated. Please set `os.environ['LITELLM_LOG'] = 'DEBUG'` for debug logs.
SYNC kwargs[caching]: False; litellm.cache: None; kwargs.get('cache')['no-cache']: False
Final returned optional params: {}


POST Request Sent from LiteLLM:
curl -X POST \
https://e2-dogfood.staging.cloud.databricks.com/serving-endpoints/chat/completions \
-H 'Authorization: *****' -H 'Content-Type: *****' \
-d '{'model': 'customazureopenaideployment', 'messages': [{'role': 'user', 'content': 'You are a helpful assistant.f39d32f420614dc0854c5095fb2763d8'}], 'stream': False}'


RAW RESPONSE:
{"error_code":"REQUEST_LIMIT_EXCEEDED","message":"REQUEST_LIMIT_EXCEEDED: User defined rate limit(s) exceeded for endpoint: customazureopenaideployment."}



Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'.

...
```