### PR TITLE
Adding openrouter llama 3.1 8b instruct models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4705,6 +4705,20 @@
         "litellm_provider": "openrouter",
         "mode": "chat"
     },
+    "openrouter/meta-llama/llama-3.1-8b-instruct:free": {
+        "max_tokens": 8192,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "openrouter",
+        "mode": "chat"
+    },
+    "openrouter/meta-llama/llama-3.1-8b-instruct": {
+        "max_tokens": 131072,
+        "input_cost_per_token": 0.00000002,
+        "output_cost_per_token": 0.00000005,
+        "litellm_provider": "openrouter",
+        "mode": "chat"
+    },
     "openrouter/openai/o1": {
         "max_tokens": 100000,
         "max_input_tokens": 200000,


### PR DESCRIPTION
## Title

Adding llama 3.1 8b instruct model hosted on open router to the model prices and context list.

## Type

🆕 New Feature

## Changes
Added 
`openrouter/meta-llama/llama-3.1-8b-instruct:free`
`openrouter/meta-llama/llama-3.1-8b-instruct`
to the `model_prices_and_context_window.json` file
Model information can be confirmed by referencing the following links 

- https://openrouter.ai/meta-llama/llama-3.1-8b-instruct:free
- https://openrouter.ai/meta-llama/llama-3.1-8b-instruct

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally