### PR TITLE
(fix) auth checks - Add regex matching for `models` on virtual keys / teams 

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -893,6 +893,8 @@ def _model_is_within_list_of_allowed_models(
         return True
     if "all-proxy-models" in allowed_models:
         return True
+    if model in allowed_models:
+        return True
     if model_matches_patterns(model=model, allowed_models=allowed_models) is True:
         return True
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -886,6 +886,21 @@ async def can_key_call_model(
 def _model_is_within_list_of_allowed_models(
     model: str, allowed_models: List[str]
 ) -> bool:
+    """
+    Checks if a model is within a list of allowed models (includes pattern matching checks)
+
+    Args:
+        model (str): The model to check (e.g., "custom_engine/model-123")
+        allowed_models (List[str]): List of allowed model patterns (e.g., ["custom_engine/*", "azure/gpt-4", "claude-sonnet"])
+
+    Returns:
+        bool: True if
+            - len(allowed_models) == 0
+            - "*" in allowed_models (means all models are allowed)
+            - "all-proxy-models" in allowed_models (means all models are allowed)
+            - model is in allowed_models list
+            - model matches any allowed pattern
+    """
     # Check for universal access patterns
     if len(allowed_models) == 0:
         return True
@@ -895,13 +910,13 @@ def _model_is_within_list_of_allowed_models(
         return True
     if model in allowed_models:
         return True
-    if model_matches_patterns(model=model, allowed_models=allowed_models) is True:
+    if _model_matches_patterns(model=model, allowed_models=allowed_models) is True:
         return True
 
     return False
 
 
-def model_matches_patterns(model: str, allowed_models: List[str]) -> bool:
+def _model_matches_patterns(model: str, allowed_models: List[str]) -> bool:
     """
     Helper function to check if a model matches any of the allowed model patterns.
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -873,7 +873,7 @@ async def can_key_call_model(
         is False
     ):
         raise ValueError(
-            f"API Key not allowed to access model. List of allowed models={filtered_models}. Tried to access {model}"
+            f"API Key not allowed to access model. This token can only access models={valid_token.models}. Tried to access {model}"
         )
 
     valid_token.models = filtered_models

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -908,6 +908,9 @@ def _model_is_within_list_of_allowed_models(
         return True
     if "all-proxy-models" in allowed_models:
         return True
+    # Note: This is here to maintain backwards compatibility. This Used to be in our code and removing could impact existing customer code
+    if "openai/*" in allowed_models:
+        return True
     if model in allowed_models:
         return True
     if _model_matches_patterns(model=model, allowed_models=allowed_models) is True:

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,24 +1,5 @@
 model_list:
-  - model_name: gpt-4o
+  - model_name: custom_engine/*
     litellm_params:
-      model: openai/gpt-4o
+      model: openai/custom_engine
       api_base: https://exampleopenaiendpoint-production.up.railway.app/
-  - model_name: fake-anthropic-endpoint
-    litellm_params:
-      model: anthropic/fake
-      api_base: https://exampleanthropicendpoint-production.up.railway.app/
-
-router_settings:
-  provider_budget_config: 
-    openai: 
-      budget_limit: 0.3 # float of $ value budget for time period
-      time_period: 1d # can be 1d, 2d, 30d 
-    anthropic:
-      budget_limit: 5
-      time_period: 1d
-  redis_host: os.environ/REDIS_HOST
-  redis_port: os.environ/REDIS_PORT
-  redis_password: os.environ/REDIS_PASSWORD
-
-litellm_settings:
-  callbacks: ["prometheus"]

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -96,6 +96,11 @@ model_list:
     litellm_params:
       model: "groq/*"
       api_key: os.environ/GROQ_API_KEY
+  - model_name: "custom-llm-engine/*"
+    litellm_params:
+      model: "openai/my-fake-model"
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      api_key: fake-key
   - model_name: mistral-embed
     litellm_params:
       model: mistral/mistral-embed

--- a/proxy_server_config.yaml
+++ b/proxy_server_config.yaml
@@ -85,6 +85,10 @@ model_list:
     litellm_params:
       model: openai/*
       api_key: os.environ/OPENAI_API_KEY
+  - model_name: custom_engine/* # regex pattern matching test for /models and /model/info endpoints
+    litellm_params:
+      model: openai/custom_engine
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
   
 
   # provider specific wildcard routing

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -409,6 +409,8 @@ def test_is_api_route_allowed(route, user_role, expected_result):
         ("custom_engine/model-123", ["custom_engine/*"], True),
         ("custom_engine/model-123", ["custom_engine/*", "azure/*"], True),
         ("custom-engine/model-123", ["custom_engine/*", "azure/*"], False),
+        ("openai/gpt-4o", ["openai/*"], True),
+        ("openai/gpt-12", ["openai/*"], True),
         ("gpt-4", ["gpt-*"], True),
         ("gpt-4", ["claude-*"], False),
         # Mixed scenarios
@@ -430,6 +432,7 @@ def test_model_is_within_list_of_allowed_models(model, allowed_models, expected_
         ("gpt-4", ["gpt-*"], True),
         ("azure/gpt-4", ["azure/*"], True),
         ("custom_engine/model-123", ["custom_engine/*"], True),
+        ("openai/my-fake-model", ["openai/*"], True),
         ("custom_engine/model-123", ["custom_engine/*", "azure/*"], True),
         ("custom-engine/model-123", ["custom_engine/*", "azure/*"], False),
         # Multiple patterns

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -474,6 +474,24 @@ async def test_openai_wildcard_chat_completion():
 
 
 @pytest.mark.asyncio
+async def test_regex_pattern_matching_e2e_test():
+    """
+    - Create key for model = "custom-llm-engine/*" -> this has access to all models matching pattern = "custom-llm-engine/*"
+    - proxy_server_config.yaml has model = "custom-llm-engine/*"
+    - Make chat completion call
+
+    """
+    async with aiohttp.ClientSession() as session:
+        key_gen = await generate_key(session=session, models=["custom-llm-engine/*"])
+        key = key_gen["key"]
+
+        # call chat/completions with a model that the key was not created for + the model is not on the config.yaml
+        await chat_completion(
+            session=session, key=key, model="custom-llm-engine/very-new-model"
+        )
+
+
+@pytest.mark.asyncio
 async def test_proxy_all_models():
     """
     - proxy_server_config.yaml has model = * / *


### PR DESCRIPTION
## Add regex matching for models on virtual keys / teams

# E2E Scenario 
The following flow was raising an error - **Fixed with this PR** 
## Key Generate
```
curl -X POST https://endpoint/key/generate \
  -H 'Authorization: Bearer sk-token' \
  -H 'Content-Type: application/json' \
  --data-raw '{"models": ["llmengine/*"]}'
```

## Chat Completions Request with new key 
```
curl -X POST https://endpoint/v1/chat/completions \
  -H "Authorization: Bearer generated-key" \
  -d '{
    "model": "llmengine/specific-model",
    "messages": [{"role": "user", "content": "Test prompt"}]
  }'
```

## Error Raised

```
{
  "error": {
    "message": "Authentication Error, API Key not allowed to access model. This token can only access models=['llmengine/*']. Tried to access llmengine/llama-3-1-8b-instruct",
    "type": "auth_error",
    "param": "None",
    "code": "401"
  }
}
```

Key Changes

- Implemented regex pattern-based model access (e.g., "custom-llm-engine/*")
- Ensure keys/teams with regex patterns can access all models in that regex pattern


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

