### PR TITLE
 [BUG] Made it easier to use the Snowflake integration

### DIFF
--- a/docs/my-website/docs/providers/snowflake.md
+++ b/docs/my-website/docs/providers/snowflake.md
@@ -63,7 +63,6 @@ response = completion(
     api_base = "snowflakecomputing.com"
 )
 ```
-and Litellm will add the `/api/v2/cortex/inference:complete/` and the `account-id` for you.
 
 ## Usage with LiteLLM Proxy 
 

--- a/docs/my-website/docs/providers/snowflake.md
+++ b/docs/my-website/docs/providers/snowflake.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 | Description | The Snowflake Cortex LLM REST API lets you access the COMPLETE function via HTTP POST requests|
 | Provider Route on LiteLLM | `snowflake/` |
 | Link to Provider Doc | [Snowflake ↗](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api) |
-| Base URL | [https://{account-id}.snowflakecomputing.com/api/v2/cortex/inference:complete/](https://{account-id}.snowflakecomputing.com/api/v2/cortex/inference:complete) |
+| Base URL | [snowflakecomputing.com](snowflakecomputing.com) |
 | Supported OpenAI Endpoints | `/chat/completions`, `/completions` |
 
 
@@ -25,16 +25,16 @@ Find the Arctic Embed models [here](https://huggingface.co/collections/Snowflake
     "response_format"
 ```
 
-## API KEYS
+## API Keys
 
-Snowflake does have API keys. Instead, you access the Snowflake API with your JWT token and account identifier.
+Snowflake does have API keys. Instead, you have to access the Snowflake API with your JWT token and account identifier.
 
 ```python
 import os 
 os.environ["SNOWFLAKE_JWT"] = "YOUR JWT"
 os.environ["SNOWFLAKE_ACCOUNT_ID"] = "YOUR ACCOUNT IDENTIFIER"
 ```
-## Usage
+## Python SDK Usage 
 
 ```python
 from litellm import completion
@@ -49,26 +49,38 @@ response = completion(
     messages = [{ "content": "Hello, how are you?","role": "user"}]
 )
 ```
+### Adding an api_base: 
+
+If you want to specify the API base, you don't have to put the full snowflake url:
+
+e.g `https://{account-id}.snowflakecomputing.com/api/v2/cortex/inference:complete/`
+
+Instead, you can just pass
+```python
+response = completion(
+    model="snowflake/mistral-7b", 
+    messages = [{ "content": "Hello, how are you?","role": "user"}],
+    api_base = "snowflakecomputing.com"
+)
+```
+and Litellm will add the `/api/v2/cortex/inference:complete/` and the `account-id` for you.
 
 ## Usage with LiteLLM Proxy 
 
-#### 1. Required env variables
-```bash
-export SNOWFLAKE_JWT=""
-export SNOWFLAKE_ACCOUNT_ID = ""
-```
 
-#### 2. Start the proxy~
+#### 1. Start the proxy~
 ```yaml
 model_list:
   - model_name: mistral-7b
     litellm_params:
         model: snowflake/mistral-7b
-        api_key: YOUR_API_KEY
-        api_base: https://YOUR-ACCOUNT-ID.snowflakecomputing.com/api/v2/cortex/inference:complete
+        snowflake_jwt: <JWT>
+        snowflake_account_id: <ACCOUNT-ID>
+        api_base: snowflakecomputing.com
 
 ```
 
+#### 2. Start Litellm Proxy Server
 ```bash
 litellm --config /path/to/config.yaml
 ```

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -575,7 +575,8 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
         api_base = (
                     api_base
                     or get_secret("SNOWFLAKE_API_BASE")
-                    or f"https://{get_secret('SNOWFLAKE_ACCOUNT_ID')}.snowflakecomputing.com/api/v2/cortex/inference:complete"
+                    or "snowflakecomputing.com"
+                    # or f"https://{get_secret('SNOWFLAKE_ACCOUNT_ID')}.snowflakecomputing.com/api/v2/cortex/inference:complete"
                 )  # type: ignore
         dynamic_api_key = api_key or get_secret("SNOWFLAKE_JWT")
 


### PR DESCRIPTION
## Made it easier to use the Snowflake integration. 
- allow the users to pass `snowflake_account_id` and `snowflake_jwt `as dynamic params via config.yaml
- allow the user to pass an `api_base` and append the `api/v2/cortex/inference:complete` to their api base like openai does. 

Example config.yaml:
```
model_list:
  - model_name: mistral-7b
    litellm_params:
        model: snowflake/mistral-7b
        snowflake_jwt: <JWT>
        snowflake_account_id: <ACCOUNT-ID>
        api_base: snowflakecomputing.com
```


## Relevant issues
Address:  #9231


## Pre-Submission checklist


- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🧹 Refactoring
📖 Documentation
✅ Test


<img width="1043" alt="Screenshot 2025-03-21 at 5 17 28 PM" src="https://github.com/user-attachments/assets/c9cf89ec-1bf5-4c0c-9745-02b1ed1cd2aa" />

