### PR TITLE
feat: Gemini models support video type

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1476,8 +1476,8 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             file_message = cast(ChatCompletionFileObject, m)
                             file_data = file_message["file"].get("file_data")
                             if file_data:
-                                image_chunk = convert_to_anthropic_image_obj(
-                                    openai_image_url=file_data,
+                                image_chunk = convert_to_anthropic_media_obj(
+                                    openai_media_url=file_data,
                                     format=file_message["file"].get("format"),
                                 )
                                 anthropic_document_param = (

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -36,7 +36,7 @@ from litellm.types.llms.vertex_ai import PartType as VertexPartType
 from litellm.types.utils import GenericMediaParsingChunk
 
 from .common_utils import convert_content_list_to_str, is_non_content_values_set
-from .image_handling import convert_url_to_base64
+from .media_handling import convert_url_to_base64
 
 
 def default_pt(messages):
@@ -721,7 +721,9 @@ def convert_to_anthropic_media_obj(
 ) -> GenericMediaParsingChunk:
     """
     Input:
-    "openai_media_url": "data:{media_type};base64,{base64_data}",
+    openai_media_url:
+      - "data:{media_type};base64,{base64_data}"
+      - HTTP URL, e.g. "http://example.com/image.jpg"
 
     Return:
     "source": {
@@ -750,7 +752,7 @@ def convert_to_anthropic_media_obj(
         if "Error: Unable to fetch media from URL" in str(e):
             raise e
         raise Exception(
-            """Media url not in expected format. Example Expected input - "openai_media_url": "data:{media_type};base64,{base64_image}". Supported formats - ['image/jpeg', 'image/png', 'image/gif', 'image/webp']."""
+            """Media url not in expected format. Example Expected input - "http://example.com/image.jpg" or "data:{media_type};base64,{base64_image}". Supported formats - ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4']."""
         )
 
 

--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -15,34 +15,34 @@ MAX_IMGS_IN_MEMORY = 10
 in_memory_cache = InMemoryCache(max_size_in_memory=MAX_IMGS_IN_MEMORY)
 
 
-def _process_image_response(response: Response, url: str) -> str:
+def _process_media_response(response: Response, url: str) -> str:
     if response.status_code != 200:
         raise Exception(
-            f"Error: Unable to fetch image from URL. Status code: {response.status_code}, url={url}"
+            f"Error: Unable to fetch media from URL. Status code: {response.status_code}, url={url}"
         )
 
-    image_bytes = response.content
-    base64_image = base64.b64encode(image_bytes).decode("utf-8")
+    media_bytes = response.content
+    base64_data = base64.b64encode(media_bytes).decode("utf-8")
 
-    image_type = response.headers.get("Content-Type")
-    if image_type is None:
-        img_type = url.split(".")[-1].lower()
-        _img_type = {
+    media_tyte = response.headers.get("Content-Type")
+    if media_tyte is None:
+        med_type = url.split(".")[-1].lower()
+        _med_type = {
             "jpg": "image/jpeg",
             "jpeg": "image/jpeg",
             "png": "image/png",
             "gif": "image/gif",
             "webp": "image/webp",
-        }.get(img_type)
-        if _img_type is None:
+        }.get(med_type)
+        if _med_type is None:
             raise Exception(
-                f"Error: Unsupported image format. Format={_img_type}. Supported types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']"
+                f"Error: Unsupported media format. Format={_med_type}. Supported types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']"
             )
-        img_type = _img_type
+        med_type = _med_type
     else:
-        img_type = image_type
+        med_type = media_tyte
 
-    result = f"data:{img_type};base64,{base64_image}"
+    result = f"data:{med_type};base64,{base64_data}"
     in_memory_cache.set_cache(url, result)
     return result
 
@@ -56,11 +56,11 @@ async def async_convert_url_to_base64(url: str) -> str:
     for _ in range(3):
         try:
             response = await client.get(url, follow_redirects=True)
-            return _process_image_response(response, url)
+            return _process_media_response(response, url)
         except Exception:
             pass
     raise Exception(
-        f"Error: Unable to fetch image from URL after 3 attempts. url={url}"
+        f"Error: Unable to fetch media from URL after 3 attempts. url={url}"
     )
 
 
@@ -73,11 +73,11 @@ def convert_url_to_base64(url: str) -> str:
     for _ in range(3):
         try:
             response = client.get(url, follow_redirects=True)
-            return _process_image_response(response, url)
+            return _process_media_response(response, url)
         except Exception as e:
             verbose_logger.exception(e)
             # print(e)
             pass
     raise Exception(
-        f"Error: Unable to fetch image from URL after 3 attempts. url={url}"
+        f"Error: Unable to fetch media from URL after 3 attempts. url={url}"
     )

--- a/litellm/litellm_core_utils/prompt_templates/image_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/image_handling.py
@@ -33,10 +33,11 @@ def _process_media_response(response: Response, url: str) -> str:
             "png": "image/png",
             "gif": "image/gif",
             "webp": "image/webp",
+            "mp4": "video/mp4",
         }.get(med_type)
         if _med_type is None:
             raise Exception(
-                f"Error: Unsupported media format. Format={_med_type}. Supported types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']"
+                f"Error: Unsupported media format. Format={_med_type}. Supported types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4']"
             )
         med_type = _med_type
     else:

--- a/litellm/litellm_core_utils/prompt_templates/media_handling.py
+++ b/litellm/litellm_core_utils/prompt_templates/media_handling.py
@@ -1,5 +1,5 @@
 """
-Helper functions to handle images passed in messages
+Helper functions to handle media passed in messages
 """
 
 import base64
@@ -24,8 +24,8 @@ def _process_media_response(response: Response, url: str) -> str:
     media_bytes = response.content
     base64_data = base64.b64encode(media_bytes).decode("utf-8")
 
-    media_tyte = response.headers.get("Content-Type")
-    if media_tyte is None:
+    media_type = response.headers.get("Content-Type")
+    if media_type is None:
         med_type = url.split(".")[-1].lower()
         _med_type = {
             "jpg": "image/jpeg",
@@ -41,7 +41,7 @@ def _process_media_response(response: Response, url: str) -> str:
             )
         med_type = _med_type
     else:
-        med_type = media_tyte
+        med_type = media_type
 
     result = f"data:{med_type};base64,{base64_data}"
     in_memory_cache.set_cache(url, result)

--- a/litellm/llms/gemini/chat/transformation.py
+++ b/litellm/llms/gemini/chat/transformation.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Optional
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (
-    convert_generic_image_chunk_to_openai_image_obj,
-    convert_to_anthropic_image_obj,
+    convert_generic_media_chunk_to_openai_media_obj,
+    convert_to_anthropic_media_obj,
 )
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.llms.vertex_ai import ContentType, PartType
@@ -121,11 +121,11 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
                         else:
                             _image_url = img_element.get("image_url")  # type: ignore
                         if _image_url and "https://" in _image_url:
-                            image_obj = convert_to_anthropic_image_obj(
+                            image_obj = convert_to_anthropic_media_obj(
                                 _image_url, format=format
                             )
                             img_element["image_url"] = (  # type: ignore
-                                convert_generic_image_chunk_to_openai_image_obj(
+                                convert_generic_media_chunk_to_openai_media_obj(
                                     image_obj
                                 )
                             )

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -211,10 +211,9 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                         elif element["type"] == "video_url":
                             element = cast(ChatCompletionVideoObject, element)
                             video_element = element
-                            format: Optional[str] = None
                             if isinstance(video_element["video_url"], dict):
                                 video_url = video_element["video_url"]["url"]
-                                format = img_element["video_url"].get("format")
+                                format = video_element["video_url"].get("format")
                             else:
                                 video_url = video_element["video_url"]
                             _part = _process_gemini_media(
@@ -224,8 +223,8 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                         elif element["type"] == "input_audio":
                             audio_element = cast(ChatCompletionAudioObject, element)
                             if audio_element["input_audio"].get("data") is not None:
-                                _part = _process_gemini_image(
-                                    image_url=audio_element["input_audio"]["data"],
+                                _part = _process_gemini_media(
+                                    media_url=audio_element["input_audio"]["data"],
                                     format=audio_element["input_audio"].get("format"),
                                 )
                                 _parts.append(_part)
@@ -240,8 +239,8 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                                     "Unknown file type. Please pass in a file_id or file_data"
                                 )
                             try:
-                                _part = _process_gemini_image(
-                                    image_url=passed_file, format=format
+                                _part = _process_gemini_media(
+                                    media_url=passed_file, format=format
                                 )
                                 _parts.append(_part)
                             except Exception:

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -106,6 +106,8 @@ def _get_media_mime_type_from_url(url: str) -> Optional[str]:
     See gemini mime types:
      - https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-understanding#image-requirements
      - https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding#video-requirements
+     - https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding#audio-requirements
+     - https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/document-understanding#document-requirements
 
     Supported by Gemini:
      application/pdf
@@ -187,6 +189,7 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 if _message_content is not None and isinstance(_message_content, list):
                     _parts: List[PartType] = []
                     for element_idx, element in enumerate(_message_content):
+                        format: Optional[str] = None
                         if (
                             element["type"] == "text"
                             and "text" in element
@@ -198,7 +201,6 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                         elif element["type"] == "image_url":
                             element = cast(ChatCompletionImageObject, element)
                             img_element = element
-                            format: Optional[str] = None
                             if isinstance(img_element["image_url"], dict):
                                 image_url = img_element["image_url"]["url"]
                                 format = img_element["image_url"].get("format")

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1576,7 +1576,7 @@ class TranscriptionResponse(OpenAIObject):
             return self.dict()
 
 
-class GenericImageParsingChunk(TypedDict):
+class GenericMediaParsingChunk(TypedDict):
     type: str
     media_type: str
     data: str

--- a/poetry.lock
+++ b/poetry.lock
@@ -1153,69 +1153,6 @@ files = [
 protobuf = ["grpcio-tools (>=1.70.0)"]
 
 [[package]]
-name = "grpcio"
-version = "1.71.0"
-description = "HTTP/2-based RPC framework"
-optional = true
-python-versions = ">=3.9"
-files = [
-    {file = "grpcio-1.71.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:c200cb6f2393468142eb50ab19613229dcc7829b5ccee8b658a36005f6669fdd"},
-    {file = "grpcio-1.71.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:b2266862c5ad664a380fbbcdbdb8289d71464c42a8c29053820ee78ba0119e5d"},
-    {file = "grpcio-1.71.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:0ab8b2864396663a5b0b0d6d79495657ae85fa37dcb6498a2669d067c65c11ea"},
-    {file = "grpcio-1.71.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c30f393f9d5ff00a71bb56de4aa75b8fe91b161aeb61d39528db6b768d7eac69"},
-    {file = "grpcio-1.71.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f250ff44843d9a0615e350c77f890082102a0318d66a99540f54769c8766ab73"},
-    {file = "grpcio-1.71.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e6d8de076528f7c43a2f576bc311799f89d795aa6c9b637377cc2b1616473804"},
-    {file = "grpcio-1.71.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9b91879d6da1605811ebc60d21ab6a7e4bae6c35f6b63a061d61eb818c8168f6"},
-    {file = "grpcio-1.71.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f71574afdf944e6652203cd1badcda195b2a27d9c83e6d88dc1ce3cfb73b31a5"},
-    {file = "grpcio-1.71.0-cp310-cp310-win32.whl", hash = "sha256:8997d6785e93308f277884ee6899ba63baafa0dfb4729748200fcc537858a509"},
-    {file = "grpcio-1.71.0-cp310-cp310-win_amd64.whl", hash = "sha256:7d6ac9481d9d0d129224f6d5934d5832c4b1cddb96b59e7eba8416868909786a"},
-    {file = "grpcio-1.71.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:d6aa986318c36508dc1d5001a3ff169a15b99b9f96ef5e98e13522c506b37eef"},
-    {file = "grpcio-1.71.0-cp311-cp311-macosx_10_14_universal2.whl", hash = "sha256:d2c170247315f2d7e5798a22358e982ad6eeb68fa20cf7a820bb74c11f0736e7"},
-    {file = "grpcio-1.71.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:e6f83a583ed0a5b08c5bc7a3fe860bb3c2eac1f03f1f63e0bc2091325605d2b7"},
-    {file = "grpcio-1.71.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4be74ddeeb92cc87190e0e376dbc8fc7736dbb6d3d454f2fa1f5be1dee26b9d7"},
-    {file = "grpcio-1.71.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd0dfbe4d5eb1fcfec9490ca13f82b089a309dc3678e2edabc144051270a66e"},
-    {file = "grpcio-1.71.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a2242d6950dc892afdf9e951ed7ff89473aaf744b7d5727ad56bdaace363722b"},
-    {file = "grpcio-1.71.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:0fa05ee31a20456b13ae49ad2e5d585265f71dd19fbd9ef983c28f926d45d0a7"},
-    {file = "grpcio-1.71.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3d081e859fb1ebe176de33fc3adb26c7d46b8812f906042705346b314bde32c3"},
-    {file = "grpcio-1.71.0-cp311-cp311-win32.whl", hash = "sha256:d6de81c9c00c8a23047136b11794b3584cdc1460ed7cbc10eada50614baa1444"},
-    {file = "grpcio-1.71.0-cp311-cp311-win_amd64.whl", hash = "sha256:24e867651fc67717b6f896d5f0cac0ec863a8b5fb7d6441c2ab428f52c651c6b"},
-    {file = "grpcio-1.71.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:0ff35c8d807c1c7531d3002be03221ff9ae15712b53ab46e2a0b4bb271f38537"},
-    {file = "grpcio-1.71.0-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:b78a99cd1ece4be92ab7c07765a0b038194ded2e0a26fd654591ee136088d8d7"},
-    {file = "grpcio-1.71.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:dc1a1231ed23caac1de9f943d031f1bc38d0f69d2a3b243ea0d664fc1fbd7fec"},
-    {file = "grpcio-1.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6beeea5566092c5e3c4896c6d1d307fb46b1d4bdf3e70c8340b190a69198594"},
-    {file = "grpcio-1.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5170929109450a2c031cfe87d6716f2fae39695ad5335d9106ae88cc32dc84c"},
-    {file = "grpcio-1.71.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5b08d03ace7aca7b2fadd4baf291139b4a5f058805a8327bfe9aece7253b6d67"},
-    {file = "grpcio-1.71.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:f903017db76bf9cc2b2d8bdd37bf04b505bbccad6be8a81e1542206875d0e9db"},
-    {file = "grpcio-1.71.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:469f42a0b410883185eab4689060a20488a1a0a00f8bbb3cbc1061197b4c5a79"},
-    {file = "grpcio-1.71.0-cp312-cp312-win32.whl", hash = "sha256:ad9f30838550695b5eb302add33f21f7301b882937460dd24f24b3cc5a95067a"},
-    {file = "grpcio-1.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:652350609332de6dac4ece254e5d7e1ff834e203d6afb769601f286886f6f3a8"},
-    {file = "grpcio-1.71.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:cebc1b34ba40a312ab480ccdb396ff3c529377a2fce72c45a741f7215bfe8379"},
-    {file = "grpcio-1.71.0-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:85da336e3649a3d2171e82f696b5cad2c6231fdd5bad52616476235681bee5b3"},
-    {file = "grpcio-1.71.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f9a412f55bb6e8f3bb000e020dbc1e709627dcb3a56f6431fa7076b4c1aab0db"},
-    {file = "grpcio-1.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47be9584729534660416f6d2a3108aaeac1122f6b5bdbf9fd823e11fe6fbaa29"},
-    {file = "grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9c80ac6091c916db81131d50926a93ab162a7e97e4428ffc186b6e80d6dda4"},
-    {file = "grpcio-1.71.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:789d5e2a3a15419374b7b45cd680b1e83bbc1e52b9086e49308e2c0b5bbae6e3"},
-    {file = "grpcio-1.71.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:1be857615e26a86d7363e8a163fade914595c81fec962b3d514a4b1e8760467b"},
-    {file = "grpcio-1.71.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a76d39b5fafd79ed604c4be0a869ec3581a172a707e2a8d7a4858cb05a5a7637"},
-    {file = "grpcio-1.71.0-cp313-cp313-win32.whl", hash = "sha256:74258dce215cb1995083daa17b379a1a5a87d275387b7ffe137f1d5131e2cfbb"},
-    {file = "grpcio-1.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:22c3bc8d488c039a199f7a003a38cb7635db6656fa96437a8accde8322ce2366"},
-    {file = "grpcio-1.71.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:c6a0a28450c16809f94e0b5bfe52cabff63e7e4b97b44123ebf77f448534d07d"},
-    {file = "grpcio-1.71.0-cp39-cp39-macosx_10_14_universal2.whl", hash = "sha256:a371e6b6a5379d3692cc4ea1cb92754d2a47bdddeee755d3203d1f84ae08e03e"},
-    {file = "grpcio-1.71.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:39983a9245d37394fd59de71e88c4b295eb510a3555e0a847d9965088cdbd033"},
-    {file = "grpcio-1.71.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9182e0063112e55e74ee7584769ec5a0b4f18252c35787f48738627e23a62b97"},
-    {file = "grpcio-1.71.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:693bc706c031aeb848849b9d1c6b63ae6bcc64057984bb91a542332b75aa4c3d"},
-    {file = "grpcio-1.71.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:20e8f653abd5ec606be69540f57289274c9ca503ed38388481e98fa396ed0b41"},
-    {file = "grpcio-1.71.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8700a2a57771cc43ea295296330daaddc0d93c088f0a35cc969292b6db959bf3"},
-    {file = "grpcio-1.71.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d35a95f05a8a2cbe8e02be137740138b3b2ea5f80bd004444e4f9a1ffc511e32"},
-    {file = "grpcio-1.71.0-cp39-cp39-win32.whl", hash = "sha256:f9c30c464cb2ddfbc2ddf9400287701270fdc0f14be5f08a1e3939f1e749b455"},
-    {file = "grpcio-1.71.0-cp39-cp39-win_amd64.whl", hash = "sha256:63e41b91032f298b3e973b3fa4093cbbc620c875e2da7b93e249d4728b54559a"},
-    {file = "grpcio-1.71.0.tar.gz", hash = "sha256:2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c"},
-]
-
-[package.extras]
-protobuf = ["grpcio-tools (>=1.71.0)"]
-
-[[package]]
 name = "grpcio-status"
 version = "1.70.0"
 description = "Status proto mapping for gRPC"
@@ -1229,22 +1166,6 @@ files = [
 [package.dependencies]
 googleapis-common-protos = ">=1.5.5"
 grpcio = ">=1.70.0"
-protobuf = ">=5.26.1,<6.0dev"
-
-[[package]]
-name = "grpcio-status"
-version = "1.71.0"
-description = "Status proto mapping for gRPC"
-optional = true
-python-versions = ">=3.9"
-files = [
-    {file = "grpcio_status-1.71.0-py3-none-any.whl", hash = "sha256:843934ef8c09e3e858952887467f8256aac3910c55f077a359a65b2b3cde3e68"},
-    {file = "grpcio_status-1.71.0.tar.gz", hash = "sha256:11405fed67b68f406b3f3c7c5ae5104a79d2d309666d10d61b152e91d28fb968"},
-]
-
-[package.dependencies]
-googleapis-common-protos = ">=1.5.5"
-grpcio = ">=1.71.0"
 protobuf = ">=5.26.1,<6.0dev"
 
 [[package]]

--- a/tests/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/tests/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+
+@pytest.mark.parametrize(
+    "http_url",
+    ["https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg",
+     "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"],
+)
+def test_convert_generic_media_chunk_to_openai_media_obj(http_url):
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        convert_generic_media_chunk_to_openai_media_obj,
+        convert_to_anthropic_media_obj,
+    )
+
+    # Convert HTTP URL to GenericMediaParsingChunk.
+    chunk = convert_to_anthropic_media_obj(http_url, format=None)
+    # Convert GenericMediaParsingChunk to base64 str.
+    base64_str = convert_generic_media_chunk_to_openai_media_obj(chunk)
+    # Convert base64 str to GenericMediaParsingChunk.
+    new_chunk = convert_to_anthropic_media_obj(base64_str, format=None)
+    assert new_chunk == chunk
+

--- a/tests/litellm/litellm_core_utils/prompt_templates/media_handling.py
+++ b/tests/litellm/litellm_core_utils/prompt_templates/media_handling.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+
+@pytest.mark.parametrize(
+    "http_url",
+    ["https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg",
+     "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"],
+)
+@pytest.mark.asyncio
+async def test_async_convert_url_to_base64(http_url):
+    from litellm.litellm_core_utils.prompt_templates.media_handling import (
+        async_convert_url_to_base64
+    )
+
+    # Convert HTTP URL to base64 str.
+    base64_str = await async_convert_url_to_base64(http_url)
+    assert base64_str.startswith("data:")
+    cached_base64_str = await async_convert_url_to_base64(http_url)
+    assert base64_str == cached_base64_str
+
+@pytest.mark.parametrize(
+    "http_url",
+    ["https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg",
+     "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"],
+)
+def test_convert_url_to_base64(http_url):
+    from litellm.litellm_core_utils.prompt_templates.media_handling import (
+        convert_url_to_base64
+    )
+
+    # Convert HTTP URL to base64 str.
+    base64_str = convert_url_to_base64(http_url)
+    assert base64_str.startswith("data:")
+    cached_base64_str = convert_url_to_base64(http_url)
+    assert base64_str == cached_base64_str
+

--- a/tests/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1,0 +1,108 @@
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.vertex_ai.gemini.transformation import (
+    _gemini_convert_messages_with_history,
+)
+
+@pytest.mark.parametrize(
+    "media_type, mime_type, content",
+    [
+        ("image_url", "image/jpeg", "1234abcd"),
+        ("video_url", "video/mp4", "dcba4321"),
+    ],
+)
+def test_vertex_only_media_user_message_with_base64data(media_type: str, mime_type: str, content: str):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": media_type,
+                    media_type: {"url": f"data:{mime_type};base64,{content}"},
+                },
+            ],
+        },
+    ]
+
+    response = _gemini_convert_messages_with_history(messages=messages)
+    print("response", response)
+
+    expected_response = [
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "inline_data": {
+                        "data": content,
+                        "mime_type": mime_type,
+                    }
+                },
+                {"text": " "},
+            ],
+        }
+    ]
+
+    assert len(response) == len(expected_response)
+    for idx, content in enumerate(response):
+        assert (
+            content == expected_response[idx]
+        ), "Invalid gemini input. Got={}, Expected={}".format(
+            content, expected_response[idx]
+        )
+
+
+@pytest.mark.parametrize(
+    "media_type, mime_type, content",
+    [
+        ("image_url", "image/jpeg", "https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg"),
+        ("video_url", "video/mp4", "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"),
+    ],
+)
+def test_vertex_only_media_user_message_with_url(media_type: str, mime_type: str, content: str):
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": media_type,
+                    media_type: content,
+                },
+            ],
+        },
+    ]
+
+    response = _gemini_convert_messages_with_history(messages=messages)
+    print("response", response)
+
+    expected_response = [
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "file_data": {
+                        "file_uri": content,
+                        "mime_type": mime_type,
+                    }
+                },
+                {"text": " "},
+            ],
+        }
+    ]
+
+    assert len(response) == len(expected_response)
+    for idx, content in enumerate(response):
+        assert (
+            content == expected_response[idx]
+        ), "Invalid gemini input. Got={}, Expected={}".format(
+            content, expected_response[idx]
+        )

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -732,23 +732,6 @@ def test_just_system_message():
         assert "bedrock requires at least one non-system message" in str(e.value)
 
 
-@pytest.mark.parametrize(
-    "url",
-    ["https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg",
-     "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"],
-)
-def test_convert_generic_media_chunk_to_openai_media_obj(url):
-    from litellm.litellm_core_utils.prompt_templates.factory import (
-        convert_generic_media_chunk_to_openai_media_obj,
-        convert_to_anthropic_media_obj,
-    )
-
-    media_obj = convert_to_anthropic_media_obj(url, format=None)
-    url_str = convert_generic_media_chunk_to_openai_media_obj(media_obj)
-    media_obj = convert_to_anthropic_media_obj(url_str, format=None)
-    print(len(media_obj))
-
-
 def test_hf_chat_template():
     from litellm.litellm_core_utils.prompt_templates.factory import (
         hf_chat_template,

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -25,9 +25,6 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_completion_messages,
 )
-from litellm.llms.vertex_ai.gemini.transformation import (
-    _gemini_convert_messages_with_history,
-)
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -430,47 +427,6 @@ def test_bedrock_parallel_tool_calling_pt(provider):
         translated_messages[number_of_messages - 1]["role"]
         != translated_messages[number_of_messages - 2]["role"]
     )
-
-
-def test_vertex_only_image_user_message():
-    base64_image = "/9j/2wCEAAgGBgcGBQ"
-
-    messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"},
-                },
-            ],
-        },
-    ]
-
-    response = _gemini_convert_messages_with_history(messages=messages)
-
-    expected_response = [
-        {
-            "role": "user",
-            "parts": [
-                {
-                    "inline_data": {
-                        "data": "/9j/2wCEAAgGBgcGBQ",
-                        "mime_type": "image/jpeg",
-                    }
-                },
-                {"text": " "},
-            ],
-        }
-    ]
-
-    assert len(response) == len(expected_response)
-    for idx, content in enumerate(response):
-        assert (
-            content == expected_response[idx]
-        ), "Invalid gemini input. Got={}, Expected={}".format(
-            content, expected_response[idx]
-        )
 
 
 def test_convert_url():

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -198,6 +198,7 @@ def test_convert_url_to_img():
         ("data:image/jpeg;base64,1234", "image/jpeg"),
         ("data:application/pdf;base64,1234", "application/pdf"),
         (r"data:image\/jpeg;base64,1234", "image/jpeg"),
+        (r"data:video\/mp4;base64,1234", "video/mp4"),
     ],
 )
 def test_base64_media_input(url, expected_media_type):
@@ -731,17 +732,21 @@ def test_just_system_message():
         assert "bedrock requires at least one non-system message" in str(e.value)
 
 
-def test_convert_generic_media_chunk_to_openai_media_obj():
+@pytest.mark.parametrize(
+    "url",
+    ["https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg",
+     "https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4"],
+)
+def test_convert_generic_media_chunk_to_openai_media_obj(url):
     from litellm.litellm_core_utils.prompt_templates.factory import (
         convert_generic_media_chunk_to_openai_media_obj,
         convert_to_anthropic_media_obj,
     )
 
-    url = "https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg"
-    image_obj = convert_to_anthropic_media_obj(url, format=None)
-    url_str = convert_generic_media_chunk_to_openai_media_obj(image_obj)
-    image_obj = convert_to_anthropic_media_obj(url_str, format=None)
-    print(image_obj)
+    media_obj = convert_to_anthropic_media_obj(url, format=None)
+    url_str = convert_generic_media_chunk_to_openai_media_obj(media_obj)
+    media_obj = convert_to_anthropic_media_obj(url_str, format=None)
+    print(len(media_obj))
 
 
 def test_hf_chat_template():

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -17,7 +17,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     anthropic_messages_pt,
     anthropic_pt,
     claude_2_1_pt,
-    convert_to_anthropic_image_obj,
+    convert_to_anthropic_media_obj,
     convert_url_to_base64,
     llama_2_chat_pt,
     prompt_factory,
@@ -200,8 +200,8 @@ def test_convert_url_to_img():
         (r"data:image\/jpeg;base64,1234", "image/jpeg"),
     ],
 )
-def test_base64_image_input(url, expected_media_type):
-    response = convert_to_anthropic_image_obj(openai_image_url=url, format=None)
+def test_base64_media_input(url, expected_media_type):
+    response = convert_to_anthropic_media_obj(openai_media_url=url, format=None)
 
     assert response["media_type"] == expected_media_type
 
@@ -731,16 +731,16 @@ def test_just_system_message():
         assert "bedrock requires at least one non-system message" in str(e.value)
 
 
-def test_convert_generic_image_chunk_to_openai_image_obj():
+def test_convert_generic_media_chunk_to_openai_media_obj():
     from litellm.litellm_core_utils.prompt_templates.factory import (
-        convert_generic_image_chunk_to_openai_image_obj,
-        convert_to_anthropic_image_obj,
+        convert_generic_media_chunk_to_openai_media_obj,
+        convert_to_anthropic_media_obj,
     )
 
     url = "https://i.pinimg.com/736x/b4/b1/be/b4b1becad04d03a9071db2817fc9fe77.jpg"
-    image_obj = convert_to_anthropic_image_obj(url, format=None)
-    url_str = convert_generic_image_chunk_to_openai_image_obj(image_obj)
-    image_obj = convert_to_anthropic_image_obj(url_str, format=None)
+    image_obj = convert_to_anthropic_media_obj(url, format=None)
+    url_str = convert_generic_media_chunk_to_openai_media_obj(image_obj)
+    image_obj = convert_to_anthropic_media_obj(url_str, format=None)
     print(image_obj)
 
 

--- a/tests/llm_translation/test_vertex.py
+++ b/tests/llm_translation/test_vertex.py
@@ -22,7 +22,7 @@ import pytest
 import litellm
 from litellm import get_optional_params
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
-from litellm.llms.vertex_ai.gemini.transformation import _process_gemini_image
+from litellm.llms.vertex_ai.gemini.transformation import _process_gemini_media
 from litellm.types.llms.vertex_ai import PartType, BlobType
 import httpx
 
@@ -1135,48 +1135,48 @@ def test_logprobs():
         assert resp.choices[0].logprobs is not None
 
 
-def test_process_gemini_image():
-    """Test the _process_gemini_image function for different image sources"""
+def test_process_gemini_media():
+    """Test the _process_gemini_media function for different media sources"""
     from litellm.llms.vertex_ai.gemini.transformation import (
-        _process_gemini_image,
+        _process_gemini_media,
     )
     from litellm.types.llms.vertex_ai import PartType, FileDataType, BlobType
 
     # Test GCS URI
-    gcs_result = _process_gemini_image("gs://bucket/image.png")
+    gcs_result = _process_gemini_media("gs://bucket/image.png")
     assert gcs_result["file_data"] == FileDataType(
         mime_type="image/png", file_uri="gs://bucket/image.png"
     )
 
     # Test gs url with format specified
-    gcs_result = _process_gemini_image("gs://bucket/image", format="image/jpeg")
+    gcs_result = _process_gemini_media("gs://bucket/image", format="image/jpeg")
     assert gcs_result["file_data"] == FileDataType(
         mime_type="image/jpeg", file_uri="gs://bucket/image"
     )
 
     # Test HTTPS JPG URL
-    https_result = _process_gemini_image("https://example.com/image.jpg")
+    https_result = _process_gemini_media("https://example.com/image.jpg")
     print("https_result JPG", https_result)
     assert https_result["file_data"] == FileDataType(
         mime_type="image/jpeg", file_uri="https://example.com/image.jpg"
     )
 
     # Test HTTPS PNG URL
-    https_result = _process_gemini_image("https://example.com/image.png")
+    https_result = _process_gemini_media("https://example.com/image.png")
     print("https_result PNG", https_result)
     assert https_result["file_data"] == FileDataType(
         mime_type="image/png", file_uri="https://example.com/image.png"
     )
 
     # Test HTTPS VIDEO URL
-    https_result = _process_gemini_image("https://cloud-samples-data/video/animals.mp4")
+    https_result = _process_gemini_media("https://cloud-samples-data/video/animals.mp4")
     print("https_result PNG", https_result)
     assert https_result["file_data"] == FileDataType(
         mime_type="video/mp4", file_uri="https://cloud-samples-data/video/animals.mp4"
     )
 
     # Test HTTPS PDF URL
-    https_result = _process_gemini_image("https://cloud-samples-data/pdf/animals.pdf")
+    https_result = _process_gemini_media("https://cloud-samples-data/pdf/animals.pdf")
     print("https_result PDF", https_result)
     assert https_result["file_data"] == FileDataType(
         mime_type="application/pdf",
@@ -1185,7 +1185,7 @@ def test_process_gemini_image():
 
     # Test base64 image
     base64_image = "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
-    base64_result = _process_gemini_image(base64_image)
+    base64_result = _process_gemini_media(base64_image)
     print("base64_result", base64_result)
     assert base64_result["inline_data"]["mime_type"] == "image/jpeg"
     assert base64_result["inline_data"]["data"] == "/9j/4AAQSkZJRg..."
@@ -1194,37 +1194,37 @@ def test_process_gemini_image():
 def test_get_image_mime_type_from_url():
     """Test the _get_image_mime_type_from_url function for different image URLs"""
     from litellm.llms.vertex_ai.gemini.transformation import (
-        _get_image_mime_type_from_url,
+        _get_media_mime_type_from_url,
     )
 
     # Test JPEG images
     assert (
-        _get_image_mime_type_from_url("https://example.com/image.jpg") == "image/jpeg"
+        _get_media_mime_type_from_url("https://example.com/image.jpg") == "image/jpeg"
     )
     assert (
-        _get_image_mime_type_from_url("https://example.com/image.jpeg") == "image/jpeg"
+        _get_media_mime_type_from_url("https://example.com/image.jpeg") == "image/jpeg"
     )
     assert (
-        _get_image_mime_type_from_url("https://example.com/IMAGE.JPG") == "image/jpeg"
+        _get_media_mime_type_from_url("https://example.com/IMAGE.JPG") == "image/jpeg"
     )
 
     # Test PNG images
-    assert _get_image_mime_type_from_url("https://example.com/image.png") == "image/png"
-    assert _get_image_mime_type_from_url("https://example.com/IMAGE.PNG") == "image/png"
+    assert _get_media_mime_type_from_url("https://example.com/image.png") == "image/png"
+    assert _get_media_mime_type_from_url("https://example.com/IMAGE.PNG") == "image/png"
 
     # Test WebP images
     assert (
-        _get_image_mime_type_from_url("https://example.com/image.webp") == "image/webp"
+        _get_media_mime_type_from_url("https://example.com/image.webp") == "image/webp"
     )
     assert (
-        _get_image_mime_type_from_url("https://example.com/IMAGE.WEBP") == "image/webp"
+        _get_media_mime_type_from_url("https://example.com/IMAGE.WEBP") == "image/webp"
     )
 
     # Test unsupported formats
-    assert _get_image_mime_type_from_url("https://example.com/image.gif") is None
-    assert _get_image_mime_type_from_url("https://example.com/image.bmp") is None
-    assert _get_image_mime_type_from_url("https://example.com/image") is None
-    assert _get_image_mime_type_from_url("invalid_url") is None
+    assert _get_media_mime_type_from_url("https://example.com/image.gif") is None
+    assert _get_media_mime_type_from_url("https://example.com/image.bmp") is None
+    assert _get_media_mime_type_from_url("https://example.com/image") is None
+    assert _get_media_mime_type_from_url("invalid_url") is None
 
 
 @pytest.mark.parametrize(
@@ -1268,7 +1268,7 @@ from unittest.mock import Mock, patch
 from typing import Dict, Any
 
 # Import your actual module here
-# from your_module import _process_gemini_image, PartType, FileDataType, BlobType
+# from your_module import _process_gemini_media, PartType, FileDataType, BlobType
 
 
 # Add these fixtures below existing fixtures
@@ -1313,15 +1313,15 @@ def mock_blob():
         "http://subdomain.domain.com/path/to/image.png",
     ],
 )
-def test_process_gemini_image_http_url(
+def test_process_gemini_media_http_url(
     http_url: str, mock_convert_url_to_base64: Mock, mock_blob: Mock
 ) -> None:
     """
-    Test that _process_gemini_image correctly handles HTTP URLs.
+    Test that _process_gemini_media correctly handles HTTP URLs.
 
     Args:
         http_url: Test HTTP URL
-        mock_convert_to_anthropic: Mocked convert_to_anthropic_image_obj function
+        mock_convert_url_to_base64: Mocked convert_to_anthropic_image_obj function
         mock_blob: Mocked BlobType instance
 
     Vertex AI supports image urls. Ensure no network requests are made.
@@ -1329,7 +1329,7 @@ def test_process_gemini_image_http_url(
     expected_image_data = "data:image/jpeg;base64,/9j/4AAQSkZJRg..."
     mock_convert_url_to_base64.return_value = expected_image_data
     # Act
-    result = _process_gemini_image(http_url)
+    result = _process_gemini_media(http_url)
     # assert result["file_data"]["file_uri"] == http_url
 
 

--- a/tests/llm_translation/test_vertex.py
+++ b/tests/llm_translation/test_vertex.py
@@ -1191,8 +1191,8 @@ def test_process_gemini_media():
     assert base64_result["inline_data"]["data"] == "/9j/4AAQSkZJRg..."
 
 
-def test_get_image_mime_type_from_url():
-    """Test the _get_image_mime_type_from_url function for different image URLs"""
+def test_get_media_mime_type_from_url():
+    """Test the _get_media_mime_type_from_url function for different image URLs"""
     from litellm.llms.vertex_ai.gemini.transformation import (
         _get_media_mime_type_from_url,
     )
@@ -1218,6 +1218,16 @@ def test_get_image_mime_type_from_url():
     )
     assert (
         _get_media_mime_type_from_url("https://example.com/IMAGE.WEBP") == "image/webp"
+    )
+
+    # Test PDF files
+    assert (
+        _get_media_mime_type_from_url("https://raft.github.io/raft.pdf") == "application/pdf"
+    )
+
+    # Test Video files
+    assert (
+        _get_media_mime_type_from_url("https://videos.pexels.com/video-files/3571264/3571264-sd_426_240_30fps.mp4") == "video/mp4"
     )
 
     # Test unsupported formats


### PR DESCRIPTION
## Title

Gemini models support video understanding

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
![image](https://github.com/user-attachments/assets/41a327d2-90c5-43aa-98e1-c50227e85aff)
![image](https://github.com/user-attachments/assets/dbc7fc0e-3a15-439a-8f30-376620d92c87)
![image](https://github.com/user-attachments/assets/ac63af5c-ae9b-462e-96d0-6a09c238c776)

- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Make Gemini models support video understanding, this patch make is possible to input video type content.

Most of this patch's change is to rename `image` to `video` in names of functions/variables, the core change is in litellm/llms/vertex_ai/gemini/transformation.py.

https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding
