### PR TITLE
[Hashicorp - secret manager] - use vault namespace for tls auth 

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -396,6 +396,7 @@ router_settings:
 | HCP_VAULT_CLIENT_KEY | Path to client key for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
 | HCP_VAULT_NAMESPACE | Namespace for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
 | HCP_VAULT_TOKEN | Token for [Hashicorp Vault Secret Manager](../secret.md#hashicorp-vault)
+| HCP_VAULT_CERT_ROLE | Role for [Hashicorp Vault Secret Manager Auth](../secret.md#hashicorp-vault)
 | HELICONE_API_KEY | API key for Helicone service
 | HOSTNAME | Hostname for the server, this will be [emitted to `datadog` logs](https://docs.litellm.ai/docs/proxy/logging#datadog)
 | HUGGINGFACE_API_BASE | Base URL for Hugging Face API

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -29,7 +29,7 @@ class HashicorpSecretManager(BaseSecretManager):
         # Optional config for TLS cert auth
         self.tls_cert_path = os.getenv("HCP_VAULT_CLIENT_CERT", "")
         self.tls_key_path = os.getenv("HCP_VAULT_CLIENT_KEY", "")
-        self.vault_cert_role = os.getenv("VAULT_CERT_ROLE", None)
+        self.vault_cert_role = os.getenv("HCP_VAULT_CERT_ROLE", None)
 
         # Validate environment
         if not self.vault_token:

--- a/tests/secret_manager_tests/test_hashicorp.py
+++ b/tests/secret_manager_tests/test_hashicorp.py
@@ -183,7 +183,8 @@ def test_hashicorp_secret_manager_tls_cert_auth():
         test_manager = HashicorpSecretManager()
         test_manager.tls_cert_path = "cert.pem"
         test_manager.tls_key_path = "key.pem"
-
+        test_manager.vault_cert_role = "test-role"
+        test_manager.vault_namespace = "test-namespace"
         # Test the TLS auth method
         token = test_manager._auth_via_tls_cert()
 
@@ -192,6 +193,8 @@ def test_hashicorp_secret_manager_tls_cert_auth():
         mock_post.assert_called_once_with(
             f"{test_manager.vault_addr}/v1/auth/cert/login",
             cert=("cert.pem", "key.pem"),
+            headers={"X-Vault-Namespace": "test-namespace"},
+            json={"name": "test-role"},
         )
 
         # Verify the token was cached


### PR DESCRIPTION
## [Hashicorp - secret manager] - use vault namespace for tls auth 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

