### PR TITLE
[Fix Ui ]: Taha-hexcode

### DIFF
--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -1,9 +1,25 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { keyDeleteCall, modelAvailableCall, getGuardrailsList } from "./networking";
-import { add } from 'date-fns';
-import { InformationCircleIcon, StatusOnlineIcon, TrashIcon, PencilAltIcon, RefreshIcon } from "@heroicons/react/outline";
-import { keySpendLogsCall, PredictedSpendLogsCall, keyUpdateCall, modelInfoCall, regenerateKeyCall } from "./networking";
+import {
+  keyDeleteCall,
+  modelAvailableCall,
+  getGuardrailsList,
+} from "./networking";
+import { add } from "date-fns";
+import {
+  InformationCircleIcon,
+  StatusOnlineIcon,
+  TrashIcon,
+  PencilAltIcon,
+  RefreshIcon,
+} from "@heroicons/react/outline";
+import {
+  keySpendLogsCall,
+  PredictedSpendLogsCall,
+  keyUpdateCall,
+  modelInfoCall,
+  regenerateKeyCall,
+} from "./networking";
 import {
   Badge,
   Card,
@@ -16,7 +32,7 @@ import {
   TableHead,
   TableHeaderCell,
   TableRow,
-  Dialog, 
+  Dialog,
   DialogPanel,
   Text,
   Title,
@@ -26,9 +42,17 @@ import {
   TextInput,
   Textarea,
 } from "@tremor/react";
-import { InfoCircleOutlined } from '@ant-design/icons';
-import { fetchAvailableModelsForTeamOrKey, getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
-import { Select as Select3, SelectItem, MultiSelect, MultiSelectItem } from "@tremor/react";
+import { InfoCircleOutlined } from "@ant-design/icons";
+import {
+  fetchAvailableModelsForTeamOrKey,
+  getModelDisplayName,
+} from "./key_team_helpers/fetch_available_models_team_key";
+import {
+  Select as Select3,
+  SelectItem,
+  MultiSelect,
+  MultiSelectItem,
+} from "@tremor/react";
 import {
   Button as Button2,
   Modal,
@@ -49,7 +73,7 @@ const { Option } = Select;
 const isLocal = process.env.NODE_ENV === "development";
 const proxyBaseUrl = isLocal ? "http://localhost:4000" : null;
 if (isLocal != true) {
-  console.log = function() {};
+  console.log = function () {};
 }
 
 interface EditKeyModalProps {
@@ -58,7 +82,6 @@ interface EditKeyModalProps {
   token: any; // Assuming TeamType is a type representing your team object
   onSubmit: (data: FormData) => void; // Assuming FormData is the type of data to be submitted
 }
-
 
 interface ModelLimitModalProps {
   visible: boolean;
@@ -108,15 +131,15 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
   data,
   setData,
   teams,
-  premiumUser
+  premiumUser,
 }) => {
   const [isButtonClicked, setIsButtonClicked] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [keyToDelete, setKeyToDelete] = useState<string | null>(null);
   const [selectedItem, setSelectedItem] = useState<ItemData | null>(null);
-  const [spendData, setSpendData] = useState<{ day: string; spend: number }[] | null>(
-    null
-  );
+  const [spendData, setSpendData] = useState<
+    { day: string; spend: number }[] | null
+  >(null);
   const [predictedSpendString, setPredictedSpendString] = useState("");
 
   const [editModalVisible, setEditModalVisible] = useState(false);
@@ -151,36 +174,44 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       return data;
     }
 
-    teams.forEach(team => {
+    teams.forEach((team) => {
       // For default team or when user is not admin, use personal keys (data)
       if (team.team_id === "default-team" || !isUserTeamAdmin(team)) {
         if (selectedTeam && selectedTeam.team_id === team.team_id && data) {
-          allKeys = [...allKeys, ...data.filter(key => key.team_id === team.team_id)];
+          allKeys = [
+            ...allKeys,
+            ...data.filter((key) => key.team_id === team.team_id),
+          ];
         }
       }
       // For teams where user is admin, use team keys
       else if (isUserTeamAdmin(team)) {
         if (selectedTeam && selectedTeam.team_id === team.team_id) {
-          allKeys = [...allKeys, ...(team.keys || [])];
+          allKeys = [
+            ...allKeys,
+            ...(data?.filter((key) => key?.team_id === team?.team_id) || []),
+          ];
         }
       }
     });
 
     // If no team is selected, show all accessible keys
     if ((!selectedTeam || selectedTeam.team_alias === "Default Team") && data) {
-      const personalKeys = data.filter(key => !key.team_id || key.team_id === "default-team");
+      const personalKeys = data.filter(
+        (key) => !key.team_id || key.team_id === "default-team"
+      );
       const adminTeamKeys = teams
-        .filter(team => isUserTeamAdmin(team))
-        .flatMap(team => team.keys || []);
+        .filter((team) => isUserTeamAdmin(team))
+        .flatMap((team) => team.keys || []);
       allKeys = [...personalKeys, ...adminTeamKeys];
     }
 
     // Filter out litellm-dashboard keys
-    allKeys = allKeys.filter(key => key.team_id !== "litellm-dashboard");
+    allKeys = allKeys.filter((key) => key.team_id !== "litellm-dashboard");
 
     // Remove duplicates based on token
     const uniqueKeys = Array.from(
-      new Map(allKeys.map(key => [key.token, key])).values()
+      new Map(allKeys.map((key) => [key.token, key])).values()
     );
 
     return uniqueKeys;
@@ -191,29 +222,29 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       if (!duration) {
         return null;
       }
-  
+
       try {
         const now = new Date();
         let newExpiry: Date;
-  
-        if (duration.endsWith('s')) {
+
+        if (duration.endsWith("s")) {
           newExpiry = add(now, { seconds: parseInt(duration) });
-        } else if (duration.endsWith('h')) {
+        } else if (duration.endsWith("h")) {
           newExpiry = add(now, { hours: parseInt(duration) });
-        } else if (duration.endsWith('d')) {
+        } else if (duration.endsWith("d")) {
           newExpiry = add(now, { days: parseInt(duration) });
         } else {
-          throw new Error('Invalid duration format');
+          throw new Error("Invalid duration format");
         }
-  
-        return newExpiry.toLocaleString('en-US', {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-          second: 'numeric',
-          hour12: true
+
+        return newExpiry.toLocaleString("en-US", {
+          year: "numeric",
+          month: "numeric",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+          hour12: true,
         });
       } catch (error) {
         return null;
@@ -221,8 +252,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     };
 
     console.log("in calculateNewExpiryTime for selectedToken", selectedToken);
-        
-  
+
     // When a new duration is entered
     if (regenerateFormData?.duration) {
       setNewExpiryTime(calculateNewExpiryTime(regenerateFormData.duration));
@@ -232,9 +262,6 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
 
     console.log("calculateNewExpiryTime:", newExpiryTime);
   }, [selectedToken, regenerateFormData?.duration]);
-  
-
-  
 
   useEffect(() => {
     const fetchUserModels = async () => {
@@ -243,7 +270,11 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
           return;
         }
 
-        const models = await fetchAvailableModelsForTeamOrKey(userID, userRole, accessToken);
+        const models = await fetchAvailableModelsForTeamOrKey(
+          userID,
+          userRole,
+          accessToken
+        );
         if (models) {
           setUserModels(models);
         }
@@ -251,10 +282,9 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
         console.error("Error fetching user models:", error);
       }
     };
-  
+
     fetchUserModels();
   }, [accessToken, userID, userRole]);
-
 
   const handleModelLimitClick = (token: ItemData) => {
     setSelectedToken(token);
@@ -293,19 +323,22 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     setSelectedToken(null);
   };
 
-
-
   useEffect(() => {
     if (teams) {
       const teamIDSet: Set<string> = new Set();
       teams.forEach((team: any, index: number) => {
-        const team_obj: string = team.team_id
+        const team_obj: string = team.team_id;
         teamIDSet.add(team_obj);
       });
-      setKnownTeamIDs(teamIDSet)
+      setKnownTeamIDs(teamIDSet);
     }
-  }, [teams])
-  const EditKeyModal: React.FC<EditKeyModalProps> = ({ visible, onCancel, token, onSubmit }) => {
+  }, [teams]);
+  const EditKeyModal: React.FC<EditKeyModalProps> = ({
+    visible,
+    onCancel,
+    token,
+    onSubmit,
+  }) => {
     const [form] = Form.useForm();
     const [keyTeam, setKeyTeam] = useState(selectedTeam);
     const [errorModels, setErrorModels] = useState<string[]>([]);
@@ -328,7 +361,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       fetchGuardrails();
     }, [accessToken]);
 
-    let metadataString = '';
+    let metadataString = "";
     try {
       // Create a copy of metadata without guardrails for display
       const displayMetadata = { ...token.metadata };
@@ -336,7 +369,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       metadataString = JSON.stringify(displayMetadata, null, 2);
     } catch (error) {
       console.error("Error stringifying metadata:", error);
-      metadataString = '';
+      metadataString = "";
     }
 
     // Extract existing guardrails from metadata
@@ -347,13 +380,15 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       console.error("Error extracting guardrails:", error);
     }
 
-    const initialValues = token ? {
-      ...token,
-      budget_duration: token.budget_duration,
-      metadata: metadataString,
-      guardrails: existingGuardrails
-    } : { metadata: metadataString, guardrails: [] };
-
+    const initialValues =
+      token ?
+        {
+          ...token,
+          budget_duration: token.budget_duration,
+          metadata: metadataString,
+          guardrails: existingGuardrails,
+        }
+      : { metadata: metadataString, guardrails: [] };
 
     const handleOk = () => {
       form
@@ -366,17 +401,17 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
         .catch((error) => {
           console.error("Validation failed:", error);
         });
-      };
+    };
 
     return (
-        <Modal
-              title="Edit Key"
-              visible={visible}
-              width={800}
-              footer={null}
-              onOk={handleOk}
-              onCancel={onCancel}
-            >
+      <Modal
+        title="Edit Key"
+        visible={visible}
+        width={800}
+        footer={null}
+        onOk={handleOk}
+        onCancel={onCancel}
+      >
         <Form
           form={form}
           onFinish={handleEditSubmit}
@@ -385,194 +420,220 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
           wrapperCol={{ span: 16 }}
           labelAlign="left"
         >
-                <>
+          <>
+            <Form.Item name="key_alias" label="Key Alias">
+              <TextInput />
+            </Form.Item>
 
-                <Form.Item name="key_alias" label="Key Alias">
-                  <TextInput />
-                </Form.Item>
-
-              <Form.Item label="Models" name="models" rules={[
+            <Form.Item
+              label="Models"
+              name="models"
+              rules={[
                 {
                   validator: (rule, value) => {
-                    const errorModels = value.filter((model: string) => (
-                      !keyTeam.models.includes(model) && 
-                      model !== "all-team-models" && 
-                      model !== "all-proxy-models" && 
-                      !keyTeam.models.includes("all-proxy-models")
-                    ));
-                    console.log(`errorModels: ${errorModels}`)
+                    const errorModels = value.filter(
+                      (model: string) =>
+                        !keyTeam.models.includes(model) &&
+                        model !== "all-team-models" &&
+                        model !== "all-proxy-models" &&
+                        !keyTeam.models.includes("all-proxy-models")
+                    );
+                    console.log(`errorModels: ${errorModels}`);
                     if (errorModels.length > 0) {
-                      return Promise.reject(`Some models are not part of the new team\'s models - ${errorModels}Team models: ${keyTeam.models}`);
+                      return Promise.reject(
+                        `Some models are not part of the new team\'s models - ${errorModels}Team models: ${keyTeam.models}`
+                      );
                     } else {
                       return Promise.resolve();
                     }
-                  }
-                }
-              ]}>
-                <Select
-                  mode="multiple"
-                  placeholder="Select models"
-                  style={{ width: "100%" }}
-                >
-                  <Option key="all-team-models" value="all-team-models">
-                    All Team Models
-                  </Option>                
-                  {keyTeam && keyTeam.models ? (
-                    keyTeam.models.includes("all-proxy-models") ? (
-                      userModels.filter(model => model !== "all-proxy-models").map((model: string) => (
+                  },
+                },
+              ]}
+            >
+              <Select
+                mode="multiple"
+                placeholder="Select models"
+                style={{ width: "100%" }}
+              >
+                <Option key="all-team-models" value="all-team-models">
+                  All Team Models
+                </Option>
+                {keyTeam && keyTeam.models ?
+                  keyTeam.models.includes("all-proxy-models") ?
+                    userModels
+                      .filter((model) => model !== "all-proxy-models")
+                      .map((model: string) => (
                         <Option key={model} value={model}>
                           {getModelDisplayName(model)}
                         </Option>
                       ))
-                    ) : (
-                      keyTeam.models.map((model: string) => (
-                        <Option key={model} value={model}>
-                          {getModelDisplayName(model)}
-                        </Option>
-                      ))
-                    )
-                  ) : (
-                    userModels.map((model: string) => (
+                  : keyTeam.models.map((model: string) => (
                       <Option key={model} value={model}>
                         {getModelDisplayName(model)}
                       </Option>
                     ))
-                  )}
-                </Select>
-              </Form.Item>
-              <Form.Item 
-                className="mt-8"
-                label="Max Budget (USD)" 
-                name="max_budget" 
-                help={`Budget cannot exceed team max budget: ${keyTeam?.max_budget !== null && keyTeam?.max_budget !== undefined ? keyTeam?.max_budget : 'unlimited'}`}
-                rules={[
-                  {
-                      validator: async (_, value) => {
-                          if (value && keyTeam && keyTeam.max_budget !== null && value > keyTeam.max_budget) {
-                              console.log(`keyTeam.max_budget: ${keyTeam.max_budget}`)
-                              throw new Error(`Budget cannot exceed team max budget: $${keyTeam.max_budget}`);
-                          }
-                      },
-                  },
-              ]}
-              >
-                <InputNumber step={0.01} precision={2} width={200} />
-              </Form.Item>
 
-              <Form.Item 
-                className="mt-8"
-                label="Reset Budget"
-                name="budget_duration"
-                help={`Current Reset Budget: ${
-                  token.budget_duration
-                }, budget will be reset: ${token.budget_reset_at ? new Date(token.budget_reset_at).toLocaleString() : 'Never'}`}
-              >
-                <Select placeholder="n/a">
-                  <Select.Option value="daily">daily</Select.Option>
-                  <Select.Option value="weekly">weekly</Select.Option>
-                  <Select.Option value="monthly">monthly</Select.Option>
-                </Select>
-              </Form.Item>
-              
-              <Form.Item
-                  label="token"
-                  name="token"
-                  hidden={true}
-                ></Form.Item>
-              <Form.Item 
-                label="Team" 
-                name="team_id"
-                className="mt-8"
-                help="the team this key belongs to"
-              >
-                <Select3 value={token.team_alias}>
-                {teams?.map((team_obj, index) => (
-                    <SelectItem
-                      key={index}
-                      value={team_obj.team_id}
-                      onClick={() => setKeyTeam(team_obj)}
-                    >
-                      {team_obj.team_alias}
-                    </SelectItem>
-                  ))}
-              </Select3>
-              </Form.Item>
-
-              <Form.Item 
-                className="mt-8"
-                label="TPM Limit (tokens per minute)" 
-                name="tpm_limit" 
-                help={`tpm_limit cannot exceed team tpm_limit ${keyTeam?.tpm_limit !== null && keyTeam?.tpm_limit !== undefined ? keyTeam?.tpm_limit : 'unlimited'}`}
-                rules={[
-                  {
-                      validator: async (_, value) => {
-                          if (value && keyTeam && keyTeam.tpm_limit !== null && value > keyTeam.tpm_limit) {
-                              console.log(`keyTeam.tpm_limit: ${keyTeam.tpm_limit}`)
-                              throw new Error(`tpm_limit cannot exceed team max tpm_limit: $${keyTeam.tpm_limit}`);
-                          }
-                      },
-                  },
-              ]}
-              >
-                <InputNumber step={1} precision={1} width={200} />
-              </Form.Item>
-              <Form.Item 
-                className="mt-8"
-                label="RPM Limit (requests per minute)" 
-                name="rpm_limit" 
-                help={`rpm_limit cannot exceed team max rpm_limit: ${keyTeam?.rpm_limit !== null && keyTeam?.rpm_limit !== undefined ? keyTeam?.rpm_limit : 'unlimited'}`}
-                rules={[
-                  {
-                      validator: async (_, value) => {
-                          if (value && keyTeam && keyTeam.rpm_limit !== null && value > keyTeam.rpm_limit) {
-                              console.log(`keyTeam.rpm_limit: ${keyTeam.rpm_limit}`)
-                              throw new Error(`rpm_limit cannot exceed team max rpm_limit: $${keyTeam.rpm_limit}`);
-                          }
-                      },
-                  },
-              ]}
-              >
-                <InputNumber step={1} precision={1} width={200} />
-              </Form.Item>
-              <Form.Item
-                label={
-                  <span>
-                    Guardrails{' '}
-                    <Tooltip title="Setup your first guardrail">
-                      <a 
-                        href="https://docs.litellm.ai/docs/proxy/guardrails/quick_start" 
-                        target="_blank" 
-                        rel="noopener noreferrer"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <InfoCircleOutlined style={{ marginLeft: '4px' }} />
-                      </a>
-                    </Tooltip>
-                  </span>
+                : userModels.map((model: string) => (
+                    <Option key={model} value={model}>
+                      {getModelDisplayName(model)}
+                    </Option>
+                  ))
                 }
-                name="guardrails" 
-                className="mt-8"
-                help="Select existing guardrails or enter new ones"
-              >
-                <Select
-                  mode="tags"
-                  style={{ width: '100%' }}
-                  placeholder="Select or enter guardrails"
-                  options={guardrailsList.map(name => ({ value: name, label: name }))}
-                />
-              </Form.Item>
-              <Form.Item
-                label="Metadata (ensure this is valid JSON)"
-                name="metadata"
-              >
-                <TextArea
-                  rows={10}
-                  onChange={(e) => {
-                    form.setFieldsValue({ metadata: e.target.value });
-                  }}
-                />
-              </Form.Item>
-            </>
+              </Select>
+            </Form.Item>
+            <Form.Item
+              className="mt-8"
+              label="Max Budget (USD)"
+              name="max_budget"
+              help={`Budget cannot exceed team max budget: ${keyTeam?.max_budget !== null && keyTeam?.max_budget !== undefined ? keyTeam?.max_budget : "unlimited"}`}
+              rules={[
+                {
+                  validator: async (_, value) => {
+                    if (
+                      value &&
+                      keyTeam &&
+                      keyTeam.max_budget !== null &&
+                      value > keyTeam.max_budget
+                    ) {
+                      console.log(`keyTeam.max_budget: ${keyTeam.max_budget}`);
+                      throw new Error(
+                        `Budget cannot exceed team max budget: $${keyTeam.max_budget}`
+                      );
+                    }
+                  },
+                },
+              ]}
+            >
+              <InputNumber step={0.01} precision={2} width={200} />
+            </Form.Item>
+
+            <Form.Item
+              className="mt-8"
+              label="Reset Budget"
+              name="budget_duration"
+              help={`Current Reset Budget: ${
+                token.budget_duration
+              }, budget will be reset: ${token.budget_reset_at ? new Date(token.budget_reset_at).toLocaleString() : "Never"}`}
+            >
+              <Select placeholder="n/a">
+                <Select.Option value="daily">daily</Select.Option>
+                <Select.Option value="weekly">weekly</Select.Option>
+                <Select.Option value="monthly">monthly</Select.Option>
+              </Select>
+            </Form.Item>
+
+            <Form.Item label="token" name="token" hidden={true}></Form.Item>
+            <Form.Item
+              label="Team"
+              name="team_id"
+              className="mt-8"
+              help="the team this key belongs to"
+            >
+              <Select3 value={token.team_alias}>
+                {teams?.map((team_obj, index) => (
+                  <SelectItem
+                    key={index}
+                    value={team_obj.team_id}
+                    onClick={() => setKeyTeam(team_obj)}
+                  >
+                    {team_obj.team_alias}
+                  </SelectItem>
+                ))}
+              </Select3>
+            </Form.Item>
+
+            <Form.Item
+              className="mt-8"
+              label="TPM Limit (tokens per minute)"
+              name="tpm_limit"
+              help={`tpm_limit cannot exceed team tpm_limit ${keyTeam?.tpm_limit !== null && keyTeam?.tpm_limit !== undefined ? keyTeam?.tpm_limit : "unlimited"}`}
+              rules={[
+                {
+                  validator: async (_, value) => {
+                    if (
+                      value &&
+                      keyTeam &&
+                      keyTeam.tpm_limit !== null &&
+                      value > keyTeam.tpm_limit
+                    ) {
+                      console.log(`keyTeam.tpm_limit: ${keyTeam.tpm_limit}`);
+                      throw new Error(
+                        `tpm_limit cannot exceed team max tpm_limit: $${keyTeam.tpm_limit}`
+                      );
+                    }
+                  },
+                },
+              ]}
+            >
+              <InputNumber step={1} precision={1} width={200} />
+            </Form.Item>
+            <Form.Item
+              className="mt-8"
+              label="RPM Limit (requests per minute)"
+              name="rpm_limit"
+              help={`rpm_limit cannot exceed team max rpm_limit: ${keyTeam?.rpm_limit !== null && keyTeam?.rpm_limit !== undefined ? keyTeam?.rpm_limit : "unlimited"}`}
+              rules={[
+                {
+                  validator: async (_, value) => {
+                    if (
+                      value &&
+                      keyTeam &&
+                      keyTeam.rpm_limit !== null &&
+                      value > keyTeam.rpm_limit
+                    ) {
+                      console.log(`keyTeam.rpm_limit: ${keyTeam.rpm_limit}`);
+                      throw new Error(
+                        `rpm_limit cannot exceed team max rpm_limit: $${keyTeam.rpm_limit}`
+                      );
+                    }
+                  },
+                },
+              ]}
+            >
+              <InputNumber step={1} precision={1} width={200} />
+            </Form.Item>
+            <Form.Item
+              label={
+                <span>
+                  Guardrails{" "}
+                  <Tooltip title="Setup your first guardrail">
+                    <a
+                      href="https://docs.litellm.ai/docs/proxy/guardrails/quick_start"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                    </a>
+                  </Tooltip>
+                </span>
+              }
+              name="guardrails"
+              className="mt-8"
+              help="Select existing guardrails or enter new ones"
+            >
+              <Select
+                mode="tags"
+                style={{ width: "100%" }}
+                placeholder="Select or enter guardrails"
+                options={guardrailsList.map((name) => ({
+                  value: name,
+                  label: name,
+                }))}
+              />
+            </Form.Item>
+            <Form.Item
+              label="Metadata (ensure this is valid JSON)"
+              name="metadata"
+            >
+              <TextArea
+                rows={10}
+                onChange={(e) => {
+                  form.setFieldsValue({ metadata: e.target.value });
+                }}
+              />
+            </Form.Item>
+          </>
           <div style={{ textAlign: "right", marginTop: "10px" }}>
             <Button2 htmlType="submit">Edit Key</Button2>
           </div>
@@ -581,8 +642,16 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     );
   };
 
-  const ModelLimitModal: React.FC<ModelLimitModalProps> = ({ visible, onCancel, token, onSubmit, accessToken }) => {
-    const [modelLimits, setModelLimits] = useState<{ [key: string]: { tpm: number, rpm: number } }>({});
+  const ModelLimitModal: React.FC<ModelLimitModalProps> = ({
+    visible,
+    onCancel,
+    token,
+    onSubmit,
+    accessToken,
+  }) => {
+    const [modelLimits, setModelLimits] = useState<{
+      [key: string]: { tpm: number; rpm: number };
+    }>({});
     const [availableModels, setAvailableModels] = useState<string[]>([]);
     const [newModelRow, setNewModelRow] = useState<string | null>(null);
 
@@ -590,22 +659,27 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       if (token.metadata) {
         const tpmLimits = token.metadata.model_tpm_limit || {};
         const rpmLimits = token.metadata.model_rpm_limit || {};
-        const combinedLimits: { [key: string]: { tpm: number, rpm: number } } = {};
-        
-        Object.keys({ ...tpmLimits, ...rpmLimits }).forEach(model => {
+        const combinedLimits: { [key: string]: { tpm: number; rpm: number } } =
+          {};
+
+        Object.keys({ ...tpmLimits, ...rpmLimits }).forEach((model) => {
           combinedLimits[model] = {
             tpm: tpmLimits[model] || 0,
-            rpm: rpmLimits[model] || 0
+            rpm: rpmLimits[model] || 0,
           };
         });
-        
+
         setModelLimits(combinedLimits);
       }
-      
+
       const fetchAvailableModels = async () => {
         try {
           const modelDataResponse = await modelInfoCall(accessToken, "", "");
-          const allModelGroups: string[] = Array.from(new Set(modelDataResponse.data.map((model: any) => model.model_name)));
+          const allModelGroups: string[] = Array.from(
+            new Set(
+              modelDataResponse.data.map((model: any) => model.model_name)
+            )
+          );
           setAvailableModels(allModelGroups);
         } catch (error) {
           console.error("Error fetching model data:", error);
@@ -616,32 +690,36 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
       fetchAvailableModels();
     }, [token, accessToken]);
 
-    const handleLimitChange = (model: string, type: 'tpm' | 'rpm', value: number | null) => {
-      setModelLimits(prev => ({
+    const handleLimitChange = (
+      model: string,
+      type: "tpm" | "rpm",
+      value: number | null
+    ) => {
+      setModelLimits((prev) => ({
         ...prev,
         [model]: {
           ...prev[model],
-          [type]: value || 0
-        }
+          [type]: value || 0,
+        },
       }));
     };
 
     const handleAddLimit = () => {
-      setNewModelRow('');
+      setNewModelRow("");
     };
 
     const handleModelSelect = (model: string) => {
       if (!modelLimits[model]) {
-        setModelLimits(prev => ({
+        setModelLimits((prev) => ({
           ...prev,
-          [model]: { tpm: 0, rpm: 0 }
+          [model]: { tpm: 0, rpm: 0 },
         }));
       }
       setNewModelRow(null);
     };
 
     const handleRemoveModel = (model: string) => {
-      setModelLimits(prev => {
+      setModelLimits((prev) => {
         const { [model]: _, ...rest } = prev;
         return rest;
       });
@@ -650,8 +728,18 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     const handleSubmit = () => {
       const updatedMetadata = {
         ...token.metadata,
-        model_tpm_limit: Object.fromEntries(Object.entries(modelLimits).map(([model, limits]) => [model, limits.tpm])),
-        model_rpm_limit: Object.fromEntries(Object.entries(modelLimits).map(([model, limits]) => [model, limits.rpm])),
+        model_tpm_limit: Object.fromEntries(
+          Object.entries(modelLimits).map(([model, limits]) => [
+            model,
+            limits.tpm,
+          ])
+        ),
+        model_rpm_limit: Object.fromEntries(
+          Object.entries(modelLimits).map(([model, limits]) => [
+            model,
+            limits.rpm,
+          ])
+        ),
       };
       onSubmit(updatedMetadata);
     };
@@ -681,13 +769,17 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                   <TableCell>
                     <InputNumber
                       value={limits.tpm}
-                      onChange={(value) => handleLimitChange(model, 'tpm', value)}
+                      onChange={(value) =>
+                        handleLimitChange(model, "tpm", value)
+                      }
                     />
                   </TableCell>
                   <TableCell>
                     <InputNumber
                       value={limits.rpm}
-                      onChange={(value) => handleLimitChange(model, 'rpm', value)}
+                      onChange={(value) =>
+                        handleLimitChange(model, "rpm", value)
+                      }
                     />
                   </TableCell>
                   <TableCell>
@@ -707,7 +799,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                       value={newModelRow || undefined}
                     >
                       {availableModels
-                        .filter(m => !modelLimits.hasOwnProperty(m))
+                        .filter((m) => !modelLimits.hasOwnProperty(m))
                         .map((m) => (
                           <Option key={m} value={m}>
                             {m}
@@ -718,30 +810,24 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                   <TableCell>-</TableCell>
                   <TableCell>-</TableCell>
                   <TableCell>
-                    <Button onClick={() => setNewModelRow(null)}>
-                      Cancel
-                    </Button>
+                    <Button onClick={() => setNewModelRow(null)}>Cancel</Button>
                   </TableCell>
                 </TableRow>
               )}
             </TableBody>
           </Table>
-          <Button onClick={handleAddLimit} disabled={newModelRow !== null}>Add Limit</Button>
+          <Button onClick={handleAddLimit} disabled={newModelRow !== null}>
+            Add Limit
+          </Button>
         </div>
         <div className="flex justify-end space-x-4 mt-6">
-          <Button onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit}>
-            Save
-          </Button>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button onClick={handleSubmit}>Save</Button>
         </div>
       </Modal>
     );
   };
-  
 
-  
   const handleEditClick = (token: any) => {
     console.log("handleEditClick:", token);
 
@@ -772,7 +858,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
 
     setSelectedToken({
       ...token,
-      budget_duration: budgetDuration
+      budget_duration: budgetDuration,
     });
 
     //setSelectedToken(token);
@@ -784,80 +870,84 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     setSelectedToken(null);
   };
 
-const handleEditSubmit = async (formValues: Record<string, any>) => {
-  /**
-   * Call API to update team with teamId and values
-   * 
-   * Client-side validation: For selected team, ensure models in team + max budget < team max budget
-   */
-  if (accessToken == null) {
-    return;
-  }
-
-  const currentKey = formValues.token; 
-  formValues.key = currentKey;
-
-  // Convert metadata back to an object if it exists and is a string
-  if (formValues.metadata && typeof formValues.metadata === 'string') {
-    try {
-      const parsedMetadata = JSON.parse(formValues.metadata);
-      // Only add guardrails if they are set in form values
-      formValues.metadata = {
-        ...parsedMetadata,
-        ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {})
-      };
-    } catch (error) {
-      console.error("Error parsing metadata JSON:", error);
-      message.error("Invalid metadata JSON for formValue " + formValues.metadata);
+  const handleEditSubmit = async (formValues: Record<string, any>) => {
+    /**
+     * Call API to update team with teamId and values
+     *
+     * Client-side validation: For selected team, ensure models in team + max budget < team max budget
+     */
+    if (accessToken == null) {
       return;
     }
-  } else {
-    // If metadata is not a string (or doesn't exist), only add guardrails if they are set
-    formValues.metadata = {
-      ...(formValues.metadata || {}),
-      ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {})
-    };
-  }
 
-  // Convert the budget_duration back to the API expected format
-  if (formValues.budget_duration) {
-    switch (formValues.budget_duration) {
-      case "daily":
-        formValues.budget_duration = "24h";
-        break;
-      case "weekly":
-        formValues.budget_duration = "7d";
-        break;
-      case "monthly":
-        formValues.budget_duration = "30d";
-        break;
+    const currentKey = formValues.token;
+    formValues.key = currentKey;
+
+    // Convert metadata back to an object if it exists and is a string
+    if (formValues.metadata && typeof formValues.metadata === "string") {
+      try {
+        const parsedMetadata = JSON.parse(formValues.metadata);
+        // Only add guardrails if they are set in form values
+        formValues.metadata = {
+          ...parsedMetadata,
+          ...(formValues.guardrails?.length > 0 ?
+            { guardrails: formValues.guardrails }
+          : {}),
+        };
+      } catch (error) {
+        console.error("Error parsing metadata JSON:", error);
+        message.error(
+          "Invalid metadata JSON for formValue " + formValues.metadata
+        );
+        return;
+      }
+    } else {
+      // If metadata is not a string (or doesn't exist), only add guardrails if they are set
+      formValues.metadata = {
+        ...(formValues.metadata || {}),
+        ...(formValues.guardrails?.length > 0 ?
+          { guardrails: formValues.guardrails }
+        : {}),
+      };
     }
-  }
 
-  console.log("handleEditSubmit:", formValues);
-
-  try {
-    let newKeyValues = await keyUpdateCall(accessToken, formValues);
-    console.log("handleEditSubmit: newKeyValues", newKeyValues);
-
-    // Update the keys with the update key
-    if (data) {
-      const updatedData = data.map((key) =>
-        key.token === currentKey ? newKeyValues : key
-      );
-      setData(updatedData);
+    // Convert the budget_duration back to the API expected format
+    if (formValues.budget_duration) {
+      switch (formValues.budget_duration) {
+        case "daily":
+          formValues.budget_duration = "24h";
+          break;
+        case "weekly":
+          formValues.budget_duration = "7d";
+          break;
+        case "monthly":
+          formValues.budget_duration = "30d";
+          break;
+      }
     }
-    message.success("Key updated successfully");
 
-    setEditModalVisible(false);
-    setSelectedToken(null);
-  } catch (error) {
-    console.error("Error updating key:", error);
-    message.error("Failed to update key");
-  }
-};
+    console.log("handleEditSubmit:", formValues);
 
+    try {
+      let newKeyValues = await keyUpdateCall(accessToken, formValues);
+      console.log("handleEditSubmit: newKeyValues", newKeyValues);
 
+      // Update the keys with the update key
+      if (data) {
+        const updatedData = data.map((key) =>
+          key.token === currentKey ? newKeyValues : key
+        );
+        setData(updatedData);
+      }
+      message.success("Key updated successfully");
+
+      setEditModalVisible(false);
+      setSelectedToken(null);
+    } catch (error) {
+      console.error("Error updating key:", error);
+      message.error("Failed to update key");
+    }
+  };
 
   const handleDelete = async (token: any) => {
     console.log("handleDelete:", token);
@@ -910,7 +1000,7 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
       max_budget: token.max_budget,
       tpm_limit: token.tpm_limit,
       rpm_limit: token.rpm_limit,
-      duration: token.duration || '',
+      duration: token.duration || "",
     });
     setRegenerateDialogVisible(true);
   };
@@ -924,7 +1014,9 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
 
   const handleRegenerateKey = async () => {
     if (!premiumUser) {
-      message.error("Regenerate API Key is an Enterprise feature. Please upgrade to use this feature.");
+      message.error(
+        "Regenerate API Key is an Enterprise feature. Please upgrade to use this feature."
+      );
       return;
     }
 
@@ -934,15 +1026,19 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
 
     try {
       const formValues = await regenerateForm.validateFields();
-      const response = await regenerateKeyCall(accessToken, selectedToken.token, formValues);
+      const response = await regenerateKeyCall(
+        accessToken,
+        selectedToken.token,
+        formValues
+      );
       setRegeneratedKey(response.key);
 
       // Update the data state with the new key_name
       if (data) {
-        const updatedData = data.map(item => 
-          item.token === selectedToken?.token 
-            ? { ...item, key_name: response.key_name, ...formValues } 
-            : item
+        const updatedData = data.map((item) =>
+          item.token === selectedToken?.token ?
+            { ...item, key_name: response.key_name, ...formValues }
+          : item
         );
         setData(updatedData);
       }
@@ -962,103 +1058,108 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
   console.log("RERENDER TRIGGERED");
   return (
     <div>
-    <Card className="w-full mx-auto flex-auto overflow-y-auto max-h-[50vh] mb-4 mt-2">
-      <Table className="mt-5 max-h-[300px] min-h-[300px]">
-        <TableHead>
-          <TableRow>
-            <TableHeaderCell>Key Alias</TableHeaderCell>
-            <TableHeaderCell>Secret Key</TableHeaderCell>
-            <TableHeaderCell>Created</TableHeaderCell>
-            <TableHeaderCell>Expires</TableHeaderCell>
-            <TableHeaderCell>Spend (USD)</TableHeaderCell>
-            <TableHeaderCell>Budget (USD)</TableHeaderCell>
-            <TableHeaderCell>Budget Reset</TableHeaderCell>
-            <TableHeaderCell>Models</TableHeaderCell>
-            <TableHeaderCell>Rate Limits</TableHeaderCell>
-            <TableHeaderCell>Rate Limits per model</TableHeaderCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {all_keys_to_display && all_keys_to_display.map((item) => {
-            console.log(item);
-            // skip item if item.team_id == "litellm-dashboard"
-            if (item.team_id === "litellm-dashboard") {
-              return null;
-            }
-            if (selectedTeam) {
-              /**
-               * if selected team id is null -> show the keys with no team id or team id's that don't exist in db
-               */
-              console.log(`item team id: ${item.team_id}, knownTeamIDs.has(item.team_id): ${knownTeamIDs.has(item.team_id)}, selectedTeam id: ${selectedTeam.team_id}`)
-              if (selectedTeam.team_id == null && item.team_id !== null && !knownTeamIDs.has(item.team_id)) {
-                // do nothing -> returns a row with this key
-              }
-              else if (item.team_id != selectedTeam.team_id) {
-                return null;
-              }
-              console.log(`item team id: ${item.team_id}, is returned`)
-            }
-            return (
-              <TableRow key={item.token}>
-                <TableCell style={{ maxWidth: "2px", whiteSpace: "pre-wrap", overflow: "hidden"  }}>
-                  {item.key_alias != null ? (
-                    <Text>{item.key_alias}</Text>
-                  ) : (
-                    <Text>Not Set</Text>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Text>{item.key_name}</Text>
-                </TableCell>
-                <TableCell>
-                    {item.created_at != null ? (
-                      <div>
-                        <p style={{ fontSize: '0.70rem' }}>{new Date(item.created_at).toLocaleDateString()}</p>
-                      </div>
-                    ) : (
-                      <p style={{ fontSize: '0.70rem' }}>Not available</p>
-                    )}
-                  </TableCell>
-                <TableCell>
-                {item.expires != null ? (
-                  <div>
-                    <p style={{ fontSize: '0.70rem' }}>{new Date(item.expires).toLocaleDateString()}</p>
-                  </div>
-                ) : (
-                  <p style={{ fontSize: '0.70rem' }}>Never</p>
-                )}
-              </TableCell>
-                <TableCell>
-                  <Text>
-                    {(() => {
-                      try {
-                        return parseFloat(item.spend).toFixed(4);
-                      } catch (error) {
-                        return item.spend;
-                      }
-                    })()}
-
-                  </Text>
-                </TableCell>
-                <TableCell>
-                  {item.max_budget != null ? (
-                    <Text>{item.max_budget}</Text>
-                  ) : (
-                    <Text>Unlimited</Text>
-                  )}
-                </TableCell>
-                <TableCell>
-                  {item.budget_reset_at != null ? (
-                    <div>
-                      <p style={{ fontSize: '0.70rem' }}>{new Date(item.budget_reset_at).toLocaleString()}</p>
-
-                    </div>
-                    
-                  ) : (
-                    <p style={{ fontSize: '0.70rem' }}>Never</p>
-                  )}
-                </TableCell>
-                {/* <TableCell style={{ maxWidth: '2px' }}>
+      <Card className="w-full mx-auto flex-auto overflow-y-auto max-h-[50vh] mb-4 mt-2">
+        <Table className="mt-5 max-h-[300px] min-h-[300px]">
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>Key Alias</TableHeaderCell>
+              <TableHeaderCell>Secret Key</TableHeaderCell>
+              <TableHeaderCell>Created</TableHeaderCell>
+              <TableHeaderCell>Expires</TableHeaderCell>
+              <TableHeaderCell>Spend (USD)</TableHeaderCell>
+              <TableHeaderCell>Budget (USD)</TableHeaderCell>
+              <TableHeaderCell>Budget Reset</TableHeaderCell>
+              <TableHeaderCell>Models</TableHeaderCell>
+              <TableHeaderCell>Rate Limits</TableHeaderCell>
+              <TableHeaderCell>Rate Limits per model</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {all_keys_to_display &&
+              all_keys_to_display.map((item) => {
+                console.log(item);
+                // skip item if item.team_id == "litellm-dashboard"
+                if (item.team_id === "litellm-dashboard") {
+                  return null;
+                }
+                if (selectedTeam) {
+                  /**
+                   * if selected team id is null -> show the keys with no team id or team id's that don't exist in db
+                   */
+                  console.log(
+                    `item team id: ${item.team_id}, knownTeamIDs.has(item.team_id): ${knownTeamIDs.has(item.team_id)}, selectedTeam id: ${selectedTeam.team_id}`
+                  );
+                  if (
+                    selectedTeam.team_id == null &&
+                    item.team_id !== null &&
+                    !knownTeamIDs.has(item.team_id)
+                  ) {
+                    // do nothing -> returns a row with this key
+                  } else if (item.team_id != selectedTeam.team_id) {
+                    return null;
+                  }
+                  console.log(`item team id: ${item.team_id}, is returned`);
+                }
+                return (
+                  <TableRow key={item.token}>
+                    <TableCell
+                      style={{
+                        maxWidth: "2px",
+                        whiteSpace: "pre-wrap",
+                        overflow: "hidden",
+                      }}
+                    >
+                      {item.key_alias != null ?
+                        <Text>{item.key_alias}</Text>
+                      : <Text>Not Set</Text>}
+                    </TableCell>
+                    <TableCell>
+                      <Text>{item.key_name}</Text>
+                    </TableCell>
+                    <TableCell>
+                      {item.created_at != null ?
+                        <div>
+                          <p style={{ fontSize: "0.70rem" }}>
+                            {new Date(item.created_at).toLocaleDateString()}
+                          </p>
+                        </div>
+                      : <p style={{ fontSize: "0.70rem" }}>Not available</p>}
+                    </TableCell>
+                    <TableCell>
+                      {item.expires != null ?
+                        <div>
+                          <p style={{ fontSize: "0.70rem" }}>
+                            {new Date(item.expires).toLocaleDateString()}
+                          </p>
+                        </div>
+                      : <p style={{ fontSize: "0.70rem" }}>Never</p>}
+                    </TableCell>
+                    <TableCell>
+                      <Text>
+                        {(() => {
+                          try {
+                            return parseFloat(item.spend).toFixed(4);
+                          } catch (error) {
+                            return item.spend;
+                          }
+                        })()}
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      {item.max_budget != null ?
+                        <Text>{item.max_budget}</Text>
+                      : <Text>Unlimited</Text>}
+                    </TableCell>
+                    <TableCell>
+                      {item.budget_reset_at != null ?
+                        <div>
+                          <p style={{ fontSize: "0.70rem" }}>
+                            {new Date(item.budget_reset_at).toLocaleString()}
+                          </p>
+                        </div>
+                      : <p style={{ fontSize: "0.70rem" }}>Never</p>}
+                    </TableCell>
+                    {/* <TableCell style={{ maxWidth: '2px' }}>
                   <ViewKeySpendReport
                     token={item.token}
                     accessToken={accessToken}
@@ -1067,254 +1168,316 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
                     keyName={item.key_name}
                   />
                 </TableCell> */}
-                {/* <TableCell style={{ maxWidth: "4px", whiteSpace: "pre-wrap", overflow: "hidden"  }}>
+                    {/* <TableCell style={{ maxWidth: "4px", whiteSpace: "pre-wrap", overflow: "hidden"  }}>
                   <Text>{item.team_alias && item.team_alias != "None" ? item.team_alias : item.team_id}</Text>
                 </TableCell> */}
-                {/* <TableCell style={{ maxWidth: "4px", whiteSpace: "pre-wrap", overflow: "hidden"  }}>
+                    {/* <TableCell style={{ maxWidth: "4px", whiteSpace: "pre-wrap", overflow: "hidden"  }}>
                   <Text>{JSON.stringify(item.metadata).slice(0, 400)}</Text>
                   
                 </TableCell> */}
 
-<TableCell>
-  {Array.isArray(item.models) ? (
-    <div style={{ display: "flex", flexDirection: "column" }}>
-      {item.models.length === 0 ? (
-        <>
-          {selectedTeam && selectedTeam.models && selectedTeam.models.length > 0 ? (
-            selectedTeam.models.map((model: string, index: number) => (
-              model === "all-proxy-models" ? (
-                <Badge key={index} size={"xs"} className="mb-1" color="red">
-                  <Text>All Proxy Models</Text>
-                </Badge>
-              ) : model === "all-team-models" ? (
-                <Badge key={index} size={"xs"} className="mb-1" color="red">
-                  <Text>All Team Models</Text>
-                </Badge>
-              ) : (
-                <Badge key={index} size={"xs"} className="mb-1" color="blue">
-                  <Text>{model.length > 30 ? `${getModelDisplayName(model).slice(0, 30)}...` : getModelDisplayName(model)}</Text>
-                </Badge>
-              )
-            ))
-          ) : (
-            // If selected team is None or selected team's models are empty, show all models
-            <Badge size={"xs"} className="mb-1" color="blue">
-              <Text>all-proxy-models</Text>
-            </Badge>
-          )}
-        </>
-      ) : (
-        item.models.map((model: string, index: number) => (
-          model === "all-proxy-models" ? (
-            <Badge key={index} size={"xs"} className="mb-1" color="red">
-              <Text>All Proxy Models</Text>
-            </Badge>
-          ) : model === "all-team-models" ? (
-            <Badge key={index} size={"xs"} className="mb-1" color="red">
-              <Text>All Team Models</Text>
-            </Badge>
-          ) : (
-            <Badge key={index} size={"xs"} className="mb-1" color="blue">
-              <Text>{model.length > 30 ? `${getModelDisplayName(model).slice(0, 30)}...` : getModelDisplayName(model)}</Text>
-            </Badge>
-          )
-        ))
-      )}
-    </div>
-  ) : null}
-</TableCell>
+                    <TableCell>
+                      {Array.isArray(item.models) ?
+                        <div
+                          style={{ display: "flex", flexDirection: "column" }}
+                        >
+                          {item.models.length === 0 ?
+                            <>
+                              {
+                                (
+                                  selectedTeam &&
+                                  selectedTeam.models &&
+                                  selectedTeam.models.length > 0
+                                ) ?
+                                  selectedTeam.models.map(
+                                    (model: string, index: number) =>
+                                      model === "all-proxy-models" ?
+                                        <Badge
+                                          key={index}
+                                          size={"xs"}
+                                          className="mb-1"
+                                          color="red"
+                                        >
+                                          <Text>All Proxy Models</Text>
+                                        </Badge>
+                                      : model === "all-team-models" ?
+                                        <Badge
+                                          key={index}
+                                          size={"xs"}
+                                          className="mb-1"
+                                          color="red"
+                                        >
+                                          <Text>All Team Models</Text>
+                                        </Badge>
+                                      : <Badge
+                                          key={index}
+                                          size={"xs"}
+                                          className="mb-1"
+                                          color="blue"
+                                        >
+                                          <Text>
+                                            {model.length > 30 ?
+                                              `${getModelDisplayName(model).slice(0, 30)}...`
+                                            : getModelDisplayName(model)}
+                                          </Text>
+                                        </Badge>
+                                  )
+                                  // If selected team is None or selected team's models are empty, show all models
+                                : <Badge
+                                    size={"xs"}
+                                    className="mb-1"
+                                    color="blue"
+                                  >
+                                    <Text>all-proxy-models</Text>
+                                  </Badge>
 
-                <TableCell>
-                  <Text>
-                    TPM: {item.tpm_limit ? item.tpm_limit : "Unlimited"}{" "}
-                    <br></br> RPM:{" "}
-                    {item.rpm_limit ? item.rpm_limit : "Unlimited"}
-                  </Text>
-                </TableCell>
-                <TableCell>
-                <Button size="xs" onClick={() => handleModelLimitClick(item)}>Edit Limits</Button>
-                </TableCell>
-                <TableCell>
-                    <Icon
-                      onClick={() => {
-                        setSelectedToken(item);
-                        setInfoDialogVisible(true);
-                      }}
-                      icon={InformationCircleIcon}
-                      size="sm"
-                    />
-                    
-                    
-                
-    <Modal
-      open={infoDialogVisible}
-      onCancel={() => {
-        setInfoDialogVisible(false);
-        setSelectedToken(null);
-      }}
-      footer={null}
-      width={800}
-    >
+                              }
+                            </>
+                          : item.models.map((model: string, index: number) =>
+                              model === "all-proxy-models" ?
+                                <Badge
+                                  key={index}
+                                  size={"xs"}
+                                  className="mb-1"
+                                  color="red"
+                                >
+                                  <Text>All Proxy Models</Text>
+                                </Badge>
+                              : model === "all-team-models" ?
+                                <Badge
+                                  key={index}
+                                  size={"xs"}
+                                  className="mb-1"
+                                  color="red"
+                                >
+                                  <Text>All Team Models</Text>
+                                </Badge>
+                              : <Badge
+                                  key={index}
+                                  size={"xs"}
+                                  className="mb-1"
+                                  color="blue"
+                                >
+                                  <Text>
+                                    {model.length > 30 ?
+                                      `${getModelDisplayName(model).slice(0, 30)}...`
+                                    : getModelDisplayName(model)}
+                                  </Text>
+                                </Badge>
+                            )
+                          }
+                        </div>
+                      : null}
+                    </TableCell>
 
-    {selectedToken && (
-      <>
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 mt-8">
-          <Card>
-            <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
-              Spend
-            </p>
-            <div className="mt-2 flex items-baseline space-x-2.5">
-              <p className="text-tremor font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-              {(() => {
-                      try {
-                        return parseFloat(selectedToken.spend).toFixed(4);
-                      } catch (error) {
-                        return selectedToken.spend;
-                      }
-                    })()}
+                    <TableCell>
+                      <Text>
+                        TPM: {item.tpm_limit ? item.tpm_limit : "Unlimited"}{" "}
+                        <br></br> RPM:{" "}
+                        {item.rpm_limit ? item.rpm_limit : "Unlimited"}
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="xs"
+                        onClick={() => handleModelLimitClick(item)}
+                      >
+                        Edit Limits
+                      </Button>
+                    </TableCell>
+                    <TableCell>
+                      <Icon
+                        onClick={() => {
+                          setSelectedToken(item);
+                          setInfoDialogVisible(true);
+                        }}
+                        icon={InformationCircleIcon}
+                        size="sm"
+                      />
 
-              </p>
-            </div>
-          </Card>
-          <Card key={item.name}>
-            <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
-              Budget
-            </p>
-            <div className="mt-2 flex items-baseline space-x-2.5">
-              <p className="text-tremor font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-              {selectedToken.max_budget != null ? (
-                  <>
-                    {selectedToken.max_budget}
-                    {selectedToken.budget_duration && (
-                      <>
-                        <br />
-                        Budget will be reset at {selectedToken.budget_reset_at ? new Date(selectedToken.budget_reset_at).toLocaleString() : 'Never'}
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <>Unlimited</>
-                )}
-              </p>
-            </div>
-          </Card>
-          <Card key={item.name}>
-            <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
-              Expires
-            </p>
-            <div className="mt-2 flex items-baseline space-x-2.5">
-              <p className="text-tremor-default font-small text-tremor-content-strong dark:text-dark-tremor-content-strong">
-              {selectedToken.expires != null ? (
-                  <>
-                  {new Date(selectedToken.expires).toLocaleString(undefined, {
-                    day: 'numeric',
-                    month: 'long',
-                    year: 'numeric',
-                    hour: 'numeric',
-                    minute: 'numeric',
-                    second: 'numeric'
-                  })}
-                </>
-                ) : (
-                  <>Never</>
-                )}
-              </p>
-            </div>
-          </Card>
-      </div>
+                      <Modal
+                        open={infoDialogVisible}
+                        onCancel={() => {
+                          setInfoDialogVisible(false);
+                          setSelectedToken(null);
+                        }}
+                        footer={null}
+                        width={800}
+                      >
+                        {selectedToken && (
+                          <>
+                            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 mt-8">
+                              <Card>
+                                <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
+                                  Spend
+                                </p>
+                                <div className="mt-2 flex items-baseline space-x-2.5">
+                                  <p className="text-tremor font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                                    {(() => {
+                                      try {
+                                        return parseFloat(
+                                          selectedToken.spend
+                                        ).toFixed(4);
+                                      } catch (error) {
+                                        return selectedToken.spend;
+                                      }
+                                    })()}
+                                  </p>
+                                </div>
+                              </Card>
+                              <Card key={item.name}>
+                                <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
+                                  Budget
+                                </p>
+                                <div className="mt-2 flex items-baseline space-x-2.5">
+                                  <p className="text-tremor font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                                    {selectedToken.max_budget != null ?
+                                      <>
+                                        {selectedToken.max_budget}
+                                        {selectedToken.budget_duration && (
+                                          <>
+                                            <br />
+                                            Budget will be reset at{" "}
+                                            {selectedToken.budget_reset_at ?
+                                              new Date(
+                                                selectedToken.budget_reset_at
+                                              ).toLocaleString()
+                                            : "Never"}
+                                          </>
+                                        )}
+                                      </>
+                                    : <>Unlimited</>}
+                                  </p>
+                                </div>
+                              </Card>
+                              <Card key={item.name}>
+                                <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
+                                  Expires
+                                </p>
+                                <div className="mt-2 flex items-baseline space-x-2.5">
+                                  <p className="text-tremor-default font-small text-tremor-content-strong dark:text-dark-tremor-content-strong">
+                                    {selectedToken.expires != null ?
+                                      <>
+                                        {new Date(
+                                          selectedToken.expires
+                                        ).toLocaleString(undefined, {
+                                          day: "numeric",
+                                          month: "long",
+                                          year: "numeric",
+                                          hour: "numeric",
+                                          minute: "numeric",
+                                          second: "numeric",
+                                        })}
+                                      </>
+                                    : <>Never</>}
+                                  </p>
+                                </div>
+                              </Card>
+                            </div>
 
-      <Card className="my-4">
-        <Title>Token Name</Title>
-        <Text className="my-1">{selectedToken.key_alias ? selectedToken.key_alias : selectedToken.key_name}</Text>
-        <Title>Token ID</Title>
-        <Text className="my-1 text-[12px]">{selectedToken.token}</Text>     
-        <Title>User ID</Title>
-        <Text className="my-1 text-[12px]">{selectedToken.user_id}</Text>            
-        <Title>Metadata</Title>
-        <Text className="my-1"><pre>{JSON.stringify(selectedToken.metadata)} </pre></Text>
-      </Card>
+                            <Card className="my-4">
+                              <Title>Token Name</Title>
+                              <Text className="my-1">
+                                {selectedToken.key_alias ?
+                                  selectedToken.key_alias
+                                : selectedToken.key_name}
+                              </Text>
+                              <Title>Token ID</Title>
+                              <Text className="my-1 text-[12px]">
+                                {selectedToken.token}
+                              </Text>
+                              <Title>User ID</Title>
+                              <Text className="my-1 text-[12px]">
+                                {selectedToken.user_id}
+                              </Text>
+                              <Title>Metadata</Title>
+                              <Text className="my-1">
+                                <pre>
+                                  {JSON.stringify(selectedToken.metadata)}{" "}
+                                </pre>
+                              </Text>
+                            </Card>
 
-        <Button
-          className="mx-auto flex items-center"
-          onClick={() => {
-            setInfoDialogVisible(false);
-            setSelectedToken(null);
-          }}
-        >
-          Close
-        </Button>
-      </>
-    )}
+                            <Button
+                              className="mx-auto flex items-center"
+                              onClick={() => {
+                                setInfoDialogVisible(false);
+                                setSelectedToken(null);
+                              }}
+                            >
+                              Close
+                            </Button>
+                          </>
+                        )}
+                      </Modal>
+                      <Icon
+                        icon={PencilAltIcon}
+                        size="sm"
+                        onClick={() => handleEditClick(item)}
+                      />
+                      <Icon
+                        onClick={() => handleRegenerateClick(item)}
+                        icon={RefreshIcon}
+                        size="sm"
+                      />
+                      <Icon
+                        onClick={() => handleDelete(item)}
+                        icon={TrashIcon}
+                        size="sm"
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </Table>
+        {isDeleteModalOpen && (
+          <div className="fixed z-10 inset-0 overflow-y-auto">
+            <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+              <div
+                className="fixed inset-0 transition-opacity"
+                aria-hidden="true"
+              >
+                <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+              </div>
 
-</Modal>
-                  <Icon
-                    icon={PencilAltIcon}
-                    size="sm"
-                    onClick={() => handleEditClick(item)}
-                  />
-                  <Icon
-                      onClick={() => handleRegenerateClick(item)}
-                      icon={RefreshIcon}
-                      size="sm"
-                    />
-                  <Icon
-                    onClick={() => handleDelete(item)}
-                    icon={TrashIcon}
-                    size="sm"
-                  />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-      {isDeleteModalOpen && (
-        <div className="fixed z-10 inset-0 overflow-y-auto">
-          <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-            <div
-              className="fixed inset-0 transition-opacity"
-              aria-hidden="true"
-            >
-              <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-            </div>
+              {/* Modal Panel */}
+              <span
+                className="hidden sm:inline-block sm:align-middle sm:h-screen"
+                aria-hidden="true"
+              >
+                &#8203;
+              </span>
 
-            {/* Modal Panel */}
-            <span
-              className="hidden sm:inline-block sm:align-middle sm:h-screen"
-              aria-hidden="true"
-            >
-              &#8203;
-            </span>
-
-            {/* Confirmation Modal Content */}
-            <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                <div className="sm:flex sm:items-start">
-                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">
-                      Delete Key
-                    </h3>
-                    <div className="mt-2">
-                      <p className="text-sm text-gray-500">
-                        Are you sure you want to delete this key ?
-                      </p>
+              {/* Confirmation Modal Content */}
+              <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+                <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <div className="sm:flex sm:items-start">
+                    <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <h3 className="text-lg leading-6 font-medium text-gray-900">
+                        Delete Key
+                      </h3>
+                      <div className="mt-2">
+                        <p className="text-sm text-gray-500">
+                          Are you sure you want to delete this key ?
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                <Button onClick={confirmDelete} color="red" className="ml-2">
-                  Delete
-                </Button>
-                <Button onClick={cancelDelete}>Cancel</Button>
+                <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                  <Button onClick={confirmDelete} color="red" className="ml-2">
+                    Delete
+                  </Button>
+                  <Button onClick={cancelDelete}>Cancel</Button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
-    </Card>
+        )}
+      </Card>
 
-    {selectedToken && (
+      {selectedToken && (
         <EditKeyModal
           visible={editModalVisible}
           onCancel={handleEditCancel}
@@ -1323,7 +1486,7 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
         />
       )}
 
-{selectedToken && (
+      {selectedToken && (
         <ModelLimitModal
           visible={modelLimitModalVisible}
           onCancel={() => setModelLimitModalVisible(false)}
@@ -1333,141 +1496,153 @@ const handleEditSubmit = async (formValues: Record<string, any>) => {
         />
       )}
 
-    {/* Regenerate Key Form Modal */}
-    <Modal
-      title="Regenerate API Key"
-      visible={regenerateDialogVisible}
-      onCancel={() => {
-        setRegenerateDialogVisible(false);
-        regenerateForm.resetFields();
-      }}
-      footer={[
-        <Button key="cancel" onClick={() => {
+      {/* Regenerate Key Form Modal */}
+      <Modal
+        title="Regenerate API Key"
+        visible={regenerateDialogVisible}
+        onCancel={() => {
           setRegenerateDialogVisible(false);
           regenerateForm.resetFields();
-        }} className="mr-2">
-          Cancel
-        </Button>,
-        <Button
-          key="regenerate"
-          onClick={handleRegenerateKey}
-          disabled={!premiumUser}
-        >
-          {premiumUser ? "Regenerate" : "Upgrade to Regenerate"}
-        </Button>
-      ]}
-    >
-      {premiumUser ? (
-        <Form 
-        form={regenerateForm} 
-        layout="vertical"
-        onValuesChange={(changedValues, allValues) => {
-          if ('duration' in changedValues) {
-            handleRegenerateFormChange('duration', changedValues.duration);
-          }
         }}
-      >
-          <Form.Item name="key_alias" label="Key Alias">
-            <TextInput disabled={true} />
-          </Form.Item>
-          <Form.Item name="max_budget" label="Max Budget (USD)">
-            <InputNumber step={0.01} precision={2} style={{ width: '100%' }} />
-          </Form.Item>
-          <Form.Item name="tpm_limit" label="TPM Limit">
-            <InputNumber style={{ width: '100%' }} />
-          </Form.Item>
-          <Form.Item name="rpm_limit" label="RPM Limit">
-            <InputNumber style={{ width: '100%' }} />
-          </Form.Item>
-          <Form.Item
-            name="duration"
-            label="Expire Key (eg: 30s, 30h, 30d)"
-            className="mt-8"
-          >
-            <TextInput placeholder="" />
-          </Form.Item>
-          <div className="mt-2 text-sm text-gray-500">
-            Current expiry: {
-              selectedToken?.expires != null ? (
-                new Date(selectedToken.expires).toLocaleString()
-              ) : (
-                'Never'
-              )
-            }
-          </div>
-          {newExpiryTime && (
-            <div className="mt-2 text-sm text-green-600">
-              New expiry: {newExpiryTime}
-            </div>
-          )}
-        </Form>
-      ) : (
-        <div>
-          <p className="mb-2 text-gray-500 italic text-[12px]">Upgrade to use this feature</p>
-          <Button variant="primary" className="mb-2">
-            <a href="https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat" target="_blank">
-              Get Free Trial
-            </a>
-          </Button>
-        </div>
-      )}
-    </Modal>
-
-    {/* Regenerated Key Display Modal */}
-    {regeneratedKey && (
-      <Modal
-        visible={!!regeneratedKey}
-        onCancel={() => setRegeneratedKey(null)}
         footer={[
-          <Button key="close" onClick={() => setRegeneratedKey(null)}>
-            Close
-          </Button>
+          <Button
+            key="cancel"
+            onClick={() => {
+              setRegenerateDialogVisible(false);
+              regenerateForm.resetFields();
+            }}
+            className="mr-2"
+          >
+            Cancel
+          </Button>,
+          <Button
+            key="regenerate"
+            onClick={handleRegenerateKey}
+            disabled={!premiumUser}
+          >
+            {premiumUser ? "Regenerate" : "Upgrade to Regenerate"}
+          </Button>,
         ]}
       >
-        <Grid numItems={1} className="gap-2 w-full">
-          <Title>Regenerated Key</Title>
-          <Col numColSpan={1}>
-            <p>
-              Please replace your old key with the new key generated. For
-              security reasons, <b>you will not be able to view it again</b> through
-              your LiteLLM account. If you lose this secret key, you will need to
-              generate a new one.
+        {premiumUser ?
+          <Form
+            form={regenerateForm}
+            layout="vertical"
+            onValuesChange={(changedValues, allValues) => {
+              if ("duration" in changedValues) {
+                handleRegenerateFormChange("duration", changedValues.duration);
+              }
+            }}
+          >
+            <Form.Item name="key_alias" label="Key Alias">
+              <TextInput disabled={true} />
+            </Form.Item>
+            <Form.Item name="max_budget" label="Max Budget (USD)">
+              <InputNumber
+                step={0.01}
+                precision={2}
+                style={{ width: "100%" }}
+              />
+            </Form.Item>
+            <Form.Item name="tpm_limit" label="TPM Limit">
+              <InputNumber style={{ width: "100%" }} />
+            </Form.Item>
+            <Form.Item name="rpm_limit" label="RPM Limit">
+              <InputNumber style={{ width: "100%" }} />
+            </Form.Item>
+            <Form.Item
+              name="duration"
+              label="Expire Key (eg: 30s, 30h, 30d)"
+              className="mt-8"
+            >
+              <TextInput placeholder="" />
+            </Form.Item>
+            <div className="mt-2 text-sm text-gray-500">
+              Current expiry:{" "}
+              {selectedToken?.expires != null ?
+                new Date(selectedToken.expires).toLocaleString()
+              : "Never"}
+            </div>
+            {newExpiryTime && (
+              <div className="mt-2 text-sm text-green-600">
+                New expiry: {newExpiryTime}
+              </div>
+            )}
+          </Form>
+        : <div>
+            <p className="mb-2 text-gray-500 italic text-[12px]">
+              Upgrade to use this feature
             </p>
-          </Col>
-          <Col numColSpan={1}>
-            <Text className="mt-3">Key Alias:</Text>
-            <div
-              style={{
-                background: "#f8f8f8",
-                padding: "10px",
-                borderRadius: "5px",
-                marginBottom: "10px",
-              }}
-            >
-              <pre style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
-                {selectedToken?.key_alias || 'No alias set'}
-              </pre>
-            </div>
-            <Text className="mt-3">New API Key:</Text>
-            <div
-              style={{
-                background: "#f8f8f8",
-                padding: "10px",
-                borderRadius: "5px",
-                marginBottom: "10px",
-              }}
-            >
-              <pre style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
-                {regeneratedKey}
-              </pre>
-            </div>
-            <CopyToClipboard text={regeneratedKey} onCopy={() => message.success("API Key copied to clipboard")}>
-              <Button className="mt-3">Copy API Key</Button>
-            </CopyToClipboard>
-          </Col>
-        </Grid>
+            <Button variant="primary" className="mb-2">
+              <a
+                href="https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat"
+                target="_blank"
+              >
+                Get Free Trial
+              </a>
+            </Button>
+          </div>
+        }
       </Modal>
-    )}
+
+      {/* Regenerated Key Display Modal */}
+      {regeneratedKey && (
+        <Modal
+          visible={!!regeneratedKey}
+          onCancel={() => setRegeneratedKey(null)}
+          footer={[
+            <Button key="close" onClick={() => setRegeneratedKey(null)}>
+              Close
+            </Button>,
+          ]}
+        >
+          <Grid numItems={1} className="gap-2 w-full">
+            <Title>Regenerated Key</Title>
+            <Col numColSpan={1}>
+              <p>
+                Please replace your old key with the new key generated. For
+                security reasons, <b>you will not be able to view it again</b>{" "}
+                through your LiteLLM account. If you lose this secret key, you
+                will need to generate a new one.
+              </p>
+            </Col>
+            <Col numColSpan={1}>
+              <Text className="mt-3">Key Alias:</Text>
+              <div
+                style={{
+                  background: "#f8f8f8",
+                  padding: "10px",
+                  borderRadius: "5px",
+                  marginBottom: "10px",
+                }}
+              >
+                <pre style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
+                  {selectedToken?.key_alias || "No alias set"}
+                </pre>
+              </div>
+              <Text className="mt-3">New API Key:</Text>
+              <div
+                style={{
+                  background: "#f8f8f8",
+                  padding: "10px",
+                  borderRadius: "5px",
+                  marginBottom: "10px",
+                }}
+              >
+                <pre style={{ wordWrap: "break-word", whiteSpace: "normal" }}>
+                  {regeneratedKey}
+                </pre>
+              </div>
+              <CopyToClipboard
+                text={regeneratedKey}
+                onCopy={() => message.success("API Key copied to clipboard")}
+              >
+                <Button className="mt-3">Copy API Key</Button>
+              </CopyToClipboard>
+            </Col>
+          </Grid>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -431,6 +431,10 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
               rules={[
                 {
                   validator: (rule, value) => {
+                    if (keyTeam.team_alias === "Default Team") {
+                      return Promise.resolve();
+                    }
+
                     const errorModels = value.filter(
                       (model: string) =>
                         !keyTeam.models.includes(model) &&
@@ -441,7 +445,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                     console.log(`errorModels: ${errorModels}`);
                     if (errorModels.length > 0) {
                       return Promise.reject(
-                        `Some models are not part of the new team\'s models - ${errorModels}Team models: ${keyTeam.models}`
+                        `Some models are not part of the new team's models - ${errorModels} Team models: ${keyTeam.models}`
                       );
                     } else {
                       return Promise.resolve();
@@ -458,22 +462,15 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
                 <Option key="all-team-models" value="all-team-models">
                   All Team Models
                 </Option>
-                {keyTeam && keyTeam.models ?
-                  keyTeam.models.includes("all-proxy-models") ?
-                    userModels
-                      .filter((model) => model !== "all-proxy-models")
-                      .map((model: string) => (
-                        <Option key={model} value={model}>
-                          {getModelDisplayName(model)}
-                        </Option>
-                      ))
-                  : keyTeam.models.map((model: string) => (
+                {keyTeam.team_alias === "Default Team" ?
+                  userModels
+                    .filter((model) => model !== "all-proxy-models")
+                    .map((model: string) => (
                       <Option key={model} value={model}>
                         {getModelDisplayName(model)}
                       </Option>
                     ))
-
-                : userModels.map((model: string) => (
+                : keyTeam.models.map((model: string) => (
                     <Option key={model} value={model}>
                       {getModelDisplayName(model)}
                     </Option>


### PR DESCRIPTION
[Fix Ui 1 ]: Display Newly Created Key on View Key Page (#8039)
- Fixed issue where all keys appeared blank for admin users.
- Implemented filtering of data via team settings to ensure all keys are displayed correctly.

[Fix Ui 2]: Allow Editing of Models for Keys Assigned to Default Team (#7985)  
Previously, users were unable to edit the models accessible to a key that is assigned to the default team. This issue occurred because the validation function incorrectly blocked model modifications for default team keys.  

Fix:  
- Updated the validator to allow model editing when `keyTeam.team_alias === "Default Team"`.  
- Ensured other teams still follow the original validation rules.  

Now, users can successfully edit models for keys under the default team while maintaining proper validation for other teams.