### PR TITLE
Fix `data:` being stripped from OpenRouter responses.

### DIFF
--- a/litellm/llms/databricks/streaming_utils.py
+++ b/litellm/llms/databricks/streaming_utils.py
@@ -89,7 +89,8 @@ class ModelResponseIterator:
             raise RuntimeError(f"Error receiving chunk from stream: {e}")
 
         try:
-            chunk = chunk.replace("data:", "")
+            if chunk.startswith("data:"):
+                chunk = chunk[5:]
             chunk = chunk.strip()
             if len(chunk) > 0:
                 json_chunk = json.loads(chunk)
@@ -134,7 +135,8 @@ class ModelResponseIterator:
             raise RuntimeError(f"Error receiving chunk from stream: {e}")
 
         try:
-            chunk = chunk.replace("data:", "")
+            if chunk.startswith("data:"):
+                chunk = chunk[5:]
             chunk = chunk.strip()
             if chunk == "[DONE]":
                 raise StopAsyncIteration


### PR DESCRIPTION
## Title

Don't string replace "`data:`" on the whole LLM response!

## Relevant issues

Doesn't fix #8143 because that's another file, but it's the same bug. I'll make a PR for that one separately.

## Type

🐛 Bug Fix

## Changes

Instead of string replacing `"data:"`, only remove it at the start of the line.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

Repro: 

1. Tell the LLM to say `"data:"`.
2. Get `"data:"` out instead of an empty string.

I'm not adding a unittest for this because this bug should never have existed in the first place.

But here's a screenshot with aider.

Before:

![Screenshot_20250304_164143](https://github.com/user-attachments/assets/5af922e3-813e-4fdf-8794-1b64cb3d3522)

After:

![Screenshot_20250304_164100](https://github.com/user-attachments/assets/e45e39ca-f1a6-42bb-9a65-d102c8759823)

