### PR TITLE
integration: add lunary to the list of compatible proxy callbacks

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -86,6 +86,7 @@ service_callback: List[CALLBACK_TYPES] = []
 logging_callback_manager = LoggingCallbackManager()
 _custom_logger_compatible_callbacks_literal = Literal[
     "lago",
+    "lunary",
     "openmeter",
     "logfire",
     "literalai",


### PR DESCRIPTION
## Title

`lunary` can only be used with `success_callback` and `failure_callback` in the config.yaml for LiteLLM proxy.
This PR allows to use it directly in on the `callback` field.