### PR TITLE
(feat) log error class, function_name on prometheus service failure hook + only log DB related failures on DB service hook 

### DIFF
--- a/litellm/_service_logger.py
+++ b/litellm/_service_logger.py
@@ -241,7 +241,8 @@ class ServiceLogging(CustomLogger):
             if callback == "prometheus_system":
                 await self.init_prometheus_services_logger_if_none()
                 await self.prometheusServicesLogger.async_service_failure_hook(
-                    payload=payload
+                    payload=payload,
+                    error=error,
                 )
             elif callback == "datadog":
                 await self.init_datadog_logger_if_none()

--- a/litellm/integrations/prometheus_services.py
+++ b/litellm/integrations/prometheus_services.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import traceback
 import uuid
+from typing import List, Optional, Union
 
 import dotenv
 import requests  # type: ignore
@@ -51,7 +52,9 @@ class PrometheusServicesLogger:
             for service in self.services:
                 histogram = self.create_histogram(service, type_of_request="latency")
                 counter_failed_request = self.create_counter(
-                    service, type_of_request="failed_requests"
+                    service,
+                    type_of_request="failed_requests",
+                    additional_labels=["error_class", "function_name"],
                 )
                 counter_total_requests = self.create_counter(
                     service, type_of_request="total_requests"
@@ -99,7 +102,12 @@ class PrometheusServicesLogger:
             buckets=LATENCY_BUCKETS,
         )
 
-    def create_counter(self, service: str, type_of_request: str):
+    def create_counter(
+        self,
+        service: str,
+        type_of_request: str,
+        additional_labels: Optional[List[str]] = None,
+    ):
         metric_name = "litellm_{}_{}".format(service, type_of_request)
         is_registered = self.is_metric_registered(metric_name)
         if is_registered:
@@ -107,7 +115,7 @@ class PrometheusServicesLogger:
         return self.Counter(
             metric_name,
             "Total {} for {} service".format(type_of_request, service),
-            labelnames=[service],
+            labelnames=[service] + (additional_labels or []),
         )
 
     def observe_histogram(
@@ -125,10 +133,11 @@ class PrometheusServicesLogger:
         counter,
         labels: str,
         amount: float,
+        additional_labels: Optional[List[str]] = [],
     ):
         assert isinstance(counter, self.Counter)
 
-        counter.labels(labels).inc(amount)
+        counter.labels(labels, *additional_labels).inc(amount)
 
     def service_success_hook(self, payload: ServiceLoggerPayload):
         if self.mock_testing:
@@ -187,16 +196,25 @@ class PrometheusServicesLogger:
                         amount=1,  # LOG TOTAL REQUESTS TO PROMETHEUS
                     )
 
-    async def async_service_failure_hook(self, payload: ServiceLoggerPayload):
+    async def async_service_failure_hook(
+        self,
+        payload: ServiceLoggerPayload,
+        error: Union[str, Exception],
+    ):
         if self.mock_testing:
             self.mock_testing_failure_calls += 1
+        error_class = error.__class__.__name__
+        function_name = payload.call_type
 
         if payload.service.value in self.payload_to_prometheus_map:
             prom_objects = self.payload_to_prometheus_map[payload.service.value]
             for obj in prom_objects:
+                # increment both failed and total requests
                 if isinstance(obj, self.Counter):
                     self.increment_counter(
                         counter=obj,
                         labels=payload.service.value,
+                        # log additional_labels=["error_class", "function_name"], used for debugging what's going wrong with the DB
+                        additional_labels=[error_class, function_name],
                         amount=1,  # LOG ERROR COUNT TO PROMETHEUS
                     )

--- a/litellm/integrations/prometheus_services.py
+++ b/litellm/integrations/prometheus_services.py
@@ -137,7 +137,10 @@ class PrometheusServicesLogger:
     ):
         assert isinstance(counter, self.Counter)
 
-        counter.labels(labels, *additional_labels).inc(amount)
+        if additional_labels:
+            counter.labels(labels, *additional_labels).inc(amount)
+        else:
+            counter.labels(labels).inc(amount)
 
     def service_success_hook(self, payload: ServiceLoggerPayload):
         if self.mock_testing:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -32,7 +32,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.route_checks import RouteChecks
-from litellm.proxy.utils import PrismaClient, ProxyLogging, log_to_opentelemetry
+from litellm.proxy.utils import PrismaClient, ProxyLogging, log_db_metrics
 from litellm.types.services import ServiceLoggerPayload, ServiceTypes
 
 from .auth_checks_organization import organization_role_based_access_check
@@ -290,7 +290,7 @@ def get_actual_routes(allowed_routes: list) -> list:
     return actual_routes
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def get_end_user_object(
     end_user_id: Optional[str],
     prisma_client: Optional[PrismaClient],
@@ -415,7 +415,7 @@ def _update_last_db_access_time(
     last_db_access_time[key] = (value, time.time())
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def get_user_object(
     user_id: str,
     prisma_client: Optional[PrismaClient],
@@ -562,7 +562,7 @@ async def _delete_cache_key_object(
         )
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def _get_team_db_check(team_id: str, prisma_client: PrismaClient):
     return await prisma_client.db.litellm_teamtable.find_unique(
         where={"team_id": team_id}
@@ -658,7 +658,7 @@ async def get_team_object(
         )
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def get_key_object(
     hashed_token: str,
     prisma_client: Optional[PrismaClient],
@@ -720,7 +720,7 @@ async def get_key_object(
         return _response
     except httpx.ConnectError as e:
         return await _handle_failed_db_connection_for_get_key_object(e=e)
-    except Exception:
+    except Exception as e:
         raise Exception(
             f"Key doesn't exist in db. key={hashed_token}. Create key via `/key/generate` call."
         )
@@ -766,7 +766,7 @@ async def _handle_failed_db_connection_for_get_key_object(
         raise e
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def get_org_object(
     org_id: str,
     prisma_client: Optional[PrismaClient],

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -720,7 +720,7 @@ async def get_key_object(
         return _response
     except httpx.ConnectError as e:
         return await _handle_failed_db_connection_for_get_key_object(e=e)
-    except Exception as e:
+    except Exception:
         raise Exception(
             f"Key doesn't exist in db. key={hashed_token}. Create key via `/key/generate` call."
         )

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -58,7 +58,7 @@ from litellm.proxy.auth.auth_checks import (
     get_org_object,
     get_team_object,
     get_user_object,
-    log_to_opentelemetry,
+    log_db_metrics,
 )
 from litellm.proxy.auth.auth_utils import (
     _get_request_ip_address,

--- a/litellm/proxy/db/log_db_metrics.py
+++ b/litellm/proxy/db/log_db_metrics.py
@@ -1,0 +1,138 @@
+"""
+Handles logging DB success/failure to ServiceLogger()
+
+ServiceLogger() then sends DB logs to Prometheus, OTEL, Datadog etc
+"""
+
+from datetime import datetime
+from functools import wraps
+from typing import Callable, Dict, Tuple
+
+from litellm._service_logger import ServiceTypes
+from litellm.litellm_core_utils.core_helpers import (
+    _get_parent_otel_span_from_kwargs,
+    get_litellm_metadata_from_kwargs,
+)
+
+
+def log_db_metrics(func):
+    """
+    Decorator to log the duration of a DB related function to ServiceLogger()
+
+    Handles logging DB success/failure to ServiceLogger(), which logs to Prometheus, OTEL, Datadog
+
+    When logging Failure it checks if the Exception is a PrismaError, httpx.ConnectError or httpx.TimeoutException and then logs that as a DB Service Failure
+
+    Args:
+        func: The function to be decorated
+
+    Returns:
+        Result from the decorated function
+
+    Raises:
+        Exception: If the decorated function raises an exception
+    """
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        from prisma.errors import PrismaError
+
+        start_time: datetime = datetime.now()
+
+        try:
+            result = await func(*args, **kwargs)
+            end_time: datetime = datetime.now()
+            from litellm.proxy.proxy_server import proxy_logging_obj
+
+            if "PROXY" not in func.__name__:
+                await proxy_logging_obj.service_logging_obj.async_service_success_hook(
+                    service=ServiceTypes.DB,
+                    call_type=func.__name__,
+                    parent_otel_span=kwargs.get("parent_otel_span", None),
+                    duration=(end_time - start_time).total_seconds(),
+                    start_time=start_time,
+                    end_time=end_time,
+                    event_metadata={
+                        "function_name": func.__name__,
+                        "function_kwargs": kwargs,
+                        "function_args": args,
+                    },
+                )
+            elif (
+                # in litellm custom callbacks kwargs is passed as arg[0]
+                # https://docs.litellm.ai/docs/observability/custom_callback#callback-functions
+                args is not None
+                and len(args) > 0
+                and isinstance(args[0], dict)
+            ):
+                passed_kwargs = args[0]
+                parent_otel_span = _get_parent_otel_span_from_kwargs(
+                    kwargs=passed_kwargs
+                )
+                if parent_otel_span is not None:
+                    metadata = get_litellm_metadata_from_kwargs(kwargs=passed_kwargs)
+                    await proxy_logging_obj.service_logging_obj.async_service_success_hook(
+                        service=ServiceTypes.BATCH_WRITE_TO_DB,
+                        call_type=func.__name__,
+                        parent_otel_span=parent_otel_span,
+                        duration=0.0,
+                        start_time=start_time,
+                        end_time=end_time,
+                        event_metadata=metadata,
+                    )
+            # end of logging to otel
+            return result
+        except Exception as e:
+            end_time: datetime = datetime.now()
+            await _handle_logging_db_exception(
+                e=e,
+                func=func,
+                kwargs=kwargs,
+                args=args,
+                start_time=start_time,
+                end_time=end_time,
+            )
+            raise e
+
+    return wrapper
+
+
+def _is_exception_related_to_db(e: Exception) -> bool:
+    """
+    Returns True if the exception is related to the DB
+    """
+
+    import httpx
+    from prisma.errors import PrismaError
+
+    return isinstance(e, (PrismaError, httpx.ConnectError, httpx.TimeoutException))
+
+
+async def _handle_logging_db_exception(
+    e: Exception,
+    func: Callable,
+    kwargs: Dict,
+    args: Tuple,
+    start_time: datetime,
+    end_time: datetime,
+) -> None:
+    from litellm.proxy.proxy_server import proxy_logging_obj
+
+    # don't log this as a DB Service Failure, if the DB did not raise an exception
+    if _is_exception_related_to_db(e) is not True:
+        return
+
+    await proxy_logging_obj.service_logging_obj.async_service_failure_hook(
+        error=e,
+        service=ServiceTypes.DB,
+        call_type=func.__name__,
+        parent_otel_span=kwargs.get("parent_otel_span"),
+        duration=(end_time - start_time).total_seconds(),
+        start_time=start_time,
+        end_time=end_time,
+        event_metadata={
+            "function_name": func.__name__,
+            "function_kwargs": kwargs,
+            "function_args": args,
+        },
+    )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -125,7 +125,7 @@ from litellm.proxy._types import *
 from litellm.proxy.analytics_endpoints.analytics_endpoints import (
     router as analytics_router,
 )
-from litellm.proxy.auth.auth_checks import log_to_opentelemetry
+from litellm.proxy.auth.auth_checks import log_db_metrics
 from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.litellm_license import LicenseCheck
@@ -747,7 +747,7 @@ async def _PROXY_failure_handler(
     pass
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def _PROXY_track_cost_callback(
     kwargs,  # kwargs to completion
     completion_response: litellm.ModelResponse,  # response from completion

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -137,7 +137,7 @@ def safe_deep_copy(data):
     return new_data
 
 
-def log_to_opentelemetry(func):
+def log_db_metrics(func):
     """
     Decorator to log the duration of a DB related function to ServiceLogger()
 
@@ -1397,7 +1397,7 @@ class PrismaClient:
 
         return
 
-    @log_to_opentelemetry
+    @log_db_metrics
     @backoff.on_exception(
         backoff.expo,
         Exception,  # base exception to catch for the backoff
@@ -1463,7 +1463,7 @@ class PrismaClient:
         max_time=10,  # maximum total time to retry for
         on_backoff=on_backoff,  # specifying the function to call on backoff
     )
-    @log_to_opentelemetry
+    @log_db_metrics
     async def get_data(  # noqa: PLR0915
         self,
         token: Optional[Union[str, list]] = None,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -55,10 +55,6 @@ from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
-from litellm.litellm_core_utils.core_helpers import (
-    _get_parent_otel_span_from_kwargs,
-    get_litellm_metadata_from_kwargs,
-)
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.custom_httpx.httpx_handler import HTTPHandler
 from litellm.proxy._types import (
@@ -77,6 +73,7 @@ from litellm.proxy.db.create_views import (
     create_missing_views,
     should_create_missing_views,
 )
+from litellm.proxy.db.log_db_metrics import log_db_metrics
 from litellm.proxy.db.prisma_client import PrismaWrapper
 from litellm.proxy.hooks.cache_control_check import _PROXY_CacheControlCheck
 from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
@@ -135,83 +132,6 @@ def safe_deep_copy(data):
         if "metadata" in data:
             data["metadata"]["litellm_parent_otel_span"] = litellm_parent_otel_span
     return new_data
-
-
-def log_db_metrics(func):
-    """
-    Decorator to log the duration of a DB related function to ServiceLogger()
-
-    Handles logging DB success/failure to ServiceLogger(), which logs to Prometheus, OTEL, Datadog
-    """
-
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        start_time: datetime = datetime.now()
-
-        try:
-            result = await func(*args, **kwargs)
-            end_time: datetime = datetime.now()
-            from litellm.proxy.proxy_server import proxy_logging_obj
-
-            if "PROXY" not in func.__name__:
-                await proxy_logging_obj.service_logging_obj.async_service_success_hook(
-                    service=ServiceTypes.DB,
-                    call_type=func.__name__,
-                    parent_otel_span=kwargs.get("parent_otel_span", None),
-                    duration=(end_time - start_time).total_seconds(),
-                    start_time=start_time,
-                    end_time=end_time,
-                    event_metadata={
-                        "function_name": func.__name__,
-                        "function_kwargs": kwargs,
-                        "function_args": args,
-                    },
-                )
-            elif (
-                # in litellm custom callbacks kwargs is passed as arg[0]
-                # https://docs.litellm.ai/docs/observability/custom_callback#callback-functions
-                args is not None
-                and len(args) > 0
-                and isinstance(args[0], dict)
-            ):
-                passed_kwargs = args[0]
-                parent_otel_span = _get_parent_otel_span_from_kwargs(
-                    kwargs=passed_kwargs
-                )
-                if parent_otel_span is not None:
-                    metadata = get_litellm_metadata_from_kwargs(kwargs=passed_kwargs)
-                    await proxy_logging_obj.service_logging_obj.async_service_success_hook(
-                        service=ServiceTypes.BATCH_WRITE_TO_DB,
-                        call_type=func.__name__,
-                        parent_otel_span=parent_otel_span,
-                        duration=0.0,
-                        start_time=start_time,
-                        end_time=end_time,
-                        event_metadata=metadata,
-                    )
-            # end of logging to otel
-            return result
-        except Exception as e:
-            from litellm.proxy.proxy_server import proxy_logging_obj
-
-            end_time: datetime = datetime.now()
-            await proxy_logging_obj.service_logging_obj.async_service_failure_hook(
-                error=e,
-                service=ServiceTypes.DB,
-                call_type=func.__name__,
-                parent_otel_span=kwargs.get("parent_otel_span"),
-                duration=(end_time - start_time).total_seconds(),
-                start_time=start_time,
-                end_time=end_time,
-                event_metadata={
-                    "function_name": func.__name__,
-                    "function_kwargs": kwargs,
-                    "function_args": args,
-                },
-            )
-            raise e
-
-    return wrapper
 
 
 class InternalUsageCache:

--- a/tests/logging_callback_tests/test_log_db_redis_services.py
+++ b/tests/logging_callback_tests/test_log_db_redis_services.py
@@ -17,23 +17,23 @@ import pytest
 import litellm
 from litellm import completion
 from litellm._logging import verbose_logger
-from litellm.proxy.utils import log_to_opentelemetry, ServiceTypes
+from litellm.proxy.utils import log_db_metrics, ServiceTypes
 from datetime import datetime
 
 
 # Test async function to decorate
-@log_to_opentelemetry
+@log_db_metrics
 async def sample_db_function(*args, **kwargs):
     return "success"
 
 
-@log_to_opentelemetry
+@log_db_metrics
 async def sample_proxy_function(*args, **kwargs):
     return "success"
 
 
 @pytest.mark.asyncio
-async def test_log_to_opentelemetry_success():
+async def test_log_db_metrics_success():
     # Mock the proxy_logging_obj
     with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
         # Setup mock
@@ -61,14 +61,14 @@ async def test_log_to_opentelemetry_success():
 
 
 @pytest.mark.asyncio
-async def test_log_to_opentelemetry_duration():
+async def test_log_db_metrics_duration():
     # Mock the proxy_logging_obj
     with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
         # Setup mock
         mock_proxy_logging.service_logging_obj.async_service_success_hook = AsyncMock()
 
         # Add a delay to the function to test duration
-        @log_to_opentelemetry
+        @log_db_metrics
         async def delayed_function(**kwargs):
             await asyncio.sleep(1)  # 1 second delay
             return "success"
@@ -95,14 +95,14 @@ async def test_log_to_opentelemetry_duration():
 
 
 @pytest.mark.asyncio
-async def test_log_to_opentelemetry_failure():
+async def test_log_db_metrics_failure():
     # Mock the proxy_logging_obj
     with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
         # Setup mock
         mock_proxy_logging.service_logging_obj.async_service_failure_hook = AsyncMock()
 
         # Create a failing function
-        @log_to_opentelemetry
+        @log_db_metrics
         async def failing_function(**kwargs):
             raise ValueError("Test error")
 


### PR DESCRIPTION
## log error class and function_name on prometheus service failure hook for DB 

Changes in this PR:
-  log error class and function_name on prometheus service failure hook for DB 
- Only log DB related failures under the DB service failure hook. We define DB failures as 
`return isinstance(e, (PrismaError, httpx.ConnectError, httpx.TimeoutException))` 

## Why ?
- User seeing high % of DB fails on prometheus services and they are not sure what's causing it 
- Adds more details on the error class and function name to help debug 

This is now what I see

```
litellm_postgres_failed_requests_total{error_class="Exception",function_name="get_key_object",postgres="postgres"} 1.0
litellm_postgres_failed_requests_total{error_class="ValueError",function_name="get_user_object",postgres="postgres"} 3.0
```



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

