### PR TITLE
(AWS Secret Manager) - Using K/V pairs in 1 AWS Secret

### DIFF
--- a/docs/my-website/docs/secret.md
+++ b/docs/my-website/docs/secret.md
@@ -96,6 +96,33 @@ litellm --config /path/to/config.yaml
 ```
 
 
+### Using K/V pairs in 1 AWS Secret
+
+You can read multiple keys from a single AWS Secret using the `primary_secret_name` parameter:
+
+```yaml
+general_settings:
+  key_management_system: "aws_secret_manager"
+  key_management_settings:
+    hosted_keys: [
+      "OPENAI_API_KEY_MODEL_1",
+      "OPENAI_API_KEY_MODEL_2",
+    ]
+    primary_secret_name: "litellm_secrets" # 👈 Read multiple keys from one JSON secret
+```
+
+The `primary_secret_name` allows you to read multiple keys from a single AWS Secret as a JSON object. For example, the "litellm_secrets" would contain:
+
+```json
+{
+  "OPENAI_API_KEY_MODEL_1": "sk-key1...",
+  "OPENAI_API_KEY_MODEL_2": "sk-key2..."
+}
+```
+
+This reduces the number of AWS Secrets you need to manage.
+
+
 ## Hashicorp Vault
 
 
@@ -353,4 +380,7 @@ general_settings:
     
     # Hosted Keys Settings
     hosted_keys: ["litellm_master_key"] # OPTIONAL. Specify which env keys you stored on AWS
+
+    # K/V pairs in 1 AWS Secret Settings
+    primary_secret_name: "litellm_secrets" # OPTIONAL. Read multiple keys from one JSON secret on AWS Secret Manager
 ```

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1161,6 +1161,13 @@ class KeyManagementSettings(LiteLLMPydanticObjectBase):
     Access mode for the secret manager, when write_only will only use for writing secrets
     """
 
+    primary_secret_name: Optional[str] = None
+    """
+    If set, will read secrets from this primary secret in the secret manager
+
+    eg. on AWS you can store multiple secret values as K/V pairs in a single secret
+    """
+
 
 class TeamDefaultSettings(LiteLLMPydanticObjectBase):
     team_id: str

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,27 +1,20 @@
 model_list:
-  - model_name: fake-openai-endpoint
+  - model_name: model-1
     litellm_params:
-      model: openai/my-fake-model
-      api_key: my-fake-key
+      model: openai/model-1
+      api_key: os.environ/OPENAI_API_KEY_MODEL_1
       api_base: https://exampleopenaiendpoint-production.up.railway.app/
-  - model_name: claude-special-alias
+  - model_name: model-2
     litellm_params:
-      model: anthropic/claude-3-haiku-20240307
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-3-5-sonnet-20241022
-    litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-3-7-sonnet-20250219
-    litellm_params:
-      model: anthropic/claude-3-7-sonnet-20250219
-      api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: anthropic/*
-    litellm_params:
-      model: anthropic/*
-      api_key: os.environ/ANTHROPIC_API_KEY
+      model: openai/model-2
+      api_key: os.environ/OPENAI_API_KEY_MODEL_2
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
 
 general_settings:
-  store_model_in_db: true
-  store_prompts_in_spend_logs: true
-
+  key_management_system: "aws_secret_manager"
+  key_management_settings:
+    hosted_keys: [
+      "OPENAI_API_KEY_MODEL_1",
+      "OPENAI_API_KEY_MODEL_2",
+    ]
+    primary_secret_name: "litellm_secrets"

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -63,6 +63,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         secret_name: str,
         optional_params: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        primary_secret_name: Optional[str] = None,
     ) -> Optional[str]:
         """
         Async function to read a secret from AWS Secrets Manager
@@ -72,6 +73,11 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         Raises:
             ValueError: If the secret is not found or an HTTP error occurs
         """
+        if primary_secret_name:
+            return await self.async_read_secret_from_primary_secret(
+                secret_name=secret_name, primary_secret_name=primary_secret_name
+            )
+
         endpoint_url, headers, body = self._prepare_request(
             action="GetSecretValue",
             secret_name=secret_name,
@@ -102,13 +108,13 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         secret_name: str,
         optional_params: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        primary_secret_name: Optional[str] = None,
     ) -> Optional[str]:
         """
         Sync function to read a secret from AWS Secrets Manager
 
         Done for backwards compatibility with existing codebase, since get_secret is a sync function
         """
-
         # self._prepare_request uses these env vars, we cannot read them from AWS Secrets Manager. If we do we'd get stuck in an infinite loop
         if secret_name in [
             "AWS_ACCESS_KEY_ID",
@@ -118,6 +124,11 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
             "AWS_BEDROCK_RUNTIME_ENDPOINT",
         ]:
             return os.getenv(secret_name)
+
+        if primary_secret_name:
+            return self.sync_read_secret_from_primary_secret(
+                secret_name=secret_name, primary_secret_name=primary_secret_name
+            )
 
         endpoint_url, headers, body = self._prepare_request(
             action="GetSecretValue",
@@ -146,6 +157,30 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
                 "Error reading secret from AWS Secrets Manager: %s", str(e)
             )
         return None
+
+    def sync_read_secret_from_primary_secret(
+        self, secret_name: str, primary_secret_name: str
+    ) -> str:
+        """
+        Read a secret from the primary secret
+        """
+        primary_secret_kv_pairs_json_str = (
+            self.sync_read_secret(secret_name=primary_secret_name) or "{}"
+        )
+        primary_secret_kv_pairs = json.loads(primary_secret_kv_pairs_json_str)
+        return primary_secret_kv_pairs.get(secret_name)
+
+    async def async_read_secret_from_primary_secret(
+        self, secret_name: str, primary_secret_name: str
+    ) -> str:
+        """
+        Read a secret from the primary secret
+        """
+        primary_secret_kv_pairs_json_str = (
+            await self.async_read_secret(secret_name=primary_secret_name) or "{}"
+        )
+        primary_secret_kv_pairs = json.loads(primary_secret_kv_pairs_json_str)
+        return primary_secret_kv_pairs.get(secret_name)
 
     async def async_write_secret(
         self,

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -274,7 +274,10 @@ def get_secret(  # noqa: PLR0915
                     )
 
                     if isinstance(client, AWSSecretsManagerV2):
-                        secret = client.sync_read_secret(secret_name=secret_name)
+                        secret = client.sync_read_secret(
+                            secret_name=secret_name,
+                            primary_secret_name=key_management_settings.primary_secret_name,
+                        )
                         print_verbose(f"get_secret_value_response: {secret}")
                 elif key_manager == KeyManagementSystem.GOOGLE_SECRET_MANAGER.value:
                     try:


### PR DESCRIPTION
## Using K/V pairs in 1 AWS Secret

You can read multiple keys from a single AWS Secret using the `primary_secret_name` parameter:

```yaml
general_settings:
  key_management_system: "aws_secret_manager"
  key_management_settings:
    hosted_keys: [
      "OPENAI_API_KEY_MODEL_1",
      "OPENAI_API_KEY_MODEL_2",
    ]
    primary_secret_name: "litellm_secrets" # 👈 Read multiple keys from one JSON secret
```

The `primary_secret_name` allows you to read multiple keys from a single AWS Secret as a JSON object. For example, the "litellm_secrets" would contain:

```json
{
  "OPENAI_API_KEY_MODEL_1": "sk-key1...",
  "OPENAI_API_KEY_MODEL_2": "sk-key2..."
}
```

This reduces the number of AWS Secrets you need to manage.


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

