### PR TITLE
fix: useable names for Bedrock Nova models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5290,6 +5290,43 @@
         "mode": "chat",
         "supports_function_calling": true
     },
+    "bedrock/us.amazon.nova-micro-v1:0": {
+        "max_tokens": 4096, 
+        "max_input_tokens": 300000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.000000035,
+        "output_cost_per_token": 0.00000014,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true
+    },
+    "bedrock/us.amazon.nova-lite-v1:0": {
+        "max_tokens": 4096, 
+        "max_input_tokens": 300000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.00000006,
+        "output_cost_per_token": 0.00000024,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true
+    },
+    "bedrock/us.amazon.nova-pro-v1:0": {
+        "max_tokens": 4096, 
+        "max_input_tokens": 300000,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000008,
+        "output_cost_per_token": 0.0000032,
+        "litellm_provider": "bedrock",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true
+    },
     "amazon.nova-micro-v1:0": {
         "max_tokens": 4096, 
         "max_input_tokens": 300000,


### PR DESCRIPTION
## Add Amazon Bedrock Nova Models to List

## Relevant issues

Fixes model names for nova-micro, lite and pro used from Bedrock. Current model names **do not work** in Aider.

Reference: https://github.com/Aider-AI/aider/issues/2526#issuecomment-2564346212

## Type

Fix

## Changes

updated model_prices_and_context_window.json

