### PR TITLE
[Bug Fix] Add support for UploadFile on LLM Pass through endpoints (OpenAI, Azure etc) 

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -414,7 +414,7 @@ class HttpPassThroughEndpointHelpers:
         return "multipart/form-data" in request.headers.get("content-type", "")
 
     @staticmethod
-    async def build_request_files_from_upload_file(
+    async def _build_request_files_from_upload_file(
         upload_file: Union[UploadFile, StarletteUploadFile],
     ) -> Tuple[Optional[str], bytes, Optional[str]]:
         """Build a request files dict from an UploadFile object"""
@@ -437,7 +437,7 @@ class HttpPassThroughEndpointHelpers:
         for field_name, field_value in form_data.items():
             if isinstance(field_value, (StarletteUploadFile, UploadFile)):
                 files[field_name] = (
-                    await HttpPassThroughEndpointHelpers.build_request_files_from_upload_file(
+                    await HttpPassThroughEndpointHelpers._build_request_files_from_upload_file(
                         upload_file=field_value
                     )
                 )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -450,6 +450,7 @@ class HttpPassThroughEndpointHelpers:
             headers=headers,
             params=requested_query_params,
             files=files,
+            data=form_data_dict,
         )
         return response
 

--- a/tests/litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1,0 +1,116 @@
+import json
+import os
+import sys
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import Request, UploadFile
+from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
+from starlette.datastructures import UploadFile as StarletteUploadFile
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    HttpPassThroughEndpointHelpers,
+)
+
+
+# Test is_multipart
+def test_is_multipart():
+    # Test with multipart content type
+    request = MagicMock(spec=Request)
+    request.headers = Headers({"content-type": "multipart/form-data; boundary=123"})
+    assert HttpPassThroughEndpointHelpers.is_multipart(request) is True
+
+    # Test with non-multipart content type
+    request.headers = Headers({"content-type": "application/json"})
+    assert HttpPassThroughEndpointHelpers.is_multipart(request) is False
+
+    # Test with no content type
+    request.headers = Headers({})
+    assert HttpPassThroughEndpointHelpers.is_multipart(request) is False
+
+
+# Test _build_request_files_from_upload_file
+@pytest.mark.asyncio
+async def test_build_request_files_from_upload_file():
+    # Test with FastAPI UploadFile
+    file_content = b"test content"
+    file = BytesIO(file_content)
+    # Create SpooledTemporaryFile with content type headers
+    headers = {"content-type": "text/plain"}
+    upload_file = UploadFile(file=file, filename="test.txt", headers=headers)
+    upload_file.read = AsyncMock(return_value=file_content)
+
+    result = await HttpPassThroughEndpointHelpers._build_request_files_from_upload_file(
+        upload_file
+    )
+    assert result == ("test.txt", file_content, "text/plain")
+
+    # Test with Starlette UploadFile
+    file2 = BytesIO(file_content)
+    starlette_file = StarletteUploadFile(
+        file=file2,
+        filename="test2.txt",
+        headers=Headers({"content-type": "text/plain"}),
+    )
+    starlette_file.read = AsyncMock(return_value=file_content)
+
+    result = await HttpPassThroughEndpointHelpers._build_request_files_from_upload_file(
+        starlette_file
+    )
+    assert result == ("test2.txt", file_content, "text/plain")
+
+
+# Test make_multipart_http_request
+@pytest.mark.asyncio
+async def test_make_multipart_http_request():
+    # Mock request with file and form field
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+
+    # Mock form data
+    file_content = b"test file content"
+    file = BytesIO(file_content)
+    # Create SpooledTemporaryFile with content type headers
+    headers = {"content-type": "text/plain"}
+    upload_file = UploadFile(file=file, filename="test.txt", headers=headers)
+    upload_file.read = AsyncMock(return_value=file_content)
+
+    form_data = {"file": upload_file, "text_field": "test value"}
+    request.form = AsyncMock(return_value=form_data)
+
+    # Mock httpx client
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+
+    async_client = MagicMock()
+    async_client.request = AsyncMock(return_value=mock_response)
+
+    # Test the function
+    response = await HttpPassThroughEndpointHelpers.make_multipart_http_request(
+        request=request,
+        async_client=async_client,
+        url=httpx.URL("http://test.com"),
+        headers={},
+        requested_query_params=None,
+    )
+
+    # Verify the response
+    assert response == mock_response
+
+    # Verify the client call
+    async_client.request.assert_called_once()
+    call_args = async_client.request.call_args[1]
+
+    assert call_args["method"] == "POST"
+    assert str(call_args["url"]) == "http://test.com"
+    assert isinstance(call_args["files"], dict)
+    assert isinstance(call_args["data"], dict)
+    assert call_args["data"]["text_field"] == "test value"

--- a/tests/pass_through_tests/test_openai_assistants_passthrough.py
+++ b/tests/pass_through_tests/test_openai_assistants_passthrough.py
@@ -2,14 +2,31 @@ import pytest
 import openai
 import aiohttp
 import asyncio
+import tempfile
 from typing_extensions import override
 from openai import AssistantEventHandler
 
+
 client = openai.OpenAI(base_url="http://0.0.0.0:4000/openai", api_key="sk-1234")
 
+def test_pass_through_file_operations():
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.txt', delete=False) as temp_file:
+        temp_file.write("This is a test file for the OpenAI Assistants API.")
+        temp_file.flush()
+
+        # create a file
+        file = client.files.create(
+            file=open(temp_file.name, "rb"),
+            purpose="assistants",
+        )
+        print("file created", file)
+
+        # delete the file
+        delete_file = client.files.delete(file.id)
+        print("file deleted", delete_file)
 
 def test_openai_assistants_e2e_operations():
-
     assistant = client.beta.assistants.create(
         name="Math Tutor",
         instructions="You are a personal math tutor. Write and run code to answer math questions.",


### PR DESCRIPTION
## [Bug Fix] Add support for UploadFile on LLM Pass through endpoints (OpenAI, Azure etc) 

## Key Details:

- Add support for multipart/form-data requests in HTTP pass-through endpoints
- This PR adds support for multipart/form-data requests in the proxy's HTTP pass-through endpoints, allowing file uploads to work correctly


## Changes in this PR
- Refactors the HTTP request handling with a dedicated method to handle different request types
- Adds detection and processing for multipart/form-data requests
- Properly handles both file uploads and form fields in multipart requests
- Adds comprehensive unit tests for the new functionality


Also includes a fix to use safe_dumps instead of json.dumps for improved error handling

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


