### PR TITLE
Update model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3486,7 +3486,17 @@
         "mode": "chat",
         "supports_function_calling": true
     },
-    "vertex_ai/mistral-large@2411": {
+    "vertex_ai/mistral-large@2411-001": {
+        "max_tokens": 8191,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8191,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000006,
+        "litellm_provider": "vertex_ai-mistral_models",
+        "mode": "chat",
+        "supports_function_calling": true
+    },
+    "vertex_ai/mistral-large-2411": {
         "max_tokens": 8191,
         "max_input_tokens": 128000,
         "max_output_tokens": 8191,


### PR DESCRIPTION
correct the mistral-large-2411 definition/pricing on vertex_ai

## Title

mistral large-2411 can be called in 2 different way 
mistral-large-2411
mistral-large@2411-001

## Relevant issues

no price diplayed

## Type

🐛 Bug Fix

## Changes

