### PR TITLE
(fix) health check - allow setting `health_check_model`

### DIFF
--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -182,6 +182,28 @@ model_list:
       mode: realtime
 ```
 
+### Wildcard Routes
+
+For wildcard routes, you can specify a `health_check_model` in your config.yaml. This model will be used for health checks for that wildcard route.
+
+In this example, when running a health check for `openai/*`, the health check will make a `/chat/completions` request to `openai/gpt-4o-mini`.
+
+```yaml
+model_list:
+  - model_name: openai/*
+    litellm_params:
+      model:  openai/*
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      health_check_model: openai/gpt-4o-mini
+  - model_name: anthropic/*
+    litellm_params:
+      model: anthropic/*
+      api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      health_check_model: anthropic/claude-3-5-sonnet-20240620
+```
+
 ## Background Health Checks 
 
 You can enable model health checks being run in the background, to prevent each model from being queried too frequently via `/health`. 

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -112,9 +112,7 @@ def _update_litellm_params_for_health_check(
     Update the litellm params for health check.
 
     - gets a short `messages` param for health check
-    - updates the `model` param with the `health_check_model` if it exists
-
-    Doc: https://docs.litellm.ai/docs/proxy/health#health_check_model
+    - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     """
     litellm_params["messages"] = _get_random_llm_message()
     _health_check_model = model_info.get("health_check_model", None)

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -70,8 +70,10 @@ async def _perform_health_check(model_list: list, details: Optional[bool] = True
     for model in model_list:
         litellm_params = model["litellm_params"]
         model_info = model.get("model_info", {})
-        litellm_params["messages"] = _get_random_llm_message()
         mode = model_info.get("mode", None)
+        litellm_params = _update_litellm_params_for_health_check(
+            model_info, litellm_params
+        )
         tasks.append(
             litellm.ahealth_check(
                 litellm_params,
@@ -101,6 +103,24 @@ async def _perform_health_check(model_list: list, details: Optional[bool] = True
             unhealthy_endpoints.append(_clean_endpoint_data(litellm_params, details))
 
     return healthy_endpoints, unhealthy_endpoints
+
+
+def _update_litellm_params_for_health_check(
+    model_info: dict, litellm_params: dict
+) -> dict:
+    """
+    Update the litellm params for health check.
+
+    - gets a short `messages` param for health check
+    - updates the `model` param with the `health_check_model` if it exists
+
+    Doc: https://docs.litellm.ai/docs/proxy/health#health_check_model
+    """
+    litellm_params["messages"] = _get_random_llm_message()
+    _health_check_model = model_info.get("health_check_model", None)
+    if _health_check_model is not None:
+        litellm_params["model"] = _health_check_model
+    return litellm_params
 
 
 async def perform_health_check(

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,15 +1,13 @@
 model_list:
-  - model_name: "gpt-4"
+  - model_name: openai/*
     litellm_params:
-      model: openai/fake
-      api_key: fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
-
-general_settings:    
-    alerting: ["slack"]
-    alert_to_webhook_url: {
-      "budget_alerts": ["https://hooks.slack.com/services/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"]
-    }
-    alerting_args:
-       budget_alert_ttl: 10
-       log_to_console: true
+      model:  openai/*
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      health_check_model: openai/gpt-4o-mini
+  - model_name: anthropic/*
+    litellm_params:
+      model: anthropic/*
+      api_key: os.environ/ANTHROPIC_API_KEY
+    model_info:
+      health_check_model: anthropic/claude-3-5-sonnet-20240620

--- a/tests/llm_translation/test_text_completion_unit_tests.py
+++ b/tests/llm_translation/test_text_completion_unit_tests.py
@@ -102,7 +102,7 @@ async def test_huggingface_text_completion_logprobs():
     client = AsyncHTTPHandler()
     with patch.object(client, "post", return_value=return_val) as mock_post:
         response = await litellm.atext_completion(
-            model="huggingface/mistralai/Mistral-7B-v0.1",
+            model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
             prompt="good morning",
             client=client,
         )

--- a/tests/local_testing/test_health_check.py
+++ b/tests/local_testing/test_health_check.py
@@ -222,3 +222,38 @@ async def test_async_realtime_health_check(model, mocker):
     )
     print(response)
     assert response == {}
+
+
+def test_update_litellm_params_for_health_check():
+    """
+    Test if _update_litellm_params_for_health_check correctly:
+    1. Updates messages with a random message
+    2. Updates model name when health_check_model is provided
+    """
+    from litellm.proxy.health_check import _update_litellm_params_for_health_check
+
+    # Test with health_check_model
+    model_info = {"health_check_model": "gpt-3.5-turbo"}
+    litellm_params = {
+        "model": "gpt-4",
+        "api_key": "fake_key",
+    }
+
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert "messages" in updated_params
+    assert isinstance(updated_params["messages"], list)
+    assert updated_params["model"] == "gpt-3.5-turbo"
+
+    # Test without health_check_model
+    model_info = {}
+    litellm_params = {
+        "model": "gpt-4",
+        "api_key": "fake_key",
+    }
+
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+
+    assert "messages" in updated_params
+    assert isinstance(updated_params["messages"], list)
+    assert updated_params["model"] == "gpt-4"

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -3940,7 +3940,7 @@ def test_completion_hf_prompt_array():
         litellm.set_verbose = True
         print("\n testing hf mistral\n")
         response = text_completion(
-            model="huggingface/mistralai/Mistral-7B-v0.1",
+            model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
             prompt=token_prompt,  # token prompt is a 2d list,
             max_tokens=0,
             temperature=0.0,
@@ -3971,7 +3971,7 @@ def test_text_completion_stream():
     try:
         for _ in range(2):  # check if closed client used
             response = text_completion(
-                model="huggingface/mistralai/Mistral-7B-v0.1",
+                model="huggingface/mistralai/Mistral-7B-Instruct-v0.3",
                 prompt="good morning",
                 stream=True,
                 max_tokens=10,


### PR DESCRIPTION
## Allow setting `health_check_model` for /health on litellm proxy config.yaml

- When setting wildcard routes, users would like to set `health_check_model` to be explicit about what model is used 

```yaml
model_list:
  - model_name: openai/*
    litellm_params:
      model:  openai/*
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      health_check_model: openai/gpt-4o-mini
  - model_name: anthropic/*
    litellm_params:
      model: anthropic/*
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      health_check_model: anthropic/claude-3-5-sonnet-20240620

```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

