### PR TITLE
Flake8 check to ensure `load_dotenv` is not called

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -44,3 +44,9 @@ ignore =
 
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 extend-ignore = E203
+
+[flake8:local-plugins]
+extension =
+   FC1 = flake8_forbidden_calls:ForbiddenCallPlugin
+paths =
+  ./ci_cd

--- a/ci_cd/flake8_forbidden_calls.py
+++ b/ci_cd/flake8_forbidden_calls.py
@@ -1,9 +1,11 @@
 """Flake8 Extension that finds usage of load_dotenv."""
+
 import ast
 from typing import Generator
 
 FORBIDDEN_CALLS = ["load_dotenv"]
 PLUGIN_CODE = "FC1"
+
 
 class ForbiddenCallPlugin:
     name = "flake8_forbidden_calls"
@@ -14,6 +16,18 @@ class ForbiddenCallPlugin:
 
     def run(self) -> Generator:
         for node in ast.walk(self._tree):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-                if node.func.id in FORBIDDEN_CALLS:
-                    yield (node.lineno, node.col_offset, f"{PLUGIN_CODE} `{node.func.id}` is not allowed.", type(self))
+            if isinstance(node, ast.Call):
+                func_name = (
+                    node.func.id
+                    if isinstance(node.func, ast.Name)
+                    else (
+                        node.func.attr if isinstance(node.func, ast.Attribute) else None
+                    )
+                )
+                if func_name in FORBIDDEN_CALLS:
+                    yield (
+                        node.lineno,
+                        node.col_offset,
+                        f"{PLUGIN_CODE} `{func_name}` is not allowed.",
+                        type(self),
+                    )

--- a/ci_cd/flake8_forbidden_calls.py
+++ b/ci_cd/flake8_forbidden_calls.py
@@ -1,0 +1,19 @@
+"""Flake8 Extension that finds usage of load_dotenv."""
+import ast
+from typing import Generator
+
+FORBIDDEN_CALLS = ["load_dotenv"]
+PLUGIN_CODE = "FC1"
+
+class ForbiddenCallPlugin:
+    name = "flake8_forbidden_calls"
+    version = "1.0.0"
+
+    def __init__(self, tree: ast.AST):
+        self._tree = tree
+
+    def run(self) -> Generator:
+        for node in ast.walk(self._tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in FORBIDDEN_CALLS:
+                    yield (node.lineno, node.col_offset, f"{PLUGIN_CODE} `{node.func.id}` is not allowed.", type(self))


### PR DESCRIPTION
## Flake8 Local Plugin to check for calls to forbidden functions (just `load_dotenv` rn)

This is my first contribution to this project so not sure how everything is laid out yet.

## Relevant issues

Fixes #4895 

## Type

🆕 New Feature

## Changes

- Added a local flake8 plugin to check if `load_dotenv` is ever called. 
- Plugin can be extended to check for calls to other 'forbidden' functions by appending to `FORBIDDEN_CALLS` list.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

<img width="482" alt="flake8_ss4" src="https://github.com/user-attachments/assets/617d98ef-d875-4b89-84be-bed966d41211">