### PR TITLE
fix: response_format is ignored in Azure OpenAI models with API version >= 2025

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -121,7 +121,10 @@ class AzureOpenAIConfig(BaseConfig):
         - check if api_version is supported for response_format
         """
 
-        is_supported = int(api_version_year) <= 2024 and int(api_version_month) >= 8
+        is_supported = (
+            int(api_version_year) >= 2025
+            or (int(api_version_year) >= 2024 and int(api_version_month) >= 8)
+        )
 
         return is_supported
 

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -286,13 +286,16 @@ def test_azure_openai_gpt_4o_naming(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "api_version",
-    [
-        "2024-10-21",
-        # "2024-02-15-preview",
-    ],
+   "api_version, should_have_response_format",
+     [
+       ("2024-02-15-preview", False),
+       ("2024-10-21", True),
+       ("2025-01-01-preview", True),
+     ],
 )
-def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
+def test_azure_gpt_4o_with_tool_call_and_response_format(
+    api_version, should_have_response_format
+):
     from litellm import completion
     from typing import Optional
     from pydantic import BaseModel
@@ -361,10 +364,12 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
 
         mock_post.assert_called_once()
 
-        if api_version == "2024-10-21":
-            assert "response_format" in mock_post.call_args.kwargs
-        else:
-            assert "response_format" not in mock_post.call_args.kwargs
+        assert (
+           "response_format"
+           in mock_post.call_args.kwargs
+           is should_have_response_format
+       )
+
 
 
 def test_map_openai_params():


### PR DESCRIPTION
## Title

This PR fixes a bug in the function `_is_response_format_supported_api_version`.
Due to this bug, we are not passing the argument `response_format` in API version >= 2025.

https://github.com/BerriAI/litellm/blob/3875df666b8a11819eda86fdc35d582be4bd8db6/litellm/llms/azure/chat/gpt_transformation.py#L117-L124

I believe it should evaluate true if it is >= "2024-08"

## Relevant issues

- https://github.com/BerriAI/litellm/pull/8438

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

I followed the [guideline](https://docs.litellm.ai/docs/extras/contributing_code) but couldn't make the existing tests pass on the fresh main branch (`Failed: Error occurred: litellm.APIError: AzureException APIError - argument of type 'NoneType' is not iterable`)

## Type

🐛 Bug Fix

## Changes

- `_is_response_format_supported_api_version` should be true when the API version >= 2025
- Added test cases