### PR TITLE
add custom health probes in helm chart

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -108,20 +108,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health/liveliness
-              port: http
+            {{- .Values.livenessProbe | toYaml | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health/readiness
-              port: http
+            {{- .Values.readinessProbe | toYaml | nindent 12 }}
           # Give the container time to start up.  Up to 5 minutes (10 * 30 seconds)
           startupProbe:
-            httpGet:
-              path: /health/readiness
-              port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            {{- .Values.startupProbe | toYaml | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -41,6 +41,26 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# health probes for litellmproxy 
+livenessProbe:
+  httpGet:
+    path: /health/liveliness
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /health/readiness
+    port: http
+# Give the container time to start up.  Up to 5 minutes (10 * 30 seconds)
+
+startupProbe:
+  httpGet:
+    path: /health/readiness
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+
+
 # A list of Kubernetes Secret objects that will be exported to the LiteLLM proxy
 #  pod as environment variables.  These secrets can then be referenced in the
 #  configuration file (or "litellm" ConfigMap) with `os.environ/<Env Var Name>`


### PR DESCRIPTION
## Title

add custom health probes in helm chart

<!-- Test procedure -->

helm template and deploy works

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add custom health probes to the Helm chart for improved configurability of liveness, readiness, and startup probes.

### Why are these changes being made?

These changes allow for greater flexibility and customization in deploying applications using the litellm Helm chart by enabling users to specify their own health probe configurations through the `values.yaml` file. This approach addresses the need for different health checks in various deployment environments and simplifies the maintenance and adaptation of probe configurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->