### PR TITLE
add new bedrock stability models & versions to model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6587,7 +6587,35 @@
         "litellm_provider": "bedrock",
         "mode": "image_generation"
     },
+    "stability.sd3-5-large-v1:0": {
+        "max_tokens": 77, 
+        "max_input_tokens": 77, 
+        "output_cost_per_image": 0.08,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation"
+    },
+    "stability.stable-image-core-v1:0": {
+        "max_tokens": 77, 
+        "max_input_tokens": 77, 
+        "output_cost_per_image": 0.04,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation"
+    },
+    "stability.stable-image-core-v1:1": {
+        "max_tokens": 77, 
+        "max_input_tokens": 77, 
+        "output_cost_per_image": 0.04,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation"
+    },
     "stability.stable-image-ultra-v1:0": {
+        "max_tokens": 77, 
+        "max_input_tokens": 77, 
+        "output_cost_per_image": 0.14,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation"
+    },
+    "stability.stable-image-ultra-v1:1": {
         "max_tokens": 77, 
         "max_input_tokens": 77, 
         "output_cost_per_image": 0.14,


### PR DESCRIPTION
## Title

add new bedrock stability models & versions to model_prices_and_context_window.json


## Type

🆕 New Feature

## Changes

* added Bedrock stable diffusion 3.5 large model
* added Bedrock stable image ultra v1.1
* added Bedrock stable image core v1.0 and v1.1

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

I'm not sure of any required testing processes, please let me know in the comments of the procedure or any other additions needed to add support for these models

<!-- Test procedure -->

