### PR TITLE
Add nest_asyncio to fix ollama embed 'event loop closed' error

### DIFF
--- a/litellm/llms/ollama/completion/handler.py
+++ b/litellm/llms/ollama/completion/handler.py
@@ -5,14 +5,17 @@ Ollama /chat/completion calls handled in llm_http_handler.py
 """
 
 import asyncio
+import nest_asyncio
+
 from typing import Any, Dict, List
 
 import litellm
 from litellm.types.utils import EmbeddingResponse
 
+nest_asyncio.apply()
+
 # ollama wants plain base64 jpeg/png files as images.  strip any leading dataURI
 # and convert to jpeg if necessary.
-
 
 async def ollama_aembeddings(
     api_base: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ azure-keyvault-secrets = {version = "^4.8.0", optional = true}
 google-cloud-kms = {version = "^2.21.3", optional = true}
 resend = {version = "^0.8.0", optional = true}
 pynacl = {version = "^1.5.0", optional = true}
+nest-asyncio = "1.6.0"
 
 [tool.poetry.extras]
 proxy = [


### PR DESCRIPTION
## Title

Use `nest_asyncio` to fix `litellm.APIConnectionError: Event loop is closed` using Ollama embeddings.

## Relevant issues

- Fixes #7332
- See also: https://github.com/superlinear-ai/raglite/issues/85


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes

Added `nest_asyncio` library to run asynchronous code inside environments that already have an active event loop, thus fixing the `litellm.APIConnectionError: Event loop is closed`. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
After the fix this code works:

```
import litellm

test_strings = ['Research Data Charta', 'Research', 'Research Data']

for t in test_strings:
    response = litellm.embedding(input=t, model='ollama/nomic-embed-text:latest')
    print(response)
```

<!-- Test procedure -->

