### PR TITLE
feat(ChatCompletionDeltaToolCall): add dictionary-like access methods

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -281,6 +281,18 @@ class ChatCompletionDeltaToolCall(OpenAIObject):
     type: Optional[str] = None
     index: int
 
+    def __contains__(self, key):
+        # Define custom behavior for the 'in' operator
+        return hasattr(self, key)
+
+    def get(self, key, default=None):
+        # Custom .get() method to access attributes with a default value if the attribute doesn't exist
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        # Allow dictionary-style access to attributes
+        return getattr(self, key)
+
 
 class HiddenParams(OpenAIObject):
     original_response: Optional[Union[str, Any]] = None


### PR DESCRIPTION
## Fix: The wrong number of toolUse blocks when using AWS Bedrock

## Relevant issues

https://github.com/BerriAI/litellm/issues/7099

## Type

🐛 Bug Fix

## Changes

<!-- List of changes -->

Add dictionary-style access support to ChatCompletionDeltaToolCall class:
- Add __contains__ for 'in' operator support
- Add get() method with default value support
- Add __getitem__ for dict-style access

<!-- Test procedure -->

Tested Open Interpreter exploratory

```
>> python -m interpreter.cli --model bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
> check litellm python package version installed please

I'll help you check the installed version of the litellm Python package using pip.
  ▶ │ bash
  1 │ pip show litellm

Run tool(s)? (y/n): y
Name: litellm
Version: 1.54.0
Summary: Library to easily interface with LLM API providers
Home-page: https://litellm.ai
Author: BerriAI
Author-email:
License: MIT
Location: /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages
Requires: aiohttp, click, httpx, importlib-metadata, jinja2, jsonschema, openai, pydantic, python-dotenv, requests, tiktoken, tokenizers
Required-by: aider-chat, open-interpreter
```
After fix such code starts returning the res, before the fix it is an empty list: 

```
from litellm.utils import ChatCompletionDeltaToolCall, Function
from litellm.llms.prompt_templates.factory import _convert_to_bedrock_tool_call_invoke

example_calls = [
    ChatCompletionDeltaToolCall(
        id="example1",
        function=Function(name="tool1", arguments={"key": "value1"}),
        type="function",
        index=0
    ),
    ChatCompletionDeltaToolCall(
        id="example2",
        function=Function(name="tool2", arguments={"key": "value2"}),
        type="function",
        index=1
    )
]

res = _convert_to_bedrock_tool_call_invoke(example_calls)
assert len(res) > 0

```

