### PR TITLE
(Feat) - Raise BadRequestError when calling native /v1/messages with unsupported provider/model

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -75,7 +75,7 @@ class AnthropicMessagesHandler:
             raise litellm.BadRequestError(
                 model=model,
                 llm_provider=custom_llm_provider,
-                message=f"model={model}, custom_llm_provider={custom_llm_provider} not supported for Anthropic /v1/messages endpoint",
+                message=f"model={model}, custom_llm_provider={custom_llm_provider} not supported for Anthropic /v1/messages endpoint. Only {AnthropicMessagesHandler.supported_messages_endpoint_providers} are supported. Mode information here https://docs.litellm.ai/docs/anthropic_unified",
             )
 
 

--- a/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
@@ -153,7 +153,7 @@ async def test_anthropic_messages_streaming_with_bad_request():
 @pytest.mark.asyncio
 async def test_anthropic_messages_streaming_with_unsupported_model():
     """
-    Test the anthropic_messages with streaming request
+    Test that BadRequestError is raised when sending an unsupported model to anthropic messages
     """
     try:
         response = await anthropic_messages(

--- a/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
@@ -151,7 +151,10 @@ async def test_anthropic_messages_streaming_with_bad_request():
 
 
 @pytest.mark.asyncio
-async def test_anthropic_messages_streaming_with_unsupported_model():
+@pytest.mark.parametrize(
+    "unsupported_model", ["gpt-4o", "gpt-3.5-turbo", "llama-3", "groq/llama-3"]
+)
+async def test_anthropic_messages_streaming_with_unsupported_model(unsupported_model):
     """
     Test that BadRequestError is raised when sending an unsupported model to anthropic messages
     """
@@ -159,7 +162,7 @@ async def test_anthropic_messages_streaming_with_unsupported_model():
         response = await anthropic_messages(
             messages=["hi"],
             api_key="hi",
-            model="gpt-4o",
+            model=unsupported_model,
             max_tokens=100,
             stream=True,
         )

--- a/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
@@ -151,6 +151,30 @@ async def test_anthropic_messages_streaming_with_bad_request():
 
 
 @pytest.mark.asyncio
+async def test_anthropic_messages_streaming_with_unsupported_model():
+    """
+    Test the anthropic_messages with streaming request
+    """
+    try:
+        response = await anthropic_messages(
+            messages=["hi"],
+            api_key="hi",
+            model="gpt-4o",
+            max_tokens=100,
+            stream=True,
+        )
+        print(response)
+        pytest.fail("Expected BadRequestError but no exception was raised")
+
+    except litellm.BadRequestError as e:
+        print("got exception", e)
+        print("vars", vars(e))
+        assert e.status_code == 400
+    except Exception as e:
+        pytest.fail(f"Expected BadRequestError but got {type(e).__name__}: {e}")
+
+
+@pytest.mark.asyncio
 async def test_anthropic_messages_router_streaming_with_bad_request():
     """
     Test the anthropic_messages with streaming request


### PR DESCRIPTION
## (Feat) - Raise BadRequestError when calling native /v1/messages with unsupported provider/model

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<!-- List of changes -->

## [REQUIRED] Testing - Attach a screenshot of any new tests passing locally
If UI changes, send a screenshot/GIF of working UI fixes

<!-- Test procedure -->

