### PR TITLE
chore: set ttlSecondsAfterFinished on the migration job in the litellm-helm chart

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -49,5 +49,6 @@ spec:
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
       restartPolicy: OnFailure
+      ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
 {{- end }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -187,6 +187,7 @@ migrationJob:
   backoffLimit: 4 # Backoff limit for Job restarts
   disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.
   annotations: {}
+  ttlSecondsAfterFinished: 120
 
 # Additional environment variables to be added to the deployment
 envVars: {


### PR DESCRIPTION
## Title

- My helm releases currently fail when updating the litellm-helm deployment because job templates are immutable

```
Error: cannot patch "litellm-migrations" with kind Job: Job.batch "litellm-migrations" is invalid:
spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"",
GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0,
CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>,
DeletionGracePeriodSeconds:(*int64)(nil),
Labels:map[string]string{"batch.kubernetes.io/controller-uid":"f3dadf7d-e41e-4f86-8e0f-85ba9708ddb5",
"batch.kubernetes.io/job-name":"litellm-migrations",
"controller-uid":"f3dadf7d-e41e-4f86-8e0f-85ba9708ddb5", "job-name":"litellm-migrations"},
Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil),
Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)},
Spec:core.PodSpec{Volumes:[]core.Volume(nil), InitContainers:[]core.Container(nil),
Containers:[]core.Container{core.Container{Name:"prisma-migrations",
Image:"ghcr.io/berriai/litellm-database:main-v1.61.6-nightly", Command:[]string{"python",
"litellm/proxy/prisma_migration.py"}, Args:[]string(nil), WorkingDir:"/app",
Ports:[]core.ContainerPort(nil), EnvFrom:[]core.EnvFromSource(nil),
Env:[]core.EnvVar{core.EnvVar{Name:"DATABASE_URL", Value:"***litellm-postgresql/litellm",
ValueFrom:(*core.EnvVarSource)(nil)}, core.EnvVar{Name:"DISABLE_SCHEMA_UPDATE", Value:"false",
ValueFrom:(*core.EnvVarSource)(nil)}},
Resources:core.ResourceRequirements{Limits:core.ResourceList(nil), Requests:core.ResourceList(nil),
Claims:[]core.ResourceClaim(nil)}, ResizePolicy:[]core.ContainerResizePolicy(nil),
RestartPolicy:(*core.ContainerRestartPolicy)(nil), VolumeMounts:[]core.VolumeMount(nil),
VolumeDevices:[]core.VolumeDevice(nil), LivenessProbe:(*core.Probe)(nil),
ReadinessProbe:(*core.Probe)(nil), StartupProbe:(*core.Probe)(nil),
Lifecycle:(*core.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log",
TerminationMessagePolicy:"File", ImagePullPolicy:"Always",
SecurityContext:(*core.SecurityContext)(0xc010a2daa0), Stdin:false, StdinOnce:false, TTY:false}},
EphemeralContainers:[]core.EphemeralContainer(nil), RestartPolicy:"OnFailure",
TerminationGracePeriodSeconds:(*int64)(0xc03d2f8870), ActiveDeadlineSeconds:(*int64)(nil),
DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"",
AutomountServiceAccountToken:(*bool)(nil), NodeName:"",
SecurityContext:(*core.PodSecurityContext)(0xc02f85a780),
ImagePullSecrets:[]core.LocalObjectReference(nil), Hostname:"", Subdomain:"",
SetHostnameAsFQDN:(*bool)(nil), Affinity:(*core.Affinity)(nil), SchedulerName:"default-scheduler",
Tolerations:[]core.Toleration(nil), HostAliases:[]core.HostAlias(nil), PriorityClassName:"",
Priority:(*int32)(nil), PreemptionPolicy:(*core.PreemptionPolicy)(nil),
DNSConfig:(*core.PodDNSConfig)(nil), ReadinessGates:[]core.PodReadinessGate(nil),
RuntimeClassName:(*string)(nil), Overhead:core.ResourceList(nil), EnableServiceLinks:(*bool)(nil),
TopologySpreadConstraints:[]core.TopologySpreadConstraint(nil), OS:(*core.PodOS)(nil),
SchedulingGates:[]core.PodSchedulingGate(nil), ResourceClaims:[]core.PodResourceClaim(nil)}}: field
is immutable 
```

- My current workaround is to manually delete the migration job whenever I make changes to litellm
- It would be better if the litellm-helm chart cleaned up after itself by setting ttlSecondsAfterFinished
- I set the default to be 2 minutes and turned it on by default, but I'm open to putting this feature behind a gate

## Type

🐛 Bug Fix

## Changes

- Sets ttlSecondsAfterFinished on the pod template spec in the migration-job.yaml

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

- I didn't add any new tests here.

