### PR TITLE
refactor: replace regex with string method for whitespace check…

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1,5 +1,4 @@
 import json
-import re
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
@@ -258,13 +257,13 @@ class AnthropicConfig(BaseConfig):
     ) -> Optional[List[str]]:
         new_stop: Optional[List[str]] = None
         if isinstance(stop, str):
-            if re.match(r'^\s+$', stop) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
+            if stop.isspace() and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
                 return new_stop
             new_stop = [stop]
         elif isinstance(stop, list):
             new_v = []
             for v in stop:
-                if re.match(r'^\s+$', v) and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
+                if v.isspace() and litellm.drop_params is True:  # anthropic doesn't allow whitespace characters as stop-sequences
                     continue
                 new_v.append(v)
             if len(new_v) > 0:


### PR DESCRIPTION
… in stop-sequences handling

## Title

This minor refactoring enhances code elegance by replacing the regular expression with Python's native isspace() string method.

## Relevant issues

Refactoring and better implementation of my previous fix https://github.com/BerriAI/litellm/pull/7484.

## Type

🧹 Refactoring

## Changes

Replaced the regular expression with the isspace() method, which also eliminates the need for the re module import, making this a more elegant implementation.