### PR TITLE
(fix) ProxyStartup - Check that prisma connection is healthy when starting an instance of LiteLLM 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1011,7 +1011,9 @@ jobs:
       - run:
           name: Check for expected error
           command: |
-            if grep -q "Error: P1001: Can't reach database server at" docker_output.log; then
+            if grep -q "Error: P1001: Can't reach database server at" docker_output.log && \
+               grep -q "httpx.ConnectError: All connection attempts failed" docker_output.log && \
+               grep -q "ERROR:    Application startup failed. Exiting." docker_output.log; then
               echo "Expected error found. Test passed."
             else
               echo "Expected error not found. Test failed."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -986,6 +986,39 @@ jobs:
       - store_test_results:
           path: test-results
 
+  test_bad_database_url:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run:
+          name: Build Docker image
+          command: |
+            docker build -t myapp . -f ./docker/Dockerfile.non_root
+      - run:
+          name: Run Docker container with bad DATABASE_URL
+          command: |
+            docker run --name my-app \
+              -p 4000:4000 \
+              -e DATABASE_URL="postgresql://wrong:wrong@wrong:5432/wrong" \
+              myapp:latest \
+              --port 4000 > docker_output.log 2>&1 || true
+      - run:
+          name: Display Docker logs
+          command: cat docker_output.log
+      - run:
+          name: Check for expected error
+          command: |
+            if grep -q "Error: P1001: Can't reach database server at" docker_output.log; then
+              echo "Expected error found. Test passed."
+            else
+              echo "Expected error not found. Test failed."
+              cat docker_output.log
+              exit 1
+            fi
+
 workflows:
   version: 2
   build_and_test:
@@ -1082,11 +1115,18 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
+      - test_bad_database_url:
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
       - publish_to_pypi:
           requires:
             - local_testing
             - build_and_test
             - load_testing
+            - test_bad_database_url
             - llm_translation_testing
             - logging_testing
             - litellm_router_testing

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3038,6 +3038,8 @@ class ProxyStartupEvent:
                 prisma_client.check_view_exists()
             )  # check if all necessary views exist. Don't block execution
 
+            # run a health check to ensure the DB is ready
+            await prisma_client.health_check()
         return prisma_client
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3039,7 +3039,7 @@ class ProxyStartupEvent:
             )  # check if all necessary views exist. Don't block execution
 
             # run a health check to ensure the DB is ready
-            # await prisma_client.health_check()
+            await prisma_client.health_check()
         return prisma_client
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3039,7 +3039,7 @@ class ProxyStartupEvent:
             )  # check if all necessary views exist. Don't block execution
 
             # run a health check to ensure the DB is ready
-            await prisma_client.health_check()
+            # await prisma_client.health_check()
         return prisma_client
 
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1083,19 +1083,16 @@ class PrismaClient:
         proxy_logging_obj: ProxyLogging,
         http_client: Optional[Any] = None,
     ):
-        verbose_proxy_logger.debug(
-            "LiteLLM: DATABASE_URL Set in config, trying to 'pip install prisma'"
-        )
         ## init logging object
         self.proxy_logging_obj = proxy_logging_obj
         self.iam_token_db_auth: Optional[bool] = str_to_bool(
             os.getenv("IAM_TOKEN_DB_AUTH")
         )
+        verbose_proxy_logger.debug("Creating Prisma Client..")
         try:
             from prisma import Prisma  # type: ignore
         except Exception:
             raise Exception("Unable to find Prisma binaries.")
-        verbose_proxy_logger.debug("Connecting Prisma Client to DB..")
         if http_client is not None:
             self.db = PrismaWrapper(
                 original_prisma=Prisma(http=http_client),
@@ -1114,7 +1111,7 @@ class PrismaClient:
                     else False
                 ),
             )  # Client to connect to Prisma db
-        verbose_proxy_logger.debug("Success - Connected Prisma Client to DB")
+        verbose_proxy_logger.debug("Success - Created Prisma Client")
 
     def hash_token(self, token: str):
         # Hash the string using SHA-256

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2345,11 +2345,7 @@ class PrismaClient:
         """
         start_time = time.time()
         try:
-            sql_query = """
-                SELECT 1
-                FROM "LiteLLM_VerificationToken"
-                LIMIT 1
-                """
+            sql_query = "SELECT 1"
 
             # Execute the raw query
             # The asterisk before `user_id_list` unpacks the list into separate arguments

--- a/tests/local_testing/test_proxy_server.py
+++ b/tests/local_testing/test_proxy_server.py
@@ -1911,6 +1911,7 @@ async def test_proxy_server_prisma_setup():
         mock_client = mock_prisma_client.return_value  # This is the mocked instance
         mock_client.connect = AsyncMock()  # Mock the connect method
         mock_client.check_view_exists = AsyncMock()  # Mock the check_view_exists method
+        mock_client.health_check = AsyncMock()  # Mock the health_check method
 
         await ProxyStartupEvent._setup_prisma_client(
             database_url=os.getenv("DATABASE_URL"),
@@ -1921,3 +1922,7 @@ async def test_proxy_server_prisma_setup():
         # Verify our mocked methods were called
         mock_client.connect.assert_called_once()
         mock_client.check_view_exists.assert_called_once()
+
+        # Note: This is REALLY IMPORTANT to check that the health check is called
+        # This is how we ensure the DB is ready before proceeding
+        mock_client.health_check.assert_called_once()


### PR DESCRIPTION
## Check that prisma connection is healthy when starting an instance of LiteLLM 

## Why do this ? 
- User had a proxy instance startup when it could not connect to the DB 
- once it started up /chat/completions requests started failing since prisma was not connected to the DB 


## Solution 
- If we did a prisma_client.health_check() on startup that would stop the pod from starting up when it's not able to connect to the DB, this would prevent faulty pods from starting up (which can lead to failed requests) 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

