### PR TITLE
[Bug fix] Reset Budget Job

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 from datetime import datetime, timedelta
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
@@ -318,9 +318,11 @@ class ResetBudgetJob:
     async def _reset_budget_common(
         item: Union[LiteLLM_TeamTable, LiteLLM_UserTable, LiteLLM_VerificationToken],
         current_time: datetime,
-        item_type: str,
+        item_type: Literal["key", "team", "user"],
     ):
         """
+        In-place, updates spend=0, and sets budget_reset_at to current_time + budget_duration
+
         Common logic for resetting budget for a team, user, or key
         """
         try:
@@ -339,19 +341,25 @@ class ResetBudgetJob:
     async def _reset_budget_for_team(
         team: LiteLLM_TeamTable, current_time: datetime
     ) -> Optional[LiteLLM_TeamTable]:
-        await ResetBudgetJob._reset_budget_common(team, current_time, "team")
+        await ResetBudgetJob._reset_budget_common(
+            item=team, current_time=current_time, item_type="team"
+        )
         return team
 
     @staticmethod
     async def _reset_budget_for_user(
         user: LiteLLM_UserTable, current_time: datetime
     ) -> Optional[LiteLLM_UserTable]:
-        await ResetBudgetJob._reset_budget_common(user, current_time, "user")
+        await ResetBudgetJob._reset_budget_common(
+            item=user, current_time=current_time, item_type="user"
+        )
         return user
 
     @staticmethod
     async def _reset_budget_for_key(
         key: LiteLLM_VerificationToken, current_time: datetime
     ) -> Optional[LiteLLM_VerificationToken]:
-        await ResetBudgetJob._reset_budget_common(key, current_time, "key")
+        await ResetBudgetJob._reset_budget_common(
+            item=key, current_time=current_time, item_type="key"
+        )
         return key

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -319,7 +319,7 @@ class ResetBudgetJob:
         item: Union[LiteLLM_TeamTable, LiteLLM_UserTable, LiteLLM_VerificationToken],
         current_time: datetime,
         item_type: str,
-    ) -> Union[LiteLLM_TeamTable, LiteLLM_UserTable, LiteLLM_VerificationToken]:
+    ):
         """
         Common logic for resetting budget for a team, user, or key
         """
@@ -339,19 +339,19 @@ class ResetBudgetJob:
     async def _reset_budget_for_team(
         team: LiteLLM_TeamTable, current_time: datetime
     ) -> Optional[LiteLLM_TeamTable]:
-        result = await ResetBudgetJob._reset_budget_common(team, current_time, "team")
-        return result if isinstance(result, LiteLLM_TeamTable) else None
+        await ResetBudgetJob._reset_budget_common(team, current_time, "team")
+        return team
 
     @staticmethod
     async def _reset_budget_for_user(
         user: LiteLLM_UserTable, current_time: datetime
     ) -> Optional[LiteLLM_UserTable]:
-        result = await ResetBudgetJob._reset_budget_common(user, current_time, "user")
-        return result if isinstance(result, LiteLLM_UserTable) else None
+        await ResetBudgetJob._reset_budget_common(user, current_time, "user")
+        return user
 
     @staticmethod
     async def _reset_budget_for_key(
         key: LiteLLM_VerificationToken, current_time: datetime
     ) -> Optional[LiteLLM_VerificationToken]:
-        result = await ResetBudgetJob._reset_budget_common(key, current_time, "key")
-        return result if isinstance(result, LiteLLM_VerificationToken) else None
+        await ResetBudgetJob._reset_budget_common(key, current_time, "key")
+        return key

--- a/tests/litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1,0 +1,201 @@
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
+from litellm.proxy.utils import ProxyLogging
+
+
+# Mock classes for testing
+class MockPrismaClient:
+    def __init__(self):
+        self.data = {"key": [], "user": [], "team": []}
+        self.updated_data = {"key": [], "user": [], "team": []}
+
+    async def get_data(self, table_name, query_type, **kwargs):
+        return self.data.get(table_name, [])
+
+    async def update_data(self, query_type, data_list, table_name):
+        self.updated_data[table_name] = data_list
+        return data_list
+
+
+class MockProxyLogging:
+    class MockServiceLogging:
+        async def async_service_success_hook(self, **kwargs):
+            pass
+
+        async def async_service_failure_hook(self, **kwargs):
+            pass
+
+    def __init__(self):
+        self.service_logging_obj = self.MockServiceLogging()
+
+
+# Test fixtures
+@pytest.fixture
+def mock_prisma_client():
+    return MockPrismaClient()
+
+
+@pytest.fixture
+def mock_proxy_logging():
+    return MockProxyLogging()
+
+
+@pytest.fixture
+def reset_budget_job(mock_prisma_client, mock_proxy_logging):
+    return ResetBudgetJob(
+        proxy_logging_obj=mock_proxy_logging, prisma_client=mock_prisma_client
+    )
+
+
+# Helper function to run async tests
+async def run_async_test(coro):
+    return await coro
+
+
+# Tests
+def test_reset_budget_for_key(reset_budget_job, mock_prisma_client):
+    # Setup test data
+    now = datetime.utcnow()
+    test_key = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {
+            "spend": 100.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now,
+            "id": "test-key-1",
+        },
+    )
+
+    mock_prisma_client.data["key"] = [test_key]
+
+    # Run the test
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_keys())
+
+    # Verify results
+    assert len(mock_prisma_client.updated_data["key"]) == 1
+    updated_key = mock_prisma_client.updated_data["key"][0]
+    assert updated_key.spend == 0.0
+    assert updated_key.budget_reset_at > now
+
+
+def test_reset_budget_for_user(reset_budget_job, mock_prisma_client):
+    # Setup test data
+    now = datetime.utcnow()
+    test_user = type(
+        "LiteLLM_UserTable",
+        (),
+        {
+            "spend": 200.0,
+            "budget_duration": "7d",
+            "budget_reset_at": now,
+            "id": "test-user-1",
+        },
+    )
+
+    mock_prisma_client.data["user"] = [test_user]
+
+    # Run the test
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_users())
+
+    # Verify results
+    assert len(mock_prisma_client.updated_data["user"]) == 1
+    updated_user = mock_prisma_client.updated_data["user"][0]
+    assert updated_user.spend == 0.0
+    assert updated_user.budget_reset_at > now
+
+
+def test_reset_budget_for_team(reset_budget_job, mock_prisma_client):
+    # Setup test data
+    now = datetime.utcnow()
+    test_team = type(
+        "LiteLLM_TeamTable",
+        (),
+        {
+            "spend": 500.0,
+            "budget_duration": "1mo",
+            "budget_reset_at": now,
+            "id": "test-team-1",
+        },
+    )
+
+    mock_prisma_client.data["team"] = [test_team]
+
+    # Run the test
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_teams())
+
+    # Verify results
+    assert len(mock_prisma_client.updated_data["team"]) == 1
+    updated_team = mock_prisma_client.updated_data["team"][0]
+    assert updated_team.spend == 0.0
+    assert updated_team.budget_reset_at > now
+
+
+def test_reset_budget_all(reset_budget_job, mock_prisma_client):
+    # Setup test data
+    now = datetime.utcnow()
+
+    # Create test objects for all three types
+    test_key = type(
+        "LiteLLM_VerificationToken",
+        (),
+        {
+            "spend": 100.0,
+            "budget_duration": "30d",
+            "budget_reset_at": now,
+            "id": "test-key-1",
+        },
+    )
+
+    test_user = type(
+        "LiteLLM_UserTable",
+        (),
+        {
+            "spend": 200.0,
+            "budget_duration": "7d",
+            "budget_reset_at": now,
+            "id": "test-user-1",
+        },
+    )
+
+    test_team = type(
+        "LiteLLM_TeamTable",
+        (),
+        {
+            "spend": 500.0,
+            "budget_duration": "1mo",
+            "budget_reset_at": now,
+            "id": "test-team-1",
+        },
+    )
+
+    mock_prisma_client.data["key"] = [test_key]
+    mock_prisma_client.data["user"] = [test_user]
+    mock_prisma_client.data["team"] = [test_team]
+
+    # Run the test
+    asyncio.run(reset_budget_job.reset_budget())
+
+    # Verify results
+    assert len(mock_prisma_client.updated_data["key"]) == 1
+    assert len(mock_prisma_client.updated_data["user"]) == 1
+    assert len(mock_prisma_client.updated_data["team"]) == 1
+
+    # Check that all spends were reset to 0
+    assert mock_prisma_client.updated_data["key"][0].spend == 0.0
+    assert mock_prisma_client.updated_data["user"][0].spend == 0.0
+    assert mock_prisma_client.updated_data["team"][0].spend == 0.0

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -3879,3 +3879,149 @@ async def test_get_paginated_teams(prisma_client):
     except Exception as e:
         print(f"Error occurred: {e}")
         pytest.fail(f"Test failed with exception: {e}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_type", ["key", "user", "team"])
+async def test_reset_budget_job(prisma_client, entity_type):
+    """
+    Test that the ResetBudgetJob correctly resets budgets for keys, users, and teams.
+
+    For each entity type:
+    1. Create a new entity with max_budget=100, spend=99, budget_duration=5s
+    2. Call the reset_budget function
+    3. Verify the entity's spend is reset to 0 and budget_reset_at is updated
+    """
+    from datetime import datetime, timedelta
+    import time
+
+    from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
+    from litellm.proxy.utils import ProxyLogging
+
+    # Setup
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    await litellm.proxy.proxy_server.prisma_client.connect()
+
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
+    reset_budget_job = ResetBudgetJob(
+        proxy_logging_obj=proxy_logging_obj, prisma_client=prisma_client
+    )
+
+    # Create entity based on type
+    entity_id = None
+    if entity_type == "key":
+        # Create a key with specific budget settings
+        key = await generate_key_fn(
+            data=GenerateKeyRequest(
+                max_budget=100,
+                budget_duration="5s",
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+        )
+        entity_id = key.token_id
+        print("generated key=", key)
+
+        # Update the key to set spend and reset_at to now
+        updated = await prisma_client.db.litellm_verificationtoken.update_many(
+            where={"token": key.token_id},
+            data={
+                "spend": 99.0,
+            },
+        )
+        print("Updated key=", updated)
+
+    elif entity_type == "user":
+        # Create a user with specific budget settings
+        user = await new_user(
+            data=NewUserRequest(
+                max_budget=100,
+                budget_duration="5s",
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+        )
+        entity_id = user.user_id
+
+        # Update the user to set spend and reset_at to now
+        await prisma_client.db.litellm_usertable.update_many(
+            where={"user_id": user.user_id},
+            data={
+                "spend": 99.0,
+            },
+        )
+
+    elif entity_type == "team":
+        # Create a team with specific budget settings
+        team_id = f"test-team-{uuid.uuid4()}"
+        team = await new_team(
+            NewTeamRequest(
+                team_id=team_id,
+                max_budget=100,
+                budget_duration="5s",
+            ),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+            http_request=Request(scope={"type": "http"}),
+        )
+        entity_id = team_id
+
+        # Update the team to set spend and reset_at to now
+        current_time = datetime.utcnow()
+        await prisma_client.db.litellm_teamtable.update(
+            where={"team_id": team_id},
+            data={
+                "spend": 99.0,
+            },
+        )
+
+    # Verify entity was created and updated with spend
+    if entity_type == "key":
+        entity_before = await prisma_client.db.litellm_verificationtoken.find_unique(
+            where={"token": entity_id}
+        )
+    elif entity_type == "user":
+        entity_before = await prisma_client.db.litellm_usertable.find_unique(
+            where={"user_id": entity_id}
+        )
+    elif entity_type == "team":
+        entity_before = await prisma_client.db.litellm_teamtable.find_unique(
+            where={"team_id": entity_id}
+        )
+
+    assert entity_before is not None
+    assert entity_before.spend == 99.0
+
+    # Wait for 5 seconds to pass
+    print("sleeping for 5 seconds")
+    time.sleep(5)
+
+    # Call the reset_budget function
+    await reset_budget_job.reset_budget()
+
+    # Verify the entity's spend is reset and budget_reset_at is updated
+    if entity_type == "key":
+        entity_after = await prisma_client.db.litellm_verificationtoken.find_unique(
+            where={"token": entity_id}
+        )
+    elif entity_type == "user":
+        entity_after = await prisma_client.db.litellm_usertable.find_unique(
+            where={"user_id": entity_id}
+        )
+    elif entity_type == "team":
+        entity_after = await prisma_client.db.litellm_teamtable.find_unique(
+            where={"team_id": entity_id}
+        )
+
+    assert entity_after is not None
+    assert entity_after.spend == 0.0


### PR DESCRIPTION
## [Bug fix] Reset Budget Job

Fixes #8364 

## Details of the issue 
- LiteLLM users reported budgets not being reset for keys, users, teams 
- When budget was being reset we set item.spend=0 and update item.budget_reset_ai and return the item 
- Before returning the item we checked `isinstance(result, LiteLLM_TeamTable)` if resetting the budget of a team, but the result was of type `prisma.LiteLLM_TeamTable` and hence returned `None`
- Line of code with the issue `return result if isinstance(result, LiteLLM_TeamTable) else None`

## 5 Whys Analysis for this issue 

Why was the budget not being reset for keys, users, and teams?
→ The function responsible for resetting budgets was returning None instead of the updated item.

Why was the function returning None?
→ The check isinstance(result, LiteLLM_TeamTable) failed because result was of type prisma.LiteLLM_TeamTable.

Why was there a mismatch in types (LiteLLM_TeamTable vs. prisma.LiteLLM_TeamTable)?
→ The code expected LiteLLM_TeamTable, but prisma.LiteLLM_TeamTable was returned due to how Prisma ORM generated the models.

Why was this type mismatch not caught earlier?
→ There were no end-to-end (E2E) tests validating the cron job execution, so the issue was not detected during testing on ci/cd. We only had unit tests around this 

Why were there no E2E tests for this scenario?
→ The initial focus was on unit tests + adding better error logging rather than full workflow validation, leading to a gap in coverage. We have now added a test to validate full workflow coverage for keys, users, teams 



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes


