### PR TITLE
feat: add default model region to proxy config

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -851,6 +851,7 @@ router_settings:
   }
   content_policy_fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for content policy violations
   fallbacks=[{"claude-2": ["my-fallback-model"]}] # List[Dict[str, List[str]]]: Fallback model for all errors
+  default_model_region: "us" # default region for all models
 ```
 
 | Name | Type | Description |
@@ -867,7 +868,16 @@ router_settings:
 | disable_cooldowns | boolean | If true, disables cooldowns for all models. [More information here](reliability) |
 | retry_policy | object | Specifies the number of retries for different types of exceptions. [More information here](reliability) |
 | allowed_fails | integer | The number of failures allowed before cooling down a model. [More information here](reliability) |
-| allowed_fails_policy | object | Specifies the number of allowed failures for different error types before cooling down a deployment. [More information here](reliability) |
+| allowed_fails_policy | object | Specifies the number of allowed failures for different error types before cooling down a deployment. [More information here]
+(reliability) |
+cooldown_time | integer | The duration (in seconds) to cooldown a model if it exceeds the allowed failures. [More information here](reliability) |
+disable_cooldowns | boolean | If true, disables cooldowns for all models. [More information here](reliability) |
+routing_strategy | string | The strategy used for routing requests. Options: "simple-shuffle", "least-busy", "usage-based-routing", "latency-based-routing". Default is "simple-shuffle". [More information here](../routing) |
+routing_strategy_args | object | Additional arguments for latency-based routing. [More information here](reliability) |
+semaphore | object | Semaphore for limiting the number of concurrent requests. [More information here](reliability) |
+alerting_config | object | Configuration for alerting. [More information here](alerting) |
+router_general_settings | object | General settings for the router. [More information here](reliability) |
+default_model_region | string | The default region for all models. [More information here](region_filtering) |
 
 
 ### environment variables - Reference

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6138,6 +6138,10 @@ async def new_end_user(
 
         new_end_user_obj: Dict = {}
 
+        ## SET DEFAULT ALLOWED MODEL REGION ##
+        if data.allowed_model_region is None and hasattr(llm_router, "default_model_region"):
+            new_end_user_obj["allowed_model_region"] = llm_router.default_model_region
+
         ## CREATE BUDGET ## if set
         if data.max_budget is not None:
             budget_record = await prisma_client.db.litellm_budgettable.create(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -241,6 +241,7 @@ class Router:
         router_general_settings: Optional[
             RouterGeneralSettings
         ] = RouterGeneralSettings(),
+        default_model_region: Optional[str] = None, # default region for all models
     ) -> None:
         """
         Initialize the Router class with the given parameters for caching, reliability, and routing strategy.
@@ -272,6 +273,9 @@ class Router:
             routing_strategy (Literal["simple-shuffle", "least-busy", "usage-based-routing", "latency-based-routing", "cost-based-routing"]): Routing strategy. Defaults to "simple-shuffle".
             routing_strategy_args (dict): Additional args for latency-based routing. Defaults to {}.
             alerting_config (AlertingConfig): Slack alerting configuration. Defaults to None.
+            router_general_settings (RouterGeneralSettings): General settings for the router. Defaults to RouterGeneralSettings(),
+            default_model_region (Optional[str]): Default region for all models. Defaults to None.
+
         Returns:
             Router: An instance of the litellm.Router class.
 
@@ -325,6 +329,7 @@ class Router:
         self.router_general_settings: RouterGeneralSettings = (
             router_general_settings or RouterGeneralSettings()
         )
+        self.default_model_region = default_model_region
 
         self.assistants_config = assistants_config
         self.deployment_names: List = (

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -149,6 +149,7 @@ router_settings:
   redis_port: os.environ/REDIS_PORT
   enable_pre_call_checks: true
   model_group_alias: {"my-special-fake-model-alias-name": "fake-openai-endpoint-3"} 
+  default_model_region: "us"
 
 general_settings: 
   master_key: sk-1234 # [OPTIONAL] Use to enforce auth on proxy. See - https://docs.litellm.ai/docs/proxy/virtual_keys


### PR DESCRIPTION
## Title

Implement default model region to proxy config

## Relevant issues

N/A

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation

## Changes

<!-- List of changes -->

- [x] Add `default_model_region` to `Router` via `router_settings` in config
- [x] Add `/end_user/update_all_regions` endpoint to be run as background task 
- [x] Update docs for `router_settings`

<!-- Test procedure -->

