### PR TITLE
Add MLflow to the side bar

### DIFF
--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -317,6 +317,7 @@ const sidebars = {
       type: "category",
       label: "Logging & Observability",
       items: [
+        "observability/mlflow",
         "observability/langfuse_integration",
         "observability/gcs_bucket_integration",
         "observability/langsmith_integration",


### PR DESCRIPTION
## Title

Adding MLflow tracing doc to the sidebar.

## Type

📖 Documentation

## Changes

Adding the [MLflow tracing page](https://docs.litellm.ai/docs/observability/mlflow) to the sidebar.

I also found the image (doc/img/mlflow_tracing.png) is not rendered. @krrishdholakia Do you have any idea why it happens?


