### PR TITLE
(litellm proxy perf) - pass num_workers cli arg to uvicorn when `num_workers` is specified

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -68,7 +68,7 @@ def is_port_in_use(port):
 @click.option(
     "--num_workers",
     default=1,
-    help="Number of gunicorn workers to spin up",
+    help="Number of uvicorn / gunicorn workers to spin up. By default, 1 uvicorn is used.",
     envvar="NUM_WORKERS",
 )
 @click.option("--api_base", default=None, help="API base URL.")
@@ -653,7 +653,7 @@ def run_server(  # noqa: PLR0915
         from litellm.proxy.proxy_server import app  # noqa
 
         uvicorn_args = {
-            "app": app,
+            "app": "litellm.proxy.proxy_server:app",
             "host": host,
             "port": port,
         }
@@ -674,6 +674,7 @@ def run_server(  # noqa: PLR0915
             uvicorn.run(
                 **uvicorn_args,
                 loop="uvloop",
+                workers=num_workers,
             )
         elif run_gunicorn is True:
             # Gunicorn Application Class


### PR DESCRIPTION
## (litellm proxy perf) - allow specifying num_workers for uvicorn

- pass `num_workers` cli arg to `uvicorn` when `num_workers` is specified 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
https://github.com/BerriAI/litellm/issues/7544

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

