### PR TITLE
Fix Bedrock throttling error mapping to match OpenAI format

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -794,7 +794,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                 ):
                     exception_mapping_worked = True
                     raise RateLimitError(
-                        message=f"ThrottlingException - Rate exceeded",
+                        message=f"BedrockException: Rate Limit Error - {error_str}",
                         model=model,
                         llm_provider="bedrock",
                         type="throttling_error",

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -794,9 +794,12 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                 ):
                     exception_mapping_worked = True
                     raise RateLimitError(
-                        message=f"BedrockException: Rate Limit Error - {error_str}",
+                        message=f"ThrottlingException - Rate exceeded",
                         model=model,
                         llm_provider="bedrock",
+                        type="throttling_error",
+                        param=None,
+                        code=429,
                         response=getattr(original_exception, "response", None),
                     )
                 elif (

--- a/tests/proxy_unit_tests/test_configs/test_bad_config.yaml
+++ b/tests/proxy_unit_tests/test_configs/test_bad_config.yaml
@@ -18,4 +18,10 @@ model_list:
       model: azure/azure-embedding-model
       api_base: os.environ/AZURE_API_BASE
       api_key: bad-key
+  - model_name: anthropic.claude-v2
+    litellm_params:
+      model: bedrock/anthropic.claude-v2
+      aws_access_key_id: bad-key
+      aws_secret_access_key: bad-key
+      aws_region_name: us-east-1
     


### PR DESCRIPTION
### Description
Adds proper error type and code to Bedrock throttling errors to match OpenAI format.

### Changes Made
- Added test case for Bedrock throttling error mapping
- Modified error mapping code to include proper OpenAI format for throttling errors (type="throttling_error", code=429)
- Added Bedrock model to test config

### Tests Added
- Added test_chat_completion_exception_bedrock_throttling to verify that Bedrock throttling errors are properly mapped to OpenAI format
- Test verifies that the error is properly converted to openai.RateLimitError

### Additional Notes
- Keeps the original error message format for backward compatibility
- Ensures consistent error handling across different providers