### PR TITLE
(UI) Fix Usage Tab - Don't make expensive UI queries after SpendLogs crosses 1M Rows

### DIFF
--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -244,6 +244,10 @@ const UsagePage: React.FC<UsagePageProps> = ({
       return;
     }
 
+    if (proxySettings?.DISABLE_EXPENSIVE_DB_QUERIES) {
+      return;  // Don't run expensive DB queries - return out when SpendLogs has more than 1M rows
+    }
+
     // the endTime put it to the last hour of the selected date
     endTime.setHours(23, 59, 59, 999);
 

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -197,21 +197,18 @@ const UsagePage: React.FC<UsagePageProps> = ({
     return formatter.format(number);
   }
 
-  useEffect(() => {
-    const fetchProxySettings = async () => {
-      if (accessToken) {
-        try {
-          const proxy_settings: ProxySettings = await getProxyUISettings(accessToken);
-          console.log("usage tab: proxy_settings", proxy_settings);
-          setProxySettings(proxy_settings);
-        } catch (error) {
-          console.error("Error fetching proxy settings:", error);
-        }
-      }
-    };
-    fetchProxySettings();
-  }, [accessToken]);
 
+  const fetchProxySettings = async () => {
+    if (accessToken) {
+      try {
+        const proxy_settings: ProxySettings = await getProxyUISettings(accessToken);
+        console.log("usage tab: proxy_settings", proxy_settings);
+        return proxy_settings;
+      } catch (error) {
+        console.error("Error fetching proxy settings:", error);
+      }
+    }
+  };
 
   useEffect(() => {
     updateTagSpendData(dateValue.from, dateValue.to);
@@ -404,26 +401,37 @@ const UsagePage: React.FC<UsagePageProps> = ({
   };
 
   useEffect(() => {
-    if (accessToken && token && userRole && userID) {
-      if (proxySettings?.DISABLE_EXPENSIVE_DB_QUERIES) {
-        return;  // Don't run expensive queries
+    const initlizeUsageData = async () => {
+      if (accessToken && token && userRole && userID) {
+        const proxy_settings: ProxySettings | undefined = await fetchProxySettings();
+        if (proxy_settings) {
+          setProxySettings(proxy_settings); // saved in state so it can be used when rendering UI
+          if (proxy_settings?.DISABLE_EXPENSIVE_DB_QUERIES) {
+            return;  // Don't run expensive UI queries - return out of initlizeUsageData at this point
+          }
+        }
+        
+
+        console.log("fetching data - valiue of proxySettings", proxySettings);
+
+
+        fetchOverallSpend();
+        fetchProviderSpend();
+        fetchTopKeys();
+        fetchTopModels();
+        fetchGlobalActivity();
+        fetchGlobalActivityPerModel();
+
+        if (isAdminOrAdminViewer(userRole)) {
+          fetchTeamSpend();
+          fetchTagNames();
+          fetchTopTags();
+          fetchTopEndUsers();
+        }
       }
+  };
 
-
-      fetchOverallSpend();
-      fetchProviderSpend();
-      fetchTopKeys();
-      fetchTopModels();
-      fetchGlobalActivity();
-      fetchGlobalActivityPerModel();
-
-      if (isAdminOrAdminViewer(userRole)) {
-        fetchTeamSpend();
-        fetchTagNames();
-        fetchTopTags();
-        fetchTopEndUsers();
-      }
-    }
+  initlizeUsageData();
   }, [accessToken, token, userRole, userID, startTime, endTime]);
 
 


### PR DESCRIPTION
## (UI) Fix Usage Tab - Don't make expensive UI queries after SpendLogs crosses 1M Rows 

This issue was already addressed - found further improvements as I was QA'ing this more 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

