### PR TITLE
Fix: Use request body in curl log for Gemini streaming mode

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1029,7 +1029,7 @@ class VertexLLM(VertexBase):
             input=messages,
             api_key="",
             additional_args={
-                "complete_input_dict": data,
+                "complete_input_dict": request_body,
                 "api_base": api_base,
                 "headers": headers,
             },


### PR DESCRIPTION
Observed an inconsistency in the `curl` log output for Gemini between sync and async streaming calls.

The `async_completion` (`stream=false`) output correctly includes the request body in the log. However, the `async_streaming` (`stream=true`) output does not.

async_streaming:

```
21:58:14 - LiteLLM:DEBUG: litellm_logging.py:739 - 
POST Request Sent from LiteLLM:
curl -X POST \
https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/google/models/gemini-2.5-pro-exp-03-25:streamGenerateContent?alt=sse \
-H 'Content-Type: ap****on' -H 'Authorization: Be****7w' \
-d '{'gemini_api_key': None, 'messages': [{'role': 'user', 'content': 'Hello'}], 'api_base': None, 'model': 'gemini-2.5-pro-exp-03-25', 'client': None, 'timeout': 6000.0, 'extra_headers': None, 'optional_params': {'temperature': 0.7, 'respon...
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

async_completion:

```
22:00:34 - LiteLLM:DEBUG: litellm_logging.py:739 - 
POST Request Sent from LiteLLM:
curl -X POST \
https://us-central1-aiplatform.googleapis.com/v1/projects/project-id/locations/us-central1/publishers/google/models/gemini-2.5-pro-exp-03-25:generateContent \
-H 'Content-Type: ap****on' -H 'Authorization: Be****nt' \
-d '{'contents': [{'role': 'user', 'parts': [{'text': 'Hello'}]}], 'system_instruction': {'parts': [{'text': 'assistant'}]}, 'generationConfig': {'temperature': 0.7, 'response_mime_type': 'application/json', 'response_...
     ^^^^^^^^^^^^^^^
```

[#https://github.com/BerriAI/litellm/blob/main/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py#L1128](https://github.com/BerriAI/litellm/blob/main/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py#L1128)



## Type

🐛 Bug Fix
