### PR TITLE
Fix passing top_k parameter for Bedrock Anthropic models

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -31,7 +31,7 @@ from litellm.types.llms.openai import (
     OpenAIMessageContentListBlock,
 )
 from litellm.types.utils import ModelResponse, Usage
-from litellm.utils import CustomStreamWrapper, add_dummy_tool, has_tool_call_blocks
+from litellm.utils import add_dummy_tool, has_tool_call_blocks
 
 from ..common_utils import (
     AmazonBedrockGlobalConfig,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -31,7 +31,7 @@ from litellm.types.llms.openai import (
     OpenAIMessageContentListBlock,
 )
 from litellm.types.utils import ModelResponse, Usage
-from litellm.utils import add_dummy_tool, has_tool_call_blocks
+from litellm.utils import CustomStreamWrapper, add_dummy_tool, has_tool_call_blocks
 
 from ..common_utils import (
     AmazonBedrockGlobalConfig,
@@ -332,9 +332,27 @@ class AmazonConverseConfig(BaseConfig):
         if "top_k" in inference_params:
             inference_params["topK"] = inference_params.pop("top_k")
         return InferenceConfig(**inference_params)
+    
+    def _handle_top_k_value(self, model: str, inference_params: dict) -> dict:
+        base_model = self._get_base_model(model)
+
+        valTopK = None
+        if "topK" in inference_params:
+            valTopK = inference_params.pop("topK")
+        elif "top_k" in inference_params:
+            valTopK = inference_params.pop("top_k")
+
+        if valTopK:
+            if (base_model.startswith("anthropic")):
+                return {"top_k": valTopK}
+            elif base_model.startswith("amazon.nova"):
+                return {'inferenceConfig': {"topK": valTopK}}                
+                
+        return {}
 
     def _transform_request_helper(
         self,
+        model: str,
         system_content_blocks: List[SystemContentBlock],
         optional_params: dict,
         messages: Optional[List[AllMessageValues]] = None,
@@ -361,35 +379,20 @@ class AmazonConverseConfig(BaseConfig):
                 )
 
         inference_params = copy.deepcopy(optional_params)
-        additional_request_keys = []
-        additional_request_params = {}
         supported_converse_params = list(
             AmazonConverseConfig.__annotations__.keys()
         ) + ["top_k"]
         supported_tool_call_params = ["tools", "tool_choice"]
         supported_guardrail_params = ["guardrailConfig"]
+        total_supported_params = supported_converse_params + supported_tool_call_params + supported_guardrail_params
         inference_params.pop("json_mode", None)  # used for handling json_schema
 
-        # send all model-specific params in 'additional_request_params'
-        for k, v in inference_params.items():
-            if (
-                k not in supported_converse_params
-                and k not in supported_tool_call_params
-                and k not in supported_guardrail_params
-            ):
-                additional_request_params[k] = v
-                additional_request_keys.append(k)
-        for key in additional_request_keys:
-            inference_params.pop(key, None)
+        # keep supported params in 'inference_params', and set all model-specific params in 'additional_request_params'
+        additional_request_params = {k: v for k, v in inference_params.items() if k not in total_supported_params}
+        inference_params = {k: v for k, v in inference_params.items() if k in total_supported_params}
 
-        if "topK" in inference_params:
-            additional_request_params["inferenceConfig"] = {
-                "topK": inference_params.pop("topK")
-            }
-        elif "top_k" in inference_params:
-            additional_request_params["inferenceConfig"] = {
-                "topK": inference_params.pop("top_k")
-            }
+        # Only set the topK value in for models that support it
+        additional_request_params.update(self._handle_top_k_value(model, inference_params))
 
         bedrock_tools: List[ToolBlock] = _bedrock_tools_pt(
             inference_params.pop("tools", [])
@@ -437,6 +440,7 @@ class AmazonConverseConfig(BaseConfig):
         ## TRANSFORMATION ##
 
         _data: CommonRequestObject = self._transform_request_helper(
+            model=model,
             system_content_blocks=system_content_blocks,
             optional_params=optional_params,
             messages=messages,
@@ -483,6 +487,7 @@ class AmazonConverseConfig(BaseConfig):
         messages, system_content_blocks = self._transform_system_message(messages)
 
         _data: CommonRequestObject = self._transform_request_helper(
+            model=model,
             system_content_blocks=system_content_blocks,
             optional_params=optional_params,
             messages=messages,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -336,17 +336,17 @@ class AmazonConverseConfig(BaseConfig):
     def _handle_top_k_value(self, model: str, inference_params: dict) -> dict:
         base_model = self._get_base_model(model)
 
-        valTopK = None
+        val_top_k = None
         if "topK" in inference_params:
-            valTopK = inference_params.pop("topK")
+            val_top_k = inference_params.pop("topK")
         elif "top_k" in inference_params:
-            valTopK = inference_params.pop("top_k")
+            val_top_k = inference_params.pop("top_k")
 
-        if valTopK:
+        if val_top_k:
             if (base_model.startswith("anthropic")):
-                return {"top_k": valTopK}
-            elif base_model.startswith("amazon.nova"):
-                return {'inferenceConfig': {"topK": valTopK}}                
+                return {"top_k": val_top_k}
+            if base_model.startswith("amazon.nova"):
+                return {'inferenceConfig': {"topK": val_top_k}}                
                 
         return {}
 

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -2580,3 +2580,20 @@ def test_bedrock_custom_deepseek():
         except Exception as e:
             print(f"Error: {str(e)}")
             raise e
+        
+@pytest.mark.parametrize(
+    "model", 
+    [
+        "bedrock/anthropic.claude-3-sonnet-20240229-v1:0", 
+        "bedrock/converse/us.amazon.nova-pro-v1:0", 
+        "bedrock/meta.llama3-70b-instruct-v1:0",
+        "bedrock/mistral.mistral-7b-instruct-v0:2",
+    ]
+)
+def test_bedrock_top_k(model):
+    litellm.completion(
+        model=model,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        top_k=2,
+    )  
+


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Fix passing top_k parameter for Bedrock Anthropic models

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #7782 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->
The bug arose from the fact that different bedrock models pass in the top_k parameter in different ways.

Specifically the nova model passes in the parameter through 
```
additionalModelRequestFields = {
    "inferenceConfig": {
         "topK": 20
    }
}
```

and the anthropic model passes it in through

```
additional_model_fields = {"top_k": top_k}
```

This PR checks the model types and sets the parameter based on that. Right now, this is a simple if statement, but a long term fix might be to create a new class for each model, and create handling logic for supported / model-specific param within each class. This way the overall converse handler does not need to know about these specifics.

This PR also simplifies the additional_model_fields creation logic 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
Tested the top_k param for 4 different models w/ real API calls:
![image](https://github.com/user-attachments/assets/59ec88da-501a-4367-9526-dd091b74ead1)

Tests still passed w/ mocks:
![image](https://github.com/user-attachments/assets/a4194ed3-f225-4e38-9e18-a7e6f9902939)
