### PR TITLE
fix completion_start_time for streaming response

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1032,6 +1032,13 @@ class Logging(LiteLLMLoggingBaseClass):
         except Exception as e:
             raise Exception(f"[Non-Blocking] LiteLLM.Success_Call Error: {str(e)}")
 
+    def chunk_handler(self, chunk: Any):
+        if self.completion_start_time is None:
+            self.completion_start_time = datetime.datetime.now()
+            self.model_call_details["completion_start_time"] = (
+                self.completion_start_time
+            )
+
     def success_handler(  # noqa: PLR0915
         self, result=None, start_time=None, end_time=None, cache_hit=None, **kwargs
     ):

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1634,6 +1634,8 @@ class CustomStreamWrapper:
                     if processed_chunk is None:
                         continue
 
+                    self.logging_obj.chunk_handler(processed_chunk)
+
                     if self.logging_obj._llm_caching_handler is not None:
                         asyncio.create_task(
                             self.logging_obj._llm_caching_handler._add_streaming_response_to_cache(
@@ -1684,6 +1686,8 @@ class CustomStreamWrapper:
                         )
                         if processed_chunk is None:
                             continue
+
+                        self.logging_obj.chunk_handler(processed_chunk)
 
                         choice = processed_chunk.choices[0]
                         if isinstance(choice, StreamingChoices):


### PR DESCRIPTION
## fix completion_start_time for streaming response

Fix the completion_start_time logging issue as described on issue #8999  

## Relevant issues

#8999

## Type

🐛 Bug Fix
