### PR TITLE
fix(non_root-migrations): add env var to indicate schema generation step should be skipped inside non_root-image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -83,6 +83,11 @@ RUN chmod +x docker/prod_entrypoint.sh
 USER nobody
 
 RUN prisma generate
+
+# Set the environment variable to skip Prisma generate in the future
+# This is necessary because the migration script will try to run Prisma generate again otherwise
+ENV LITELLM_MIGRATION_SKIP_PRISMA_GENERATE=true
+
 ### End of Prisma Handling for Non-Root #########################################
 
 EXPOSE 4000/tcp


### PR DESCRIPTION
## Title

Fix: New env var indicates no schema generation should be run in migration job of non_root-image

## Relevant issues

Fixes #7173 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [~] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [~] I have added a screenshot of my new test passing locally 
- [~] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

- Introduced new env var LITELLM_MIGRATION_SKIP_PRISMA_GENERATE in Dockerfile.non_root
- Check for new env var in prisma_migration script and skip schema generation skip if set