### PR TITLE
[UI] Fix 1 - instantly show newly create keys on Admin UI (don't require refresh)

### DIFF
--- a/ui/litellm-dashboard/src/components/all_keys_table.tsx
+++ b/ui/litellm-dashboard/src/components/all_keys_table.tsx
@@ -32,6 +32,7 @@ interface AllKeysTableProps {
   userRole: string | null;
   organizations: Organization[] | null;
   setCurrentOrg: React.Dispatch<React.SetStateAction<Organization | null>>;
+  refresh?: () => void;
 }
 
 // Define columns similar to our logs table
@@ -98,6 +99,7 @@ export function AllKeysTable({
   userRole,
   organizations,
   setCurrentOrg,
+  refresh,
 }: AllKeysTableProps) {
   const [selectedKeyId, setSelectedKeyId] = useState<string | null>(null);
   const [userList, setUserList] = useState<UserResponse[]>([]);
@@ -130,6 +132,22 @@ export function AllKeysTable({
       fetchUserList();
     }
   }, [accessToken, keys]);
+
+  // Add a useEffect to call refresh when a key is created
+  useEffect(() => {
+    if (refresh) {
+      const handleStorageChange = () => {
+        refresh();
+      };
+      
+      // Listen for storage events that might indicate a key was created
+      window.addEventListener('storage', handleStorageChange);
+      
+      return () => {
+        window.removeEventListener('storage', handleStorageChange);
+      };
+    }
+  }, [refresh]);
 
   const columns: ColumnDef<KeyResponse>[] = [
     {

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -274,11 +274,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
       message.success("API Key Created");
       form.resetFields();
       localStorage.removeItem("userData" + userID);
-      
-      // We don't need to call refresh anymore since we're directly updating the state
-      // if (window.refreshKeysList) {
-      //   window.refreshKeysList();
-      // }
+
     } catch (error) {
       console.log("error in create key:", error);
       message.error(`Error creating the key: ${error}`);

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -266,6 +266,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({
       message.success("API Key Created");
       form.resetFields();
       localStorage.removeItem("userData" + userID);
+      
+      // Add this line to refresh the keys list immediately
+      if (window.refreshKeysList) {
+        window.refreshKeysList();
+      }
     } catch (error) {
       console.log("error in create key:", error);
       message.error(`Error creating the key: ${error}`);

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -260,17 +260,25 @@ const CreateKey: React.FC<CreateKeyProps> = ({
       const response = await keyCreateCall(accessToken, userID, formValues);
 
       console.log("key create Response:", response);
-      setData((prevData) => (prevData ? [...prevData, response] : [response])); // Check if prevData is null
+      
+      // Update the data state in this component
+      setData((prevData) => (prevData ? [...prevData, response] : [response]));
+      
+      // Also directly update the keys list in AllKeysTable without an API call
+      if (window.addNewKeyToList) {
+        window.addNewKeyToList(response);
+      }
+      
       setApiKey(response["key"]);
       setSoftBudget(response["soft_budget"]);
       message.success("API Key Created");
       form.resetFields();
       localStorage.removeItem("userData" + userID);
       
-      // Add this line to refresh the keys list immediately
-      if (window.refreshKeysList) {
-        window.refreshKeysList();
-      }
+      // We don't need to call refresh anymore since we're directly updating the state
+      // if (window.refreshKeysList) {
+      //   window.refreshKeysList();
+      // }
     } catch (error) {
       console.log("error in create key:", error);
       message.error(`Error creating the key: ${error}`);

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -100,6 +100,7 @@ isLoading: boolean;
 error: Error | null;
 pagination: PaginationData;
 refresh: (params?: Record<string, unknown>) => Promise<void>;
+setKeys: (newKeysOrUpdater: KeyResponse[] | ((prevKeys: KeyResponse[]) => KeyResponse[])) => void;
 }
 
 const useKeyList = ({
@@ -149,16 +150,30 @@ const useKeyList = ({
         console.log("selectedTeam", selectedTeam, "currentOrg", currentOrg, "accessToken", accessToken);
     }, [selectedTeam, currentOrg, accessToken]);
 
+    const setKeys = (newKeysOrUpdater: KeyResponse[] | ((prevKeys: KeyResponse[]) => KeyResponse[])) => {
+        setKeyData(prevData => {
+            const newKeys = typeof newKeysOrUpdater === 'function' 
+                ? newKeysOrUpdater(prevData.keys) 
+                : newKeysOrUpdater;
+                
+            return {
+                ...prevData,
+                keys: newKeys
+            };
+        });
+    };
+
     return {
         keys: keyData.keys,
         isLoading,
         error,
         pagination: {
-        currentPage: keyData.current_page,
-        totalPages: keyData.total_pages,
-        totalCount: keyData.total_count
+            currentPage: keyData.current_page,
+            totalPages: keyData.total_pages,
+            totalCount: keyData.total_count
         },
-        refresh: fetchKeys
+        refresh: fetchKeys,
+        setKeys
     };
 };
 

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -176,15 +176,19 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
   // Build a memoized filters object for the backend call.
 
   // Pass filters into the hook so the API call includes these query parameters.
-  const { keys, isLoading, error, pagination, refresh } = useKeyList({
+  const { keys, isLoading, error, pagination, refresh, setKeys } = useKeyList({
     selectedTeam,
     currentOrg,
     accessToken,
   });
 
-  // Make refresh function available globally so CreateKey can access it
+  // Make both refresh and addKey functions available globally
   if (typeof window !== 'undefined') {
     window.refreshKeysList = refresh;
+    window.addNewKeyToList = (newKey) => {
+      // Add the new key to the keys list without making an API call
+      setKeys((prevKeys) => [newKey, ...prevKeys]);
+    };
   }
 
   const handlePageChange = (newPage: number) => {
@@ -625,10 +629,11 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
   );
 };
 
-// Add this type declaration at the top of the file to avoid TypeScript errors
+// Update the type declaration to include the new function
 declare global {
   interface Window {
     refreshKeysList?: () => void;
+    addNewKeyToList?: (newKey: any) => void;
   }
 }
 

--- a/ui/litellm-dashboard/src/components/view_key_table.tsx
+++ b/ui/litellm-dashboard/src/components/view_key_table.tsx
@@ -182,6 +182,11 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     accessToken,
   });
 
+  // Make refresh function available globally so CreateKey can access it
+  if (typeof window !== 'undefined') {
+    window.refreshKeysList = refresh;
+  }
+
   const handlePageChange = (newPage: number) => {
     refresh({ page: newPage });
   };
@@ -421,6 +426,7 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
         userRole={userRole}
         organizations={organizations}
         setCurrentOrg={setCurrentOrg}
+        refresh={refresh}
       />
 
       {isDeleteModalOpen && (
@@ -618,5 +624,12 @@ const ViewKeyTable: React.FC<ViewKeyTableProps> = ({
     </div>
   );
 };
+
+// Add this type declaration at the top of the file to avoid TypeScript errors
+declare global {
+  interface Window {
+    refreshKeysList?: () => void;
+  }
+}
 
 export default ViewKeyTable;


### PR DESCRIPTION
## [UI] Fix 1 - instantly show newly create keys on Admin UI (don't require refresh)

Instantly show new keys after successfully creating them on UI

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes


