### PR TITLE
chore: ruff.toml about ignore and select

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-ignore = ["F405", "E402", "F401", "E501", "F403"]
-extend-select = ["E501", "PLR0915"]
+lint.ignore = ["F405", "E402", "F401", "E501", "F403"]
+lint.extend-select = ["E501", "PLR0915"]
 line-length = 120
 exclude = ["litellm/types/*", "litellm/__init__.py", "litellm/proxy/example_config_yaml/*"]


### PR DESCRIPTION
## Type

🧹 Refactoring

## Changes

In ruff 0.6.9, shows warnings.

```
[info] warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `.../ruff.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

https://docs.astral.sh/ruff/settings/#lint_ignore
https://docs.astral.sh/ruff/settings/#lint_select
