### PR TITLE
(fix) Strip trailing slash in api_base for prometheus metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -789,7 +789,7 @@ class PrometheusLogger(CustomLogger):
             _litellm_params = request_kwargs.get("litellm_params", {}) or {}
             litellm_model_name = request_kwargs.get("model", None)
             model_group = standard_logging_payload.get("model_group", None)
-            api_base = standard_logging_payload.get("api_base", None)
+            api_base = self._strip_trailing_slash(standard_logging_payload.get("api_base", None))
             model_id = standard_logging_payload.get("model_id", None)
             exception: Exception = request_kwargs.get("exception", None)
 
@@ -864,7 +864,7 @@ class PrometheusLogger(CustomLogger):
                 return
 
             model_group = standard_logging_payload["model_group"]
-            api_base = standard_logging_payload["api_base"]
+            api_base = self._strip_trailing_slash(standard_logging_payload["api_base"])
             _response_headers = request_kwargs.get("response_headers")
             _litellm_params = request_kwargs.get("litellm_params", {}) or {}
             _metadata = _litellm_params.get("metadata", {})
@@ -1093,7 +1093,7 @@ class PrometheusLogger(CustomLogger):
         self,
         litellm_model_name: str,
         model_id: str,
-        api_base: str,
+        api_base: Optional[str],
         api_provider: str,
     ):
         self.set_litellm_deployment_state(
@@ -1160,3 +1160,13 @@ class PrometheusLogger(CustomLogger):
             return max_budget
 
         return max_budget - spend
+
+    def _strip_trailing_slash(
+        self, api_base: Optional[str]
+    ) -> Optional[str]:
+        """
+        Return api_base without a trailing slash
+        """
+        if api_base:
+            return api_base.rstrip("/")
+        return api_base

--- a/litellm/router_utils/cooldown_callbacks.py
+++ b/litellm/router_utils/cooldown_callbacks.py
@@ -44,7 +44,7 @@ async def router_cooldown_event_callback(
     _api_base = (
         litellm.get_api_base(model=_model_name, optional_params=temp_litellm_params)
         or ""
-    )
+    ).rstrip("/")
     model_info = _deployment["model_info"]
     model_id = model_info.id
 

--- a/tests/router_unit_tests/test_router_cooldown_utils.py
+++ b/tests/router_unit_tests/test_router_cooldown_utils.py
@@ -11,6 +11,7 @@ from litellm.router import Deployment, LiteLLM_Params, ModelInfo
 from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
 from dotenv import load_dotenv
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.router_utils.cooldown_callbacks import router_cooldown_event_callback
@@ -36,8 +37,8 @@ class CustomPrometheusLogger(PrometheusLogger):
     def set_deployment_complete_outage(
         self,
         litellm_model_name: str,
-        model_id: str,
-        api_base: str,
+        model_id: Optional[str],
+        api_base: Optional[str],
         api_provider: str,
     ):
         self.deployment_complete_outages.append(


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove trailing slashes from `api_base` in the prometheus metrics

### Why are these changes being made?

Trailing slashes in `api_base` values can cause increased metric cardinality resulting in higher custom metrics cost in platform such as Datadog. This can also cause metrics not getting aggregated correctly for the same `api_base`.

example metrics with trailing slash:

```
litellm_deployment_success_responses_total{api_base="https://api.openai.com/v1/",api_key_alias="None",api_provider="openai",hashed_api_key="None",litellm_model_name="gpt-4o",model_id="0816ddaaddd6d762d4ba80f754895c0386360bdecc35430e5644bba7eb905b4f",requested_model="openai-gpt-4o",team="None",team_alias="None"} 4.0
litellm_deployment_success_responses_total{api_base="https://my-test-instance.openai.azure.com//openai/",api_key_alias="None",api_provider="azure",hashed_api_key="None",litellm_model_name="gpt-4o",model_id="4346bb17b8f946ed63b7a315d50b765be26387b0ffe3f1875c37a1efdcf0e82e",requested_model="azure-gpt-4o",team="None",team_alias="None"} 3.0
litellm_deployment_success_responses_total{api_base="https://api.openai.com/v1",api_key_alias="None",api_provider="openai",hashed_api_key="EMPTY",litellm_model_name="gpt-4o",model_id="0816ddaaddd6d762d4ba80f754895c0386360bdecc35430e5644bba7eb905b4f",requested_model="openai-gpt-4o",team="None",team_alias="None"} 1.0
```

By stripping trailing slashes, this improves metrics aggregation and reduces custom metrics cost.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->