### PR TITLE
(UI + SpendLogs) - Store SpendLogs in UTC Timezone, Fix filtering logs by start/end time

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1,7 +1,7 @@
 #### SPEND MANAGEMENT #####
 import collections
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, List, Optional
 
 import fastapi
@@ -1688,13 +1688,18 @@ async def ui_view_spend_logs(  # noqa: PLR0915
         )
 
     try:
+
         # Convert the date strings to datetime objects
-        start_date_obj = datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
-        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
+        start_date_obj = datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
 
         # Convert to ISO format strings for Prisma
-        start_date_iso = start_date_obj.isoformat() + "Z"  # Add Z to indicate UTC
-        end_date_iso = end_date_obj.isoformat() + "Z"  # Add Z to indicate UTC
+        start_date_iso = start_date_obj.isoformat()  # Already in UTC, no need to add Z
+        end_date_iso = end_date_obj.isoformat()  # Already in UTC, no need to add Z
 
         # Build where conditions
         where_conditions: dict[str, Any] = {

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -1,6 +1,8 @@
 import json
 import secrets
+from datetime import datetime
 from datetime import datetime as dt
+from datetime import timezone
 from typing import Optional, cast
 
 from pydantic import BaseModel
@@ -153,9 +155,9 @@ def get_logging_payload(  # noqa: PLR0915
             call_type=call_type or "",
             api_key=str(api_key),
             cache_hit=str(cache_hit),
-            startTime=start_time,
-            endTime=end_time,
-            completionStartTime=completion_start_time,
+            startTime=_ensure_datetime_utc(start_time),
+            endTime=_ensure_datetime_utc(end_time),
+            completionStartTime=_ensure_datetime_utc(completion_start_time),
             model=kwargs.get("model", "") or "",
             user=kwargs.get("litellm_params", {})
             .get("metadata", {})
@@ -193,6 +195,12 @@ def get_logging_payload(  # noqa: PLR0915
             "Error creating spendlogs object - {}".format(str(e))
         )
         raise e
+
+
+def _ensure_datetime_utc(timestamp: datetime) -> datetime:
+    """Helper to ensure datetime is in UTC"""
+    timestamp = timestamp.astimezone(timezone.utc)
+    return timestamp
 
 
 async def get_spend_by_team_and_customer(

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -61,9 +61,11 @@ export const columns: ColumnDef<LogEntry>[] = [
     header: "Request ID",
     accessorKey: "request_id",
     cell: (info: any) => (
-      <span className="font-mono text-xs max-w-[100px] truncate block">
-        {String(info.getValue() || "")}
-      </span>
+      <Tooltip title={String(info.getValue() || "")}>
+        <span className="font-mono text-xs max-w-[100px] truncate block">
+          {String(info.getValue() || "")}
+        </span>
+      </Tooltip>
     ),
   },
   {

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { CountryCell } from "./country_cell";
 import { getProviderLogoAndName } from "../provider_info_helpers";
 import { Tooltip } from "antd";
+import { TimeCell } from "./time_cell";
 
 export type LogEntry = {
   request_id: string;
@@ -53,9 +54,7 @@ export const columns: ColumnDef<LogEntry>[] = [
   {
     header: "Time",
     accessorKey: "startTime",
-    cell: (info: any) => (
-      <span>{moment(info.getValue()).format("MMM DD HH:mm:ss")}</span>
-    ),
+    cell: (info: any) => <TimeCell utcTime={info.getValue()} />,
   },
   {
     header: "Request ID",

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -105,10 +105,13 @@ export default function SpendLogsTable({
         };
       }
 
-      const formattedStartTime = moment(startTime).format("YYYY-MM-DD HH:mm:ss");
+      const formattedStartTime = moment(startTime).utc().format("YYYY-MM-DD HH:mm:ss");
       const formattedEndTime = isCustomDate 
-        ? moment(endTime).format("YYYY-MM-DD HH:mm:ss")
-        : moment().format("YYYY-MM-DD HH:mm:ss");
+        ? moment(endTime).utc().format("YYYY-MM-DD HH:mm:ss")
+        : moment().utc().format("YYYY-MM-DD HH:mm:ss");
+
+      console.log("formattedStartTime", formattedStartTime);
+      console.log("formattedEndTime", formattedEndTime);
 
       return await uiSpendLogsCall(
         accessToken,

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -105,13 +105,10 @@ export default function SpendLogsTable({
         };
       }
 
-      const formattedStartTime = moment(startTime).utc().format("YYYY-MM-DD HH:mm:ss");
+      const formattedStartTime = moment(startTime).format("YYYY-MM-DD HH:mm:ss");
       const formattedEndTime = isCustomDate 
-        ? moment(endTime).utc().format("YYYY-MM-DD HH:mm:ss")
-        : moment().utc().format("YYYY-MM-DD HH:mm:ss");
-
-      console.log("formattedStartTime", formattedStartTime);
-      console.log("formattedEndTime", formattedEndTime);
+        ? moment(endTime).format("YYYY-MM-DD HH:mm:ss")
+        : moment().format("YYYY-MM-DD HH:mm:ss");
 
       return await uiSpendLogsCall(
         accessToken,
@@ -179,7 +176,7 @@ export default function SpendLogsTable({
         <h1 className="text-xl font-semibold">Request Logs</h1>
       </div>
       
-      <div className="bg-white rounded-lg shadow overflow-hidden">
+      <div className="bg-white rounded-lg shadow">
         <div className="border-b px-6 py-4">
           <div className="flex flex-col md:flex-row items-start md:items-center justify-between space-y-4 md:space-y-0">
             <div className="flex flex-wrap items-center gap-3">

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -105,10 +105,11 @@ export default function SpendLogsTable({
         };
       }
 
-      const formattedStartTime = moment(startTime).format("YYYY-MM-DD HH:mm:ss");
+      // Convert times to UTC before formatting
+      const formattedStartTime = moment(startTime).utc().format("YYYY-MM-DD HH:mm:ss");
       const formattedEndTime = isCustomDate 
-        ? moment(endTime).format("YYYY-MM-DD HH:mm:ss")
-        : moment().format("YYYY-MM-DD HH:mm:ss");
+        ? moment(endTime).utc().format("YYYY-MM-DD HH:mm:ss")
+        : moment().utc().format("YYYY-MM-DD HH:mm:ss");
 
       return await uiSpendLogsCall(
         accessToken,

--- a/ui/litellm-dashboard/src/components/view_logs/time_cell.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/time_cell.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+interface TimeCellProps {
+  utcTime: string;
+}
+
+const getLocalTime = (utcTime: string): string => {
+  try {
+    const date = new Date(utcTime);
+    return date.toLocaleString('en-US', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: true
+    }).replace(',', '');
+  } catch (e) {
+    return "Error converting time";
+  }
+};
+
+export const TimeCell: React.FC<TimeCellProps> = ({ utcTime }) => {
+  return (
+    <span style={{
+      fontFamily: 'monospace',
+      width: '180px',
+      display: 'inline-block'
+    }}>
+      {getLocalTime(utcTime)}
+    </span>
+  );
+};
+
+export const getTimeZone = (): string => {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+};


### PR DESCRIPTION
## (UI + SpendLogs) - Store SpendLogs in UTC Timezone 
<img width="866" alt="Screenshot 2025-02-01 at 4 24 36 PM" src="https://github.com/user-attachments/assets/f3d79a1d-0d95-4c1e-a9c9-a81f589232e6" />

<img width="255" alt="Screenshot 2025-02-01 at 4 25 49 PM" src="https://github.com/user-attachments/assets/df8276a2-f3fc-425b-aee4-a22745b42155" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

