### PR TITLE
Arize Phoenix - ensure correct endpoint/protocol are used; and default to phoenix cloud

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -34,24 +34,24 @@ class ArizePhoenixLogger:
         Returns:
             ArizePhoenixConfig: A Pydantic model containing Arize Phoenix configuration.
         """
-        api_key = os.environ.get("PHOENIX_API_KEY")
-        grpc_endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT")
-        http_endpoint = os.environ.get("PHOENIX_COLLECTOR_HTTP_ENDPOINT")
+        api_key = os.environ.get("PHOENIX_API_KEY", None)
+        grpc_endpoint = os.environ.get("PHOENIX_COLLECTOR_ENDPOINT", None)
+        http_endpoint = os.environ.get("PHOENIX_COLLECTOR_HTTP_ENDPOINT", None)
 
         endpoint = None
-        protocol: Protocol = "otlp_grpc"
+        protocol: Protocol = "otlp_http"
 
-        if grpc_endpoint is not None:
+        if grpc_endpoint:
             endpoint = grpc_endpoint
             protocol = "otlp_grpc"
-        elif http_endpoint is not None:
+        elif http_endpoint:
             endpoint = http_endpoint
             protocol = "otlp_http"
         else:
             endpoint = ARIZE_HOSTED_PHOENIX_ENDPOINT
-            protocol = "otlp_grpc"       
+            protocol = "otlp_http"       
             verbose_logger.debug(
-                f"No PHOENIX_COLLECTOR_ENDPOINT or PHOENIX_COLLECTOR_HTTP_ENDPOINT found, using default endpoint: {ARIZE_HOSTED_PHOENIX_ENDPOINT}"
+                f"No PHOENIX_COLLECTOR_ENDPOINT or PHOENIX_COLLECTOR_HTTP_ENDPOINT found, using default endpoint with http: {ARIZE_HOSTED_PHOENIX_ENDPOINT}"
             )
 
         otlp_auth_headers = None

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -41,12 +41,12 @@ class ArizePhoenixLogger:
         endpoint = None
         protocol: Protocol = "otlp_http"
 
-        if grpc_endpoint:
-            endpoint = grpc_endpoint
-            protocol = "otlp_grpc"
-        elif http_endpoint:
+        if http_endpoint:
             endpoint = http_endpoint
             protocol = "otlp_http"
+        elif grpc_endpoint:
+            endpoint = grpc_endpoint
+            protocol = "otlp_grpc"
         else:
             endpoint = ARIZE_HOSTED_PHOENIX_ENDPOINT
             protocol = "otlp_http"       

--- a/tests/local_testing/test_arize_phoenix.py
+++ b/tests/local_testing/test_arize_phoenix.py
@@ -36,8 +36,15 @@ async def test_async_otel_callback():
             {"PHOENIX_API_KEY": "test_api_key"},
             "api_key=test_api_key",
             "https://app.phoenix.arize.com/v1/traces",
-            "otlp_grpc",
-            id="default to grpc protocol and Arize hosted Phoenix endpoint",
+            "otlp_http",
+            id="default to http protocol and Arize hosted Phoenix endpoint",
+        ),
+        pytest.param(
+            {"PHOENIX_COLLECTOR_HTTP_ENDPOINT": "", "PHOENIX_API_KEY": "test_api_key"},
+            "api_key=test_api_key",
+            "https://app.phoenix.arize.com/v1/traces",
+            "otlp_http",
+            id="empty string/unset endpoint will default to http protocol and Arize hosted Phoenix endpoint",
         ),
         pytest.param(
             {"PHOENIX_COLLECTOR_ENDPOINT": "https://localhost:6006", "PHOENIX_API_KEY": "test_api_key"},

--- a/tests/local_testing/test_arize_phoenix.py
+++ b/tests/local_testing/test_arize_phoenix.py
@@ -47,6 +47,13 @@ async def test_async_otel_callback():
             id="empty string/unset endpoint will default to http protocol and Arize hosted Phoenix endpoint",
         ),
         pytest.param(
+            {"PHOENIX_COLLECTOR_HTTP_ENDPOINT": "http://localhost:4318", "PHOENIX_COLLECTOR_ENDPOINT": "http://localhost:4317", "PHOENIX_API_KEY": "test_api_key"},
+            "Authorization=Bearer test_api_key",
+            "http://localhost:4318",
+            "otlp_http",
+            id="prioritize http if both endpoints are set",
+        ),
+        pytest.param(
             {"PHOENIX_COLLECTOR_ENDPOINT": "https://localhost:6006", "PHOENIX_API_KEY": "test_api_key"},
             "Authorization=Bearer test_api_key",
             "https://localhost:6006",


### PR DESCRIPTION
## Title
- Ensure that the correct endpoint/protocol are used by including an empty string check on the environment variables
- Use http protocol by default since grpc is not supported yet in Phoenix cloud
- Prioritize http if both endpoints are set


## Relevant issues


## Type
🧹 Refactoring


## Changes

Tested directly using a local llm proxy
![Uploading Screenshot 2025-02-23 at 9.46.05 PM.png…]()

