### PR TITLE
Fix error of "Too little data for declared Content-Length" when invoking Sagemaker compeletion

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -433,6 +433,10 @@ class SagemakerLLM(BaseAWSLLM):
             "messages": messages,
         }
         prepared_request = await asyncified_prepare_request(**prepared_request_args)
+        if model_id is not None:  # Fixes https://github.com/BerriAI/litellm/issues/8889
+            prepared_request.headers.update(
+                {"X-Amzn-SageMaker-Inference-Component": model_id}
+            )
         completion_stream = await self.make_async_call(
             api_base=prepared_request.url,
             headers=prepared_request.headers,  # type: ignore

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -213,7 +213,7 @@ class SagemakerLLM(BaseAWSLLM):
                 sync_response = sync_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=data,
+                    data=json.dumps(data),
                     stream=stream,
                 )
 
@@ -308,7 +308,7 @@ class SagemakerLLM(BaseAWSLLM):
                 sync_response = sync_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=_data,
+                    data=json.dumps(_data),
                     timeout=timeout,
                 )
 
@@ -368,7 +368,7 @@ class SagemakerLLM(BaseAWSLLM):
             response = await client.post(
                 api_base,
                 headers=headers,
-                json=data,
+                data=json.dumps(data),
                 stream=True,
             )
 
@@ -433,10 +433,6 @@ class SagemakerLLM(BaseAWSLLM):
             "messages": messages,
         }
         prepared_request = await asyncified_prepare_request(**prepared_request_args)
-        if model_id is not None:  # Fixes https://github.com/BerriAI/litellm/issues/8889
-            prepared_request.headers.update(
-                {"X-Amzn-SageMaker-Inference-Component": model_id}
-            )
         completion_stream = await self.make_async_call(
             api_base=prepared_request.url,
             headers=prepared_request.headers,  # type: ignore
@@ -522,7 +518,7 @@ class SagemakerLLM(BaseAWSLLM):
                 response = await async_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=data,
+                    data=json.dumps(data),
                     timeout=timeout,
                 )
 


### PR DESCRIPTION
## Title

Fix error of "Too little data for declared Content-Length" when invoking Sagemaker completion

## Relevant issues

When invoking Sagemaker in completion mode, there is error of "Too little data for declared Content-Length" as below.

"""
LiteLLM:DEBUG: litellm_logging.py:637 - 

POST Request Sent from LiteLLM:
curl -X POST \
https://runtime.sagemaker.us-east-1.amazonaws.com/endpoints/*-meta-textgeneration-l-20250228-051448/invocations \
-H 'Content-Type: *' -H 'X-Amz-Date: *****' -H 'Authorization: AWS4-HMAC-SHA256 Credential=*******/20250228/us-east-1/sagemaker/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=be6739fdd5b4b6854aa8********************************************' -H 'Content-Length: *' \
-d '{'parameters': {}, 'inputs': 'Hello, how are you?'}'

17:30:31 - LiteLLM:DEBUG: utils.py:304 - RAW RESPONSE:
Too little data for declared Content-Length
"""

## Type

🐛 Bug Fix


## Changes

Change parameters of http post from json=_data to data=json.dumps(_data) in the handler.py 

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes
![litellm-bugfix](https://github.com/user-attachments/assets/fa91cedb-4201-41a8-8590-008c44327ba8)


