### PR TITLE
chore: LiteLLM.Info: If you need to debug this error, use `litellm.suppress_debug_info=True'.

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -110,7 +110,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
             "\033[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\033[0m"  # noqa
         )  # noqa
         print(  # noqa
-            "LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'."  # noqa
+            "LiteLLM.Info: If you need to debug this error, use `litellm.suppress_debug_info=True'."  # noqa
         )  # noqa
         print()  # noqa
 


### PR DESCRIPTION
## Change

```
LiteLLM.Info: If you need to debug this error, use `litellm.set_verbose=True'.
　↓
LiteLLM.Info: If you need to debug this error, use `litellm.suppress_debug_info=True'.
```

## Type

🧹 Refactoring

