### PR TITLE
Fix json_mode parameter propagation in OpenAILikeChatHandler

### DIFF
--- a/litellm/llms/openai_like/chat/handler.py
+++ b/litellm/llms/openai_like/chat/handler.py
@@ -337,6 +337,7 @@ class OpenAILikeChatHandler(OpenAILikeBase):
                     timeout=timeout,
                     base_model=base_model,
                     client=client,
+                    json_mode=json_mode
                 )
         else:
             ## COMPLETION CALL


### PR DESCRIPTION
## Title

Fix json_mode parameter propagation in OpenAILikeChatHandler async completion

## Relevant issues

When using structured responses, `acompletion()` and `completion()` produce different results specifically with Groq models. This occurs because the `json_mode` parameter isn't being properly propagated through the async completion flow.

Related Issue: #8060

## Type
🐛 Bug Fix

## Changes

```diff
 return self.acompletion_function(
     model=model,
     messages=messages,
     data=data,
     api_base=api_base,
     custom_prompt_dict=custom_prompt_dict,
     custom_llm_provider=custom_llm_provider,
     model_response=model_response,
     print_verbose=print_verbose,
     encoding=encoding,
     api_key=api_key,
     logging_obj=logging_obj,
     optional_params=optional_params,
     stream=stream,
     litellm_params=litellm_params,
     logger_fn=logger_fn,
     headers=headers,
     timeout=timeout,
     base_model=base_model,
     client=client,
+    json_mode=json_mode
 )
````
