### PR TITLE
Add `supports_pdf_input: true` for specific Bedrock Claude models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6280,6 +6280,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+	"supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -6293,6 +6294,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+	"supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
@@ -6305,6 +6307,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
+	"supports_pdf_input": true,
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true, 
         "supports_response_schema": true,
@@ -6321,6 +6324,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "anthropic.claude-3-5-haiku-20241022-v1:0": {
@@ -6332,6 +6336,7 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_assistant_prefill": true,
+	"supports_pdf_input": true,
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_prompt_caching": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6280,7 +6280,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
-	"supports_pdf_input": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -6294,7 +6294,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
-	"supports_pdf_input": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
@@ -6307,7 +6307,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
-	"supports_pdf_input": true,
+        "supports_pdf_input": true,
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true, 
         "supports_response_schema": true,
@@ -6336,7 +6336,7 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_assistant_prefill": true,
-	"supports_pdf_input": true,
+        "supports_pdf_input": true,
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_prompt_caching": true,
@@ -6366,6 +6366,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -6379,6 +6380,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
@@ -6391,6 +6393,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
@@ -6407,6 +6410,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
@@ -6418,6 +6422,7 @@
         "litellm_provider": "bedrock",
         "mode": "chat",
         "supports_assistant_prefill": true,
+        "supports_pdf_input": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
@@ -6447,6 +6452,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -6460,6 +6466,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": {
@@ -6472,6 +6479,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
@@ -6488,6 +6496,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_vision": true,
+        "supports_pdf_input": true,
         "supports_tool_choice": true
     },
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
@@ -6500,6 +6509,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
+        "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true


### PR DESCRIPTION
Added `"supports_pdf_input": true` for the following Bedrock models in `model_prices_and_context_window.json`.

- `bedrock/anthropic.claude-3-haiku-20240307-v1:0`
- `bedrock/anthropic.claude-3-sonnet-20240229-v1:0`
- `bedrock/anthropic.claude-3-5-haiku-20241022-v1:0`
- `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`
- `bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0`

PDF input has been tested locally and confirmed to work.