### PR TITLE
docs: fix typo in lm_studio.md

### DIFF
--- a/docs/my-website/docs/providers/lm_studio.md
+++ b/docs/my-website/docs/providers/lm_studio.md
@@ -69,7 +69,7 @@ for chunk in response:
 
 ## Usage with LiteLLM Proxy Server
 
-Here's how to call a XAI model with the LiteLLM Proxy Server
+Here's how to call a LM Studio model with the LiteLLM Proxy Server
 
 1. Modify the config.yaml 
 


### PR DESCRIPTION
## Title
typo fix 

## Type

📖 Documentation

## Changes

replaced "xAI" reference with "LM Studio".
