### PR TITLE
Support structured outputs for Databricks models

### DIFF
--- a/litellm/llms/databricks/chat.py
+++ b/litellm/llms/databricks/chat.py
@@ -50,6 +50,7 @@ class DatabricksConfig:
     top_k: Optional[int] = None
     stop: Optional[Union[List[str], str]] = None
     n: Optional[int] = None
+    response_format: Optional[dict] = None
 
     def __init__(
         self,
@@ -59,6 +60,7 @@ class DatabricksConfig:
         top_k: Optional[int] = None,
         stop: Optional[Union[List[str], str]] = None,
         n: Optional[int] = None,
+        response_format: Optional[dict] = None,
     ) -> None:
         locals_ = locals()
         for key, value in locals_.items():
@@ -109,6 +111,7 @@ class DatabricksConfig:
             "max_tokens",
             "max_completion_tokens",
             "n",
+            "response_format",
         ]
 
     def map_openai_params(self, non_default_params: dict, optional_params: dict):

--- a/litellm/llms/databricks/chat.py
+++ b/litellm/llms/databricks/chat.py
@@ -128,6 +128,8 @@ class DatabricksConfig:
                 optional_params["top_p"] = value
             if param == "stop":
                 optional_params["stop"] = value
+            if param == "response_format":
+                optional_params["response_format"] = value
         return optional_params
 
 


### PR DESCRIPTION
## Title

Support structured outputs for Databricks models

## Relevant issues

None

## Type

🆕 New Feature

## Changes

Support structured outputs for Databricks models

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

Ran the following script that uses structured outputs with a Databricks Llama model & confirmed that the response conforms to the structured output schema.

```
from litellm import completion
from pydantic import BaseModel

class Output(BaseModel):
    happy: bool

response = completion(
    model="databricks/databricks-meta-llama-3-1-70b-instruct",
    messages = [{ "content": "Hello, how are you?","role": "user"}],
    stream=False,
    response_format=Output
)
print(response)
```

```
$ python structured_outputs_test.py

ModelResponse(id='chatcmpl_574b6f77-2461-4752-a3ce-4d872a4c6174', created=1733121497, model='databricks/meta-llama-3.1-70b-instruct-082724', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='stop', index=0, message=Message(content='{"happy": true}', role='assistant', tool_calls=None, function_call=None))], usage=Usage(completion_tokens=6, prompt_tokens=107, total_tokens=113, completion_tokens_details=None, prompt_tokens_details=None))
```