### PR TITLE
[Feat] Allow assigning SSO users to teams on MSFT SSO

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -10,6 +10,6 @@ anthropic
 orjson==3.9.15
 pydantic==2.10.2
 google-cloud-aiplatform==1.43.0
-fastapi-sso==0.10.0
+fastapi-sso==0.16.0 
 uvloop==0.21.0
 mcp==1.5.0    # for MCP server  

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -502,8 +502,6 @@ async def auth_callback(request: Request):  # noqa: PLR0915
         )
     # User is Authe'd in - generate key for the UI to access Proxy
     verbose_proxy_logger.debug(f"SSO callback result: {result}")
-    result = cast(CustomOpenID, result)
-    result.team_ids = jwt_handler.get_team_ids_from_jwt(cast(dict, result))
     user_email: Optional[str] = getattr(result, "email", None)
     user_id: Optional[str] = getattr(result, "id", None) if result is not None else None
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -494,6 +494,7 @@ async def auth_callback(request: Request):  # noqa: PLR0915
             redirect_url=redirect_url,
         )
     # User is Authe'd in - generate key for the UI to access Proxy
+    verbose_proxy_logger.debug(f"SSO callback result: {result}")
     user_email: Optional[str] = getattr(result, "email", None)
     user_id: Optional[str] = getattr(result, "id", None) if result is not None else None
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -485,7 +485,14 @@ async def auth_callback(request: Request):  # noqa: PLR0915
             redirect_uri=redirect_url,
             allow_insecure_http=True,
         )
-        result = await microsoft_sso.verify_and_process(request)
+        original_msft_result = await microsoft_sso.verify_and_process(
+            request=request,
+            convert_response=False,
+        )
+        result = MicrosoftSSOHandler.openid_from_response(
+            response=original_msft_result,
+            jwt_handler=jwt_handler,
+        )
     elif generic_client_id is not None:
         result = await get_generic_sso_response(
             request=request,
@@ -495,6 +502,8 @@ async def auth_callback(request: Request):  # noqa: PLR0915
         )
     # User is Authe'd in - generate key for the UI to access Proxy
     verbose_proxy_logger.debug(f"SSO callback result: {result}")
+    result = cast(CustomOpenID, result)
+    result.team_ids = jwt_handler.get_team_ids_from_jwt(cast(dict, result))
     user_email: Optional[str] = getattr(result, "email", None)
     user_id: Optional[str] = getattr(result, "id", None) if result is not None else None
 
@@ -780,3 +789,27 @@ async def get_ui_settings(request: Request):
         ),
         "DISABLE_EXPENSIVE_DB_QUERIES": disable_expensive_db_queries,
     }
+
+
+class MicrosoftSSOHandler:
+    """
+    Handles Microsoft SSO callback response and returns a CustomOpenID object
+    """
+
+    @staticmethod
+    def openid_from_response(
+        response: Optional[dict], jwt_handler: JWTHandler
+    ) -> CustomOpenID:
+        response = response or {}
+        verbose_proxy_logger.debug(f"Microsoft SSO Callback Response: {response}")
+        openid_response = CustomOpenID(
+            email=response.get("mail"),
+            display_name=response.get("displayName"),
+            provider="microsoft",
+            id=response.get("id"),
+            first_name=response.get("givenName"),
+            last_name=response.get("surname"),
+            team_ids=jwt_handler.get_team_ids_from_jwt(cast(dict, response)),
+        )
+        verbose_proxy_logger.debug(f"Microsoft SSO OpenID Response: {openid_response}")
+        return openid_response

--- a/tests/litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1,0 +1,81 @@
+import json
+import os
+import sys
+from typing import Optional, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.auth.handle_jwt import JWTHandler
+from litellm.proxy.management_endpoints.types import CustomOpenID
+from litellm.proxy.management_endpoints.ui_sso import MicrosoftSSOHandler
+
+
+def test_microsoft_sso_handler_openid_from_response():
+    # Arrange
+    # Create a mock response similar to what Microsoft SSO would return
+    mock_response = {
+        "mail": "test@example.com",
+        "displayName": "Test User",
+        "id": "user123",
+        "givenName": "Test",
+        "surname": "User",
+        "some_other_field": "value",
+    }
+
+    # Create a mock JWTHandler that returns predetermined team IDs
+    mock_jwt_handler = MagicMock(spec=JWTHandler)
+    expected_team_ids = ["team1", "team2"]
+    mock_jwt_handler.get_team_ids_from_jwt.return_value = expected_team_ids
+
+    # Act
+    # Call the method being tested
+    result = MicrosoftSSOHandler.openid_from_response(
+        response=mock_response, jwt_handler=mock_jwt_handler
+    )
+
+    # Assert
+    # Verify the JWT handler was called with the correct parameters
+    mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with(
+        cast(dict, mock_response)
+    )
+
+    # Check that the result is a CustomOpenID object with the expected values
+    assert isinstance(result, CustomOpenID)
+    assert result.email == "test@example.com"
+    assert result.display_name == "Test User"
+    assert result.provider == "microsoft"
+    assert result.id == "user123"
+    assert result.first_name == "Test"
+    assert result.last_name == "User"
+    assert result.team_ids == expected_team_ids
+
+
+def test_microsoft_sso_handler_with_empty_response():
+    # Arrange
+    # Test with None response
+    mock_jwt_handler = MagicMock(spec=JWTHandler)
+    mock_jwt_handler.get_team_ids_from_jwt.return_value = []
+
+    # Act
+    result = MicrosoftSSOHandler.openid_from_response(
+        response=None, jwt_handler=mock_jwt_handler
+    )
+
+    # Assert
+    assert isinstance(result, CustomOpenID)
+    assert result.email is None
+    assert result.display_name is None
+    assert result.provider == "microsoft"
+    assert result.id is None
+    assert result.first_name is None
+    assert result.last_name is None
+    assert result.team_ids == []
+
+    # Make sure the JWT handler was called with an empty dict
+    mock_jwt_handler.get_team_ids_from_jwt.assert_called_once_with({})


### PR DESCRIPTION
## [Feat] Allow assigning SSO users to teams on MSFT SSO

Auto add users from MSFT SSO to a team 

```
general_settings:
  master_key: sk-1234
  litellm_jwtauth:
    team_ids_jwt_field: "groups" # 👈 CAN BE ANY FIELD
```

This is assuming your SSO token looks like this:

```
{
  ...,
  "groups": ["team_id_1", "team_id_2"]
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


