### PR TITLE
Don't fail for `global_max_parallel_requests` = 1

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -222,7 +222,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             )
             # check if below limit
             if current_global_requests is None:
-                current_global_requests = 1
+                current_global_requests = 0
             # if above -> raise error
             if current_global_requests >= global_max_parallel_requests:
                 return self.raise_rate_limit_error(

--- a/tests/local_testing/test_parallel_request_limiter.py
+++ b/tests/local_testing/test_parallel_request_limiter.py
@@ -67,6 +67,35 @@ async def test_global_max_parallel_requests():
         except Exception as e:
             print(e)
 
+    # Test: n requests (up to global_max_parallel_requests) must succeed
+    #       and (n+1)th request must fail.
+    global_max_parallel_requests = 4
+    for _ in range(global_max_parallel_requests):
+        await parallel_request_handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={
+                "metadata": {
+                    "global_max_parallel_requests": global_max_parallel_requests
+                }
+            },
+            call_type="",
+        )
+    try:
+        await parallel_request_handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={
+                "metadata": {
+                    "global_max_parallel_requests": global_max_parallel_requests
+                }
+            },
+            call_type="",
+        )
+        pytest.fail("Expected call to fail")
+    except Exception as e:
+        print(e)
+
 
 @pytest.mark.flaky(retries=6, delay=1)
 @pytest.mark.asyncio


### PR DESCRIPTION
When `global_max_parallel_requests` was set to `1`, all requests failed.

## Title

Fix `global_max_parallel_requests` initial request

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

- Fix `global_max_parallel_requests` initial request

![image](https://github.com/user-attachments/assets/e74b1666-aaea-4ab2-a0c4-4cbbea873fc7)

