### PR TITLE
Add prompt caching flag for Azure OpenAI gpt-4o-2024-08-06

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -756,7 +756,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_prompt_caching": true
     },
     "azure/gpt-4o-2024-11-20": {
         "max_tokens": 16384,
@@ -795,7 +796,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_prompt_caching": true
     },
     "azure/global-standard/gpt-4o-2024-11-20": {
         "max_tokens": 16384,


### PR DESCRIPTION
## Title

Add prompt caching flag for Azure OpenAI gpt-4o-2024-08-06

## Relevant issues

Current JSON description for `gpt-4o-2024-08-06` did not explicitly state its support for prompt caching.

https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/prompt-caching

![image](https://github.com/user-attachments/assets/1d7a5c1b-4dcc-4116-bd7b-f1f073e0ce75)

## Type

🧹 Refactoring

