### PR TITLE
feat(helm): add db.secret.enabled key

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -33,5 +33,5 @@ dependencies:
     condition: db.deployStandalone
   - name: redis
     version: ">=18.0.0"
-    repository: oci://registry-1.docker.io/bitnamicharts 
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -77,7 +77,7 @@ proxyConfigMap:
 # proxy_config is ignored in this mode
 ```
 
-#### Example `environmentSecrets` Secret 
+#### Example `environmentSecrets` Secret
 
 
 ```
@@ -97,6 +97,7 @@ type: Opaque
 | `db.endpoint`                                              | If `db.useExisting` is `true`, this is the IP, Hostname or Service Name of the Postgres server to connect to.                                                                         | `localhost`  |
 | `db.database`                                              | If `db.useExisting` is `true`, the name of the existing database to connect to.                                                                                                       | `litellm`  |
 | `db.url`                                              | If `db.useExisting` is `true`, the connection url of the existing database to connect to can be overwritten with this value.                                                                                                       | `postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)`  |
+| `db.secret.enabled`                                        | If `db.secretenabled` is `true`, a Kubernetes Secret that contains credentials will be created.                                                                                       | `true`      |
 | `db.secret.name`                                           | If `db.useExisting` is `true`, the name of the Kubernetes Secret that contains credentials.                                                                                           | `postgres`  |
 | `db.secret.usernameKey`                                    | If `db.useExisting` is `true`, the name of the key within the Kubernetes Secret that holds the username for authenticating with the Postgres instance.                                | `username`  |
 | `db.secret.passwordKey`                                    | If `db.useExisting` is `true`, the name of the key within the Kubernetes Secret that holds the password associates with the above user.                                               | `password`  |

--- a/deploy/charts/litellm-helm/templates/secret-dbcredentials.yaml
+++ b/deploy/charts/litellm-helm/templates/secret-dbcredentials.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.db.deployStandalone -}}
+{{- if or .Values.db.deployStandalone  .Values.db.secret.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -166,6 +166,7 @@ db:
   database: litellm
   url: postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)
   secret:
+    enabled: true
     name: postgres
     usernameKey: username
     passwordKey: password


### PR DESCRIPTION
## Title

feat(helm): add db.secret.enabled key

## Relevant issues

Hey folks 👋 

First of all thanks a lot for the fantastic work on this project 🤩 . The goal of this PR is quite simple : basically it allows to create the kubernetes secret that will contains the DB credentials/details. It can be details about an external database, moreover it allows to keep all the configuration inside the helm values (without the need to rely on a preexisting secret).
If you have any question, do not hesitate to reach me 😉 

Cheers ☀️ 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure


## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

