### PR TITLE
(prometheus - minor bug fix) - `litellm_llm_api_time_to_first_token_metric` not populating for bedrock models

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -626,17 +626,13 @@ class PrometheusLogger(CustomLogger):
         user_api_key_alias: Optional[str],
         user_api_team: Optional[str],
         user_api_team_alias: Optional[str],
-        standard_logging_payload: StandardLoggingPayload,
         enum_values: UserAPIKeyLabelValues,
     ):
         # latency metrics
-        model_parameters: dict = standard_logging_payload["model_parameters"]
         end_time: datetime = kwargs.get("end_time") or datetime.now()
         start_time: Optional[datetime] = kwargs.get("start_time")
         api_call_start_time = kwargs.get("api_call_start_time", None)
-
         completion_start_time = kwargs.get("completion_start_time", None)
-
         if (
             completion_start_time is not None
             and isinstance(completion_start_time, datetime)

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -640,7 +640,7 @@ class PrometheusLogger(CustomLogger):
         if (
             completion_start_time is not None
             and isinstance(completion_start_time, datetime)
-            and kwargs.get("stream") is True is True  # only emit for streaming requests
+            and kwargs.get("stream", False) is True  # only emit for streaming requests
         ):
             time_to_first_token_seconds = (
                 completion_start_time - api_call_start_time

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -640,8 +640,7 @@ class PrometheusLogger(CustomLogger):
         if (
             completion_start_time is not None
             and isinstance(completion_start_time, datetime)
-            and model_parameters.get("stream")
-            is True  # only emit for streaming requests
+            and kwargs.get("stream") is True is True  # only emit for streaming requests
         ):
             time_to_first_token_seconds = (
                 completion_start_time - api_call_start_time

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -449,7 +449,6 @@ class PrometheusLogger(CustomLogger):
             # why type ignore below?
             # 1. We just checked if isinstance(standard_logging_payload, dict). Pyright complains.
             # 2. Pyright does not allow us to run isinstance(standard_logging_payload, StandardLoggingPayload) <- this would be ideal
-            standard_logging_payload=standard_logging_payload,  # type: ignore
             enum_values=enum_values,
         )
 

--- a/tests/llm_translation/test_text_completion_unit_tests.py
+++ b/tests/llm_translation/test_text_completion_unit_tests.py
@@ -102,7 +102,7 @@ async def test_huggingface_text_completion_logprobs():
     client = AsyncHTTPHandler()
     with patch.object(client, "post", return_value=return_val) as mock_post:
         response = await litellm.atext_completion(
-            model="huggingface/mistralai/Mistral-7B-v0.1",
+            model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
             prompt="good morning",
             client=client,
         )

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -3940,7 +3940,7 @@ def test_completion_hf_prompt_array():
         litellm.set_verbose = True
         print("\n testing hf mistral\n")
         response = text_completion(
-            model="huggingface/mistralai/Mistral-7B-v0.1",
+            model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
             prompt=token_prompt,  # token prompt is a 2d list,
             max_tokens=0,
             temperature=0.0,
@@ -3971,7 +3971,7 @@ def test_text_completion_stream():
     try:
         for _ in range(2):  # check if closed client used
             response = text_completion(
-                model="huggingface/mistralai/Mistral-7B-v0.1",
+                model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
                 prompt="good morning",
                 stream=True,
                 max_tokens=10,

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -331,7 +331,6 @@ def test_set_latency_metrics(prometheus_logger):
         user_api_key_alias="alias1",
         user_api_team="team1",
         user_api_team_alias="team_alias1",
-        standard_logging_payload=standard_logging_payload,
         enum_values=enum_values,
     )
 

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -298,7 +298,6 @@ def test_set_latency_metrics(prometheus_logger):
     time to first token, llm api latency, and request total latency metrics are set to the values in the standard logging payload
     """
     standard_logging_payload = create_standard_logging_payload()
-    standard_logging_payload["model_parameters"] = {"stream": True}
     prometheus_logger.litellm_llm_api_time_to_first_token_metric = MagicMock()
     prometheus_logger.litellm_llm_api_latency_metric = MagicMock()
     prometheus_logger.litellm_request_total_latency_metric = MagicMock()
@@ -322,6 +321,7 @@ def test_set_latency_metrics(prometheus_logger):
         "api_call_start_time": now - timedelta(seconds=1.5),  # when the api call starts
         "completion_start_time": now
         - timedelta(seconds=1),  # when the completion starts
+        "stream": True,
     }
 
     prometheus_logger._set_latency_metrics(

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -112,6 +112,7 @@ async def test_async_log_success_event(prometheus_logger):
     standard_logging_object = create_standard_logging_payload()
     kwargs = {
         "model": "gpt-3.5-turbo",
+        "stream": True,
         "litellm_params": {
             "metadata": {
                 "user_api_key": "test_key",


### PR DESCRIPTION
## (prometheus - minor bug fix) - `litellm_llm_api_time_to_first_token_metric` not populating for bedrock models


<img width="1279" alt="Screenshot 2025-01-13 at 7 39 28 AM" src="https://github.com/user-attachments/assets/30f1b29b-9eb3-4466-a4dc-242f8b0bc689" />

## Cause of the issue ?
- we were checking `model_parameters["stream]` in standard_logging_payload to confirm if we should emit `time_to_first_token_metric` 
- kwargs["stream"] was the location where we should have checked

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

