### PR TITLE
Support max_completion_tokens on Mistral

### DIFF
--- a/litellm/llms/mistral/mistral_chat_transformation.py
+++ b/litellm/llms/mistral/mistral_chat_transformation.py
@@ -28,7 +28,9 @@ class MistralConfig(OpenAIGPTConfig):
 
     - `top_p` (number or null): An alternative to sampling with temperature, used for nucleus sampling. API Default - 1.
 
-    - `max_tokens` (integer or null): This optional parameter helps to set the maximum number of tokens to generate in the chat completion. API Default - null.
+    - `max_tokens` [DEPRECATED - use max_completion_tokens] (integer or null): This optional parameter helps to set the maximum number of tokens to generate in the chat completion. API Default - null.
+
+    - `max_completion_tokens` (integer or null): This optional parameter helps to set the maximum number of tokens to generate in the chat completion. API Default - null.
 
     - `tools` (list or null): A list of available tools for the model. Use this to specify functions for which the model can generate JSON inputs.
 
@@ -46,6 +48,7 @@ class MistralConfig(OpenAIGPTConfig):
     temperature: Optional[int] = None
     top_p: Optional[int] = None
     max_tokens: Optional[int] = None
+    max_completion_tokens: Optional[int] = None
     tools: Optional[list] = None
     tool_choice: Optional[Literal["auto", "any", "none"]] = None
     random_seed: Optional[int] = None
@@ -58,6 +61,7 @@ class MistralConfig(OpenAIGPTConfig):
         temperature: Optional[int] = None,
         top_p: Optional[int] = None,
         max_tokens: Optional[int] = None,
+        max_completion_tokens: Optional[int] = None,
         tools: Optional[list] = None,
         tool_choice: Optional[Literal["auto", "any", "none"]] = None,
         random_seed: Optional[int] = None,
@@ -80,6 +84,7 @@ class MistralConfig(OpenAIGPTConfig):
             "temperature",
             "top_p",
             "max_tokens",
+            "max_completion_tokens"
             "tools",
             "tool_choice",
             "seed",
@@ -104,6 +109,8 @@ class MistralConfig(OpenAIGPTConfig):
     ) -> dict:
         for param, value in non_default_params.items():
             if param == "max_tokens":
+                optional_params["max_tokens"] = value
+            if param == "max_completion_tokens": # max_completion_tokens should take priority
                 optional_params["max_tokens"] = value
             if param == "tools":
                 optional_params["tools"] = value

--- a/tests/litellm/llms/mistral/test_mistral_transformation
+++ b/tests/litellm/llms/mistral/test_mistral_transformation
@@ -1,0 +1,45 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.mistral.mistral_chat_transformation import MistralConfig
+
+
+class TestMistralTransform:
+    def setup_method(self):
+        self.config = MistralConfig()
+        self.model = "mistral-small-latest"
+        self.logging_obj = MagicMock()
+
+    def test_map_mistral_params(self):
+        """Test that parameters are correctly mapped"""
+        test_params = {"input": "Hello world", "temperature": 0.7, "max_tokens": 200, "max_completion_tokens": 256}
+
+        result = self.config.map_openai_params(
+            non_default_params=test_params,
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        # The function should properly map max_completion_tokens to max_tokens and override max_tokens
+        assert result == {"input": "Hello world", "temperature": 0.7, "max_tokens": 256}
+
+    def test_mistral_max_tokens_backward_compat(self):
+        """Test that parameters are correctly mapped"""
+        test_params = {"input": "Hello world", "temperature": 0.7, "max_tokens": 200,}
+
+        result = self.config.map_openai_params(
+            non_default_params=test_params,
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        # The function should properly map max_completion_tokens to max_tokens and override max_tokens
+        assert result == {"input": "Hello world", "temperature": 0.7, "max_tokens": 200}

--- a/tests/litellm/llms/mistral/test_mistral_transformation.py
+++ b/tests/litellm/llms/mistral/test_mistral_transformation.py
@@ -18,7 +18,7 @@ class TestMistralTransform:
 
     def test_map_mistral_params(self):
         """Test that parameters are correctly mapped"""
-        test_params = {"input": "Hello world", "temperature": 0.7, "max_tokens": 200, "max_completion_tokens": 256}
+        test_params = {"temperature": 0.7, "max_tokens": 200, "max_completion_tokens": 256}
 
         result = self.config.map_openai_params(
             non_default_params=test_params,
@@ -28,11 +28,11 @@ class TestMistralTransform:
         )
 
         # The function should properly map max_completion_tokens to max_tokens and override max_tokens
-        assert result == {"input": "Hello world", "temperature": 0.7, "max_tokens": 256}
+        assert result == {"temperature": 0.7, "max_tokens": 256}
 
     def test_mistral_max_tokens_backward_compat(self):
         """Test that parameters are correctly mapped"""
-        test_params = {"input": "Hello world", "temperature": 0.7, "max_tokens": 200,}
+        test_params = {"temperature": 0.7, "max_tokens": 200,}
 
         result = self.config.map_openai_params(
             non_default_params=test_params,
@@ -41,5 +41,5 @@ class TestMistralTransform:
             drop_params=False,
         )
 
-        # The function should properly map max_completion_tokens to max_tokens and override max_tokens
-        assert result == {"input": "Hello world", "temperature": 0.7, "max_tokens": 200}
+        # The function should properly map max_tokens if max_completion_tokens is not provided
+        assert result == {"temperature": 0.7, "max_tokens": 200}


### PR DESCRIPTION
## Title

Allow `max_completion_tokens` for Mistral

Note: I am having some issues getting the entire test suite to run locally. Issues with poetry packages and seemingly necessary env variables. But the new tests are passing here. 

## Relevant issues

Fixes #9589

## Pre-Submission checklist
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/899e3b07-30b7-4a8b-814b-8d084d9173a6" />

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


