### PR TITLE
Don't fail for `global_max_parallel_requests` = 1

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -220,7 +220,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             )
             # check if below limit
             if current_global_requests is None:
-                current_global_requests = 1
+                current_global_requests = 0
             # if above -> raise error
             if current_global_requests >= global_max_parallel_requests:
                 return self.raise_rate_limit_error(

--- a/tests/litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.hooks.parallel_request_limiter import _PROXY_MaxParallelRequestsHandler
+from litellm.proxy.utils import InternalUsageCache
+from litellm.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+@pytest.mark.asyncio
+async def test_async_pre_call_hook():
+  dual_cache = DualCache()
+  internal_usage_cache = InternalUsageCache(dual_cache=dual_cache)
+  handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=internal_usage_cache)
+
+  data={"metadata": {"global_max_parallel_requests": 1}}
+
+  user_api_key_dict = UserAPIKeyAuth()
+
+  # The first parallel request succeeds
+  await handler.async_pre_call_hook(
+    user_api_key_dict=user_api_key_dict,
+    cache=dual_cache,
+    data=data,
+    call_type="completion",
+  )
+
+  # The second parallel request fails
+  try:
+    await handler.async_pre_call_hook(
+      user_api_key_dict=user_api_key_dict,
+      cache=dual_cache,
+      data=data,
+      call_type="completion",
+    )
+    assert False
+  except HTTPException as e:
+    pass


### PR DESCRIPTION
When `global_max_parallel_requests` was set to `1`, all requests were failing.

## Title

Fix `global_max_parallel_requests` initial request

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

- Fix `global_max_parallel_requests` initial request

![image](https://github.com/user-attachments/assets/e74b1666-aaea-4ab2-a0c4-4cbbea873fc7)


<!-- Test procedure -->

