### PR TITLE
Fix incorrect cost calculation when creation cached input tokens in Anthropic

### DIFF
--- a/litellm/llms/anthropic/cost_calculation.py
+++ b/litellm/llms/anthropic/cost_calculation.py
@@ -50,7 +50,7 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     _cache_creation_input_token_cost = model_info.get("cache_creation_input_token_cost")
     if _cache_creation_input_token_cost is not None:
         prompt_cost += (
-            float(usage._cache_creation_input_tokens) * _cache_creation_input_token_cost
+            float(usage._cache_creation_input_tokens) * (_cache_creation_input_token_cost - model_info["input_cost_per_token"])
         )
 
     ## CALCULATE OUTPUT COST


### PR DESCRIPTION
## Fix incorrect cost calculation when creation cached input tokens in Anthropic

## Relevant issues

Fixes #6575

## Type

🐛 Bug Fix

## Changes

Stopped double counting the tokens.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
There don't seem to be any tests of this function? Seems out of scope for this bug fix to add them.
