### PR TITLE
fix: drop model name from fallback args since it causes TypeError

### DIFF
--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -40,7 +40,7 @@ async def async_completion_with_fallbacks(**kwargs):
 
             # Handle dictionary fallback configurations
             if isinstance(fallback, dict):
-                model = fallback.get("model", original_model)
+                model = fallback.pop("model", original_model)
                 completion_kwargs.update(fallback)
             else:
                 model = fallback


### PR DESCRIPTION
Currently, if a user provides multiple fallback models to the completion/acompletion functions with model name specified, an error is thrown saying `litellm.main.acompletion() got multiple values for keyword argument 'model'`

That's because in `fallback_utils.py`, on line 43, the code gets the model name from the fallback model but doesn't remove that key.

This causes an error on line 48. On this line, the code already provides a model.

The solution is to just change `fallback.get` to `fallback.pop`. This way, the model name is retrieved with a default value and being removed at the same time.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

`fallback_utils.py` - line 43 - change `fallback.get` to `fallback.pop`

