### PR TITLE
fix: VoyageAI `prompt_token` always empty

### DIFF
--- a/litellm/llms/voyage/embedding/transformation.py
+++ b/litellm/llms/voyage/embedding/transformation.py
@@ -131,7 +131,7 @@ class VoyageEmbeddingConfig(BaseEmbeddingConfig):
         model_response.object = raw_response_json.get("object")
 
         usage = Usage(
-            prompt_tokens=raw_response_json.get("usage", {}).get("prompt_tokens", 0),
+            prompt_tokens=raw_response_json.get("usage", {}).get("total_tokens", 0),
             total_tokens=raw_response_json.get("usage", {}).get("total_tokens", 0),
         )
         model_response.usage = usage

--- a/tests/llm_translation/test_voyage_ai.py
+++ b/tests/llm_translation/test_voyage_ai.py
@@ -54,3 +54,27 @@ def test_voyage_ai_embedding_extra_params():
 
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+def test_voyage_ai_embedding_prompt_token_mapping():
+    try:
+
+        client = HTTPHandler()
+        litellm.set_verbose = True
+
+        with patch.object(client, "post", return_value=MagicMock(status_code=200, json=lambda: {"usage": {"total_tokens": 120}})) as mock_client:
+            response = litellm.embedding(
+                model="voyage/voyage-3-lite",
+                input=["a"],
+                dimensions=512,
+                input_type="document",
+                client=client,
+            )
+
+            mock_client.assert_called_once()
+            # Assert the response
+            assert response.usage.prompt_tokens == 120
+            assert response.usage.total_tokens == 120
+
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")


### PR DESCRIPTION
## VoyageAI `prompt_token` always empty


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

### Unit test screenshot

![image](https://github.com/user-attachments/assets/1dc74d67-1331-4d23-9a02-06c4d23774e4)


## Type

🐛 Bug Fix

## Changes

- Map `total_tokens` in usage response also to `prompt_tokens`, because voyage does *not* return `prompt_tokens` in their response
  - OpenAI Spec: https://platform.openai.com/docs/api-reference/embeddings/create
  - Voyage Spec: https://docs.voyageai.com/reference/embeddings-api
    - has *no* `prompt_tokens`


## Additional information

I had to install these additional dependencies to run the test. I am not sure if that's my mistake or if they are missing in the `pyproject.toml

```
botocore = "^1.37.12"
hypercorn = "^0.17.3"
boto3 = "^1.37.12"
```


