### PR TITLE
handle alias map name in get_llm_provider

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -102,6 +102,10 @@ def get_llm_provider(  # noqa: PLR0915
     """
 
     try:
+        # If model name is in the alias map
+        if model in litellm.model_alias_map:
+            model = litellm.model_alias_map[model]
+
         ## IF LITELLM PARAMS GIVEN ##
         if litellm_params is not None:
             assert (


### PR DESCRIPTION
## Title

This PR updates the `get_llm_provider` to correctly return the provider when model alias is provided.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

- Check if model passed is in the alias map & if so, use the alias map to return provider info. 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

