### PR TITLE
(Feat) - emit `litellm_team_budget_reset_at_metric` and `litellm_api_key_budget_remaining_hours_metric` on prometheus 

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -139,7 +139,27 @@ class PrometheusLogger(CustomLogger):
             self.litellm_remaining_team_budget_metric = Gauge(
                 "litellm_remaining_team_budget_metric",
                 "Remaining budget for team",
-                labelnames=["team_id", "team_alias"],
+                labelnames=PrometheusMetricLabels.get_labels(
+                    label_name="litellm_remaining_team_budget_metric"
+                ),
+            )
+
+            # Max Budget for Team
+            self.litellm_team_max_budget_metric = Gauge(
+                "litellm_team_max_budget_metric",
+                "Maximum budget set for team",
+                labelnames=PrometheusMetricLabels.get_labels(
+                    label_name="litellm_team_max_budget_metric"
+                ),
+            )
+
+            # Team Budget Reset At
+            self.litellm_team_budget_reset_at_metric = Gauge(
+                "litellm_team_budget_reset_at_metric",
+                "Time when the team budget will be reset",
+                labelnames=PrometheusMetricLabels.get_labels(
+                    label_name="litellm_team_budget_reset_at_metric"
+                ),
             )
 
             # Remaining Budget for API Key
@@ -147,13 +167,6 @@ class PrometheusLogger(CustomLogger):
                 "litellm_remaining_api_key_budget_metric",
                 "Remaining budget for api key",
                 labelnames=["hashed_api_key", "api_key_alias"],
-            )
-
-            # Max Budget for Team
-            self.litellm_team_max_budget_metric = Gauge(
-                "litellm_team_max_budget_metric",
-                "Maximum budget set for team",
-                labelnames=["team_id", "team_alias"],
             )
 
             # Max Budget for API Key
@@ -1370,6 +1383,12 @@ class PrometheusLogger(CustomLogger):
                         spend=team.spend,
                     )
                 )
+
+            if team.budget_reset_at is not None:
+                self.litellm_team_budget_reset_at_metric.labels(
+                    team.team_id,
+                    team.team_alias or "",
+                ).set(team.budget_reset_at.timestamp())
 
 
 def prometheus_label_factory(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1417,13 +1417,13 @@ class PrometheusLogger(CustomLogger):
         from litellm.proxy.auth.auth_checks import get_team_object
         from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
+        _total_team_spend = (spend or 0) + response_cost
         team_object = LiteLLM_TeamTable(
             team_id=team_id,
             team_alias=team_alias,
-            spend=spend or 0 + response_cost,
+            spend=_total_team_spend,
             max_budget=max_budget,
         )
-
         try:
             team_info = await get_team_object(
                 team_id=team_id,
@@ -1541,11 +1541,12 @@ class PrometheusLogger(CustomLogger):
         from litellm.proxy.auth.auth_checks import get_key_object
         from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
+        _total_key_spend = (key_spend or 0) + response_cost
         user_api_key_dict = UserAPIKeyAuth(
             token=user_api_key,
             key_alias=user_api_key_alias,
             max_budget=key_max_budget,
-            spend=key_spend or 0 + response_cost,
+            spend=_total_key_spend,
         )
         try:
             if user_api_key_dict.token:

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1515,7 +1515,7 @@ class PrometheusLogger(CustomLogger):
         user_api_key_alias: Optional[str],
         response_cost: float,
         key_max_budget: float,
-        key_spend: float,
+        key_spend: Optional[float],
     ):
         if user_api_key:
             user_api_key_dict = await self._assemble_key_object(
@@ -1532,7 +1532,7 @@ class PrometheusLogger(CustomLogger):
         user_api_key: str,
         user_api_key_alias: str,
         key_max_budget: float,
-        key_spend: float,
+        key_spend: Optional[float],
         response_cost: float,
     ) -> UserAPIKeyAuth:
         """
@@ -1545,7 +1545,7 @@ class PrometheusLogger(CustomLogger):
             token=user_api_key,
             key_alias=user_api_key_alias,
             max_budget=key_max_budget,
-            spend=key_spend + response_cost,
+            spend=key_spend or 0 + response_cost,
         )
         try:
             if user_api_key_dict.token:

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1464,9 +1464,8 @@ class PrometheusLogger(CustomLogger):
                 team.team_id,
                 team.team_alias or "",
             ).set(
-                self._safe_get_remaining_budget(
-                    max_budget=team.max_budget,
-                    spend=team.spend,
+                self._get_remaining_hours_for_budget_reset(
+                    budget_reset_at=team.budget_reset_at
                 )
             )
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -658,6 +658,9 @@ async def get_team_object(
     - Check if team id in proxy Team Table
     - if valid, return LiteLLM_TeamTable object with defined limits
     - if not, then raise an error
+
+    Raises:
+        - Exception: If team doesn't exist in db or cache
     """
     if prisma_client is None:
         raise Exception(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -14,7 +14,6 @@ import json
 import traceback
 import uuid
 from datetime import datetime, timedelta, timezone
-from functools import lru_cache
 from typing import List, Optional, Tuple, Union, cast
 
 import fastapi
@@ -1200,9 +1199,16 @@ async def team_info(
                 ),
             )
 
-        team_info: Optional[LiteLLM_TeamTable] = await _get_team_info_from_db(
-            team_id=team_id, prisma_client=prisma_client
+        team_info: Optional[Union[LiteLLM_TeamTable, dict]] = (
+            await prisma_client.get_data(
+                team_id=team_id, table_name="team", query_type="find_unique"
+            )
         )
+        if team_info is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"message": f"Team not found, passed team id: {team_id}."},
+            )
 
         ## GET ALL KEYS ##
         keys = await prisma_client.get_data(
@@ -1220,7 +1226,7 @@ async def team_info(
             spend = 0
             for k in keys:
                 spend += getattr(k, "spend", 0)
-            team_info = LiteLLM_TeamTable(spend=spend)
+            team_info = {"spend": spend}
 
         ## REMOVE HASHED TOKEN INFO before returning ##
         for key in keys:
@@ -1236,9 +1242,16 @@ async def team_info(
             prisma_client, [team_id], user_id=None
         )
 
+        if isinstance(team_info, dict):
+            _team_info = LiteLLM_TeamTable(**team_info)
+        elif isinstance(team_info, BaseModel):
+            _team_info = LiteLLM_TeamTable(**team_info.model_dump())
+        else:
+            _team_info = LiteLLM_TeamTable()
+
         response_object = TeamInfoResponseObject(
             team_id=team_id,
-            team_info=team_info,
+            team_info=_team_info,
             keys=keys,
             team_memberships=returned_tm,
         )
@@ -1265,37 +1278,6 @@ async def team_info(
             param=getattr(e, "param", "None"),
             code=status.HTTP_400_BAD_REQUEST,
         )
-
-
-async def _get_team_info_from_db(
-    team_id: str, prisma_client: PrismaClient
-) -> Optional[LiteLLM_TeamTable]:
-    """
-    Get team info from db
-    """
-    team_info: Optional[Union[LiteLLM_TeamTable, dict]] = await prisma_client.get_data(
-        team_id=team_id, table_name="team", query_type="find_unique"
-    )
-    if team_info is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"message": f"Team not found, passed team id: {team_id}."},
-        )
-
-    if isinstance(team_info, dict):
-        return LiteLLM_TeamTable(**team_info)
-    else:
-        return team_info
-
-
-@lru_cache(maxsize=16)
-async def _get_team_info_from_db_lru_cached(
-    team_id: str, prisma_client: PrismaClient
-) -> Optional[LiteLLM_TeamTable]:
-    """
-    Get team info from db and cache the result
-    """
-    return await _get_team_info_from_db(team_id=team_id, prisma_client=prisma_client)
 
 
 @router.post(

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -83,7 +83,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_deployment_failed_fallbacks",
     "litellm_remaining_team_budget_metric",
     "litellm_team_max_budget_metric",
-    "litellm_team_budget_reset_at_metric",
+    "litellm_team_budget_remaining_days_metric",
 ]
 
 
@@ -199,7 +199,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]
 
-    litellm_team_budget_reset_at_metric = [
+    litellm_team_budget_remaining_days_metric = [
         UserAPIKeyLabelNames.TEAM.value,
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -84,6 +84,9 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_remaining_team_budget_metric",
     "litellm_team_max_budget_metric",
     "litellm_team_budget_remaining_hours_metric",
+    "litellm_remaining_api_key_budget_metric",
+    "litellm_api_key_max_budget_metric",
+    "litellm_api_key_budget_remaining_hours_metric",
 ]
 
 
@@ -203,6 +206,17 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM.value,
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]
+
+    litellm_remaining_api_key_budget_metric = [
+        UserAPIKeyLabelNames.API_KEY_HASH.value,
+        UserAPIKeyLabelNames.API_KEY_ALIAS.value,
+    ]
+
+    litellm_api_key_max_budget_metric = litellm_remaining_api_key_budget_metric
+
+    litellm_api_key_budget_remaining_hours_metric = (
+        litellm_remaining_api_key_budget_metric
+    )
 
     @staticmethod
     def get_labels(label_name: DEFINED_PROMETHEUS_METRICS) -> List[str]:

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -83,7 +83,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_deployment_failed_fallbacks",
     "litellm_remaining_team_budget_metric",
     "litellm_team_max_budget_metric",
-    "litellm_team_budget_remaining_days_metric",
+    "litellm_team_budget_remaining_hours_metric",
 ]
 
 
@@ -199,7 +199,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]
 
-    litellm_team_budget_remaining_days_metric = [
+    litellm_team_budget_remaining_hours_metric = [
         UserAPIKeyLabelNames.TEAM.value,
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
     ]

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -986,31 +986,86 @@ async def test_initialize_remaining_budget_metrics(prometheus_logger):
         "litellm.proxy.management_endpoints.team_endpoints.get_paginated_teams"
     ) as mock_get_teams:
 
-        # Create mock team data
+        # Create mock team data with proper datetime objects for budget_reset_at
+        future_reset = datetime.now() + timedelta(hours=24)  # Reset 24 hours from now
         mock_teams = [
-            MagicMock(team_id="team1", team_alias="alias1", max_budget=100, spend=30),
-            MagicMock(team_id="team2", team_alias="alias2", max_budget=200, spend=50),
-            MagicMock(team_id="team3", team_alias=None, max_budget=300, spend=100),
+            MagicMock(
+                team_id="team1",
+                team_alias="alias1",
+                max_budget=100,
+                spend=30,
+                budget_reset_at=future_reset,
+            ),
+            MagicMock(
+                team_id="team2",
+                team_alias="alias2",
+                max_budget=200,
+                spend=50,
+                budget_reset_at=future_reset,
+            ),
+            MagicMock(
+                team_id="team3",
+                team_alias=None,
+                max_budget=300,
+                spend=100,
+                budget_reset_at=future_reset,
+            ),
         ]
 
         # Mock get_paginated_teams to return our test data
         mock_get_teams.return_value = (mock_teams, len(mock_teams))
 
-        # Mock the Prometheus metric
+        # Mock the Prometheus metrics
         prometheus_logger.litellm_remaining_team_budget_metric = MagicMock()
+        prometheus_logger.litellm_team_budget_remaining_hours_metric = MagicMock()
 
         # Call the function
         await prometheus_logger._initialize_remaining_budget_metrics()
 
-        # Verify the metric was set correctly for each team
-        expected_calls = [
+        # Verify the remaining budget metric was set correctly for each team
+        expected_budget_calls = [
             call.labels("team1", "alias1").set(70),  # 100 - 30
             call.labels("team2", "alias2").set(150),  # 200 - 50
             call.labels("team3", "").set(200),  # 300 - 100
         ]
 
         prometheus_logger.litellm_remaining_team_budget_metric.assert_has_calls(
-            expected_calls, any_order=True
+            expected_budget_calls, any_order=True
+        )
+
+        # Get all the calls made to the hours metric
+        hours_calls = (
+            prometheus_logger.litellm_team_budget_remaining_hours_metric.mock_calls
+        )
+
+        # Verify the structure and approximate values of the hours calls
+        assert len(hours_calls) == 6  # 3 teams * 2 calls each (labels + set)
+
+        # Helper function to extract hours value from call
+        def get_hours_from_call(call_obj):
+            if "set" in str(call_obj):
+                return call_obj[1][0]  # Extract the hours value
+            return None
+
+        # Verify each team's hours are approximately 24 (within reasonable bounds)
+        hours_values = [
+            get_hours_from_call(call)
+            for call in hours_calls
+            if get_hours_from_call(call) is not None
+        ]
+        for hours in hours_values:
+            assert (
+                23.9 <= hours <= 24.0
+            ), f"Hours value {hours} not within expected range"
+
+        # Verify the labels were called with correct team information
+        label_calls = [
+            call.labels("team1", "alias1"),
+            call.labels("team2", "alias2"),
+            call.labels("team3", ""),
+        ]
+        prometheus_logger.litellm_team_budget_remaining_hours_metric.assert_has_calls(
+            label_calls, any_order=True
         )
 
 

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -251,7 +251,8 @@ def test_increment_token_metrics(prometheus_logger):
     )
 
 
-def test_increment_remaining_budget_metrics(prometheus_logger):
+@pytest.mark.asyncio
+async def test_increment_remaining_budget_metrics(prometheus_logger):
     """
     Test the increment_remaining_budget_metrics method
 
@@ -272,12 +273,13 @@ def test_increment_remaining_budget_metrics(prometheus_logger):
         }
     }
 
-    prometheus_logger._increment_remaining_budget_metrics(
+    await prometheus_logger._increment_remaining_budget_metrics(
         user_api_team="team1",
         user_api_team_alias="team_alias1",
         user_api_key="key1",
         user_api_key_alias="alias1",
         litellm_params=litellm_params,
+        response_cost=10,
     )
 
     # Test remaining budget metrics
@@ -285,14 +287,14 @@ def test_increment_remaining_budget_metrics(prometheus_logger):
         "team1", "team_alias1"
     )
     prometheus_logger.litellm_remaining_team_budget_metric.labels().set.assert_called_once_with(
-        50  # 100 - 50
+        40  # 100 - (50 + 10)
     )
 
     prometheus_logger.litellm_remaining_api_key_budget_metric.labels.assert_called_once_with(
         "key1", "alias1"
     )
     prometheus_logger.litellm_remaining_api_key_budget_metric.labels().set.assert_called_once_with(
-        50  # 75 - 25
+        40  # 75 - (25 + 10)
     )
 
     # Test max budget metrics


### PR DESCRIPTION
## (Feat) - emit `litellm_team_budget_remaining_hours_metric` and `litellm_api_key_budget_remaining_hours_metric ` on prometheus 

```
litellm_team_budget_remaining_hours_metric{team="4e945c11-7987-43b3-861c-6f582671073e",team_alias="central"} 163.92450555222223
```


```
litellm_api_key_budget_remaining_hours_metric{api_key_alias="budget_test_key_ec6f3ded-93f0-4292-8297-e237d496c237",hashed_api_key="e5104b137f452ef765f294834dc06e40b863d048a699436c481135495c020845"} 167.99964245916667
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

- e2e testing for updating key/team remaining budget metrics on /metrics 
- verify the same value is seen on /key/info and /team/info endpoints 
- e2e testing for budget remaining hours 
- unit testing for incrementing remaining team / key budget metrics 

