### PR TITLE
(Bug Fix) - Accurate token counting for `/anthropic/` API Routes on LiteLLM Proxy 

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -810,9 +810,7 @@ class ModelResponseIterator:
         except ValueError as e:
             raise RuntimeError(f"Error parsing chunk: {e},\nReceived chunk: {chunk}")
 
-    def convert_str_chunk_to_generic_chunk(
-        self, chunk: str
-    ) -> Union[GenericStreamingChunk, ModelResponseStream]:
+    def convert_str_chunk_to_generic_chunk(self, chunk: str) -> ModelResponseStream:
         """
         Convert a string chunk to a GenericStreamingChunk
 
@@ -832,11 +830,4 @@ class ModelResponseIterator:
             data_json = json.loads(str_line[5:])
             return self.chunk_parser(chunk=data_json)
         else:
-            return GenericStreamingChunk(
-                text="",
-                is_finished=False,
-                finish_reason="",
-                usage=None,
-                index=0,
-                tool_use=None,
-            )
+            return ModelResponseStream()

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -7,9 +7,6 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.litellm_logging import (
-    get_standard_logging_object_payload,
-)
 from litellm.llms.anthropic.chat.handler import (
     ModelResponseIterator as AnthropicModelResponseIterator,
 )

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -116,22 +116,11 @@ class AnthropicPassthroughLoggingHandler:
                         {"proxy_server_request": {"body": {"user": user}}}
                     )
 
-            # Make standard logging object for Anthropic
-            standard_logging_object = get_standard_logging_object_payload(
-                kwargs=kwargs,
-                init_response_obj=litellm_model_response,
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=logging_obj,
-                status="success",
-            )
-
             # pretty print standard logging object
             verbose_proxy_logger.debug(
-                "standard_logging_object= %s",
-                json.dumps(standard_logging_object, indent=4),
+                "kwargs= %s",
+                json.dumps(kwargs, indent=4, default=str),
             )
-            kwargs["standard_logging_object"] = standard_logging_object
 
             # set litellm_call_id to logging response object
             litellm_model_response.id = logging_obj.litellm_call_id

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -205,14 +205,16 @@ class AnthropicPassthroughLoggingHandler:
         all_openai_chunks = []
         for _chunk_str in all_chunks:
             try:
-                generic_chunk = anthropic_model_response_iterator.convert_str_chunk_to_generic_chunk(
+                transformed_openai_chunk = anthropic_model_response_iterator.convert_str_chunk_to_generic_chunk(
                     chunk=_chunk_str
                 )
-                litellm_chunk = litellm_custom_stream_wrapper.chunk_creator(
-                    chunk=generic_chunk
+                if transformed_openai_chunk is not None:
+                    all_openai_chunks.append(transformed_openai_chunk)
+
+                verbose_proxy_logger.debug(
+                    "all openai chunks= %s",
+                    json.dumps(all_openai_chunks, indent=4, default=str),
                 )
-                if litellm_chunk is not None:
-                    all_openai_chunks.append(litellm_chunk)
             except (StopIteration, StopAsyncIteration):
                 break
         complete_streaming_response = litellm.stream_chunk_builder(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -196,12 +196,6 @@ class AnthropicPassthroughLoggingHandler:
             streaming_response=None,
             sync_stream=False,
         )
-        litellm_custom_stream_wrapper = litellm.CustomStreamWrapper(
-            completion_stream=anthropic_model_response_iterator,
-            model=model,
-            logging_obj=litellm_logging_obj,
-            custom_llm_provider="anthropic",
-        )
         all_openai_chunks = []
         for _chunk_str in all_chunks:
             try:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -236,21 +236,8 @@ class VertexPassthroughLoggingHandler:
         kwargs["response_cost"] = response_cost
         kwargs["model"] = model
 
-        # Make standard logging object for Vertex AI
-        standard_logging_object = get_standard_logging_object_payload(
-            kwargs=kwargs,
-            init_response_obj=litellm_model_response,
-            start_time=start_time,
-            end_time=end_time,
-            logging_obj=logging_obj,
-            status="success",
-        )
-
         # pretty print standard logging object
-        verbose_proxy_logger.debug(
-            "standard_logging_object= %s", json.dumps(standard_logging_object, indent=4)
-        )
-        kwargs["standard_logging_object"] = standard_logging_object
+        verbose_proxy_logger.debug("kwargs= %s", json.dumps(kwargs, indent=4))
 
         # set litellm_call_id to logging response object
         litellm_model_response.id = logging_obj.litellm_call_id

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -8,9 +8,6 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.litellm_logging import (
-    get_standard_logging_object_payload,
-)
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as VertexModelResponseIterator,
 )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -4,9 +4,9 @@ import json
 from base64 import b64encode
 from datetime import datetime
 from typing import List, Optional
+from urllib.parse import urlparse
 
 import httpx
-from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 
@@ -26,6 +26,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.custom_http import httpxSpecialProvider
+from litellm.types.utils import StandardLoggingUserAPIKeyMetadata
 
 from .streaming_handler import PassThroughStreamingHandler
 from .success_handler import PassThroughEndpointLogging
@@ -607,12 +608,19 @@ def _init_kwargs_for_pass_through_endpoint(
 ) -> dict:
     _parsed_body = _parsed_body or {}
     _litellm_metadata: Optional[dict] = _parsed_body.pop("litellm_metadata", None)
-    _metadata = {
-        "user_api_key": user_api_key_dict.api_key,
-        "user_api_key_user_id": user_api_key_dict.user_id,
-        "user_api_key_team_id": user_api_key_dict.team_id,
-        "user_api_key_end_user_id": user_api_key_dict.end_user_id,
-    }
+    _metadata = dict(
+        StandardLoggingUserAPIKeyMetadata(
+            user_api_key_hash=user_api_key_dict.api_key,
+            user_api_key_alias=user_api_key_dict.key_alias,
+            user_api_key_user_email=user_api_key_dict.user_email,
+            user_api_key_user_id=user_api_key_dict.user_id,
+            user_api_key_team_id=user_api_key_dict.team_id,
+            user_api_key_org_id=user_api_key_dict.org_id,
+            user_api_key_team_alias=user_api_key_dict.team_alias,
+            user_api_key_end_user_id=user_api_key_dict.end_user_id,
+        )
+    )
+    _metadata["user_api_key"] = user_api_key_dict.token
     if _litellm_metadata:
         _metadata.update(_litellm_metadata)
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -620,7 +620,7 @@ def _init_kwargs_for_pass_through_endpoint(
             user_api_key_end_user_id=user_api_key_dict.end_user_id,
         )
     )
-    _metadata["user_api_key"] = user_api_key_dict.token
+    _metadata["user_api_key"] = user_api_key_dict.api_key
     if _litellm_metadata:
         _metadata.update(_litellm_metadata)
 

--- a/tests/logging_callback_tests/test_token_counting.py
+++ b/tests/logging_callback_tests/test_token_counting.py
@@ -157,3 +157,90 @@ async def test_stream_token_counting_with_redaction():
         actual_usage.completion_tokens == custom_logger.recorded_usage.completion_tokens
     )
     assert actual_usage.total_tokens == custom_logger.recorded_usage.total_tokens
+
+
+@pytest.mark.asyncio
+async def test_stream_token_counting_anthropic_with_include_usage():
+    """ """
+    from anthropic import Anthropic
+
+    anthropic_client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    litellm._turn_on_debug()
+
+    custom_logger = TestCustomLogger()
+    litellm.logging_callback_manager.add_litellm_callback(custom_logger)
+
+    input_text = "Respond in just 1 word. Say ping"
+
+    response = await litellm.acompletion(
+        model="claude-3-5-sonnet-20240620",
+        messages=[{"role": "user", "content": input_text}],
+        max_tokens=4096,
+        stream=True,
+    )
+
+    actual_usage = None
+    output_text = ""
+    async for chunk in response:
+        output_text += chunk["choices"][0]["delta"]["content"] or ""
+        pass
+
+    await asyncio.sleep(1)
+
+    print("\n\n\n\n\n")
+    print(
+        "recorded_usage",
+        json.dumps(custom_logger.recorded_usage, indent=4, default=str),
+    )
+    print("\n\n\n\n\n")
+
+    # print making the same request with anthropic client
+    anthropic_response = anthropic_client.messages.create(
+        model="claude-3-5-sonnet-20240620",
+        max_tokens=4096,
+        messages=[{"role": "user", "content": input_text}],
+        stream=True,
+    )
+    usage = None
+    all_anthropic_usage_chunks = []
+    for chunk in anthropic_response:
+        print("chunk", json.dumps(chunk, indent=4, default=str))
+        if hasattr(chunk, "message"):
+            if chunk.message.usage:
+                print(
+                    "USAGE BLOCK",
+                    json.dumps(chunk.message.usage, indent=4, default=str),
+                )
+                all_anthropic_usage_chunks.append(chunk.message.usage)
+        elif hasattr(chunk, "usage"):
+            print("USAGE BLOCK", json.dumps(chunk.usage, indent=4, default=str))
+            all_anthropic_usage_chunks.append(chunk.usage)
+
+    print(
+        "all_anthropic_usage_chunks",
+        json.dumps(all_anthropic_usage_chunks, indent=4, default=str),
+    )
+
+    input_tokens_anthropic_api = sum(
+        [getattr(usage, "input_tokens", 0) for usage in all_anthropic_usage_chunks]
+    )
+    output_tokens_anthropic_api = sum(
+        [getattr(usage, "output_tokens", 0) for usage in all_anthropic_usage_chunks]
+    )
+    print("input_tokens_anthropic_api", input_tokens_anthropic_api)
+    print("output_tokens_anthropic_api", output_tokens_anthropic_api)
+
+    print("input_tokens_litellm", custom_logger.recorded_usage.prompt_tokens)
+    print("output_tokens_litellm", custom_logger.recorded_usage.completion_tokens)
+
+    ## Assert Accuracy of token counting
+    # input tokens should be exactly the same
+    assert input_tokens_anthropic_api == custom_logger.recorded_usage.prompt_tokens
+
+    # output tokens can have at max abs diff of 10. We can't guarantee the response from two api calls will be exactly the same
+    assert (
+        abs(
+            output_tokens_anthropic_api - custom_logger.recorded_usage.completion_tokens
+        )
+        <= 10
+    )

--- a/tests/pass_through_tests/test_anthropic_passthrough.py
+++ b/tests/pass_through_tests/test_anthropic_passthrough.py
@@ -207,9 +207,30 @@ async def test_anthropic_streaming_with_headers():
                         collected_output.append(text[6:])  # Remove 'data: ' prefix
 
             print("Collected output:", "".join(collected_output))
+            anthropic_api_usage_chunks = []
+            for chunk in collected_output:
+                chunk_json = json.loads(chunk)
+                if "usage" in chunk_json:
+                    anthropic_api_usage_chunks.append(chunk_json["usage"])
+                elif "message" in chunk_json and "usage" in chunk_json["message"]:
+                    anthropic_api_usage_chunks.append(chunk_json["message"]["usage"])
+
+            print(
+                "anthropic_api_usage_chunks",
+                json.dumps(anthropic_api_usage_chunks, indent=4, default=str),
+            )
+
+            anthropic_api_input_tokens = sum(
+                [usage.get("input_tokens", 0) for usage in anthropic_api_usage_chunks]
+            )
+            anthropic_api_output_tokens = max(
+                [usage.get("output_tokens", 0) for usage in anthropic_api_usage_chunks]
+            )
+            print("anthropic_api_input_tokens", anthropic_api_input_tokens)
+            print("anthropic_api_output_tokens", anthropic_api_output_tokens)
 
             # Wait for spend to be logged
-            await asyncio.sleep(20)
+            await asyncio.sleep(10)
 
             # Check spend logs for this specific request
             async with session.get(
@@ -246,8 +267,11 @@ async def test_anthropic_streaming_with_headers():
                 ), "Spend should be a number"
                 assert log_entry["total_tokens"] > 0, "Should have some tokens"
                 assert (
-                    log_entry["completion_tokens"] > 0
-                ), "Should have completion tokens"
+                    log_entry["prompt_tokens"] == anthropic_api_input_tokens
+                ), f"Should have prompt tokens matching anthropic api. Expected {anthropic_api_input_tokens} but got {log_entry['prompt_tokens']}"
+                assert (
+                    log_entry["completion_tokens"] == anthropic_api_output_tokens
+                ), f"Should have completion tokens matching anthropic api. Expected {anthropic_api_output_tokens} but got {log_entry['completion_tokens']}"
                 assert (
                     log_entry["total_tokens"]
                     == log_entry["prompt_tokens"] + log_entry["completion_tokens"]

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -124,10 +124,16 @@ def test_init_kwargs_for_pass_through_endpoint_basic(
     # Check metadata
     expected_metadata = {
         "user_api_key": "test-key",
+        "user_api_key_hash": "test-key",
+        "user_api_key_alias": None,
+        "user_api_key_user_email": None,
         "user_api_key_user_id": "test-user",
         "user_api_key_team_id": "test-team",
+        "user_api_key_org_id": None,
+        "user_api_key_team_alias": None,
         "user_api_key_end_user_id": "test-user",
     }
+
     assert result["litellm_params"]["metadata"] == expected_metadata
 
 

--- a/tests/pass_through_unit_tests/test_unit_test_anthropic_pass_through.py
+++ b/tests/pass_through_unit_tests/test_unit_test_anthropic_pass_through.py
@@ -353,6 +353,7 @@ def test_handle_logging_anthropic_collected_chunks(all_chunks):
     )
 
     assert isinstance(result["result"], ModelResponse)
+    print("result=", json.dumps(result, indent=4, default=str))
 
 
 def test_build_complete_streaming_response(all_chunks):
@@ -370,3 +371,6 @@ def test_build_complete_streaming_response(all_chunks):
     )
 
     assert isinstance(result, ModelResponse)
+    assert result.usage.prompt_tokens == 17
+    assert result.usage.completion_tokens == 249
+    assert result.usage.total_tokens == 266

--- a/tests/pass_through_unit_tests/test_unit_test_anthropic_pass_through.py
+++ b/tests/pass_through_unit_tests/test_unit_test_anthropic_pass_through.py
@@ -200,11 +200,6 @@ def test_create_anthropic_response_logging_payload(mock_logging_obj, metadata_pa
     assert isinstance(result, dict)
     assert "model" in result
     assert "response_cost" in result
-    assert "standard_logging_object" in result
-    if metadata_params:
-        assert "test" == result["standard_logging_object"]["end_user"]
-    else:
-        assert "" == result["standard_logging_object"]["end_user"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## (Bug Fix) - Accurate token counting for `/anthropic/` API Routes on LiteLLM Proxy 

## Issues this PR fixes
- Anthropic streaming prompt tokens for `/anthropic/` routes was not being tracked accurately. When sending a large request we'd see 0-10 tokens counted, but Anthropic reported a 200 token usage

Following assertions were added:
- Ensure litellm python SDK usage == usage from anthropic API streaming + non streaming 
- Ensure `/anthropic/` route stream + non stream matches exactly reported usage from Anthropic API 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

