### PR TITLE
feat: offline support for tiktoken

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -35,6 +35,10 @@ RUN pip install dist/*.whl
 # install dependencies as wheels
 RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 
+# Download tiktoken for offline usage of image, see https://stackoverflow.com/a/76107077. Let tiktoken itself download the file, to ensure correct naming
+ENV TIKTOKEN_CACHE_DIR="/tiktoken"
+RUN mkdir /tiktoken && python -c "import tiktoken; tiktoken.get_encoding('cl100k_base'); print('tiktoken imported successfully')" 
+
 # Runtime stage
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
@@ -49,6 +53,10 @@ RUN ls -la /app
 # Copy the built wheel from the builder stage to the runtime stage; assumes only one wheel file is present
 COPY --from=builder /app/dist/*.whl .
 COPY --from=builder /wheels/ /wheels/
+
+# Copy tiktoken from build stage, and set env variable to stop tiktoken from downloading file
+COPY --from=builder /tiktoken /tiktoken
+ENV CUSTOM_TIKTOKEN_CACHE_DIR="/tiktoken"
 
 # Install the built wheel using pip; again using a wildcard if it's the only file
 RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ && rm -f *.whl && rm -rf /wheels

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -560,9 +560,9 @@ ghcr.io/berriai/litellm-database:main-latest --config your_config.yaml
 
 ## LiteLLM without Internet Connection
 
-By default `prisma generate` downloads [prisma's engine binaries](https://www.prisma.io/docs/orm/reference/environment-variables-reference#custom-engine-file-locations). This might cause errors when running without internet connection. 
+By default `prisma generate` downloads [prisma's engine binaries](https://www.prisma.io/docs/orm/reference/environment-variables-reference#custom-engine-file-locations). LiteLLM also uses `tiktoken` for tracking the number of tokens in a given user input (for openai models). This might cause errors when running without internet connection.
 
-Use this docker image to deploy litellm with pre-generated prisma binaries.
+Use this docker image to deploy litellm with pre-generated prisma binaries, and pre-downloaded tiktoken tokenizer files.
 
 ```bash
 docker pull ghcr.io/berriai/litellm-non_root:main-stable


### PR DESCRIPTION
## Title

Implement pre-download of tiktoken tokenizer file for the non_root offline image

## Relevant issues

N/A

## Type

🆕 New Feature

## Changes

* In Dockerfile.non_root, invoke tiktoken with custom cache dir specified to download during build.
* Set the `CUSTOM_TIKTOKEN_CACHE_DIR` environment value in the final image so litellm will set the correct offline cache dir
* Update documentation for offline deployment to mention this change

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Tested by running openai / non recognized model, which defaults to tiktoken

## Future work

Pre-download llama-2 and llama-3 tokenizers. Cohere and Anthropic ones are probably not required, as these are not available for self hosting without internet connection anyways.
