### PR TITLE
Set the ollama_models list based on locally available models when litellm starts.

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -814,6 +814,7 @@ models_by_provider: dict = {
     "bedrock": bedrock_models + bedrock_converse_models,
     "petals": petals_models,
     "ollama": ollama_models,
+    "ollama_chat": ollama_models,
     "deepinfra": deepinfra_models,
     "perplexity": perplexity_models,
     "maritalk": maritalk_models,

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -27,8 +27,6 @@ from litellm._logging import (
     log_level,
 )
 import re
-import requests
-import sys
 from litellm.constants import (
     DEFAULT_BATCH_SIZE,
     DEFAULT_FLUSH_INTERVAL_SECONDS,
@@ -707,26 +705,7 @@ petals_models = [
 
 # Since Ollama models are local, it is inexpensive to refresh the list at startup.
 # Also, this list can change very quickly.
-
-ollama_dir = os.environ.get("OLLAMA_MODELS", None)
-if ollama_dir is None:
-    home = Path(os.environ.get("HOME", None))
-    if home and (home / ".ollama").exists():
-        ollama_dir = home / ".ollama"
-
-if ollama_dir is None:
-    # No ollama install found.  Skip the HTTP request.
-    ollama_models = []
-else:
-    # Hit the local Ollama endpoint for a list of model names.
-    url = "http://localhost:11434/api/tags"
-    try:
-        response = requests.get(url)
-        json_dict = response.json()
-        ollama_models = [m["name"] for m in json_dict["models"]]
-    except Exception:
-        print(f"Error checking for ollama models at: {url}", file=sys.stderr)
-        ollama_models = []
+ollama_models = []
 
 maritalk_models = ["maritalk"]
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4618,7 +4618,7 @@ def _get_model_info_helper(  # noqa: PLR0915
             )
         elif (
             custom_llm_provider == "ollama" or custom_llm_provider == "ollama_chat"
-        ) and not _is_potential_model_name_in_model_cost(potential_model_names):
+        ) and not _is_potential_model_name_in_model_cost(potential_model_names) and "*" not in model:
             return litellm.OllamaConfig().get_model_info(model)
         else:
             """


### PR DESCRIPTION
## Title

Set `ollama_models` from the locally installed list at bootup.

## Relevant issues

Fixes #8095

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Previously: the `ollama_models` list was hard-coded to one model that might or might not be available on the host.
Now: if the host has an ollama install available, it gets the list at bootup, and if not it has a zero-size list

Previously: using `ollama/*` or `ollama_chat/*` failed wildcard expansion when used in a config.
Now: Either work to match all ollama models available at litellm start.


## Attach a screenshot of any new tests passing locally
No new tests.

## Functionality Demonstration

A CLI-based demonstration of litellm finding the full list of local ollama models:
```
> curl http://localhost:4000/models | jq '.data[].id' | grep ollama 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11154  100 11154    0     0  3370k      0 --:--:-- --:--:-- --:--:-- 3630k
"ollama/chsword/deepseek-v3:latest"
"ollama/command-r7b:7b"
"ollama/command-r7b:latest"
"ollama/deepseek-coder:6.7b"
"ollama/deepseek-r1:14b"
"ollama/dolphin3:8b"
"ollama/granite3.1-dense:8b"
"ollama/granite3.1-moe:3b"
"ollama/llama3-groq-tool-use:8b"
"ollama/llama3.2:3b"
"ollama/llama3.2:latest"
"ollama/nezahatkorkmaz/deepseek-v3:latest"
"ollama/olmo2:13b"
"ollama/orca2:7b"
"ollama/phi4:14b"
"ollama/qwen2.5-coder:14b"
"ollama/qwen2.5-coder:32b"
```

Demonstration of equivalent data in the local ollama system:
```
> ollama ls
NAME                                 ID              SIZE      MODIFIED     
deepseek-r1:14b                      ea35dfe18182    9.0 GB    9 days ago      
phi4:14b                             ac896e5b8b34    9.1 GB    12 days ago     
llama3.2:3b                          a80c4f17acd5    2.0 GB    12 days ago     
qwen2.5-coder:32b                    4bd6cbf2d094    19 GB     2 weeks ago     
command-r7b:latest                   bb9fe394b3e9    5.1 GB    2 weeks ago     
command-r7b:7b                       bb9fe394b3e9    5.1 GB    2 weeks ago     
chsword/deepseek-v3:latest           2ef1746094f1    2.0 GB    2 weeks ago     
olmo2:13b                            6c279ebc980f    8.4 GB    2 weeks ago     
nezahatkorkmaz/deepseek-v3:latest    2ef1746094f1    2.0 GB    2 weeks ago     
granite3.1-moe:3b                    df6f6578dba8    2.0 GB    2 weeks ago     
granite3.1-dense:8b                  86ac4cf0cb84    4.9 GB    2 weeks ago     
llama3-groq-tool-use:8b              36211dad2b15    4.7 GB    2 weeks ago     
dolphin3:8b                          d5ab9ae8e1f2    4.9 GB    2 weeks ago     
deepseek-coder:6.7b                  ce298d984115    3.8 GB    3 weeks ago     
qwen2.5-coder:14b                    3028237cc8c5    9.0 GB    2 months ago    
orca2:7b                             ea98cc422de3    3.8 GB    2 months ago    
llama3.2:latest                      a80c4f17acd5    2.0 GB    2 months ago    
```

Demonstration of the model counts matching (1-off b/c of the header):
```
> ollama ls | wc -l
      18
>
> curl http://localhost:4000/models | jq '.data[].id' | grep ollama | sort | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11154  100 11154    0     0  2829k      0 --:--:-- --:--:-- --:--:-- 3630k
      17
```