### PR TITLE
[#9449] Update `model_params_helper.py` to use `.__dict__()` in place of `.__annotations__` for `openai.types.audio.transcription_create_params.TranscriptionCreateParams`

### DIFF
--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -123,7 +123,7 @@ class ModelParamHelper:
 
         This follows the OpenAI API Spec
         """
-        return set(TranscriptionCreateParams.__annotations__.keys())
+        return set(TranscriptionCreateParams.__dict__.keys())
 
     @staticmethod
     def _get_exclude_kwargs() -> Set[str]:


### PR DESCRIPTION
## Title

Update `model_params_helper.py` to use `.__dict__()` in place of `.__annotations__` for `openai.types.audio.transcription_create_params.TranscriptionCreateParams`

## Relevant issues

Fixes #9449 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Simple change to use `.__dict__()` attribute in place of `.__annotations__()`. Clears logging warning

