### PR TITLE
Upgrade prisma-client to v0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ uvloop==0.21.0 # uvicorn dep, gives us much better performance under load
 boto3==1.34.34 # aws bedrock/sagemaker calls
 redis==5.0.0 # caching
 numpy==2.1.1 # semantic caching
-prisma==0.11.0 # for db
+prisma==0.15.0 # for db
 mangum==0.17.0 # for aws lambda functions
 pynacl==1.5.0 # for encrypting keys
 google-cloud-aiplatform==1.47.0 # for vertex ai calls


### PR DESCRIPTION
## Title

The update to Prisma v0.15.0 appears to be compatible. However, I strongly recommend conducting thorough testing of litellm before merging this change.

## Relevant issues

Fixes #8918

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Update pridma python package to v0.15.0

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally


