### PR TITLE
fix(vertex_ai/gemini): improve chunk parsing for streaming responses

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1431,7 +1431,9 @@ class ModelResponseIterator:
 
     def _common_chunk_parsing_logic(self, chunk: str) -> GenericStreamingChunk:
         try:
-            chunk = chunk.replace("data:", "")
+            chunk = chunk.strip()
+            if chunk.startswith("data:"):
+                chunk = chunk[len("data:"):].strip()
             if len(chunk) > 0:
                 """
                 Check if initial chunk valid json

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1431,9 +1431,8 @@ class ModelResponseIterator:
 
     def _common_chunk_parsing_logic(self, chunk: str) -> GenericStreamingChunk:
         try:
-            chunk = chunk.strip()
-            if chunk.startswith("data:"):
-                chunk = chunk[len("data:"):].strip()
+            if chunk.startswith("data: "):
+                chunk = chunk[len("data: "):]
             if len(chunk) > 0:
                 """
                 Check if initial chunk valid json


### PR DESCRIPTION
This PR fixes bug #8143 by updating the vertex_ai streaming chunk parsing logic to remove only a leading `data:` prefix.



## Relevant issues
#8143 


## Type

🐛 Bug Fix

## Changes

```diff
    def _common_chunk_parsing_logic(self, chunk: str) -> GenericStreamingChunk:
        try:
-            chunk = chunk.replace("data:", "")
+            chunk = chunk.strip()
+            if chunk.startswith("data:"):
+                chunk = chunk[len("data:"):].strip()
             if len(chunk) > 0:
                 """
                 Check if initial chunk valid json
                 - if partial json -> enter accumulated json logic
                 - if valid - continue
                 """
                 if self.chunk_type == "valid_json":
                     return self.handle_valid_json_chunk(chunk=chunk)
                 elif self.chunk_type == "accumulated_json":
                     return self.handle_accumulated_json_chunk(chunk=chunk)
```