### PR TITLE
adding public routes when using custom header

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -304,10 +304,17 @@ async def user_api_key_auth(  # noqa: PLR0915
         # if user wants to pass LiteLLM_Master_Key as a custom header, example pass litellm keys as X-LiteLLM-Key: Bearer sk-1234
         custom_litellm_key_header_name = general_settings.get("litellm_key_header_name")
         if custom_litellm_key_header_name is not None:
-            api_key = get_api_key_from_custom_header(
-                request=request,
-                custom_litellm_key_header_name=custom_litellm_key_header_name,
-            )
+            if (
+                route in LiteLLMRoutes.public_routes.value
+                or route_in_additonal_public_routes(current_route=route)
+            ):
+            # check if public endpoint
+                return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY)
+            else:
+                api_key = get_api_key_from_custom_header(
+                    request=request,
+                    custom_litellm_key_header_name=custom_litellm_key_header_name,
+                )
 
         if open_telemetry_logger is not None:
             parent_otel_span = open_telemetry_logger.tracer.start_span(


### PR DESCRIPTION
## Implementing public_routes when using custom_litellm_key_header_name

## Relevant issues

Fixes the availability of public routes when having custom header key in litellm settings

![image](https://github.com/user-attachments/assets/6feb4624-d10b-402a-8ffb-0da834d8572c)

![image](https://github.com/user-attachments/assets/2cfba922-a53a-4b3c-a659-5eec33c2bfe0)

![image](https://github.com/user-attachments/assets/7e14053d-909e-41e3-8f4a-bcd20ab4091b)

## Type

🐛 Bug Fix

## Changes

![image](https://github.com/user-attachments/assets/62a6edf3-091d-4bf4-a939-d6cb3885471c)

@krrishdholakia @ishaan-jaff 
