### PR TITLE
feat: Add support for ollama structured outputs

### DIFF
--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -2,6 +2,7 @@ from typing import Union
 
 import httpx
 
+from litellm._logging import verbose_logger
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
@@ -43,3 +44,29 @@ def _convert_image(image):
     image_data.convert("RGB").save(jpeg_image, "JPEG")
     jpeg_image.seek(0)
     return base64.b64encode(jpeg_image.getvalue()).decode("utf-8")
+
+
+def process_response_format(response_format: dict) -> str:
+    """
+    Process OpenAI-style response format specification into Ollama API format
+    string
+
+    Args:
+        response_format (dict): OpenAI-style response format specification
+
+    Returns:
+        str: Format string for Ollama API
+    """
+    format_type = response_format.get("type")
+    if format_type == "json_object":
+        return "json"
+    elif format_type == "json_schema":
+        schema = response_format.get("json_schema", {}).get("schema")
+        if not schema:
+            raise ValueError("Invalid JSON schema format")
+        return schema
+    else:
+        verbose_logger.warning(
+            f"Unsupported response format type: {format_type}, falling back to 'json'"
+        )
+        return "json"

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import httpx
 
@@ -46,7 +46,7 @@ def _convert_image(image):
     return base64.b64encode(jpeg_image.getvalue()).decode("utf-8")
 
 
-def process_response_format(response_format: dict) -> str:
+def process_response_format(response_format: dict) -> Optional[str]:
     """
     Process OpenAI-style response format specification into Ollama API format
     string
@@ -66,7 +66,4 @@ def process_response_format(response_format: dict) -> str:
             raise ValueError("Invalid JSON schema format")
         return schema
     else:
-        verbose_logger.warning(
-            f"Unsupported response format type: {format_type}, falling back to 'json'"
-        )
-        return "json"
+        verbose_logger.warning(f"Unsupported response format type: {format_type}")

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -172,7 +172,9 @@ class OllamaConfig(BaseConfig):
             if param == "stop":
                 optional_params["stop"] = value
             if param == "response_format" and isinstance(value, dict):
-                optional_params["format"] = process_response_format(value)
+                format = process_response_format(value)
+                if format is not None:
+                    optional_params["format"] = format
 
         return optional_params
 

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -22,7 +22,7 @@ from litellm.types.utils import (
     ProviderField,
 )
 
-from ..common_utils import OllamaError, _convert_image
+from ..common_utils import OllamaError, _convert_image, process_response_format
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -172,8 +172,7 @@ class OllamaConfig(BaseConfig):
             if param == "stop":
                 optional_params["stop"] = value
             if param == "response_format" and isinstance(value, dict):
-                if value["type"] == "json_object":
-                    optional_params["format"] = "json"
+                optional_params["format"] = process_response_format(value)
 
         return optional_params
 

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -154,7 +154,9 @@ class OllamaChatConfig(OpenAIGPTConfig):
             if param == "stop":
                 optional_params["stop"] = value
             if param == "response_format" and isinstance(value, dict):
-                optional_params["format"] = process_response_format(value)
+                format = process_response_format(value)
+                if format is not None:
+                    optional_params["format"] = format
             ### FUNCTION CALLING LOGIC ###
             if param == "tools":
                 # ollama actually supports json output

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 import litellm
 from litellm import verbose_logger
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.llms.ollama.common_utils import process_response_format
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.llms.ollama import OllamaToolCall, OllamaToolCallFunction
 from litellm.types.llms.openai import ChatCompletionAssistantToolCall
@@ -152,8 +153,8 @@ class OllamaChatConfig(OpenAIGPTConfig):
                 optional_params["repeat_penalty"] = value
             if param == "stop":
                 optional_params["stop"] = value
-            if param == "response_format" and value["type"] == "json_object":
-                optional_params["format"] = "json"
+            if param == "response_format" and isinstance(value, dict):
+                optional_params["format"] = process_response_format(value)
             ### FUNCTION CALLING LOGIC ###
             if param == "tools":
                 # ollama actually supports json output


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Add support for `ollama` structured outputs

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #7131

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

<!-- List of changes -->

- Added `process_response_format` function to convert OpenAI-style response format to Ollama API format.
- Updated `OllamaConfig` and `OllamaChatConfig` to use the new `process_response_format` function.
- Added unit test `test_ollama_structured_format` to validate the structured JSON schema format.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

<img width="1272" alt="Screenshot 2024-12-20 at 10 44 49 PM" src="https://github.com/user-attachments/assets/a010673b-8a97-42de-9cfd-a14a1020664f" />


<!-- Test procedure -->
```python
from pydantic import BaseModel

import litellm


class Country(BaseModel):
    name: str
    capital: str
    languages: list[str]


messages = [{"role": "user", "content": "Tell me about Canada."}]
print("Sending the following messages to the model:", messages)

response = litellm.completion(
    "ollama_chat/mistral-nemo", messages, response_format=Country
)

print(response.choices[0].message)
```

output:
```
❯ python test.py
Sending the following messages to the model: [{'role': 'user', 'content': 'Tell me about Canada.'}]
Message(content='{ "name": "Canada", "capital": "Ottawa", "languages": ["English", "French", "Aboriginal languages"] }', role='assistant', tool_calls=None, function_call=None)
```