### PR TITLE
Handle azure deepseek reasoning response

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -89,6 +89,7 @@ from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response impo
     convert_to_model_response_object,
     convert_to_streaming_response,
     convert_to_streaming_response_async,
+    _parse_content_for_reasoning,
 )
 from litellm.litellm_core_utils.llm_response_utils.get_api_base import get_api_base
 from litellm.litellm_core_utils.llm_response_utils.get_formatted_prompt import (

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -864,6 +864,18 @@ def test_convert_model_response_object():
             == '{"type":"error","error":{"type":"invalid_request_error","message":"Output blocked by content filtering policy"}}'
         )
 
+@pytest.mark.parametrize(
+    "content, expected_reasoning, expected_content", 
+    [
+        (None, None, None),
+        ("<think>I am thinking here</think>The sky is a canvas of blue", "I am thinking here", "The sky is a canvas of blue"),
+        ("I am a regular response", None, "I am a regular response"),
+
+    ]
+)
+def test_parse_content_for_reasoning(content, expected_reasoning, expected_content):
+    assert(litellm.utils._parse_content_for_reasoning(content) == (expected_reasoning, expected_content))
+
 
 @pytest.mark.parametrize(
     "model, expected_bool",

--- a/tests/llm_translation/test_azure_ai.py
+++ b/tests/llm_translation/test_azure_ai.py
@@ -13,7 +13,7 @@ import litellm.types.utils
 from litellm.llms.anthropic.chat import ModelResponseIterator
 import httpx
 import json
-from respx import MockRouter
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 load_dotenv()
 import io
@@ -184,3 +184,45 @@ def test_completion_azure_ai_command_r():
         pass
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+def test_azure_deepseek_reasoning_content():
+    import json
+
+    client = HTTPHandler()
+
+    with patch.object(client, "post") as mock_post:
+        mock_response = MagicMock()
+        
+        mock_response.text = json.dumps(
+            {
+                "choices": [
+                    {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "message": {
+                        "content": "<think>I am thinking here</think>\n\nThe sky is a canvas of blue",
+                        "role": "assistant",
+                    }
+                    }
+                ],
+            }
+        ) 
+            
+        mock_response.status_code = 200
+        # Add required response attributes
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+        
+
+        response = litellm.completion(
+            model='azure_ai/deepseek-r1',
+            messages=[{"role": "user", "content": "Hello, world!"}],
+            api_base="https://litellm8397336933.services.ai.azure.com/models/chat/completions",
+            api_key="my-fake-api-key",
+            client=client
+        )  
+
+        print(response)
+        assert(response.choices[0].message.reasoning_content == "I am thinking here")
+        assert(response.choices[0].message.content == "\n\nThe sky is a canvas of blue")


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #8267
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

Some deepseek model hosts (specifically Azure) returns the reasoning content within the content itself as `<think>Thinking Content<think>User facing response`. This PR properly handles that case and puts the reasoning content on the api response as intended. This fix should work in general for all hosts that set the reasoning content like this.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
Added test w/ reasoning content and it passed
![image](https://github.com/user-attachments/assets/1dba94d1-165e-487b-b1e1-170e56d03878)
![image](https://github.com/user-attachments/assets/b9a9f436-6991-472a-a7c8-1a69c5efecd5)

Unit test for helper also passes
![image](https://github.com/user-attachments/assets/855bda61-b41f-492c-a19d-3ced121bad16)


