### PR TITLE
feat - track `custom_llm_provider`  in StandardLoggingPayload

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2359,6 +2359,7 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
         _in_memory_loggers.append(_mlflow_logger)
         return _mlflow_logger  # type: ignore
 
+
 def get_custom_logger_compatible_class(
     logging_integration: litellm._custom_logger_compatible_callbacks_literal,
 ) -> Optional[CustomLogger]:
@@ -2850,6 +2851,7 @@ def get_standard_logging_object_payload(
             request_tags=request_tags,
             end_user=end_user_id or "",
             api_base=litellm_params.get("api_base", ""),
+            custom_llm_provider=litellm_params.get("custom_llm_provider", None),
             model_group=_model_group,
             model_id=_model_id,
             requester_ip_address=clean_metadata.get("requester_ip_address", None),

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1542,6 +1542,7 @@ class StandardLoggingPayload(TypedDict):
     model_id: Optional[str]
     model_group: Optional[str]
     api_base: str
+    custom_llm_provider: Optional[str]
     metadata: StandardLoggingMetadata
     cache_hit: Optional[bool]
     cache_key: Optional[str]


### PR DESCRIPTION
## Title

## Why ?

Prometheus and SpendLogs both need to start logging `custom_llm_provider`, makes sense to have 1 source of truth for this value 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

