### PR TITLE
Strip `data:image/jpeg;base64,` from the base64 image for Vertex AI multimodal embeddings

### DIFF
--- a/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
@@ -226,7 +226,7 @@ class VertexMultimodalEmbedding(VertexLLM):
             else:
                 return Instance(image=InstanceImage(gcsUri=input_element))
         elif is_base64_encoded(s=input_element):
-            return Instance(image=InstanceImage(bytesBase64Encoded=input_element))
+            return Instance(image=InstanceImage(bytesBase64Encoded=input_element.split(",")[1] if "," in input_element else input_element))            
         else:
             return Instance(text=input_element)
 


### PR DESCRIPTION
## Title

Strip `data:image/jpeg;base64,` from the base64 image input of vertex ai's multimodal embeddings.
Vertex_ai's multimodal embeddings endpoint expects a raw base64 string **without** any `data:image/jpeg;base64,` prefix.

## Relevant issues

[#7571](https://github.com/BerriAI/litellm/issues/7571)

## Type

🐛 Bug Fix
