### PR TITLE
feat: parameter added to use custom tokenizer with usage-based-routing strategies.

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5486,7 +5486,8 @@ class Router:
         messages: Optional[List[Dict[str, str]]] = None,
         input: Optional[Union[str, List]] = None,
         specific_deployment: Optional[bool] = False,
-        request_kwargs: Optional[Dict] = None,
+        custom_tokenizer: Optional[Dict] = None,
+        request_kwargs: Optional[Dict] = None
     ):
         """
         Returns the deployment based on routing strategy
@@ -5569,6 +5570,7 @@ class Router:
                 healthy_deployments=healthy_deployments,  # type: ignore
                 messages=messages,
                 input=input,
+                custom_tokenizer=custom_tokenizer,
             )
         elif (
             self.routing_strategy == "usage-based-routing-v2"
@@ -5579,6 +5581,7 @@ class Router:
                 healthy_deployments=healthy_deployments,  # type: ignore
                 messages=messages,
                 input=input,
+                custom_tokenizer=custom_tokenizer,
             )
         else:
             deployment = None

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -176,6 +176,7 @@ class LowestTPMLoggingHandler(CustomLogger):
         healthy_deployments: list,
         messages: Optional[List[Dict[str, str]]] = None,
         input: Optional[Union[str, List]] = None,
+        custom_tokenizer: Optional[Dict] = None,
     ):
         """
         Returns a deployment with the lowest TPM/RPM usage.
@@ -195,7 +196,7 @@ class LowestTPMLoggingHandler(CustomLogger):
             f"tpm_key={tpm_key}, tpm_dict: {tpm_dict}, rpm_dict: {rpm_dict}"
         )
         try:
-            input_tokens = token_counter(messages=messages, text=input)
+            input_tokens = token_counter(messages=messages, text=input, custom_tokenizer=custom_tokenizer)
         except Exception:
             input_tokens = 0
         verbose_router_logger.debug(f"input_tokens={input_tokens}")

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -605,7 +605,7 @@ class LowestTPMLoggingHandler_v2(CustomLogger):
             rpm_values=rpm_values,
             messages=messages,
             input=input,
-            custom_tokenizer: custom_tokenizer,
+            custom_tokenizer=custom_tokenizer,
         )
 
         try:

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -343,6 +343,7 @@ class LowestTPMLoggingHandler_v2(CustomLogger):
         rpm_values: Optional[list],
         messages: Optional[List[Dict[str, str]]] = None,
         input: Optional[Union[str, List]] = None,
+        custom_tokenizer: Optional[Dict] = None,
     ) -> Optional[dict]:
         """
         Common checks for get available deployment, across sync + async implementations
@@ -359,7 +360,7 @@ class LowestTPMLoggingHandler_v2(CustomLogger):
             rpm_dict[rpm_keys[idx]] = rpm_values[idx]
 
         try:
-            input_tokens = token_counter(messages=messages, text=input)
+            input_tokens = token_counter(messages=messages, text=input, custom_tokenizer=custom_tokenizer)
         except Exception:
             input_tokens = 0
         verbose_router_logger.debug(f"input_tokens={input_tokens}")
@@ -563,6 +564,7 @@ class LowestTPMLoggingHandler_v2(CustomLogger):
         messages: Optional[List[Dict[str, str]]] = None,
         input: Optional[Union[str, List]] = None,
         parent_otel_span: Optional[Span] = None,
+        custom_tokenizer: Optional[Dict] = None,
     ):
         """
         Returns a deployment with the lowest TPM/RPM usage.
@@ -603,6 +605,7 @@ class LowestTPMLoggingHandler_v2(CustomLogger):
             rpm_values=rpm_values,
             messages=messages,
             input=input,
+            custom_tokenizer: custom_tokenizer,
         )
 
         try:


### PR DESCRIPTION
## Implement custom tokenizer with usage-based-routing strategies.

## Relevant issues
- I couldn't find a relevant issue and have solved it myself instead opening an issue.

## Type
🆕 New Feature

## Changes
- custom tokenizer can be given to `completion` function of the Router class and will be used with usage-based-routing strategies

## Testing 
![image](https://github.com/user-attachments/assets/25f1c9b4-5629-4486-b1d9-1eff4dcf460e)
The screenshot taken from groq playground shows the input token as 1645. However, look at the calculated input token by default:
![image](https://github.com/user-attachments/assets/b70d5818-2149-42fa-92f8-5da0b0d2f282)

I can be able to use a custom pretrained model like `Xenova/Meta-Llama-3.1-Tokenizer` which gives more relevant calculation after making the changes.
![image](https://github.com/user-attachments/assets/0fe56217-c28d-4bb1-be4f-9b17727be610)
