### PR TITLE
Provider Budget Routing - Get Budget, Spend Details

### DIFF
--- a/docs/my-website/docs/proxy/provider_budget_routing.md
+++ b/docs/my-website/docs/proxy/provider_budget_routing.md
@@ -126,6 +126,53 @@ Expected response on failure
 
 ## Monitoring Provider Remaining Budget
 
+### Get Budget, Spend Details
+
+Use this endpoint to check current budget, spend and budget reset time for a provider
+
+Example Request
+
+```bash
+curl -X GET http://localhost:4000/provider/budgets \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234"
+```
+
+Example Response
+
+```json
+{
+    "providers": {
+        "openai": {
+            "budget_limit": 1e-12,
+            "time_period": "1d",
+            "spend": 0.0,
+            "budget_reset_at": null
+        },
+        "azure": {
+            "budget_limit": 100.0,
+            "time_period": "1d",
+            "spend": 0.0,
+            "budget_reset_at": null
+        },
+        "anthropic": {
+            "budget_limit": 100.0,
+            "time_period": "10d",
+            "spend": 0.0,
+            "budget_reset_at": null
+        },
+        "vertex_ai": {
+            "budget_limit": 100.0,
+            "time_period": "12d",
+            "spend": 0.0,
+            "budget_reset_at": null
+        }
+    }
+}
+```
+
+### Prometheus Metric
+
 LiteLLM will emit the following metric on Prometheus to track the remaining budget for each provider
 
 This metric indicates the remaining budget for a provider in dollars (USD)

--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -423,3 +423,12 @@ class DualCache(BaseCache):
             self.in_memory_cache.delete_cache(key)
         if self.redis_cache is not None:
             await self.redis_cache.async_delete_cache(key)
+
+    async def async_get_ttl(self, key: str) -> Optional[int]:
+        """
+        Get the remaining TTL of a key in in-memory cache or redis
+        """
+        ttl = await self.in_memory_cache.async_get_ttl(key)
+        if ttl is None and self.redis_cache is not None:
+            ttl = await self.redis_cache.async_get_ttl(key)
+        return ttl

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -145,3 +145,9 @@ class InMemoryCache(BaseCache):
     def delete_cache(self, key):
         self.cache_dict.pop(key, None)
         self.ttl_dict.pop(key, None)
+
+    async def async_get_ttl(self, key: str) -> Optional[int]:
+        """
+        Get the remaining TTL of a key in in-memory cache
+        """
+        return self.ttl_dict.get(key, None)

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -980,3 +980,26 @@ class RedisCache(BaseCache):
                 str(e),
             )
             raise e
+
+    async def async_get_ttl(self, key: str) -> Optional[int]:
+        """
+        Get the remaining TTL of a key in Redis
+
+        Args:
+            key (str): The key to get TTL for
+
+        Returns:
+            Optional[int]: The remaining TTL in seconds, or None if key doesn't exist
+
+        Redis ref: https://redis.io/docs/latest/commands/ttl/
+        """
+        try:
+            _redis_client = await self.init_async_client()
+            async with _redis_client as redis_client:
+                ttl = await redis_client.ttl(key)
+                if ttl <= -1:  # -1 means the key does not exist, -2 key does not exist
+                    return None
+                return ttl
+        except Exception as e:
+            verbose_logger.debug(f"Redis TTL Error: {e}")
+            return None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2193,3 +2193,25 @@ LiteLLM_ManagementEndpoint_MetadataFields = [
     "tags",
     "enforced_params",
 ]
+
+
+class ProviderBudgetResponseObject(LiteLLMBase):
+    """
+    Configuration for a single provider's budget settings
+    """
+
+    budget_limit: float  # Budget limit in USD for the time period
+    time_period: str  # Time period for budget (e.g., '1d', '30d', '1mo')
+    spend: float = 0.0  # Current spend for this provider
+    budget_reset_at: Optional[datetime] = None  # When the current budget period resets
+
+
+class ProviderBudgetResponse(LiteLLMBase):
+    """
+    Complete provider budget configuration and status.
+    Maps provider names to their budget configs.
+    """
+
+    providers: Dict[str, ProviderBudgetResponseObject] = (
+        {}
+    )  # Dictionary mapping provider names to their budget configurations

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2203,7 +2203,7 @@ class ProviderBudgetResponseObject(LiteLLMBase):
     budget_limit: float  # Budget limit in USD for the time period
     time_period: str  # Time period for budget (e.g., '1d', '30d', '1mo')
     spend: float = 0.0  # Current spend for this provider
-    budget_reset_at: Optional[datetime] = None  # When the current budget period resets
+    budget_reset_at: Optional[str] = None  # When the current budget period resets
 
 
 class ProviderBudgetResponse(LiteLLMBase):

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -12,3 +12,27 @@ model_list:
 
 litellm_settings:
   callbacks: ["datadog"] 
+
+
+router_settings:
+  provider_budget_config: 
+    openai: 
+      budget_limit: 0.000000000001 # float of $ value budget for time period
+      time_period: 1d # can be 1d, 2d, 30d, 1mo, 2mo
+    azure:
+      budget_limit: 100
+      time_period: 1d
+    anthropic:
+      budget_limit: 100
+      time_period: 10d
+    vertex_ai:
+      budget_limit: 100
+      time_period: 12d
+    gemini:
+      budget_limit: 100
+      time_period: 12d
+  
+  # OPTIONAL: Set Redis Host, Port, and Password if using multiple instance of LiteLLM
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+  redis_password: os.environ/REDIS_PASSWORD

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2470,6 +2470,53 @@ async def global_predict_spend_logs(request: Request):
 
 @router.get("/provider/budgets", response_model=ProviderBudgetResponse)
 async def provider_budgets() -> ProviderBudgetResponse:
+    """
+    Provider Budget Routing - Get Budget, Spend Details https://docs.litellm.ai/docs/proxy/provider_budget_routing
+
+    Use this endpoint to check current budget, spend and budget reset time for a provider
+
+    Example Request
+
+    ```bash
+    curl -X GET http://localhost:4000/provider/budgets \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer sk-1234"
+    ```
+
+    Example Response
+
+    ```json
+    {
+        "providers": {
+            "openai": {
+                "budget_limit": 1e-12,
+                "time_period": "1d",
+                "spend": 0.0,
+                "budget_reset_at": null
+            },
+            "azure": {
+                "budget_limit": 100.0,
+                "time_period": "1d",
+                "spend": 0.0,
+                "budget_reset_at": null
+            },
+            "anthropic": {
+                "budget_limit": 100.0,
+                "time_period": "10d",
+                "spend": 0.0,
+                "budget_reset_at": null
+            },
+            "vertex_ai": {
+                "budget_limit": 100.0,
+                "time_period": "12d",
+                "spend": 0.0,
+                "budget_reset_at": null
+            }
+        }
+    }
+    ```
+
+    """
     from litellm.proxy.proxy_server import llm_router
 
     try:

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -8,10 +8,12 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
+from litellm.proxy._types import ProviderBudgetResponse, ProviderBudgetResponseObject
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.spend_tracking.spend_tracking_utils import (
     get_spend_by_team_and_customer,
 )
+from litellm.proxy.utils import handle_exception_on_proxy
 
 router = APIRouter()
 
@@ -2464,3 +2466,45 @@ async def global_predict_spend_logs(request: Request):
     data = await request.json()
     data = data.get("data")
     return _forecast_daily_cost(data)
+
+
+@router.get("/provider/budgets", response_model=ProviderBudgetResponse)
+async def provider_budgets() -> ProviderBudgetResponse:
+    from litellm.proxy.proxy_server import llm_router
+
+    try:
+        if llm_router is None:
+            raise HTTPException(
+                status_code=500, detail={"error": "No llm_router found"}
+            )
+
+        provider_budget_config = llm_router.provider_budget_config
+        if provider_budget_config is None:
+            raise ValueError(
+                "No provider budget config found. Please set a provider budget config in the router settings. https://docs.litellm.ai/docs/proxy/provider_budget_routing"
+            )
+
+        provider_budget_response_dict: Dict[str, ProviderBudgetResponseObject] = {}
+        for _provider, _budget_info in provider_budget_config.items():
+            _provider_spend = (
+                await llm_router.provider_budget_logger._get_current_provider_spend(
+                    _provider
+                )
+                or 0.0
+            )
+            _provider_budget_ttl = await llm_router.provider_budget_logger._get_current_provider_budget_reset_at(
+                _provider
+            )
+            provider_budget_response_object = ProviderBudgetResponseObject(
+                budget_limit=_budget_info.budget_limit,
+                time_period=_budget_info.time_period,
+                spend=_provider_spend,
+                budget_reset_at=_provider_budget_ttl,
+            )
+            provider_budget_response_dict[_provider] = provider_budget_response_object
+        return ProviderBudgetResponse(providers=provider_budget_response_dict)
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            "/provider/budgets: Exception occured - {}".format(str(e))
+        )
+        raise handle_exception_on_proxy(e)

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -646,3 +646,12 @@ ProviderBudgetConfigType = Dict[str, ProviderBudgetInfo]
 class RouterCacheEnum(enum.Enum):
     TPM = "global_router:{id}:{model}:tpm:{current_minute}"
     RPM = "global_router:{id}:{model}:rpm:{current_minute}"
+
+
+class ProviderBudgetWindowDetails(BaseModel):
+    """Details about a provider's budget window"""
+
+    budget_start: float
+    spend_key: str
+    start_time_key: str
+    ttl_seconds: int

--- a/tests/local_testing/test_router_provider_budgets.py
+++ b/tests/local_testing/test_router_provider_budgets.py
@@ -546,7 +546,11 @@ async def test_get_current_provider_budget_reset_at():
 
     # Test provider with budget config but no TTL
     reset_at = await provider_budget._get_current_provider_budget_reset_at("openai")
-    assert reset_at is None
+    assert reset_at is not None
+    reset_time = datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+    expected_time = datetime.now(timezone.utc) + timedelta(seconds=(24 * 60 * 60))
+    time_difference = abs((reset_time - expected_time).total_seconds())
+    assert time_difference < 5
 
     # Test provider with budget config and TTL
     reset_at = await provider_budget._get_current_provider_budget_reset_at("vertex_ai")

--- a/tests/local_testing/test_router_provider_budgets.py
+++ b/tests/local_testing/test_router_provider_budgets.py
@@ -21,6 +21,7 @@ from litellm.caching.caching import DualCache, RedisCache
 import logging
 from litellm._logging import verbose_router_logger
 import litellm
+from datetime import timezone, timedelta
 
 verbose_router_logger.setLevel(logging.DEBUG)
 
@@ -476,3 +477,85 @@ async def test_sync_in_memory_spend_with_redis():
 
     assert float(openai_spend) == 50.0
     assert float(anthropic_spend) == 75.0
+
+
+@pytest.mark.asyncio
+async def test_get_current_provider_spend():
+    """
+    Test _get_current_provider_spend helper method
+
+    Scenarios:
+    1. Provider with no budget config returns None
+    2. Provider with budget config but no spend returns 0.0
+    3. Provider with budget config and spend returns correct value
+    """
+    cleanup_redis()
+    provider_budget = ProviderBudgetLimiting(
+        router_cache=DualCache(),
+        provider_budget_config={
+            "openai": ProviderBudgetInfo(time_period="1d", budget_limit=100),
+        },
+    )
+
+    # Test provider with no budget config
+    spend = await provider_budget._get_current_provider_spend("anthropic")
+    assert spend is None
+
+    # Test provider with budget config but no spend
+    spend = await provider_budget._get_current_provider_spend("openai")
+    assert spend == 0.0
+
+    # Test provider with budget config and spend
+    spend_key = "provider_spend:openai:1d"
+    await provider_budget.router_cache.async_set_cache(key=spend_key, value=50.5)
+
+    spend = await provider_budget._get_current_provider_spend("openai")
+    assert spend == 50.5
+
+
+@pytest.mark.asyncio
+async def test_get_current_provider_budget_reset_at():
+    """
+    Test _get_current_provider_budget_reset_at helper method
+
+    Scenarios:
+    1. Provider with no budget config returns None
+    2. Provider with budget config but no TTL returns None
+    3. Provider with budget config and TTL returns correct ISO timestamp
+    """
+    cleanup_redis()
+    provider_budget = ProviderBudgetLimiting(
+        router_cache=DualCache(
+            redis_cache=RedisCache(
+                host=os.getenv("REDIS_HOST"),
+                port=int(os.getenv("REDIS_PORT")),
+                password=os.getenv("REDIS_PASSWORD"),
+            )
+        ),
+        provider_budget_config={
+            "openai": ProviderBudgetInfo(time_period="1d", budget_limit=100),
+            "vertex_ai": ProviderBudgetInfo(time_period="1h", budget_limit=100),
+        },
+    )
+
+    await asyncio.sleep(2)
+
+    # Test provider with no budget config
+    reset_at = await provider_budget._get_current_provider_budget_reset_at("anthropic")
+    assert reset_at is None
+
+    # Test provider with budget config but no TTL
+    reset_at = await provider_budget._get_current_provider_budget_reset_at("openai")
+    assert reset_at is None
+
+    # Test provider with budget config and TTL
+    reset_at = await provider_budget._get_current_provider_budget_reset_at("vertex_ai")
+    assert reset_at is not None
+
+    # Verify the timestamp format and approximate time
+    reset_time = datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+    expected_time = datetime.now(timezone.utc) + timedelta(seconds=3600)
+
+    # Allow for small time differences (within 5 seconds)
+    time_difference = abs((reset_time - expected_time).total_seconds())
+    assert time_difference < 5


### PR DESCRIPTION
### Provider Budget Routing - Get Budget, Spend Details

Use this endpoint to check current budget, spend and budget reset time for a provider

Example Request

```bash
curl -X GET http://localhost:4000/provider/budgets \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234"
```

Example Response

```json
{
    "providers": {
        "openai": {
            "budget_limit": 1e-12,
            "time_period": "1d",
            "spend": 0.0,
            "budget_reset_at": null
        },
        "azure": {
            "budget_limit": 100.0,
            "time_period": "1d",
            "spend": 0.0,
            "budget_reset_at": null
        },
        "anthropic": {
            "budget_limit": 100.0,
            "time_period": "10d",
            "spend": 0.0,
            "budget_reset_at": null
        },
        "vertex_ai": {
            "budget_limit": 100.0,
            "time_period": "12d",
            "spend": 0.0,
            "budget_reset_at": null
        }
    }
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

