### PR TITLE
(Feat) - Allow Admins to set max allowed ttl for client side ttl settings

### DIFF
--- a/docs/my-website/docs/proxy/caching.md
+++ b/docs/my-website/docs/proxy/caching.md
@@ -2,7 +2,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # Caching 
-Cache LLM Responses
 
 :::note 
 
@@ -10,14 +9,19 @@ For OpenAI/Anthropic Prompt Caching, go [here](../completion/prompt_caching.md)
 
 :::
 
-LiteLLM supports:
+Cache LLM Responses. LiteLLM's caching system stores and reuses LLM responses to save costs and reduce latency. When you make the same request twice, the cached response is returned instead of calling the LLM API again.
+
+
+
+### Supported Caches
+
 - In Memory Cache
 - Redis Cache 
 - Qdrant Semantic Cache
 - Redis Semantic Cache
 - s3 Bucket Cache 
 
-## Quick Start - Redis, s3 Cache, Semantic Cache
+## Quick Start
 <Tabs>
 
 <TabItem value="redis" label="redis cache">
@@ -369,9 +373,9 @@ $ litellm --config /path/to/config.yaml
 </Tabs>
 
 
+## Usage
 
-
-## Using Caching - /chat/completions
+### Basic
 
 <Tabs>
 <TabItem value="chat_completions" label="/chat/completions">
@@ -415,6 +419,239 @@ curl --location 'http://0.0.0.0:4000/embeddings' \
 ```
 </TabItem>
 </Tabs>
+
+### Dynamic Cache Controls
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `ttl` | *Optional(int)* | Will cache the response for the user-defined amount of time (in seconds) |
+| `s-maxage` | *Optional(int)* | Will only accept cached responses that are within user-defined range (in seconds) |
+| `no-cache` | *Optional(bool)* | Will not store the response in cache. |
+| `no-store` | *Optional(bool)* | Will not cache the response |
+| `namespace` | *Optional(str)* | Will cache the response under a user-defined namespace |
+
+Each cache parameter can be controlled on a per-request basis. Here are examples for each parameter:
+
+### `ttl`
+
+Set how long (in seconds) to cache a response.
+
+<Tabs>
+<TabItem value="openai" label="OpenAI Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "cache": {
+            "ttl": 300  # Cache response for 5 minutes
+        }
+    }
+)
+```
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "cache": {"ttl": 300},
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+</TabItem>
+</Tabs>
+
+### `s-maxage`
+
+Only accept cached responses that are within the specified age (in seconds).
+
+<Tabs>
+<TabItem value="openai" label="OpenAI Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "cache": {
+            "s-maxage": 600  # Only use cache if less than 10 minutes old
+        }
+    }
+)
+```
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "cache": {"s-maxage": 600},
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+</TabItem>
+</Tabs>
+
+### `no-cache`
+Force a fresh response, bypassing the cache.
+
+<Tabs>
+<TabItem value="openai" label="OpenAI Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "cache": {
+            "no-cache": True  # Skip cache check, get fresh response
+        }
+    }
+)
+```
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "cache": {"no-cache": true},
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+</TabItem>
+</Tabs>
+
+### `no-store`
+
+Will not store the response in cache.
+
+
+<Tabs>
+<TabItem value="openai" label="OpenAI Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "cache": {
+            "no-store": True  # Don't cache this response
+        }
+    }
+)
+```
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "cache": {"no-store": true},
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+</TabItem>
+</Tabs>
+
+### `namespace`
+Store the response under a specific cache namespace.
+
+<Tabs>
+<TabItem value="openai" label="OpenAI Python SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="your-api-key",
+    base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello"}],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "cache": {
+            "namespace": "my-custom-namespace"  # Store in custom namespace
+        }
+    }
+)
+```
+</TabItem>
+
+<TabItem value="curl" label="curl">
+
+```shell
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "cache": {"namespace": "my-custom-namespace"},
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+</TabItem>
+</Tabs>
+
+
 
 ## Set cache for proxy, but not on the actual llm api call
 
@@ -499,253 +736,6 @@ litellm_settings:
     # Optional configurations
     supported_call_types: ["acompletion", "atext_completion", "aembedding", "atranscription"]
                       # /chat/completions, /completions, /embeddings, /audio/transcriptions
-```
-
-### **Turn on / off caching per request. **
-
-The proxy support 4 cache-controls:
-
-- `ttl`: *Optional(int)* - Will cache the response for the user-defined amount of time (in seconds).
-- `s-maxage`: *Optional(int)* Will only accept cached responses that are within user-defined range (in seconds).
-- `no-cache`: *Optional(bool)* Will not return a cached response, but instead call the actual endpoint. 
-- `no-store`: *Optional(bool)* Will not cache the response. 
-
-[Let us know if you need more](https://github.com/BerriAI/litellm/issues/1218)
-
-**Turn off caching**
-
-Set `no-cache=True`, this will not return a cached response
-
-<Tabs>
-<TabItem value="openai" label="OpenAI Python SDK">
-
-```python
-import os
-from openai import OpenAI
-
-client = OpenAI(
-    # This is the default and can be omitted
-    api_key=os.environ.get("OPENAI_API_KEY"),
-		base_url="http://0.0.0.0:4000"
-)
-
-chat_completion = client.chat.completions.create(
-    messages=[
-        {
-            "role": "user",
-            "content": "Say this is a test",
-        }
-    ],
-    model="gpt-3.5-turbo",
-    extra_body = {        # OpenAI python accepts extra args in extra_body
-        cache: {
-          "no-cache": True # will not return a cached response 
-      }
-    }
-)
-```
-</TabItem>
-
-<TabItem value="curl" label="curl">
-
-```shell
-curl http://localhost:4000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-1234" \
-  -d '{
-    "model": "gpt-3.5-turbo",
-    "cache": {"no-cache": True},
-    "messages": [
-      {"role": "user", "content": "Say this is a test"}
-    ]
-  }'
-```
-
-</TabItem>
-
-</Tabs>
-
-**Turn on caching**
-
-By default cache is always on
-
-<Tabs>
-<TabItem value="openai" label="OpenAI Python SDK">
-
-```python
-import os
-from openai import OpenAI
-
-client = OpenAI(
-    # This is the default and can be omitted
-    api_key=os.environ.get("OPENAI_API_KEY"),
-		base_url="http://0.0.0.0:4000"
-)
-
-chat_completion = client.chat.completions.create(
-    messages=[
-        {
-            "role": "user",
-            "content": "Say this is a test",
-        }
-    ],
-    model="gpt-3.5-turbo"
-)
-```
-</TabItem>
-
-<TabItem value="curl on" label="curl">
-
-```shell
-curl http://localhost:4000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-1234" \
-  -d '{
-    "model": "gpt-3.5-turbo",
-    "messages": [
-      {"role": "user", "content": "Say this is a test"}
-    ]
-  }'
-```
-
-</TabItem>
-
-</Tabs>
-
-**Set `ttl`**
-
-Set `ttl=600`, this will caches response for 10 minutes (600 seconds)
-
-<Tabs>
-<TabItem value="openai" label="OpenAI Python SDK">
-
-```python
-import os
-from openai import OpenAI
-
-client = OpenAI(
-    # This is the default and can be omitted
-    api_key=os.environ.get("OPENAI_API_KEY"),
-		base_url="http://0.0.0.0:4000"
-)
-
-chat_completion = client.chat.completions.create(
-    messages=[
-        {
-            "role": "user",
-            "content": "Say this is a test",
-        }
-    ],
-    model="gpt-3.5-turbo",
-    extra_body = {        # OpenAI python accepts extra args in extra_body
-        cache: {
-          "ttl": 600 # caches response for 10 minutes 
-      }
-    }
-)
-```
-</TabItem>
-
-<TabItem value="curl on" label="curl">
-
-```shell
-curl http://localhost:4000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-1234" \
-  -d '{
-    "model": "gpt-3.5-turbo",
-    "cache": {"ttl": 600},
-    "messages": [
-      {"role": "user", "content": "Say this is a test"}
-    ]
-  }'
-```
-
-</TabItem>
-
-</Tabs>
-
-
-
-**Set `s-maxage`**
-
-Set `s-maxage`, this will only get responses cached within last 10 minutes 
-
-<Tabs>
-<TabItem value="openai" label="OpenAI Python SDK">
-
-```python
-import os
-from openai import OpenAI
-
-client = OpenAI(
-    # This is the default and can be omitted
-    api_key=os.environ.get("OPENAI_API_KEY"),
-		base_url="http://0.0.0.0:4000"
-)
-
-chat_completion = client.chat.completions.create(
-    messages=[
-        {
-            "role": "user",
-            "content": "Say this is a test",
-        }
-    ],
-    model="gpt-3.5-turbo",
-    extra_body = {        # OpenAI python accepts extra args in extra_body
-        cache: {
-          "s-maxage": 600 # only get responses cached within last 10 minutes 
-      }
-    }
-)
-```
-</TabItem>
-
-<TabItem value="curl on" label="curl">
-
-```shell
-curl http://localhost:4000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer sk-1234" \
-  -d '{
-    "model": "gpt-3.5-turbo",
-    "cache": {"s-maxage": 600},
-    "messages": [
-      {"role": "user", "content": "Say this is a test"}
-    ]
-  }'
-```
-
-</TabItem>
-
-</Tabs>
-
-
-### Turn on / off caching per Key.
-
-1. Add cache params when creating a key [full list](#turn-on--off-caching-per-key)
-
-```bash 
-curl -X POST 'http://0.0.0.0:4000/key/generate' \
--H 'Authorization: Bearer sk-1234' \
--H 'Content-Type: application/json' \
--d '{
-    "user_id": "222",
-    "metadata": {
-        "cache": {
-            "no-cache": true
-        }
-    }
-}'
-```
-
-2. Test it! 
-
-```bash 
-curl -X POST 'http://localhost:4000/chat/completions' \
--H 'Content-Type: application/json' \
--H 'Authorization: Bearer <YOUR_NEW_KEY>' \
--d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "bom dia"}]}'
 ```
 
 ### Deleting Cache Keys - `/cache/delete` 

--- a/litellm/caching/base_cache.py
+++ b/litellm/caching/base_cache.py
@@ -22,7 +22,7 @@ else:
 class BaseCache(ABC):
     def __init__(
         self,
-        default_ttl: int = 60,
+        default_ttl: Optional[int] = 60,
         maximum_ttl: Optional[int] = None,
     ):
         """
@@ -36,6 +36,9 @@ class BaseCache(ABC):
         self.maximum_ttl = maximum_ttl
 
     def get_ttl(self, **kwargs) -> Optional[int]:
+        """
+        Get the TTL to use for storing a LLM response in the cache
+        """
         kwargs_ttl: Optional[int] = kwargs.get("ttl")
         if kwargs_ttl is not None:
             try:

--- a/litellm/caching/base_cache.py
+++ b/litellm/caching/base_cache.py
@@ -23,17 +23,17 @@ class BaseCache(ABC):
     def __init__(
         self,
         default_ttl: Optional[int] = 60,
-        maximum_ttl: Optional[int] = None,
+        max_allowed_ttl: Optional[int] = None,
     ):
         """
         Initialize the BaseCache
 
         Args:
             default_ttl: The default TTL for the cache
-            maximum_ttl: The maximum allowed dynamic TTL for the cache
+            max_allowed_ttl: The maximum allowed dynamic TTL for the cache
         """
         self.default_ttl = default_ttl
-        self.maximum_ttl = maximum_ttl
+        self.max_allowed_ttl = max_allowed_ttl
 
     def get_ttl(self, **kwargs) -> Optional[int]:
         """
@@ -78,6 +78,6 @@ class BaseCache(ABC):
 
         Allows a admin to set the maxmium allowed TTL for dynamic ttl requests
         """
-        if self.maximum_ttl is not None:
-            return min(kwargs_ttl, self.maximum_ttl)
+        if self.max_allowed_ttl is not None:
+            return min(kwargs_ttl, self.max_allowed_ttl)
         return kwargs_ttl

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -549,10 +549,13 @@ class Cache:
             else:
                 cache_key = self.get_cache_key(**kwargs)
             if cache_key is not None:
-                cache_control_args = kwargs.get("cache", {})
-                max_age = cache_control_args.get(
-                    "s-max-age", cache_control_args.get("s-maxage", float("inf"))
+                cache_control_args: DynamicCacheControl = kwargs.get("cache", {})
+                max_age = (
+                    cache_control_args.get("s-maxage")
+                    or cache_control_args.get("s-max-age")
+                    or float("inf")
                 )
+                cached_result = self.cache.get_cache(cache_key, messages=messages)
                 cached_result = self.cache.get_cache(cache_key, messages=messages)
                 return self._get_cache_logic(
                     cached_result=cached_result, max_age=max_age

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -277,9 +277,7 @@ class Cache:
 
         verbose_logger.debug("\nCreated cache key: %s", cache_key)
         hashed_cache_key = Cache._get_hashed_cache_key(cache_key)
-        hashed_cache_key = self._add_redis_namespace_to_cache_key(
-            hashed_cache_key, **kwargs
-        )
+        hashed_cache_key = self._add_namespace_to_cache_key(hashed_cache_key, **kwargs)
         self._set_preset_cache_key_in_kwargs(
             preset_cache_key=hashed_cache_key, **kwargs
         )
@@ -455,7 +453,7 @@ class Cache:
         verbose_logger.debug("Hashed cache key (SHA-256): %s", hash_hex)
         return hash_hex
 
-    def _add_redis_namespace_to_cache_key(self, hash_hex: str, **kwargs) -> str:
+    def _add_namespace_to_cache_key(self, hash_hex: str, **kwargs) -> str:
         """
         If a redis namespace is provided, add it to the cache key
 
@@ -466,7 +464,12 @@ class Cache:
         Returns:
             str: The final hashed cache key with the redis namespace.
         """
-        namespace = kwargs.get("metadata", {}).get("redis_namespace") or self.namespace
+        dynamic_cache_control: DynamicCacheControl = kwargs.get("cache", {})
+        namespace = (
+            dynamic_cache_control.get("namespace")
+            or kwargs.get("metadata", {}).get("redis_namespace")
+            or self.namespace
+        )
         if namespace:
             hash_hex = f"{namespace}:{hash_hex}"
         verbose_logger.debug("Final hashed key: %s", hash_hex)

--- a/litellm/caching/disk_cache.py
+++ b/litellm/caching/disk_cache.py
@@ -12,7 +12,12 @@ else:
 
 
 class DiskCache(BaseCache):
-    def __init__(self, disk_cache_dir: Optional[str] = None):
+    def __init__(
+        self,
+        disk_cache_dir: Optional[str] = None,
+        max_allowed_ttl: Optional[int] = None,
+        **kwargs,
+    ):
         import diskcache as dc
 
         # if users don't provider one, use the default litellm cache
@@ -20,6 +25,8 @@ class DiskCache(BaseCache):
             self.disk_cache = dc.Cache(".litellm_cache")
         else:
             self.disk_cache = dc.Cache(disk_cache_dir)
+
+        super().__init__(max_allowed_ttl=max_allowed_ttl, **kwargs)
 
     def set_cache(self, key, value, **kwargs):
         if "ttl" in kwargs:

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -22,6 +22,8 @@ class InMemoryCache(BaseCache):
         default_ttl: Optional[
             int
         ] = 600,  # default ttl is 10 minutes. At maximum litellm rate limiting logic requires objects to be in memory for 1 minute
+        max_allowed_ttl: Optional[int] = None,
+        **kwargs,
     ):
         """
         max_size_in_memory [int]: Maximum number of items in cache. done to prevent memory leaks. Use 200 items as a default
@@ -34,6 +36,9 @@ class InMemoryCache(BaseCache):
         # in-memory cache
         self.cache_dict: dict = {}
         self.ttl_dict: dict = {}
+        super().__init__(
+            default_ttl=default_ttl, max_allowed_ttl=max_allowed_ttl, **kwargs
+        )
 
     def evict_cache(self):
         """

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -11,7 +11,7 @@ Has 4 methods:
 import ast
 import asyncio
 import json
-from typing import Any
+from typing import Any, Optional
 
 import litellm
 from litellm._logging import print_verbose
@@ -29,6 +29,8 @@ class QdrantSemanticCache(BaseCache):
         quantization_config=None,
         embedding_model="text-embedding-ada-002",
         host_type=None,
+        max_allowed_ttl: Optional[int] = None,
+        **kwargs,
     ):
         import os
 
@@ -148,6 +150,8 @@ class QdrantSemanticCache(BaseCache):
                 )
             else:
                 raise Exception("Error while creating new collection")
+
+        super().__init__(max_allowed_ttl=max_allowed_ttl, **kwargs)
 
     def _get_cache_logic(self, cached_response: Any):
         if cached_response is None:

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -122,10 +122,12 @@ class RedisCache(BaseCache):
                 "Error connecting to Sync Redis client", extra={"error": str(e)}
             )
 
-        if litellm.default_redis_ttl is not None:
-            super().__init__(default_ttl=int(litellm.default_redis_ttl))
-        else:
-            super().__init__()  # defaults to 60s
+        default_ttl = (
+            int(litellm.default_redis_ttl)
+            if litellm.default_redis_ttl is not None
+            else None
+        )
+        super().__init__(default_ttl=default_ttl, **kwargs)
 
     def init_async_client(
         self,

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -48,14 +48,25 @@ class RedisCache(BaseCache):
 
     def __init__(
         self,
-        host=None,
-        port=None,
-        password=None,
+        host: Optional[str] = None,
+        port: Optional[str] = None,
+        password: Optional[str] = None,
         redis_flush_size: Optional[int] = 100,
         namespace: Optional[str] = None,
         startup_nodes: Optional[List] = None,  # for redis-cluster
+        max_allowed_ttl: Optional[int] = None,
         **kwargs,
     ):
+        """
+        Args:
+           host: The host for the redis cache. Defaults to None.
+           port: The port for the redis cache. Defaults to None.
+           password: The password for the redis cache. Defaults to None.
+           redis_flush_size: The size of the redis flush buffer. Defaults to 100.
+           namespace: The namespace for the redis cache. Defaults to None.
+           startup_nodes: The startup nodes for the redis cluster. Defaults to None.
+           max_allowed_ttl: The maximum allowed ttl for cache requests. Defaults to None. This is the ceiling when a user passes a dynamic ttl to a cache request.
+        """
 
         from litellm._service_logger import ServiceLogging
 
@@ -127,7 +138,9 @@ class RedisCache(BaseCache):
             if litellm.default_redis_ttl is not None
             else None
         )
-        super().__init__(default_ttl=default_ttl, **kwargs)
+        super().__init__(
+            default_ttl=default_ttl, max_allowed_ttl=max_allowed_ttl, **kwargs
+        )
 
     def init_async_client(
         self,

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -11,7 +11,7 @@ Has 4 methods:
 import ast
 import asyncio
 import json
-from typing import Any
+from typing import Any, Optional
 
 import litellm
 from litellm._logging import print_verbose
@@ -29,6 +29,7 @@ class RedisSemanticCache(BaseCache):
         similarity_threshold=None,
         use_async=False,
         embedding_model="text-embedding-ada-002",
+        max_allowed_ttl: Optional[int] = None,
         **kwargs,
     ):
         from redisvl.index import SearchIndex
@@ -84,6 +85,7 @@ class RedisSemanticCache(BaseCache):
             schema["index"]["name"] = "litellm_semantic_cache_index_async"
             self.index = SearchIndex.from_dict(schema)
             self.index.connect(redis_url=redis_url, use_async=True)
+        super().__init__(max_allowed_ttl=max_allowed_ttl, **kwargs)
 
     #
     def _get_cache_logic(self, cached_response: Any):

--- a/litellm/caching/s3_cache.py
+++ b/litellm/caching/s3_cache.py
@@ -33,6 +33,7 @@ class S3Cache(BaseCache):
         s3_aws_session_token=None,
         s3_config=None,
         s3_path=None,
+        max_allowed_ttl: Optional[int] = None,
         **kwargs,
     ):
         import boto3
@@ -54,6 +55,8 @@ class S3Cache(BaseCache):
             config=s3_config,
             **kwargs,
         )
+
+        super().__init__(max_allowed_ttl=max_allowed_ttl, **kwargs)
 
     def set_cache(self, key, value, **kwargs):
         try:

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -6,10 +6,10 @@ model_list:
       api_base: https://exampleopenaiendpoint-production.up.railway.app/
 
 
-general_settings:
-  store_model_in_db: true
-
-
 litellm_settings:
-  callbacks: ["gcs_bucket"]
+  cache: true
+  cache_params:
+    type: redis
+    max_allowed_ttl: 100
+  callbacks: ["langfuse"]
 

--- a/litellm/types/caching.py
+++ b/litellm/types/caching.py
@@ -38,10 +38,16 @@ class RedisPipelineIncrementOperation(TypedDict):
 DynamicCacheControl = TypedDict(
     "DynamicCacheControl",
     {
+        # Will cache the response for the user-defined amount of time (in seconds).
         "ttl": Optional[int],
+        # Namespace to use for caching
         "namespace": Optional[str],
+        # Max Age to use for caching
         "s-maxage": Optional[int],
+        "s-max-age": Optional[int],
+        # Will not return a cached response, but instead call the actual endpoint.
         "no-cache": Optional[bool],
+        # Will not store the response in the cache.
         "no-store": Optional[bool],
     },
 )

--- a/litellm/types/caching.py
+++ b/litellm/types/caching.py
@@ -33,3 +33,15 @@ class RedisPipelineIncrementOperation(TypedDict):
     key: str
     increment_value: float
     ttl: Optional[int]
+
+
+DynamicCacheControl = TypedDict(
+    "DynamicCacheControl",
+    {
+        "ttl": Optional[int],
+        "namespace": Optional[str],
+        "s-maxage": Optional[int],
+        "no-cache": Optional[bool],
+        "no-store": Optional[bool],
+    },
+)

--- a/tests/local_testing/test_base_cache.py
+++ b/tests/local_testing/test_base_cache.py
@@ -29,7 +29,7 @@ def test_get_ttl_with_maximum_ttl():
     """
     Test that get_ttl respects the maximum_ttl configuration when set
     """
-    cache = TestCache(maximum_ttl=100)
+    cache = TestCache(max_allowed_ttl=100)
     # Test with TTL exceeding maximum
     assert cache.get_ttl(ttl=150) == 100, "TTL should be capped at maximum_ttl"
     # Test with TTL below maximum

--- a/tests/local_testing/test_base_cache.py
+++ b/tests/local_testing/test_base_cache.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import time
+import traceback
+import uuid
+
+from dotenv import load_dotenv
+
+load_dotenv()
+import os
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+import asyncio
+import hashlib
+import random
+
+import pytest
+from litellm.caching.base_cache import BaseCache
+
+
+class TestCache(BaseCache):
+    async def async_set_cache_pipeline(self, cache_list, **kwargs):
+        pass
+
+
+def test_get_ttl_with_maximum_ttl():
+    """
+    Test that get_ttl respects the maximum_ttl configuration when set
+    """
+    cache = TestCache(maximum_ttl=100)
+    # Test with TTL exceeding maximum
+    assert cache.get_ttl(ttl=150) == 100, "TTL should be capped at maximum_ttl"
+    # Test with TTL below maximum
+    assert (
+        cache.get_ttl(ttl=50) == 50
+    ), "TTL should remain unchanged when below maximum_ttl"
+    # Test with TTL equal to maximum
+    assert cache.get_ttl(ttl=100) == 100, "TTL should equal maximum_ttl when matching"
+
+
+def test_get_ttl_without_maximum_ttl():
+    """
+    Test that get_ttl allows any TTL value when maximum_ttl is not set
+    """
+    cache = TestCache()  # No maximum_ttl set
+    high_ttl = 1000000
+    assert (
+        cache.get_ttl(ttl=high_ttl) == high_ttl
+    ), "TTL should not be capped when maximum_ttl is None"
+
+
+def test_get_ttl_invalid_input():
+    """
+    Test that get_ttl handles invalid TTL inputs gracefully
+    """
+    cache = TestCache(default_ttl=60)
+    # Test with non-integer TTL
+    assert (
+        cache.get_ttl(ttl="invalid") == 60
+    ), "Should return default_ttl for invalid TTL input"
+    # Test with no TTL specified
+    assert cache.get_ttl() == 60, "Should return default_ttl when no TTL specified"

--- a/tests/local_testing/test_caching.py
+++ b/tests/local_testing/test_caching.py
@@ -2481,7 +2481,13 @@ async def test_redis_get_ttl():
 
 
 def test_redis_caching_multiple_namespaces():
-    import json
+    """
+    Test that redis caching works with multiple namespaces
+
+    If client side request specifies a namespace, it should be used for caching
+
+    The same request with different namespaces should not be cached under the same key
+    """
     import uuid
 
     messages = [{"role": "user", "content": f"what is litellm? {uuid.uuid4()}"}]
@@ -2501,12 +2507,18 @@ def test_redis_caching_multiple_namespaces():
         model="gpt-3.5-turbo", messages=messages, cache={"namespace": namespace_1}
     )
 
+    response_4 = completion(model="gpt-3.5-turbo", messages=messages)
+
     print("response 1: ", response_1.model_dump_json(indent=4))
     print("response 2: ", response_2.model_dump_json(indent=4))
     print("response 3: ", response_3.model_dump_json(indent=4))
+    print("response 4: ", response_4.model_dump_json(indent=4))
 
     # request 1 & 3 used under the same namespace
     assert response_1.id == response_3.id
 
     # request 2 used under a different namespace
     assert response_2.id != response_1.id
+
+    # request 4 without a namespace should not be cached under the same key as request 3
+    assert response_4.id != response_3.id

--- a/tests/local_testing/test_caching.py
+++ b/tests/local_testing/test_caching.py
@@ -2478,3 +2478,35 @@ async def test_redis_get_ttl():
     except Exception as e:
         print(f"Error occurred: {str(e)}")
         raise e
+
+
+def test_redis_caching_multiple_namespaces():
+    import json
+    import uuid
+
+    messages = [{"role": "user", "content": f"what is litellm? {uuid.uuid4()}"}]
+    litellm.cache = Cache(type="redis")
+    namespace_1 = "org-id1"
+    namespace_2 = "org-id2"
+
+    response_1 = completion(
+        model="gpt-3.5-turbo", messages=messages, cache={"namespace": namespace_1}
+    )
+
+    response_2 = completion(
+        model="gpt-3.5-turbo", messages=messages, cache={"namespace": namespace_2}
+    )
+
+    response_3 = completion(
+        model="gpt-3.5-turbo", messages=messages, cache={"namespace": namespace_1}
+    )
+
+    print("response 1: ", response_1.model_dump_json(indent=4))
+    print("response 2: ", response_2.model_dump_json(indent=4))
+    print("response 3: ", response_3.model_dump_json(indent=4))
+
+    # request 1 & 3 used under the same namespace
+    assert response_1.id == response_3.id
+
+    # request 2 used under a different namespace
+    assert response_2.id != response_1.id

--- a/tests/local_testing/test_unit_test_caching.py
+++ b/tests/local_testing/test_unit_test_caching.py
@@ -150,6 +150,15 @@ def test_add_namespace_to_cache_key():
     result = cache._add_namespace_to_cache_key(hashed_key, **kwargs)
     assert result == "custom_namespace:abcdef1234567890"
 
+    # Test with cache control namespace
+    kwargs = {"cache": {"namespace": "cache_control_namespace"}}
+    result = cache._add_namespace_to_cache_key(hashed_key, **kwargs)
+    assert result == "cache_control_namespace:abcdef1234567890"
+
+    kwargs = {"cache": {"namespace": "cache_control_namespace-2"}}
+    result = cache._add_namespace_to_cache_key(hashed_key, **kwargs)
+    assert result == "cache_control_namespace-2:abcdef1234567890"
+
 
 def test_get_model_param_value():
     cache = Cache()

--- a/tests/local_testing/test_unit_test_caching.py
+++ b/tests/local_testing/test_unit_test_caching.py
@@ -137,17 +137,17 @@ def test_get_hashed_cache_key():
     assert len(hashed_key) == 64  # SHA-256 produces a 64-character hex string
 
 
-def test_add_redis_namespace_to_cache_key():
+def test_add_namespace_to_cache_key():
     cache = Cache(namespace="test_namespace")
     hashed_key = "abcdef1234567890"
 
     # Test with class-level namespace
-    result = cache._add_redis_namespace_to_cache_key(hashed_key)
+    result = cache._add_namespace_to_cache_key(hashed_key)
     assert result == "test_namespace:abcdef1234567890"
 
     # Test with metadata namespace
     kwargs = {"metadata": {"redis_namespace": "custom_namespace"}}
-    result = cache._add_redis_namespace_to_cache_key(hashed_key, **kwargs)
+    result = cache._add_namespace_to_cache_key(hashed_key, **kwargs)
     assert result == "custom_namespace:abcdef1234567890"
 
 


### PR DESCRIPTION
## (Feat) - Allow Admins to set max allowed ttl for client side ttl settings

```yaml
model_list:
  - model_name: fake-openai-endpoint
    litellm_params:
      model: openai/my-fake-model
      api_key: my-fake-key
      api_base: https://exampleopenaiendpoint-production.up.railway.app/


litellm_settings:
  cache: true
  cache_params:
    type: redis
    max_allowed_ttl: 100
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

