### PR TITLE
(helm) - bug fix - allow using `migrationJob.enabled` variable within job

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -18,7 +18,7 @@
       spec:
         containers:
           - name: prisma-migrations
-            image: ghcr.io/berriai/litellm-database:main-latest
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
             command: ["python", "litellm/proxy/prisma_migration.py"]
             workingDir: "/app"
             env:

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -1,49 +1,50 @@
-# This job runs the prisma migrations for the LiteLLM DB.
-
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ include "litellm.fullname" . }}-migrations
-  annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: Never # keep this resource so we can debug status on ArgoCD
-    checksum/config: {{ toYaml .Values | sha256sum }}
-spec:
-  template:
-    metadata:
-      annotations:
-        {{- with .Values.migrationJob.annotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      containers:
-        - name: prisma-migrations
-          image: ghcr.io/berriai/litellm-database:main-latest
-          command: ["python", "litellm/proxy/prisma_migration.py"]
-          workingDir: "/app"
-          env:
-            {{- if .Values.db.useExisting }}
-            - name: DATABASE_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.db.secret.name }}
-                  key: {{ .Values.db.secret.usernameKey }}
-            - name: DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.db.secret.name }}
-                  key: {{ .Values.db.secret.passwordKey }}
-            - name: DATABASE_HOST
-              value: {{ .Values.db.endpoint }}
-            - name: DATABASE_NAME
-              value: {{ .Values.db.database }}
-            - name: DATABASE_URL
-              value: {{ .Values.db.url | quote }}
-            {{- else }}
-            - name: DATABASE_URL
-              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
-            {{- end }}
-            - name: DISABLE_SCHEMA_UPDATE
-              value: "false" # always run the migration from the Helm PreSync hook, override the value set
-      restartPolicy: OnFailure
-  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+{{- if .Values.migrationJob.enabled }}
+  # This job runs the prisma migrations for the LiteLLM DB.
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: {{ include "litellm.fullname" . }}-migrations
+    annotations:
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/hook-delete-policy: Never # keep this resource so we can debug status on ArgoCD
+      checksum/config: {{ toYaml .Values | sha256sum }}
+  spec:
+    template:
+      metadata:
+        annotations:
+          {{- with .Values.migrationJob.annotations }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+      spec:
+        containers:
+          - name: prisma-migrations
+            image: ghcr.io/berriai/litellm-database:main-latest
+            command: ["python", "litellm/proxy/prisma_migration.py"]
+            workingDir: "/app"
+            env:
+              {{- if .Values.db.useExisting }}
+              - name: DATABASE_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.db.secret.name }}
+                    key: {{ .Values.db.secret.usernameKey }}
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.db.secret.name }}
+                    key: {{ .Values.db.secret.passwordKey }}
+              - name: DATABASE_HOST
+                value: {{ .Values.db.endpoint }}
+              - name: DATABASE_NAME
+                value: {{ .Values.db.database }}
+              - name: DATABASE_URL
+                value: {{ .Values.db.url | quote }}
+              {{- else }}
+              - name: DATABASE_URL
+                value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
+              {{- end }}
+              - name: DISABLE_SCHEMA_UPDATE
+                value: "false" # always run the migration from the Helm PreSync hook, override the value set
+        restartPolicy: OnFailure
+    backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+{{- end }}

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -6,7 +6,7 @@
     name: {{ include "litellm.fullname" . }}-migrations
     annotations:
       argocd.argoproj.io/hook: PreSync
-      argocd.argoproj.io/hook-delete-policy: Never # keep this resource so we can debug status on ArgoCD
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation # delete old migration on a new deploy in case the migration needs to make updates
       checksum/config: {{ toYaml .Values | sha256sum }}
   spec:
     template:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -182,7 +182,7 @@ redis:
 
 # Prisma migration job settings
 migrationJob:
-  enabled: true # Enable or disable the schema migration Job
+  enabled: false # Enable or disable the schema migration Job
   retries: 3 # Number of retries for the Job in case of failure
   backoffLimit: 4 # Backoff limit for Job restarts
   disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -182,7 +182,7 @@ redis:
 
 # Prisma migration job settings
 migrationJob:
-  enabled: false # Enable or disable the schema migration Job
+  enabled: true # Enable or disable the schema migration Job
   retries: 3 # Number of retries for the Job in case of failure
   backoffLimit: 4 # Backoff limit for Job restarts
   disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.


### PR DESCRIPTION
## (helm) - bug fix - allow using `migrationJob.enabled` variable within job

Issues:
- using `migrationJob.enabled` did not work on values.yaml
- changed `argocd.argoproj.io/hook-delete-policy` BeforeHookCreation because I want the migration job to delete old migration on a new deploy in case the migration needs to make updates
- Don't hardcode image url in migration job


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

