### PR TITLE
(Bug fix) prometheus - safely set latency metrics 

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -691,7 +691,7 @@ class PrometheusLogger(CustomLogger):
         start_time: Optional[datetime] = kwargs.get("start_time")
         api_call_start_time = kwargs.get("api_call_start_time", None)
         completion_start_time = kwargs.get("completion_start_time", None)
-        time_to_first_token_seconds = self.safe_duration_seconds(
+        time_to_first_token_seconds = self._safe_duration_seconds(
             start_time=api_call_start_time,
             end_time=completion_start_time,
         )
@@ -711,7 +711,7 @@ class PrometheusLogger(CustomLogger):
                 "Time to first token metric not emitted, stream option in model_parameters is not True"
             )
 
-        api_call_total_time_seconds = self.safe_duration_seconds(
+        api_call_total_time_seconds = self._safe_duration_seconds(
             start_time=api_call_start_time,
             end_time=end_time,
         )
@@ -727,7 +727,7 @@ class PrometheusLogger(CustomLogger):
             )
 
         # total request latency
-        total_time_seconds = self.safe_duration_seconds(
+        total_time_seconds = self._safe_duration_seconds(
             start_time=start_time,
             end_time=end_time,
         )
@@ -741,21 +741,6 @@ class PrometheusLogger(CustomLogger):
             self.litellm_request_total_latency_metric.labels(**_labels).observe(
                 total_time_seconds
             )
-
-    def safe_duration_seconds(
-        self,
-        start_time: Any,
-        end_time: Any,
-    ) -> Optional[float]:
-        """
-        Compute the duration in seconds between two objects.
-
-        Returns the duration as a float if both start and end are instances of datetime,
-        otherwise returns None.
-        """
-        if isinstance(start_time, datetime) and isinstance(end_time, datetime):
-            return (end_time - start_time).total_seconds()
-        return None
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         from litellm.types.utils import StandardLoggingPayload
@@ -1706,6 +1691,21 @@ class PrometheusLogger(CustomLogger):
         return (
             budget_reset_at - datetime.now(budget_reset_at.tzinfo)
         ).total_seconds() / 3600
+
+    def _safe_duration_seconds(
+        self,
+        start_time: Any,
+        end_time: Any,
+    ) -> Optional[float]:
+        """
+        Compute the duration in seconds between two objects.
+
+        Returns the duration as a float if both start and end are instances of datetime,
+        otherwise returns None.
+        """
+        if isinstance(start_time, datetime) and isinstance(end_time, datetime):
+            return (end_time - start_time).total_seconds()
+        return None
 
 
 def prometheus_label_factory(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -691,14 +691,14 @@ class PrometheusLogger(CustomLogger):
         start_time: Optional[datetime] = kwargs.get("start_time")
         api_call_start_time = kwargs.get("api_call_start_time", None)
         completion_start_time = kwargs.get("completion_start_time", None)
+        time_to_first_token_seconds = self.safe_duration_seconds(
+            start_time=api_call_start_time,
+            end_time=completion_start_time,
+        )
         if (
-            completion_start_time is not None
-            and isinstance(completion_start_time, datetime)
+            time_to_first_token_seconds is not None
             and kwargs.get("stream", False) is True  # only emit for streaming requests
         ):
-            time_to_first_token_seconds = (
-                completion_start_time - api_call_start_time
-            ).total_seconds()
             self.litellm_llm_api_time_to_first_token_metric.labels(
                 model,
                 user_api_key,
@@ -710,11 +710,12 @@ class PrometheusLogger(CustomLogger):
             verbose_logger.debug(
                 "Time to first token metric not emitted, stream option in model_parameters is not True"
             )
-        if api_call_start_time is not None and isinstance(
-            api_call_start_time, datetime
-        ):
-            api_call_total_time: timedelta = end_time - api_call_start_time
-            api_call_total_time_seconds = api_call_total_time.total_seconds()
+
+        api_call_total_time_seconds = self.safe_duration_seconds(
+            start_time=api_call_start_time,
+            end_time=end_time,
+        )
+        if api_call_total_time_seconds is not None:
             _labels = prometheus_label_factory(
                 supported_enum_labels=PrometheusMetricLabels.get_labels(
                     label_name="litellm_llm_api_latency_metric"
@@ -726,9 +727,11 @@ class PrometheusLogger(CustomLogger):
             )
 
         # total request latency
-        if start_time is not None and isinstance(start_time, datetime):
-            total_time: timedelta = end_time - start_time
-            total_time_seconds = total_time.total_seconds()
+        total_time_seconds = self.safe_duration_seconds(
+            start_time=start_time,
+            end_time=end_time,
+        )
+        if total_time_seconds is not None:
             _labels = prometheus_label_factory(
                 supported_enum_labels=PrometheusMetricLabels.get_labels(
                     label_name="litellm_request_total_latency_metric"
@@ -738,6 +741,21 @@ class PrometheusLogger(CustomLogger):
             self.litellm_request_total_latency_metric.labels(**_labels).observe(
                 total_time_seconds
             )
+
+    def safe_duration_seconds(
+        self,
+        start_time: Any,
+        end_time: Any,
+    ) -> Optional[float]:
+        """
+        Compute the duration in seconds between two objects.
+
+        Returns the duration as a float if both start and end are instances of datetime,
+        otherwise returns None.
+        """
+        if isinstance(start_time, datetime) and isinstance(end_time, datetime):
+            return (end_time - start_time).total_seconds()
+        return None
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         from litellm.types.utils import StandardLoggingPayload


### PR DESCRIPTION
## (Bug fix) prometheus - safely set latency metrics 

Fixes this error 

```
{"message": "LiteLLM.LoggingError: [Non-Blocking] Exception occurred while success logging Traceback (most recent call last):\n  File \"/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/litellm_logging.py\", line 1674, in async_success_handler\n    await callback.async_log_success_event(\n    ...<6 lines>...\n    )\n  File \"/usr/lib/python3.13/site-packages/litellm/integrations/prometheus.py\", line 499, in async_log_success_event\n    self._set_latency_metrics(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~^\n        kwargs=kwargs,\n        ^^^^^^^^^^^^^^\n    ...<8 lines>...\n        enum_values=enum_values,\n        ^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/usr/lib/python3.13/site-packages/litellm/integrations/prometheus.py\", line 700, in _set_latency_metrics\n    completion_start_time - api_call_start_time\n    ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~\nTypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'\n", "level": "ERROR", "timestamp": "2025-02-19T15:15:24.801804"}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

