### PR TITLE
fix_delta_get_default

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -543,7 +543,8 @@ class Delta(OpenAIObject):
 
     def get(self, key, default=None):
         # Custom .get() method to access attributes with a default value if the attribute doesn't exist
-        return getattr(self, key, default)
+        value = getattr(self, key, default)
+        return default if value is None else value
 
     def __getitem__(self, key):
         # Allow dictionary-style access to attributes


### PR DESCRIPTION
## Title

fix for default value output

## Relevant issues

[never outputs a default value for function_call #7714](https://github.com/BerriAI/litellm/issues/7714)

## Type

🐛 Bug Fix

## Changes

ables get method to actually output a default value for fields explicitly set to None by default. I'm a junior dev and unable to do a better fix in a reasonable time. I handled this issue in my project differently already.

Testing - Attach a screenshot of any new tests passing locally

This function used to raise raised an AttributeError, as function_call was implicitly set to None in Delta.get("function_call", {}).get("name").
![image](https://github.com/user-attachments/assets/736392e8-7186-4c60-8959-6bdcfa0e94a0)


