### PR TITLE
Fix TTFT prioritization for streaming in LowestLatencyLoggingHandler

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -469,8 +469,6 @@ class LowestLatencyLoggingHandler(CustomLogger):
             total: float = 0.0
             if (
                 request_kwargs is not None
-                and len(item_latency) > 0
-                and isinstance(item_latency[0], timedelta)
                 and request_kwargs.get("stream", None) is not None
                 and request_kwargs["stream"] is True
                 and len(item_ttft_latency) > 0
@@ -478,6 +476,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 for _call_latency in item_ttft_latency:
                     if isinstance(_call_latency, float):
                         total += _call_latency
+                total = total / len(item_ttft_latency) if total > 0 else float('inf')
             elif len(item_latency) > 0 and isinstance(item_latency[0], timedelta):
                 for _call_latency in item_latency:
                     total += _call_latency.total_seconds()
@@ -485,7 +484,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 for _call_latency in item_latency:
                     if isinstance(_call_latency, float):
                         total += _call_latency
-            item_latency = total / len(item_latency)
+            item_latency = total / len(item_latency) if total > 0 else float('inf')
 
             # -------------- #
             # Debugging Logic


### PR DESCRIPTION
## Title

Fix TTFT prioritization for streaming in LowestLatencyLoggingHandler

## Type
🐛 Bug Fix

## Changes
Corrected _get_available_deployments to properly use time_to_first_token latency
for streaming requests by removing incorrect timedelta check and fixing averaging
logic. Ensures deployment with fastest TTFT is selected for streaming, while
maintaining correct total latency selection for non-streaming. Fixes test failure
in test_lowest_latency_routing_time_to_first_token.

