### PR TITLE
(Feat - litellm proxy) - Allow users to Opt into logging request messages / responses in DB

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1855,6 +1855,8 @@ class SpendLogsPayload(TypedDict):
     end_user: Optional[str]
     requester_ip_address: Optional[str]
     custom_llm_provider: Optional[str]
+    messages: Optional[Union[str, list, dict]]
+    response: Optional[Union[str, list, dict]]
 
 
 class SpanAttributes(str, enum.Enum):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1603,6 +1603,8 @@ class LiteLLM_SpendLogs(LiteLLMPydanticObjectBase):
     cache_key: Optional[str] = None
     request_tags: Optional[Json] = None
     requester_ip_address: Optional[str] = None
+    messages: Optional[Union[str, list, dict]]
+    response: Optional[Union[str, list, dict]]
 
 
 class LiteLLM_ErrorLogs(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -12,5 +12,6 @@ model_list:
     model_info:
       health_check_model: anthropic/claude-3-5-sonnet-20240620
 
-litellm_settings:
-  callbacks: ["datadog_llm_observability"]
+general_settings:
+  store_prompts_in_spend_logs: true
+

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -204,6 +204,8 @@ model LiteLLM_SpendLogs {
   team_id             String? 
   end_user            String?
   requester_ip_address String?
+  messages            Json?     @default("{}")
+  response            Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])
 }

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -1,7 +1,7 @@
 import json
 import secrets
 from datetime import datetime as dt
-from typing import Optional, cast
+from typing import Optional, Union, cast
 
 from pydantic import BaseModel
 
@@ -9,6 +9,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import SpendLogsMetadata, SpendLogsPayload
 from litellm.proxy.utils import PrismaClient, hash_token
+from litellm.types.utils import StandardLoggingPayload
 
 
 def _is_master_key(api_key: str, _master_key: Optional[str]) -> bool:
@@ -57,6 +58,9 @@ def get_logging_payload(
         usage = dict(usage)
     id = cast(dict, response_obj).get("id") or kwargs.get("litellm_call_id")
     api_key = metadata.get("user_api_key", "")
+    standard_logging_payload: Optional[StandardLoggingPayload] = kwargs.get(
+        "standard_logging_object", None
+    )
     if api_key is not None and isinstance(api_key, str):
         if api_key.startswith("sk-"):
             # hash the api_key
@@ -151,6 +155,8 @@ def get_logging_payload(
             model_id=_model_id,
             requester_ip_address=clean_metadata.get("requester_ip_address", None),
             custom_llm_provider=kwargs.get("custom_llm_provider", ""),
+            messages=_get_messages_for_spend_logs_payload(standard_logging_payload),
+            response=_get_response_for_spend_logs_payload(standard_logging_payload),
         )
 
         verbose_proxy_logger.debug(
@@ -239,3 +245,29 @@ async def get_spend_by_team_and_customer(
         return []
 
     return db_response
+
+
+def _get_messages_for_spend_logs_payload(
+    payload: Optional[StandardLoggingPayload],
+) -> Optional[Union[str, list, dict]]:
+    if payload is None:
+        return None
+    if _should_store_prompts_and_responses_in_spend_logs():
+        return payload.get("messages", {})
+    return None
+
+
+def _get_response_for_spend_logs_payload(
+    payload: Optional[StandardLoggingPayload],
+) -> Optional[Union[str, list, dict]]:
+    if payload is None:
+        return None
+    if _should_store_prompts_and_responses_in_spend_logs():
+        return payload.get("response", {})
+    return None
+
+
+def _should_store_prompts_and_responses_in_spend_logs() -> bool:
+    from litellm.proxy.proxy_server import general_settings
+
+    return general_settings.get("store_prompts_in_spend_logs") is True

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -160,7 +160,8 @@ def get_logging_payload(
         )
 
         verbose_proxy_logger.debug(
-            "SpendTable: created payload - payload: %s\n\n", payload
+            "SpendTable: created payload - payload: %s\n\n",
+            json.dumps(payload, indent=4, default=str),
         )
 
         return payload
@@ -249,22 +250,22 @@ async def get_spend_by_team_and_customer(
 
 def _get_messages_for_spend_logs_payload(
     payload: Optional[StandardLoggingPayload],
-) -> Optional[Union[str, list, dict]]:
+) -> str:
     if payload is None:
-        return None
+        return ""
     if _should_store_prompts_and_responses_in_spend_logs():
-        return payload.get("messages", {})
-    return None
+        return json.dumps(payload.get("messages", {}))
+    return ""
 
 
 def _get_response_for_spend_logs_payload(
     payload: Optional[StandardLoggingPayload],
-) -> Optional[Union[str, list, dict]]:
+) -> str:
     if payload is None:
-        return None
+        return ""
     if _should_store_prompts_and_responses_in_spend_logs():
-        return payload.get("response", {})
-    return None
+        return json.dumps(payload.get("response", {}))
+    return ""
 
 
 def _should_store_prompts_and_responses_in_spend_logs() -> bool:

--- a/schema.prisma
+++ b/schema.prisma
@@ -204,6 +204,8 @@ model LiteLLM_SpendLogs {
   team_id             String? 
   end_user            String?
   requester_ip_address String?
+  messages            Json?     @default("{}")
+  response            Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])
 }


### PR DESCRIPTION
## (Feat - litellm proxy) - Allow users to Opt into logging request messages / responses in DB

- only log request / response in the DB if user opts into logging request / response 


<img width="947" alt="Xnapper-2025-01-17-14 28 03" src="https://github.com/user-attachments/assets/d1715b27-fc3a-4257-a9d5-bd390bb833f6" />

<img width="848" alt="Xnapper-2025-01-17-14 33 04" src="https://github.com/user-attachments/assets/7f306b4d-1fb2-46fd-9a28-ce1c41c88d79" />


This is only enabled if the following is enabled on the config `store_prompts_in_spend_logs: true` 

```yaml
model_list:
  - model_name: openai/*
    litellm_params:
      model:  openai/*
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      health_check_model: openai/gpt-4o-mini
  - model_name: anthropic/*
    litellm_params:
      model: anthropic/*
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      health_check_model: anthropic/claude-3-5-sonnet-20240620

general_settings:
  store_prompts_in_spend_logs: true


```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

