### PR TITLE
[Fix] properly set completion_start_time for streaming requests

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import httpx
+from datetime import datetime
 from pydantic import BaseModel
 
 import litellm
@@ -1722,6 +1723,11 @@ class CustomStreamWrapper:
                     )
                     if processed_chunk is None:
                         continue
+
+                    if self.logging_obj.completion_start_time is None:
+                        completion_start_time = datetime.now()
+                        self.logging_obj.completion_start_time = completion_start_time
+                        self.logging_obj.model_call_details["completion_start_time"] = completion_start_time
 
                     choice = processed_chunk.choices[0]
                     if isinstance(choice, StreamingChoices):


### PR DESCRIPTION
## [Fix] properly set completion_start_time for streaming requests
Set `completion_start_time` after receiving first token for correct TTFT measurement in logging integrations

Originally, TTFT measurement through integrations like langfuse was broken for `stream=True` requests.

This PR fixes the issue by setting `completion_start_time` after receiving the first token in `CustomStreamWrapper.__anext__`

Attached below is the screenshot result of an E2E test with langfuse.
- [Before] broken TTFT(almost same as latency) due to completion_start_time not being properly set
- [After] valid TTFT after setting completion_start_time
<img width="1279" alt="Screenshot 2025-03-26 at 10 08 05 PM" src="https://github.com/user-attachments/assets/a13e99a0-8b21-4f94-9974-908fd6c2c241" />


## Relevant issues
#9210 

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Set `self.logging_obj.completion_start_time` and `self.logging_obj.model_call_details["completion_start_time"]` in `CompletionStreamWrapper.__anext__`