### PR TITLE
Add azure/deepseek-r1

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -945,6 +945,17 @@
         "output_cost_per_second": 0.0001, 
         "litellm_provider": "azure"
     },
+    "azure/deepseek-r1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "input_cost_per_token_cache_hit": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_prompt_caching": true
+    },
     "azure/o3-mini": {
         "max_tokens": 100000,
         "max_input_tokens": 200000,


### PR DESCRIPTION
Adding Deepseek-R1 deployed on Azure AI Foundry. Cost is for now set to 0, R1 is free.

Source: https://azure.microsoft.com/en-us/blog/deepseek-r1-is-now-available-on-azure-ai-foundry-and-github/?msockid=2053f19411e068d21e7ee54810c8697a