### PR TITLE
Convert tool use arguments to string before counting tokens

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1635,7 +1635,7 @@ def token_counter(
                     for tool_call in message["tool_calls"]:
                         if "function" in tool_call:
                             function_arguments = tool_call["function"]["arguments"]
-                            text += function_arguments
+                            text += str(function_arguments)
         else:
             raise ValueError("text and messages cannot both be None")
     elif isinstance(text, List):


### PR DESCRIPTION

## Convert tool use arguments to string before counting tokens

## Relevant issues

Fixes #6958 

## Type


🐛 Bug Fix

## Changes

In at least some cases the `messages["tool_calls"]["function"]["arguments"]` is a dict, not a string. In order to tokenize it properly it needs to be a string. In the case that it is already a string this is a noop, which is also fine.

## Testing

I'm not sure how to prove that this works, but I'm happy to provide some proof if you suggest how to do that.

