### PR TITLE
Correct handling of max_retries=0 to disable AzureOpenAI retries

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -861,7 +861,8 @@ class AzureChatCompletion(BaseLLM):
             self._client_session = self.create_client_session()
         try:
             data = {"model": model, "input": input, **optional_params}
-            max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES
+            if max_retries is None:
+                max_retries = litellm.DEFAULT_MAX_RETRIES
             if not isinstance(max_retries, int):
                 raise AzureOpenAIError(
                     status_code=422, message="max retries must be an int"


### PR DESCRIPTION
## Title

Correct handling of max_retries=0 to disable AzureOpenAI retries

## Relevant issues
Follow-up PR to fix #7003 

## Type

🐛 Bug Fix

## Changes

* Explicitly check if `max_retries` is `None` before using the default value. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
[This unit test](https://github.com/BerriAI/litellm/commit/5a8b53791934d11a0173c4bb10234ff22afbde10#diff-b41c0b95c60bf3c8b21ec3f5957edd3e1a6f8e961982f880a2fa097a61f39b20R62-R67) is unreliable because we aren't sure that the parameter will be passed correctly into the objects in the OpenAI library, but I haven't figured out a better test.



