### PR TITLE
fix: wrong indentation of ttlSecondsAfterFinished in chart

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -65,6 +65,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
 {{- end }}


### PR DESCRIPTION
## Title

Fix wrong indentation of "ttlSecondsAfterFinished" for the migration job. It should be on the `spec` level of the job and not at the container level.

## Relevant issues

follow-up of #8593 

## Type

🐛 Bug Fix

## Changes

indentation of ttlSecondsAfterFinished in the job yaml of the chart


