### PR TITLE
fix(model prices & context window) - add claude-3-5-haiku-latest & cl…

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2034,6 +2034,22 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true
     },
+    "claude-3-5-haiku-latest": {
+        "max_tokens": 8192,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "cache_creation_input_token_cost": 0.00000125,
+        "cache_read_input_token_cost": 0.0000001,
+        "litellm_provider": "anthropic",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "tool_use_system_prompt_tokens": 264,
+        "supports_assistant_prefill": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true
+    },
     "claude-3-opus-20240229": {
         "max_tokens": 4096,
         "max_input_tokens": 200000,
@@ -2084,6 +2100,24 @@
         "supports_response_schema": true
     },
     "claude-3-5-sonnet-20241022": {
+        "max_tokens": 8192,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "cache_creation_input_token_cost": 0.00000375,
+        "cache_read_input_token_cost": 0.0000003,
+        "litellm_provider": "anthropic",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "supports_assistant_prefill": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true
+    },
+    "claude-3-5-sonnet-latest": {
         "max_tokens": 8192,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
@@ -4060,7 +4094,31 @@
         "supports_function_calling": true,
         "tool_use_system_prompt_tokens": 264
     },
+    "openrouter/anthropic/claude-3-5-haiku-latest": {
+        "max_tokens": 8192,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "tool_use_system_prompt_tokens": 264
+    },
     "openrouter/anthropic/claude-3.5-sonnet": {
+        "max_tokens": 8192,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "tool_use_system_prompt_tokens": 159,
+        "supports_assistant_prefill": true
+    },
+    "openrouter/anthropic/claude-3.5-sonnet-latest": {
         "max_tokens": 8192,
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,


### PR DESCRIPTION
…aude-3-5-sonnet-latest to base anthropic & openrouter/anthropic model definitions

## Title

Add "claude-3-5-sonnet-latest" & "claude-3-5-haiku-latest" to model pricing & context window config

## Relevant issues

Fixes 

```bash
01:17:33 - LiteLLM:ERROR: token_counter.py:78 - litellm.litellm_core_utils.token_counter.py::get_modified_max_tokens() - Error while checking max token limit: This model isn't mapped yet. model=anthropic/claude-3-5-haiku-latest, custom_llm_provider=anthropic. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.
model=anthropic/claude-3-5-haiku-latest, base_model=anthropic/claude-3-5-haiku-latest
```

## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->

Added definitions for "claude-3-5-sonnet-latest" & "claude-3-5-haiku-latest", to base anthropic & open router model defintions.

<!-- Test procedure -->

