### PR TITLE
fix default max_tokens param for anthropic provider

### DIFF
--- a/tests/llm_translation/test_max_completion_tokens.py
+++ b/tests/llm_translation/test_max_completion_tokens.py
@@ -134,6 +134,62 @@ async def test_anthropic_api_max_completion_tokens(model: str):
         }
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["anthropic/claude-3-sonnet-20240229", "anthropic/claude-3-7-sonnet-20250219"],
+)
+@pytest.mark.asyncio()
+async def test_anthropic_api_default_max_completion_tokens(model: str):
+    """
+    Tests that:
+    - max_completion_tokens is passed as max_tokens to anthropic models
+    """
+    litellm.set_verbose = True
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    mock_response = {
+        "content": [{"text": "Hi! My name is Claude.", "type": "text"}],
+        "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
+        "model": "claude-3-5-sonnet-20240620",
+        "role": "assistant",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "type": "message",
+        "usage": {"input_tokens": 2095, "output_tokens": 503},
+    }
+
+    client = HTTPHandler()
+
+    print("\n\nmock_response: ", mock_response)
+
+    # Test the case where max_completion_tokens is not passed
+    with patch.object(client, "post") as mock_client:
+        try:
+            response = await litellm.acompletion(
+                model=model,
+                messages=[{"role": "user", "content": "Hello!"}],
+                client=client,
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+        mock_client.assert_called_once()
+        request_body = mock_client.call_args.kwargs["json"]
+
+        print("request_body: ", request_body)
+
+        expected_max_token = 4096
+        if model == "anthropic/claude-3-7-sonnet-20250219":
+            expected_max_token = 8192
+
+        assert request_body == {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
+            ],
+            "max_tokens": expected_max_token,
+            "model": model.split("/")[-1],
+        }
+
+
 def test_all_model_configs():
     from litellm.llms.vertex_ai.vertex_ai_partner_models.ai21.transformation import (
         VertexAIAi21Config,


### PR DESCRIPTION
## Fix default max_tokens parameter for Anthropic provider

## Relevant issues

Fixes #8835

## Type

🐛 Bug Fix

## Testing

```
python -m pytest tests/llm_translation/test_max_completion_tokens.py
```

<img width="696" alt="image" src="https://github.com/user-attachments/assets/78898d08-0436-424b-b8ec-4203833c2837" />