### PR TITLE
(Feat) - Allow Admin UI users to view spend logs even when not storing messages / responses 

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -13,8 +13,7 @@ model_list:
       api_key: fake-key
       api_base: https://exampleopenaiendpoint-production.up.railway.app/
 
-general_settings:
-  store_prompts_in_spend_logs: true
+
 
 litellm_settings:
   callbacks: ["prometheus"]

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1667,17 +1667,7 @@ async def ui_view_spend_logs(  # noqa: PLR0915
             param="None",
             code=status.HTTP_401_UNAUTHORIZED,
         )
-    if _should_store_prompts_and_responses_in_spend_logs() is not True:
-        verbose_proxy_logger.debug(
-            "Prompts and responses are not stored in spend logs, returning empty list"
-        )
-        return {
-            "data": [],
-            "total": 0,
-            "page": page,
-            "page_size": page_size,
-            "total_pages": 0,
-        }
+
     if start_date is None or end_date is None:
         raise ProxyException(
             message="Start date and end date are required",


### PR DESCRIPTION
## (Feat) - Allow Admin UI users to view spend logs even when not storing messages / responses 

<img width="1364" alt="Xnapper-2025-01-23-15 18 18" src="https://github.com/user-attachments/assets/4efd5a46-2f62-410f-9c1e-9a26139e9ee8" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

