### PR TITLE
Include reasoning_content in response

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -417,6 +417,7 @@ def convert_to_model_response_object(  # noqa: PLR0915
                             provider_specific_fields[field] = choice["message"][field]
                     message = Message(
                         content=choice["message"].get("content", None),
+                        reasoning_content=choice["message"].get("reasoning_content", None),
                         role=choice["message"]["role"] or "assistant",
                         function_call=choice["message"].get("function_call", None),
                         tool_calls=tool_calls,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -434,6 +434,7 @@ ChatCompletionMessage(content='This is a test', role='assistant', function_call=
 
 class Message(OpenAIObject):
     content: Optional[str]
+    reasoning_content: Optional[str] = None
     role: Literal["assistant", "user", "system", "tool", "function"]
     tool_calls: Optional[List[ChatCompletionMessageToolCall]]
     function_call: Optional[FunctionCall]
@@ -445,6 +446,7 @@ class Message(OpenAIObject):
     def __init__(
         self,
         content: Optional[str] = None,
+        reasoning_content: Optional[str] = None,
         role: Literal["assistant"] = "assistant",
         function_call=None,
         tool_calls: Optional[list] = None,
@@ -474,6 +476,9 @@ class Message(OpenAIObject):
 
         if audio is not None:
             init_values["audio"] = audio
+
+        if reasoning_content is not None:
+            init_values["reasoning_content"] = reasoning_content
 
         super(Message, self).__init__(
             **init_values,  # type: ignore


### PR DESCRIPTION
## Title

Include `reasoning_content` in response

## Type

🆕 New Feature

## Changes

Include optional `reasoning_content` field into `Message` to support access to `deepseek-reasoner` [internal reasoning](https://api-docs.deepseek.com/guides/reasoning_model#api-example)
