### PR TITLE
Added a resource configuration placeholder to migrationJob in the Helm chart.

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -48,6 +48,8 @@ spec:
             {{- end }}
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
+          resources:
+            {{- toYaml .Values.migrationJob.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -194,6 +194,17 @@ migrationJob:
   disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.
   annotations: {}
   ttlSecondsAfterFinished: 120
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 # Additional environment variables to be added to the deployment
 envVars: {


### PR DESCRIPTION
## Title

Added a resource configuration placeholder to migrationJob in the Helm chart.

## Relevant issues

W0321 13:07:51.567917   23993 warnings.go:70] autopilot-default-resources-mutator:Autopilot updated Job litellm/litellm-migrations: defaulted unspecified 'cpu' resource for containers [prisma-migrations] (see http://g.co/gke/autopilot-defaults).
![image](https://github.com/user-attachments/assets/a29ef0a1-4073-43b4-a87f-6c2acb7be28a)


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

The warning message is no longer displayed.
![image](https://github.com/user-attachments/assets/4076a1b6-19e2-4bf0-97a9-cc36b20fd235)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes


