### PR TITLE
fix redis sentinel client handling to solve authentication error with password protected sentinel

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -204,7 +204,18 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
 
 def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
+    sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
+    
+    connection_kwargs = {}
+    args = _get_redis_cluster_kwargs()
+    for arg in redis_kwargs:
+        if arg in args:
+            connection_kwargs[arg] = redis_kwargs[arg]
+            
+    # Use connection_kwargs and override special kwargs for sentinel
+    sentinel_kwargs = dict(connection_kwargs)
+    sentinel_kwargs["password"] = sentinel_password   
 
     if not sentinel_nodes or not service_name:
         raise ValueError(
@@ -214,7 +225,12 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     verbose_logger.debug("init_redis_sentinel: sentinel nodes are being initialized.")
 
     # Set up the Sentinel client
-    sentinel = redis.Sentinel(sentinel_nodes, socket_timeout=0.1)
+    sentinel = redis.Sentinel(
+        sentinel_nodes,
+        socket_timeout=0.1,
+        sentinel_kwargs=sentinel_kwargs,
+        **connection_kwargs
+    )
 
     # Return the master instance for the given service
 


### PR DESCRIPTION


## Title

Implement correct redis sentinel client handling to fix a bug with sentinel_password not working as intended (authentication error when sentinel is using requirepass) as no password would be used to authenticate against sentinel.

In the previous implementation sentinel_password was passed directly as "password" which will be used by sentinel as **connection_kwargs** to connect to the redis master and not for authentication of the sentinel node. For sentinel authentication the **sentinel_kwargs** dict will be used instead.

The fix adopts the implementation to match the redis-py documentation for the sentinel Client (https://redis-py.readthedocs.io/en/v5.0.0/connections.html#sentinel-client) and allows the user to set REDIS_PASSWORD and REDIS_SENTINEL_PASSWORD correctly. It is also possible now to handle situations where users use different passwords for redis and sentinel nodes.

Cite from the manual:
> **sentinel_kwargs** is a dictionary of connection arguments used when connecting to sentinel instances. Any argument that can be passed to a normal Redis connection can be specified here. If sentinel_kwargs is not specified, any socket_timeout and socket_keepalive options specified in connection_kwargs will be used.

> **connection_kwargs** are keyword arguments that will be used when establishing a connection to a Redis server.

## Relevant issues

#6154

## Type

🐛 Bug Fix

## Changes

- sentinel_password is now passed to sentinel_kwargs instead connection_kwargs
- added additional connection_kwargs as it was done with redis_cluster implementation to support more redis parameters

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Tested with a redis-sentinel cluster with 3 sentinels and 3 redis nodes in a kubernetes deployment

