### PR TITLE
feat: Add option to skip creating opentelemetry exporter

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -82,8 +82,6 @@ class OpenTelemetry(CustomLogger):
         **kwargs,
     ):
         from opentelemetry import trace
-        from opentelemetry.sdk.resources import Resource
-        from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.trace import SpanKind
 
         if config is None:
@@ -93,11 +91,16 @@ class OpenTelemetry(CustomLogger):
         self.OTEL_EXPORTER = self.config.exporter
         self.OTEL_ENDPOINT = self.config.endpoint
         self.OTEL_HEADERS = self.config.headers
-        provider = TracerProvider(resource=Resource(attributes=LITELLM_RESOURCE))
-        provider.add_span_processor(self._get_span_processor())
         self.callback_name = callback_name
 
-        trace.set_tracer_provider(provider)
+        if self.OTEL_EXPORTER != "none":
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+
+            provider = TracerProvider(resource=Resource(attributes=LITELLM_RESOURCE))
+            provider.add_span_processor(self._get_span_processor())
+            trace.set_tracer_provider(provider)
+
         self.tracer = trace.get_tracer(LITELLM_TRACER_NAME)
 
         self.span_kind = SpanKind


### PR DESCRIPTION
## Title

Add option to skip creating opentelemetry exporter

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

If you're using litellm as a library (not the proxy server) you may want to use the opentelemetry integration, but not have litellm create its own exporter. In my case, we use [opentelemetry auto-instrumentation](https://opentelemetry.io/docs/zero-code/python/) which sets up exporters for you.

If you do it this way, litellm will create its own tracer, which will be connected to the existing exporter.

FYI, I didn't update the docs yet, if the code looks good, I can do so.