### PR TITLE
Use AsyncRetry in acompletion_with_retries

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3191,13 +3191,13 @@ async def acompletion_with_retries(*args, **kwargs):
     retry_strategy = kwargs.pop("retry_strategy", "constant_retry")
     original_function = kwargs.pop("original_function", completion)
     if retry_strategy == "exponential_backoff_retry":
-        retryer = tenacity.Retrying(
+        retryer = tenacity.AsyncRetrying(
             wait=tenacity.wait_exponential(multiplier=1, max=10),
             stop=tenacity.stop_after_attempt(num_retries),
             reraise=True,
         )
     else:
-        retryer = tenacity.Retrying(
+        retryer = tenacity.AsyncRetrying(
             stop=tenacity.stop_after_attempt(num_retries), reraise=True
         )
     return await retryer(original_function, *args, **kwargs)

--- a/tests/local_testing/test_completion_with_retries.py
+++ b/tests/local_testing/test_completion_with_retries.py
@@ -155,22 +155,18 @@ async def test_acompletion_with_retries_retries():
 
     from unittest.mock import patch
 
-    retry_count = 0
     with patch.object(litellm, "acompletion") as mock_completion:
         async def timeout_fnc(*args, **kwargs):
-            nonlocal retry_count
-            retry_count += 1
-            
             await mock_completion(*args, **kwargs)
-            if retry_count < 3:
-                raise litellm.Timeout(message='test', model='gpt-3.5-turbo', llm_provider='mock')
+            raise litellm.Timeout(message='test', model='gpt-3.5-turbo', llm_provider='mock')
         
-        await acompletion_with_retries(
-            model="gpt-3.5-turbo",
-            messages=[{"gm": "vibe", "role": "user"}],
-            num_retries=3,
-            original_function=timeout_fnc,
-        )
+        with pytest.raises(litellm.Timeout):
+            await acompletion_with_retries(
+                model="gpt-3.5-turbo",
+                messages=[{"gm": "vibe", "role": "user"}],
+                num_retries=3,
+                original_function=timeout_fnc,
+            )
     
     assert mock_completion.call_count == 3
     


### PR DESCRIPTION
## Title

This PR fixes the retry mechanism in `main.acompletion_with_retries`. Although this method is deprecated, it is used in the `utils.client.wrapper_async` method, which is _not_ marked as deprecated - meaning this should be fixed, or `utils.client.wrapper_async` should be updated to use `main.acompletion` or `router.acompletion`. 

## Relevant issues

Similar to #4908 however updating `utils.client.wrapper_async` to use `main.acompletion` causes unexpected results.

## Pre-Submission checklist

![image](https://github.com/user-attachments/assets/d027d2f5-e88a-4082-8056-6b77e9cf49bf)


**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


