### PR TITLE
Added custom_attributes to additional_keys which can be sent to athina

### DIFF
--- a/docs/my-website/docs/observability/athina_integration.md
+++ b/docs/my-website/docs/observability/athina_integration.md
@@ -78,7 +78,7 @@ Following are the allowed fields in metadata, their types, and their description
 * `context: Optional[Union[dict, str]]` - This is the context used as information for the prompt. For RAG applications, this is the "retrieved" data. You may log context as a string or as an object (dictionary).
 * `expected_response: Optional[str]` - This is the reference response to compare against for evaluation purposes. This is useful for segmenting inference calls by expected response.
 * `user_query: Optional[str]` - This is the user's query. For conversational applications, this is the user's last message.
-
+* `custom_attributes: Optional[dict]` - This is a dictionary of custom attributes. This is useful for additional information about the inference.
 
 ## Using a self hosted deployment of Athina
 

--- a/litellm/integrations/athina.py
+++ b/litellm/integrations/athina.py
@@ -23,6 +23,7 @@ class AthinaLogger:
             "context",
             "expected_response",
             "user_query",
+            "custom_attributes",
         ]
 
     def log_event(self, kwargs, response_obj, start_time, end_time, print_verbose):


### PR DESCRIPTION
## Title

Added custom_attributes to additional_keys which can be sent to athina

## Type

🆕 New Feature

## Changes

Added custom_attributes to additional_keys which are sent to Athina using the AthinaLogger

##  Screenshots of tests passing locally
 
<img width="852" alt="Screenshot 2025-02-13 at 5 19 35 PM" src="https://github.com/user-attachments/assets/676515f0-ffc4-4f70-9168-980cffeef583" />
<img width="1511" alt="Screenshot 2025-02-13 at 5 19 19 PM" src="https://github.com/user-attachments/assets/ff3b16c7-a14c-4f3c-826c-2f7c1e7dd735" />


