### PR TITLE
Update Documentation - Gemini Embedding

### DIFF
--- a/docs/my-website/docs/embedding/supported_embedding.md
+++ b/docs/my-website/docs/embedding/supported_embedding.md
@@ -394,6 +394,32 @@ print(response)
 |--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | mistral-embed | `embedding(model="mistral/mistral-embed", input)` | 
 
+## Gemini AI Embedding Models
+
+### API keys
+
+This can be set as env variables or passed as **params to litellm.embedding()**
+```python
+import os
+os.environ["GEMINI_API_KEY"] = ""
+```
+
+### Usage - Embedding
+```python
+from litellm import embedding
+response = embedding(
+  model="gemini/text-embedding-004",
+  input=["good morning from litellm"],
+)
+print(response)
+```
+
+All models listed [here](https://ai.google.dev/gemini-api/docs/models/gemini) are supported:
+
+| Model Name         | Function Call                                         |
+| :---               | :---                                                  |
+| text-embedding-004 | `embedding(model="gemini/text-embedding-004", input)` |
+
 
 ## Vertex AI Embedding Models
 
@@ -411,7 +437,7 @@ response = embedding(
 print(response)
 ```
 
-## Supported Models
+### Supported Models
 All models listed [here](https://github.com/BerriAI/litellm/blob/57f37f743886a0249f630a6792d49dffc2c5d9b7/model_prices_and_context_window.json#L835) are supported
 
 | Model Name               | Function Call                                                                                                                                                      |


### PR DESCRIPTION
## **Update Documentation - Gemini Embeddings**

This PR updates the documentation page by including Gemini in the list of supported embeddings.

For those who might not know, the library `litellm`  already has Gemini embeddings integrated, but it hadn’t highlighted this in docs until now. This PR fixes that by adding Gemini to the supported embeddings list.

Here’s a quick and easy code snippet to show you how to use Gemini embeddings:

```python
import os
os.environ["GEMINI_API_KEY"] = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

from litellm import embedding
# Check out the Gemini API docs: https://ai.google.dev/gemini-api/docs/models/gemini
# And our embedding docs: https://docs.litellm.ai/docs/embedding/supported_embedding
response = embedding(
    model="gemini/text-embedding-004",
    input=["good morning from litellm"],
)
print(response)

# Explore more about Gemini providers here: https://docs.litellm.ai/docs/providers/gemini
# And Gemini models here: https://ai.google.dev/gemini-api/docs/models/gemini
from litellm import completion
response = completion(
    model="gemini/gemini-2.0-flash-exp", 
    messages=[{"role": "user", "content": "write code for saying hi from LiteLLM"}]
)
print(response["choices"][0].message.content)
```

Also, [other libraries like `txtai`](https://github.com/neuml/txtai/issues/843) use `litellm`. Making it clear that Gemini is supported will help others understand and appreciate the capabilities of the `litellm` library even more. 🚀

## Relevant issues

- https://github.com/BerriAI/litellm/issues/4922#issuecomment-2374234548
- https://github.com/BerriAI/litellm/issues/4922#issuecomment-2388821371

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

