### PR TITLE
lazy load httpx clients

### DIFF
--- a/tests/litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/litellm/llms/custom_httpx/test_http_handler.py
@@ -1,6 +1,7 @@
 import io
 import os
 import pathlib
+import respx
 import ssl
 import sys
 from unittest.mock import MagicMock
@@ -27,3 +28,29 @@ async def test_ssl_security_level(monkeypatch):
 
     # Verify that the SSL context exists and has the correct cipher string
     assert isinstance(ssl_context, ssl.SSLContext)
+
+@pytest.mark.asyncio
+async def test_basic_async_request(respx_mock: respx.MockRouter):
+    respx_mock.get("https://api.example.com").respond(
+        json={"message": "Hello, world!"}
+    )
+
+    # Create async client with SSL verification disabled to isolate SSL context testing
+    client = AsyncHTTPHandler(ssl_verify=False)
+
+    response = await client.get("https://api.example.com")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, world!"}
+
+
+def test_basic_sync_request(respx_mock: respx.MockRouter):
+    respx_mock.get("https://api.example.com").respond(
+        json={"message": "Hello, world!"}
+    )
+
+    # Create async client with SSL verification disabled to isolate SSL context testing
+    client = HTTPHandler(ssl_verify=False)
+
+    response = client.get("https://api.example.com")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, world!"}


### PR DESCRIPTION
## Title

partial fix for #7605, lazy load httpx client


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

partial fix for fix for #7605,

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="859" alt="image" src="https://github.com/user-attachments/assets/b04857db-d3cd-487b-b771-5b9e5e2f85de" />

## Type


🐛 Bug Fix

## Changes


There's a few of these clients instantiated at startup, and they start adding up. They were around 10ms to 30ms each to create, so this shaves off ~50ms of startup time. Its fairly insignificant in the scheme of things, but seems like a pretty minor change


Before:

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/8e417082-2771-4df0-9ac7-ded4ec7bb7b8" />

After:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1779c51d-9d0b-45a5-9f95-f0a966bd579e" />
