### PR TITLE
(bug fix router.py) - safely handle `choices=[]` on llm responses 

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3699,8 +3699,9 @@ class Router:
 
         Else, original response is returned.
         """
-        if response.choices[0].finish_reason != "content_filter":
-            return False
+        if response.choices and len(response.choices) > 0:
+            if response.choices[0].finish_reason != "content_filter":
+                return False
 
         content_policy_fallbacks = kwargs.get(
             "content_policy_fallbacks", self.content_policy_fallbacks

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -324,3 +324,28 @@ async def test_anthropic_router_completion_e2e(model_list):
     AnthropicResponse.model_validate(response)
 
     assert response.model == "gpt-3.5-turbo"
+
+
+@pytest.mark.asyncio
+async def test_router_with_empty_choices(model_list):
+    """
+    https://github.com/BerriAI/litellm/issues/8306
+    """
+    router = Router(model_list=model_list)
+    mock_response = litellm.ModelResponse(
+        choices=[],
+        usage=litellm.Usage(
+            prompt_tokens=10,
+            completion_tokens=10,
+            total_tokens=20,
+        ),
+        model="gpt-3.5-turbo",
+        object="chat.completion",
+        created=1723081200,
+    ).model_dump()
+    response = await router.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "Hello, how are you?"}],
+        mock_response=mock_response,
+    )
+    assert response is not None


### PR DESCRIPTION
## (bug fix router.py) - safely handle `choices=[]` on llm responses 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

