### PR TITLE
Fix: Follow infinity api url format

### DIFF
--- a/litellm/llms/infinity/rerank/transformation.py
+++ b/litellm/llms/infinity/rerank/transformation.py
@@ -20,6 +20,13 @@ from .common_utils import InfinityError
 
 
 class InfinityRerankConfig(CohereRerankConfig):
+    def get_complete_url(self, api_base: str, model: str) -> str:
+        # Remove trailing slashes and ensure clean base URL
+        api_base = api_base.rstrip("/")
+        if not api_base.endswith("/rerank"):
+            api_base = f"{api_base}/rerank"
+        return api_base
+        
     def validate_environment(
         self,
         headers: dict,

--- a/tests/llm_translation/test_infinity.py
+++ b/tests/llm_translation/test_infinity.py
@@ -69,7 +69,7 @@ async def test_infinity_rerank():
         _url = mock_post.call_args.kwargs["url"]
         print("Arguments passed to API=", args_to_api)
         print("url = ", _url)
-        assert _url == "https://api.infinity.ai/v1/rerank"
+        assert _url == "https://api.infinity.ai/rerank"
 
         request_data = json.loads(args_to_api)
         assert request_data["query"] == expected_payload["query"]
@@ -133,7 +133,7 @@ async def test_infinity_rerank_with_env(monkeypatch):
         _url = mock_post.call_args.kwargs["url"]
         print("Arguments passed to API=", args_to_api)
         print("url = ", _url)
-        assert _url == "https://env.infinity.ai/v1/rerank"
+        assert _url == "https://env.infinity.ai/rerank"
 
         request_data = json.loads(args_to_api)
         assert request_data["query"] == expected_payload["query"]


### PR DESCRIPTION
## Title
Follow infinity api url format

## Relevant issues
Infinity rerank API format is `api_base + /rerank` instead of `api_base + /v1/rerank`
![image](https://github.com/user-attachments/assets/99cf180f-8c5a-431e-b940-87746f3bd7ef)


## Type
🐛 Bug Fix


