### PR TITLE
Fix Metadata not updating in Team UI

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -184,7 +184,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         max_budget: values.max_budget,
         budget_duration: values.budget_duration,
         metadata: {
-          ...teamData?.team_info?.metadata,
+          ...values.metadata,
           guardrails: values.guardrails || []
         }
       };


### PR DESCRIPTION

## Type
🐛 Bug Fix

## Changes

The Form for updating the team used the wrong metadata value. It used the already existing metadata and not the one that is changed in the form.
