### PR TITLE
eliminate uncontrolled inputs & preppend model name with provider

### DIFF
--- a/ui/litellm-dashboard/src/components/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard.tsx
@@ -1493,6 +1493,11 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
                 labelCol={{ span: 10 }}
                 wrapperCol={{ span: 16 }}
                 labelAlign="left"
+                initialValues={{
+                  model: "",
+                  model_name: "",
+                  custom_llm_provider: ""
+                }}
               >
                 <>
                   {/* Provider Selection */}
@@ -1510,10 +1515,23 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
                       onChange={(value) => {
                         setSelectedProvider(value);
                         setProviderModelsFn(value);
-                        form.setFieldsValue({ 
-                          model: [],
-                          model_name: undefined 
-                        });
+                        if (value) {
+                          // Update both model and model_name fields with the wildcard pattern
+                          const litellmProvider = provider_map[value]?.toLowerCase();
+                          if (litellmProvider) {
+                            const providerLiteLLMName = `${litellmProvider}/*`;
+                            form.setFieldsValue({ 
+                              model: providerLiteLLMName,
+                              model_name: providerLiteLLMName 
+                            });
+                          }
+                        } else {
+                          // Clear the fields if no provider is selected
+                          form.setFieldsValue({ 
+                            model: "",
+                            model_name: "" 
+                          });
+                        }
                       }}
                     >
                       {Object.entries(Providers).map(([providerEnum, providerDisplayName]) => (


### PR DESCRIPTION
## Title

eliminate uncontrolled inputs & preppend model name with provider

## Relevant issues

#8398

## Type

🆕 New Feature

## Changes

- Resolves uncontrolled inputs by instantiating 
- Preppend model name with provider component

## NOTES

- Allowing changing the selected provider from the model name will require some more work into the Ant Design component if not hacking into it
- Currently the compoents intention seems to be to allow a list of models but that is not currently supported, not sure how compatible that is with the rest of LiteLLM and currently it will require a bit of refactoring to support
- Adding a cusom provider is not yet supported

