### PR TITLE
Fix incorrect streaming response

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -832,6 +832,10 @@ class StreamingChoices(OpenAIObject):
             self.finish_reason = None
         self.index = index
         if delta is not None:
+            # Fix Perplexity return both delta and message cause OpenWebUI repect text
+            # https://github.com/BerriAI/litellm/issues/8455
+            if 'message' in params:
+                del self.message
             if isinstance(delta, Delta):
                 self.delta = delta
             elif isinstance(delta, dict):


### PR DESCRIPTION
## Title

Fix incorrect streaming response when both delta and message exist on `StreamingChoices`

## Relevant issues

Fixed https://github.com/BerriAI/litellm/issues/8455

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

