### PR TITLE
(fix) Pass `subject` with correct value to OpenMeter in OpenMeter integration

### DIFF
--- a/litellm/integrations/openmeter.py
+++ b/litellm/integrations/openmeter.py
@@ -70,7 +70,7 @@ class OpenMeterLogger(CustomLogger):
                 "total_tokens": response_obj["usage"].get("total_tokens"),
             }
 
-        subject = (kwargs.get("user", None),)  # end-user passed in via 'user' param
+        subject = kwargs.get("user", None)  # end-user passed in via 'user' param
         if not subject:
             raise Exception("OpenMeter: user is required")
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
OpenMeter rejects requests from this logger here:
https://github.com/BerriAI/litellm/blob/1890fde3f377b0896e7ca5908953ef948ec1c8a7/litellm/integrations/openmeter.py#L128-L135
Because the value of `subject` is not a string. See [schema here](https://openmeter.io/docs/api/cloud#tag/events).

This is because instead of assigning the `subject` property with the value of the `user` param in `kwargs`, it is instead wrapping that value in a tuple:
https://github.com/BerriAI/litellm/blob/1890fde3f377b0896e7ca5908953ef948ec1c8a7/litellm/integrations/openmeter.py#L73

## Relevant issues

<!-- e.g. "Fixes #000" -->
N/A

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes

<!-- List of changes -->

- Assign `subject` with the value of the `user` param, rather than as a tuple containing the value of the `user` param.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

- Set up OpenMeter according to the docs
- [ ] Observe the OpenMeter rejection responses without the changes
- [ ] Observe the OpenMeter success responses with the changes