### PR TITLE
fix: Add credential templates in migration job when using existing DB

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -18,6 +18,20 @@ spec:
           workingDir: "/app"
           env:
             {{- if .Values.db.useExisting }}
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: {{ .Values.db.secret.usernameKey }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: {{ .Values.db.secret.passwordKey }}
+            - name: DATABASE_HOST
+              value: {{ .Values.db.endpoint }}
+            - name: DATABASE_NAME
+              value: {{ .Values.db.database }}
             - name: DATABASE_URL
               value: {{ .Values.db.url | quote }}
             {{- else }}


### PR DESCRIPTION
## Title

Fix migration job failing for existing databases.

## Relevant issues

Fixes #6791

## Type

🐛 Bug Fix

## Changes

If the chart is configured to use an existing database, the migration job will pull the necessary database credential information from secrets within the cluster. This follows the same [pattern that the Deployment template currently uses](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/templates/deployment.yaml#L60-L76).
