### PR TITLE
Fix function calling type to follow open ai standard

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1263,8 +1263,9 @@ class CustomStreamWrapper:
                                         and "function" in tool
                                         and isinstance(tool["function"], dict)
                                         and ("type" not in tool or tool["type"] is None)
+                                        and tool.get('id')
                                     ):
-                                        # if function returned but type set to None - mistral's api returns type: None
+                                        # Refer to the test test_function_calling_tool_type
                                         tool["type"] = "function"
                             model_response.choices[0].delta = Delta(**_json_delta)
                         except Exception as e:

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -769,3 +769,61 @@ async def test_function_calling_with_dbrx():
         json_data = json.loads(mock_completion.call_args.kwargs["data"])
         assert "tools" in json_data
         assert "tool_choice" in json_data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4-1106-preview",
+        "mistral/mistral-small-latest",
+    ],
+)
+async def test_function_calling_tool_type(model):
+    """
+    Test the API's response when streaming tool calls. 
+    - The first streamed chunk contains a tool call with an ID and type "function".
+    - Subsequent chunks may only contain arguments, with ID and type being None.
+    """
+    response = completion(
+        model=model, 
+        messages=[{
+            "role": "user", 
+            "content": "Search for recent AI breakthroughs"
+        }],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Searches the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"}
+                        },
+                        "required": ["query"]
+                    }
+                }
+            }],
+        stream=True,
+        temperature=0.00000001
+    )
+
+
+    async for chunk in response:
+        print(json.dumps(chunk, indent=2, default=str))
+        if "choices" not in chunk or not chunk.choices:
+            raise ValueError("Unexpected chunk structure: 'choices' missing or empty")
+
+        delta = chunk.choices[0].delta
+        tool_calls = getattr(delta, "tool_calls", None)
+
+        if not tool_calls or not isinstance(tool_calls, list):
+            continue
+
+        tool_call = tool_calls[0]
+        id = getattr(tool_call, "id", None)
+        type = getattr(tool_call, "type", None)
+
+        if id:
+            assert type == "function", f"Expected type 'function' for id {id}, got '{type}'"


### PR DESCRIPTION
## Title

When streaming openai the first chunk the next chunks only the arguments are being streamed and id and type are none. For mistral the type is none even with id, so we add type to make it consistent. 

## Relevant issues

Fixes #8012  

## Type

🐛 Bug Fix


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

![image](https://github.com/user-attachments/assets/5dced4de-8ab2-4e64-b360-6700d38d3f02)


## How to reproduce 

### Open ai 

```
import os
from openai import OpenAI

client = OpenAI(api_key="")

response = client.chat.completions.create(
    model="gpt-4-1106-preview",
    messages=[{
        "role": "user", 
        "content": "Search for recent AI breakthroughs"
    }],
    tools=[{
        "type": "function",
        "function": {
            "name": "web_search",
            "description": "Searches the web",
            "parameters": {
                "type": "object",
                "properties": {
                    "query": {"type": "string"}
                },
                "required": ["query"]
            }
        }
    }],
    stream=True
)

print("Stream output:")
for chunk in response:
    print(chunk)

```

### Litellm

```
import os
from litellm import completion
import json

# Set your API key
os.environ["OPENAI_API_KEY"] = ""

# Create the chat completion request
response = completion(
    model="gpt-4-1106-preview",
    messages=[{
        "role": "user", 
        "content": "Search for recent AI breakthroughs"
    }],
    tools=[{
        "type": "function",
        "function": {
            "name": "web_search",
            "description": "Searches the web",
            "parameters": {
                "type": "object",
                "properties": {
                    "query": {"type": "string"}
                },
                "required": ["query"]
            }
        }
    }],
    stream=True
)

print("Stream output:")
for chunk in response:
    # Pretty print the chunk
    print(json.dumps(chunk, indent=2, default=str))
    print("---")  
```

<!-- Test procedure -->

