### PR TITLE
removing max_retries param of custom vertex_ai model

### DIFF
--- a/litellm/llms/vertex_ai_and_google_ai_studio/vertex_ai_non_gemini.py
+++ b/litellm/llms/vertex_ai_and_google_ai_studio/vertex_ai_non_gemini.py
@@ -272,6 +272,7 @@ def completion(  # noqa: PLR0915
         else:  # assume vertex model garden on public endpoint
             mode = "custom"
 
+            optional_params.pop("max_retries", None)
             instances = [optional_params.copy()]
             instances[0]["prompt"] = prompt
             instances = [


### PR DESCRIPTION
## Title

To remove 'max_retries' param of the custom model hosted on Vertex_AI

## Relevant issues
Fixes [#6480](https://github.com/BerriAI/litellm/issues/6480)

## Type

🐛 Bug Fix

## Changes

- removed 'max_retries' param from optional_params dict which was causing error while calling a custom model deployed on Vertex_AI


