### PR TITLE
fix(model_param_helper.py): update `_get_litellm_supported_transcription_kwargs()` to use proper annotations from `TranscriptionCreateParamsNonStreaming` & ``TranscriptionCreateParamsStreaming`

### DIFF
--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -1,6 +1,9 @@
 from typing import Set
 
-from openai.types.audio.transcription_create_params import TranscriptionCreateParams
+from openai.types.audio.transcription_create_params import (
+    TranscriptionCreateParamsNonStreaming,
+    TranscriptionCreateParamsStreaming,
+)
 from openai.types.chat.completion_create_params import (
     CompletionCreateParamsNonStreaming,
     CompletionCreateParamsStreaming,
@@ -123,7 +126,10 @@ class ModelParamHelper:
 
         This follows the OpenAI API Spec
         """
-        return set(TranscriptionCreateParams.__dict__.keys())
+        all_transcription_kwargs = set(
+            TranscriptionCreateParamsNonStreaming.__annotations__.keys()
+        ).union(set(TranscriptionCreateParamsStreaming.__annotations__.keys()))
+        return all_transcription_kwargs
 
     @staticmethod
     def _get_exclude_kwargs() -> Set[str]:

--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -123,7 +123,7 @@ class ModelParamHelper:
 
         This follows the OpenAI API Spec
         """
-        return set(TranscriptionCreateParams.__annotations__.keys())
+        return set(TranscriptionCreateParams.__dict__.keys())
 
     @staticmethod
     def _get_exclude_kwargs() -> Set[str]:


### PR DESCRIPTION
## Title

fix(model_param_helper.py): update `_get_litellm_supported_transcription_kwargs()` to use proper annotations from `TranscriptionCreateParamsNonStreaming` & ``TranscriptionCreateParamsStreaming`

## Relevant issues

Fixes #9449

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ X ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Changed use of `__annotation__` on `TranscriptionCreateParams` Union type, to use correct `TranscriptionCreateParamsStreaming` & `TranscriptionCreateParamsNonStreaming`. Clears logging issue.
