### PR TITLE
Add Logic to pass JSON Schema 'Description' params to Bedrock

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -162,6 +162,7 @@ class AmazonConverseConfig(BaseConfig):
         self,
         json_schema: Optional[dict] = None,
         schema_name: str = "json_tool_call",
+        schema_description: str = "",
     ) -> ChatCompletionToolParam:
         """
         Handles creating a tool call for getting responses in JSON format.
@@ -190,6 +191,8 @@ class AmazonConverseConfig(BaseConfig):
                 name=schema_name, parameters=_input_schema
             ),
         )
+        if schema_description != "":
+            _tool["function"]["description"] = schema_description
         return _tool
 
     def map_openai_params(
@@ -204,12 +207,14 @@ class AmazonConverseConfig(BaseConfig):
             if param == "response_format":
                 json_schema: Optional[dict] = None
                 schema_name: str = ""
+                schema_description: str = ""
                 if "response_schema" in value:
                     json_schema = value["response_schema"]
                     schema_name = "json_tool_call"
                 elif "json_schema" in value:
                     json_schema = value["json_schema"]["schema"]
                     schema_name = value["json_schema"]["name"]
+                    schema_description = value["json_schema"].get("description", "")
                 """
                 Follow similar approach to anthropic - translate to a single tool call. 
 
@@ -222,6 +227,7 @@ class AmazonConverseConfig(BaseConfig):
                 _tool = self._create_json_tool_call_for_response_format(
                     json_schema=json_schema,
                     schema_name=schema_name if schema_name != "" else "json_tool_call",
+                    schema_description=schema_description,
                 )
                 optional_params["tools"] = [_tool]
                 if litellm.utils.supports_tool_choice(


### PR DESCRIPTION
## Add logic to pass the 'description' parameter if provided.

For models like Amazon Nova, it is a key parameter as per [documentation](https://docs.aws.amazon.com/nova/latest/userguide/tool-use-definition.html): "The name, description, and the input schema must be explicit with the exact functionality of the tool."

At the moment, 'description, is not passed correctly; and if omitted is [mapped](https://github.com/BerriAI/litellm/blob/de8497309b930ff5cee1e168c26c181f477fdd9e/litellm/litellm_core_utils/prompt_templates/factory.py#L3254) to the 'name' of the schema.

This parameter could help resolve errors related to the error code: "An error occurred (ModelErrorException) when calling the Converse operation: The system encountered an unexpected error during processing. Try your request again."


## Type
🐛 Bug Fix




