### PR TITLE
Mitigate Event Loop Errors in Gemini by Adding Connection: close Header

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1053,6 +1053,7 @@ class VertexLLM(VertexBase):
             messages=messages,
             optional_params=optional_params,
         )
+        headers["Connection"] = "close"
 
         request_body = await async_transform_request_body(**data)  # type: ignore
         _async_client_params = {}

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -69,6 +69,7 @@ from .transformation import (
     sync_transform_request_body,
 )
 
+
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
@@ -812,7 +813,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ) -> Dict:
         default_headers = {
             "Content-Type": "application/json",
-            "Connection": "close",
         }
         if api_key is not None:
             default_headers["Authorization"] = f"Bearer {api_key}"
@@ -834,6 +834,7 @@ async def make_call(
     if client is None:
         client = get_async_httpx_client(
             llm_provider=litellm.LlmProviders.VERTEX_AI,
+            params={"timeout": httpx.Timeout(timeout=600.0, connect=5.0)}
         )
 
     try:
@@ -1059,9 +1060,11 @@ class VertexLLM(VertexBase):
         _async_client_params = {}
         if timeout:
             _async_client_params["timeout"] = timeout
+        
         if client is None or not isinstance(client, AsyncHTTPHandler):
             client = get_async_httpx_client(
-                params=_async_client_params, llm_provider=litellm.LlmProviders.VERTEX_AI
+                params=_async_client_params, 
+                llm_provider=litellm.LlmProviders.VERTEX_AI
             )
         else:
             client = client  # type: ignore

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -812,6 +812,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ) -> Dict:
         default_headers = {
             "Content-Type": "application/json",
+            "Connection": "close",
         }
         if api_key is not None:
             default_headers["Authorization"] = f"Bearer {api_key}"
@@ -1053,7 +1054,6 @@ class VertexLLM(VertexBase):
             messages=messages,
             optional_params=optional_params,
         )
-        headers["Connection"] = "close"
 
         request_body = await async_transform_request_body(**data)  # type: ignore
         _async_client_params = {}


### PR DESCRIPTION
## Title
Mitigate Event Loop Errors in Gemini by Adding Connection: close Header
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->
#4032 #7667

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

I am a user of litellm via the zerox library, and I’ve encountered issues that have been widely reported in #7667, and #4032. It appears that sending multiple concurrent requests leads to event loop-related errors.

Upon investigating these issues, it seems that the caching logic for reusing the httpxclient is causing problems under concurrent scenarios. Although I’m not in a position to solve the entire problem, this PR aims to prevent the issue—at least in the Gemini environment I’m using—by applying the workaround suggested by @quangngoc in #4032.

Specifically, as mentioned in [this comment](https://github.com/encode/httpx/issues/2959):

> Adding extra_headers={"Connection": "close"} resolved the issue for me.

In my case, this method has successfully resolved the problem. While it might not be the most elegant solution, it effectively mitigates the failure mode (where the process would otherwise abort completion due to exceptions). I hope this PR is received positively.
<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

