### PR TITLE
Add model: AWS Bedrock Claude 3.7 Sonnet with inference profile

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6468,6 +6468,21 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+        "max_tokens": 8192,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "litellm_provider": "bedrock_converse",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_assistant_prefill": true,
+        "supports_prompt_caching": true, 
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "us.anthropic.claude-3-haiku-20240307-v1:0": {
         "max_tokens": 4096,
         "max_input_tokens": 200000,


### PR DESCRIPTION
## Title
Add model: AWS Bedrock Claude 3.7 Sonnet with inference profile


## Relevant issues


## Type
🆕 New Feature


## Changes
Support cross-region inference profile, currently AWS Bedrock only supports inference profile options for Claude 3.7 Sonnet


## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

