### PR TITLE
(Feat) prometheus - emit remaining team budget metric on proxy startup

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1255,6 +1255,7 @@ class PrometheusLogger(CustomLogger):
     async def _initialize_remaining_budget_metrics(self):
         """
         Initialize remaining budget metrics for all teams to avoid metric discrepancies.
+
         Runs when prometheus logger starts up.
         """
         from litellm.proxy.management_endpoints.team_endpoints import (

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1,17 +1,24 @@
 # used for /metrics endpoint on LiteLLM Proxy
 #### What this does ####
 #    On success, log events to Prometheus
+import asyncio
 import sys
 from datetime import datetime, timedelta
-from typing import List, Optional, cast
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.integrations.prometheus import *
 from litellm.types.utils import StandardLoggingPayload
 from litellm.utils import get_end_user_id_for_cost_tracking
+
+if TYPE_CHECKING:
+    from litellm.proxy._types import LiteLLM_TeamTable
+else:
+    LiteLLM_TeamTable = Any
 
 
 class PrometheusLogger(CustomLogger):
@@ -305,6 +312,8 @@ class PrometheusLogger(CustomLogger):
                     label_name="litellm_requests_metric"
                 ),
             )
+
+            asyncio.create_task(self._initialize_remaining_budget_metrics())
 
         except Exception as e:
             print_verbose(f"Got exception on init prometheus client {str(e)}")
@@ -1242,6 +1251,56 @@ class PrometheusLogger(CustomLogger):
             return max_budget
 
         return max_budget - spend
+
+    async def _initialize_remaining_budget_metrics(self):
+        """
+        Initialize remaining budget metrics for all teams to avoid metric discrepancies.
+        Runs when prometheus logger starts up.
+        """
+        from litellm.proxy.management_endpoints.team_endpoints import (
+            get_paginated_teams,
+        )
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            return
+
+        try:
+            page = 1
+            page_size = 50
+            teams, total_count = await get_paginated_teams(
+                prisma_client=prisma_client, page_size=page_size, page=page
+            )
+
+            # Calculate total pages needed
+            total_pages = (total_count + page_size - 1) // page_size
+
+            # Set metrics for first page of teams
+            await self._set_team_budget_metrics(teams)
+
+            # Get and set metrics for remaining pages
+            for page in range(2, total_pages + 1):
+                teams, _ = await get_paginated_teams(
+                    prisma_client=prisma_client, page_size=page_size, page=page
+                )
+                await self._set_team_budget_metrics(teams)
+
+        except Exception as e:
+            print_verbose(f"Error initializing team budget metrics: {str(e)}")
+
+    async def _set_team_budget_metrics(self, teams: List[LiteLLM_TeamTable]):
+        """Helper function to set budget metrics for a list of teams"""
+        for team in teams:
+            if team.max_budget is not None:
+                self.litellm_remaining_team_budget_metric.labels(
+                    team.team_id,
+                    team.team_alias or "",
+                ).set(
+                    self._safe_get_remaining_budget(
+                        max_budget=team.max_budget,
+                        spend=team.spend,
+                    )
+                )
 
 
 def prometheus_label_factory(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, List, Optional, cast
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.integrations.prometheus import *
 from litellm.types.utils import StandardLoggingPayload

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -312,7 +312,7 @@ class PrometheusLogger(CustomLogger):
                 ),
             )
 
-            asyncio.create_task(self._initialize_remaining_budget_metrics())
+            self._initialize_prometheus_startup_metrics()
 
         except Exception as e:
             print_verbose(f"Got exception on init prometheus client {str(e)}")
@@ -1250,6 +1250,20 @@ class PrometheusLogger(CustomLogger):
             return max_budget
 
         return max_budget - spend
+
+    def _initialize_prometheus_startup_metrics(self):
+        """
+        Initialize prometheus startup metrics
+
+        Helper to create tasks for initializing metrics that are required on startup - eg. remaining budget metrics
+        """
+        try:
+            if asyncio.get_running_loop():
+                asyncio.create_task(self._initialize_remaining_budget_metrics())
+        except RuntimeError as e:  # no running event loop
+            verbose_logger.exception(
+                f"No running event loop - skipping budget metrics initialization: {str(e)}"
+            )
 
     async def _initialize_remaining_budget_metrics(self):
         """

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1300,7 +1300,9 @@ class PrometheusLogger(CustomLogger):
                 await self._set_team_budget_metrics(teams)
 
         except Exception as e:
-            print_verbose(f"Error initializing team budget metrics: {str(e)}")
+            verbose_logger.exception(
+                f"Error initializing team budget metrics: {str(e)}"
+            )
 
     async def _set_team_budget_metrics(self, teams: List[LiteLLM_TeamTable]):
         """Helper function to set budget metrics for a list of teams"""

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -11,3 +11,6 @@ model_list:
       api_key: os.environ/ANTHROPIC_API_KEY
     model_info:
       health_check_model: anthropic/claude-3-5-sonnet-20240620
+
+litellm_settings:
+  callbacks: ["prometheus"]

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -3759,3 +3759,47 @@ def test_should_track_cost_callback():
         team_id=None,
         end_user_id="1234",
     )
+
+
+@pytest.mark.asyncio
+async def test_get_paginated_teams(prisma_client):
+    """
+    Test the get_paginated_teams function:
+    1. Test pagination returns valid results
+    2. Test total count matches across pages
+    3. Test page size is respected
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import get_paginated_teams
+
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    await litellm.proxy.proxy_server.prisma_client.connect()
+
+    try:
+        # Get first page with page_size=2
+        teams_page_1, total_count_1 = await get_paginated_teams(
+            prisma_client=prisma_client, page_size=2, page=1
+        )
+
+        print("teams_page_1=", teams_page_1)
+        print("total_count_1=", total_count_1)
+
+        # Get second page
+        teams_page_2, total_count_2 = await get_paginated_teams(
+            prisma_client=prisma_client, page_size=2, page=2
+        )
+
+        print("teams_page_2=", teams_page_2)
+        print("total_count_2=", total_count_2)
+
+        # Verify results
+        assert isinstance(teams_page_1, list)  # Should return a list
+        assert isinstance(total_count_1, int)  # Should return an integer count
+        assert (
+            total_count_1 == total_count_2
+        )  # Total count should be consistent across pages
+        assert len(teams_page_1) <= 2  # Should respect page_size limit
+
+    except Exception as e:
+        print(f"Error occurred: {e}")
+        pytest.fail(f"Test failed with exception: {e}")


### PR DESCRIPTION
## (Feat) prometheus - emit remaining team budget metric on proxy startup

emitted on startup 

<img width="630" alt="Screenshot 2025-01-14 at 8 03 15 PM" src="https://github.com/user-attachments/assets/1cedea47-f628-48ce-b22b-6dd12233ce4c" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

