### PR TITLE
[integrations/lunary] allow to pass custom parent run id to LLM calls

### DIFF
--- a/litellm/integrations/lunary.py
+++ b/litellm/integrations/lunary.py
@@ -153,6 +153,7 @@ class LunaryLogger:
                 type,
                 "start",
                 run_id,
+                parent_run_id=metadata.get("parent_run_id", None),
                 user_id=user_id,
                 name=model,
                 input=parse_messages(input),


### PR DESCRIPTION
## Title

Allow users to wrap their LiteLLM LLM calls inside custom chains/agents, so they can visualize them as traces inside Lunary. It's done by passing a custom parent run id inside the metadata.

## Relevant issues

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


