### PR TITLE
(bug fix) /key/update was not storing `budget_duration` in the DB 

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -476,6 +476,7 @@ def prepare_key_update_data(
             duration_s = duration_in_seconds(duration=budget_duration)
             key_reset_at = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
             non_default_values["budget_reset_at"] = key_reset_at
+            non_default_values["budget_duration"] = budget_duration
 
     _metadata = existing_key_row.metadata or {}
 

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -2791,11 +2791,9 @@ async def test_update_user_role(prisma_client):
 @pytest.mark.asyncio()
 async def test_update_user_unit_test(prisma_client):
     """
-    Tests if we update user role, incorrect values are not stored in cache
-    -> create a user with role == INTERNAL_USER
-    -> access an Admin only route -> expect to fail
-    -> update user role to == PROXY_ADMIN
-    -> access an Admin only route -> expect to succeed
+    Unit test for /user/update
+
+    Ensure that params are updated for UpdateUserRequest
     """
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -1349,7 +1349,13 @@ def test_generate_and_update_key(prisma_client):
                 "days between now and budget_reset_at",
                 (budget_reset_at - current_time).days,
             )
-            assert (budget_reset_at - current_time).days >= 29  # around 1 month
+            # assert budget_reset_at is 30 days from now
+            assert (
+                abs(
+                    (budget_reset_at - current_time).total_seconds() - 30 * 24 * 60 * 60
+                )
+                <= 10
+            )
 
             # cleanup - delete key
             delete_key_request = KeyRequest(keys=[generated_key])
@@ -2628,6 +2634,15 @@ async def test_create_update_team(prisma_client):
     assert _updated_info["budget_duration"] == "2d"
     assert _updated_info["budget_reset_at"] is not None and isinstance(
         _updated_info["budget_reset_at"], datetime.datetime
+    )
+
+    # budget_reset_at should be 2 days from now
+    budget_reset_at = _updated_info["budget_reset_at"].replace(tzinfo=timezone.utc)
+    current_time = datetime.datetime.now(timezone.utc)
+
+    # assert budget_reset_at is 2 days from now
+    assert (
+        abs((budget_reset_at - current_time).total_seconds() - 2 * 24 * 60 * 60) <= 10
     )
 
     # now hit team_info


### PR DESCRIPTION
## /key/update was not storing budget_duration in the DB

- Fixes the budget_duration field was not being written to the DB on /key/update 
- Added test to ensure this is stored to /key, /team, /user update 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

