### PR TITLE
(Feat) - Allow calling Nova models on `/bedrock/invoke/`

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -360,7 +360,7 @@ BEDROCK_CONVERSE_MODELS = [
     "meta.llama3-2-90b-instruct-v1:0",
 ]
 BEDROCK_INVOKE_PROVIDERS_LITERAL = Literal[
-    "cohere", "anthropic", "mistral", "amazon", "meta", "llama", "ai21"
+    "cohere", "anthropic", "mistral", "amazon", "meta", "llama", "ai21", "nova"
 ]
 ####### COMPLETION MODELS ###################
 open_ai_chat_completion_models: List = []

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -863,6 +863,9 @@ from .llms.bedrock.common_utils import (
 from .llms.bedrock.chat.invoke_transformations.amazon_ai21_transformation import (
     AmazonAI21Config,
 )
+from .llms.bedrock.chat.invoke_transformations.amazon_nova_transformation import (
+    AmazonInvokeNovaConfig,
+)
 from .llms.bedrock.chat.invoke_transformations.anthropic_claude2_transformation import (
     AmazonAnthropicConfig,
 )

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1342,7 +1342,7 @@ class AWSEventStreamDecoder:
             text = chunk_data.get("completions")[0].get("data").get("text")  # type: ignore
             is_finished = True
             finish_reason = "stop"
-        ######## converse bedrock.anthropic mappings ###############
+        ######## /bedrock/converse mappings ###############
         elif (
             "contentBlockIndex" in chunk_data
             or "stopReason" in chunk_data
@@ -1350,6 +1350,11 @@ class AWSEventStreamDecoder:
             or "trace" in chunk_data
         ):
             return self.converse_chunk_parser(chunk_data=chunk_data)
+        ######### /bedrock/invoke nova mappings ###############
+        elif "contentBlockDelta" in chunk_data:
+            # when using /bedrock/invoke/nova, the chunk_data is nested under "contentBlockDelta"
+            _chunk_data = chunk_data.get("contentBlockDelta", None)
+            return self.converse_chunk_parser(chunk_data=_chunk_data)
         ######## bedrock.mistral mappings ###############
         elif "outputs" in chunk_data:
             if (

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
@@ -1,0 +1,38 @@
+"""
+Handles transforming requests for `bedrock/invoke/{nova} models`
+
+Inherits from `AmazonConverseConfig`
+
+Nova + Invoke API Tutorial: https://docs.aws.amazon.com/nova/latest/userguide/using-invoke-api.html
+"""
+
+from typing import List
+
+import litellm
+from litellm.types.llms.bedrock import BedrockInvokeNovaRequest
+from litellm.types.llms.openai import AllMessageValues
+
+
+class AmazonInvokeNovaConfig(litellm.AmazonConverseConfig):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        _transformed_nova_request = super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        bedrock_invoke_nova_request = dict(
+            BedrockInvokeNovaRequest(**_transformed_nova_request)
+        )
+        return bedrock_invoke_nova_request

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
@@ -14,6 +14,10 @@ from litellm.types.llms.openai import AllMessageValues
 
 
 class AmazonInvokeNovaConfig(litellm.AmazonConverseConfig):
+    """
+    Config for sending `nova` requests to `/bedrock/invoke/`
+    """
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
@@ -37,7 +37,7 @@ class AmazonInvokeNovaConfig(litellm.AmazonConverseConfig):
             headers=headers,
         )
         _bedrock_invoke_nova_request = BedrockInvokeNovaRequest(
-            **_transformed_nova_request
+            messages=_transformed_nova_request["messages"], **_transformed_nova_request
         )
         self._remove_empty_system_messages(_bedrock_invoke_nova_request)
         bedrock_invoke_nova_request = self._filter_allowed_fields(

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_nova_transformation.py
@@ -37,7 +37,7 @@ class AmazonInvokeNovaConfig(litellm.AmazonConverseConfig):
             headers=headers,
         )
         _bedrock_invoke_nova_request = BedrockInvokeNovaRequest(
-            messages=_transformed_nova_request["messages"], **_transformed_nova_request
+            **_transformed_nova_request
         )
         self._remove_empty_system_messages(_bedrock_invoke_nova_request)
         bedrock_invoke_nova_request = self._filter_allowed_fields(

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast, get_a
 import httpx
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.litellm_core_utils.prompt_templates.factory import (
@@ -166,7 +167,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
 
         return dict(request.headers)
 
-    def transform_request(  # noqa: PLR0915
+    def transform_request(
         self,
         model: str,
         messages: List[AllMessageValues],
@@ -218,6 +219,14 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 request_data = {"prompt": prompt, **inference_params}
         elif provider == "anthropic":
             return litellm.AmazonAnthropicClaude3Config().transform_request(
+                model=model,
+                messages=messages,
+                optional_params=optional_params,
+                litellm_params=litellm_params,
+                headers=headers,
+            )
+        elif provider == "nova":
+            return litellm.AmazonInvokeNovaConfig().transform_request(
                 model=model,
                 messages=messages,
                 optional_params=optional_params,
@@ -297,6 +306,10 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             raise BedrockError(
                 message=raw_response.text, status_code=raw_response.status_code
             )
+        verbose_logger.debug(
+            "bedrock invoke response % s",
+            json.dumps(completion_response, indent=4, default=str),
+        )
         provider = self.get_bedrock_invoke_provider(model)
         outputText: Optional[str] = None
         try:
@@ -321,6 +334,18 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                     encoding=encoding,
                     api_key=api_key,
                     json_mode=json_mode,
+                )
+            elif provider == "nova":
+                return litellm.AmazonInvokeNovaConfig().transform_response(
+                    model=model,
+                    raw_response=raw_response,
+                    model_response=model_response,
+                    logging_obj=logging_obj,
+                    request_data=request_data,
+                    messages=messages,
+                    optional_params=optional_params,
+                    litellm_params=litellm_params,
+                    encoding=encoding,
                 )
             elif provider == "ai21":
                 outputText = (
@@ -503,6 +528,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         1. model=invoke/anthropic.claude-3-5-sonnet-20240620-v1:0 -> Returns `anthropic`
         2. model=anthropic.claude-3-5-sonnet-20240620-v1:0 -> Returns `anthropic`
         3. model=llama/arn:aws:bedrock:us-east-1:086734376398:imported-model/r4c4kewx2s0n -> Returns `llama`
+        4. model=us.amazon.nova-pro-v1:0 -> Returns `nova`
         """
         if model.startswith("invoke/"):
             model = model.replace("invoke/", "", 1)
@@ -515,6 +541,10 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         provider = AmazonInvokeConfig._get_provider_from_model_path(model)
         if provider is not None:
             return provider
+
+        # check if provider == "nova"
+        if "nova" in model:
+            return "nova"
         return None
 
     @staticmethod

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -189,7 +189,7 @@ class BedrockInvokeNovaRequest(TypedDict, total=False):
     Request object for sending `nova` requests to `/bedrock/invoke/`
     """
 
-    messages: Required[List[MessageBlock]]
+    messages: List[MessageBlock]
     inferenceConfig: InferenceConfig
     system: List[SystemContentBlock]
     toolConfig: ToolConfigBlock

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -184,6 +184,18 @@ class RequestObject(CommonRequestObject, total=False):
     messages: Required[List[MessageBlock]]
 
 
+class BedrockInvokeNovaRequest(TypedDict, total=False):
+    """
+    Request object for sending `nova` requests to `/bedrock/invoke/`
+    """
+
+    messages: Required[List[MessageBlock]]
+    inferenceConfig: InferenceConfig
+    system: List[SystemContentBlock]
+    toolConfig: ToolConfigBlock
+    guardrailConfig: Optional[GuardrailConfigBlock]
+
+
 class GenericStreamingChunk(TypedDict):
     text: Required[str]
     tool_use: Optional[ChatCompletionToolCallChunk]

--- a/tests/llm_translation/test_bedrock_invoke_tests.py
+++ b/tests/llm_translation/test_bedrock_invoke_tests.py
@@ -26,3 +26,15 @@ class TestBedrockInvokeClaudeJson(BaseLLMChatTest):
             pytest.skip(
                 f"Skipping non-JSON test: {request.function.__name__} does not contain 'json'"
             )
+
+
+class TestBedrockInvokeNovaJson(BaseLLMChatTest):
+    def get_base_completion_call_args(self) -> dict:
+        litellm._turn_on_debug()
+        return {
+            "model": "bedrock/invoke/us.amazon.nova-micro-v1:0",
+        }
+
+    def test_tool_call_no_arguments(self, tool_call_no_arguments):
+        """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""
+        pass

--- a/tests/llm_translation/test_bedrock_invoke_tests.py
+++ b/tests/llm_translation/test_bedrock_invoke_tests.py
@@ -38,3 +38,10 @@ class TestBedrockInvokeNovaJson(BaseLLMChatTest):
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""
         pass
+
+    @pytest.fixture(autouse=True)
+    def skip_non_json_tests(self, request):
+        if not "json" in request.function.__name__.lower():
+            pytest.skip(
+                f"Skipping non-JSON test: {request.function.__name__} does not contain 'json'"
+            )


### PR DESCRIPTION
## (Feat) - Allow calling Nova models on `/bedrock/invoke/`

- Uses the existing Nova transformations for the `/invoke` routes 
- There's a minor difference between Nova on converse vs invoke - which we handle in the `AmazonInvokeNovaConfig` 
- Minor difference in where the stream content is located from the converse vs invoke routes 


```python
response = litellm.completion(
  model="bedrock/invoke/us.amazon.nova-micro-v1:0",
  messages=[]
)
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
e2e testing for Nova JSON mode 

