### PR TITLE
Add litellm pytest plugin

### DIFF
--- a/litellm/pytest_plugin.py
+++ b/litellm/pytest_plugin.py
@@ -1,0 +1,7 @@
+import pytest
+import litellm
+
+
+@pytest.fixture(autouse=True)
+def cleanup_caches() -> None:
+    litellm.in_memory_llm_clients_cache.flush_cache()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ profile = "black"
 [tool.poetry.scripts]
 litellm = 'litellm:run_server'
 
+[tool.poetry.plugins.pytest11]
+pytest_litellm = "litellm.pytest_plugin"
+
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.1.0"
 black = "^23.12.0"

--- a/tests/pytest_plugin_tests/conftest.py
+++ b/tests/pytest_plugin_tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "pytester"

--- a/tests/pytest_plugin_tests/test_pytest_plugin.py
+++ b/tests/pytest_plugin_tests/test_pytest_plugin.py
@@ -1,0 +1,24 @@
+from pytest import Pytester
+
+
+class TestIsolationFixture:
+    CODE = """
+        import litellm
+        def test_write_cache_a():
+            assert litellm.in_memory_llm_clients_cache.get_cache("flushme") is None
+            litellm.in_memory_llm_clients_cache.set_cache(key="flushme", value="old_client")
+        
+        def test_write_cache_b():
+            assert litellm.in_memory_llm_clients_cache.get_cache("flushme") is None
+            litellm.in_memory_llm_clients_cache.set_cache(key="flushme", value="new_client")
+        """
+
+    def test_fixture_isolates(self, testdir: Pytester) -> None:
+        testdir.makepyfile(self.CODE)
+        result = testdir.runpytest("-p", "litellm.pytest_plugin")
+        result.assert_outcomes(passed=2)
+
+    def test_fixture_needed(self, testdir: Pytester) -> None:
+        testdir.makepyfile(self.CODE)
+        result = testdir.runpytest("-p", "no:litellm.pytest_plugin")
+        result.assert_outcomes(passed=1, failed=1)

--- a/tests/pytest_plugin_tests/test_pytest_plugin.py
+++ b/tests/pytest_plugin_tests/test_pytest_plugin.py
@@ -15,10 +15,15 @@ class TestIsolationFixture:
 
     def test_fixture_isolates(self, testdir: Pytester) -> None:
         testdir.makepyfile(self.CODE)
-        result = testdir.runpytest("-p", "litellm.pytest_plugin")
+        result = testdir.runpytest("-p", "pytest_litellm")
         result.assert_outcomes(passed=2)
 
     def test_fixture_needed(self, testdir: Pytester) -> None:
         testdir.makepyfile(self.CODE)
-        result = testdir.runpytest("-p", "no:litellm.pytest_plugin")
+        result = testdir.runpytest("-p", "no:pytest_litellm")
         result.assert_outcomes(passed=1, failed=1)
+
+    def test_fixture_used_automatically(self, testdir: Pytester) -> None:
+        testdir.makepyfile(self.CODE)
+        result = testdir.runpytest()
+        result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Add litellm pytest plugin

## Relevant issues

Fixes #5854.

## Type

🚄 Infrastructure
✅ Test

## Changes

Adds a  pytest plugin that automatically clears the llm caches. Comes in handy for projects using litellm in async tests.

As described in the issue, the event loop is closed after each async test instance by pytest-asyncio. So, the cached clients still have a reference to the old loop in new test instances. This exposes a auto-use fixture for pytest that automatically clears the cached httpx llm clients. 

<!-- Test procedure -->

Test with `pytest tests/pytest_plugin_tests/`:
![image](https://github.com/user-attachments/assets/e37f8c95-8468-472a-892a-d1c2e473db35)

The first commit contains the actual plugin. In the second commit, this plugin is automatically registered with pytest, so every fixture is available to anyone using litellm and pytest. I don't know if you want this, or if you need documentation changes for this.

