### PR TITLE
Add support for Gemini 2.0 GoogleSearch tool

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -395,6 +395,7 @@ class VertexGeminiConfig(BaseConfig):
 
     def _map_function(self, value: List[dict]) -> List[Tools]:
         gtool_func_declarations = []
+        googleSearch: Optional[dict] = None
         googleSearchRetrieval: Optional[dict] = None
         code_execution: Optional[dict] = None
         # remove 'additionalProperties' from tools
@@ -425,6 +426,8 @@ class VertexGeminiConfig(BaseConfig):
                 openai_function_object = ChatCompletionToolParamFunctionChunk(**tool)  # type: ignore
 
             # check if grounding
+            if tool.get("googleSearch", None) is not None:
+                googleSearch = tool["googleSearch"]
             if tool.get("googleSearchRetrieval", None) is not None:
                 googleSearchRetrieval = tool["googleSearchRetrieval"]
             elif tool.get("code_execution", None) is not None:
@@ -449,6 +452,8 @@ class VertexGeminiConfig(BaseConfig):
         _tools = Tools(
             function_declarations=gtool_func_declarations,
         )
+        if googleSearch is not None:
+            _tools["googleSearch"] = googleSearch
         if googleSearchRetrieval is not None:
             _tools["googleSearchRetrieval"] = googleSearchRetrieval
         if code_execution is not None:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -428,7 +428,7 @@ class VertexGeminiConfig(BaseConfig):
             # check if grounding
             if tool.get("googleSearch", None) is not None:
                 googleSearch = tool["googleSearch"]
-            if tool.get("googleSearchRetrieval", None) is not None:
+            elif tool.get("googleSearchRetrieval", None) is not None:
                 googleSearchRetrieval = tool["googleSearchRetrieval"]
             elif tool.get("code_execution", None) is not None:
                 code_execution = tool["code_execution"]

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -164,8 +164,8 @@ class GenerationConfig(TypedDict, total=False):
 
 class Tools(TypedDict, total=False):
     function_declarations: List[FunctionDeclaration]
-    googleSearchRetrieval: dict
     googleSearch: dict
+    googleSearchRetrieval: dict
     code_execution: dict
     retrieval: Retrieval
 

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -165,6 +165,7 @@ class GenerationConfig(TypedDict, total=False):
 class Tools(TypedDict, total=False):
     function_declarations: List[FunctionDeclaration]
     googleSearchRetrieval: dict
+    googleSearch: dict
     code_execution: dict
     retrieval: Retrieval
 

--- a/tests/llm_translation/test_vertex.py
+++ b/tests/llm_translation/test_vertex.py
@@ -125,6 +125,7 @@ def test_build_vertex_schema():
 @pytest.mark.parametrize(
     "tools, key",
     [
+        ([{"googleSearch": {}}], "googleSearch"),
         ([{"googleSearchRetrieval": {}}], "googleSearchRetrieval"),
         ([{"code_execution": {}}], "code_execution"),
     ],

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -866,6 +866,7 @@ def test_gemini_pro_grounding(value_in_dict):
     except litellm.RateLimitError:
         pass
 
+
 # @pytest.mark.skip(reason="exhausted vertex quota. need to refactor to mock the call")
 @pytest.mark.parametrize(
     "model", ["vertex_ai_beta/gemini-1.5-pro", "vertex_ai/claude-3-sonnet@20240229"]

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -60,6 +60,7 @@ VERTEX_MODELS_TO_NOT_TEST = [
     "gemini-1.5-flash-exp-0827",
     "gemini-pro-flash",
     "gemini-1.5-flash-exp-0827",
+    "gemini-2.0-flash-exp"
 ]
 
 
@@ -854,51 +855,6 @@ def test_gemini_pro_grounding(value_in_dict):
             )
             assert (
                 mock_call.call_args.kwargs["json"]["tools"][0]["googleSearchRetrieval"]
-                == value_in_dict
-            )
-
-            assert "vertex_ai_grounding_metadata" in resp._hidden_params
-            assert isinstance(resp._hidden_params["vertex_ai_grounding_metadata"], list)
-
-    except litellm.InternalServerError:
-        pass
-    except litellm.RateLimitError:
-        pass
-
-@pytest.mark.parametrize("value_in_dict", [{}, {"disable_attribution": False}])  #
-def test_gemini_2_0_grounding(value_in_dict):
-    try:
-        load_vertex_ai_credentials()
-        litellm.set_verbose = True
-
-        tools = [{"googleSearch": value_in_dict}]
-
-        litellm.set_verbose = True
-
-        from litellm.llms.custom_httpx.http_handler import HTTPHandler
-
-        client = HTTPHandler()
-
-        with patch.object(
-            client, "post", side_effect=vertex_httpx_grounding_post
-        ) as mock_call:
-            resp = litellm.completion(
-                model="vertex_ai_beta/gemini-2.0-flash-exp",
-                messages=[{"role": "user", "content": "Who won the world cup?"}],
-                tools=tools,
-                client=client,
-            )
-
-            mock_call.assert_called_once()
-
-            print(mock_call.call_args.kwargs["json"]["tools"][0])
-
-            assert (
-                "googleSearch"
-                in mock_call.call_args.kwargs["json"]["tools"][0]
-            )
-            assert (
-                mock_call.call_args.kwargs["json"]["tools"][0]["googleSearch"]
                 == value_in_dict
             )
 


### PR DESCRIPTION
## Title

Add `googleSearch()` tool to valid tool list for Gemini/VertexAI models to support Gemini 2.0 grounding.

## Relevant issues

Enhances https://github.com/BerriAI/litellm/issues/7188

## Type

🆕 New Feature
✅ Test

## Changes

- Add `googleSearch()` tool to list of valid tools for Gemini/VertexAI models
- Update test

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

![image](https://github.com/user-attachments/assets/621edeb4-6836-46f7-b10a-bdb700c2f9d9)

