### PR TITLE
feature: add trace_id to langfuse failure

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
 else:
     DynamicLoggingCache = Any
 
-
 class LangFuseLogger:
     # Class variables or attributes
     def __init__(
@@ -181,6 +180,7 @@ class LangFuseLogger:
         """
         Logs a success or error event on Langfuse
         """
+        trace_id = None
         try:
             verbose_logger.debug(
                 f"Langfuse Logging - Enters logging function for model {kwargs}"
@@ -226,7 +226,6 @@ class LangFuseLogger:
             verbose_logger.debug(
                 f"OUTPUT IN LANGFUSE: {output}; original: {response_obj}"
             )
-            trace_id = None
             generation_id = None
             if self._is_langfuse_v2():
                 trace_id, generation_id = self._log_langfuse_v2(
@@ -809,7 +808,6 @@ class LangFuseLogger:
         """
         return int(os.getenv("LANGFUSE_FLUSH_INTERVAL") or flush_interval)
 
-
 def _add_prompt_to_generation_params(
     generation_params: dict,
     clean_metadata: dict,
@@ -898,7 +896,6 @@ def _add_prompt_to_generation_params(
 
     return generation_params
 
-
 def log_provider_specific_information_as_span(
     trace,
     clean_metadata,
@@ -941,7 +938,6 @@ def log_provider_specific_information_as_span(
                 name="vertex_ai_grounding_metadata",
                 input=vertex_ai_grounding_metadata,
             )
-
 
 def log_requester_metadata(clean_metadata: dict):
     returned_metadata = {}

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -265,7 +265,7 @@ class LangFuseLogger:
             verbose_logger.exception(
                 "Langfuse Layer Error(): Exception occured - {}".format(str(e))
             )
-            return {"trace_id": None, "generation_id": None}
+            return {"trace_id": trace_id, "generation_id": None}
 
     def _get_langfuse_input_output_content(
         self,


### PR DESCRIPTION
## Title

Add `trace_id` to Langfuse exceptions

## Relevant issues

[<!-- e.g. "Fixes #000" -->](https://github.com/BerriAI/litellm/issues/6568)

## Type

🆕 New Feature


## Changes

- Simply adds the `trace_id` that was already there, to Langfuse exceptions raised during logging

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

- Add a `raise Exception` in `litellm.integrations.langfuse.lanfuse#log_event_on_langfuse`
- As long as Langfuse returns the trace on failure, should be pretty easy to verify the `trace_id` in your debugger (unless the trace generation itself has an error)
  - Langfuse seems to _always_ at least generate a `trace_id` so if `trace.generation` get's called, `trace_id` being `None` should be the result of something before `trace.generation` failing

