### PR TITLE
Update AWS bedrock regions

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -44,7 +44,18 @@ class AmazonBedrockGlobalConfig:
         )
 
     def get_ap_regions(self) -> List[str]:
-        return ["ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1"]
+        """
+        Source: https://www.aws-services.info/bedrock.html
+        """
+        return [
+            "ap-northeast-1",  # Asia Pacific (Tokyo)
+            "ap-northeast-2",  # Asia Pacific (Seoul)
+            "ap-northeast-3",  # Asia Pacific (Osaka)
+            "ap-south-1",      # Asia Pacific (Mumbai)
+            "ap-south-2",      # Asia Pacific (Hyderabad)
+            "ap-southeast-1",  # Asia Pacific (Singapore)
+            "ap-southeast-2",  # Asia Pacific (Sydney)
+        ]
 
     def get_sa_regions(self) -> List[str]:
         return ["sa-east-1"]
@@ -54,10 +65,14 @@ class AmazonBedrockGlobalConfig:
         Source: https://www.aws-services.info/bedrock.html
         """
         return [
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "eu-central-1",
+            "eu-west-1",      # Europe (Ireland)
+            "eu-west-2",      # Europe (London)
+            "eu-west-3",      # Europe (Paris)
+            "eu-central-1",   # Europe (Frankfurt)
+            "eu-central-2",   # Europe (Zurich)
+            "eu-south-1",     # Europe (Milan)
+            "eu-south-2",     # Europe (Spain)
+            "eu-north-1",     # Europe (Stockholm)
         ]
 
     def get_ca_regions(self) -> List[str]:
@@ -68,11 +83,11 @@ class AmazonBedrockGlobalConfig:
         Source: https://www.aws-services.info/bedrock.html
         """
         return [
-            "us-east-2",
-            "us-east-1",
-            "us-west-1",
-            "us-west-2",
-            "us-gov-west-1",
+            "us-east-1",      # US East (N. Virginia)
+            "us-east-2",      # US East (Ohio)
+            "us-west-2",      # US West (Oregon)
+            "us-gov-east-1",  # AWS GovCloud (US-East)
+            "us-gov-west-1",  # AWS GovCloud (US-West)
         ]
 
 


### PR DESCRIPTION
## Update AWS bedrock regions

If Litellm doesn't know which AWS regions support bedrock it is confused when calculating the costs (but only if streaming is disabled).

## Relevant issues

#9306

## Type

🐛 Bug Fix


