### PR TITLE
(fix) GCS bucket logger - apply `truncate_standard_logging_payload_content` to `standard_logging_payload` and ensure GCS flushes queue on fails

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -256,10 +256,6 @@ class DataDogLogger(CustomBatchLogger):
         """
         import json
 
-        from litellm.litellm_core_utils.litellm_logging import (
-            truncate_standard_logging_payload_content,
-        )
-
         standard_logging_object: Optional[StandardLoggingPayload] = kwargs.get(
             "standard_logging_object", None
         )
@@ -271,7 +267,6 @@ class DataDogLogger(CustomBatchLogger):
             status = DataDogStatus.ERROR
 
         # Build the initial payload
-        truncate_standard_logging_payload_content(standard_logging_object)
         json_payload = json.dumps(standard_logging_object, default=str)
 
         verbose_logger.debug("Datadog: Logger - Logging payload = %s", json_payload)

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -138,11 +138,11 @@ class GCSBucketLogger(GCSBucketBase):
                     logging_payload=logging_payload,
                 )
 
-            # Clear the queue after processing
-            self.log_queue.clear()
-
         except Exception as e:
             verbose_logger.exception(f"GCS Bucket batch logging error: {str(e)}")
+        finally:
+            # Clear the queue after processing
+            self.log_queue.clear()
 
     def _get_object_name(
         self, kwargs: Dict, logging_payload: StandardLoggingPayload, response_obj: Any

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 import httpx
 
 from litellm._logging import verbose_logger
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+from litellm.types.llms.openai import AllMessageValues
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3061,6 +3061,7 @@ def truncate_standard_logging_payload_content(
         verbose_logger.exception(
             "Error truncating standard logging payload - {}".format(str(e))
         )
+        return
 
 
 def _truncate_text(text: str, max_length: int) -> str:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3026,6 +3026,8 @@ def get_standard_logging_object_payload(
             ),
         )
 
+        truncate_standard_logging_payload_content(payload)
+
         return payload
     except Exception as e:
         verbose_logger.exception(
@@ -3040,19 +3042,24 @@ def truncate_standard_logging_payload_content(
     """
     Truncate error strings and message content in logging payload
 
-    Some loggers like DataDog have a limit on the size of the payload. (1MB)
+    Most logging integrations - DataDog / GCS Bucket / have a limit on the size of the payload. ~around(1MB)
 
     This function truncates the error string and the message content if they exceed a certain length.
     """
-    MAX_STR_LENGTH = 10_000
+    try:
+        MAX_STR_LENGTH = 10_000
 
-    # Truncate fields that might exceed max length
-    fields_to_truncate = ["error_str", "messages", "response"]
-    for field in fields_to_truncate:
-        _truncate_field(
-            standard_logging_object=standard_logging_object,
-            field_name=field,
-            max_length=MAX_STR_LENGTH,
+        # Truncate fields that might exceed max length
+        fields_to_truncate = ["error_str", "messages", "response"]
+        for field in fields_to_truncate:
+            _truncate_field(
+                standard_logging_object=standard_logging_object,
+                field_name=field,
+                max_length=MAX_STR_LENGTH,
+            )
+    except Exception as e:
+        verbose_logger.exception(
+            "Error truncating standard logging payload - {}".format(str(e))
         )
 
 

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -13,7 +13,7 @@ from litellm.llms.base_llm.chat.transformation import LiteLLMLoggingObj
 from litellm.llms.openai.common_utils import drop_params_from_unprocessable_entity_error
 from litellm.llms.openai.openai import OpenAIConfig
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse, ProviderField
 from litellm.utils import _add_path_to_api_base
 


### PR DESCRIPTION
## (fix) GCS bucket logger - apply `truncate_standard_logging_payload_content` to `standard_logging_payload` and ensure GCS flushes queue on fails

> sending async requests containing images.
Very quickly, the memory usage spikes up and the proxy shuts down

## Key fixes:
- use `truncate_standard_logging_payload_content` for all logging integrations. Ensures no field in `standard_logging_payload` is more than length `10_000`
- for gcs_bucket logging, clear the in-memory queue even if the current batch has a failure 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

