### PR TITLE
(Feat) - allow including dd-trace in litellm base image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
+ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
+ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,10 +67,11 @@ RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl 
 # Generate prisma client
 RUN prisma generate
 RUN chmod +x docker/entrypoint.sh
+RUN chmod +x docker/prod_entrypoint.sh
 
 EXPOSE 4000/tcp
 
-ENTRYPOINT ["litellm"]
+ENTRYPOINT ["docker/prod_entrypoint.sh"]
 
 # Append "--detailed_debug" to the end of CMD to view detailed debug logs 
 CMD ["--port", "4000"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -48,8 +48,11 @@ COPY --from=builder /wheels/ /wheels/
 # Install the built wheel using pip; again using a wildcard if it's the only file
 RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl && rm -rf /wheels
 
+RUN chmod +x docker/entrypoint.sh
+RUN chmod +x docker/prod_entrypoint.sh
+
 EXPOSE 4000/tcp
 
 # Set your entrypoint and command
-ENTRYPOINT ["litellm"]
+ENTRYPOINT ["docker/prod_entrypoint.sh"]
 CMD ["--port", "4000"]

--- a/docker/Dockerfile.custom_ui
+++ b/docker/Dockerfile.custom_ui
@@ -33,6 +33,7 @@ WORKDIR /app
 
 # Make sure your docker/entrypoint.sh is executable
 RUN chmod +x docker/entrypoint.sh
+RUN chmod +x docker/prod_entrypoint.sh
 
 # Expose the necessary port
 EXPOSE 4000/tcp

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
+ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -67,12 +67,12 @@ RUN chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh
 # Generate prisma client
 RUN prisma generate
 RUN chmod +x docker/entrypoint.sh
-
+RUN chmod +x docker/prod_entrypoint.sh
 EXPOSE 4000/tcp
 
 # # Set your entrypoint and command
 
-ENTRYPOINT ["litellm"]
+ENTRYPOINT ["docker/prod_entrypoint.sh"]
 
 # Append "--detailed_debug" to the end of CMD to view detailed debug logs 
 # CMD ["--port", "4000", "--detailed_debug"]

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
+ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -71,13 +71,15 @@ RUN chmod -R 777 /.cache
 RUN pip install nodejs-bin
 RUN pip install prisma
 RUN prisma generate
+
 RUN chmod +x docker/entrypoint.sh
+RUN chmod +x docker/prod_entrypoint.sh
 
 EXPOSE 4000/tcp
 
 # # Set your entrypoint and command
 
-ENTRYPOINT ["litellm"]
+ENTRYPOINT ["docker/prod_entrypoint.sh"]
 
 # Append "--detailed_debug" to the end of CMD to view detailed debug logs 
 # CMD ["--port", "4000", "--detailed_debug"]

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
+ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -1,8 +1,8 @@
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=python:3.12.8-slim
+ARG LITELLM_BUILD_IMAGE=python:3.13.1-slim
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=python:3.12.8-slim
+ARG LITELLM_RUNTIME_IMAGE=python:3.13.1-slim
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
 

--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$USE_DDTRACE" = "true" ]; then
+    exec ddtrace-run litellm "$@"
+else
+    exec litellm "$@"
+fi

--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1070,6 +1070,7 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 LiteLLM Supports logging to the following Datdog Integrations:
 - `datadog` [Datadog Logs](https://docs.datadoghq.com/logs/)
 - `datadog_llm_observability` [Datadog LLM Observability](https://www.datadoghq.com/product/llm-observability/)
+- `ddtrace-run` [Datadog Tracing](#datadog-tracing)
 
 <Tabs>
 <TabItem value="datadog" label="Datadog Logs">
@@ -1141,6 +1142,21 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 Expected output on Datadog
 
 <Image img={require('../../img/dd_small1.png')} />
+
+#### Datadog Tracing
+
+Use `ddtrace-run` to enable [Datadog Tracing](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html) on litellm proxy
+
+Pass `USE_DDTRACE=true` to the docker run command. When `USE_DDTRACE=true`, the proxy will run `ddtrace-run litellm` as the `ENTRYPOINT` instead of just `litellm`
+
+```bash
+docker run \
+    -v $(pwd)/litellm_config.yaml:/app/config.yaml \
+    -e USE_DDTRACE=true \
+    -p 4000:4000 \
+    ghcr.io/berriai/litellm:main-latest \
+    --config /app/config.yaml --detailed_debug
+```
 
 ### Set DD variables (`DD_SERVICE` etc)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
 langfuse==2.45.0 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
+ddtrace==2.18.1           # for advanced DD tracing / profiling
 orjson==3.10.12 # fast /embedding responses
 apscheduler==3.10.4 # for resetting budget in background 
 fastapi-sso==0.16.0 # admin UI, SSO

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
 langfuse==2.45.0 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
-ddtrace==2.18.1           # for advanced DD tracing / profiling
+ddtrace==2.19.0rc1       # for advanced DD tracing / profiling
 orjson==3.10.12 # fast /embedding responses
 apscheduler==3.10.4 # for resetting budget in background 
 fastapi-sso==0.16.0 # admin UI, SSO


### PR DESCRIPTION
## (Feat) - allow including dd-trace in litellm base image 

Adds support for using `ddtrace-run` 


#### Datadog Tracing

Use `ddtrace-run` to enable [Datadog Tracing](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html) on litellm proxy

Pass `USE_DDTRACE=true` to the docker run command. When `USE_DDTRACE=true`, the proxy will run `ddtrace-run litellm` as the `ENTRYPOINT` instead of just `litellm`

```bash
docker run \
    -v $(pwd)/litellm_config.yaml:/app/config.yaml \
    -e USE_DDTRACE=true \
    -p 4000:4000 \
    ghcr.io/berriai/litellm:main-latest \
    --config /app/config.yaml --detailed_debug
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

