### PR TITLE
fix: VertexAI outputDimensionality configuration

### DIFF
--- a/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
@@ -79,7 +79,7 @@ class VertexAITextEmbeddingConfig(BaseModel):
     ):
         for param, value in non_default_params.items():
             if param == "dimensions":
-                optional_params["output_dimensionality"] = value
+                optional_params["outputDimensionality"] = value
 
         if "input_type" in kwargs:
             optional_params["task_type"] = kwargs.pop("input_type")

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -2174,9 +2174,6 @@ async def test_vertexai_multimodal_embedding_base64image_in_input():
         print("Response:", response)
 
 
-@pytest.mark.skip(
-    reason="new test - works locally running into vertex version issues on ci/cd"
-)
 def test_vertexai_embedding_embedding_latest():
     try:
         load_vertex_ai_credentials()


### PR DESCRIPTION
## Title

VertexAI's API documentation [1] is an absolute mess. In it, they describe the parameter to configure output dimensionality as `output_dimensionality`. In the API example, they switch to using snake case `outputDimensionality`, which is the correct variant.

[1]: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#generative-ai-get-text-embedding-drest

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** 
  - Actually I unskipped a test which was failing on main, and now no longer fails
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Test run output:

```
> pytest -v tests/local_testing/test_amazing_vertex_completion.py -k test_vertexai_embedding_embedding_latest
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.12.9, pytest-7.4.4, pluggy-1.5.0 -- /Users/james/Development/litellm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/james/Development/litellm
plugins: asyncio-0.23.8, respx-0.22.0, ignore-flaky-2.2.1, anyio-4.5.2, mock-3.14.0
asyncio: mode=Mode.STRICT
collected 96 items / 94 deselected / 2 selected

tests/local_testing/test_amazing_vertex_completion.py::test_vertexai_embedding_embedding_latest PASSED                                                                    [ 50%]
tests/local_testing/test_amazing_vertex_completion.py::test_vertexai_embedding_embedding_latest_input_type SKIPPED (need to get gecko permissions on vertex ai to run...) [100%]
```

FYI you need to improve your testing infrastructure. It's really broken.

- I had to add the following to the project's `pyproject.toml` because these dependencies are used but not specified:

```diff
a/pyproject.toml b/pyproject.toml
index 38d568780..52f7a13dd 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,10 @@ flake8 = "^6.1.0"
 black = "^23.12.0"
 mypy = "^1.0"
 pytest = "^7.4.3"
+pytest-asyncio = "*"
 pytest-mock = "^3.12.0"
+pytest-ignore-flaky = "*"
+respx = "*"
```

- I also had to hack around the `load_vertex_ai_credentials` and `tests/local_testing/vertex_key.json` to make the test run.

## Type

🐛 Bug Fix

## Changes


