### PR TITLE
(bug fix) - don't log messages, prompt, input in `model_parameters`  in StandardLoggingPayload

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1963,3 +1963,14 @@ class ProviderSpecificHeader(TypedDict):
 class SelectTokenizerResponse(TypedDict):
     type: Literal["openai_tokenizer", "huggingface_tokenizer"]
     tokenizer: Any
+
+
+class FieldsWithMessageContent(str, Enum):
+    MESSAGES = "messages"
+    INPUT = "input"
+    PROMPT = "prompt"
+    QUERY = "query"
+
+    @classmethod
+    def get_all_fields(cls) -> List[str]:
+        return [field.value for field in cls]

--- a/tests/litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/litellm/litellm_core_utils/test_litellm_logging.py
@@ -5,11 +5,11 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
-
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
+
+from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
 
 def test_remove_message_content_from_dict():
@@ -58,3 +58,47 @@ def test_get_model_parameters():
 
     result = StandardLoggingPayloadSetup._get_model_parameters(kwargs)
     assert result == expected_output
+
+
+def test_get_model_parameters_complex():
+    # Test with more complex optional parameters
+    kwargs = {
+        "optional_params": {
+            "temperature": 0.8,
+            "messages": [{"role": "user", "content": "sensitive"}],
+            "max_tokens": 100,
+            "stop": ["\n", "stop"],
+            "presence_penalty": 0.5,
+            "frequency_penalty": 0.3,
+            "prompt": "secret prompt",
+            "n": 1,
+            "best_of": 2,
+            "logit_bias": {"50256": -100},
+        }
+    }
+
+    expected_output = {
+        "temperature": 0.8,
+        "max_tokens": 100,
+        "stop": ["\n", "stop"],
+        "presence_penalty": 0.5,
+        "frequency_penalty": 0.3,
+        "n": 1,
+        "best_of": 2,
+        "logit_bias": {"50256": -100},
+    }
+
+    result = StandardLoggingPayloadSetup._get_model_parameters(kwargs)
+    assert result == expected_output
+
+
+def test_get_model_parameters_empty_optional_params():
+    # Test with empty optional_params dictionary
+    kwargs = {"optional_params": {}}
+    assert StandardLoggingPayloadSetup._get_model_parameters(kwargs) == {}
+
+
+def test_get_model_parameters_missing_optional_params():
+    # Test with missing optional_params key
+    kwargs = {"model": "gpt-4", "api_key": "test"}
+    assert StandardLoggingPayloadSetup._get_model_parameters(kwargs) == {}

--- a/tests/litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,0 +1,60 @@
+import json
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+
+def test_remove_message_content_from_dict():
+    # Test with None input
+    assert StandardLoggingPayloadSetup._remove_message_content_from_dict(None) == {}
+
+    # Test with empty dict
+    assert StandardLoggingPayloadSetup._remove_message_content_from_dict({}) == {}
+
+    # Test with sensitive content
+    input_dict = {
+        "messages": "sensitive content",
+        "input": "secret prompt",
+        "prompt": "confidential text",
+        "safe_key": "safe value",
+        "temperature": 0.7,
+    }
+
+    expected_output = {"safe_key": "safe value", "temperature": 0.7}
+
+    result = StandardLoggingPayloadSetup._remove_message_content_from_dict(input_dict)
+    assert result == expected_output
+
+
+def test_get_model_parameters():
+    # Test with empty kwargs
+    assert StandardLoggingPayloadSetup._get_model_parameters({}) == {}
+
+    # Test with None optional_params
+    assert (
+        StandardLoggingPayloadSetup._get_model_parameters({"optional_params": None})
+        == {}
+    )
+
+    # Test with actual parameters
+    kwargs = {
+        "optional_params": {
+            "temperature": 0.8,
+            "messages": "sensitive data",
+            "max_tokens": 100,
+            "prompt": "secret prompt",
+        }
+    }
+
+    expected_output = {"temperature": 0.8, "max_tokens": 100}
+
+    result = StandardLoggingPayloadSetup._get_model_parameters(kwargs)
+    assert result == expected_output


### PR DESCRIPTION
## (bug fix) - don't log messages, prompt, input in `model_parameters`  in StandardLoggingPayload

Details
- `messages` was getting logged under `model_parameters` within StandardLoggingPayload
- this was unexpected behavior and is patched in this PR
- subsequent work will be done to prevent this and address the root cause of the issue 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

