### PR TITLE
(proxy perf) - service logger don't always import OTEL in helper function

### DIFF
--- a/litellm/_service_logger.py
+++ b/litellm/_service_logger.py
@@ -8,13 +8,12 @@ from litellm.proxy._types import UserAPIKeyAuth
 
 from .integrations.custom_logger import CustomLogger
 from .integrations.datadog.datadog import DataDogLogger
+from .integrations.opentelemetry import OpenTelemetry
 from .integrations.prometheus_services import PrometheusServicesLogger
 from .types.services import ServiceLoggerPayload, ServiceTypes
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
-
-    from litellm.integrations.opentelemetry import OpenTelemetry
 
     Span = _Span
     OTELClass = OpenTelemetry
@@ -116,8 +115,6 @@ class ServiceLogging(CustomLogger):
         """
         - For counting if the redis, postgres call is successful
         """
-        from litellm.integrations.opentelemetry import OpenTelemetry
-
         if self.mock_testing:
             self.mock_testing_async_success_hook += 1
 
@@ -190,7 +187,6 @@ class ServiceLogging(CustomLogger):
         initializes otel_logger if it is None or no attribute exists on ServiceLogging Object
 
         """
-        from litellm.integrations.opentelemetry import OpenTelemetry
         from litellm.proxy.proxy_server import open_telemetry_logger
 
         if not hasattr(self, "otel_logger"):
@@ -218,8 +214,6 @@ class ServiceLogging(CustomLogger):
         """
         - For counting if the redis, postgres call is unsuccessful
         """
-        from litellm.integrations.opentelemetry import OpenTelemetry
-
         if self.mock_testing:
             self.mock_testing_async_failure_hook += 1
 


### PR DESCRIPTION
## (proxy perf) - service logger don't always import OTEL in helper function

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

