### PR TITLE
OllamaChatConfig support for structured output

### DIFF
--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -154,6 +154,8 @@ class OllamaChatConfig(OpenAIGPTConfig):
                 optional_params["stop"] = value
             if param == "response_format" and value["type"] == "json_object":
                 optional_params["format"] = "json"
+            if param == "response_format" and value["type"] == "json_schema":
+                optional_params["format"] = value["json_schema"]["schema"]
             ### FUNCTION CALLING LOGIC ###
             if param == "tools":
                 # ollama actually supports json output


### PR DESCRIPTION

## Adds the support for the new structured_response for ollama

[See here](https://ollama.com/blog/structured-outputs)

## Type

🆕 New Feature

## Changes

-- Adds support in map_openai_params method


