### PR TITLE
fixed user id passed as null when keyuser is you

### DIFF
--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -160,6 +160,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({
       message.info("Making API Call");
       setIsModalVisible(true);
 
+      if(keyOwner === "you"){
+        formValues.user_id = userID 
+      }
       // If it's a service account, add the service_account_id to the metadata
       if (keyOwner === "service_account") {
         // Parse existing metadata or create an empty object


### PR DESCRIPTION
## Title

fixed user id passed as null when keyuser is you

## Relevant issues

user id is being sent as null when internalUser/any user creates key when ownedby is you. as result of which key created by the user doesn't show up after a page refresh.

also fixes #8027

## Type

🐛 Bug Fix


## Changes

changes was made in create_key_button.tsx file

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
![image](https://github.com/user-attachments/assets/2997cd81-9780-449d-91b3-16ed11b34ee5)
<!-- Test procedure -->

