### PR TITLE
fix: add azure/o1-2024-12-17 to model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1069,6 +1069,21 @@
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
+    "azure/o1-2024-12-17": {
+        "max_tokens": 100000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 100000,
+        "input_cost_per_token": 0.000015,
+        "output_cost_per_token": 0.000060,
+        "cache_read_input_token_cost": 0.0000075,
+        "litellm_provider": "azure",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true
+    },
     "azure/o1-preview": {
         "max_tokens": 32768,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Adding `azure/o1-2024-12-17` to model cost map
Add `azure/o1-2024-12-17` with parameters identical to the current `azure/o1`, due to the following message we are seeing:

`Failed to calculate request cost: This model isn't mapped yet. model=o1-2024-12-17, custom_llm_provider=azure. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.`

## Type
🐛 Bug Fix

## Changes

* Add `azure/o1-2024-12-17` to model cost map

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

