### PR TITLE
Fix async_post_call_streaming_hook Not Working

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -63,7 +63,7 @@ from litellm.proxy.hooks.parallel_request_limiter import (
 from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.secret_managers.main import str_to_bool
 from litellm.types.integrations.slack_alerting import DEFAULT_ALERT_TYPES
-from litellm.types.utils import CallTypes, LoggedLiteLLMParams
+from litellm.types.utils import CallTypes, LoggedLiteLLMParams, ModelResponseStream
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -967,7 +967,7 @@ class ProxyLogging:
         1. /chat/completions
         """
         response_str: Optional[str] = None
-        if isinstance(response, ModelResponse):
+        if isinstance(response, ModelResponseStream):
             response_str = litellm.get_response_string(response_obj=response)
         if response_str is not None:
             for callback in litellm.callbacks:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3883,7 +3883,7 @@ def _count_characters(text: str) -> int:
     return len(filtered_text)
 
 
-def get_response_string(response_obj: ModelResponse) -> str:
+def get_response_string(response_obj: ModelResponse | ModelResponseStream) -> str:
     _choices: List[Union[Choices, StreamingChoices]] = response_obj.choices
 
     response_str = ""


### PR DESCRIPTION
## Fix `async_post_call_streaming_hook` Not Working

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

https://github.com/BerriAI/litellm/issues/8628

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix


## Changes
In `proxy/utils.py:async_post_call_streaming_hook`, I've changed the `isinstance` check from `ModelResponse` to `ModelResponseStream` which fixes the issue of this hook not triggering. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

