### PR TITLE
fix: duplicate exception_type for gemini

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1018,7 +1018,6 @@ def exception_type(  # type: ignore  # noqa: PLR0915
             elif (
                 custom_llm_provider == "vertex_ai"
                 or custom_llm_provider == "vertex_ai_beta"
-                or custom_llm_provider == "gemini"
             ):
                 if (
                     "Vertex AI API has not been used in project" in error_str
@@ -1216,7 +1215,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     raise BadRequestError(
                         message="GeminiException - Invalid api key",
                         model=model,
-                        llm_provider="palm",
+                        llm_provider=custom_llm_provider,
                         response=getattr(original_exception, "response", None),
                     )
                 if (
@@ -1227,14 +1226,14 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     raise Timeout(
                         message=f"GeminiException - {original_exception.message}",
                         model=model,
-                        llm_provider="palm",
+                        llm_provider=custom_llm_provider,
                     )
                 if "400 Request payload size exceeds" in error_str:
                     exception_mapping_worked = True
                     raise ContextWindowExceededError(
                         message=f"GeminiException - {error_str}",
                         model=model,
-                        llm_provider="palm",
+                        llm_provider=custom_llm_provider,
                         response=getattr(original_exception, "response", None),
                     )
                 if (
@@ -1245,7 +1244,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     raise APIError(
                         status_code=getattr(original_exception, "status_code", 500),
                         message=f"GeminiException - {original_exception.message}",
-                        llm_provider="palm",
+                        llm_provider=custom_llm_provider,
                         model=model,
                         request=httpx.Response(
                             status_code=429,
@@ -1261,7 +1260,15 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         raise BadRequestError(
                             message=f"GeminiException - {error_str}",
                             model=model,
-                            llm_provider="palm",
+                            llm_provider=custom_llm_provider,
+                            response=getattr(original_exception, "response", None),
+                        )
+                    if original_exception.status_code == 503:
+                        exception_mapping_worked = True
+                        raise BadRequestError(
+                            message=f"GeminiException - {error_str}",
+                            model=model,
+                            llm_provider=custom_llm_provider,
                             response=getattr(original_exception, "response", None),
                         )
                 # Dailed: Error occurred: 400 Request payload size exceeds the limit: 20000 bytes


### PR DESCRIPTION
## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

The exception_type for "gemini" is handled same as "palm" now.
Original code of "gemini" was in both "vertex_ai" and "palm".

Recentry, gemini often throws 503, so adding switch case as vertex_ai.
 
This is sample output. 
Note: logger_fn of exception_logging() is always None. Understanding was not easy for me. 
‘‘‘
{'exception': litellm.BadRequestError: GeminiException - {
  "error": {
    "code": 503,
    "message": "The model is overloaded. Please try again later.",
    "status": "UNAVAILABLE"
  }
}
‘‘‘
