### PR TITLE
VertexAI: Add support for explicitly stating mime type of the provided file and improve mime-type handling.

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/transformation.py
@@ -87,7 +87,8 @@ class AnthropicExperimentalPassThroughConfig:
                             new_user_content_list.append(text_obj)
                         elif content["type"] == "image":
                             image_url = ChatCompletionImageUrlObject(
-                                url=f"data:{content['type']};base64,{content['source']}"
+                                url=f"data:{content['type']};base64,{content['source']}",
+                                mime_type=content['type']
                             )
                             image_obj = ChatCompletionImageObject(
                                 type="image_url", image_url=image_url

--- a/litellm/types/files.py
+++ b/litellm/types/files.py
@@ -1,6 +1,8 @@
+import os
 from enum import Enum
 from types import MappingProxyType
-from typing import List, Set, Mapping
+from typing import List, Set, Mapping, Optional
+from urllib.parse import urlparse
 
 """
 Base Enums/Consts
@@ -8,7 +10,10 @@ Base Enums/Consts
 
 
 class FileType(Enum):
+    AIFF = "AIFF"
     AAC = "AAC"
+    AVI = "AVI"
+    CSS = "CSS"
     CSV = "CSV"
     DOC = "DOC"
     DOCX = "DOCX"
@@ -22,10 +27,12 @@ class FileType(Enum):
     HEIC = "HEIC"
     HEIF = "HEIF"
     HTML = "HTML"
+    JAVA_SCRIPT = "JAVA_SCRIPT"
     JPEG = "JPEG"
     JSON = "JSON"
     M4A = "M4A"
     M4V = "M4V"
+    MARKDOWN = "MARKDOWN"
     MOV = "MOV"
     MP3 = "MP3"
     MP4 = "MP4"
@@ -41,6 +48,7 @@ class FileType(Enum):
     PNG = "PNG"
     PPT = "PPT"
     PPTX = "PPTX"
+    PYTHON = "PYTHON"
     RTF = "RTF"
     THREE_GPP = "3GPP"
     TXT = "TXT"
@@ -48,13 +56,17 @@ class FileType(Enum):
     WEBM = "WEBM"
     WEBP = "WEBP"
     WMV = "WMV"
+    XML = "XML"
     XLS = "XLS"
     XLSX = "XLSX"
 
 
 FILE_EXTENSIONS: Mapping[FileType, List[str]] = MappingProxyType(
     {
+        FileType.AIFF: ["aif"],
         FileType.AAC: ["aac"],
+        FileType.AVI: ["avi"],
+        FileType.CSS: ["css"],
         FileType.CSV: ["csv"],
         FileType.DOC: ["doc"],
         FileType.DOCX: ["docx"],
@@ -68,10 +80,12 @@ FILE_EXTENSIONS: Mapping[FileType, List[str]] = MappingProxyType(
         FileType.HEIC: ["heic"],
         FileType.HEIF: ["heif"],
         FileType.HTML: ["html", "htm"],
+        FileType.JAVA_SCRIPT: ["js"],
         FileType.JPEG: ["jpeg", "jpg"],
         FileType.JSON: ["json"],
         FileType.M4A: ["m4a"],
         FileType.M4V: ["m4v"],
+        FileType.MARKDOWN: ["md"],
         FileType.MOV: ["mov"],
         FileType.MP3: ["mp3"],
         FileType.MP4: ["mp4"],
@@ -87,6 +101,7 @@ FILE_EXTENSIONS: Mapping[FileType, List[str]] = MappingProxyType(
         FileType.PNG: ["png"],
         FileType.PPT: ["ppt"],
         FileType.PPTX: ["pptx"],
+        FileType.PYTHON: ["py"],
         FileType.RTF: ["rtf"],
         FileType.THREE_GPP: ["3gpp"],
         FileType.TXT: ["txt"],
@@ -94,6 +109,7 @@ FILE_EXTENSIONS: Mapping[FileType, List[str]] = MappingProxyType(
         FileType.WEBM: ["webm"],
         FileType.WEBP: ["webp"],
         FileType.WMV: ["wmv"],
+        FileType.XML: ["xml"],
         FileType.XLS: ["xls"],
         FileType.XLSX: ["xlsx"],
     }
@@ -101,7 +117,10 @@ FILE_EXTENSIONS: Mapping[FileType, List[str]] = MappingProxyType(
 
 FILE_MIME_TYPES: Mapping[FileType, str] = MappingProxyType(
     {
+        FileType.AIFF: "audio/aiff",
         FileType.AAC: "audio/aac",
+        FileType.AVI: "video/avi",
+        FileType.CSS: "text/css",
         FileType.CSV: "text/csv",
         FileType.DOC: "application/msword",
         FileType.DOCX: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -115,10 +134,12 @@ FILE_MIME_TYPES: Mapping[FileType, str] = MappingProxyType(
         FileType.HEIC: "image/heic",
         FileType.HEIF: "image/heif",
         FileType.HTML: "text/html",
+        FileType.JAVA_SCRIPT: "text/javascript",
         FileType.JPEG: "image/jpeg",
         FileType.JSON: "application/json",
         FileType.M4A: "audio/x-m4a",
         FileType.M4V: "video/x-m4v",
+        FileType.MARKDOWN: "text/md",
         FileType.MOV: "video/quicktime",
         FileType.MP3: "audio/mpeg",
         FileType.MP4: "video/mp4",
@@ -134,13 +155,15 @@ FILE_MIME_TYPES: Mapping[FileType, str] = MappingProxyType(
         FileType.PNG: "image/png",
         FileType.PPT: "application/vnd.ms-powerpoint",
         FileType.PPTX: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        FileType.RTF: "application/rtf",
+        FileType.PYTHON: "text/x-python",
+        FileType.RTF: "text/rtf",
         FileType.THREE_GPP: "video/3gpp",
         FileType.TXT: "text/plain",
         FileType.WAV: "audio/wav",
         FileType.WEBM: "video/webm",
         FileType.WEBP: "image/webp",
         FileType.WMV: "video/wmv",
+        FileType.XML: "text/xml",
         FileType.XLS: "application/vnd.ms-excel",
         FileType.XLSX: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     }
@@ -152,15 +175,17 @@ Util Functions
 
 
 def get_file_extension_from_mime_type(mime_type: str) -> str:
+    lowercase_mime_type = mime_type.lower()
     for file_type, mime in FILE_MIME_TYPES.items():
-        if mime.lower() == mime_type.lower():
+        if mime.lower() == lowercase_mime_type:
             return FILE_EXTENSIONS[file_type][0]
     raise ValueError(f"Unknown extension for mime type: {mime_type}")
 
 
 def get_file_type_from_extension(extension: str) -> FileType:
+    lowercase_extension = extension.lower()
     for file_type, extensions in FILE_EXTENSIONS.items():
-        if extension.lower() in extensions:
+        if lowercase_extension in extensions:
             return file_type
 
     raise ValueError(f"Unknown file type for extension: {extension}")
@@ -200,6 +225,7 @@ def is_image_file_type(file_type):
 
 # Videos
 VIDEO_FILE_TYPES = {
+    FileType.AVI,
     FileType.MOV,
     FileType.MP4,
     FileType.MPEG,
@@ -219,6 +245,7 @@ def is_video_file_type(file_type):
 
 # Audio
 AUDIO_FILE_TYPES = {
+    FileType.AIFF,
     FileType.AAC,
     FileType.FLAC,
     FileType.MP3,
@@ -235,49 +262,40 @@ def is_audio_file_type(file_type):
 
 
 # Text
-TEXT_FILE_TYPES = {FileType.CSV, FileType.HTML, FileType.RTF, FileType.TXT}
+TEXT_FILE_TYPES = {
+    FileType.CSS,
+    FileType.CSV,
+    FileType.HTML,
+    FileType.JAVA_SCRIPT,
+    FileType.MARKDOWN,
+    FileType.PYTHON,
+    FileType.RTF,
+    FileType.TXT,
+    FileType.XML
+}
 
 
 def is_text_file_type(file_type):
     return file_type in TEXT_FILE_TYPES
 
 
-"""
-Other FileType Groupings
-"""
-# Accepted file types for GEMINI 1.5 through Vertex AI
-# https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/send-multimodal-prompts#gemini-send-multimodal-samples-images-nodejs
-GEMINI_1_5_ACCEPTED_FILE_TYPES: Set[FileType] = {
-    # Image
-    FileType.PNG,
-    FileType.JPEG,
-    FileType.WEBP,
-    # Audio
-    FileType.AAC,
-    FileType.FLAC,
-    FileType.MP3,
-    FileType.MPA,
-    FileType.MPEG,
-    FileType.MPGA,
-    FileType.OPUS,
-    FileType.PCM,
-    FileType.WAV,
-    FileType.WEBM,
-    # Video
-    FileType.FLV,
-    FileType.MOV,
-    FileType.MPEG,
-    FileType.MPEGPS,
-    FileType.MPG,
-    FileType.MP4,
-    FileType.WEBM,
-    FileType.WMV,
-    FileType.THREE_GPP,
-    # PDF
-    FileType.PDF,
-    FileType.TXT,
-}
+def get_mime_type_from_url(url: str) -> Optional[str]:
+    """
+    Get mime type for common URLs, handling query strings and path parameters.
 
+    Example:
+        url = https://example.com/image.jpg?width=100
+        Returns: image/jpeg
+    """
+    # Parse the URL and get the path component
+    parsed_url = urlparse(url.lower())
+    path = parsed_url.path
 
-def is_gemini_1_5_accepted_file_type(file_type: FileType) -> bool:
-    return file_type in GEMINI_1_5_ACCEPTED_FILE_TYPES
+    # Get extension without the dot
+    extension_with_dot = os.path.splitext(path)[-1]  # Ex: ".png"
+    if not extension_with_dot:
+        raise ValueError(f"URL does not have an extension: {url}")
+
+    extension = extension_with_dot[1:]  # Ex: "png"
+    return get_file_mime_type_from_extension(extension)
+

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -370,6 +370,7 @@ class ChatCompletionTextObject(
 
 class ChatCompletionImageUrlObject(TypedDict, total=False):
     url: Required[str]
+    mime_type: str
     detail: str
 
 

--- a/tests/local_testing/test_file_types.py
+++ b/tests/local_testing/test_file_types.py
@@ -7,6 +7,7 @@ from litellm.types.files import (
     get_file_extension_for_file_type,
     get_file_mime_type_for_file_type,
     get_file_mime_type_from_extension,
+    get_mime_type_from_url,
 )
 import pytest
 
@@ -52,3 +53,28 @@ class TestFileConsts:
         # Test that uppercase extensions return the correct MIME type
         assert get_file_mime_type_from_extension("AAC") == "audio/aac"
         assert get_file_mime_type_from_extension("PDF") == "application/pdf"
+
+    def test_get_mime_type_from_url(self):
+        """Test get_mime_type_from_url function for all supported file types"""
+        # Test each file type and its extensions
+        for file_type, extensions in FILE_EXTENSIONS.items():
+            mime_type = FILE_MIME_TYPES[file_type]
+            for ext in extensions:
+                # Test regular URL
+                assert get_mime_type_from_url(f"https://example.com/file.{ext}") == mime_type
+                # Test uppercase extension
+                assert get_mime_type_from_url(f"https://example.com/file.{ext.upper()}") == mime_type
+                # Test with query parameters
+                assert get_mime_type_from_url(f"https://example.com/file.{ext}?param=value") == mime_type
+                # Test with gs:// URL
+                assert get_mime_type_from_url(f"gs://example.com/file.{ext}?param=value") == mime_type
+
+        # Test error cases
+        with pytest.raises(ValueError):
+            get_mime_type_from_url("https://example.com/file.unknown")
+        with pytest.raises(ValueError):
+            get_mime_type_from_url("https://example.com/file")
+        with pytest.raises(ValueError):
+            get_mime_type_from_url("invalid_url")
+
+


### PR DESCRIPTION
## Title

### Improve mime-type handling of the Vertex AI attached files

## Explanation

Currently the library tries to guess the mime type by either file extension of the given URL or by Content-Type header that is returned when the URL is resolved. For the Google Storage URLs specifying the file extension is not mandatory and they cannot be publicly resolved. This PR allows the caller to provide a mime type as an argument and improves the mime-type resolution logic in case that it is not provided.

## Relevant issues

Fixes [#8809](https://github.com/BerriAI/litellm/issues/8809)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
🚄 Infrastructure
✅ Test

## Changes

<!-- List of changes -->
 - GEMINI_1_5_ACCEPTED_FILE_TYPES is moved out from common files.py file to vertex_ai/gemini/transformation.py
 - Additional file types that are supported by gemini are added to files.py
 - Added tests for all the types of supported URL schemes _process_gemini_image test case.
 
![Screenshot 2025-02-25 at 17 38 40](https://github.com/user-attachments/assets/846ea187-e710-4aec-97b1-fedc33d734a0)
![Screenshot 2025-02-25 at 17 40 20](https://github.com/user-attachments/assets/adcb4f0a-094a-48dc-be58-d9127faa30c4)


<!-- Test procedure -->

