### PR TITLE
add: Allow auth extra_headers to be set via .env

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -322,6 +322,7 @@ router_settings:
 | AWS_SECRET_ACCESS_KEY | Secret Access Key for AWS services
 | AWS_SESSION_NAME | Name for AWS session
 | AWS_WEB_IDENTITY_TOKEN | Web identity token for AWS
+| AWS_EXTRA_HEADERS_AUTH_BEARER_TOKEN | Bearer token for custom API endpoints
 | AZURE_API_VERSION | Version of the Azure API being used
 | AZURE_AUTHORITY_HOST | Azure authority host URL
 | AZURE_CLIENT_ID | Client ID for Azure services

--- a/tests/litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/litellm/llms/bedrock/test_base_aws_llm.py
@@ -98,3 +98,28 @@ def test_auth_functions_tracer_wrapping():
             assert (
                 has_tracer_wrap
             ), f"Auth function on line {line_number} is not wrapped with @tracer.wrap: {line.strip()}"
+
+
+def test_loading_bearer_token_from_env():
+    aws_region_name = "us"
+    endpoint_url = f"https://bedrock-runtime.{aws_region_name}.amazonaws.com"
+    data = ""
+    headers = {}
+
+    os.environ['AWS_SECRET_ACCESS_KEY'] = "fake_aws_secret_access_key"
+    os.environ['AWS_ACCESS_KEY_ID'] = "fake_aws_access_key_id"
+
+    extra_headers = {}
+    base_aws_llm = BaseAWSLLM()
+    credentials = base_aws_llm.get_credentials()
+    aws_prep_req = base_aws_llm.get_request_headers(credentials, aws_region_name, extra_headers, endpoint_url, data, headers)
+    assert 'Authorization' in aws_prep_req.headers.keys()
+    assert 'Bearer' not in aws_prep_req.headers["Authorization"]
+
+    os.environ['AWS_EXTRA_HEADERS_AUTH_BEARER_TOKEN'] = "fake_token"
+    extra_headers = {}
+    base_aws_llm = BaseAWSLLM()
+    credentials = base_aws_llm.get_credentials()
+    aws_prep_req = base_aws_llm.get_request_headers(credentials, aws_region_name, extra_headers, endpoint_url, data, headers)
+    assert 'Authorization' in aws_prep_req.headers.keys()
+    assert aws_prep_req.headers['Authorization'] == "Bearer fake_token"


### PR DESCRIPTION
## Title

Allow auth `extra_headers` to be set via environment variables

## Relevant issues

Related issue: https://github.com/BerriAI/litellm/issues/8085

## Type

🆕 New Feature
✅ Test

## Changes

Load `Authorization` header from environment variables when available.

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
```
Documents/Projects/litellm ‹main› » pytest tests/litellm/llms/bedrock/test_base_aws_llm.py       
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.3, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/gkaretka/Documents/Projects/litellm
plugins: ddtrace-2.19.0, anyio-4.4.0, mock-3.14.0
collected 3 items                                                                                                                                                        

tests/litellm/llms/bedrock/test_base_aws_llm.py ...     
```

<!-- Test procedure -->

