### PR TITLE
Docs: Update configs.md

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -474,6 +474,7 @@ credential_list:
 #### Key Parameters
 - `credential_name`: Unique identifier for the credential set
 - `credential_values`: Key-value pairs of credentials/secrets (supports `os.environ/` syntax)
+- `credential_info`: Key-value pairs of user provided credentials information.  No key-value pairs are required, but the dictionary must exist.
 
 ### Load API Keys from Secret Managers (Azure Vault, etc)
 


### PR DESCRIPTION
credential_info is a required key

## Title

Add documentation of credential_info in credential_list

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [n/a ] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [n/a ] I have added a screenshot of my new test passing locally 
- [n/a] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Adds a note that credential_info is required to be present, even if empty. 

Note: I was going to propose that we make credential_info optional, but I presume it's required presence was for a reason.