### PR TITLE
fix: drop unsupported non-whitespace characters for real when calling…

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
@@ -257,17 +258,13 @@ class AnthropicConfig(BaseConfig):
     ) -> Optional[List[str]]:
         new_stop: Optional[List[str]] = None
         if isinstance(stop, str):
-            if (
-                stop == "\n"
-            ) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
+            if re.match(r'^\s+$', stop) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
                 return new_stop
             new_stop = [stop]
         elif isinstance(stop, list):
             new_v = []
             for v in stop:
-                if (
-                    v == "\n"
-                ) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
+                if re.match(r'^\s+$', v) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
                     continue
                 new_v.append(v)
             if len(new_v) > 0:

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -1015,3 +1015,23 @@ def test_anthropic_json_mode_and_tool_call_response(
     assert (
         result is None if expect_null_response else result is not None
     ), f"Expected result to be {None if expect_null_response else 'not None'}, but got {result}"
+
+
+@pytest.mark.parametrize(
+    "stop_input,expected_output,drop_params",
+    [
+        ("stop", ["stop"], True),  # basic string
+        (["stop1", "stop2"], ["stop1", "stop2"], True),  # list of strings
+        ("   ", None, True),  # whitespace string should be dropped when drop_params is True
+        ("   ", ["   "], False),  # whitespace string should be kept when drop_params is False
+        (["stop1", "  ", "stop2"], ["stop1", "stop2"], True),  # list with whitespace that should be filtered
+        (["stop1", "  ", "stop2"], ["stop1", "  ", "stop2"], False),  # list with whitespace that should be kept
+        (None, None, True),  # None input
+    ],
+)
+def test_map_stop_sequences(stop_input, expected_output, drop_params):
+    """Test the _map_stop_sequences method of AnthropicConfig"""
+    litellm.drop_params = drop_params
+    config = AnthropicConfig()
+    result = config._map_stop_sequences(stop_input)
+    assert result == expected_output


### PR DESCRIPTION
… anthropic with stop sequences

## Title

Anthropic doesn't allow whitespace characters as stop-sequences. This fix expands upon a previous implementation and fully fixes the issue.

## Relevant issues

Expands upon https://github.com/BerriAI/litellm/pull/3436 and fixes https://github.com/BerriAI/litellm/issues/3286 for real.

## Type

🐛 Bug Fix

## Changes

The original fix only applied to a single newline, which didn't help when other or multiple kinds of whitespace were used. This new implementation of the old fix now covers any and all types and numbers of whitespace, solving the issue completely.