### PR TITLE
Add user alias to API endpoint

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1625,6 +1625,7 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     model_max_budget: Optional[Dict] = {}
     model_spend: Optional[Dict] = {}
     user_email: Optional[str] = None
+    user_alias: Optional[str] = None
     models: list = []
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None


### PR DESCRIPTION
## Add user-alias property to the User API endpoints

This adds back the `user_alias` property to the API endpoints that handles the user.

## Relevant issues

Fixes: https://github.com/BerriAI/litellm/issues/9851

🆕 New Feature
