### PR TITLE
Fix redis cluster mode for routers

### DIFF
--- a/tests/local_testing/test_router_caching.py
+++ b/tests/local_testing/test_router_caching.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 import traceback
+from unittest.mock import patch
 
 import pytest
 
@@ -13,6 +14,8 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 from litellm import Router
+from litellm.caching import RedisCache, RedisClusterCache
+
 
 ## Scenarios
 ## 1. 2 models - openai + azure - 1 model group "gpt-3.5-turbo",
@@ -322,3 +325,36 @@ async def test_acompletion_caching_on_router_caching_groups():
     except Exception as e:
         traceback.print_exc()
         pytest.fail(f"Error occurred: {e}")
+
+
+@pytest.mark.parametrize(
+    "startup_nodes, expected_cache_type",
+    [
+        pytest.param(
+            [dict(host="node1.localhost", port=6379)],
+            RedisClusterCache,
+            id="Expects a RedisClusterCache instance when startup_nodes provided",
+        ),
+        pytest.param(
+            None,
+            RedisCache,
+            id="Expects a RedisCache instance when there is no startup nodes",
+        ),
+    ],
+)
+def test_create_correct_redis_cache_instance(
+    startup_nodes: list[dict] | None,
+    expected_cache_type: type[RedisClusterCache | RedisCache],
+):
+    cache_config = dict(
+        host="mockhost",
+        port=6379,
+        password="mock-password",
+        startup_nodes=startup_nodes,
+    )
+
+    def _mock_redis_cache_init(*args, **kwargs): ...
+
+    with patch.object(RedisCache, "__init__", _mock_redis_cache_init):
+        redis_cache = Router._create_redis_cache(cache_config)
+        assert isinstance(redis_cache, expected_cache_type)


### PR DESCRIPTION
## Fix redis cluster mode for routers

Fix Redis Cache in cluster mode doesn't work in litellm router issue as described on issue #8760 

## Relevant issues

#8760 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

