### PR TITLE
(perf) - proxy, use `orjson` for reading request body 

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, List, Optional
 
+import orjson
 from fastapi import Request, UploadFile, status
 
 from litellm._logging import verbose_proxy_logger
@@ -32,13 +33,10 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
             if not body:
                 return {}
 
-            # Decode the body to a string
-            body_str = body.decode()
-
             # Attempt JSON parsing (safe for untrusted input)
-            return json.loads(body_str)
+            return orjson.loads(body)
 
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, orjson.JSONDecodeError):
         # Log detailed information for debugging
         verbose_proxy_logger.exception("Invalid JSON payload received.")
         return {}


### PR DESCRIPTION
## (perf) - proxy, use `orjson` for reading request body 

- using orjson led to a 3x increase in RPS on the proxy 
- public benchmarks for orjson here: https://dollardhingra.com/blog/python-json-benchmarking/ 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
https://github.com/BerriAI/litellm/issues/7544

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

