### PR TITLE
(sdk perf fix) - only print args passed to litellm when debugging mode is on 

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -102,3 +102,12 @@ def print_verbose(print_statement):
             print(print_statement)  # noqa
     except Exception:
         pass
+
+
+def _is_debugging_on() -> bool:
+    """
+    Returns True if debugging is on
+    """
+    if verbose_logger.isEnabledFor(logging.DEBUG) or set_verbose is True:
+        return True
+    return False

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4,7 +4,6 @@
 import copy
 import datetime
 import json
-import logging
 import os
 import re
 import subprocess

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -23,8 +23,8 @@ from litellm import (
     json_logs,
     log_raw_request_response,
     turn_off_message_logging,
-    verbose_logger,
 )
+from litellm._logging import _is_debugging_on, verbose_logger
 from litellm.caching.caching import DualCache, InMemoryCache
 from litellm.caching.caching_handler import LLMCachingHandler
 from litellm.cost_calculator import _select_model_name_for_cost_calc
@@ -589,7 +589,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
         Prints the RAW curl command sent from LiteLLM
         """
-        if verbose_logger.isEnabledFor(logging.DEBUG) or litellm.set_verbose is True:
+        if _is_debugging_on():
             if json_logs:
                 masked_headers = self._get_masked_headers(headers)
                 verbose_logger.debug(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -183,7 +183,7 @@ from litellm.llms.base_llm.completion.transformation import BaseTextCompletionCo
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
 
-from ._logging import verbose_logger
+from ._logging import _is_debugging_on, verbose_logger
 from .caching.caching import (
     Cache,
     QdrantSemanticCache,
@@ -5612,6 +5612,8 @@ def get_valid_models(check_provider_endpoint: bool = False) -> List[str]:
 
 
 def print_args_passed_to_litellm(original_function, args, kwargs):
+    if not _is_debugging_on():
+        return
     try:
         # we've already printed this for acompletion, don't print for completion
         if (


### PR DESCRIPTION
## (sdk perf fix) - only print args passed to litellm when debugging mode is on 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

