### PR TITLE
(security fix) - remove hf model with exposed security token

### DIFF
--- a/litellm/llms/huggingface/huggingface_llms_metadata/hf_text_generation_models.txt
+++ b/litellm/llms/huggingface/huggingface_llms_metadata/hf_text_generation_models.txt
@@ -36159,7 +36159,6 @@ CHIH-HUNG/llama-2-13b-FINETUNE3_3.3w-r4-q_k_v_o
 GozdeA/Llama-2-7b-chat-finetune-GAtest
 mncai/Llama2-7B-Active_3rd-floor-LoRA-dim64_epoch4
 ajcdp/CM
-Nagharjun17/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
 BigSalmon/InformalToFormalLincoln114Paraphrase
 AtheerAlgherairy/llama-2-7b-chat-dst_JSON_Prompt_fullTrain
 MindNetML/llama-2-7b-hf-personal


### PR DESCRIPTION
## (security fix) - remove hf model with exposed security token

- litellm maintains a list of hf models for routing 
- one of the hf models contained a hf token (i'm assuming someone uploaded this on hf) 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

