### PR TITLE
Return a copy from strict key removal to not break cache keys

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -331,10 +331,9 @@ class Cache:
         """
         Get the preset cache key from kwargs["litellm_params"]
 
-        We use _get_preset_cache_keys for two reasons
+        Is set after the cache is first calculated in order to not mutate between request and response time,
+        in case the implementation mutates the original objects (and avoids doing duplicate key calculations)
 
-        1. optional params like max_tokens, get transformed for bedrock -> max_new_tokens
-        2. avoid doing duplicate / repeated work
         """
         if kwargs:
             if "litellm_params" in kwargs:


### PR DESCRIPTION
## Caching stability improvements

A) Return a copy from strict key removal to not break cache keys. This change seems nice and simple. All of the callers I saw using it were updating their reference, e.g. `thing = _remove_strict_from_schema(thing)`, so this seems like it should work just fine. After digging deeper, this part may be unnecessary?

B I also saw there's a property that can be set to re-use the same cache key later, in case mutation occurs, but I guess that only happens if `litellm_params` object has been set previously. Looks like there's a good opportunity to initialize it in `wrapper_async`, such that it can be used to cache the key between request and response if it was not otherwise set.

Origination of this is perhaps a bit of an edge case, but I think these improvements will help.
1. My request didn't have `litellm_params`, although this is probably normal
2. I had erroneously set strict: true on my json schema 

## Relevant issues

fix #9692

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

☝️ this last one is debatable. I could remove part A) to make this simpler

Tests passing screenshots
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/46802cf9-2a89-471d-9da1-f9259bd1f7ac" />
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/5dcd931b-b3bb-43ad-888d-c1ad8d20739a" />

<img width="1117" alt="image" src="https://github.com/user-attachments/assets/86db0cb1-5497-407b-b4e0-f4929e881dce" />



## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Return a copy from strict key removal to not break cache keys
