### PR TITLE
Update prompt_caching.md to fix typo

### DIFF
--- a/docs/my-website/docs/completion/prompt_caching.md
+++ b/docs/my-website/docs/completion/prompt_caching.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 # Prompt Caching 
 
 Supported Providers:
-- OpenAI (`deepseek/`)
+- OpenAI (`openai/`)
 - Anthropic API (`anthropic/`)
 - Bedrock (`bedrock/`, `bedrock/invoke/`, `bedrock/converse`) ([All models bedrock supports prompt caching on](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html))
 - Deepseek API (`deepseek/`)


### PR DESCRIPTION
openai endpoint is presumably supposed to read `openai/` not `deepseek/` here. not yet at least :)

## Title

Update prompt_caching.md to fix typo


