### PR TITLE
Mitigate Event Loop Error with cache key including loop id

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -663,6 +663,11 @@ def get_async_httpx_client(
 
     Caches the new client and returns it.
     """
+    try:
+        current_loop = asyncio.get_running_loop()
+        loop_id = id(current_loop)
+    except RuntimeError:
+        loop_id = "no_loop"
     _params_key_name = ""
     if params is not None:
         for key, value in params.items():
@@ -671,7 +676,7 @@ def get_async_httpx_client(
             except Exception:
                 pass
 
-    _cache_key_name = "async_httpx_client" + _params_key_name + llm_provider
+    _cache_key_name = "async_httpx_client" + _params_key_name + llm_provider + f"_loop_{loop_id}"
     _cached_client = litellm.in_memory_llm_clients_cache.get_cache(_cache_key_name)
     if _cached_client:
         return _cached_client

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import time
-import weakref
 from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional, Union
 
 import httpx
@@ -654,83 +653,42 @@ class HTTPHandler:
             return None
 
 
-# Per-event-loop client cache to prevent event loop closed errors
-class AsyncClientCache:
-    def __init__(self):
-        # Use WeakKeyDictionary to allow loops to be garbage collected
-        self._clients = weakref.WeakKeyDictionary()
-    
-    def get_client(self, provider: str, params=None, loop=None):
-        """
-        Get or create a client for the specified event loop, provider, and params.
-        Uses loop-specific caching to prevent event loop closed errors.
-        
-        Args:
-            provider: The LLM provider identifier
-            params: Parameters to pass to AsyncHTTPHandler
-            loop: The event loop to use (gets current loop if None)
-            
-        Returns:
-            AsyncHTTPHandler instance specific to this loop and params
-        """
-        if loop is None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                # No running event loop, create a new client and return it without caching
-                return AsyncHTTPHandler(**(params or {}))
-                
-        # Initialize nested dict for this loop if needed
-        if loop not in self._clients:
-            self._clients[loop] = {}
-            
-        # Create a unique key for this provider + params combination
-        params_key = ""
-        if params is not None:
-            for key, value in params.items():
-                try:
-                    params_key += f"{key}_{value}"
-                except Exception:
-                    pass
-                    
-        cache_key = f"{provider}_{params_key}"
-        
-        # Create a new client if needed
-        if cache_key not in self._clients[loop]:
-            if params is not None:
-                self._clients[loop][cache_key] = AsyncHTTPHandler(**params)
-            else:
-                self._clients[loop][cache_key] = AsyncHTTPHandler(
-                    timeout=httpx.Timeout(timeout=600.0, connect=5.0)
-                )
-            
-        return self._clients[loop][cache_key]
-
-# Global cache instance
-_async_client_cache = AsyncClientCache()
-
 def get_async_httpx_client(
     llm_provider: Union[LlmProviders, httpxSpecialProvider],
     params: Optional[dict] = None,
 ) -> AsyncHTTPHandler:
     """
-    Retrieves the async HTTP client from the event-loop-aware cache.
-    If not present, creates a new client for the current event loop.
-    
-    This implementation uses per-event-loop caching to prevent "event loop closed"
-    errors that can occur in async environments.
+    Retrieves the async HTTP client from the cache
+    If not present, creates a new client
 
-    Args:
-        llm_provider: Provider identifier string
-        params: Parameters to pass to the AsyncHTTPHandler constructor
-        
-    Returns:
-        AsyncHTTPHandler: An HTTP client instance specific to the current event loop
+    Caches the new client and returns it.
     """
-    return _async_client_cache.get_client(
-        provider=str(llm_provider),
-        params=params
+    _params_key_name = ""
+    if params is not None:
+        for key, value in params.items():
+            try:
+                _params_key_name += f"{key}_{value}"
+            except Exception:
+                pass
+
+    _cache_key_name = "async_httpx_client" + _params_key_name + llm_provider
+    _cached_client = litellm.in_memory_llm_clients_cache.get_cache(_cache_key_name)
+    if _cached_client:
+        return _cached_client
+
+    if params is not None:
+        _new_client = AsyncHTTPHandler(**params)
+    else:
+        _new_client = AsyncHTTPHandler(
+            timeout=httpx.Timeout(timeout=600.0, connect=5.0)
+        )
+
+    litellm.in_memory_llm_clients_cache.set_cache(
+        key=_cache_key_name,
+        value=_new_client,
+        ttl=_DEFAULT_TTL_FOR_HTTPX_CLIENTS,
     )
+    return _new_client
 
 
 def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -69,7 +69,6 @@ from .transformation import (
     sync_transform_request_body,
 )
 
-
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
@@ -834,7 +833,6 @@ async def make_call(
     if client is None:
         client = get_async_httpx_client(
             llm_provider=litellm.LlmProviders.VERTEX_AI,
-            params={"timeout": httpx.Timeout(timeout=600.0, connect=5.0)}
         )
 
     try:
@@ -1060,11 +1058,9 @@ class VertexLLM(VertexBase):
         _async_client_params = {}
         if timeout:
             _async_client_params["timeout"] = timeout
-        
         if client is None or not isinstance(client, AsyncHTTPHandler):
             client = get_async_httpx_client(
-                params=_async_client_params, 
-                llm_provider=litellm.LlmProviders.VERTEX_AI
+                params=_async_client_params, llm_provider=litellm.LlmProviders.VERTEX_AI
             )
         else:
             client = client  # type: ignore

--- a/tests/local_testing/test_ollama.py
+++ b/tests/local_testing/test_ollama.py
@@ -228,9 +228,14 @@ async def test_async_ollama_ssl_verify(stream):
     except Exception as e:
         print(e)
 
-    client: AsyncHTTPHandler = litellm.in_memory_llm_clients_cache.get_cache(
-        "async_httpx_clientssl_verify_Falseollama"
-    )
+    try:
+        current_loop = asyncio.get_running_loop()
+        loop_id = id(current_loop)
+    except RuntimeError:
+        loop_id = "no_loop"
+    
+    cache_key = f"async_httpx_clientssl_verify_Falseollama_loop_{loop_id}"
+    client: AsyncHTTPHandler = litellm.in_memory_llm_clients_cache.get_cache(cache_key)
 
     test_client = httpx.AsyncClient(verify=False)
     print(client)


### PR DESCRIPTION
Add event loop ID to async HTTP client cache keys to prevent potential conflicts and improve client management across different event loops. This change ensures more robust client caching by incorporating the current event loop's unique identifier into the cache key.

Signed-off-by: Hankyeol Kyung <kghnkl0103@gmail.com>

## Title
Mitigate Event Loop Error with cache key including loop id
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
#8480 changes cache key logic a lot, revert it and just add loop id in current cache key.
<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

