### PR TITLE
(Security) - Allow setting  litellm.default_key_max_budget

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -236,6 +236,7 @@ max_budget: float = 0.0  # set the max budget across all providers
 budget_duration: Optional[str] = (
     None  # proxy only - resets budget after fixed duration. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
 )
+default_key_max_budget: Optional[float] = None  # set a default max budget for all keys
 default_soft_budget: float = (
     50.0  # by default all litellm proxy keys have a soft budget of 50.0
 )

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2307,7 +2307,7 @@ class BedrockImageProcessor:
         """Synchronous image processing."""
         if "base64" in image_url:
             img_bytes, mime_type, image_format = cls._parse_base64_image(image_url)
-        elif "https:/" in image_url:
+        elif "http://" in image_url or "https://" in image_url:
             img_bytes, mime_type = BedrockImageProcessor.get_image_details(image_url)
             image_format = mime_type.split("/")[1]
         else:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1152,6 +1152,7 @@ async def _virtual_key_default_budget_check(
             raise litellm.BudgetExceededError(
                 current_cost=valid_token.spend,
                 max_budget=litellm.default_key_max_budget,
+                message=f"Default key max budget has been exceeded! Current cost: {valid_token.spend}, Max budget: {litellm.default_key_max_budget}",
             )
 
 

--- a/tests/local_testing/test_stream_chunk_builder.py
+++ b/tests/local_testing/test_stream_chunk_builder.py
@@ -187,7 +187,7 @@ def test_stream_chunk_builder_litellm_usage_chunks():
 
     usage: litellm.Usage = Usage(
         completion_tokens=27,
-        prompt_tokens=55,
+        prompt_tokens=50,
         total_tokens=82,
         completion_tokens_details=None,
         prompt_tokens_details=None,
@@ -213,7 +213,9 @@ def test_stream_chunk_builder_litellm_usage_chunks():
 
     # assert prompt tokens are the same
 
-    assert gemini_pt == stream_rebuilt_pt
+    assert (
+        gemini_pt == stream_rebuilt_pt
+    ), f"Stream builder is not able to rebuild usage correctly. Got={stream_rebuilt_pt}, expected={gemini_pt}"
 
 
 def test_stream_chunk_builder_litellm_mixed_calls():
@@ -729,6 +731,7 @@ def test_stream_chunk_builder_openai_audio_output_usage():
     assert (
         usage_dict == response_usage_dict
     ), f"\nExpected: {usage_dict}\nGot: {response_usage_dict}"
+
 
 def test_stream_chunk_builder_empty_initial_chunk():
     from litellm.litellm_core_utils.streaming_chunk_builder_utils import (


### PR DESCRIPTION
## (Security) - Allow setting  litellm.default_key_max_budget

- Use this to set a default max budget for all new / existing keys. Protect against malicious attacks 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

