### PR TITLE
`aiohttp_openai/` fixes - allow using `aiohttp_openai/gpt-4o` 

### DIFF
--- a/litellm/llms/aiohttp_openai/chat/transformation.py
+++ b/litellm/llms/aiohttp_openai/chat/transformation.py
@@ -9,7 +9,7 @@ New config to ensure we introduce this without causing breaking changes for user
 
 from typing import TYPE_CHECKING, Any, List, Optional
 
-import httpx
+from aiohttp import ClientResponse
 
 from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
 from litellm.types.llms.openai import AllMessageValues
@@ -51,10 +51,10 @@ class AiohttpOpenAIChatConfig(OpenAILikeChatConfig):
     ) -> dict:
         return {"Authorization": f"Bearer {api_key}"}
 
-    def transform_response(
+    async def transform_response(  # type: ignore
         self,
         model: str,
-        raw_response: httpx.Response,
+        raw_response: ClientResponse,
         model_response: ModelResponse,
         logging_obj: LiteLLMLoggingObj,
         request_data: dict,
@@ -65,4 +65,5 @@ class AiohttpOpenAIChatConfig(OpenAILikeChatConfig):
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
     ) -> ModelResponse:
-        return ModelResponse(**raw_response.json())
+        _json_response = await raw_response.json()
+        return ModelResponse(**_json_response)

--- a/litellm/llms/aiohttp_openai/chat/transformation.py
+++ b/litellm/llms/aiohttp_openai/chat/transformation.py
@@ -24,6 +24,22 @@ else:
 
 
 class AiohttpOpenAIChatConfig(OpenAILikeChatConfig):
+    def get_complete_url(
+        self,
+        api_base: str,
+        model: str,
+        optional_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        """
+        Ensure - /v1/chat/completions is at the end of the url
+
+        """
+
+        if not api_base.endswith("/chat/completions"):
+            api_base += "/chat/completions"
+        return api_base
+
     def validate_environment(
         self,
         headers: dict,
@@ -33,7 +49,7 @@ class AiohttpOpenAIChatConfig(OpenAILikeChatConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        return {}
+        return {"Authorization": f"Bearer {api_key}"}
 
     def transform_response(
         self,

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -172,9 +172,19 @@ class BaseLLMAIOHTTPHandler:
             litellm_params=litellm_params,
             stream=False,
         )
-        _json_response = await _response.json()
-
-        return _json_response
+        _transformed_response = await provider_config.transform_response(  # type: ignore
+            model=model,
+            raw_response=_response,  # type: ignore
+            model_response=model_response,
+            logging_obj=logging_obj,
+            api_key=api_key,
+            request_data=data,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            encoding=encoding,
+        )
+        return _transformed_response
 
     def completion(
         self,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1482,6 +1482,43 @@ def completion(  # type: ignore # noqa: PLR0915
                 custom_llm_provider=custom_llm_provider,
                 encoding=encoding,
             )
+        elif custom_llm_provider == "aiohttp_openai":
+            # NEW aiohttp provider for 10-100x higher RPS
+            api_base = (
+                api_base  # for deepinfra/perplexity/anyscale/groq/friendliai we check in get_llm_provider and pass in the api base from there
+                or litellm.api_base
+                or get_secret("OPENAI_API_BASE")
+                or "https://api.openai.com/v1"
+            )
+            # set API KEY
+            api_key = (
+                api_key
+                or litellm.api_key  # for deepinfra/perplexity/anyscale/friendliai we check in get_llm_provider and pass in the api key from there
+                or litellm.openai_key
+                or get_secret("OPENAI_API_KEY")
+            )
+
+            headers = headers or litellm.headers
+
+            if extra_headers is not None:
+                optional_params["extra_headers"] = extra_headers
+            response = base_llm_aiohttp_handler.completion(
+                model=model,
+                messages=messages,
+                headers=headers,
+                model_response=model_response,
+                api_key=api_key,
+                api_base=api_base,
+                acompletion=acompletion,
+                logging_obj=logging,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+                timeout=timeout,
+                client=client,
+                custom_llm_provider=custom_llm_provider,
+                encoding=encoding,
+                stream=stream,
+            )
         elif (
             model in litellm.open_ai_chat_completion_models
             or custom_llm_provider == "custom_openai"
@@ -2806,42 +2843,6 @@ def completion(  # type: ignore # noqa: PLR0915
                 )
                 return response
             response = model_response
-        elif custom_llm_provider == "aiohttp_openai":
-            api_base = (
-                api_base  # for deepinfra/perplexity/anyscale/groq/friendliai we check in get_llm_provider and pass in the api base from there
-                or litellm.api_base
-                or get_secret("OPENAI_API_BASE")
-                or "https://api.openai.com/v1"
-            )
-            # set API KEY
-            api_key = (
-                api_key
-                or litellm.api_key  # for deepinfra/perplexity/anyscale/friendliai we check in get_llm_provider and pass in the api key from there
-                or litellm.openai_key
-                or get_secret("OPENAI_API_KEY")
-            )
-
-            headers = headers or litellm.headers
-
-            if extra_headers is not None:
-                optional_params["extra_headers"] = extra_headers
-            response = base_llm_aiohttp_handler.completion(
-                model=model,
-                messages=messages,
-                headers=headers,
-                model_response=model_response,
-                api_key=api_key,
-                api_base=api_base,
-                acompletion=acompletion,
-                logging_obj=logging,
-                optional_params=optional_params,
-                litellm_params=litellm_params,
-                timeout=timeout,
-                client=client,
-                custom_llm_provider=custom_llm_provider,
-                encoding=encoding,
-                stream=stream,
-            )
         elif custom_llm_provider == "custom":
             url = litellm.api_base or api_base or ""
             if url is None or url == "":

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7656,6 +7656,22 @@
         "litellm_provider": "voyage",
         "mode": "embedding"
     },
+    "voyage/voyage-finance-2": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
+        "input_cost_per_token": 0.00000012,
+        "output_cost_per_token": 0.000000,
+        "litellm_provider": "voyage",
+        "mode": "embedding"
+    },
+    "voyage/voyage-lite-02-instruct": {
+        "max_tokens": 4000,
+        "max_input_tokens": 4000,
+        "input_cost_per_token": 0.0000001,
+        "output_cost_per_token": 0.000000,
+        "litellm_provider": "voyage",
+        "mode": "embedding"
+    },
     "voyage/voyage-law-2": {
         "max_tokens": 16000,
         "max_input_tokens": 16000,
@@ -7680,21 +7696,67 @@
         "litellm_provider": "voyage",
         "mode": "embedding"
     },
-    "voyage/voyage-lite-02-instruct": {
-        "max_tokens": 4000,
-        "max_input_tokens": 4000,
-        "input_cost_per_token": 0.0000001,
+    "voyage/voyage-3-large": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
+        "input_cost_per_token": 0.00000018,
         "output_cost_per_token": 0.000000,
         "litellm_provider": "voyage",
         "mode": "embedding"
     },
-    "voyage/voyage-finance-2": {
-        "max_tokens": 4000,
-        "max_input_tokens": 4000,
+    "voyage/voyage-3": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
+        "input_cost_per_token": 0.00000006,
+        "output_cost_per_token": 0.000000,
+        "litellm_provider": "voyage",
+        "mode": "embedding"
+    },
+    "voyage/voyage-3-lite": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
+        "input_cost_per_token": 0.00000002,
+        "output_cost_per_token": 0.000000,
+        "litellm_provider": "voyage",
+        "mode": "embedding"
+    },
+    "voyage/voyage-code-3": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
+        "input_cost_per_token": 0.00000018,
+        "output_cost_per_token": 0.000000,
+        "litellm_provider": "voyage",
+        "mode": "embedding"
+    },
+    "voyage/voyage-multimodal-3": {
+        "max_tokens": 32000,
+        "max_input_tokens": 32000,
         "input_cost_per_token": 0.00000012,
         "output_cost_per_token": 0.000000,
         "litellm_provider": "voyage",
         "mode": "embedding"
+    },
+    "voyage/rerank-2": {
+        "max_tokens": 16000,
+        "max_input_tokens": 16000,
+        "max_output_tokens": 16000,
+        "max_query_tokens": 16000,
+        "input_cost_per_token": 0.00000005,
+        "input_cost_per_query": 0.00000005,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "mode": "rerank"
+    },
+    "voyage/rerank-2-lite": {
+        "max_tokens": 8000,
+        "max_input_tokens": 8000,
+        "max_output_tokens": 8000,
+        "max_query_tokens": 8000,
+        "input_cost_per_token": 0.00000002,
+        "input_cost_per_query": 0.00000002,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "voyage",
+        "mode": "rerank"
     },
     "databricks/databricks-meta-llama-3-1-405b-instruct": {
         "max_tokens": 128000,

--- a/tests/llm_translation/test_aiohttp_openai.py
+++ b/tests/llm_translation/test_aiohttp_openai.py
@@ -11,7 +11,7 @@ sys.path.insert(
 import litellm
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_aiohttp_openai():
     litellm.set_verbose = True
     response = await litellm.acompletion(
@@ -23,7 +23,7 @@ async def test_aiohttp_openai():
     print(response)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_aiohttp_openai_gpt_4o():
     litellm.set_verbose = True
     response = await litellm.acompletion(

--- a/tests/llm_translation/test_aiohttp_openai.py
+++ b/tests/llm_translation/test_aiohttp_openai.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../")
-)  # Adds the parent directory to the system path
+)  # Adds the parent directory to the system-path
 
 import litellm
 

--- a/tests/llm_translation/test_aiohttp_openai.py
+++ b/tests/llm_translation/test_aiohttp_openai.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(
     0, os.path.abspath("../../")
-)  # Adds the parent directory to the system-path
+)  # Adds the parent directory to the system path
 
 import litellm
 

--- a/tests/llm_translation/test_aiohttp_openai.py
+++ b/tests/llm_translation/test_aiohttp_openai.py
@@ -21,3 +21,13 @@ async def test_aiohttp_openai():
         api_key="fake-key",
     )
     print(response)
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_openai_gpt_4o():
+    litellm.set_verbose = True
+    response = await litellm.acompletion(
+        model="aiohttp_openai/gpt-4o",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+    )
+    print(response)


### PR DESCRIPTION
## `aiohttp_openai/` fixes - allow using `aiohttp_openai/gpt-4o` 

Fixes for using like this
```python
    response = await litellm.acompletion(
        model="aiohttp_openai/gpt-4o",
        messages=[{"role": "user", "content": "Hello, world!"}],
    )
    print(response)

```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

