### PR TITLE
Parallelize router initialization

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4044,11 +4044,14 @@ class Router:
             return True
         return False
 
+    def get_cpu_count(self):
+        return os.cpu_count() or 1  # in case cpu_count return None, assumed to be 1
+
     def set_model_list(self, model_list: list):
         original_model_list = copy.deepcopy(model_list)
         self.model_list = []
         # we add api_base/api_key each model so load balancing between azure/gpt on api_base1 and api_base2 works
-        cpu_count = os.cpu_count() or 1 # in case cpu_count return None, assumed to be 1
+        cpu_count = self.get_cpu_count()
         if cpu_count > 1:
             with ProcessPoolExecutor() as executor:
                 results = executor.map(self._process_model, original_model_list)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4109,7 +4109,6 @@ class Router:
         return deployments
 
     def _add_deployment(self, deployment: Deployment) -> Deployment:
-        import os
 
         #### DEPLOYMENT NAMES INIT ########
         self.deployment_names.append(deployment.litellm_params.model)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4048,7 +4048,8 @@ class Router:
         original_model_list = copy.deepcopy(model_list)
         self.model_list = []
         # we add api_base/api_key each model so load balancing between azure/gpt on api_base1 and api_base2 works
-        if os.cpu_count() > 1: # type: ignore
+        cpu_count = os.cpu_count() or 1 # in case cpu_count return None, assumed to be 1
+        if cpu_count > 1:
             with ProcessPoolExecutor() as executor:
                 results = executor.map(self._process_model, original_model_list)
                 # Collect the results in the main process


### PR DESCRIPTION
## Title

Use ProcessPoolExecutor to parallelize set_model_list in Router initialization

## Relevant issues

Related to #7647 

## Type

🆕 New Feature

## Changes

Use ProcessPoolExecutor to parallelize set_model_list in Router initialization

## [REQUIRED]
A test script to test the router creation time
```python
import time
from litellm import Router

# Function to create a list of model configurations
def generate_model_configs(num_models):
    model_configs = []
    for i in range(num_models):
        model_config = {
            "model_name": f"model_{i}",
            "litellm_params": {
                "model": f"openai/model_{i}",
                "api_key": "your-api-key",
                "api_base": "https://api.openai.com/v1"
            }
        }
        model_configs.append(model_config)
    return model_configs

# Function to test router creation time
def test_router_creation(num_models):
    model_configs = generate_model_configs(num_models)

    start_time = time.time()
    router = Router(model_list=model_configs)
    end_time = time.time()

    creation_time = end_time - start_time
    print(f"Router num models: {len(router.model_list)}")
    print(f"Time to create router with {num_models} models: {creation_time:.4f} seconds")

# Test with varying number of models
model_counts = [10, 20, 30, 40, 50]
for count in model_counts:
    test_router_creation(count)
```
