### PR TITLE
fix: add missing params presence_penalty and frequency_penalty for vertex_ai

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -167,6 +167,8 @@ class VertexAIConfig:
             "n",
             "stop",
             "extra_headers",
+            "frequency_penalty",
+            "presence_penalty",
         ]
 
     def map_openai_params(self, non_default_params: dict, optional_params: dict):


### PR DESCRIPTION
## Add missing params presence_penalty and frequency_penalty for vertex_ai


## Relevant issues
Fixes #7378

## Type
🐛 Bug Fix


