### PR TITLE
Replace deprecated Pydantic Config class with model_config BerriAI/litellm#6902

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1451,6 +1451,8 @@ class UserAPIKeyAuth(
     user_tpm_limit: Optional[int] = None
     user_rpm_limit: Optional[int] = None
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     @model_validator(mode="before")
     @classmethod
     def check_api_key(cls, values):
@@ -1461,9 +1463,6 @@ class UserAPIKeyAuth(
             ).startswith("sk-"):
                 values.update({"api_key": hash_token(values.get("api_key"))})
         return values
-
-    class Config:
-        arbitrary_types_allowed = True
 
 
 class UserInfoResponse(LiteLLMBase):


### PR DESCRIPTION
## Title

Replace deprecated Pydantic Config class with model_config

## Relevant issues

Fixes #6902 

## Type

🧹 Refactoring

## Changes

Replace Pydantic Config class with model_config
