### PR TITLE
(Feat) - Hashicorp secret manager, use TLS cert authentication 

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -391,6 +391,8 @@ router_settings:
 | GOOGLE_KMS_RESOURCE_NAME | Name of the resource in Google KMS
 | HF_API_BASE | Base URL for Hugging Face API
 | HCP_VAULT_ADDR | Address for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
+| HCP_VAULT_CLIENT_CERT | Path to client certificate for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
+| HCP_VAULT_CLIENT_KEY | Path to client key for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
 | HCP_VAULT_NAMESPACE | Namespace for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
 | HCP_VAULT_TOKEN | Token for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
 | HELICONE_API_KEY | API key for Helicone service

--- a/docs/my-website/docs/secret.md
+++ b/docs/my-website/docs/secret.md
@@ -246,10 +246,22 @@ Read secrets from [Hashicorp Vault](https://developer.hashicorp.com/vault/docs/s
 
 Step 1. Add Hashicorp Vault details in your environment
 
+LiteLLM supports two methods of authentication:
+
+1. TLS cert authentication - `HCP_VAULT_CLIENT_CERT` and `HCP_VAULT_CLIENT_KEY`
+2. Token authentication - `HCP_VAULT_TOKEN`
+
 ```bash
 HCP_VAULT_ADDR="https://test-cluster-public-vault-0f98180c.e98296b2.z1.hashicorp.cloud:8200"
 HCP_VAULT_NAMESPACE="admin"
+
+# Authentication via TLS cert
+HCP_VAULT_CLIENT_CERT="path/to/client.pem"
+HCP_VAULT_CLIENT_KEY="path/to/client.key"
+
+# OR - Authentication via token
 HCP_VAULT_TOKEN="hvs.CAESIG52gL6ljBSdmq*****"
+
 
 # OPTIONAL
 HCP_VAULT_REFRESH_INTERVAL="86400" # defaults to 86400, frequency of cache refresh for Hashicorp Vault

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -26,7 +26,6 @@ class HashicorpSecretManager:
 
         # Optional config for TLS cert auth
         self.tls_cert_path = os.getenv("HCP_VAULT_CLIENT_CERT", "")
-        self.tls_ca_cert_path = os.getenv("HCP_VAULT_CA_CERT", "")
         self.tls_key_path = os.getenv("HCP_VAULT_CLIENT_KEY", "")
 
         # Validate environment
@@ -87,7 +86,6 @@ class HashicorpSecretManager:
             resp = httpx.post(
                 login_url,
                 cert=(self.tls_cert_path, self.tls_key_path),
-                verify=self.tls_ca_cert_path,  # Add this line to specify CA certificate
             )
             resp.raise_for_status()
             token = resp.json()["auth"]["client_token"]

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -98,7 +98,6 @@ class HashicorpSecretManager:
 
             # For KV v2, the secret is in response.json()["data"]["data"]
             json_resp = response.json()
-            verbose_logger.debug(f"Hashicorp secret manager response: {json_resp}")
             _value = self._get_secret_value_from_json_response(json_resp)
             self.cache.set_cache(secret_name, _value)
             return _value

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -1,6 +1,8 @@
 import os
 from typing import Optional
 
+import httpx
+
 import litellm
 from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
@@ -22,6 +24,11 @@ class HashicorpSecretManager:
         # If your KV engine is mounted somewhere other than "secret", adjust here:
         self.vault_namespace = os.getenv("HCP_VAULT_NAMESPACE", None)
 
+        # Optional config for TLS cert auth
+        self.tls_cert_path = os.getenv("HCP_VAULT_CLIENT_CERT", "")
+        self.tls_ca_cert_path = os.getenv("HCP_VAULT_CA_CERT", "")
+        self.tls_key_path = os.getenv("HCP_VAULT_CLIENT_KEY", "")
+
         # Validate environment
         if not self.vault_token:
             raise ValueError(
@@ -41,12 +48,69 @@ class HashicorpSecretManager:
                 f"Hashicorp secret manager is only available for premium users. {CommonProxyErrors.not_premium_user.value}"
             )
 
+    def _auth_via_tls_cert(self) -> str:
+        """
+        Ref: https://developer.hashicorp.com/vault/api-docs/auth/cert
+
+        Request:
+        ```
+        curl \
+            --request POST \
+            --cacert vault-ca.pem \
+            --cert cert.pem \
+            --key key.pem \
+            --data @payload.json \
+            https://127.0.0.1:8200/v1/auth/cert/login
+
+        ```
+
+        Response:
+        ```
+        {
+            "auth": {
+                "client_token": "cf95f87d-f95b-47ff-b1f5-ba7bff850425",
+                "policies": ["web", "stage"],
+                "lease_duration": 3600,
+                "renewable": true
+            }
+        }
+
+        ```
+        """
+        verbose_logger.debug("Using TLS cert auth for Hashicorp Vault")
+
+        # Vault endpoint for cert-based login, e.g. '/v1/auth/cert/login'
+        login_url = f"{self.vault_addr}/v1/auth/cert/login"
+
+        try:
+            # We use the client cert and key for mutual TLS
+            resp = httpx.post(
+                login_url,
+                cert=(self.tls_cert_path, self.tls_key_path),
+                verify=self.tls_ca_cert_path,  # Add this line to specify CA certificate
+            )
+            resp.raise_for_status()
+            token = resp.json()["auth"]["client_token"]
+            _lease_duration = resp.json()["auth"]["lease_duration"]
+            verbose_logger.info("Successfully obtained Vault token via TLS cert auth.")
+            self.cache.set_cache(
+                key="hcp_vault_token", value=token, ttl=_lease_duration
+            )
+            return token
+        except Exception as e:
+            raise RuntimeError(f"Could not authenticate to Vault via TLS cert: {e}")
+
     def get_url(self, secret_name: str) -> str:
         _url = f"{self.vault_addr}/v1/"
         if self.vault_namespace:
             _url += f"{self.vault_namespace}/"
         _url += f"secret/data/{secret_name}"
         return _url
+
+    def _get_request_headers(self) -> dict:
+        if self.tls_cert_path and self.tls_key_path:
+            return {"X-Vault-Token": self._auth_via_tls_cert()}
+        return {"X-Vault-Token": self.vault_token}
 
     async def async_read_secret(self, secret_name: str) -> Optional[str]:
         """
@@ -65,9 +129,7 @@ class HashicorpSecretManager:
             _url = self.get_url(secret_name)
             url = _url
 
-            response = await async_client.get(
-                url, headers={"X-Vault-Token": self.vault_token}
-            )
+            response = await async_client.get(url, headers=self._get_request_headers())
             response.raise_for_status()
 
             # For KV v2, the secret is in response.json()["data"]["data"]
@@ -93,7 +155,7 @@ class HashicorpSecretManager:
             # For KV v2: /v1/<mount>/data/<path>
             url = self.get_url(secret_name)
 
-            response = sync_client.get(url, headers={"X-Vault-Token": self.vault_token})
+            response = sync_client.get(url, headers=self._get_request_headers())
             response.raise_for_status()
 
             # For KV v2, the secret is in response.json()["data"]["data"]

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -292,9 +292,6 @@ def get_secret(  # noqa: PLR0915
                 elif key_manager == KeyManagementSystem.HASHICORP_VAULT.value:
                     try:
                         secret = client.read_secret(secret_name)
-                        print_verbose(
-                            f"secret from hashicorp secret manager:  {secret}"
-                        )
                         if secret is None:
                             raise ValueError(
                                 f"No secret found in Hashicorp Secret Manager for {secret_name}"


### PR DESCRIPTION
## (Feat) - Hashicorp secret manager, use TLS cert authentication 

Use TLS cert auth for Hashicorp 


## Hashicorp Vault

Read secrets from [Hashicorp Vault](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)

Step 1. Add Hashicorp Vault details in your environment

LiteLLM supports two methods of authentication:

1. TLS cert authentication - `HCP_VAULT_CLIENT_CERT` and `HCP_VAULT_CLIENT_KEY`
2. Token authentication - `HCP_VAULT_TOKEN`

```bash
HCP_VAULT_ADDR="https://test-cluster-public-vault-0f98180c.e98296b2.z1.hashicorp.cloud:8200"
HCP_VAULT_NAMESPACE="admin"

# Authentication via TLS cert
HCP_VAULT_CLIENT_CERT="path/to/client.pem"
HCP_VAULT_CLIENT_KEY="path/to/client.key"

# OR - Authentication via token
HCP_VAULT_TOKEN="hvs.CAESIG52gL6ljBSdmq*****"


# OPTIONAL
HCP_VAULT_REFRESH_INTERVAL="86400" # defaults to 86400, frequency of cache refresh for Hashicorp Vault
```

Step 2. Add to proxy config.yaml

```yaml
general_settings:
  key_management_system: "hashicorp_vault"
```

Step 3. Start + test proxy

```
$ litellm --config /path/to/config.yaml
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

