### PR TITLE
Remove redundant `apk update` in Dockerfiles (cc #5016)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ WORKDIR /app
 USER root
 
 # Install build dependencies
-RUN apk update && \
-    apk add --no-cache gcc python3-dev openssl openssl-dev
+RUN apk add --no-cache gcc python3-dev openssl openssl-dev
 
 
 RUN pip install --upgrade pip && \
@@ -55,8 +54,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies
-RUN apk update && \
-    apk add --no-cache openssl
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -35,7 +35,7 @@ RUN pip wheel --no-cache-dir --wheel-dir=/wheels/ -r requirements.txt
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
 # Update dependencies and clean up
-RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
+RUN apk upgrade --no-cache
 
 WORKDIR /app
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -12,8 +12,7 @@ WORKDIR /app
 USER root
 
 # Install build dependencies
-RUN apk update && \
-    apk add --no-cache gcc python3-dev openssl openssl-dev
+RUN apk add --no-cache gcc python3-dev openssl openssl-dev
 
 
 RUN pip install --upgrade pip && \
@@ -44,8 +43,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies
-RUN apk update && \
-    apk add --no-cache openssl
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 # Copy the current directory contents into the container at /app


### PR DESCRIPTION
## Title

Remove redundant `apk update` in Dockerfiles (cc #5016)

## Type

🧹 Refactoring
🚄 Infrastructure

## Changes

The `apk` commands can utilize the `--no-cache` option, making the `update` step superfluous and ensuring the latest packages are used without maintaining a local cache. An additional `apk update` in the Dockerfile will just make the image larger with no benefits.
