### PR TITLE
fix(rerank): properly use LiteLLM api key when reranking through proxy

### DIFF
--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -187,7 +187,7 @@ def rerank(  # noqa: PLR0915
                 optional_rerank_params=optional_rerank_params,
                 logging_obj=litellm_logging_obj,
                 timeout=optional_params.timeout,
-                api_key=dynamic_api_key or optional_params.api_key,
+                api_key=api_key,
                 api_base=api_base,
                 _is_async=_is_async,
                 headers=headers or litellm.headers or {},


### PR DESCRIPTION
`litellm.api_key` wasn't used as an option when calling the rerank API. As a result, using rerank with custom_llm_provider="litellm_proxy" always resulted in the following error:
Cohere API key is required. Please set 'COHERE_API_KEY' or 'CO_API_KEY' or 'litellm.cohere_key'

## Title

Properly configure API key for proxy rerank

## Relevant issues

Fixes #8077 on top of https://github.com/BerriAI/litellm/pull/8815
<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes



## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->
I wasn't able to run the tests locally
