### PR TITLE
Add O3-Mini for Azure and Remove Vision Support

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -211,7 +211,7 @@
         "cache_read_input_token_cost": 0.00000055,
         "litellm_provider": "openai",
         "mode": "chat",
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "o3-mini-2025-01-31": {
@@ -223,7 +223,7 @@
         "cache_read_input_token_cost": 0.00000055,
         "litellm_provider": "openai",
         "mode": "chat",
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "o1-mini-2024-09-12": {
@@ -928,6 +928,30 @@
         "mode": "audio_speech", 
         "input_cost_per_character": 0.000030,
         "litellm_provider": "openai"
+    },
+    "azure/o3-mini": {
+        "max_tokens": 100000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "input_cost_per_token": 0.0000011,
+        "output_cost_per_token": 0.0000044,
+        "cache_read_input_token_cost": 0.00000055,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_vision": false,
+        "supports_prompt_caching": true
+    },
+    "azure/o3-mini-2025-01-31": {
+        "max_tokens": 100000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "input_cost_per_token": 0.0000011,
+        "output_cost_per_token": 0.0000044,
+        "cache_read_input_token_cost": 0.00000055,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_vision": false,
+        "supports_prompt_caching": true
     },
     "azure/tts-1": {
         "mode": "audio_speech", 


### PR DESCRIPTION
* Azure Released O3-mini at the same time as OAI, so i've added support here. Confirmed to work with Sweden Central.

## Add O3-Mini for Azure and Remove Vision Support


## Type

🆕 New Feature


## Changes

- Added Azure O3-mini
- Disabled Vision Support

https://azure.microsoft.com/en-us/blog/announcing-the-availability-of-the-o3-mini-reasoning-model-in-microsoft-azure-openai-service/

