### PR TITLE
Refactor: LiteLLM Model Selection: Allow Custom Model Name Input for OpenAI_Compatible Provider

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/litellm_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/litellm_model_name.tsx
@@ -37,8 +37,8 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
           noStyle
         >
           {(selectedProvider === Providers.Azure) || 
-           (selectedProvider === Providers.OpenAI_Compatible) || 
-           (selectedProvider === Providers.Ollama) ? (
+           (selectedProvider === Providers.Ollama) || 
+           (selectedProvider.toString() === Providers.OpenAI_Compatible.toString()) ? (
             <TextInput placeholder={getPlaceholder(selectedProvider.toString())} />
           ) : providerModels.length > 0 ? (
             <AntSelect

--- a/ui/litellm-dashboard/src/components/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard.tsx
@@ -1544,30 +1544,11 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
                       ))}
                     </AntdSelect>
                   </Form.Item>
-                  <Form.Item
-                    label="LiteLLM Model Name"
-                    name="model"
-                    rules={[{ required: true, message: 'Required' }]}
-                    tooltip="The model name passed to litellm.completion()"
-                    labelCol={{ span: 10 }}
-                    labelAlign="left"
-                  >
-                    <AntdSelect
-                      showSearch
-                      placeholder={getPlaceholder(selectedProvider)}
-                      optionFilterProp="children"
-                      allowClear
-                      mode="tags"         // This enables custom input
-                      maxTagCount={1}     // Only show one tag/value
-                      maxTagTextLength={60}
-                    >
-                      {providerModels.map((model) => (
-                        <AntdSelect.Option key={model} value={model}>
-                          {model}
-                        </AntdSelect.Option>
-                      ))}
-                    </AntdSelect>
-                  </Form.Item>
+                  <LiteLLMModelNameField
+                      selectedProvider={selectedProvider}
+                      providerModels={providerModels}
+                      getPlaceholder={getPlaceholder}
+                    />
                   
                   {/* Conditionally Render "Public Model Name" */}
                   <ConditionalPublicModelName  />

--- a/ui/litellm-dashboard/src/components/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard.tsx
@@ -1544,11 +1544,30 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
                       ))}
                     </AntdSelect>
                   </Form.Item>
-                  <LiteLLMModelNameField
-                      selectedProvider={selectedProvider}
-                      providerModels={providerModels}
-                      getPlaceholder={getPlaceholder}
-                    />
+                  <Form.Item
+                    label="LiteLLM Model Name"
+                    name="model"
+                    rules={[{ required: true, message: 'Required' }]}
+                    tooltip="The model name passed to litellm.completion()"
+                    labelCol={{ span: 10 }}
+                    labelAlign="left"
+                  >
+                    <AntdSelect
+                      showSearch
+                      placeholder={getPlaceholder(selectedProvider)}
+                      optionFilterProp="children"
+                      allowClear
+                      mode="tags"         // This enables custom input
+                      maxTagCount={1}     // Only show one tag/value
+                      maxTagTextLength={60}
+                    >
+                      {providerModels.map((model) => (
+                        <AntdSelect.Option key={model} value={model}>
+                          {model}
+                        </AntdSelect.Option>
+                      ))}
+                    </AntdSelect>
+                  </Form.Item>
                   
                   {/* Conditionally Render "Public Model Name" */}
                   <ConditionalPublicModelName  />


### PR DESCRIPTION
## Title

Allow custom model name input for OpenAI_Compatible provider in LiteLLM model selection

## Relevant issues

Fixes #8396 

## Type

🧹 Refactoring

## Changes

1. Updated the LiteLLMModelNameField component to allow the OpenAI_Compatible provider to accept custom model names directly via a TextInput.

2. Ensured that the dropdown selection is still available for other providers while allowing custom input for OpenAI_Compatible.

3. Maintained existing functionality for Azure and Ollama providers, which also use TextInput for model names.

<!-- List of changes -->


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

I am having some issues with getting the testing framework setup and running the UI on my side. So can someone else confirm that the dropdown allows you to type custom model names.

If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->



