### PR TITLE
feat: implement support for limit, order, before, and after parameters in get_assistants

### DIFF
--- a/litellm/assistants/main.py
+++ b/litellm/assistants/main.py
@@ -131,6 +131,10 @@ def get_assistants(
             timeout=timeout,
             max_retries=optional_params.max_retries,
             organization=organization,
+            order=getattr(optional_params, "order", "desc"),
+            limit=getattr(optional_params, "limit", 20),
+            before=getattr(optional_params, "before", None),
+            after=getattr(optional_params, "after", None),
             client=client,
             aget_assistants=aget_assistants,  # type: ignore
         )  # type: ignore

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1928,6 +1928,10 @@ class OpenAIAssistantsAPI(BaseLLM):
         max_retries: Optional[int],
         organization: Optional[str],
         client: Optional[AsyncOpenAI],
+        order: Optional[str] = 'desc',
+        limit: Optional[int] = 20,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
     ) -> AsyncCursorPage[Assistant]:
         openai_client = self.async_get_openai_client(
             api_key=api_key,
@@ -1937,8 +1941,16 @@ class OpenAIAssistantsAPI(BaseLLM):
             organization=organization,
             client=client,
         )
-
-        response = await openai_client.beta.assistants.list()
+        request_params = {
+            "order": order,
+            "limit": limit,
+        }
+        if before:
+            request_params["before"] = before
+        if after:
+            request_params["after"] = after
+            
+        response = await openai_client.beta.assistants.list(**request_params)
 
         return response
 
@@ -1953,7 +1965,11 @@ class OpenAIAssistantsAPI(BaseLLM):
         max_retries: Optional[int],
         organization: Optional[str],
         client: Optional[AsyncOpenAI],
-        aget_assistants: Literal[True], 
+        aget_assistants: Literal[True],
+        order: Optional[str] = 'desc',
+        limit: Optional[int] = 20,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
     ) -> Coroutine[None, None, AsyncCursorPage[Assistant]]:
         ...
 
@@ -1966,7 +1982,11 @@ class OpenAIAssistantsAPI(BaseLLM):
         max_retries: Optional[int],
         organization: Optional[str],
         client: Optional[OpenAI],
-        aget_assistants: Optional[Literal[False]], 
+        aget_assistants: Optional[Literal[False]],
+        order: Optional[str] = 'desc',
+        limit: Optional[int] = 20,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
     ) -> SyncCursorPage[Assistant]: 
         ...
 
@@ -1981,6 +2001,10 @@ class OpenAIAssistantsAPI(BaseLLM):
         organization: Optional[str],
         client=None,
         aget_assistants=None,
+        order: Optional[str] = 'desc',
+        limit: Optional[int] = 20,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
     ):
         if aget_assistants is not None and aget_assistants is True:
             return self.async_get_assistants(
@@ -1990,6 +2014,10 @@ class OpenAIAssistantsAPI(BaseLLM):
                 max_retries=max_retries,
                 organization=organization,
                 client=client,
+                order=order,
+                limit=limit,
+                before=before,
+                after=after,
             )
         openai_client = self.get_openai_client(
             api_key=api_key,
@@ -2000,7 +2028,18 @@ class OpenAIAssistantsAPI(BaseLLM):
             client=client,
         )
 
-        response = openai_client.beta.assistants.list()
+        request_params = {
+            "order": order,
+            "limit": limit,
+        }
+
+        if before:
+            request_params["before"] = before
+        if after:
+            request_params["after"] = after
+
+
+        response = openai_client.beta.assistants.list(**request_params)
 
         return response
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4430,6 +4430,10 @@ async def get_assistants(
     request: Request,
     fastapi_response: Response,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    order: Optional[str] = Query(None, description="Sort order by the created_at timestamp of the objects. asc for ascending order and desc for descending order."),
+    limit: Optional[int] = Query(None, description="A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 20."),
+    after: Optional[str] = Query(None, description="A cursor for use in pagination. after is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include after=obj_foo in order to fetch the next page of the list."),
+    before: Optional[str] = Query(None, description="A cursor for use in pagination. before is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with obj_foo, your subsequent call can include before=obj_foo in order to fetch the previous page of the list."),
 ):
     """
     Returns a list of assistants.
@@ -4451,6 +4455,28 @@ async def get_assistants(
             version=version,
             proxy_config=proxy_config,
         )
+
+        # Validate `order` parameter
+        if order and order not in ["asc", "desc"]:
+            raise HTTPException(
+                status_code=400, detail={"error": "order must be 'asc' or 'desc'"}
+            )
+        if order:
+            data["order"] = order
+
+        # Validate `limit` parameter
+        if limit is not None:
+            if not (1 <= limit <= 100):
+                raise HTTPException(
+                    status_code=400, detail={"error": "limit must be between 1 and 100"}
+                )
+            data["limit"] = limit
+
+        # Add pagination cursors if provided
+        if after:
+            data["after"] = after
+        if before:
+            data["before"] = before
 
         # for now use custom_llm_provider=="openai" -> this will change as LiteLLM adds more providers for acreate_batch
         if llm_router is None:


### PR DESCRIPTION
## Title
Implement support for limit, order, before, and after parameters in get_assistants
https://platform.openai.com/docs/api-reference/assistants/listAssistants

## Relevant issues
Fixes #6530

## Type
🆕 New Feature

## Changes

- Added support for limit and order parameters to allow control over the number of results and sorting direction (asc or desc).
- Added support for before and after parameters to enable cursor-based pagination.
- Ensured the API request now respects these parameters instead of returning a default of 20 items with no ordering.



## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
### Test case code:
```python
import requests

def fetch_assistants(order=None, limit=None, before=None, after=None):
    url = "http://0.0.0.0:4000/v1/assistants"
    headers = {
        "Content-Type": "application/json",
        "Authorization": "Bearer jean@123"
    }
    
    # Add only non-None parameters to the request
    params = {
        "order": order,
        "limit": limit,
        "before": before,
        "after": after,
    }
    params = {k: v for k, v in params.items() if v is not None}  # Remove None values
    
    print(f"Testing with parameters: {params}")
    
    try:
        response = requests.get(url, headers=headers, params=params)
        response.raise_for_status()  # Raise an exception for HTTP errors
        data = response.json()
        
        if "data" in data:
            assistants = data["data"]
            print(f"Returned count: {len(assistants)}")
            
            for assistant in assistants:
                name = assistant.get("name", "No Name")
                id_ = assistant.get("id", "No ID")
                print(f"Name: {name}, ID: {id_}")
        else:
            print("Unexpected API response:", data)
    
    except requests.exceptions.RequestException as e:
        print("Error while making the request:", e)

if __name__ == "__main__":
    test_cases = [
        {},  # Test case with no parameters
        {"order": "asc", "limit": 2, "before": None, "after": None},
        {"order": "desc", "limit": 5, "before": None, "after": None},
        {"order": "asc", "limit": 4, "before": "asst_6PDftNbL9gprW8L14alVevU0", "after": None},  # Go Tutor
        {"order": "desc", "limit": 10, "before": None, "after": "asst_WCpsnvu6HQqxD1UalzC40aUG"},  # SQL Tutor
        {"order": "asc", "limit": 2, "before": "asst_eKTpuDe5OOxejJam1CD4sJzr", "after": None},  # Biology Tutor
        {"order": "desc", "limit": 1, "before": None, "after": "asst_DRs7oh2tYEcmcr4SG9tHqkys"},  # Game Code Tutor
    ]

    for case in test_cases:
        fetch_assistants(**case)
        print("-" * 50)
```
### Results:
```sh
myenv) jeansouza@Jeans-Laptop test-litellm % python3 curl-assistant-api.py
Testing with parameters: {}
Returned count: 20
Name: Git Tutor, ID: asst_WAW8Cjt331mqTRwFT48aMbzr
Name: C Tutor, ID: asst_hTePoqSkgPTN1JUZj2o3hJzZ
Name: Go Tutor, ID: asst_6PDftNbL9gprW8L14alVevU0
Name: Java Tutor, ID: asst_dysBers4SBpp9T7lljIuaulH
Name: SQL Tutor, ID: asst_WCpsnvu6HQqxD1UalzC40aUG
Name: C# Tutor, ID: asst_N2IeW4pFamLHwSJriHyhDst3
Name: Angular Tutor, ID: asst_HK26MolragMP8x5sksSYdgyK
Name: VueJS Tutor, ID: asst_IAcjTnbBFotMbXFO9rp0EEba
Name: JavaScript Tutor, ID: asst_f5dCwR2zvctcfTAjVmyLV6Xe
Name: PHP Tutor, ID: asst_2xrvm7jGTWeOchbW8StMRcxt
Name: Lua Tutor, ID: asst_okxVum8b4z6LGGPURsHTHgoV
Name: C++ Tutor, ID: asst_vnpwQtcAROXB7cewGPoagcjw
Name: Game code Tutor, ID: asst_DRs7oh2tYEcmcr4SG9tHqkys
Name: Sociology Tutor, ID: asst_1HqXedKRd6dHJlYXjIPQeJwb
Name: Psicology Tutor, ID: asst_38UQ7Q4NKJfbrN9UDDkJ7Cnx
Name: Biology Tutor, ID: asst_eKTpuDe5OOxejJam1CD4sJzr
Name: Computer Science Tutor, ID: asst_K4MIvzlZgHUvwLwpNcqJTil3
Name: English Tutor, ID: asst_VBMZE4TZ41whZGEDuoNYDGeA
Name: Polish Tutor, ID: asst_BD9LdbZQWCOiKtL4irS11IJm
Name: Germany Tutor, ID: asst_jpb3YhQuFZovPUSIfHItTDCD
--------------------------------------------------
Testing with parameters: {'order': 'asc', 'limit': 2}
Returned count: 2
Name: Math Tutor, ID: asst_XjFYvqpVFyAsdWmtdIkygdAJ
Name: Portuguese Tutor, ID: asst_WdYY4vi1v62Wra6zEX9aBXBX
--------------------------------------------------
Testing with parameters: {'order': 'desc', 'limit': 5}
Returned count: 5
Name: Git Tutor, ID: asst_WAW8Cjt331mqTRwFT48aMbzr
Name: C Tutor, ID: asst_hTePoqSkgPTN1JUZj2o3hJzZ
Name: Go Tutor, ID: asst_6PDftNbL9gprW8L14alVevU0
Name: Java Tutor, ID: asst_dysBers4SBpp9T7lljIuaulH
Name: SQL Tutor, ID: asst_WCpsnvu6HQqxD1UalzC40aUG
--------------------------------------------------
Testing with parameters: {'order': 'asc', 'limit': 4, 'before': 'asst_6PDftNbL9gprW8L14alVevU0'}
Returned count: 4
Name: Math Tutor, ID: asst_XjFYvqpVFyAsdWmtdIkygdAJ
Name: Portuguese Tutor, ID: asst_WdYY4vi1v62Wra6zEX9aBXBX
Name: Germany Tutor, ID: asst_jpb3YhQuFZovPUSIfHItTDCD
Name: Polish Tutor, ID: asst_BD9LdbZQWCOiKtL4irS11IJm
--------------------------------------------------
Testing with parameters: {'order': 'desc', 'limit': 10, 'after': 'asst_WCpsnvu6HQqxD1UalzC40aUG'}
Returned count: 10
Name: C# Tutor, ID: asst_N2IeW4pFamLHwSJriHyhDst3
Name: Angular Tutor, ID: asst_HK26MolragMP8x5sksSYdgyK
Name: VueJS Tutor, ID: asst_IAcjTnbBFotMbXFO9rp0EEba
Name: JavaScript Tutor, ID: asst_f5dCwR2zvctcfTAjVmyLV6Xe
Name: PHP Tutor, ID: asst_2xrvm7jGTWeOchbW8StMRcxt
Name: Lua Tutor, ID: asst_okxVum8b4z6LGGPURsHTHgoV
Name: C++ Tutor, ID: asst_vnpwQtcAROXB7cewGPoagcjw
Name: Game code Tutor, ID: asst_DRs7oh2tYEcmcr4SG9tHqkys
Name: Sociology Tutor, ID: asst_1HqXedKRd6dHJlYXjIPQeJwb
Name: Psicology Tutor, ID: asst_38UQ7Q4NKJfbrN9UDDkJ7Cnx
--------------------------------------------------
Testing with parameters: {'order': 'asc', 'limit': 2, 'before': 'asst_eKTpuDe5OOxejJam1CD4sJzr'}
Returned count: 2
Name: Math Tutor, ID: asst_XjFYvqpVFyAsdWmtdIkygdAJ
Name: Portuguese Tutor, ID: asst_WdYY4vi1v62Wra6zEX9aBXBX
--------------------------------------------------
Testing with parameters: {'order': 'desc', 'limit': 1, 'after': 'asst_DRs7oh2tYEcmcr4SG9tHqkys'}
Returned count: 1
Name: Sociology Tutor, ID: asst_1HqXedKRd6dHJlYXjIPQeJwb
--------------------------------------------------
```

1. Limit and Order Functionality:

- Perform an API request with limit=10 and verify that exactly 10 results are returned.
- Perform an API request with order=asc and desc and validate that the results are sorted correctly by creation timestamp.

2. Pagination Parameters (before, after)

- Perform an API request with after=obj_foo and ensure that the results start after obj_foo.
- Perform an API request with before=obj_bar and ensure that the results end before obj_bar.

3. Default Behavior:

- Perform an API request without limit, order, before, and after and ensure it defaults to 20 items with descending order.