### PR TITLE
fix(docs): update xAI Grok vision model reference

### DIFF
--- a/docs/my-website/docs/providers/xai.md
+++ b/docs/my-website/docs/providers/xai.md
@@ -82,7 +82,7 @@ from litellm import completion
 os.environ["XAI_API_KEY"] = "your-api-key"
 
 response = completion(
-    model="xai/grok-2-latest",
+    model="xai/grok-2-vision-latest",
     messages=[
         {
             "role": "user",


### PR DESCRIPTION
## Title

fix(docs): update xAI Grok vision model reference

## Relevant issues

[<!-- e.g. "Fixes #000" -->](https://github.com/BerriAI/litellm/issues/9278)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - No tests were needed for this documentation-only change
- [x] I have added a screenshot of my new test passing locally
  - N/A for documentation change
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Updated the XAI provider documentation to correctly reference "grok-2-vision-latest" instead of "grok-2-latest" in the vision example. The regular Grok-2 model doesn't support vision capabilities, so this correction ensures the example works as expected.
