### PR TITLE
fix: #7239 to move Nova topK parameter to `additionalModelRequestFields`

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -378,6 +378,12 @@ class AmazonConverseConfig:
         for key in additional_request_keys:
             inference_params.pop(key, None)
 
+        if 'topK' in inference_params:
+            additional_request_params["inferenceConfig"] = {'topK': inference_params.pop("topK")}
+        elif 'top_k' in inference_params:
+            additional_request_params["inferenceConfig"] = {'topK': inference_params.pop("top_k")}
+
+
         bedrock_tools: List[ToolBlock] = _bedrock_tools_pt(
             inference_params.pop("tools", [])
         )


### PR DESCRIPTION
## Title

move Nova topK parameter to `additionalModelRequestFields`

## Relevant issues

#7239 
#7087 


## Type
🐛 Bug Fix
✅ Test

## Changes

- move `topK` to `additionalModelRequestFields` --> `inferenceConfig` per Amazon Nova request spec
- added mock to validate topK is going to the correct location in the request body

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
<img width="589" alt="CleanShot 2024-12-14 at 20 00 22@2x" src="https://github.com/user-attachments/assets/10305257-8576-45c1-b9d1-34429dc41516" />


