### PR TITLE
fix: apply api_key param to amoderation factory

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2569,6 +2569,7 @@ class Router:
                 model=kwargs["model"]
             )
             kwargs["model"] = deployment["litellm_params"]["model"]
+            kwargs["api_key"] = deployment["litellm_params"]["api_key"]
         return await original_function(**kwargs)
 
     def factory_function(


### PR DESCRIPTION
## Apply api_key param to amoderation factory

<!-- e.g. "Implement user authentication feature" -->

## Type

🐛 Bug Fix

## Changes

```
    | Traceback (most recent call last):
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/langfuse/decorators/langfuse_decorator.py", line 188, in async_wrapper
    |     self._handle_exception(observation, e)
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/langfuse/decorators/langfuse_decorator.py", line 428, in _handle_exception
    |     raise e
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/langfuse/decorators/langfuse_decorator.py", line 186, in async_wrapper
    |     result = await func(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/src/external/moderation.py", line 23, in moderation
    |     response = await router.amoderation(
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/router.py", line 2593, in new_function
    |     return await self._pass_through_moderation_endpoint_factory(  # type: ignore
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/router.py", line 2572, in _pass_through_moderation_endpoint_factory
    |     return await original_function(**kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/utils.py", line 1175, in wrapper_async
    |     raise e
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/utils.py", line 1031, in wrapper_async
    |     result = await original_function(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/main.py", line 4353, in amoderation
    |     _openai_client: AsyncOpenAI = openai_chat_completions._get_openai_client(  # type: ignore
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/litellm/llms/OpenAI/openai.py", line 570, in _get_openai_client
    |     _new_client: Union[OpenAI, AsyncOpenAI] = AsyncOpenAI(
    |                                               ^^^^^^^^^^^^
    |   File "/Users/karter/Desktop/lisa/.venv/lib/python3.12/site-packages/openai/_client.py", line 319, in __init__
    |     raise OpenAIError(
    | openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
    +------------------------------------
```

- after litellm started usting `factory_function` for `amoderation` api, it keep returning above error exception

![image](https://github.com/user-attachments/assets/76cd2eda-eb32-41eb-8313-92e94af917a3)

- but this error shouldn't happen if we use `api_key` properly
- many projects are using multiple api keys for moderation api to mitigate rate limit issue
- therefore we should not use global single api key for openai, but should use registered api key for model
- i fixed this issue

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall

<!-- Test procedure -->

