### PR TITLE
fix: Opentelemetry span attributes have incorrect names

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -378,7 +378,7 @@ class OpenTelemetry(CustomLogger):
                 if not function:
                     continue
 
-                prefix = f"{SpanAttributes.LLM_REQUEST_FUNCTIONS}.{i}"
+                prefix = f"{SpanAttributes.LLM_REQUEST_FUNCTIONS.value}.{i}"
                 self.safe_set_attribute(
                     span=span,
                     key=f"{prefix}.name",
@@ -434,7 +434,7 @@ class OpenTelemetry(CustomLogger):
                 _value = _function.get(key)
                 if _value:
                     kv_pairs[
-                        f"{SpanAttributes.LLM_COMPLETIONS}.{idx}.function_call.{key}"
+                        f"{SpanAttributes.LLM_COMPLETIONS.value}.{idx}.function_call.{key}"
                     ] = _value
 
         return kv_pairs
@@ -597,7 +597,7 @@ class OpenTelemetry(CustomLogger):
                     if prompt.get("role"):
                         self.safe_set_attribute(
                             span=span,
-                            key=f"{SpanAttributes.LLM_PROMPTS}.{idx}.role",
+                            key=f"{SpanAttributes.LLM_PROMPTS.value}.{idx}.role",
                             value=prompt.get("role"),
                         )
 
@@ -606,7 +606,7 @@ class OpenTelemetry(CustomLogger):
                             prompt["content"] = str(prompt.get("content"))
                         self.safe_set_attribute(
                             span=span,
-                            key=f"{SpanAttributes.LLM_PROMPTS}.{idx}.content",
+                            key=f"{SpanAttributes.LLM_PROMPTS.value}.{idx}.content",
                             value=prompt.get("content"),
                         )
             #############################################
@@ -618,14 +618,14 @@ class OpenTelemetry(CustomLogger):
                         if choice.get("finish_reason"):
                             self.safe_set_attribute(
                                 span=span,
-                                key=f"{SpanAttributes.LLM_COMPLETIONS}.{idx}.finish_reason",
+                                key=f"{SpanAttributes.LLM_COMPLETIONS.value}.{idx}.finish_reason",
                                 value=choice.get("finish_reason"),
                             )
                         if choice.get("message"):
                             if choice.get("message").get("role"):
                                 self.safe_set_attribute(
                                     span=span,
-                                    key=f"{SpanAttributes.LLM_COMPLETIONS}.{idx}.role",
+                                    key=f"{SpanAttributes.LLM_COMPLETIONS.value}.{idx}.role",
                                     value=choice.get("message").get("role"),
                                 )
                             if choice.get("message").get("content"):
@@ -637,7 +637,7 @@ class OpenTelemetry(CustomLogger):
                                     )
                                 self.safe_set_attribute(
                                     span=span,
-                                    key=f"{SpanAttributes.LLM_COMPLETIONS}.{idx}.content",
+                                    key=f"{SpanAttributes.LLM_COMPLETIONS.value}.{idx}.content",
                                     value=choice.get("message").get("content"),
                                 )
 

--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -1,8 +1,6 @@
 # What is this?
 ## Unit tests for opentelemetry integration
 
-# What is this?
-## Unit test for presidio pii masking
 import sys, os, asyncio, time, random
 from datetime import datetime
 import traceback
@@ -17,7 +15,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import pytest
 import litellm
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 from base_test import BaseLoggingCallbackTest
 from litellm.types.utils import ModelResponse
 
@@ -26,15 +24,14 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
     def test_parallel_tool_calls(self, mock_response_obj: ModelResponse):
         tool_calls = mock_response_obj.choices[0].message.tool_calls
         from litellm.integrations.opentelemetry import OpenTelemetry
-        from litellm.proxy._types import SpanAttributes
 
         kv_pair_dict = OpenTelemetry._tool_calls_kv_pair(tool_calls)
 
         assert kv_pair_dict == {
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.function_call.arguments": '{"city": "New York"}',
-            f"{SpanAttributes.LLM_COMPLETIONS}.0.function_call.name": "get_weather",
-            f"{SpanAttributes.LLM_COMPLETIONS}.1.function_call.arguments": '{"city": "New York"}',
-            f"{SpanAttributes.LLM_COMPLETIONS}.1.function_call.name": "get_news",
+            "gen_ai.completion.0.function_call.arguments": '{"city": "New York"}',
+            "gen_ai.completion.0.function_call.name": "get_weather",
+            "gen_ai.completion.1.function_call.arguments": '{"city": "New York"}',
+            "gen_ai.completion.1.function_call.name": "get_news",
         }
 
     @pytest.mark.asyncio

--- a/tests/logging_callback_tests/test_otel_logging.py
+++ b/tests/logging_callback_tests/test_otel_logging.py
@@ -1,8 +1,5 @@
-import json
 import os
 import sys
-from datetime import datetime
-from unittest.mock import AsyncMock
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -10,7 +7,7 @@ sys.path.insert(
 
 import pytest
 import litellm
-from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig, Span
+from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
 import asyncio
 import logging
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -86,6 +83,10 @@ def validate_litellm_request(span):
         "llm.usage.total_tokens",
         "gen_ai.usage.completion_tokens",
         "gen_ai.usage.prompt_tokens",
+        "gen_ai.prompt.0.role",
+        "gen_ai.prompt.0.content",
+        "gen_ai.completion.0.role",
+        "gen_ai.completion.0.content",
     ]
 
     # get the str of all the span attributes


### PR DESCRIPTION
## Title

Span attributes have incorrect names

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally (no new tests needed)
- [X] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Prior to this change, there were a bunch of span attributes that looked like the following:

```
        "SpanAttributes.LLM_PROMPTS.1.role": "assistant",
        "SpanAttributes.LLM_PROMPTS.1.content": "Hello! How can I help you today?",
        "SpanAttributes.LLM_PROMPTS.2.role": "user",
        "SpanAttributes.LLM_PROMPTS.2.content": "testing 123",
        "SpanAttributes.LLM_COMPLETIONS.0.finish_reason": "stop",
        "SpanAttributes.LLM_COMPLETIONS.0.role": "assistant",
```

This is caused by how fstrings format enums. It uses the enum name, not the value of the enum.

After this fix, you get this:

```
        "gen_ai.prompt.1.role": "assistant",
        "gen_ai.prompt.1.content": "Hello! How can I help you today?",
        "gen_ai.prompt.2.role": "user",
        "gen_ai.prompt.2.content": "testing 123",
        "gen_ai.completion.0.finish_reason": "stop",
        "gen_ai.completion.0.role": "assistant",
```

I opted to fix this by explicitly calling `.value` in the fstring, but another option is to add a `__format__` method to the `SpanAttributes` enum to return the value, that might be a safer approach in case someone else forgets call `.value` but it could impact other things that use the enum.