### PR TITLE
docs(gemini): fix typo

### DIFF
--- a/docs/my-website/docs/providers/gemini.md
+++ b/docs/my-website/docs/providers/gemini.md
@@ -365,7 +365,7 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 </Tabs>
 
 ## Specifying Safety Settings 
-In certain use-cases you may need to make calls to the models and pass [safety settigns](https://ai.google.dev/docs/safety_setting_gemini) different from the defaults. To do so, simple pass the `safety_settings` argument to `completion` or `acompletion`. For example:
+In certain use-cases you may need to make calls to the models and pass [safety settings](https://ai.google.dev/docs/safety_setting_gemini) different from the defaults. To do so, simple pass the `safety_settings` argument to `completion` or `acompletion`. For example:
 
 ```python
 response = completion(


### PR DESCRIPTION
## Title

Typo in Gemini web-documentation - [docs/providers/gemini](https://github.com/BerriAI/litellm/blob/3ca34a181cae83b8b3c73e5937f07e36509a7f35/docs/my-website/docs/providers/gemini.md?plain=1#L368)

## Pre-Submission checklist
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Typo in [gemini.md](https://github.com/BerriAI/litellm/blob/3ca34a181cae83b8b3c73e5937f07e36509a7f35/docs/my-website/docs/providers/gemini.md?plain=1#L368) has been corrected:

OLD: `[safety settigns]`
NEW: `[safety settings]`






