### PR TITLE
(proxy admin ui) - show Teams sorted by `Team Alias` 

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -382,7 +382,7 @@ async def user_info(
 
         ## REMOVE HASHED TOKEN INFO before returning ##
         returned_keys = _process_keys_for_user_info(keys=keys, all_teams=teams_1)
-
+        team_list.sort(key=lambda x: (getattr(x, "team_alias", "")))
         _user_info = (
             user_info.model_dump() if isinstance(user_info, BaseModel) else user_info
         )
@@ -436,6 +436,7 @@ async def _get_user_info_for_proxy_admin():
     # cast all teams to LiteLLM_TeamTable
     _teams_in_db: List = results[0]["teams"] or []
     _teams_in_db = [LiteLLM_TeamTable(**team) for team in _teams_in_db]
+    _teams_in_db.sort(key=lambda x: (getattr(x, "team_alias", "")))
     returned_keys = _process_keys_for_user_info(keys=keys_in_db, all_teams=_teams_in_db)
     return UserInfoResponse(
         user_id=None,

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -436,7 +436,7 @@ async def _get_user_info_for_proxy_admin():
     # cast all teams to LiteLLM_TeamTable
     _teams_in_db: List = results[0]["teams"] or []
     _teams_in_db = [LiteLLM_TeamTable(**team) for team in _teams_in_db]
-    _teams_in_db.sort(key=lambda x: (getattr(x, "team_alias", "")))
+    _teams_in_db.sort(key=lambda x: (getattr(x, "team_alias", "") or ""))
     returned_keys = _process_keys_for_user_info(keys=keys_in_db, all_teams=_teams_in_db)
     return UserInfoResponse(
         user_id=None,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1425,5 +1425,6 @@ async def list_team(
             )
             verbose_proxy_logger.exception(team_exception)
             continue
-
+    # Sort the responses by team_alias
+    returned_responses.sort(key=lambda x: (getattr(x, "team_alias", "")))
     return returned_responses

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1426,5 +1426,5 @@ async def list_team(
             verbose_proxy_logger.exception(team_exception)
             continue
     # Sort the responses by team_alias
-    returned_responses.sort(key=lambda x: (getattr(x, "team_alias", "")))
+    returned_responses.sort(key=lambda x: (getattr(x, "team_alias", "") or ""))
     return returned_responses

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -768,5 +768,12 @@ async def test_user_info_as_proxy_admin(prisma_client):
     assert user_info_response.teams is not None
     assert len(user_info_response.teams) > 0, "Expected at least one team in response"
 
+    # assert that the teams are sorted by team_alias
+    team_aliases = [
+        getattr(team, "team_alias", "") or "" for team in user_info_response.teams
+    ]
+    print("Team aliases order in response=", team_aliases)
+    assert team_aliases == sorted(team_aliases), "Teams are not sorted by team_alias"
+
     assert user_info_response.keys is not None
     assert len(user_info_response.keys) > 0, "Expected at least one key in response"


### PR DESCRIPTION
## (proxy admin ui) - show Teams sorted by `Team Alias` 

<img width="1458" alt="Xnapper-2024-12-18-10 10 57" src="https://github.com/user-attachments/assets/52d522ae-de1c-403c-838f-04ac61392c39" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

