### PR TITLE
Prevent istio injection for db migrations cron job

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -12,7 +12,9 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: {{ .Values.migrationJob.istioInjection | quote }}
+        {{- with .Values.migrationJob.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: prisma-migrations

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -10,6 +10,9 @@ metadata:
     checksum/config: {{ toYaml .Values | sha256sum }}
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: {{ .Values.migrationJob.istioInjection | quote }}
     spec:
       containers:
         - name: prisma-migrations

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -186,7 +186,6 @@ migrationJob:
   retries: 3
   backoffLimit: 4
   disableSchemaUpdate: false
-  annotations:
-    sidecar.istio.io/inject: "false"
+  annotations: {}
 
 

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -182,9 +182,10 @@ redis:
 
 # Prisma migration job settings
 migrationJob:
-  enabled: true # Enable or disable the schema migration Job
-  retries: 3 # Number of retries for the Job in case of failure
-  backoffLimit: 4 # Backoff limit for Job restarts
-  disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.
+  enabled: true
+  retries: 3
+  backoffLimit: 4
+  disableSchemaUpdate: false
+  istioInjection: false
 
 

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -186,6 +186,7 @@ migrationJob:
   retries: 3
   backoffLimit: 4
   disableSchemaUpdate: false
-  istioInjection: false
+  annotations:
+    sidecar.istio.io/inject: "false"
 
 

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -182,10 +182,10 @@ redis:
 
 # Prisma migration job settings
 migrationJob:
-  enabled: true
-  retries: 3
-  backoffLimit: 4
-  disableSchemaUpdate: false
+  enabled: true # Enable or disable the schema migration Job
+  retries: 3 # Number of retries for the Job in case of failure
+  backoffLimit: 4 # Backoff limit for Job restarts
+  disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.
   annotations: {}
 
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Allow a way to prevent istio injection for cron jobs initialized in the helm chart. Istio containers do not exit in cron jobs, and therefore prevent the cron job pods from exiting gracefully. 

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

