### PR TITLE
(proxy - RPS) - Get 2K RPS at 4 instances, minor fix for caching_handler

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -670,6 +670,8 @@ class LLMCachingHandler:
         Raises:
             None
         """
+        if litellm.cache is None:
+            return
 
         new_kwargs = kwargs.copy()
         new_kwargs.update(
@@ -678,8 +680,6 @@ class LLMCachingHandler:
                 args,
             )
         )
-        if litellm.cache is None:
-            return
         # [OPTIONAL] ADD TO CACHE
         if self._should_store_result_in_cache(
             original_function=original_function, kwargs=new_kwargs


### PR DESCRIPTION
## (proxy - RPS) - Get 2K RPS at 4 instances, minor fix for caching_handler

Addressing: https://github.com/BerriAI/litellm/issues/7544

- move the check for if litellm.cache is None at the start of caching handler 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

