### PR TITLE
docs(vertexai): fix typo in required env variables

### DIFF
--- a/docs/my-website/docs/index.md
+++ b/docs/my-website/docs/index.md
@@ -111,8 +111,8 @@ from litellm import completion
 import os
 
 # auth: run 'gcloud auth application-default'
-os.environ["VERTEX_PROJECT"] = "hardy-device-386718"
-os.environ["VERTEX_LOCATION"] = "us-central1"
+os.environ["VERTEXAI_PROJECT"] = "hardy-device-386718"
+os.environ["VERTEXAI_LOCATION"] = "us-central1"
 
 response = completion(
   model="vertex_ai/gemini-1.5-pro",


### PR DESCRIPTION
## Title

Fix typo in required environment variables for using with Vertex AI 

## Relevant issues

I did not find an existing issue for this but noticed the difference when [`validate_environment` method](https://github.com/BerriAI/litellm/blob/ce9b6f49bb047b573a14ad0a877592209cd3bd29/litellm/utils.py#L4871-L4875) threw an error.
Its correct in other sections and this is the only place where it was different. 
https://docs.litellm.ai/docs/providers/vertex#environment-variables

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
📖 Documentation

## Changes
* Replace `VERTEX_PROJECT` with `VERTEXAI_PROJECT`
* Replace `VERTEX_LOCATION` with `VERTEXAI_LOCATION`
