### PR TITLE
(UI) Logs Page - Keep expanded log in focus on LiteLLM UI

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -42,9 +42,23 @@ export const columns: ColumnDef<LogEntry>[] = [
           {...{
             onClick: row.getToggleExpandedHandler(),
             style: { cursor: "pointer" },
+            "aria-label": row.getIsExpanded() ? "Collapse row" : "Expand row",
           }}
+          className="w-6 h-6 flex items-center justify-center"
         >
-          {row.getIsExpanded() ? "▼" : "▶"}
+          <svg
+            className={`w-4 h-4 transition-transform ${row.getIsExpanded() ? 'transform rotate-90' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
         </button>
       ) : (
         "●"

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -67,6 +67,7 @@ export default function SpendLogsTable({
   const [filterByCurrentUser, setFilterByCurrentUser] = useState(
     userRole && internalUserRoles.includes(userRole)
   );
+  const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null);
 
   const queryClient = useQueryClient();
 
@@ -176,6 +177,18 @@ export default function SpendLogsTable({
     refetchIntervalInBackground: true,
   });
 
+  // Add this effect to preserve expanded state when data refreshes
+  useEffect(() => {
+    if (logs.data?.data && expandedRequestId) {
+      // Check if the expanded request ID still exists in the new data
+      const stillExists = logs.data.data.some(log => log.request_id === expandedRequestId);
+      if (!stillExists) {
+        // If the request ID no longer exists in the data, clear the expanded state
+        setExpandedRequestId(null);
+      }
+    }
+  }, [logs.data?.data, expandedRequestId]);
+
   if (!accessToken || !token || !userRole || !userID) {
     console.log(
       "got None values for one of accessToken, token, userRole, userID",
@@ -218,6 +231,10 @@ export default function SpendLogsTable({
     if (diffHours <= 24) return 'Last 24 Hours';
     if (diffHours <= 168) return 'Last 7 Days';
     return `${start.format('MMM D')} - ${now.format('MMM D')}`;
+  };
+
+  const handleRowExpand = (requestId: string | null) => {
+    setExpandedRequestId(requestId);
   };
 
   return (
@@ -573,6 +590,8 @@ export default function SpendLogsTable({
           data={filteredData}
           renderSubComponent={RequestViewer}
           getRowCanExpand={() => true}
+          onRowExpand={handleRowExpand}
+          expandedRequestId={expandedRequestId}
         />
       </div>
     </div>


### PR DESCRIPTION
## (UI) Logs Page - Keep expanded log in focus on LiteLLM UI
When getting traffic, keeps the selected log in focus 

<img width="1126" alt="Screenshot 2025-03-07 at 1 52 51 PM" src="https://github.com/user-attachments/assets/05c2112b-0c0c-4003-83e6-faa5d92da742" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

