### PR TITLE
Ensure cost per token is float.

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1972,6 +1972,11 @@ def register_model(model_cost: Union[str, dict]):  # noqa: PLR0915
         loaded_model_cost = litellm.get_model_cost_map(url=model_cost)
 
     for key, value in loaded_model_cost.items():
+        ## Change, if present, input_cost_per_token and output_cost_per_token to float
+        if "input_cost_per_token" in value:
+            value["input_cost_per_token"] = float(value["input_cost_per_token"])
+        if "output_cost_per_token" in value:
+            value["output_cost_per_token"] = float(value["output_cost_per_token"])
         ## get model info ##
         try:
             existing_model: Union[ModelInfo, dict] = get_model_info(model=key)


### PR DESCRIPTION
## Title

When you pass in a quoted string in the config, it will append the values (on streamed responses) and it will fail to do the calculation. In addition to that, if you do not quote the floats using the helm charts, they are converted to their scientific notation.

There's no validation at the moment, this results in something like this:

```
adding spend to team db. Response cost: 1e-061e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e-065e- │
│ 065e-065e-065e-065e-06. team_id: None.
```

By casting these values, if present, to make sure they are floats we can fix this.

## Relevant issues

https://github.com/BerriAI/litellm/issues/6641

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Changes the register_model to ensure it casts to float.