### PR TITLE
fix: langfuse logging bug on `router.chat.completions`

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -272,15 +272,16 @@ class Completions:
         self.router_obj = router_obj
 
     def create(self, messages, model=None, **kwargs):
+        new_params = deepcopy(self.params)
         for k, v in kwargs.items():
-            self.params[k] = v
-        model = model or self.params.get("model")
+            new_params[k] = v
+        model = model or new_params.get("model")
         if self.router_obj is not None:
             response = self.router_obj.completion(
-                model=model, messages=messages, **self.params
+                model=model, messages=messages, **new_params
             )
         else:
-            response = completion(model=model, messages=messages, **self.params)
+            response = completion(model=model, messages=messages, **new_params)
         return response
 
 
@@ -290,15 +291,16 @@ class AsyncCompletions:
         self.router_obj = router_obj
 
     async def create(self, messages, model=None, **kwargs):
+        new_params = deepcopy(self.params)
         for k, v in kwargs.items():
-            self.params[k] = v
-        model = model or self.params.get("model")
+            new_params[k] = v
+        model = model or new_params.get("model")
         if self.router_obj is not None:
             response = await self.router_obj.acompletion(
-                model=model, messages=messages, **self.params
+                model=model, messages=messages, **new_params
             )
         else:
-            response = await acompletion(model=model, messages=messages, **self.params)
+            response = await acompletion(model=model, messages=messages, **new_params)
         return response
 
 


### PR DESCRIPTION
## Title

Solves Langfuse logging bug on `router.chat.completions.create` reported on issue below.

Actual problem was not in langfuse nor redis, but bad management of a mutable dictionary object.

Explanation: langfuse logging bug happened because each call to `chat.completions.create` function overrode `Chat` params (which included langfuse context's `trace_id` in one of it's fields).

Added a concise unit test that asserts the appropriate mutable object management. (Test fails in in current codebase but succeeds with changes from this PR)

## Relevant issues

Fixes #6783 

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

- Minor: just uses asyncify utility to avoid duplicate code
- Stops inplace modification of `Completions` and `AsyncCompletions` `params` attribute inside create function, since it is the same object (in memory) as Router's `default_litellm_params` attribute.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally

## Experiments

Proved the problem is solved by replicating bug from issue.

- Running `router.chat.completions.create` originally resulted in messes langfuse logging
Note that one of the ids appears 3 times while the other 5
```
get_current_trace_id: b6bd8fc2-ae78-443f-8f94-6d22f8bf46e9
get_current_trace_id: 647afd10-7d76-4df7-b52e-283bdbd83fa9
get_current_trace_id: 647afd10-7d76-4df7-b52e-283bdbd83fa9
Real sent trace_id: 647afd10-7d76-4df7-b52e-283bdbd83fa9
get_current_trace_id: b6bd8fc2-ae78-443f-8f94-6d22f8bf46e9
Real sent trace_id: 647afd10-7d76-4df7-b52e-283bdbd83fa9
Real sent trace_id: 647afd10-7d76-4df7-b52e-283bdbd83fa9
Real sent trace_id: b6bd8fc2-ae78-443f-8f94-6d22f8bf46e9
```

- After changes results are as expected

```
get_current_trace_id: 500873c4-2d85-45b3-af5c-3e2d5b1a2302
get_current_trace_id: 71a72d19-22db-4e0f-bb2b-8a840c7c2400
get_current_trace_id: 71a72d19-22db-4e0f-bb2b-8a840c7c2400
Real sent trace_id: 71a72d19-22db-4e0f-bb2b-8a840c7c2400
get_current_trace_id: 500873c4-2d85-45b3-af5c-3e2d5b1a2302
Real sent trace_id: 500873c4-2d85-45b3-af5c-3e2d5b1a2302
Real sent trace_id: 71a72d19-22db-4e0f-bb2b-8a840c7c2400
Real sent trace_id: 500873c4-2d85-45b3-af5c-3e2d5b1a2302
```
