### PR TITLE
Fix bedrock anthropic prompt too long detection

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -732,6 +732,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     "too many tokens" in error_str
                     or "expected maxLength:" in error_str
                     or "Input is too long" in error_str
+                    or "prompt is too long" in error_str
                     or "prompt: length: 1.." in error_str
                     or "Too many input tokens" in error_str
                 ):

--- a/tests/proxy_unit_tests/test_configs/test_bad_config.yaml
+++ b/tests/proxy_unit_tests/test_configs/test_bad_config.yaml
@@ -18,4 +18,8 @@ model_list:
       model: azure/azure-embedding-model
       api_base: os.environ/AZURE_API_BASE
       api_key: bad-key
+  - model_name: anthropic/claude-3-sonnet
+    litellm_params:
+      model: anthropic/claude-3-sonnet
+      api_key: bad-key
     

--- a/tests/proxy_unit_tests/test_proxy_exception_mapping.py
+++ b/tests/proxy_unit_tests/test_proxy_exception_mapping.py
@@ -316,3 +316,66 @@ def test_chat_completion_exception_azure_context_window(mock_acompletion, client
 
     except Exception as e:
         pytest.fail(f"LiteLLM Proxy test failed. Exception {str(e)}")
+
+
+# Test for Anthropic "prompt is too long" error pattern
+anthropic_context_length_exceeded_error_response_dict = {
+    "error": {
+        "message": "litellm.ContextWindowExceededError: AnthropicError - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"prompt is too long: 209303 tokens > 200000 maximum\"}}",
+        "type": None,
+        "param": None,
+        "code": 400,
+    },
+}
+anthropic_context_length_exceeded_error_response = Response(
+    status_code=400,
+    content=json.dumps(anthropic_context_length_exceeded_error_response_dict),
+)
+
+@mock.patch(
+    "litellm.proxy.proxy_server.llm_router.acompletion",
+    return_value=anthropic_context_length_exceeded_error_response,
+)
+def test_chat_completion_exception_anthropic_context_window(mock_acompletion, client):
+    try:
+        # Your test data
+        test_data = {
+            "model": "anthropic/claude-3-sonnet",
+            "messages": [
+                {"role": "user", "content": "hi" * 100000},
+            ],
+            "max_tokens": 10,
+        }
+        response = None
+
+        response = client.post("/chat/completions", json=test_data)
+        print("got response from server", response)
+
+        mock_acompletion.assert_called_once_with(
+            **test_data,
+            litellm_call_id=mock.ANY,
+            litellm_logging_obj=mock.ANY,
+            request_timeout=mock.ANY,
+            metadata=mock.ANY,
+            proxy_server_request=mock.ANY,
+        )
+
+        json_response = response.json()
+
+        print("keys in json response", json_response.keys())
+
+        assert json_response.keys() == {"error"}
+
+        assert json_response == anthropic_context_length_exceeded_error_response_dict
+
+        # make an openai client to call _make_status_error_from_response
+        openai_client = openai.OpenAI(api_key="anything")
+        openai_exception = openai_client._make_status_error_from_response(
+            response=response
+        )
+        print("exception from proxy", openai_exception)
+        assert isinstance(openai_exception, openai.BadRequestError)
+        print("passed exception is of type BadRequestError")
+
+    except Exception as e:
+        pytest.fail(f"LiteLLM Proxy test failed. Exception {str(e)}")


### PR DESCRIPTION
## Title

In using bedrock for querying anthropic, we are getting "prompt is too long" messages that are not properly mapped.


```
litellm.BadRequestError: OpenAIException - Error code: 400 - {'error': {'message': 'litellm.BadRequestError: BedrockException - {"message":"messages.32.content: Conversation blocks and tool result blocks cannot be provided in the same turn."}\n. Enable \'litellm.modify_params=True\' (for PROXY do: `litellm_settings::modify_params: True`) to insert a dummy assistant message and fix this error.\nReceived Model Group=claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=[\'anthropic/claude-3-5-sonnet-20241022\']\nError doing the fallback: litellm.BadRequestError: litellm.ContextWindowExceededError: AnthropicError - {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 209303 tokens > 200000 maximum"}}\nReceived Model Group=anthropic/claude-3-5-sonnet-20241022\nAvailable Model Group Fallbacks=None\nError doing the fallback: litellm.BadRequestError: litellm.ContextWindowExceededError: AnthropicError - {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 209303 tokens > 200000 maximum"}}', 'type': None, 'param': None, 'code': '400'}}
```

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/6629
Also fixes an error we're encountering: https://github.com/All-Hands-AI/OpenHands/issues/5350

## Type

🐛 Bug Fix

## Changes

This adds "prompt is too long" to the list of mapped exceptions

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

<img width="885" alt="Screenshot 2024-12-01 at 9 18 24 PM" src="https://github.com/user-attachments/assets/c8770f46-16c2-4dc5-b48d-976c2061113b">
