### PR TITLE
o3-mini in Azure does not support vision

### DIFF
--- a/azure_o3_mini_vision_false
+++ b/azure_o3_mini_vision_false
@@ -954,7 +954,7 @@
         "cache_read_input_token_cost": 0.00000055,
         "litellm_provider": "azure",
         "mode": "chat",
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_prompt_caching": true
     },
     "azure/o1-mini": {


### PR DESCRIPTION
…ni_vision_false

o3-mini in Azure does not support images: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#o-series-models

## Title

o3-mini in Azure does not support vision

## Relevant issues


## Type

🐛 Bug Fix

## Changes


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes


