### PR TITLE
(fix) allow gracefully handling DB connection errors on proxy 

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -803,7 +803,7 @@ async def user_api_key_auth(  # noqa: PLR0915
         if (
             prisma_client is None
         ):  # if both master key + user key submitted, and user key != master key, and no db connected, raise an error
-            await _handle_failed_db_connection_for_get_key_object(
+            return await _handle_failed_db_connection_for_get_key_object(
                 e=Exception("No connected db.")
             )
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -51,6 +51,7 @@ from litellm._service_logger import ServiceLogging
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import (
     _cache_key_object,
+    _handle_failed_db_connection_for_get_key_object,
     allowed_routes_check,
     can_key_call_model,
     common_checks,
@@ -802,7 +803,9 @@ async def user_api_key_auth(  # noqa: PLR0915
         if (
             prisma_client is None
         ):  # if both master key + user key submitted, and user key != master key, and no db connected, raise an error
-            raise Exception("No connected db.")
+            await _handle_failed_db_connection_for_get_key_object(
+                e=Exception("No connected db.")
+            )
 
         ## check for cache hit (In-Memory Cache)
         _user_role = None


### PR DESCRIPTION
## (fix) allow gracefully handling DB connection errors on proxy

- handle case when `prisma_client` is None and user passes no DB
- In this case, if user has opted in the flag gracefully fail 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

Added test coverage for scenario when `prisma_client=None`


