### PR TITLE
feat(bedrock): add support for thinking output for sonnet 3.7 in chat completion

### DIFF
--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -839,6 +839,21 @@ def test_bedrock_claude_3_tool_calling():
         pass
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+        
+
+def test_bedrock_claude_3_7_thinking_output():
+    from litellm import completion
+
+    resp = completion(
+        model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    )
+
+    print(resp.choices[0].message)
+    assert resp.choices[0].message.thinking is not None
+    assert isinstance(resp.choices[0].message.thinking, list)
+    assert len(resp.choices[0].message.thinking) > 0
 
 
 def encode_image(image_path):


### PR DESCRIPTION
## Title

Added support for returning the thinking text and signature from Claude Sonnet 3.7 when called from Amazon Bedrock and added a test

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

- added support for returning the reasoning content of Claude 3.7 Sonnet as a "thinking" field in the response from Bedrock

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

I added ```test_bedrock_claude_3_7_thinking_output``` to test if the response contains the new thinking blocks


![image](https://github.com/user-attachments/assets/119bb88c-56f5-4857-bc55-917e4f09ffd5)
![image](https://github.com/user-attachments/assets/1a273fcd-e62b-41a2-ba37-9feca8a6dbd9)

