### PR TITLE
(Refactor) Code Quality improvement - stop redefining LiteLLMBase

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -17,7 +17,7 @@ from litellm.types.router import RouterErrors, UpdateRouterConfig
 from litellm.types.utils import (
     EmbeddingResponse,
     ImageResponse,
-    LiteLLMBase,
+    LiteLLMPydanticObjectBase,
     ModelResponse,
     ProviderField,
     StandardCallbackDynamicParams,
@@ -135,7 +135,7 @@ def hash_token(token: str):
     return hashed_token
 
 
-class LiteLLM_UpperboundKeyGenerateParams(LiteLLMBase):
+class LiteLLM_UpperboundKeyGenerateParams(LiteLLMPydanticObjectBase):
     """
     Set default upperbound to max budget a key called via `/key/generate` can be.
 
@@ -391,7 +391,7 @@ class LiteLLMRoutes(enum.Enum):
     )
 
 
-# class LiteLLMAllowedRoutes(LiteLLMBase):
+# class LiteLLMAllowedRoutes(LiteLLMPydanticObjectBase):
 #     """
 #     Defines allowed routes based on key type.
 
@@ -403,7 +403,7 @@ class LiteLLMRoutes(enum.Enum):
 #     ] = ["management_routes"]
 
 
-class LiteLLM_JWTAuth(LiteLLMBase):
+class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     """
     A class to define the roles and permissions for a LiteLLM Proxy w/ JWT Auth.
 
@@ -461,7 +461,7 @@ class LiteLLM_JWTAuth(LiteLLMBase):
         super().__init__(**kwargs)
 
 
-class LiteLLMPromptInjectionParams(LiteLLMBase):
+class LiteLLMPromptInjectionParams(LiteLLMPydanticObjectBase):
     heuristics_check: bool = False
     vector_db_check: bool = False
     llm_api_check: bool = False
@@ -500,7 +500,7 @@ class LiteLLMPromptInjectionParams(LiteLLMBase):
 
 
 ######### Request Class Definition ######
-class ProxyChatCompletionRequest(LiteLLMBase):
+class ProxyChatCompletionRequest(LiteLLMPydanticObjectBase):
     model: str
     messages: List[Dict[str, str]]
     temperature: Optional[float] = None
@@ -537,11 +537,11 @@ class ProxyChatCompletionRequest(LiteLLMBase):
     )  # allow params not defined here, these fall in litellm.completion(**kwargs)
 
 
-class ModelInfoDelete(LiteLLMBase):
+class ModelInfoDelete(LiteLLMPydanticObjectBase):
     id: str
 
 
-class ModelInfo(LiteLLMBase):
+class ModelInfo(LiteLLMPydanticObjectBase):
     id: Optional[str]
     mode: Optional[Literal["embedding", "chat", "completion"]]
     input_cost_per_token: Optional[float] = 0.0
@@ -581,16 +581,16 @@ class ModelInfo(LiteLLMBase):
         return values
 
 
-class ProviderInfo(LiteLLMBase):
+class ProviderInfo(LiteLLMPydanticObjectBase):
     name: str
     fields: List[ProviderField]
 
 
-class BlockUsers(LiteLLMBase):
+class BlockUsers(LiteLLMPydanticObjectBase):
     user_ids: List[str]  # required
 
 
-class ModelParams(LiteLLMBase):
+class ModelParams(LiteLLMPydanticObjectBase):
     model_name: str
     litellm_params: dict
     model_info: ModelInfo
@@ -607,7 +607,7 @@ class ModelParams(LiteLLMBase):
         return values
 
 
-class GenerateRequestBase(LiteLLMBase):
+class GenerateRequestBase(LiteLLMPydanticObjectBase):
     """
     Overlapping schema between key and user generate/update requests
     """
@@ -697,11 +697,11 @@ class RegenerateKeyRequest(GenerateKeyRequest):
     metadata: Optional[dict] = None
 
 
-class KeyRequest(LiteLLMBase):
+class KeyRequest(LiteLLMPydanticObjectBase):
     keys: List[str]
 
 
-class LiteLLM_ModelTable(LiteLLMBase):
+class LiteLLM_ModelTable(LiteLLMPydanticObjectBase):
     model_aliases: Optional[Union[str, dict]] = None  # json dump the dict
     created_by: str
     updated_by: str
@@ -769,14 +769,14 @@ class UpdateUserRequest(GenerateRequestBase):
         return values
 
 
-class DeleteUserRequest(LiteLLMBase):
+class DeleteUserRequest(LiteLLMPydanticObjectBase):
     user_ids: List[str]  # required
 
 
 AllowedModelRegion = Literal["eu", "us"]
 
 
-class BudgetNew(LiteLLMBase):
+class BudgetNew(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = Field(default=None, description="The unique budget id.")
     max_budget: Optional[float] = Field(
         default=None,
@@ -801,15 +801,15 @@ class BudgetNew(LiteLLMBase):
     )
 
 
-class BudgetRequest(LiteLLMBase):
+class BudgetRequest(LiteLLMPydanticObjectBase):
     budgets: List[str]
 
 
-class BudgetDeleteRequest(LiteLLMBase):
+class BudgetDeleteRequest(LiteLLMPydanticObjectBase):
     id: str
 
 
-class CustomerBase(LiteLLMBase):
+class CustomerBase(LiteLLMPydanticObjectBase):
     user_id: str
     alias: Optional[str] = None
     spend: float = 0.0
@@ -845,7 +845,7 @@ class NewCustomerRequest(BudgetNew):
         return values
 
 
-class UpdateCustomerRequest(LiteLLMBase):
+class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     """
     Update a Customer, use this to update customer budgets etc
 
@@ -864,7 +864,7 @@ class UpdateCustomerRequest(LiteLLMBase):
     )
 
 
-class DeleteCustomerRequest(LiteLLMBase):
+class DeleteCustomerRequest(LiteLLMPydanticObjectBase):
     """
     Delete multiple Customers
     """
@@ -872,7 +872,7 @@ class DeleteCustomerRequest(LiteLLMBase):
     user_ids: List[str]
 
 
-class MemberBase(LiteLLMBase):
+class MemberBase(LiteLLMPydanticObjectBase):
     user_id: Optional[str] = None
     user_email: Optional[str] = None
 
@@ -901,7 +901,7 @@ class OrgMember(MemberBase):
     ]
 
 
-class TeamBase(LiteLLMBase):
+class TeamBase(LiteLLMPydanticObjectBase):
     team_alias: Optional[str] = None
     team_id: Optional[str] = None
     organization_id: Optional[str] = None
@@ -927,13 +927,13 @@ class NewTeamRequest(TeamBase):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class GlobalEndUsersSpend(LiteLLMBase):
+class GlobalEndUsersSpend(LiteLLMPydanticObjectBase):
     api_key: Optional[str] = None
     startTime: Optional[datetime] = None
     endTime: Optional[datetime] = None
 
 
-class UpdateTeamRequest(LiteLLMBase):
+class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     """
     UpdateTeamRequest, used by /team/update when you need to update a team
 
@@ -963,7 +963,7 @@ class UpdateTeamRequest(LiteLLMBase):
     model_aliases: Optional[dict] = None
 
 
-class ResetTeamBudgetRequest(LiteLLMBase):
+class ResetTeamBudgetRequest(LiteLLMPydanticObjectBase):
     """
     internal type used to reset the budget on a team
     used by reset_budget()
@@ -979,19 +979,19 @@ class ResetTeamBudgetRequest(LiteLLMBase):
     updated_at: datetime
 
 
-class DeleteTeamRequest(LiteLLMBase):
+class DeleteTeamRequest(LiteLLMPydanticObjectBase):
     team_ids: List[str]  # required
 
 
-class BlockTeamRequest(LiteLLMBase):
+class BlockTeamRequest(LiteLLMPydanticObjectBase):
     team_id: str  # required
 
 
-class BlockKeyRequest(LiteLLMBase):
+class BlockKeyRequest(LiteLLMPydanticObjectBase):
     key: str  # required
 
 
-class AddTeamCallback(LiteLLMBase):
+class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
     callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
         "success_and_failure"
@@ -1013,7 +1013,7 @@ class AddTeamCallback(LiteLLMBase):
         return values
 
 
-class TeamCallbackMetadata(LiteLLMBase):
+class TeamCallbackMetadata(LiteLLMPydanticObjectBase):
     success_callback: Optional[List[str]] = []
     failure_callback: Optional[List[str]] = []
     # for now - only supported for langfuse
@@ -1069,11 +1069,11 @@ class LiteLLM_TeamTableCachedObj(LiteLLM_TeamTable):
     last_refreshed_at: Optional[float] = None
 
 
-class TeamRequest(LiteLLMBase):
+class TeamRequest(LiteLLMPydanticObjectBase):
     teams: List[str]
 
 
-class LiteLLM_BudgetTable(LiteLLMBase):
+class LiteLLM_BudgetTable(LiteLLMPydanticObjectBase):
     """Represents user-controllable params for a LiteLLM_BudgetTable record"""
 
     soft_budget: Optional[float] = None
@@ -1107,7 +1107,7 @@ class NewOrganizationRequest(LiteLLM_BudgetTable):
     budget_id: Optional[str] = None
 
 
-class LiteLLM_OrganizationTable(LiteLLMBase):
+class LiteLLM_OrganizationTable(LiteLLMPydanticObjectBase):
     """Represents user-controllable params for a LiteLLM_OrganizationTable record"""
 
     organization_id: Optional[str] = None
@@ -1125,7 +1125,7 @@ class NewOrganizationResponse(LiteLLM_OrganizationTable):
     updated_at: datetime
 
 
-class OrganizationRequest(LiteLLMBase):
+class OrganizationRequest(LiteLLMPydanticObjectBase):
     organizations: List[str]
 
 
@@ -1138,7 +1138,7 @@ class KeyManagementSystem(enum.Enum):
     AWS_KMS = "aws_kms"
 
 
-class KeyManagementSettings(LiteLLMBase):
+class KeyManagementSettings(LiteLLMPydanticObjectBase):
     hosted_keys: Optional[List] = None
     store_virtual_keys: Optional[bool] = False
     """
@@ -1155,7 +1155,7 @@ class KeyManagementSettings(LiteLLMBase):
     """
 
 
-class TeamDefaultSettings(LiteLLMBase):
+class TeamDefaultSettings(LiteLLMPydanticObjectBase):
     team_id: str
 
     model_config = ConfigDict(
@@ -1163,7 +1163,7 @@ class TeamDefaultSettings(LiteLLMBase):
     )  # allow params not defined here, these fall in litellm.completion(**kwargs)
 
 
-class DynamoDBArgs(LiteLLMBase):
+class DynamoDBArgs(LiteLLMPydanticObjectBase):
     billing_mode: Literal["PROVISIONED_THROUGHPUT", "PAY_PER_REQUEST"]
     read_capacity_units: Optional[int] = None
     write_capacity_units: Optional[int] = None
@@ -1184,7 +1184,7 @@ class DynamoDBArgs(LiteLLMBase):
     assume_role_aws_session_name: Optional[str] = None
 
 
-class PassThroughGenericEndpoint(LiteLLMBase):
+class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
     path: str = Field(description="The route to be added to the LiteLLM Proxy Server.")
     target: str = Field(
         description="The URL to which requests for this path should be forwarded."
@@ -1194,17 +1194,17 @@ class PassThroughGenericEndpoint(LiteLLMBase):
     )
 
 
-class PassThroughEndpointResponse(LiteLLMBase):
+class PassThroughEndpointResponse(LiteLLMPydanticObjectBase):
     endpoints: List[PassThroughGenericEndpoint]
 
 
-class ConfigFieldUpdate(LiteLLMBase):
+class ConfigFieldUpdate(LiteLLMPydanticObjectBase):
     field_name: str
     field_value: Any
     config_type: Literal["general_settings"]
 
 
-class ConfigFieldDelete(LiteLLMBase):
+class ConfigFieldDelete(LiteLLMPydanticObjectBase):
     config_type: Literal["general_settings"]
     field_name: str
 
@@ -1217,7 +1217,7 @@ class FieldDetail(BaseModel):
     stored_in_db: Optional[bool]
 
 
-class ConfigList(LiteLLMBase):
+class ConfigList(LiteLLMPydanticObjectBase):
     field_name: str
     field_type: str
     field_description: str
@@ -1230,7 +1230,7 @@ class ConfigList(LiteLLMBase):
     )
 
 
-class ConfigGeneralSettings(LiteLLMBase):
+class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     """
     Documents all the fields supported by `general_settings` in config.yaml
     """
@@ -1336,7 +1336,7 @@ class ConfigGeneralSettings(LiteLLMBase):
     )
 
 
-class ConfigYAML(LiteLLMBase):
+class ConfigYAML(LiteLLMPydanticObjectBase):
     """
     Documents all the fields supported by the config.yaml
     """
@@ -1362,7 +1362,7 @@ class ConfigYAML(LiteLLMBase):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class LiteLLM_VerificationToken(LiteLLMBase):
+class LiteLLM_VerificationToken(LiteLLMPydanticObjectBase):
     token: Optional[str] = None
     key_name: Optional[str] = None
     key_alias: Optional[str] = None
@@ -1453,19 +1453,19 @@ class UserAPIKeyAuth(
         arbitrary_types_allowed = True
 
 
-class UserInfoResponse(LiteLLMBase):
+class UserInfoResponse(LiteLLMPydanticObjectBase):
     user_id: Optional[str]
     user_info: Optional[Union[dict, BaseModel]]
     keys: List
     teams: List
 
 
-class LiteLLM_Config(LiteLLMBase):
+class LiteLLM_Config(LiteLLMPydanticObjectBase):
     param_name: str
     param_value: Dict
 
 
-class LiteLLM_OrganizationMembershipTable(LiteLLMBase):
+class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     """
     This is the table that track what organizations a user belongs to and users spend within the organization
     """
@@ -1485,7 +1485,7 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMBase):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class LiteLLM_UserTable(LiteLLMBase):
+class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     user_id: str
     max_budget: Optional[float]
     spend: float = 0.0
@@ -1510,7 +1510,7 @@ class LiteLLM_UserTable(LiteLLMBase):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class LiteLLM_EndUserTable(LiteLLMBase):
+class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
     user_id: str
     blocked: bool
     alias: Optional[str] = None
@@ -1529,7 +1529,7 @@ class LiteLLM_EndUserTable(LiteLLMBase):
     model_config = ConfigDict(protected_namespaces=())
 
 
-class LiteLLM_SpendLogs(LiteLLMBase):
+class LiteLLM_SpendLogs(LiteLLMPydanticObjectBase):
     request_id: str
     api_key: str
     model: Optional[str] = ""
@@ -1549,7 +1549,7 @@ class LiteLLM_SpendLogs(LiteLLMBase):
     requester_ip_address: Optional[str] = None
 
 
-class LiteLLM_ErrorLogs(LiteLLMBase):
+class LiteLLM_ErrorLogs(LiteLLMPydanticObjectBase):
     request_id: Optional[str] = str(uuid.uuid4())
     api_base: Optional[str] = ""
     model_group: Optional[str] = ""
@@ -1563,7 +1563,7 @@ class LiteLLM_ErrorLogs(LiteLLMBase):
     endTime: Union[str, datetime, None]
 
 
-class LiteLLM_AuditLogs(LiteLLMBase):
+class LiteLLM_AuditLogs(LiteLLMPydanticObjectBase):
     id: str
     updated_at: datetime
     changed_by: str
@@ -1580,24 +1580,24 @@ class LiteLLM_AuditLogs(LiteLLMBase):
     updated_values: Optional[Json] = None
 
 
-class LiteLLM_SpendLogs_ResponseObject(LiteLLMBase):
+class LiteLLM_SpendLogs_ResponseObject(LiteLLMPydanticObjectBase):
     response: Optional[List[Union[LiteLLM_SpendLogs, Any]]] = None
 
 
-class TokenCountRequest(LiteLLMBase):
+class TokenCountRequest(LiteLLMPydanticObjectBase):
     model: str
     prompt: Optional[str] = None
     messages: Optional[List[dict]] = None
 
 
-class TokenCountResponse(LiteLLMBase):
+class TokenCountResponse(LiteLLMPydanticObjectBase):
     total_tokens: int
     request_model: str
     model_used: str
     tokenizer_type: str
 
 
-class CallInfo(LiteLLMBase):
+class CallInfo(LiteLLMPydanticObjectBase):
     """Used for slack budget alerting"""
 
     spend: float
@@ -1631,20 +1631,20 @@ class SpecialModelNames(enum.Enum):
     all_proxy_models = "all-proxy-models"
 
 
-class InvitationNew(LiteLLMBase):
+class InvitationNew(LiteLLMPydanticObjectBase):
     user_id: str
 
 
-class InvitationUpdate(LiteLLMBase):
+class InvitationUpdate(LiteLLMPydanticObjectBase):
     invitation_id: str
     is_accepted: bool
 
 
-class InvitationDelete(LiteLLMBase):
+class InvitationDelete(LiteLLMPydanticObjectBase):
     invitation_id: str
 
 
-class InvitationModel(LiteLLMBase):
+class InvitationModel(LiteLLMPydanticObjectBase):
     id: str
     user_id: str
     is_accepted: bool
@@ -1656,24 +1656,24 @@ class InvitationModel(LiteLLMBase):
     updated_by: str
 
 
-class InvitationClaim(LiteLLMBase):
+class InvitationClaim(LiteLLMPydanticObjectBase):
     invitation_link: str
     user_id: str
     password: str
 
 
-class ConfigFieldInfo(LiteLLMBase):
+class ConfigFieldInfo(LiteLLMPydanticObjectBase):
     field_name: str
     field_value: Any
 
 
-class CallbackOnUI(LiteLLMBase):
+class CallbackOnUI(LiteLLMPydanticObjectBase):
     litellm_callback_name: str
     litellm_callback_params: Optional[list]
     ui_callback_name: str
 
 
-class AllCallbacks(LiteLLMBase):
+class AllCallbacks(LiteLLMPydanticObjectBase):
     langfuse: CallbackOnUI = CallbackOnUI(
         litellm_callback_name="langfuse",
         ui_callback_name="Langfuse",
@@ -1845,7 +1845,7 @@ class SpanAttributes(str, enum.Enum):
     LLM_OPENAI_API_TYPE = "gen_ai.openai.api_type"
 
 
-class ManagementEndpointLoggingPayload(LiteLLMBase):
+class ManagementEndpointLoggingPayload(LiteLLMPydanticObjectBase):
     route: str
     request_data: dict
     response: Optional[dict] = None
@@ -1907,7 +1907,7 @@ class CommonProxyErrors(str, enum.Enum):
     not_premium_user = "You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. If you want to obtain a license meet with us here: https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat. \nPricing: https://www.litellm.ai/#pricing"
 
 
-class SpendCalculateRequest(LiteLLMBase):
+class SpendCalculateRequest(LiteLLMPydanticObjectBase):
     model: Optional[str] = None
     messages: Optional[List] = None
     completion_response: Optional[dict] = None
@@ -1934,20 +1934,20 @@ class SSOUserDefinedValues(TypedDict):
     budget_duration: Optional[str]
 
 
-class VirtualKeyEvent(LiteLLMBase):
+class VirtualKeyEvent(LiteLLMPydanticObjectBase):
     created_by_user_id: str
     created_by_user_role: str
     created_by_key_alias: Optional[str]
     request_kwargs: dict
 
 
-class CreatePassThroughEndpoint(LiteLLMBase):
+class CreatePassThroughEndpoint(LiteLLMPydanticObjectBase):
     path: str
     target: str
     headers: dict
 
 
-class LiteLLM_TeamMembership(LiteLLMBase):
+class LiteLLM_TeamMembership(LiteLLMPydanticObjectBase):
     user_id: str
     team_id: str
     budget_id: str
@@ -1957,7 +1957,7 @@ class LiteLLM_TeamMembership(LiteLLMBase):
 #### Organization / Team Member Requests ####
 
 
-class MemberAddRequest(LiteLLMBase):
+class MemberAddRequest(LiteLLMPydanticObjectBase):
     member: Union[List[Member], Member]
 
     def __init__(self, **data):
@@ -1976,7 +1976,7 @@ class MemberAddRequest(LiteLLMBase):
         super().__init__(**data)
 
 
-class OrgMemberAddRequest(LiteLLMBase):
+class OrgMemberAddRequest(LiteLLMPydanticObjectBase):
     member: Union[List[OrgMember], OrgMember]
 
     def __init__(self, **data):
@@ -2000,13 +2000,13 @@ class TeamAddMemberResponse(LiteLLM_TeamTable):
     updated_team_memberships: List[LiteLLM_TeamMembership]
 
 
-class OrganizationAddMemberResponse(LiteLLMBase):
+class OrganizationAddMemberResponse(LiteLLMPydanticObjectBase):
     organization_id: str
     updated_users: List[LiteLLM_UserTable]
     updated_organization_memberships: List[LiteLLM_OrganizationMembershipTable]
 
 
-class MemberDeleteRequest(LiteLLMBase):
+class MemberDeleteRequest(LiteLLMPydanticObjectBase):
     user_id: Optional[str] = None
     user_email: Optional[str] = None
 
@@ -2018,7 +2018,7 @@ class MemberDeleteRequest(LiteLLMBase):
         return values
 
 
-class MemberUpdateResponse(LiteLLMBase):
+class MemberUpdateResponse(LiteLLMPydanticObjectBase):
     user_id: str
     user_email: Optional[str] = None
 
@@ -2185,7 +2185,7 @@ LiteLLM_ManagementEndpoint_MetadataFields = [
 ]
 
 
-class ProviderBudgetResponseObject(LiteLLMBase):
+class ProviderBudgetResponseObject(LiteLLMPydanticObjectBase):
     """
     Configuration for a single provider's budget settings
     """
@@ -2196,7 +2196,7 @@ class ProviderBudgetResponseObject(LiteLLMBase):
     budget_reset_at: Optional[str] = None  # When the current budget period resets
 
 
-class ProviderBudgetResponse(LiteLLMBase):
+class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     """
     Complete provider budget configuration and status.
     Maps provider names to their budget configs.

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -17,6 +17,7 @@ from litellm.types.router import RouterErrors, UpdateRouterConfig
 from litellm.types.utils import (
     EmbeddingResponse,
     ImageResponse,
+    LiteLLMBase,
     ModelResponse,
     ProviderField,
     StandardCallbackDynamicParams,
@@ -132,28 +133,6 @@ def hash_token(token: str):
     hashed_token = hashlib.sha256(token.encode()).hexdigest()
 
     return hashed_token
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump(**kwargs)  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict(**kwargs)
-
-    def fields_set(self):
-        try:
-            return self.model_fields_set  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.__fields_set__
-
-    model_config = ConfigDict(protected_namespaces=())
 
 
 class LiteLLM_UpperboundKeyGenerateParams(LiteLLMBase):

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -11,7 +11,7 @@ from litellm import ModelResponse, token_counter, verbose_logger
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.types.utils import LiteLLMBase
+from litellm.types.utils import LiteLLMPydanticObjectBase
 
 
 class LowestCostLoggingHandler(CustomLogger):

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -11,19 +11,7 @@ from litellm import ModelResponse, token_counter, verbose_logger
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump()  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict()
+from litellm.types.utils import LiteLLMBase
 
 
 class LowestCostLoggingHandler(CustomLogger):

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -12,7 +12,7 @@ from litellm import ModelResponse, token_counter, verbose_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
-from litellm.types.utils import LiteLLMBase
+from litellm.types.utils import LiteLLMPydanticObjectBase
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -22,7 +22,7 @@ else:
     Span = Any
 
 
-class RoutingArgs(LiteLLMBase):
+class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: float = 1 * 60 * 60  # 1 hour
     lowest_latency_buffer: float = 0
     max_latency_list_size: int = 10

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -12,6 +12,7 @@ from litellm import ModelResponse, token_counter, verbose_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
+from litellm.types.utils import LiteLLMBase
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -19,19 +20,6 @@ if TYPE_CHECKING:
     Span = _Span
 else:
     Span = Any
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump()  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict()
 
 
 class RoutingArgs(LiteLLMBase):

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -14,11 +14,11 @@ from litellm import token_counter
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.types.utils import LiteLLMBase
+from litellm.types.utils import LiteLLMPydanticObjectBase
 from litellm.utils import print_verbose
 
 
-class RoutingArgs(LiteLLMBase):
+class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: int = 1 * 60  # 1min (RPM/TPM expire key)
 
 

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -14,20 +14,8 @@ from litellm import token_counter
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.types.utils import LiteLLMBase
 from litellm.utils import print_verbose
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump()  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict()
 
 
 class RoutingArgs(LiteLLMBase):

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -14,7 +14,7 @@ from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.types.router import RouterErrors
-from litellm.types.utils import LiteLLMBase
+from litellm.types.utils import LiteLLMPydanticObjectBase
 from litellm.utils import get_utc_datetime, print_verbose
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ else:
     Span = Any
 
 
-class RoutingArgs(LiteLLMBase):
+class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: int = 1 * 60  # 1min (RPM/TPM expire key)
 
 

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -14,6 +14,7 @@ from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.types.router import RouterErrors
+from litellm.types.utils import LiteLLMBase
 from litellm.utils import get_utc_datetime, print_verbose
 
 if TYPE_CHECKING:
@@ -22,19 +23,6 @@ if TYPE_CHECKING:
     Span = _Span
 else:
     Span = Any
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump()  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict()
 
 
 class RoutingArgs(LiteLLMBase):

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, TypedDict
 
 from pydantic import BaseModel, Field
 
-from litellm.types.utils import LiteLLMBase
+from litellm.types.utils import LiteLLMPydanticObjectBase
 
 
 class BaseOutageModel(TypedDict):
@@ -40,7 +40,7 @@ class SlackAlertingArgsEnum(Enum):
     max_outage_alert_list_size = 1 * 10
 
 
-class SlackAlertingArgs(LiteLLMBase):
+class SlackAlertingArgs(LiteLLMPydanticObjectBase):
     daily_report_frequency: int = Field(
         default=int(
             os.getenv(
@@ -80,7 +80,7 @@ class SlackAlertingArgs(LiteLLMBase):
     )  # prevent memory leak
 
 
-class DeploymentMetrics(LiteLLMBase):
+class DeploymentMetrics(LiteLLMPydanticObjectBase):
     """
     Metrics per deployment, stored in cache
 

--- a/litellm/types/integrations/slack_alerting.py
+++ b/litellm/types/integrations/slack_alerting.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Literal, Optional, Set, TypedDict
 
 from pydantic import BaseModel, Field
 
+from litellm.types.utils import LiteLLMBase
+
 
 class BaseOutageModel(TypedDict):
     alerts: List[int]
@@ -25,19 +27,6 @@ class ProviderRegionOutageModel(BaseOutageModel):
 # we use this for the email header, please send a test email if you change this. verify it looks good on email
 LITELLM_LOGO_URL = "https://litellm-listing.s3.amazonaws.com/litellm_logo.png"
 LITELLM_SUPPORT_CONTACT = "support@berri.ai"
-
-
-class LiteLLMBase(BaseModel):
-    """
-    Implements default functions, all pydantic objects should have.
-    """
-
-    def json(self, **kwargs):  # type: ignore
-        try:
-            return self.model_dump()  # noqa
-        except Exception:
-            # if using pydantic v1
-            return self.dict()
 
 
 class SlackAlertingArgsEnum(Enum):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -33,7 +33,7 @@ def _generate_id():  # private helper function
     return "chatcmpl-" + str(uuid.uuid4())
 
 
-class LiteLLMBase(BaseModel):
+class LiteLLMPydanticObjectBase(BaseModel):
     """
     Implements default functions, all pydantic objects should have.
     """

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -33,6 +33,28 @@ def _generate_id():  # private helper function
     return "chatcmpl-" + str(uuid.uuid4())
 
 
+class LiteLLMBase(BaseModel):
+    """
+    Implements default functions, all pydantic objects should have.
+    """
+
+    def json(self, **kwargs):  # type: ignore
+        try:
+            return self.model_dump(**kwargs)  # noqa
+        except Exception:
+            # if using pydantic v1
+            return self.dict(**kwargs)
+
+    def fields_set(self):
+        try:
+            return self.model_fields_set  # noqa
+        except Exception:
+            # if using pydantic v1
+            return self.__fields_set__
+
+    model_config = ConfigDict(protected_namespaces=())
+
+
 class LiteLLMCommonStrings(Enum):
     redacted_by_litellm = "redacted by litellm. 'litellm.turn_off_message_logging=True'"
 


### PR DESCRIPTION

## (Refactor) Code Quality improvement - stop redefining `LiteLLMBase`

- Stop redefining `LiteLLMBase`
- rename `LiteLLMBase` -> `LiteLLMPydanticObjectBase` to make it clear that this is the base pydantic object for the repo 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Addressing feedback here: https://github.com/andrewyng/aisuite/issues/113#issuecomment-2512369132 (s/o to @vemonet for the great feedback) cc litellm users @TashaSkyUp, @vilmar-hillow

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

