### PR TITLE
(feat) Allow using include to include external YAML files in a config.yaml

### DIFF
--- a/docs/my-website/docs/proxy/config_management.md
+++ b/docs/my-website/docs/proxy/config_management.md
@@ -1,0 +1,59 @@
+# File Management
+
+## `include` external YAML files in a config.yaml 
+
+You can use `include` to include external YAML files in a config.yaml. 
+
+**Quick Start Usage:**
+
+To include a config file, use `include` with either a single file or a list of files. 
+
+Contents of `parent_config.yaml`:
+```yaml
+include:
+  - model_config.yaml # 👈 Key change, will include the contents of model_config.yaml
+
+litellm_settings:
+  callbacks: ["prometheus"] 
+```
+
+
+Contents of `model_config.yaml`:
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+  - model_name: fake-anthropic-endpoint
+    litellm_params:
+      model: anthropic/fake
+      api_base: https://exampleanthropicendpoint-production.up.railway.app/
+
+```
+
+Start proxy server 
+
+This will start the proxy server with config `parent_config.yaml`. Since the `include` directive is used, the server will also include the contents of `model_config.yaml`.
+```
+litellm --config parent_config.yaml --detailed_debug
+```
+
+
+
+
+
+## Examples using `include`
+
+Include a single file:
+```yaml
+include:
+  - model_config.yaml
+```
+
+Include multiple files:
+```yaml
+include:
+  - model_config.yaml
+  - another_config.yaml
+```

--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -2,7 +2,7 @@ import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Proxy Config.yaml
+# Overview
 Set model list, `api_base`, `api_key`, `temperature` & proxy server settings (`master-key`) on the config.yaml. 
 
 | Param Name           | Description                                                   |

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -32,7 +32,7 @@ const sidebars = {
         {
           "type": "category", 
           "label": "Config.yaml",
-          "items": ["proxy/configs", "proxy/config_settings"]
+          "items": ["proxy/configs", "proxy/config_management", "proxy/config_settings"]
         },
         {
           type: "category",

--- a/litellm/proxy/model_config.yaml
+++ b/litellm/proxy/model_config.yaml
@@ -1,0 +1,10 @@
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+  - model_name: fake-anthropic-endpoint
+    litellm_params:
+      model: anthropic/fake
+      api_base: https://exampleanthropicendpoint-production.up.railway.app/
+

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,25 +1,5 @@
-model_list:
-  - model_name: gpt-4o
-    litellm_params:
-      model: openai/gpt-4o
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
-  - model_name: fake-anthropic-endpoint
-    litellm_params:
-      model: anthropic/fake
-      api_base: https://exampleanthropicendpoint-production.up.railway.app/
-
-router_settings:
-  provider_budget_config: 
-    openai: 
-      budget_limit: 0.3 # float of $ value budget for time period
-      time_period: 1d # can be 1d, 2d, 30d 
-    anthropic:
-      budget_limit: 5
-      time_period: 1d
-  redis_host: os.environ/REDIS_HOST
-  redis_port: os.environ/REDIS_PORT
-  redis_password: os.environ/REDIS_PASSWORD
+include:
+  - model_config.yaml
 
 litellm_settings:
-  callbacks: ["prometheus"]
-  success_callback: ["langfuse"]
+  callbacks: ["prometheus"] 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1377,6 +1377,16 @@ class ProxyConfig:
         _, file_extension = os.path.splitext(config_file_path)
         return file_extension.lower() == ".yaml" or file_extension.lower() == ".yml"
 
+    def _load_yaml_file(self, file_path: str) -> dict:
+        """
+        Load and parse a YAML file
+        """
+        try:
+            with open(file_path, "r") as file:
+                return yaml.safe_load(file) or {}
+        except Exception as e:
+            raise Exception(f"Error loading yaml file {file_path}: {str(e)}")
+
     async def _get_config_from_file(
         self, config_file_path: Optional[str] = None
     ) -> dict:
@@ -1407,6 +1417,51 @@ class ProxyConfig:
                 "litellm_settings": {},
             }
 
+        # Process includes
+        config = self._process_includes(
+            config=config, base_dir=os.path.dirname(os.path.abspath(file_path or ""))
+        )
+
+        verbose_proxy_logger.debug(f"loaded config={json.dumps(config, indent=4)}")
+        return config
+
+    def _process_includes(self, config: dict, base_dir: str) -> dict:
+        """
+        Process includes by appending their contents to the main config
+
+        Handles nested config.yamls with `include` section
+
+        Example config: This will get the contents from files in `include` and append it
+        ```yaml
+        include:
+            - model_config.yaml
+
+        litellm_settings:
+            callbacks: ["prometheus"]
+        ```
+        """
+        if "include" not in config:
+            return config
+
+        if not isinstance(config["include"], list):
+            raise ValueError("'include' must be a list of file paths")
+
+        # Load and append all included files
+        for include_file in config["include"]:
+            file_path = os.path.join(base_dir, include_file)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Included file not found: {file_path}")
+
+            included_config = self._load_yaml_file(file_path)
+            # Simply update/extend the main config with included config
+            for key, value in included_config.items():
+                if isinstance(value, list) and key in config:
+                    config[key].extend(value)
+                else:
+                    config[key] = value
+
+        # Remove the include directive
+        del config["include"]
         return config
 
     async def save_config(self, new_config: dict):

--- a/tests/proxy_unit_tests/example_config_yaml/config_with_include.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/config_with_include.yaml
@@ -1,0 +1,5 @@
+include:
+  - included_models.yaml
+
+litellm_settings:
+  callbacks: ["prometheus"]

--- a/tests/proxy_unit_tests/example_config_yaml/config_with_missing_include.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/config_with_missing_include.yaml
@@ -1,0 +1,5 @@
+include:
+  - non-existent-file.yaml
+
+litellm_settings:
+  callbacks: ["prometheus"]

--- a/tests/proxy_unit_tests/example_config_yaml/config_with_multiple_includes.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/config_with_multiple_includes.yaml
@@ -1,0 +1,6 @@
+include:
+  - models_file_1.yaml
+  - models_file_2.yaml
+
+litellm_settings:
+  callbacks: ["prometheus"]

--- a/tests/proxy_unit_tests/example_config_yaml/included_models.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/included_models.yaml
@@ -1,0 +1,4 @@
+model_list:
+  - model_name: included-model
+    litellm_params:
+      model: gpt-4

--- a/tests/proxy_unit_tests/example_config_yaml/models_file_1.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/models_file_1.yaml
@@ -1,0 +1,4 @@
+model_list:
+  - model_name: included-model-1
+    litellm_params:
+      model: gpt-4

--- a/tests/proxy_unit_tests/example_config_yaml/models_file_2.yaml
+++ b/tests/proxy_unit_tests/example_config_yaml/models_file_2.yaml
@@ -1,0 +1,4 @@
+model_list:
+  - model_name: included-model-2
+    litellm_params:
+      model: gpt-3.5-turbo


### PR DESCRIPTION
## Allow using `include` to include external YAML files in a config.yaml 

Implementation follows the same pattern as Gitlab: https://docs.gitlab.com/ee/ci/yaml/includes.html 

```yaml
include:
  - model_config.yaml

litellm_settings:
  callbacks: ["prometheus"] 
```

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_base: https://exampleopenaiendpoint-production.up.railway.app/
  - model_name: fake-anthropic-endpoint
    litellm_params:
      model: anthropic/fake
      api_base: https://exampleanthropicendpoint-production.up.railway.app/


```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

