### PR TITLE
Fix edge token count error

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1836,7 +1836,9 @@ def token_counter(
         tokenizer_json = custom_tokenizer or _select_tokenizer(model=model)
         if tokenizer_json["type"] == "huggingface_tokenizer":
             enc = tokenizer_json["tokenizer"].encode(text)
-            num_tokens = len(enc.ids)
+            num_tokens = 0
+            if hasattr(enc, "ids"):
+                num_tokens = len(enc.ids)
         elif tokenizer_json["type"] == "openai_tokenizer":
             if (
                 model in litellm.open_ai_chat_completion_models


### PR DESCRIPTION
In some cases avoid a crash if the tokenizer don't find anything else

Maybe it is opinionated because we did some patches for https://github.com/BerriAI/litellm/issues/8587 but I think that a check if the list is not empty is not bad as assure more safety in litellm itself, also is not a problematic change.