### PR TITLE
(fix) proxy auth - allow using Azure JS SDK routes as llm_api_routes

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -177,6 +177,9 @@ class RouteChecks:
                 ):
                     return True
 
+        if RouteChecks._is_azure_openai_route(route=route):
+            return True
+
         # Pass through Bedrock, VertexAI, and Cohere Routes
         if "/bedrock/" in route:
             return True
@@ -193,6 +196,22 @@ class RouteChecks:
         if "/azure/" in route:
             return True
         if "/openai/" in route:
+            return True
+        return False
+
+    @staticmethod
+    def _is_azure_openai_route(route: str) -> bool:
+        """
+        Check if route is a route from AzureOpenAI SDK client
+
+        eg.
+        route='/openai/deployments/vertex_ai/gemini-1.5-flash/chat/completions'
+        """
+        # Add support for deployment and engine model paths
+        deployment_pattern = r"^/openai/deployments/[^/]+/[^/]+/chat/completions$"
+        engine_pattern = r"^/engines/[^/]+/chat/completions$"
+
+        if re.match(deployment_pattern, route) or re.match(engine_pattern, route):
             return True
         return False
 

--- a/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
+++ b/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
@@ -63,6 +63,25 @@ def test_is_llm_api_route():
     assert RouteChecks.is_llm_api_route("/anthropic/v1/messages") is True
     assert RouteChecks.is_llm_api_route("/azure/endpoint") is True
 
+    assert (
+        RouteChecks.is_llm_api_route(
+            "/openai/deployments/vertex_ai/gemini-1.5-flash/chat/completions"
+        )
+        is True
+    )
+    assert (
+        RouteChecks.is_llm_api_route(
+            "/openai/deployments/gemini/gemini-1.5-flash/chat/completions"
+        )
+        is True
+    )
+    assert (
+        RouteChecks.is_llm_api_route(
+            "/openai/deployments/anthropic/claude-3-5-sonnet-20240620/chat/completions"
+        )
+        is True
+    )
+
     # check non-matching routes
     assert RouteChecks.is_llm_api_route("/some/random/route") is False
     assert RouteChecks.is_llm_api_route("/key/regenerate/82akk800000000jjsk") is False


### PR DESCRIPTION
## (fix) proxy auth - allow using Azure JS SDK routes as llm_api_routes

Check if route is a route from AzureOpenAI SDK client

eg. `route='/openai/deployments/vertex_ai/gemini-1.5-flash/chat/completions'`

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

