### PR TITLE
Add double quotes to prevent view names from being lowercased

### DIFF
--- a/db_scripts/create_views.py
+++ b/db_scripts/create_views.py
@@ -5,7 +5,6 @@ python script to pre-create all views required by LiteLLM Proxy Server
 import asyncio
 
 # Enter your DATABASE_URL here
-
 from prisma import Prisma
 
 db = Prisma(
@@ -37,11 +36,11 @@ async def check_view_exists():  # noqa: PLR0915
         await db.execute_raw(
             """
                 CREATE VIEW "LiteLLM_VerificationTokenView" AS
-                SELECT 
-                v.*, 
-                t.spend AS team_spend, 
-                t.max_budget AS team_max_budget, 
-                t.tpm_limit AS team_tpm_limit, 
+                SELECT
+                v.*,
+                t.spend AS team_spend,
+                t.max_budget AS team_max_budget,
+                t.tpm_limit AS team_tpm_limit,
                 t.rpm_limit AS team_rpm_limit
                 FROM "LiteLLM_VerificationToken" v
                 LEFT JOIN "LiteLLM_TeamTable" t ON v.team_id = t.team_id;
@@ -55,15 +54,15 @@ async def check_view_exists():  # noqa: PLR0915
         print("MonthlyGlobalSpend Exists!")  # noqa
     except Exception:
         sql_query = """
-        CREATE OR REPLACE VIEW "MonthlyGlobalSpend" AS 
+        CREATE OR REPLACE VIEW "MonthlyGlobalSpend" AS
         SELECT
-        DATE("startTime") AS date, 
-        SUM("spend") AS spend 
-        FROM 
-        "LiteLLM_SpendLogs" 
-        WHERE 
+        DATE("startTime") AS date,
+        SUM("spend") AS spend
+        FROM
+        "LiteLLM_SpendLogs"
+        WHERE
         "startTime" >= (CURRENT_DATE - INTERVAL '30 days')
-        GROUP BY 
+        GROUP BY
         DATE("startTime");
         """
         await db.execute_raw(query=sql_query)
@@ -76,14 +75,14 @@ async def check_view_exists():  # noqa: PLR0915
     except Exception:
         sql_query = """
         CREATE OR REPLACE VIEW "Last30dKeysBySpend" AS
-        SELECT 
-        L."api_key", 
+        SELECT
+        L."api_key",
         V."key_alias",
         V."key_name",
         SUM(L."spend") AS total_spend
         FROM
         "LiteLLM_SpendLogs" L
-        LEFT JOIN 
+        LEFT JOIN
         "LiteLLM_VerificationToken" V
         ON
         L."api_key" = V."token"
@@ -125,16 +124,16 @@ async def check_view_exists():  # noqa: PLR0915
         print("MonthlyGlobalSpendPerKey Exists!")  # noqa
     except Exception:
         sql_query = """
-            CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerKey" AS 
+            CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerKey" AS
             SELECT
-            DATE("startTime") AS date, 
+            DATE("startTime") AS date,
             SUM("spend") AS spend,
             api_key as api_key
-            FROM 
-            "LiteLLM_SpendLogs" 
-            WHERE 
+            FROM
+            "LiteLLM_SpendLogs"
+            WHERE
             "startTime" >= (CURRENT_DATE - INTERVAL '30 days')
-            GROUP BY 
+            GROUP BY
             DATE("startTime"),
             api_key;
         """
@@ -142,23 +141,21 @@ async def check_view_exists():  # noqa: PLR0915
 
         print("MonthlyGlobalSpendPerKey Created!")  # noqa
     try:
-        await db.query_raw(
-            """SELECT 1 FROM "MonthlyGlobalSpendPerUserPerKey" LIMIT 1"""
-        )
+        await db.query_raw("""SELECT 1 FROM "MonthlyGlobalSpendPerUserPerKey" LIMIT 1""")
         print("MonthlyGlobalSpendPerUserPerKey Exists!")  # noqa
     except Exception:
         sql_query = """
-            CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerUserPerKey" AS 
+            CREATE OR REPLACE VIEW "MonthlyGlobalSpendPerUserPerKey" AS
             SELECT
-            DATE("startTime") AS date, 
+            DATE("startTime") AS date,
             SUM("spend") AS spend,
             api_key as api_key,
             "user" as "user"
-            FROM 
-            "LiteLLM_SpendLogs" 
-            WHERE 
+            FROM
+            "LiteLLM_SpendLogs"
+            WHERE
             "startTime" >= (CURRENT_DATE - INTERVAL '30 days')
-            GROUP BY 
+            GROUP BY
             DATE("startTime"),
             "user",
             api_key;
@@ -172,7 +169,7 @@ async def check_view_exists():  # noqa: PLR0915
         print("DailyTagSpend Exists!")  # noqa
     except Exception:
         sql_query = """
-        CREATE OR REPLACE VIEW DailyTagSpend AS
+        CREATE OR REPLACE VIEW "DailyTagSpend" AS
         SELECT
             jsonb_array_elements_text(request_tags) AS individual_request_tag,
             DATE(s."startTime") AS spend_date,


### PR DESCRIPTION
## Add double quotes to prevent view names from being lowercased

<!-- e.g. "Implement user authentication feature" -->

Creating the `DailyTagSpend` View on PostgreSQL without quotes creates a lowercase view named `dailytagspend`.
This causes a mismatch with the expected value below.

https://github.com/BerriAI/litellm/blob/c6ca8350469dab8a94ffc4033fc39bd6d5fd207b/litellm/proxy/utils.py#L1114

 And logging in warning message below.

https://github.com/BerriAI/litellm/blob/c6ca8350469dab8a94ffc4033fc39bd6d5fd207b/litellm/proxy/utils.py#L1173-L1177

This patch prevents those warnings from being logged.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locall
If UI changes, send a screenshot/GIF of working UI fixes

- Improve create view statement to suppress warnings.

<!-- Test procedure -->

