### PR TITLE
Modify completion handler for SageMaker to use payload from `prepared_request`

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -213,7 +213,7 @@ class SagemakerLLM(BaseAWSLLM):
                 sync_response = sync_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=data,
+                    data=prepared_request.body,
                     stream=stream,
                 )
 

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -308,7 +308,7 @@ class SagemakerLLM(BaseAWSLLM):
                 sync_response = sync_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=_data,
+                    data=prepared_request.body,
                     timeout=timeout,
                 )
 
@@ -356,7 +356,7 @@ class SagemakerLLM(BaseAWSLLM):
         self,
         api_base: str,
         headers: dict,
-        data: dict,
+        data: str,
         logging_obj,
         client=None,
     ):
@@ -368,7 +368,7 @@ class SagemakerLLM(BaseAWSLLM):
             response = await client.post(
                 api_base,
                 headers=headers,
-                json=data,
+                data=data,
                 stream=True,
             )
 
@@ -440,7 +440,7 @@ class SagemakerLLM(BaseAWSLLM):
         completion_stream = await self.make_async_call(
             api_base=prepared_request.url,
             headers=prepared_request.headers,  # type: ignore
-            data=data,
+            data=prepared_request.body,
             logging_obj=logging_obj,
         )
         streaming_response = CustomStreamWrapper(
@@ -522,7 +522,7 @@ class SagemakerLLM(BaseAWSLLM):
                 response = await async_handler.post(
                     url=prepared_request.url,
                     headers=prepared_request.headers,  # type: ignore
-                    json=data,
+                    data=prepared_request.body,
                     timeout=timeout,
                 )
 

--- a/tests/local_testing/test_sagemaker.py
+++ b/tests/local_testing/test_sagemaker.py
@@ -265,7 +265,7 @@ async def test_acompletion_sagemaker_non_stream():
         # Assert
         mock_post.assert_called_once()
         _, kwargs = mock_post.call_args
-        args_to_sagemaker = kwargs["json"]
+        args_to_sagemaker = json.loads(kwargs["data"])
         print("Arguments passed to sagemaker=", args_to_sagemaker)
         assert args_to_sagemaker == expected_payload
         assert (
@@ -325,7 +325,7 @@ async def test_completion_sagemaker_non_stream():
         # Assert
         mock_post.assert_called_once()
         _, kwargs = mock_post.call_args
-        args_to_sagemaker = kwargs["json"]
+        args_to_sagemaker = json.loads(kwargs["data"])
         print("Arguments passed to sagemaker=", args_to_sagemaker)
         assert args_to_sagemaker == expected_payload
         assert (
@@ -386,7 +386,7 @@ async def test_completion_sagemaker_prompt_template_non_stream():
         # Assert
         mock_post.assert_called_once()
         _, kwargs = mock_post.call_args
-        args_to_sagemaker = kwargs["json"]
+        args_to_sagemaker = json.loads(kwargs["data"])
         print("Arguments passed to sagemaker=", args_to_sagemaker)
         assert args_to_sagemaker == expected_payload
 
@@ -445,7 +445,7 @@ async def test_completion_sagemaker_non_stream_with_aws_params():
         # Assert
         mock_post.assert_called_once()
         _, kwargs = mock_post.call_args
-        args_to_sagemaker = kwargs["json"]
+        args_to_sagemaker = json.loads(kwargs["data"])
         print("Arguments passed to sagemaker=", args_to_sagemaker)
         assert args_to_sagemaker == expected_payload
         assert (


### PR DESCRIPTION
## Title

Modifies SageMaker Completion handler to use the input as bytes from `prepared_request` as input instead of using JSON input. 

`prepared_request` from [here](https://github.com/BerriAI/litellm/blob/3875df666b8a11819eda86fdc35d582be4bd8db6/litellm/llms/sagemaker/completion/handler.py#L275-L283) calculates the Content-Length in regards to the `_data` parameter. This also will encode the input to be used in the API successfully. Therefore we can reuse the payload under `prepared_request.body` as an input into our HTTP handler POST parameter where the payload is accurate to the `Content-Length`. As this is already encoded we pass it under the `data=` parameter rather than the `json=` parameter.

This requires a few changes in the unit tests as they expect the input to be in the `json` key.

## Relevant issues

Fixes #8534 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

PR results when running `poetry run pytest tests/local_testing/test_sagemaker.py` on my SageMaker endpoint
![image](https://github.com/user-attachments/assets/f277e874-7c60-4885-adfe-e2fe78933876)

My SageMaker container did require changing the max_tokens to a negative value to raise bad request as the large number appeared to work fine. However I have not changed this in this PR in case it is working elsewhere.


## Type

🐛 Bug Fix

## Changes

Changes litellm/llms/sagemaker/completion/handler.py to pass `data=prepared_request.body` into API calls instead of `json=_data`. When passing in the `json=_data` it throws `Too little data for declared Content-Length`.

Unit tests for `tests/local_testing/test_sagemaker.py` were updated to account for this.
