### PR TITLE
(UI fix) - Internal Users, show accurate number of keys owned by an internal user

### DIFF
--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -379,6 +379,80 @@ async def test_get_users(prisma_client):
 
 
 @pytest.mark.asyncio
+async def test_get_users_filters_dashboard_keys(prisma_client):
+    """
+    Tests that /users/list endpoint doesn't return keys with team_id='litellm-dashboard'
+
+    The dashboard keys should be filtered out from the response
+    """
+    litellm.set_verbose = True
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    await litellm.proxy.proxy_server.prisma_client.connect()
+
+    # Create a test user
+    new_user_id = f"test_user_with_keys-{uuid.uuid4()}"
+    test_user = NewUserRequest(
+        user_id=new_user_id,
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    await new_user(
+        test_user,
+        UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="admin",
+        ),
+    )
+
+    # Create two keys for the user - one with team_id="litellm-dashboard" and one without
+    dashboard_key = await generate_key_helper_fn(
+        user_id=test_user.user_id,
+        request_type="key",
+        team_id="litellm-dashboard",  # This key should be filtered out
+        models=[],
+        aliases={},
+        config={},
+        spend=0,
+        duration=None,
+    )
+
+    regular_key = await generate_key_helper_fn(
+        user_id=test_user.user_id,
+        request_type="key",
+        team_id=None,  # This key should be included in the response
+        models=[],
+        aliases={},
+        config={},
+        spend=0,
+        duration=None,
+    )
+
+    # Test get_users for the specific user
+    result = await get_users(
+        user_ids=test_user.user_id,
+        role=None,
+        page=1,
+        page_size=20,
+    )
+
+    print("get users result", result)
+    assert "users" in result
+    assert len(result["users"]) == 1
+
+    # Verify the key count is correct (should be 1, not counting dashboard keys)
+    user = result["users"][0]
+    assert user.user_id == test_user.user_id
+    assert user.key_count == 1  # Only count the regular key, not the dashboard key
+
+    # Clean up test user and keys
+    await prisma_client.db.litellm_usertable.delete(
+        where={"user_id": test_user.user_id}
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_users_key_count(prisma_client):
     """
     Test that verifies the key_count in get_users increases when a new key is created for a user

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -93,7 +93,7 @@ export const columns: ColumnDef<LogEntry>[] = [
     accessorKey: "request_id",
     cell: (info: any) => (
       <Tooltip title={String(info.getValue() || "")}>
-        <span className="font-mono text-xs max-w-[100px] truncate block">
+        <span className="font-mono text-xs max-w-[15ch] truncate block">
           {String(info.getValue() || "")}
         </span>
       </Tooltip>
@@ -114,7 +114,11 @@ export const columns: ColumnDef<LogEntry>[] = [
   {
     header: "Team Name",
     accessorKey: "metadata.user_api_key_team_alias",
-    cell: (info: any) => <span>{String(info.getValue() || "-")}</span>,
+    cell: (info: any) => (
+      <Tooltip title={String(info.getValue() || "-")}>
+        <span className="max-w-[15ch] truncate block">{String(info.getValue() || "-")}</span>
+      </Tooltip>
+    ),
   },
   {
     header: "Key Hash",
@@ -123,7 +127,7 @@ export const columns: ColumnDef<LogEntry>[] = [
       const value = String(info.getValue() || "-");
       return (
         <Tooltip title={value}>
-          <span className="font-mono">{value.slice(0, 5)}...</span>
+          <span className="font-mono max-w-[15ch] truncate block">{value}</span>
         </Tooltip>
       );
     },
@@ -131,7 +135,11 @@ export const columns: ColumnDef<LogEntry>[] = [
   {
     header: "Key Name",
     accessorKey: "metadata.user_api_key_alias",
-    cell: (info: any) => <span>{String(info.getValue() || "-")}</span>,
+    cell: (info: any) => (
+      <Tooltip title={String(info.getValue() || "-")}>
+        <span className="max-w-[15ch] truncate block">{String(info.getValue() || "-")}</span>
+      </Tooltip>
+    ),
   },
   {
     header: "Model",
@@ -154,7 +162,7 @@ export const columns: ColumnDef<LogEntry>[] = [
             />
           )}
           <Tooltip title={modelName}>
-            <span className="max-w-[100px] truncate">
+            <span className="max-w-[15ch] truncate block">
               {modelName}
             </span>
           </Tooltip>
@@ -181,12 +189,20 @@ export const columns: ColumnDef<LogEntry>[] = [
   {
     header: "Internal User",
     accessorKey: "user",
-    cell: (info: any) => <span>{String(info.getValue() || "-")}</span>,
+    cell: (info: any) => (
+      <Tooltip title={String(info.getValue() || "-")}>
+        <span className="max-w-[15ch] truncate block">{String(info.getValue() || "-")}</span>
+      </Tooltip>
+    ),
   },
   {
     header: "End User",
     accessorKey: "end_user",
-    cell: (info: any) => <span>{String(info.getValue() || "-")}</span>,
+    cell: (info: any) => (
+      <Tooltip title={String(info.getValue() || "-")}>
+        <span className="max-w-[15ch] truncate block">{String(info.getValue() || "-")}</span>
+      </Tooltip>
+    ),
   },
 
   {

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -37,20 +37,29 @@ export const columns: ColumnDef<LogEntry>[] = [
     id: "expander",
     header: () => null,
     cell: ({ row }) => {
+      const [localExpanded, setLocalExpanded] = React.useState(row.getIsExpanded());
+
+      // Memoize the toggle handler to prevent unnecessary re-renders
+      const toggleHandler = React.useCallback(() => {
+        setLocalExpanded((prev) => !prev);
+        row.getToggleExpandedHandler()();
+      }, [row]);
+
       return row.getCanExpand() ? (
         <button
-          {...{
-            onClick: row.getToggleExpandedHandler(),
-            style: { cursor: "pointer" },
-            "aria-label": row.getIsExpanded() ? "Collapse row" : "Expand row",
-          }}
-          className="w-6 h-6 flex items-center justify-center"
+          onClick={toggleHandler}
+          style={{ cursor: "pointer" }}
+          aria-label={localExpanded ? "Collapse row" : "Expand row"}
+          className="w-6 h-6 flex items-center justify-center focus:outline-none"
         >
           <svg
-            className={`w-4 h-4 transition-transform ${row.getIsExpanded() ? 'transform rotate-90' : ''}`}
+            className={`w-4 h-4 transform transition-transform duration-75 ${
+              localExpanded ? 'rotate-90' : ''
+            }`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
               strokeLinecap="round"
@@ -61,7 +70,7 @@ export const columns: ColumnDef<LogEntry>[] = [
           </svg>
         </button>
       ) : (
-        "●"
+        <span className="w-6 h-6 flex items-center justify-center">●</span>
       );
     },
   },

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -637,7 +637,7 @@ function RequestViewer({ row }: { row: Row<LogEntry> }) {
   const hasMessages = row.original.messages && 
     (Array.isArray(row.original.messages) ? row.original.messages.length > 0 : Object.keys(row.original.messages).length > 0);
   const hasResponse = row.original.response && Object.keys(formatData(row.original.response)).length > 0;
-  const missingData = !hasMessages || !hasResponse;
+  const missingData = !hasMessages && !hasResponse;
   
   // Format the response with error details if present
   const formattedResponse = () => {


### PR DESCRIPTION
## (UI fix) - Internal Users, show accurate number of keys owned by an internal user

- previously we were showing ui session tokens to users as part of their key count
- this pr fixes that 

<img width="1204" alt="Screenshot 2025-03-07 at 8 47 34 PM" src="https://github.com/user-attachments/assets/02526645-dc4b-45f8-9ef8-faf52c06ea52" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

