### PR TITLE
(redis fix) - fix `AbstractConnection.__init__() got an unexpected keyword argument 'ssl'`

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -313,12 +313,13 @@ def get_redis_async_client(**env_overrides) -> async_redis.Redis:
 
 def get_redis_connection_pool(**env_overrides):
     redis_kwargs = _get_redis_client_logic(**env_overrides)
+    verbose_logger.debug("get_redis_connection_pool: redis_kwargs", redis_kwargs)
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
         return async_redis.BlockingConnectionPool.from_url(
             timeout=5, url=redis_kwargs["url"]
         )
     connection_class = async_redis.Connection
-    if "ssl" in redis_kwargs and redis_kwargs["ssl"] is not None:
+    if "ssl" in redis_kwargs:
         connection_class = async_redis.SSLConnection
         redis_kwargs.pop("ssl", None)
         redis_kwargs["connection_class"] = connection_class

--- a/tests/local_testing/test_caching_ssl.py
+++ b/tests/local_testing/test_caching_ssl.py
@@ -111,6 +111,7 @@ async def test_redis_with_ssl():
     from litellm._redis import get_redis_connection_pool, get_redis_async_client
 
     # Get the connection pool with SSL
+    # REDIS_HOST_WITH_SSL is just a redis cloud instance with Transport layer security (TLS) enabled
     pool = get_redis_connection_pool(
         host=os.environ.get("REDIS_HOST_WITH_SSL"),
         port=os.environ.get("REDIS_PORT_WITH_SSL"),

--- a/tests/local_testing/test_caching_ssl.py
+++ b/tests/local_testing/test_caching_ssl.py
@@ -112,9 +112,9 @@ async def test_redis_with_ssl():
 
     # Get the connection pool with SSL
     pool = get_redis_connection_pool(
-        host=os.environ.get("REDIS_HOST"),
-        port=os.environ.get("REDIS_PORT"),
-        password=os.environ.get("REDIS_PASSWORD"),
+        host=os.environ.get("REDIS_HOST_WITH_SSL"),
+        port=os.environ.get("REDIS_PORT_WITH_SSL"),
+        password=os.environ.get("REDIS_PASSWORD_WITH_SSL"),
         ssl=None,
     )
 

--- a/tests/local_testing/test_caching_ssl.py
+++ b/tests/local_testing/test_caching_ssl.py
@@ -99,3 +99,28 @@ def test_caching_router():
 
 
 # test_caching_router()
+@pytest.mark.asyncio
+async def test_redis_with_ssl():
+    """
+    Test connecting to redis connection pool when ssl=None
+
+
+    Relevant issue:
+        User was seeing this error: `TypeError: AbstractConnection.__init__() got an unexpected keyword argument 'ssl'`
+    """
+    from litellm._redis import get_redis_connection_pool, get_redis_async_client
+
+    # Get the connection pool with SSL
+    pool = get_redis_connection_pool(
+        host=os.environ.get("REDIS_HOST"),
+        port=os.environ.get("REDIS_PORT"),
+        password=os.environ.get("REDIS_PASSWORD"),
+        ssl=None,
+    )
+
+    # Create Redis client with the pool
+    redis_client = get_redis_async_client(connection_pool=pool)
+
+    print("pinging redis")
+    print(await redis_client.ping())
+    print("pinged redis")


### PR DESCRIPTION
## Fixes `AbstractConnection.__init__() got an unexpected keyword argument 'ssl'` message user was seeing 

What causes this ? 

- There was a check when init Redis pools with these args, litellm would raise an obscure error message which would mislead the user 

```python
pool = get_redis_connection_pool(
    host=os.environ.get("REDIS_HOST"),
    port=os.environ.get("REDIS_PORT"),
    password=os.environ.get("REDIS_PASSWORD"),
    ssl=None,
)
``` 

This was the error message 

```
`AbstractConnection.__init__() got an unexpected keyword argument 'ssl'` message user was seeing 
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

