### PR TITLE
fix(security): Add API key masking in exceptions

### DIFF
--- a/tests/test_exceptions_masking.py
+++ b/tests/test_exceptions_masking.py
@@ -1,0 +1,59 @@
+import unittest
+import litellm
+from litellm import exceptions
+
+
+class TestExceptionsMasking(unittest.TestCase):
+    def test_api_key_masking_in_exceptions(self):
+        """Test that API keys are properly masked in exception messages"""
+        
+        # Test with a message containing an API key
+        api_key = "sk-12345678901234567890"
+        message = f"Failed to authenticate with API key {api_key}"
+        
+        # Create an exception with this message
+        exception = exceptions.AuthenticationError(
+            message=message,
+            llm_provider="test_provider",
+            model="test_model"
+        )
+        
+        # Check that the API key is not present in the exception message
+        self.assertNotIn(api_key, exception.message)
+        # Check that a masked version is present instead (should have the prefix and suffix)
+        self.assertIn("sk-1", exception.message)
+        self.assertIn("7890", exception.message)
+        
+    def test_multiple_sensitive_keys_masked(self):
+        """Test that multiple sensitive keys in the same message are masked"""
+        
+        # Message with multiple sensitive information
+        message = (
+            "Error occurred. API key: sk-abc123def456, "
+            "Secret key: secret_xyz987, "
+            "Password: pass123word"
+        )
+        
+        # Create an exception with this message
+        exception = exceptions.BadRequestError(
+            message=message,
+            model="test_model",
+            llm_provider="test_provider"
+        )
+        
+        # Check that none of the sensitive data is present
+        self.assertNotIn("sk-abc123def456", exception.message)
+        self.assertNotIn("secret_xyz987", exception.message)
+        self.assertNotIn("pass123word", exception.message)
+        
+        # Check that masked versions are present
+        self.assertIn("sk-a", exception.message)
+        self.assertIn("456", exception.message)
+        self.assertIn("secr", exception.message)
+        self.assertIn("987", exception.message)
+        self.assertIn("pass", exception.message)
+        self.assertIn("word", exception.message)
+
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
# Title
fix(security): Add API key masking in exceptions

## Relevant issues
https://github.com/BerriAI/litellm/issues/9007

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - Created `tests/test_exceptions_masking.py` with tests for API key masking
- [x] I have added a screenshot of my new test passing locally - Tests pass successfully 
<img width="840" alt="Screenshot 2025-03-15 at 5 05 33 PM" src="https://github.com/user-attachments/assets/727db43e-fc34-4cf0-b95a-f6fc8ba45762" />

- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR adds API key masking functionality to all exception messages in litellm to prevent accidental exposure of sensitive data like API keys in error messages and logs.

Changes include:
- Import `SensitiveDataMasker` utility from `litellm.litellm_core_utils.sensitive_data_masker`
- Implement a `_mask_message` helper function in `exceptions.py` that uses regex patterns to detect and mask sensitive information like API keys
- Apply the masking function to all exception types
- Add comprehensive regex patterns for various API key formats (OpenAI, AWS, Azure, etc.)
- Add unit tests to verify the masking functionality

The implementation uses regex patterns to identify sensitive data in exception messages and masks them with the original prefixes and suffixes visible, but the middle portion replaced with asterisks.
