### PR TITLE
fix ollama embedding model response #7451

### DIFF
--- a/litellm/llms/ollama/completion/handler.py
+++ b/litellm/llms/ollama/completion/handler.py
@@ -52,7 +52,7 @@ async def ollama_aembeddings(
 
     response = await litellm.module_level_aclient.post(url=url, json=data)
 
-    response_json = await response.json()
+    response_json = response.json()
 
     embeddings: List[List[float]] = response_json["embeddings"]
     for idx, emb in enumerate(embeddings):


### PR DESCRIPTION
## Title

Fix Ollama embedding response.

## Relevant issues

#7451 

## Type

🐛 Bug Fix

## Changes

Do not use await while converting the response into dict. The response is a normal object and was created with await in the previous line.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Works with the patch:

```bash
curl --location 'https://litellm.example.com/embeddings' \
--header 'Authorization: Bearer SECRET' \
--header 'Content-Type: application/json' \
--data '{"input": "Academia.edu uses", "model": "nomic-embed-text:latest"}'
```

