### PR TITLE
(UI) Minor fix, clear new team form after adding a new team

### DIFF
--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -285,6 +285,7 @@ const Teams: React.FC<TeamProps> = ({
         }
         console.log(`response for team create call: ${response}`);
         message.success("Team created");
+        form.resetFields();
         setIsTeamModalVisible(false);
       }
     } catch (error) {
@@ -616,14 +617,35 @@ const Teams: React.FC<TeamProps> = ({
                   <TextInput placeholder="" />
                 </Form.Item>
                 <Form.Item
-                  label="Organization"
+                  label={
+                    <span>
+                      Organization{' '}
+                      <Tooltip title={
+                        <span>
+                          Organizations can have multiple teams. Learn more about{' '}
+                          <a 
+                            href="https://docs.litellm.ai/docs/proxy/user_management_heirarchy"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: '#1890ff', textDecoration: 'underline' }}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            user management hierarchy
+                          </a>
+                        </span>
+                      }>
+                        <InfoCircleOutlined style={{ marginLeft: '4px' }} />
+                      </Tooltip>
+                    </span>
+                  }
                   name="organization_id"
                   initialValue={currentOrg ? currentOrg.organization_id : null}
                   className="mt-8"
                 >
                   <Select2
                     showSearch
-                    placeholder="Search or select a team"
+                    allowClear
+                    placeholder="Search or select an Organization"
                     onChange={(value) => {
                       form.setFieldValue('organization_id', value);
                       setCurrentOrgForCreateTeam(organizations?.find((org) => org.organization_id === value) || null);


### PR DESCRIPTION
## (UI) Minor fix, clear new team form after adding a new team

- the form for a new team on the UI would remain the same as I added multiple teams
-  Minor UX fix 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

