### PR TITLE
[BUG] fixed infinite loop in together_ai

### DIFF
--- a/litellm/llms/together_ai/chat.py
+++ b/litellm/llms/together_ai/chat.py
@@ -9,6 +9,7 @@ Docs: https://docs.together.ai/reference/completions-1
 from typing import Optional
 
 from litellm import get_model_info, verbose_logger
+from litellm.utils import supports_function_calling
 
 from ..openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -20,25 +21,12 @@ class TogetherAIConfig(OpenAIGPTConfig):
 
         Docs: https://docs.together.ai/docs/json-mode
         """
-        supports_function_calling: Optional[bool] = None
-        
-        supported_models = [
-            "deepseek-ai/DeepSeek-V3",
-            "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-            "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-            "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
-            "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-            "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "mistralai/Mistral-7B-Instruct-v0.1",
-            "Qwen/Qwen2.5-7B-Instruct-Turbo",
-            "Qwen/Qwen2.5-72B-Instruct-Turbo"
-        ]
+        function_calling: Optional[bool] = supports_function_calling(model, custom_llm_provider = "together_ai")
 
-        supports_function_calling = model in supported_models
 
         optional_params = super().get_supported_openai_params(model)
 
-        if supports_function_calling is not True:
+        if function_calling is not True:
             verbose_logger.debug(
                 "Only some together models support function calling/response_format. Docs - https://docs.together.ai/docs/function-calling"
             )

--- a/litellm/llms/together_ai/chat.py
+++ b/litellm/llms/together_ai/chat.py
@@ -21,16 +21,23 @@ class TogetherAIConfig(OpenAIGPTConfig):
         Docs: https://docs.together.ai/docs/json-mode
         """
         supports_function_calling: Optional[bool] = None
-        try:
-            model_info = get_model_info(model, custom_llm_provider="together_ai")
-            supports_function_calling = model_info.get(
-                "supports_function_calling", False
-            )
-        except Exception as e:
-            verbose_logger.debug(f"Error getting supported openai params: {e}")
-            pass
+        
+        supported_models = [
+            "deepseek-ai/DeepSeek-V3",
+            "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+            "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+            "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "mistralai/Mistral-7B-Instruct-v0.1",
+            "Qwen/Qwen2.5-7B-Instruct-Turbo",
+            "Qwen/Qwen2.5-72B-Instruct-Turbo"
+        ]
+
+        supports_function_calling = model in supported_models
 
         optional_params = super().get_supported_openai_params(model)
+
         if supports_function_calling is not True:
             verbose_logger.debug(
                 "Only some together models support function calling/response_format. Docs - https://docs.together.ai/docs/function-calling"


### PR DESCRIPTION
## [BUG] fixed infinite loop in together_ai
There was an infinite loop in when checking `get_openai_supported_params`. This was caused by an unneccesary call to `get_model_info` [here](https://github.com/BerriAI/litellm/blob/main/litellm/llms/together_ai/chat.py#L25). This was probably to check which models supported function calling. To fix this, I just replaced the `get_model_info`  call with a list of supported models. 

Reference:
https://docs.together.ai/docs/function-calling 

## Relevant issues

Fixes:  #7185

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

##Testing

This change doesn't affect the Together AI tests:
<img width="1204" alt="Screenshot 2025-03-06 at 7 48 41 PM" src="https://github.com/user-attachments/assets/38504b1c-8c3e-4c92-9111-5144cba54533" />

There is no longer and infinite loop between `completion`, `get_supported_openai_params`  and `get_model_info` in debugger.

