### PR TITLE
(feat) Add Bedrock knowledge base pass through endpoints 

### DIFF
--- a/docs/my-website/docs/pass_through/bedrock.md
+++ b/docs/my-website/docs/pass_through/bedrock.md
@@ -143,7 +143,7 @@ curl "https://bedrock-runtime.us-west-2.amazonaws.com/guardrail/guardrailIdentif
 ### **Example 3: Query Knowledge Base**
 
 ```bash
-curl -X POST "http://0.0.0.0:4000/bedrock/agents/knowledgebases/{knowledgeBaseId}/retrieve" \
+curl -X POST "http://0.0.0.0:4000/bedrock/knowledgebases/{knowledgeBaseId}/retrieve" \
 -H 'Authorization: Bearer sk-anything' \
 -H 'Content-Type: application/json' \
 -d '{

--- a/docs/my-website/docs/pass_through/bedrock.md
+++ b/docs/my-website/docs/pass_through/bedrock.md
@@ -143,7 +143,7 @@ curl "https://bedrock-runtime.us-west-2.amazonaws.com/guardrail/guardrailIdentif
 ### **Example 3: Query Knowledge Base**
 
 ```bash
-curl -X POST "http://0.0.0.0:4000/bedrock/knowledgebases/{knowledgeBaseId}/retrieve" \
+curl -X POST "http://0.0.0.0:4000/bedrock/agents/knowledgebases/{knowledgeBaseId}/retrieve" \
 -H 'Authorization: Bearer sk-anything' \
 -H 'Content-Type: application/json' \
 -d '{
@@ -164,7 +164,7 @@ curl -X POST "http://0.0.0.0:4000/bedrock/knowledgebases/{knowledgeBaseId}/retri
 #### Direct Bedrock API Call 
 
 ```bash
-curl -X POST "https://bedrock-runtime.us-west-2.amazonaws.com/knowledgebases/{knowledgeBaseId}/retrieve" \
+curl -X POST "https://bedrock-agent-runtime.us-west-2.amazonaws.com/knowledgebases/{knowledgeBaseId}/retrieve" \
 -H 'Authorization: AWS4-HMAC-SHA256..' \
 -H 'Content-Type: application/json' \
 -d '{

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -80,4 +80,12 @@ MAX_SPENDLOG_ROWS_TO_QUERY = (
 RATE_LIMIT_ERROR_MESSAGE_FOR_VIRTUAL_KEY = "LiteLLM Virtual Key user_api_key_hash"
 
 # pass through route constansts
-BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES = ["agents/", "knowledgebases/"]
+BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES = [
+    "agents/",
+    "knowledgebases/",
+    "flows/",
+    "retrieveAndGenerate/",
+    "rerank/",
+    "generateQuery/",
+    "optimize-prompt/",
+]

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -72,8 +72,12 @@ LITELLM_CHAT_PROVIDERS = [
 RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"  # default tool name used when converting response format to tool call
 
 ########################### LiteLLM Proxy Specific Constants ###########################
+########################################################################################
 MAX_SPENDLOG_ROWS_TO_QUERY = (
     1_000_000  # if spendLogs has more than 1M rows, do not query the DB
 )
 # makes it clear this is a rate limit error for a litellm virtual key
 RATE_LIMIT_ERROR_MESSAGE_FOR_VIRTUAL_KEY = "LiteLLM Virtual Key user_api_key_hash"
+
+# pass through route constansts
+BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES = ["agents/", "knowledgebases/"]

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -260,10 +260,6 @@ async def bedrock_proxy_route(
     if not encoded_endpoint.startswith("/"):
         encoded_endpoint = "/" + encoded_endpoint
 
-    # Remove agent from knowledgebase url /agents/knowledgebases/ -> /knowledgebases/
-    if "knowledgebases" in encoded_endpoint:
-        encoded_endpoint = encoded_endpoint.replace("/agents", "")
-
     # Construct the full target URL using httpx
     base_url = httpx.URL(base_target_url)
     updated_url = base_url.copy_with(path=encoded_endpoint)

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -32,6 +32,7 @@ from starlette.datastructures import QueryParams
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.batches.main import FileObject
+from litellm.constants import BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES
 from litellm.fine_tuning.main import vertex_fine_tuning_apis_instance
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -247,7 +248,7 @@ async def bedrock_proxy_route(
         raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
 
     aws_region_name = litellm.utils.get_secret(secret_name="AWS_REGION_NAME")
-    if endpoint.startswith("agents/"):  # handle bedrock agents
+    if _is_bedrock_agent_runtime_route(endpoint=endpoint):  # handle bedrock agents
         base_target_url = (
             f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"
         )
@@ -305,6 +306,16 @@ async def bedrock_proxy_route(
     )
 
     return received_value
+
+
+def _is_bedrock_agent_runtime_route(endpoint: str) -> bool:
+    """
+    Return True, if the endpoint should be routed to the `bedrock-agent-runtime` endpoint.
+    """
+    for _route in BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES:
+        if _route in endpoint:
+            return True
+    return False
 
 
 @router.api_route(

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -259,6 +259,10 @@ async def bedrock_proxy_route(
     if not encoded_endpoint.startswith("/"):
         encoded_endpoint = "/" + encoded_endpoint
 
+    # Remove agent from knowledgebase url /agents/knowledgebases/ -> /knowledgebases/
+    if "knowledgebases" in encoded_endpoint:
+        encoded_endpoint = encoded_endpoint.replace("/agents", "")
+
     # Construct the full target URL using httpx
     base_url = httpx.URL(base_target_url)
     updated_url = base_url.copy_with(path=encoded_endpoint)

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -355,3 +355,29 @@ def test_pass_through_routes_support_all_methods():
     # Check both routers
     check_router_methods(llm_router)
     check_router_methods(vertex_router)
+
+
+def test_is_bedrock_agent_runtime_route():
+    """
+    Test that _is_bedrock_agent_runtime_route correctly identifies bedrock agent runtime endpoints
+    """
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        _is_bedrock_agent_runtime_route,
+    )
+
+    # Test agent runtime endpoints (should return True)
+    assert _is_bedrock_agent_runtime_route("/knowledgebases/kb-123/retrieve") is True
+    assert (
+        _is_bedrock_agent_runtime_route("/agents/knowledgebases/kb-123/retrieve")
+        is True
+    )
+
+    # Test regular bedrock runtime endpoints (should return False)
+    assert (
+        _is_bedrock_agent_runtime_route("/guardrail/test-id/version/1/apply") is False
+    )
+    assert (
+        _is_bedrock_agent_runtime_route("/model/cohere.command-r-v1:0/converse")
+        is False
+    )
+    assert _is_bedrock_agent_runtime_route("/some/random/endpoint") is False


### PR DESCRIPTION
## Proxy /bedrock pass through routes - agents, knowledgebases, retrieveAndGenerate etc


For the following bedrock/ routes 

```
BEDROCK_AGENT_RUNTIME_PASS_THROUGH_ROUTES = [
    "agents/",
    "knowledgebases/",
    "flows/",
    "retrieveAndGenerate/",
    "rerank/",
    "generateQuery/",
    "optimize-prompt/",
]

```

route the request to `f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"`

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

