### PR TITLE
[Security fix - CVE-2025-0330] - Leakage of Langfuse API keys in team exception handling

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -10,11 +10,12 @@ model_list:
       api_key: fake-key
 
 litellm_settings:
-  require_auth_for_metrics_endpoint: true
-  
-
-  callbacks: ["prometheus"]
-  service_callback: ["prometheus_system"]
-
-router_settings:
-  enable_tag_filtering: True # 👈 Key Change
+  default_team_settings:
+      - team_id: test_dev
+        success_callback: ["langfuse", "s3"]
+        langfuse_secret: secret-test-key
+        langfuse_public_key: public-test-key
+      - team_id: my_workflows
+        success_callback: ["langfuse", "s3"]
+        langfuse_secret: secret-workflows-key
+        langfuse_public_key: public-workflows-key

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -139,6 +139,7 @@ from litellm.litellm_core_utils.core_helpers import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.proxy._experimental.mcp_server.server import router as mcp_router
 from litellm.proxy._experimental.mcp_server.tool_registry import (
@@ -387,6 +388,7 @@ global_max_parallel_request_retries_env: Optional[str] = os.getenv(
     "LITELLM_GLOBAL_MAX_PARALLEL_REQUEST_RETRIES"
 )
 proxy_state = ProxyState()
+SENSITIVE_DATA_MASKER = SensitiveDataMasker()
 if global_max_parallel_request_retries_env is None:
     global_max_parallel_request_retries: int = 3
 else:
@@ -1397,7 +1399,9 @@ class ProxyConfig:
         team_config: dict = {}
         for team in all_teams_config:
             if "team_id" not in team:
-                raise Exception(f"team_id missing from team: {team}")
+                raise Exception(
+                    f"team_id missing from team: {SENSITIVE_DATA_MASKER.mask_dict(team)}"
+                )
             if team_id == team["team_id"]:
                 team_config = team
                 break

--- a/tests/litellm/proxy/test_proxy_server.py
+++ b/tests/litellm/proxy/test_proxy_server.py
@@ -162,3 +162,28 @@ async def test_aaaproxy_startup_master_key(mock_prisma, monkeypatch, tmp_path):
         from litellm.proxy.proxy_server import master_key
 
         assert master_key == test_resolved_key
+
+
+def test_team_info_masking():
+    """
+    Test that sensitive team information is properly masked
+    """
+    from litellm.proxy.proxy_server import SENSITIVE_DATA_MASKER, ProxyConfig
+
+    proxy_config = ProxyConfig()
+    # Test team object with sensitive data
+    team1_info = {
+        "success_callback": "['langfuse', 's3']",
+        "langfuse_secret": "secret-test-key",
+        "langfuse_public_key": "public-test-key",
+    }
+
+    with pytest.raises(Exception) as exc_info:
+        proxy_config._get_team_config(
+            team_id="test_dev",
+            all_teams_config=[team1_info],
+        )
+
+    print("Got exception: {}".format(exc_info.value))
+    assert "secret-test-key" not in str(exc_info.value)
+    assert "public-test-key" not in str(exc_info.value)

--- a/tests/litellm/proxy/test_proxy_server.py
+++ b/tests/litellm/proxy/test_proxy_server.py
@@ -167,8 +167,10 @@ async def test_aaaproxy_startup_master_key(mock_prisma, monkeypatch, tmp_path):
 def test_team_info_masking():
     """
     Test that sensitive team information is properly masked
+
+    Ref: https://huntr.com/bounties/661b388a-44d8-4ad5-862b-4dc5b80be30a
     """
-    from litellm.proxy.proxy_server import SENSITIVE_DATA_MASKER, ProxyConfig
+    from litellm.proxy.proxy_server import ProxyConfig
 
     proxy_config = ProxyConfig()
     # Test team object with sensitive data


### PR DESCRIPTION
## [Security fix - CVE-2025-0330] - Leakage of Langfuse API keys in team exception handling

## Details 
This pull request addresses a security vulnerability in the _get_team_config method. The method previously lacked proper handling of sensitive data in the exception message, potentially exposing sensitive langfuse keys in the exception

## Fix
To mitigate this vulnerability, we used the SENSITIVE_DATA_MASKER class from the litellm core utils. This class masks sensitive data before including it in the exception message.

## Impact 
- litellm python sdk users are not impacted by this 
- if you use litellm proxy with team configs, https://docs.litellm.ai/docs/proxy/team_logging#setting-team-logging-via-configyaml this could impact you. This PR fixes the problem. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


