### PR TITLE
(litellm sdk speedup router) - adds a helper `_cached_get_model_group_info` to use when trying to get deployment tpm/rpm limits

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4709,9 +4709,6 @@ class Router:
         return self.get_model_group_info(model_group)
 
     async def get_remaining_model_group_usage(self, model_group: str) -> Dict[str, int]:
-
-        current_tpm, current_rpm = await self.get_model_group_usage(model_group)
-
         model_group_info = self._cached_get_model_group_info(model_group)
 
         if model_group_info is not None and model_group_info.tpm is not None:
@@ -4723,6 +4720,11 @@ class Router:
             rpm_limit = model_group_info.rpm
         else:
             rpm_limit = None
+
+        if tpm_limit is None and rpm_limit is None:
+            return {}
+
+        current_tpm, current_rpm = await self.get_model_group_usage(model_group)
 
         returned_dict = {}
         if tpm_limit is not None:

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1126,3 +1126,21 @@ async def test_async_callback_filter_deployments(model_list):
     )
 
     assert len(new_healthy_deployments) == len(healthy_deployments)
+
+
+def test_cached_get_model_group_info(model_list):
+    """Test if the '_cached_get_model_group_info' function is working correctly with LRU cache"""
+    router = Router(model_list=model_list)
+
+    # First call - should hit the actual function
+    result1 = router._cached_get_model_group_info("gpt-3.5-turbo")
+
+    # Second call with same argument - should hit the cache
+    result2 = router._cached_get_model_group_info("gpt-3.5-turbo")
+
+    # Verify results are the same
+    assert result1 == result2
+
+    # Verify the cache info shows hits
+    cache_info = router._cached_get_model_group_info.cache_info()
+    assert cache_info.hits > 0  # Should have at least one cache hit


### PR DESCRIPTION
## (litellm sdk speedup router) - adds a helper `_cached_get_model_group_info` to use when trying to get deployment tpm/rpm limits

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
https://github.com/BerriAI/litellm/issues/7544

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

