### PR TITLE
docs(perplexity.md): removing `return_citations` documentation

### DIFF
--- a/docs/my-website/docs/providers/perplexity.md
+++ b/docs/my-website/docs/providers/perplexity.md
@@ -64,71 +64,7 @@ All models listed here https://docs.perplexity.ai/docs/model-cards are supported
 
 
 
-## Return citations 
-
-Perplexity supports returning citations via `return_citations=True`. [Perplexity Docs](https://docs.perplexity.ai/reference/post_chat_completions). Note: Perplexity has this feature in **closed beta**, so you need them to grant you access to get citations from their API. 
-
-If perplexity returns citations, LiteLLM will pass it straight through. 
-
 :::info
 
-For passing more provider-specific, [go here](../completion/provider_specific_params.md)
+For more information about passing provider-specific parameters, [go here](../completion/provider_specific_params.md)
 :::
-
-<Tabs>
-<TabItem value="sdk" label="SDK">
-
-```python
-from litellm import completion
-import os
-
-os.environ['PERPLEXITYAI_API_KEY'] = ""
-response = completion(
-    model="perplexity/mistral-7b-instruct", 
-    messages=messages,
-    return_citations=True
-)
-print(response)
-```
-
-</TabItem>
-<TabItem value="proxy" label="PROXY">
-
-1. Add perplexity to config.yaml
-
-```yaml
-model_list:
-  - model_name: "perplexity-model"
-    litellm_params:
-      model: "llama-3.1-sonar-small-128k-online"
-      api_key: os.environ/PERPLEXITY_API_KEY
-```
-
-2. Start proxy 
-
-```bash
-litellm --config /path/to/config.yaml
-```
-
-3. Test it! 
-
-```bash
-curl -L -X POST 'http://0.0.0.0:4000/chat/completions' \
--H 'Content-Type: application/json' \
--H 'Authorization: Bearer sk-1234' \
--d '{
-    "model": "perplexity-model",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Who won the world cup in 2022?"
-      }
-    ],
-    "return_citations": true
-}'
-```
-
-[**Call w/ OpenAI SDK, Langchain, Instructor, etc.**](../proxy/user_keys.md#chatcompletions)
-
-</TabItem>
-</Tabs>


### PR DESCRIPTION
## Changes

Removed mention of return_citations from documentation.  Citations are now passed by default. Official documentation here:

> Deprecation Notice:
> 
> Effective immediately, all API users will see citations returned as part of their requests by default. This is not a breaking change. The return_citations parameter will no longer have any effect.
> 
> [source](https://docs.perplexity.ai/changelog/changelog#citations-public-release-and-increased-default-rate-limits)

## Type

📖 Documentation
