### PR TITLE
Bug fix: support bytes.IO when handling audio files for transcription

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -873,7 +873,7 @@ class BaseLLMHTTPHandler:
         elif isinstance(audio_file, bytes):
             # Assume it's already binary data
             binary_data = audio_file
-        elif isinstance(audio_file, io.BufferedReader):
+        elif isinstance(audio_file, io.BufferedReader) or isinstance(audio_file, io.BytesIO):
             # Handle file-like objects
             binary_data = audio_file.read()
 

--- a/tests/litellm/llms/custom_httpx/test_handle_audio_file.py
+++ b/tests/litellm/llms/custom_httpx/test_handle_audio_file.py
@@ -1,0 +1,47 @@
+
+import os
+import io
+import pathlib
+import sys
+
+import pytest
+
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+import litellm
+
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+@pytest.fixture
+def test_bytes():
+    return b'litellm', b'litellm'
+
+@pytest.fixture
+def test_io_bytes(test_bytes):
+    return io.BytesIO(test_bytes[0]), test_bytes[1]
+
+@pytest.fixture
+def test_file():
+    pwd = os.path.dirname(os.path.realpath(__file__))
+    pwd_path = pathlib.Path(pwd)
+    test_root = pwd_path.parents[2]
+    file_path = os.path.join(test_root, "gettysburg.wav")
+    f = open(file_path, "rb")
+    content = f.read()
+    f.seek(0)
+    return f, content
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "test_bytes",
+        "test_io_bytes",
+        "test_file",
+    ]
+)
+def test_audio_file_handling(fixture_name, request):
+    handler = BaseLLMHTTPHandler()
+    (audio_file, expected_output) = request.getfixturevalue(fixture_name)
+    assert expected_output == handler.handle_audio_file(audio_file)


### PR DESCRIPTION
## Bug fix: support bytes.IO when handling audio files for transcription

## Relevant issues

Fixes #9065 

## Type

🐛 Bug Fix
✅ Test

## Changes

Handles `io.BytesIO` the same as `io.BufferedReader`

<img width="754" alt="Screenshot 2025-03-07 at 6 37 39 PM" src="https://github.com/user-attachments/assets/6bf5c633-ea55-46a6-8ad3-09a8b4c8b125" />

<!-- Test procedure -->

