### PR TITLE
Fixed meta llama 3.3 key for Databricks API

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8015,7 +8015,7 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "metadata": {"notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."}
     },
-    "databricks/meta-llama-3.3-70b-instruct": {
+    "databricks/databricks-meta-llama-3-3-70b-instruct": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000, 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8015,7 +8015,7 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "metadata": {"notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."}
     },
-    "databricks/meta-llama-3.3-70b-instruct": {
+    "databricks/databricks-meta-llama-3-3-70b-instruct": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000, 


### PR DESCRIPTION
## Fixed meta llama 3.3 key for Databricks API


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Corrected the databricks endpoint for llama 3.3-70b-instruct

See correct key reference here: https://docs.databricks.com/en/machine-learning/model-serving/foundation-model-overview.html#pay-per-token

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

Tested locally