### PR TITLE
add max tokens to health check

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -72,6 +72,7 @@ async def _perform_health_check(model_list: list, details: Optional[bool] = True
         litellm_params = model["litellm_params"]
         model_info = model.get("model_info", {})
         litellm_params["messages"] = _get_random_llm_message()
+        litellm_params["max_tokens"] = 1
         mode = model_info.get("mode", None)
         tasks.append(
             litellm.ahealth_check(


### PR DESCRIPTION
## Title

health check should only need a minimal token completion call

## Relevant issues

## Type
🐛 Bug Fix

## Changes

With the health check endpoint we really only care if we get a 200 status back not the output, so its best to send max_tokens, otherwise as we have seen, sending a health check every 300 seconds can get very expensive for output tokens.

