### PR TITLE
Pass stream options

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3947,6 +3947,7 @@ async def atext_completion(
                 ),
                 model=model,
                 custom_llm_provider=custom_llm_provider,
+                stream_options=kwargs.get('stream_options'),
             )
         else:
             ## OpenAI / Azure Text Completion Returns here

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -377,6 +377,32 @@ async def test_chat_completion_streaming():
 
     print(f"response_str: {response_str}")
 
+@pytest.mark.asyncio
+async def test_completion_streaming_usage_metrics():
+    """
+    [PROD Test] Ensures logprobs are returned correctly
+    """
+    client = AsyncOpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000")
+
+    response = await client.completions.create(
+        model="gpt-3.5-turbo-large",
+        prompt="hey", 
+        stream=True, 
+        stream_options={"include_usage": True}, 
+        max_tokens=4,
+        temperature=0.00000001,
+    )
+
+    last_chunk = None
+    async for chunk in response:
+        last_chunk = chunk
+
+    assert last_chunk is not None, "No chunks were received"
+    assert last_chunk.usage is not None, "Usage information was not received"
+    assert last_chunk.usage.prompt_tokens > 0, "Prompt tokens should be greater than 0"
+    assert last_chunk.usage.completion_tokens > 0, "Completion tokens should be greater than 0"
+    assert last_chunk.usage.total_tokens > 0, "Total tokens should be greater than 0"
+
 
 @pytest.mark.asyncio
 async def test_chat_completion_anthropic_structured_output():


### PR DESCRIPTION
## Title

Fix bug zero usage returned for streaming from text completions api of litellm proxy server. 

## Relevant issues

Fixes #8349 

## Type

🐛 Bug Fix
✅ Test

## Changes

Simple fix suggest by issue creator
Add test for it. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

![image](https://github.com/user-attachments/assets/9d9878b7-5ec1-45cd-a31b-af43e6c46fd3)

