### PR TITLE
Update team_budgets.md

### DIFF
--- a/docs/my-website/docs/proxy/team_budgets.md
+++ b/docs/my-website/docs/proxy/team_budgets.md
@@ -56,7 +56,7 @@ Possible values for `budget_duration`
 | `budget_duration="1m"` | every 1 min |
 | `budget_duration="1h"` | every 1 hour |
 | `budget_duration="1d"` | every 1 day |
-| `budget_duration="1mo"` | every 1 month |
+| `budget_duration="30d"` | every 1 month |
 
 
 ### 2. Create a key for the `team`


### PR DESCRIPTION
## Title

Correct budget duration value for 1 months

## Relevant issues

the documentation was sayinf 1mo as value instead of 30d what lead to no budget rotation/reset every month 

## Type

📖 Documentation

## Changes



