### PR TITLE
(proxy perf) - only parse request body 1 time per request

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -21,26 +21,32 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
     try:
         if request is None:
             return {}
+
+        # Check if we already read and parsed the body
+        if hasattr(request.state, "parsed_body"):
+            return request.state.parsed_body
+
         _request_headers: dict = _safe_get_request_headers(request=request)
         content_type = _request_headers.get("content-type", "")
+
         if "form" in content_type:
-            return dict(await request.form())
+            parsed_body = dict(await request.form())
         else:
             # Read the request body
             body = await request.body()
 
             # Return empty dict if body is empty or None
             if not body:
-                return {}
+                parsed_body = {}
+            parsed_body = orjson.loads(body)
 
-            # Attempt JSON parsing (safe for untrusted input)
-            return orjson.loads(body)
+        # Cache the parsed result
+        request.state.parsed_body = parsed_body
+        return parsed_body
 
     except (json.JSONDecodeError, orjson.JSONDecodeError):
-        # Log detailed information for debugging
         verbose_proxy_logger.exception("Invalid JSON payload received.")
         return {}
-
     except Exception as e:
         # Catch unexpected errors to avoid crashes
         verbose_proxy_logger.exception(


### PR DESCRIPTION
## (proxy perf) - only parse request body 1 time per request

- perf improvement 
- it's costly to keep on reading the request body
- Auth layer and routes require access to request body. This ensure we only read + parse it once per request 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🧹 Refactoring
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

