### PR TITLE
(Fix + Testing) - Add `dd-trace-run` to litellm ci/cd pipeline + fix bug caused by `dd-trace` patching OpenAI sdk 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1120,6 +1120,9 @@ jobs:
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e AUTO_INFER_REGION=True \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
+              -e USE_DDTRACE=True \
+              -e DD_API_KEY=$DD_API_KEY \
+              -e DD_SITE=$DD_SITE \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e LANGFUSE_PROJECT1_PUBLIC=$LANGFUSE_PROJECT1_PUBLIC \
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
@@ -1239,6 +1242,9 @@ jobs:
               -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e AUTO_INFER_REGION=True \
+              -e USE_DDTRACE=True \
+              -e DD_API_KEY=$DD_API_KEY \
+              -e DD_SITE=$DD_SITE \
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e LANGFUSE_PROJECT1_PUBLIC=$LANGFUSE_PROJECT1_PUBLIC \
@@ -1355,6 +1361,9 @@ jobs:
               -e APORIA_API_BASE_1=$APORIA_API_BASE_1 \
               -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
               -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+              -e USE_DDTRACE=True \
+              -e DD_API_KEY=$DD_API_KEY \
+              -e DD_SITE=$DD_SITE \
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e APORIA_API_KEY_1=$APORIA_API_KEY_1 \
               -e COHERE_API_KEY=$COHERE_API_KEY \
@@ -1499,6 +1508,9 @@ jobs:
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e APORIA_API_KEY_1=$APORIA_API_KEY_1 \
               -e COHERE_API_KEY=$COHERE_API_KEY \
+              -e USE_DDTRACE=True \
+              -e DD_API_KEY=$DD_API_KEY \
+              -e DD_SITE=$DD_SITE \
               -e GCS_FLUSH_INTERVAL="1" \
               --name my-app \
               -v $(pwd)/litellm_config.yaml:/app/config.yaml \
@@ -1597,6 +1609,9 @@ jobs:
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
               -e GEMINI_API_KEY=$GEMINI_API_KEY \
               -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+              -e USE_DDTRACE=True \
+              -e DD_API_KEY=$DD_API_KEY \
+              -e DD_SITE=$DD_SITE \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/pass_through_config.yaml:/app/config.yaml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1457,14 +1457,14 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y docker-ce docker-ce-cli containerd.io
       - run:
-          name: Install Python 3.9
+          name: Install Python 3.13
           command: |
             curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
             bash miniconda.sh -b -p $HOME/miniconda
             export PATH="$HOME/miniconda/bin:$PATH"
             conda init bash
             source ~/.bashrc
-            conda create -n myenv python=3.9 -y
+            conda create -n myenv python=3.13 -y
             conda activate myenv
             python --version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1455,7 +1455,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Docker CLI (In case it's not already installed)
+          name: Install Docker CLI
           command: |
             sudo apt-get update
             sudo apt-get install -y docker-ce docker-ce-cli containerd.io
@@ -1464,12 +1464,14 @@ jobs:
           command: |
             curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
             bash miniconda.sh -b -p $HOME/miniconda
-            export PATH="$HOME/miniconda/bin:$PATH"
+            echo 'export PATH="$HOME/miniconda/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
             conda init bash
-            source ~/.bashrc
+            source ~/.bashrc || true
             conda create -n myenv python=3.13 -y
-            conda activate myenv
-            python --version
+            echo 'source $HOME/miniconda/etc/profile.d/conda.sh' >> $BASH_ENV
+            echo 'conda activate myenv' >> $BASH_ENV
+            source $BASH_ENV
       - run:
           name: Install Dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1445,8 +1445,11 @@ jobs:
       - store_test_results:
           path: test-results
   proxy_build_from_pip_tests:
-    machine:
-      image: ubuntu-2204:2023.10.1
+    docker:
+      - image: cimg/python:3.13.1
+        auth:
+          username: ${DOCKERHUB_USERNAME}
+          password: ${DOCKERHUB_PASSWORD}
     resource_class: xlarge
     working_directory: ~/project
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1445,33 +1445,25 @@ jobs:
       - store_test_results:
           path: test-results
   proxy_build_from_pip_tests:
-    docker:
-      - image: cimg/python:3.13.1
-        auth:
-          username: ${DOCKERHUB_USERNAME}
-          password: ${DOCKERHUB_PASSWORD}
+    # Change from docker to machine executor
+    machine:
+      image: ubuntu-2204:2023.10.1
     resource_class: xlarge
     working_directory: ~/project
     steps:
       - checkout
-      - run:
-          name: Install Docker CLI
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+      # Remove Docker CLI installation since it's already available in machine executor
       - run:
           name: Install Python 3.13
           command: |
             curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
             bash miniconda.sh -b -p $HOME/miniconda
-            echo 'export PATH="$HOME/miniconda/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
+            export PATH="$HOME/miniconda/bin:$PATH"
             conda init bash
-            source ~/.bashrc || true
+            source ~/.bashrc
             conda create -n myenv python=3.13 -y
-            echo 'source $HOME/miniconda/etc/profile.d/conda.sh' >> $BASH_ENV
-            echo 'conda activate myenv' >> $BASH_ENV
-            source $BASH_ENV
+            conda activate myenv
+            python --version
       - run:
           name: Install Dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1472,6 +1472,7 @@ jobs:
           command: |
             pip install "pytest==7.3.1"
             pip install "pytest-asyncio==0.21.1"
+            pip install "ddtrace==1.19.0"
             pip install aiohttp
             python -m pip install --upgrade pip
             pip install "pytest==7.3.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1477,7 +1477,7 @@ jobs:
           command: |
             pip install "pytest==7.3.1"
             pip install "pytest-asyncio==0.21.1"
-            pip install "ddtrace==1.19.0"
+            pip install "ddtrace==2.19.0"
             pip install aiohttp
             python -m pip install --upgrade pip
             pip install "pytest==7.3.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1469,7 +1469,6 @@ jobs:
           command: |
             pip install "pytest==7.3.1"
             pip install "pytest-asyncio==0.21.1"
-            pip install "ddtrace==2.19.0"
             pip install aiohttp
             python -m pip install --upgrade pip
             pip install "pytest==7.3.1"

--- a/docker/build_from_pip/requirements.txt
+++ b/docker/build_from_pip/requirements.txt
@@ -1,4 +1,5 @@
-litellm[proxy]==1.57.3 # Specify the litellm version you want to use
+litellm[proxy] # Specify the litellm version you want to use
 prometheus_client
 langfuse
 prisma
+ddtrace==2.19.0 # for advanced DD tracing / profiling

--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-exec litellm "$@"
+if [ "$USE_DDTRACE" = "true" ]; then
+    export DD_TRACE_OPENAI_ENABLED="False"
+    exec ddtrace-run litellm "$@"
+else
+    exec litellm "$@"
+fi

--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-if [ "$USE_DDTRACE" = "true" ]; then
-    exec ddtrace-run litellm "$@"
-else
-    exec litellm "$@"
-fi
+exec litellm "$@"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3251,7 +3251,7 @@ class ProxyStartupEvent:
         if get_secret_bool("USE_DDTRACE", False) is True:
             import ddtrace
 
-            ddtrace.patch_all(logging=True)
+            ddtrace.patch_all(logging=True, openai=False)
 
 
 #### API ENDPOINTS ####

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
 langfuse==2.45.0 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
-ddtrace==2.19.0rc1       # for advanced DD tracing / profiling
+ddtrace==2.19.0      # for advanced DD tracing / profiling
 orjson==3.10.12 # fast /embedding responses
 apscheduler==3.10.4 # for resetting budget in background 
 fastapi-sso==0.16.0 # admin UI, SSO


### PR DESCRIPTION
## (Fix + Testing) - Add `dd-trace-run` to litellm ci/cd pipeline + fix bug caused by `dd-trace` patching OpenAI sdk 

## What is the issue ? 
- `dd-trace-run`  on python 3.13 does not allow re-using Async OpenAI clients. Re-using openai clients across requests is critical, when we don't memory usage and latency spike 

- We're able to isolate the issue to dd-trace patching the OpenAI sdk, our fix is to tell dd-trace to not patch openai sdk 
- Added `-e USE_DDTRACE=True` to litellm ci/cd testing


### Error Logs caused when `dd-trace` is active 

```
  File "/usr/lib/python3.13/site-packages/litellm/router.py", line 2717, in _pass_through_moderation_endpoint_factory
    return await original_function(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/litellm/utils.py", line 1241, in wrapper_async
    raise e
  File "/usr/lib/python3.13/site-packages/litellm/utils.py", line 1093, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/litellm/main.py", line 4281, in amoderation
    response = await _openai_client.moderations.create(input=input)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: coroutine already executing
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
https://github.com/DataDog/dd-trace-py/issues/11994

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

