### PR TITLE
feature: Allow config litellm.api_key and litellm.api_base by environment variables

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1,4 +1,11 @@
 ### Hide pydantic namespace conflict warnings globally ###
+"""
+    This automatically infers the following arguments from their corresponding environment variables if they are not provided:
+    - `api_key` from `LITELLM_API_KEY`
+    - `api_base` from `LITELLM_API_BASE`
+    
+    If provided they will be overwritten by provided values
+"""
 import warnings
 
 warnings.filterwarnings("ignore", message=".*conflict with protected namespace.*")
@@ -155,7 +162,7 @@ drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
 modify_params = False
 retry = True
 ### AUTH ###
-api_key: Optional[str] = None
+api_key: Optional[str] = os.getenv("LITELLM_API_KEY")
 openai_key: Optional[str] = None
 groq_key: Optional[str] = None
 databricks_key: Optional[str] = None
@@ -328,7 +335,7 @@ def identify(event_details):
 
 
 ####### ADDITIONAL PARAMS ################### configurable params if you use proxy models like Helicone, map spend to org id, etc.
-api_base: Optional[str] = None
+api_base: Optional[str] = os.getenv("LITELLM_API_BASE")
 headers = None
 api_version = None
 organization = None


### PR DESCRIPTION

## Title

<!-- e.g. "Implement user authentication feature" -->
Allow config api_key & api_base by environment variable
## Relevant issues

<!-- e.g. "Fixes #000" -->
Feature #9075 
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
- Added support to read api_base & api_key form env variables. It will overwrite if these variable are specifically provided in code.
- Added Module notes so user can see it in function description.
- Unit test case result:
<img width="1029" alt="Code 2025-03-13 11 17 10" src="https://github.com/user-attachments/assets/e217fb39-ae13-4f2e-a6be-8574ffe04740" />

