### PR TITLE
Fix __init__ types on Message class

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -432,7 +432,7 @@ ChatCompletionMessage(content='This is a test', role='assistant', function_call=
 
 class Message(OpenAIObject):
     content: Optional[str]
-    role: Literal["assistant", "user", "system", "tool", "function"]
+    role: Literal["assistant", "user", "system", "tool", "function", "developer"]
     tool_calls: Optional[List[ChatCompletionMessageToolCall]]
     function_call: Optional[FunctionCall]
     audio: Optional[ChatCompletionAudioResponse] = None
@@ -440,7 +440,7 @@ class Message(OpenAIObject):
     def __init__(
         self,
         content: Optional[str] = None,
-        role: Literal["assistant", "user", "system", "tool", "function"] = "assistant",
+        role: Literal["assistant", "user", "system", "tool", "function", "developer"] = "assistant",
         function_call: Optional[FunctionCall] = None,
         tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None,
         audio: Optional[ChatCompletionAudioResponse] = None,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -440,9 +440,9 @@ class Message(OpenAIObject):
     def __init__(
         self,
         content: Optional[str] = None,
-        role: Literal["assistant"] = "assistant",
-        function_call=None,
-        tool_calls: Optional[list] = None,
+        role: Literal["assistant", "user", "system", "tool", "function"] = "assistant",
+        function_call: Optional[FunctionCall] = None,
+        tool_calls: Optional[List[ChatCompletionMessageToolCall]] = None,
         audio: Optional[ChatCompletionAudioResponse] = None,
         **params,
     ):


### PR DESCRIPTION
## Fix __init__ types on Message class

## Relevant issues

Fixes #7630

## Type

🐛 Bug Fix

## Changes

Copy types from the root attributes to the __init__ parameters.

## Testing

Does cicd type check?

