### PR TITLE
[FIX] replace cgi for python 3.13 with email.Message as suggested in PEP 594

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2153,7 +2153,7 @@ def stringify_json_tool_call_content(messages: List) -> List:
 
 import base64
 import mimetypes
-from cgi import parse_header
+from email.message import Message
 
 import httpx
 
@@ -2174,8 +2174,9 @@ from litellm.types.llms.bedrock import ToolUseBlock as BedrockToolUseBlock
 
 
 def _parse_content_type(content_type: str) -> str:
-    main_type, _ = parse_header(content_type)
-    return main_type
+    m = Message()
+    m['content-type'] = content_type
+    return m.get_content_type()
 
 
 class BedrockImageProcessor:


### PR DESCRIPTION
## Title

[FIX] replace cgi for python 3.13 with email.Message as suggested in PEP 594

## Relevant issues

"Fixes #8081"

## Type

🐛 Bug Fix

## Changes

change `cgi.parse_header` to `email.Message.get_content_type`

## [REQUIRED] Testing

```python
from email.message import Message

def _parse_content_type(content_type: str) -> str:
    m = Message()
    m["content-type"] = content_type
    return m.get_content_type()

print(_parse_content_type('text/html; charset="utf-8"'))
```

result: `text/html`
