### PR TITLE
(Fix) - Hashicorp secret manager -  don't print hcorp secrets in debug logs

### DIFF
--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -98,7 +98,6 @@ class HashicorpSecretManager:
 
             # For KV v2, the secret is in response.json()["data"]["data"]
             json_resp = response.json()
-            verbose_logger.debug(f"Hashicorp secret manager response: {json_resp}")
             _value = self._get_secret_value_from_json_response(json_resp)
             self.cache.set_cache(secret_name, _value)
             return _value

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -292,9 +292,6 @@ def get_secret(  # noqa: PLR0915
                 elif key_manager == KeyManagementSystem.HASHICORP_VAULT.value:
                     try:
                         secret = client.read_secret(secret_name)
-                        print_verbose(
-                            f"secret from hashicorp secret manager:  {secret}"
-                        )
                         if secret is None:
                             raise ValueError(
                                 f"No secret found in Hashicorp Secret Manager for {secret_name}"


### PR DESCRIPTION
## (Fix) - Hashicorp secret manager -  don't print hcorp secrets in debug logs

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

