### PR TITLE
Azure AI Foundry - Deepseek R1

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -975,17 +975,6 @@
         "output_cost_per_second": 0.0001, 
         "litellm_provider": "azure"
     },
-    "azure/deepseek-r1": {
-        "max_tokens": 8192,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 0.0,
-        "input_cost_per_token_cache_hit": 0.0,
-        "output_cost_per_token": 0.0,
-        "litellm_provider": "azure",
-        "mode": "chat",
-        "supports_prompt_caching": true
-    },
     "azure/o3-mini": {
         "max_tokens": 100000,
         "max_input_tokens": 200000,
@@ -1490,6 +1479,17 @@
         "output_cost_per_token": 0.0,
         "litellm_provider": "azure", 
         "mode": "image_generation"
+    },
+     "azure_ai/deepseek-r1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "input_cost_per_token_cache_hit": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "azure_ai",
+        "mode": "chat",
+        "supports_prompt_caching": true
     },
     "azure_ai/jamba-instruct": {
         "max_tokens": 4096,


### PR DESCRIPTION
##  Preview Deepseek R1 on Azure AI Foundry/Studio

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Moved Deepseek R1 from azure to azure_ai since this model is hosted on Azure AI Foundry/Studio (*deployment*.*region*.models.ai.azure.com) rather than OpenAI (*deployment*.openai.azure.com).

