### PR TITLE
feat: Add gemini-exp-1206 model configuration with 2M input tokens

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3538,6 +3538,33 @@
             "notes": "Rate limits not documented for gemini-exp-1114. Assuming same as gemini-1.5-pro."
         }
     },
+    "gemini/gemini-exp-1206": {
+        "max_tokens": 8192,
+        "max_input_tokens": 2097152,
+        "max_output_tokens": 8192,
+        "max_images_per_prompt": 3000,
+        "max_videos_per_prompt": 10,
+        "max_video_length": 1,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_pdf_size_mb": 30, 
+        "input_cost_per_token": 0,
+        "input_cost_per_token_above_128k_tokens": 0,
+        "output_cost_per_token": 0,
+        "output_cost_per_token_above_128k_tokens": 0,
+        "litellm_provider": "gemini",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_response_schema": true,
+        "tpm": 4000000,
+        "rpm": 1000,
+        "source": "https://ai.google.dev/pricing",
+        "metadata": {
+            "notes": "Rate limits not documented for gemini-exp-1206. Assuming same as gemini-1.5-pro."
+        }
+    },
     "gemini/gemini-1.5-flash-exp-0827": {
         "max_tokens": 8192,
         "max_input_tokens": 1048576,


### PR DESCRIPTION
Adds model configuration for gemini-exp-1206

I have assumed config values from previous experimental models remain the same, but updated max_input_tokens to 2097152.