### PR TITLE
Support multiple namespaces for Redis Prompt Caching

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -283,9 +283,6 @@ class Cache:
         self._set_preset_cache_key_in_kwargs(
             preset_cache_key=hashed_cache_key, **kwargs
         )
-        print(kwargs)
-        print("HASHED_KEY")
-        print(hashed_cache_key)
         return hashed_cache_key
 
     def _get_param_value(
@@ -555,7 +552,7 @@ class Cache:
                     "s-max-age", cache_control_args.get("s-maxage", float("inf"))
                 )
                 # Need to add kwargs here
-                cached_result = self.cache.get_cache(cache_key, messages=messages)
+                cached_result = self.cache.get_cache(cache_key, **kwargs)
                 return self._get_cache_logic(
                     cached_result=cached_result, max_age=max_age
                 )

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -283,6 +283,9 @@ class Cache:
         self._set_preset_cache_key_in_kwargs(
             preset_cache_key=hashed_cache_key, **kwargs
         )
+        print(kwargs)
+        print("HASHED_KEY")
+        print(hashed_cache_key)
         return hashed_cache_key
 
     def _get_param_value(
@@ -466,7 +469,7 @@ class Cache:
         Returns:
             str: The final hashed cache key with the redis namespace.
         """
-        namespace = kwargs.get("metadata", {}).get("redis_namespace") or self.namespace
+        namespace = kwargs.get("metadata", {}).get("redis_namespace") or kwargs.get("extra_body", {}).get("cache", {}).get("namespace") or self.namespace
         if namespace:
             hash_hex = f"{namespace}:{hash_hex}"
         verbose_logger.debug("Final hashed key: %s", hash_hex)
@@ -545,11 +548,13 @@ class Cache:
                 cache_key = kwargs["cache_key"]
             else:
                 cache_key = self.get_cache_key(**kwargs)
+
             if cache_key is not None:
                 cache_control_args = kwargs.get("cache", {})
                 max_age = cache_control_args.get(
                     "s-max-age", cache_control_args.get("s-maxage", float("inf"))
                 )
+                # Need to add kwargs here
                 cached_result = self.cache.get_cache(cache_key, messages=messages)
                 return self._get_cache_logic(
                     cached_result=cached_result, max_age=max_age

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -627,10 +627,8 @@ class RedisCache(BaseCache):
 
     def get_cache(self, key, parent_otel_span: Optional[Span] = None, **kwargs):
         try:
-            print("GOT HERE")
-            print(kwargs, "get_cache")
             key = self.check_and_fix_namespace(key=key, **kwargs)
-            print(f"Get Redis Cache: key: {key}")
+            print_verbose(f"Get Redis Cache: key: {key}")
             start_time = time.time()
             cached_response = self.redis_client.get(key)
             end_time = time.time()

--- a/tests/local_testing/test_caching.py
+++ b/tests/local_testing/test_caching.py
@@ -2519,8 +2519,6 @@ def test_redis_caching_multiple_namespaces():
             model="gpt-3.5-turbo", 
             messages=messages, 
             caching=True, 
-            api_base="https://litellm8397336933.services.ai.azure.com/models/chat/completions",
-            api_key="my-fake-api-key",
             extra_body = {
                 "cache": {
                     "namespace": namespace_1
@@ -2547,6 +2545,7 @@ def test_redis_caching_multiple_namespaces():
                 }
             })
 
+        # We expect the hashed keys sent to the redis client to be the same between the first and third call
         assert(mock_redis_client_get.call_args_list[0] == mock_redis_client_get.call_args_list[2])
         assert(mock_redis_client_get.call_args_list[0] != mock_redis_client_get.call_args_list[1])
 

--- a/tests/local_testing/test_unit_test_caching.py
+++ b/tests/local_testing/test_unit_test_caching.py
@@ -150,6 +150,10 @@ def test_add_redis_namespace_to_cache_key():
     result = cache._add_redis_namespace_to_cache_key(hashed_key, **kwargs)
     assert result == "custom_namespace:abcdef1234567890"
 
+    # Test with extra_body namespace
+    kwargs = {"extra_body": {"cache": {"namespace": "custom_namespace_2"}}}
+    result = cache._add_redis_namespace_to_cache_key(hashed_key, **kwargs)
+    assert result == "custom_namespace_2:abcdef1234567890"
 
 def test_get_model_param_value():
     cache = Cache()


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #8411

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->
A user wants to set a name space client side for redis cache requests

This PR ensure that the namespace passed into the completion request is used for accessing redis. It will even overwrite the namespace initialized with the cache.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
E2e test passed:
![image](https://github.com/user-attachments/assets/74f46de6-07f1-467f-9952-c87931f4d93b)

All unit tests passed:
![image](https://github.com/user-attachments/assets/f5231c75-88cc-4975-bb1e-84a3c7dfe385)

