### PR TITLE
(pricing): Fix multiple mistakes in Claude pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1886,11 +1886,13 @@
         "supports_prompt_caching": true
     },
     "claude-3-5-haiku-20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
+        "cache_creation_input_token_cost": 0.00000125,
+        "cache_read_input_token_cost": 0.0000001,
         "litellm_provider": "anthropic",
         "mode": "chat",
         "supports_function_calling": true,
@@ -2812,9 +2814,9 @@
         "supports_assistant_prefill": true
     },
     "vertex_ai/claude-3-5-haiku@20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
         "litellm_provider": "vertex_ai-anthropic_models",
@@ -3816,9 +3818,9 @@
         "tool_use_system_prompt_tokens": 264
     },
     "openrouter/anthropic/claude-3-5-haiku-20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
         "litellm_provider": "openrouter",
@@ -4529,9 +4531,9 @@
         "supports_vision": true
     },
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096, 
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",
@@ -4559,6 +4561,7 @@
         "output_cost_per_token": 0.000005,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "supports_assistant_prefill": true,
         "supports_function_calling": true
     },
     "anthropic.claude-3-opus-20240229-v1:0": {
@@ -4595,9 +4598,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",
@@ -4625,6 +4628,7 @@
         "output_cost_per_token": 0.000005,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "supports_assistant_prefill": true,
         "supports_function_calling": true
     },
     "us.anthropic.claude-3-opus-20240229-v1:0": {
@@ -4661,9 +4665,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1886,11 +1886,13 @@
         "supports_prompt_caching": true
     },
     "claude-3-5-haiku-20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
+        "cache_creation_input_token_cost": 0.00000125,
+        "cache_read_input_token_cost": 0.0000001,
         "litellm_provider": "anthropic",
         "mode": "chat",
         "supports_function_calling": true,
@@ -2812,9 +2814,9 @@
         "supports_assistant_prefill": true
     },
     "vertex_ai/claude-3-5-haiku@20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
         "litellm_provider": "vertex_ai-anthropic_models",
@@ -3816,9 +3818,9 @@
         "tool_use_system_prompt_tokens": 264
     },
     "openrouter/anthropic/claude-3-5-haiku-20241022": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000001,
         "output_cost_per_token": 0.000005,
         "litellm_provider": "openrouter",
@@ -4529,9 +4531,9 @@
         "supports_vision": true
     },
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096, 
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",
@@ -4559,6 +4561,7 @@
         "output_cost_per_token": 0.000005,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "supports_assistant_prefill": true,
         "supports_function_calling": true
     },
     "anthropic.claude-3-opus-20240229-v1:0": {
@@ -4595,9 +4598,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",
@@ -4625,6 +4628,7 @@
         "output_cost_per_token": 0.000005,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "supports_assistant_prefill": true,
         "supports_function_calling": true
     },
     "us.anthropic.claude-3-opus-20240229-v1:0": {
@@ -4661,9 +4665,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": {
-        "max_tokens": 4096,
+        "max_tokens": 8192,
         "max_input_tokens": 200000,
-        "max_output_tokens": 4096,
+        "max_output_tokens": 8192,
         "input_cost_per_token": 0.000003,
         "output_cost_per_token": 0.000015,
         "litellm_provider": "bedrock",


### PR DESCRIPTION
Replaces #6586.

Confusingly Bedrock now supports 8192 tokens for Claude 3.5 Sonnet v2, but all other Claude 3.x models are limited to 4096. There was no announcement for this change that I can find, I just noticed it by testing it out.