### PR TITLE
Fix(litellm-vetexai-gemini): adding the supported files as per gemini documentation

### DIFF
--- a/litellm/types/files.py
+++ b/litellm/types/files.py
@@ -275,7 +275,7 @@ GEMINI_1_5_ACCEPTED_FILE_TYPES: Set[FileType] = {
     FileType.THREE_GPP,
     # PDF
     FileType.PDF,
-    FileType.text,
+    FileType.TXT,
 }
 
 

--- a/litellm/types/files.py
+++ b/litellm/types/files.py
@@ -251,15 +251,18 @@ GEMINI_1_5_ACCEPTED_FILE_TYPES: Set[FileType] = {
     # Image
     FileType.PNG,
     FileType.JPEG,
+    FileType.WEBP,
     # Audio
     FileType.AAC,
     FileType.FLAC,
     FileType.MP3,
     FileType.MPA,
+    FileType.MPEG,
     FileType.MPGA,
     FileType.OPUS,
     FileType.PCM,
     FileType.WAV,
+    FileType.WEBM,
     # Video
     FileType.FLV,
     FileType.MOV,
@@ -272,6 +275,7 @@ GEMINI_1_5_ACCEPTED_FILE_TYPES: Set[FileType] = {
     FileType.THREE_GPP,
     # PDF
     FileType.PDF,
+    FileType.text,
 }
 
 


### PR DESCRIPTION

## Title
Adding the missing supported files supported by Gemini 

## Relevant issues
Fixes #8557 

## Type
🐛 Bug Fix


## Changes
- Adding missing Image types supported by gemini [as per vertex ai documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding)
- Adding missing Audio types supported by gemini [as per vertex ai documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding)
- Adding missing Document types supported by gemini [as per vertex ai documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/document-understanding)

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

