### PR TITLE
feat(helm): add securityContext and pull policy values to migration job

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -19,6 +19,9 @@ spec:
       containers:
         - name: prisma-migrations
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command: ["python", "litellm/proxy/prisma_migration.py"]
           workingDir: "/app"
           env:

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -1,50 +1,50 @@
 {{- if .Values.migrationJob.enabled }}
-  # This job runs the prisma migrations for the LiteLLM DB.
-  apiVersion: batch/v1
-  kind: Job
-  metadata:
-    name: {{ include "litellm.fullname" . }}-migrations
-    annotations:
-      argocd.argoproj.io/hook: PreSync
-      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation # delete old migration on a new deploy in case the migration needs to make updates
-      checksum/config: {{ toYaml .Values | sha256sum }}
-  spec:
-    template:
-      metadata:
-        annotations:
-          {{- with .Values.migrationJob.annotations }}
-          {{- toYaml . | nindent 8 }}
-          {{- end }}
-      spec:
-        containers:
-          - name: prisma-migrations
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
-            command: ["python", "litellm/proxy/prisma_migration.py"]
-            workingDir: "/app"
-            env:
-              {{- if .Values.db.useExisting }}
-              - name: DATABASE_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Values.db.secret.name }}
-                    key: {{ .Values.db.secret.usernameKey }}
-              - name: DATABASE_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Values.db.secret.name }}
-                    key: {{ .Values.db.secret.passwordKey }}
-              - name: DATABASE_HOST
-                value: {{ .Values.db.endpoint }}
-              - name: DATABASE_NAME
-                value: {{ .Values.db.database }}
-              - name: DATABASE_URL
-                value: {{ .Values.db.url | quote }}
-              {{- else }}
-              - name: DATABASE_URL
-                value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
-              {{- end }}
-              - name: DISABLE_SCHEMA_UPDATE
-                value: "false" # always run the migration from the Helm PreSync hook, override the value set
-        restartPolicy: OnFailure
-    backoffLimit: {{ .Values.migrationJob.backoffLimit }}
+# This job runs the prisma migrations for the LiteLLM DB.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "litellm.fullname" . }}-migrations
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation # delete old migration on a new deploy in case the migration needs to make updates
+    checksum/config: {{ toYaml .Values | sha256sum }}
+spec:
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.migrationJob.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: prisma-migrations
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "main-%s" .Chart.AppVersion) }}"
+          command: ["python", "litellm/proxy/prisma_migration.py"]
+          workingDir: "/app"
+          env:
+            {{- if .Values.db.useExisting }}
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: {{ .Values.db.secret.usernameKey }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: {{ .Values.db.secret.passwordKey }}
+            - name: DATABASE_HOST
+              value: {{ .Values.db.endpoint }}
+            - name: DATABASE_NAME
+              value: {{ .Values.db.database }}
+            - name: DATABASE_URL
+              value: {{ .Values.db.url | quote }}
+            {{- else }}
+            - name: DATABASE_URL
+              value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
+            {{- end }}
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "false" # always run the migration from the Helm PreSync hook, override the value set
+      restartPolicy: OnFailure
+  backoffLimit: {{ .Values.migrationJob.backoffLimit }}
 {{- end }}


### PR DESCRIPTION
## Title

Add chart variables for migration job security context and image

In environments where Pod Security Admission is set to `restrictive`, and enforcement is enabled, the default security context policy of a pod will prevent it from running. The main pod deployment already allows for overriding the security context, this PR reuses the same security context settings for the migration job.

## Relevant issues

N/A

## Type

🚄 Infrastructure

## Changes

* Reuse the same security context and image pull policy from the main pod
* Revert indentation introduced in #7639

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Tested deployment in restrictive environment where default security context otherwise would fail.

