### PR TITLE
fix: support azure o3 model family for fake streaming workaround

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -81,7 +81,7 @@ def get_supported_openai_params(  # noqa: PLR0915
     elif custom_llm_provider == "openai":
         return litellm.OpenAIConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "azure":
-        if litellm.AzureOpenAIO1Config().is_o1_model(model=model):
+        if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
             return litellm.AzureOpenAIO1Config().get_supported_openai_params(
                 model=model
             )

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -81,7 +81,7 @@ def get_supported_openai_params(  # noqa: PLR0915
     elif custom_llm_provider == "openai":
         return litellm.OpenAIConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "azure":
-        if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
+        if litellm.AzureOpenAIO1Config().is_o_series_model(model=model):
             return litellm.AzureOpenAIO1Config().get_supported_openai_params(
                 model=model
             )

--- a/litellm/llms/azure/chat/o1_handler.py
+++ b/litellm/llms/azure/chat/o1_handler.py
@@ -1,7 +1,7 @@
 """
-Handler file for calls to Azure OpenAI's o1 family of models
+Handler file for calls to Azure OpenAI's o1/o3 family of models
 
-Written separately to handle faking streaming for o1 models.
+Written separately to handle faking streaming for o1 and o3 models.
 """
 
 from typing import Optional, Union

--- a/litellm/llms/azure/chat/o1_transformation.py
+++ b/litellm/llms/azure/chat/o1_transformation.py
@@ -47,5 +47,5 @@ class AzureOpenAIO1Config(OpenAIO1Config):
 
         return True
 
-    def is_reasoning_model(self, model: str) -> bool:
+    def is_o_series_model(self, model: str) -> bool:
         return "o1" in model or "o3" in model

--- a/litellm/llms/azure/chat/o1_transformation.py
+++ b/litellm/llms/azure/chat/o1_transformation.py
@@ -1,5 +1,5 @@
 """
-Support for o1 model family 
+Support for o1 and o3 model families
 
 https://platform.openai.com/docs/guides/reasoning
 
@@ -47,5 +47,5 @@ class AzureOpenAIO1Config(OpenAIO1Config):
 
         return True
 
-    def is_o1_model(self, model: str) -> bool:
-        return "o1" in model
+    def is_reasoning_model(self, model: str) -> bool:
+        return "o1" in model or "o3" in model

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1201,7 +1201,7 @@ def completion(  # type: ignore # noqa: PLR0915
             if extra_headers is not None:
                 optional_params["extra_headers"] = extra_headers
 
-            if litellm.AzureOpenAIO1Config().is_o1_model(model=model):
+            if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
                 ## LOAD CONFIG - if set
                 config = litellm.AzureOpenAIO1Config.get_config()
                 for k, v in config.items():

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1201,7 +1201,7 @@ def completion(  # type: ignore # noqa: PLR0915
             if extra_headers is not None:
                 optional_params["extra_headers"] = extra_headers
 
-            if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
+            if litellm.AzureOpenAIO1Config().is_o_series_model(model=model):
                 ## LOAD CONFIG - if set
                 config = litellm.AzureOpenAIO1Config.get_config()
                 for k, v in config.items():

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3489,7 +3489,7 @@ def get_optional_params(  # noqa: PLR0915
             ),
         )
     elif custom_llm_provider == "azure":
-        if litellm.AzureOpenAIO1Config().is_o1_model(model=model):
+        if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
             optional_params = litellm.AzureOpenAIO1Config().map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -5997,7 +5997,7 @@ class ProviderConfigManager:
         ):
             return litellm.AI21ChatConfig()
         elif litellm.LlmProviders.AZURE == provider:
-            if litellm.AzureOpenAIO1Config().is_o1_model(model=model):
+            if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
                 return litellm.AzureOpenAIO1Config()
             return litellm.AzureOpenAIConfig()
         elif litellm.LlmProviders.AZURE_AI == provider:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3489,7 +3489,7 @@ def get_optional_params(  # noqa: PLR0915
             ),
         )
     elif custom_llm_provider == "azure":
-        if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
+        if litellm.AzureOpenAIO1Config().is_o_series_model(model=model):
             optional_params = litellm.AzureOpenAIO1Config().map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -5997,7 +5997,7 @@ class ProviderConfigManager:
         ):
             return litellm.AI21ChatConfig()
         elif litellm.LlmProviders.AZURE == provider:
-            if litellm.AzureOpenAIO1Config().is_reasoning_model(model=model):
+            if litellm.AzureOpenAIO1Config().is_o_series_model(model=model):
                 return litellm.AzureOpenAIO1Config()
             return litellm.AzureOpenAIConfig()
         elif litellm.LlmProviders.AZURE_AI == provider:


### PR DESCRIPTION
## Support o3 model family for fake streaming workaround from Azure
`o3-mini` is already available on Azure, but sadly it looks like it doesn't support streaming, just like the `o1` models.

So this PR updates the logic for the fake streaming workaround to also support the `o3` family. Note that there's a wider refactor to generalize the name of `AzureOpenAIO1Config` that I'm not making here.

## Relevant issues
Fixes https://github.com/BerriAI/litellm/issues/8158
<!-- e.g. "Fixes #000" -->

## Type
🐛 Bug Fix

## Changes
* Added `o3*` to the list of models for the Azure fake streaming workaround
<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
I didn't see any obvious tests in this area, so manually tested the fake streaming is now working with `o3-mini`, `o1-mini`, as well as non-streaming on `o3-mini`. Also validated that real streaming is still working with `gpt-4o`.

