### PR TITLE
Fix 7955: allow datetime filtering on /spend/logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ opentelemetry-exporter-otlp==1.25.0
 sentry_sdk==2.2.1 # for sentry error handling
 detect-secrets==1.5.0 # Enterprise - secret detection / masking in LLM requests
 cryptography==43.0.1
+python-dateutil==2.9.0.post0
 
 ### LITELLM PACKAGE DEPENDENCIES
 python-dotenv==1.0.0 # for env 


### PR DESCRIPTION
## Allow datetime filtering on /spend/logs

This change allows you to query the spend logs with a datetime range filter. This functionality is currently unavailable (the existing `start_date` and `end_date` parameters do something altogether different).


## Relevant issues

Implements #7955 7955

## Type

🆕 New Feature

## Changes
- Add additional params to /spend/logs
- Improve documentation of /spend/logs
- Pass new params down the chain of query functions, without changing their overall structure (though I am not sure why we go from the spendlog API implementation into a generalised query function which then branches on the table type anyway? seems like an unnecessary level of indirection).

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

I have not included tests yet, happy to add them if this PR is considered desirable.

