### PR TITLE
migrate Pydantic to v2 config

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -227,47 +227,22 @@ class PrometheusMetricLabels:
         ]
 
 
-from typing import List, Optional
-
-from pydantic import BaseModel, Field
-
-
 class UserAPIKeyLabelValues(BaseModel):
-    end_user: Optional[str] = None
-    user: Optional[str] = None
-    hashed_api_key: Optional[str] = None
-    api_key_alias: Optional[str] = None
-    team: Optional[str] = None
-    team_alias: Optional[str] = None
-    requested_model: Optional[str] = None
-    model: Optional[str] = None
-    litellm_model_name: Optional[str] = None
-    tags: List[str] = []
-    custom_metadata_labels: Dict[str, str] = {}
-    model_id: Optional[str] = None
-    api_base: Optional[str] = None
-    api_provider: Optional[str] = None
-    exception_status: Optional[str] = None
-    exception_class: Optional[str] = None
-    status_code: Optional[str] = None
-    fallback_model: Optional[str] = None
-
-    class Config:
-        fields = {
-            "end_user": {"alias": UserAPIKeyLabelNames.END_USER},
-            "user": {"alias": UserAPIKeyLabelNames.USER},
-            "hashed_api_key": {"alias": UserAPIKeyLabelNames.API_KEY_HASH},
-            "api_key_alias": {"alias": UserAPIKeyLabelNames.API_KEY_ALIAS},
-            "team": {"alias": UserAPIKeyLabelNames.TEAM},
-            "team_alias": {"alias": UserAPIKeyLabelNames.TEAM_ALIAS},
-            "requested_model": {"alias": UserAPIKeyLabelNames.REQUESTED_MODEL},
-            "model": {"alias": UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME},
-            "litellm_model_name": {"alias": UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME},
-            "model_id": {"alias": UserAPIKeyLabelNames.MODEL_ID},
-            "api_base": {"alias": UserAPIKeyLabelNames.API_BASE},
-            "api_provider": {"alias": UserAPIKeyLabelNames.API_PROVIDER},
-            "exception_status": {"alias": UserAPIKeyLabelNames.EXCEPTION_STATUS},
-            "exception_class": {"alias": UserAPIKeyLabelNames.EXCEPTION_CLASS},
-            "status_code": {"alias": UserAPIKeyLabelNames.STATUS_CODE},
-            "fallback_model": {"alias": UserAPIKeyLabelNames.FALLBACK_MODEL},
-        }
+    end_user: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.END_USER.value)
+    user: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.USER.value)
+    hashed_api_key: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.API_KEY_HASH.value)
+    api_key_alias: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.API_KEY_ALIAS.value)
+    team: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.TEAM.value)
+    team_alias: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.TEAM_ALIAS.value)
+    requested_model: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.REQUESTED_MODEL.value)
+    model: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value)
+    litellm_model_name: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME.value)
+    tags: List[str] = Field(default_factory=list)
+    custom_metadata_labels: Dict[str, str] = Field(default_factory=dict)
+    model_id: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.MODEL_ID.value)
+    api_base: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.API_BASE.value)
+    api_provider: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.API_PROVIDER.value)
+    exception_status: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.EXCEPTION_STATUS.value)
+    exception_class: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.EXCEPTION_CLASS.value )
+    status_code: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.STATUS_CODE.value)
+    fallback_model: Optional[str] = Field(None, validation_alias=UserAPIKeyLabelNames.FALLBACK_MODEL.value)


### PR DESCRIPTION
## Update Prometheus Pydantic class to use v2 configuration

## Relevant issues

Fixes #7560 

## Type
🐛 Bug Fix

## Changes

<!-- List of changes -->
/litellm/litellm/types/integrations/prometheus.py

* Updated UserAPIKeyLabelValues - moved validation aliases into Field(validation_alias=...)
* Had to set validation alias to UserAPIKeyLabelNames.ITEM.value as it needs a string
