### PR TITLE
Correct the Azure OpenAI API version check for response_format

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -121,11 +121,11 @@ class AzureOpenAIConfig(BaseConfig):
     ) -> bool:
         """
         - check if api_version is supported for response_format
+        https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/structured-outputs?tabs=python-secure%2Cdotnet-entra-id&pivots=programming-language-csharp#api-support
         """
-
-        is_supported = int(api_version_year) <= 2024 and int(api_version_month) >= 8
-
-        return is_supported
+        year = int(api_version_year)
+        month = int(api_version_month)
+        return (year == 2024 and month >= 8) or year > 2024
 
     def map_openai_params(
         self,

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -290,6 +290,7 @@ def test_azure_openai_gpt_4o_naming(monkeypatch):
     [
         "2024-10-21",
         # "2024-02-15-preview",
+        "2025-02-01-preview",
     ],
 )
 def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
@@ -361,7 +362,7 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
 
         mock_post.assert_called_once()
 
-        if api_version == "2024-10-21":
+        if api_version == "2024-10-21" or api_version == "2025-02-01-preview":
             assert "response_format" in mock_post.call_args.kwargs
         else:
             assert "response_format" not in mock_post.call_args.kwargs


### PR DESCRIPTION
## Relevant issues
Fixes #9703 
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
The API version check didn't take into account versions with the year > 2024, so this PR corrects that.
