### PR TITLE
fix(azure): Patch for Function Calling Bug & Update Default API Version to `2025-02-01-preview` 

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -195,7 +195,7 @@ in_memory_llm_clients_cache: LLMClientCache = LLMClientCache()
 safe_memory_mode: bool = False
 enable_azure_ad_token_refresh: Optional[bool] = False
 ### DEFAULT AZURE API VERSION ###
-AZURE_DEFAULT_API_VERSION = "2024-12-01-preview"  # this is updated to the latest
+AZURE_DEFAULT_API_VERSION = "2025-02-01-preview"  # this is updated to the latest
 ### DEFAULT WATSONX API VERSION ###
 WATSONX_DEFAULT_API_VERSION = "2024-03-13"
 ### COHERE EMBEDDINGS DEFAULT TYPE ###

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -195,7 +195,7 @@ in_memory_llm_clients_cache: LLMClientCache = LLMClientCache()
 safe_memory_mode: bool = False
 enable_azure_ad_token_refresh: Optional[bool] = False
 ### DEFAULT AZURE API VERSION ###
-AZURE_DEFAULT_API_VERSION = "2024-08-01-preview"  # this is updated to the latest
+AZURE_DEFAULT_API_VERSION = "2024-12-01-preview"  # this is updated to the latest
 ### DEFAULT WATSONX API VERSION ###
 WATSONX_DEFAULT_API_VERSION = "2024-03-13"
 ### COHERE EMBEDDINGS DEFAULT TYPE ###


### PR DESCRIPTION
## **Title**  
fix(azure): Patch for Function Calling Bug & Update Default API Version to `2025-02-01-preview`  

## **Description**  
This update bumps the default Azure API version to `2025-02-01-preview` and addresses a critical issue where **function calling was not working with Azure models when using the LiteLLM proxy** due to unsupported parameters.  

## **Errors Resolved**  
This update addresses the following errors encountered when making requests to Azure through the LiteLLM proxy:  

1. **`litellm.UnsupportedParamsError`**: Azure does not support parameters `{ 'tools': [{'type': 'function', 'function': ...}] }`  
2. **`litellm.UnsupportedParamsError`**: Azure does not support parameters `{ 'response_format': {'type': 'json_schema', 'json_schema': ...} }`  

These errors indicated that **tool calling was failing when routed through the LiteLLM proxy**, as Azure’s older API versions did not support the required parameters. Updating to `2025-02-01-preview` ensures compatibility with function calling and tool invocation.  

### **Important Configuration Change**  
To ensure compatibility and prevent older, unsupported parameters from being passed, you **must** update your `config.yaml` with the following setting:  

```yaml
litellm_settings:
  drop_params: True
```  

This ensures that any deprecated or unsupported parameters are automatically removed, preventing further API errors.  

## **Pre-Submission Checklist**  
Please complete all items before requesting a review from a LiteLLM maintainer:  

- [ ] **Added Tests (if applicable)**: Not applicable for this PR as it only updates the default API version.  
- [ ] **Test Screenshot**: Not applicable since no new tests were added.  
- [ ] **Unit Tests Pass (with caveat)**: `make test-unit` fails, but the failures are unrelated to this change. I have pulled the latest from `main` and confirmed that my changes did not introduce new issues.  
- [ ] **Scoped Changes**: The PR only addresses one specific problem (updating Azure’s default API version and ensuring function calling works with the LiteLLM proxy).  

## **Type of Change**  
🐛 **Bug Fix**  

## **Changes Made**  
- Updated the default Azure API version in `litellm/__init__.py` to `2025-02-01-preview`.  
- Fixed an issue where **function calling was not working with Azure models when using the LiteLLM proxy** due to unsupported parameters.  