### PR TITLE
(fix) IBM Watsonx using ZenApiKey

### DIFF
--- a/litellm/llms/watsonx/common_utils.py
+++ b/litellm/llms/watsonx/common_utils.py
@@ -182,7 +182,9 @@ class IBMWatsonXMixin:
         if token:
             headers["Authorization"] = f"Bearer {token}"
         elif get_secret_str("WATSONX_ZENAPIKEY"):
-            headers["Authorization"] = f"Bearer {get_secret_str('WATSONX_ZENAPIKEY')}"
+            headers["Authorization"] = (
+                f"ZenApiKey {get_secret_str('WATSONX_ZENAPIKEY')}"
+            )
         else:
             token = _generate_watsonx_token(api_key=api_key, token=token)
             # build auth headers

--- a/litellm/llms/watsonx/common_utils.py
+++ b/litellm/llms/watsonx/common_utils.py
@@ -181,10 +181,8 @@ class IBMWatsonXMixin:
         )
         if token:
             headers["Authorization"] = f"Bearer {token}"
-        elif get_secret_str("WATSONX_ZENAPIKEY"):
-            headers["Authorization"] = (
-                f"ZenApiKey {get_secret_str('WATSONX_ZENAPIKEY')}"
-            )
+        elif zen_api_key := get_secret_str("WATSONX_ZENAPIKEY"):
+            headers["Authorization"] = f"ZenApiKey {zen_api_key}"
         else:
             token = _generate_watsonx_token(api_key=api_key, token=token)
             # build auth headers

--- a/litellm/llms/watsonx/common_utils.py
+++ b/litellm/llms/watsonx/common_utils.py
@@ -177,12 +177,12 @@ class IBMWatsonXMixin:
             return {**default_headers, **headers}
         token = cast(
             Optional[str],
-            optional_params.get("token")
-            or get_secret_str("WATSONX_ZENAPIKEY")
-            or get_secret_str("WATSONX_TOKEN"),
+            optional_params.get("token") or get_secret_str("WATSONX_TOKEN"),
         )
         if token:
             headers["Authorization"] = f"Bearer {token}"
+        elif get_secret_str("WATSONX_ZENAPIKEY"):
+            headers["Authorization"] = f"Bearer {get_secret_str('WATSONX_ZENAPIKEY')}"
         else:
             token = _generate_watsonx_token(api_key=api_key, token=token)
             # build auth headers

--- a/tests/llm_translation/test_watsonx.py
+++ b/tests/llm_translation/test_watsonx.py
@@ -98,9 +98,16 @@ def test_watsonx_token_in_env_var(
     mock_post, _ = watsonx_chat_completion_call(patch_token_call=False)
 
     assert mock_post.call_count == 1
-    assert (
-        mock_post.call_args[1]["headers"]["Authorization"] == "Bearer my-custom-token"
-    )
+    if env_var_key == "WATSONX_ZENAPIKEY":
+        assert (
+            mock_post.call_args[1]["headers"]["Authorization"]
+            == "ZenApiKey my-custom-token"
+        )
+    else:
+        assert (
+            mock_post.call_args[1]["headers"]["Authorization"]
+            == "Bearer mock_access_token"
+        )
 
 
 def test_watsonx_chat_completions_endpoint(watsonx_chat_completion_call):


### PR DESCRIPTION
## (fix) IBM Watsonx using ZenApiKey

- ZenApiKey needs to use `"Authorization: ZenApiKey {TOKEN}"` 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

