### PR TITLE
[FIX] - Add password to sync sentinel client

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -202,6 +202,7 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
 
 def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     sentinel_nodes = redis_kwargs.get("sentinel_nodes")
+    sentinel_password = redis_kwargs.get("sentinel_password")
     service_name = redis_kwargs.get("service_name")
 
     if not sentinel_nodes or not service_name:
@@ -212,7 +213,11 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     verbose_logger.debug("init_redis_sentinel: sentinel nodes are being initialized.")
 
     # Set up the Sentinel client
-    sentinel = redis.Sentinel(sentinel_nodes, socket_timeout=0.1)
+    sentinel = redis.Sentinel(
+        sentinel_nodes, 
+        socket_timeout=0.1,
+        password=sentinel_password,
+    )
 
     # Return the master instance for the given service
 


### PR DESCRIPTION
## Title

Adding sentinel password to redis sync sentinel connection

## Relevant issues

Was trying out a setup where my redis cache for my Router is hosted in redis sentinel with a password, was able to manually use the redis cache, but only using the async methods, but failing to authenticate in sync methods.
Then I found out this discrepancy between how the Sentinel object was initialized in sync and async init_sentinel client methods.

Without this, using a sentinel redis connection doesn't work, as pretty much all router usage of the redis cache is with the sync interface, not with the async methods.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

Adds redis_sentinel to sync sentinel connection, which was present in async sentinel connection creation method but not in async

