### PR TITLE
feat: Add support for file-based secrets in config values

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -448,6 +448,19 @@ model_list:
 
 s/o to [@David Manouchehri](https://www.linkedin.com/in/davidmanouchehri/) for helping with this. 
 
+### Load API Keys / config values from Files
+
+If you need to load secrets from files, you can use the `file/` prefix followed by the file path. This works for any value in the config.yaml that accepts an os.environ environment variable reference.
+
+```yaml 
+model_list:
+  - model_name: azure-model
+    litellm_params:
+      model: azure/chatgpt-v-2
+      api_key: file//path/to/secret/file # 👈 Read from file.  Notice the double / to start from root.  That is read as 'file /' + '/path/to/secret/file'
+      api_base: file/~/.azure_api_base # 👈 Supports tilde expansion for home directory
+```
+
 ### Load API Keys from Secret Managers (Azure Vault, etc)
 
 [**Using Secret Managers with LiteLLM Proxy**](../secret)

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -194,6 +194,20 @@ def get_secret(  # noqa: PLR0915
         else:
             raise ValueError("Unsupported OIDC provider")
 
+    # Example: file//home/user/keys/azure file/~/.apikey_azure
+    if secret_name.startswith("file/"):
+        file_path = secret_name.replace("file/", "", 1)
+        file_path = os.path.expanduser(file_path)  # Handle ~ expansion
+        try:
+            with open(file_path, "r") as f:
+                return f.read().strip()  # Remove any trailing newlines
+        except FileNotFoundError:
+            raise ValueError(f"Secret file not found at path: {file_path}")
+        except PermissionError as pe:
+            raise PermissionError(f"Permission denied accessing file: {file_path}") from pe
+        except Exception as e:
+            raise ValueError(f"Error reading secret file: {str(e)}")
+
     try:
         if (
             _should_read_secret_from_secret_manager()

--- a/tests/litellm_utils_tests/test_get_secret.py
+++ b/tests/litellm_utils_tests/test_get_secret.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import tempfile
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -28,3 +29,73 @@ async def test_azure_kms():
         litellm._key_management_system = KeyManagementSystem.AZURE_KEY_VAULT
         secret = get_secret(secret_name="ishaan-test-key")
         assert secret == "mocked_secret_value"
+
+
+def test_file_based_secret_valid():
+    """Test reading a secret from a valid file"""
+    with tempfile.NamedTemporaryFile(mode="w+") as tmpfile:
+        tmpfile.write("test-secret-123")
+        tmpfile.flush()
+        secret = get_secret(f"file/{tmpfile.name}")
+        assert secret == "test-secret-123"
+
+
+def test_file_based_secret_missing_file():
+    """Test error handling when file is missing"""
+    with pytest.raises(ValueError) as excinfo:
+        get_secret("file/nonexistent/file.txt")
+    assert "Secret file not found at path" in str(excinfo.value)
+
+def test_file_based_secret_with_tilde_expansion():
+    """Test home directory expansion with ~/ in file paths"""
+    from pathlib import Path
+    import tempfile
+
+    # Create test file in home directory
+    home_dir = Path.home()
+    test_content = "tilde-secret-123"
+    
+    try:
+        # Create temp file in home dir
+        with tempfile.NamedTemporaryFile(mode="w+", dir=home_dir, delete=False) as tmpfile:
+            tmpfile.write(test_content)
+            tmpfile.flush()
+            file_name = Path(tmpfile.name).name
+            
+            # Test tilde expansion
+            secret = get_secret(f"file/~/{file_name}")
+            assert secret == test_content
+    finally:
+        # Cleanup
+        temp_path = Path(tmpfile.name)
+        if temp_path.exists():
+            temp_path.unlink()
+
+def test_file_based_secret_permission_denied():
+    """Test handling of files with insufficient permissions"""
+    import stat
+    
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmpfile:
+        tmpfile.write("secret-content")
+        tmpfile.flush()
+        tmpfile_path = tmpfile.name
+    
+    try:
+        # Remove read permissions
+        os.chmod(tmpfile_path, 0o000)  # No permissions
+        
+        with pytest.raises(PermissionError) as excinfo:
+            get_secret(f"file/{tmpfile_path}")
+            
+        assert "Permission denied accessing file" in str(excinfo.value)
+    finally:
+        # Restore permissions to allow cleanup
+        os.chmod(tmpfile_path, 0o600)  # Owner read/write
+        os.unlink(tmpfile_path)
+
+def test_file_based_secret_empty_file():
+    """Test handling of empty files"""
+    with tempfile.NamedTemporaryFile(mode="w+") as tmpfile:
+        # File is empty by default
+        secret = get_secret(f"file/{tmpfile.name}")
+        assert secret == ""


### PR DESCRIPTION
## Title

Implement reading values (api_key, etc.) from files.

## Relevant issues

Fixes #9240 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

Added file/ as a valid config file marker for read from file similar to os.environ/ and oidc/
Tests added
Docs added

Note: Linting and unit test failures unrelated to my code have been ignored.

![shot](https://github.com/user-attachments/assets/a1b6e964-e97b-408b-909c-002bbd893837)
