### PR TITLE
build: Add Makefile for LiteLLM project with test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# LiteLLM Makefile
+# Simple Makefile for running tests and basic development tasks
+
+.PHONY: help test test-unit test-integration
+
+# Default target
+help:
+	@echo "Available commands:"
+	@echo "  make test               - Run all tests"
+	@echo "  make test-unit          - Run unit tests"
+	@echo "  make test-integration   - Run integration tests"
+
+# Testing
+test:
+	poetry run pytest tests/
+
+test-unit:
+	poetry run pytest tests/litellm/
+
+test-integration:
+	poetry run pytest tests/ -k "not litellm" 


### PR DESCRIPTION
## Type

🚄 Infrastructure

## Changes

- Added a Makefile to simplify common development tasks
- Implemented test targets for running all tests, unit tests, and integration tests
- Added help command with documentation of available targets
- Used poetry for running tests to maintain consistency with project's package management

## Testing
> *No new tests or tested features introduced*

The Makefile has been tested locally and all commands work as expected:
- `make help` displays available commands
- `make test` runs all tests
- `make test-unit` runs only unit tests in tests/litellm/
- `make test-integration` runs all tests except those in tests/litellm/
