### PR TITLE
(bug fix - patch) - don't overwrite litellm.anthropic_models when running auth checks

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,5 +1,6 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
+import copy
 from typing import Dict, List, Optional, Set
 
 import litellm
@@ -30,7 +31,7 @@ def get_provider_models(provider: str) -> Optional[List[str]]:
         return get_valid_models()
 
     if provider in litellm.models_by_provider:
-        provider_models = litellm.models_by_provider[provider]
+        provider_models = copy.deepcopy(litellm.models_by_provider[provider])
         for idx, _model in enumerate(provider_models):
             if provider not in _model:
                 provider_models[idx] = f"{provider}/{_model}"


### PR DESCRIPTION
## (bug fix - patch) - don't overwrite litellm.anthropic_models when running auth checks

## Details 
This is a patch, litellm.anthropic_models["claude-3-5-sonnet-20241022"] was getting overwritten to litellm.anthropic_models["anthropic/claude-3-5-sonnet-20241022"] when a specific auth check was running for wildcard models 

This is only a patch and a subsequent PR with a root cause fix + testing will be done 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

