### PR TITLE
[Bug fix]: v1.58.0 - issue with read request body

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -41,7 +41,8 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
             # Return empty dict if body is empty or None
             if not body:
                 parsed_body = {}
-            parsed_body = orjson.loads(body)
+            else:
+                parsed_body = orjson.loads(body)
 
         # Cache the parsed result
         _safe_set_request_parsed_body(request=request, parsed_body=parsed_body)


### PR DESCRIPTION
## [Bug fix]: v1.58.0 - issue with read request body


```shell
{"message": "Invalid JSON payload received.", "level": "ERROR", "timestamp": "2025-01-13T14:57:48.815953", "stacktrace": "Traceback (most recent call last):\n  File \"/usr/lib/python3.13/site-packages/litellm/proxy/common_utils/http_parsing_utils.py\", line 44, in _read_request_body\n    parsed_body = orjson.loads(body)\norjson.JSONDecodeError: Input is a zero-length, empty document: line 1 column 1 (char 0)"}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

