### PR TITLE
(UI) - Usage page show days when spend is 0 and round spend figures on charts to 2 sig figs

### DIFF
--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -459,49 +459,22 @@ const UsagePage: React.FC<UsagePageProps> = ({
   };
 
   // Update the fetchGlobalActivity function
-  const fetchGlobalActivity = async () => {
+  const fetchGlobalActivity = () => {
     if (!accessToken) return;
-    try {
-      const data = await adminGlobalActivity(accessToken, startTime, endTime);
-      
-      // Fill in missing dates for activity data
-      const filledData = fillMissingDates(
-        data.daily_data,
-        new Date(startTime),
-        new Date(endTime),
-        []
-      );
-      
-      setGlobalActivity({
-        ...data,
-        daily_data: filledData
-      });
-    } catch (error) {
-      console.error("Error fetching global activity:", error);
-    }
+    fetchAndSetData(
+      () => adminGlobalActivity(accessToken, startTime, endTime),
+      setGlobalActivity,
+      "Error fetching global activity"
+    );
   };
 
-  // Update the fetchGlobalActivityPerModel function
-  const fetchGlobalActivityPerModel = async () => {
+  const fetchGlobalActivityPerModel = () => {
     if (!accessToken) return;
-    try {
-      const data = await adminGlobalActivityPerModel(accessToken, startTime, endTime);
-      
-      // Fill in missing dates for each model's data
-      const filledData = data.map((modelData: any) => ({
-        ...modelData,
-        daily_data: fillMissingDates(
-          modelData.daily_data,
-          new Date(startTime),
-          new Date(endTime),
-          []
-        )
-      }));
-      
-      setGlobalActivityPerModel(filledData);
-    } catch (error) {
-      console.error("Error fetching global activity per model:", error);
-    }
+    fetchAndSetData(
+      () => adminGlobalActivityPerModel(accessToken, startTime, endTime),
+      setGlobalActivityPerModel,
+      "Error fetching global activity per model"
+    );
   };
 
   useEffect(() => {

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -625,14 +625,19 @@ const UsagePage: React.FC<UsagePageProps> = ({
         <TabPanels>
           <TabPanel>
             <Grid numItems={2} className="gap-2 h-[100vh] w-full">
-            <ViewUserSpend
-            userID={userID}
-            userRole={userRole}
-            accessToken={accessToken}
-            userSpend={totalMonthlySpend}
-            selectedTeam={null}
-            userMaxBudget={null}
-          />
+              <Col numColSpan={2}>
+                <Text className="text-tremor-default text-tremor-content dark:text-dark-tremor-content mb-2 mt-2 text-lg">
+                  Project Spend {new Date().toLocaleString('default', { month: 'long' })} 1 - {new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0).getDate()}
+                </Text>
+                <ViewUserSpend
+                  userID={userID}
+                  userRole={userRole}
+                  accessToken={accessToken}
+                  userSpend={totalMonthlySpend}
+                  selectedTeam={null}
+                  userMaxBudget={null}
+                />
+              </Col>
               <Col numColSpan={2}>
                 <Card>
                   <Title>Monthly Spend</Title>

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -165,6 +165,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
     to: new Date(),
   });
   const [proxySettings, setProxySettings] = useState<ProxySettings | null>(null);
+  const [totalMonthlySpend, setTotalMonthlySpend] = useState<number>(0);
 
   const firstDay = new Date(
     currentDate.getFullYear(),
@@ -375,6 +376,10 @@ const UsagePage: React.FC<UsagePageProps> = ({
       
       // Fill in missing dates
       const filledData = fillMissingDates(data, firstDay, lastDay, []);
+      
+      // Calculate total spend for the month and round to 2 decimal places
+      const monthlyTotal = Number(filledData.reduce((sum, day) => sum + (day.spend || 0), 0).toFixed(2));
+      setTotalMonthlySpend(monthlyTotal);
       
       setKeySpendData(filledData);
     } catch (error) {
@@ -624,7 +629,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
             userID={userID}
             userRole={userRole}
             accessToken={accessToken}
-            userSpend={null}
+            userSpend={totalMonthlySpend}
             selectedTeam={null}
             userMaxBudget={null}
           />

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -373,7 +373,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
         const top_keys = await adminTopKeysCall(accessToken);
         return top_keys.map((k: any) => ({
           key: (k["key_alias"] || k["key_name"] || k["api_key"]).substring(0, 10),
-          spend: k["total_spend"],
+          spend: Number(k["total_spend"].toFixed(2)),
         }));
       },
       setTopKeys,
@@ -388,7 +388,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
         const top_models = await adminTopModelsCall(accessToken);
         return top_models.map((k: any) => ({
           key: k["model"],
-          spend: k["total_spend"],
+          spend: Number(k["total_spend"].toFixed(2)),
         }));
       },
       setTopModels,
@@ -625,6 +625,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                     layout="vertical"
                     showXAxis={false}
                     showLegend={false}
+                    valueFormatter={(value) => `$${value.toFixed(2)}`}
                   />
                 </Card>
               </Col>
@@ -641,6 +642,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                     layout="vertical"
                     showXAxis={false}
                     showLegend={false}
+                    valueFormatter={(value) => `$${value.toFixed(2)}`}
                   />
                 </Card>
                
@@ -661,6 +663,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                       index="provider"
                       category="spend"
                       colors={["cyan"]}
+                      valueFormatter={(value) => `$${value.toFixed(2)}`}
                     />
                   </Col>
                   <Col numColSpan={1}>


### PR DESCRIPTION
## (UI) - Usage page show days when spend is 0 and round spend figures

<!-- e.g. "Implement user authentication feature" -->
<img width="1118" alt="Screenshot 2025-01-24 at 6 48 11 PM" src="https://github.com/user-attachments/assets/b8db0a50-5dcf-4a3a-9546-fbaf0c7086a1" />

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

