### PR TITLE
[#9502] fix(litellm.llms.openai.transcriptions.handler.): bypass `response_format` parameter swap to `verbose_json` from `text` or `json` to allow for `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` support

### DIFF
--- a/litellm/llms/openai/transcriptions/handler.py
+++ b/litellm/llms/openai/transcriptions/handler.py
@@ -89,9 +89,14 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         if "response_format" not in data or (
             data["response_format"] == "text" or data["response_format"] == "json"
         ):
-            data["response_format"] = (
-                "verbose_json"  # ensures 'duration' is received - used for cost calculation
-            )
+            # NOTE:
+            # THIS IS A HACK TO ALLOW OPENAI 'GPT-4o' TRANSCRIBE MODELS TO WORK
+            if 'transcribe' in data['model']:
+                data['response_format'] = data['response_format']
+            else:
+                data["response_format"] = (
+                    "verbose_json"  # ensures 'duration' is received - used for cost calculation
+                )
 
         if atranscription is True:
             return self.async_audio_transcriptions(  # type: ignore


### PR DESCRIPTION
## Title

[#9502] fix(litellm.llms.openai.transcriptions.handler.): bypass `response_format` parameter swap to `verbose_json` from `text` or `json` to allow for `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` support

## Relevant issues

Fixes automatic parameter changing for `response_format` leading in failed transcription generations for `gpt-4o-transcribe` & `gpt-4o-mini-transcribe`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ X ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🐛 Bug Fix


## Changes

Changed

```python
      if "response_format" not in data or (
          data["response_format"] == "text" or data["response_format"] == "json"
      ):
          data["response_format"] = (
              "verbose_json"  # ensures 'duration' is received - used for cost calculation
          )
```

To

```python
        if "response_format" not in data or (
            data["response_format"] == "text" or data["response_format"] == "json"
        ):
            # NOTE:
            # THIS IS A HACK TO ALLOW OPENAI 'GPT-4o' TRANSCRIBE MODELS TO WORK
            if 'transcribe' in data['model']:
                data['response_format'] = data['response_format']
            else:
                data["response_format"] = (
                    "verbose_json"  # ensures 'duration' is received - used for cost calculation
                )
```


