### PR TITLE
Fix timeout bug for SageMaker Messages API completion

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2575,6 +2575,7 @@ def completion(  # type: ignore # noqa: PLR0915
                 print_verbose=print_verbose,
                 optional_params=optional_params,
                 litellm_params=litellm_params,
+                timeout=timeout,
                 custom_prompt_dict=custom_prompt_dict,
                 logger_fn=logger_fn,
                 encoding=encoding,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5328,6 +5328,28 @@
         "supports_vision": true,
         "supports_tool_choice": true
     },
+    "openrouter/google/gemini-2.0-flash-001": {
+        "max_tokens": 8192,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 8192,
+        "max_images_per_prompt": 3000,
+        "max_videos_per_prompt": 10,
+        "max_video_length": 1,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_pdf_size_mb": 30,
+        "input_cost_per_audio_token": 0.0000007,
+        "input_cost_per_token": 0.0000001,
+        "output_cost_per_token": 0.0000004,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_response_schema": true,
+        "supports_audio_output": true,
+        "supports_tool_choice": true
+    },
     "openrouter/mistralai/mixtral-8x22b-instruct": {
         "max_tokens": 65536,
         "input_cost_per_token": 0.00000065,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5348,7 +5348,7 @@
         "supports_vision": true,
         "supports_response_schema": true,
         "supports_audio_output": true,
-        "supports_tool_choice": true,
+        "supports_tool_choice": true
     },
     "openrouter/mistralai/mixtral-8x22b-instruct": {
         "max_tokens": 65536,

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2961,3 +2961,18 @@ async def test_cost_calculator_with_custom_pricing_router(model_item, custom_pri
     )
     # assert resp.model == "random-model"
     assert resp._hidden_params["response_cost"] > 0
+
+
+def test_json_valid_model_cost_map():
+    import json
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+    model_cost = litellm.get_model_cost_map(url="")
+
+    try:
+        # Attempt to serialize and deserialize the JSON
+        json_str = json.dumps(model_cost)
+        json.loads(json_str)
+    except json.JSONDecodeError as e:
+        assert False, f"Invalid JSON format: {str(e)}"


### PR DESCRIPTION
## Title

The `timeout` parameter is not being successfully passed to the `completion` function in `llms/sagemaker/chat/handler.py` causing completion timeouts.

## Relevant issues

Fixes #8373

## Type

🐛 Bug Fix

## Changes

Added `timeout` parameter to the `sagemaker_chat_completion.completion` function call in `main.py`.