### PR TITLE
add a step to install the proxy extra

### DIFF
--- a/docs/my-website/docs/observability/opentelemetry_integration.md
+++ b/docs/my-website/docs/observability/opentelemetry_integration.md
@@ -16,6 +16,12 @@ Install the OpenTelemetry SDK:
 pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
+Install the `proxy` extra that is required for the OpenTelemetry integration:
+
+```
+pip install litellm[proxy]
+```
+
 Set the environment variables (different providers may require different variables):
 
 


### PR DESCRIPTION
## Title

add a step to install the proxy extra

## Relevant issues

N/A

When following the example in this doc without the `proxy` extra installed, I get the following error

```
15:54:27 - LiteLLM:ERROR: litellm_logging.py:2583 - [Non-Blocking Error] Error initializing custom logger: Missing dependency No module named 'backoff'. Run `pip install 'litellm[proxy]'`
Traceback (most recent call last):
  File "/Users/din/laminar/sandbox/lite/.venv/lib/python3.12/site-packages/litellm/proxy/proxy_server.py", line 55, in <module>
    import backoff
ModuleNotFoundError: No module named 'backoff'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/din/laminar/sandbox/lite/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/litellm_logging.py", line 2467, in _init_custom_logger_compatible_class
    **_get_custom_logger_settings_from_proxy_server(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/din/laminar/sandbox/lite/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/litellm_logging.py", line 2726, in _get_custom_logger_settings_from_proxy_server
    from litellm.proxy.proxy_server import callback_settings
  File "/Users/din/laminar/sandbox/lite/.venv/lib/python3.12/site-packages/litellm/proxy/proxy_server.py", line 61, in <module>
    raise ImportError(f"Missing dependency {e}. Run `pip install 'litellm[proxy]'`")
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<img width="914" alt="Screenshot 2025-01-23 at 18 35 41" src="https://github.com/user-attachments/assets/4942a297-a2b8-43ac-a546-4b41087c6188" />

