### PR TITLE
(Fix) - Slack Alerting , don't send duplicate spend report when used on multi instance settings 

### DIFF
--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -925,3 +925,59 @@ async def test_print_alerting_payload_warning():
     # Clean up
     verbose_proxy_logger.removeHandler(handler)
     log_stream.close()
+
+
+@pytest.mark.parametrize("report_type", ["weekly", "monthly"])
+@pytest.mark.asyncio
+async def test_spend_report_cache(report_type):
+    """
+    Test that spend reports are only sent once within their period
+    """
+    # Mock prisma client response
+    mock_spend_data = [
+        {"team_alias": "team1", "total_spend": 100.0},
+        {"team_alias": "team2", "total_spend": 200.0},
+    ]
+
+    mock_tag_data = [
+        {"individual_request_tag": "tag1", "total_spend": 150.0},
+        {"individual_request_tag": "tag2", "total_spend": 150.0},
+    ]
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+        # Setup mock for database query
+        mock_prisma.db.query_raw = AsyncMock(
+            side_effect=[mock_spend_data, mock_tag_data]
+        )
+
+        slack_alerting = SlackAlerting(
+            alerting=["webhook"], internal_usage_cache=DualCache()
+        )
+
+        user_info = CallInfo(
+            token="test_token",
+            spend=100,
+            max_budget=1000,
+            user_id="test@test.com",
+            user_email="test@test.com",
+            key_alias="test-key",
+        )
+
+        with patch.object(
+            slack_alerting, "send_alert", new=AsyncMock()
+        ) as mock_send_alert:
+            # First call should send alert
+            if report_type == "weekly":
+                await slack_alerting.send_weekly_spend_report()
+            else:
+                await slack_alerting.send_monthly_spend_report()
+
+            mock_send_alert.assert_called_once()
+            mock_send_alert.reset_mock()
+
+            # Second call should not send alert (cached)
+            if report_type == "weekly":
+                await slack_alerting.send_weekly_spend_report()
+            else:
+                await slack_alerting.send_monthly_spend_report()
+            mock_send_alert.assert_not_called()


### PR DESCRIPTION
## (Fix) - Slack Alerting , don't send duplicate spend report when used on multi instance settings 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

