### PR TITLE
fix bedrock embedding invocations with app inference profiles

### DIFF
--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -5,6 +5,7 @@ Handles embedding calls to Bedrock's `/invoke` endpoint
 import copy
 import json
 from typing import Any, Callable, List, Optional, Tuple, Union
+import urllib.parse
 
 import httpx
 
@@ -348,6 +349,16 @@ class BedrockEmbedding(BaseAWSLLM):
         credentials, aws_region_name = self._load_credentials(optional_params)
 
         ### TRANSFORMATION ###
+        unencoded_model_id = (
+            optional_params.pop("model_id", None) or model
+        ) # default to model if not passed
+        modelId = urllib.parse.quote(unencoded_model_id, safe="")
+        aws_region_name = self._get_aws_region_name(
+            optional_params=optional_params,
+            model=model,
+            model_id=unencoded_model_id,
+        )
+
         provider = model.split(".")[0]
         inference_params = copy.deepcopy(optional_params)
         inference_params = {
@@ -358,9 +369,6 @@ class BedrockEmbedding(BaseAWSLLM):
         inference_params.pop(
             "user", None
         )  # make sure user is not passed in for bedrock call
-        modelId = (
-            optional_params.pop("model_id", None) or model
-        )  # default to model if not passed
 
         data: Optional[CohereEmbeddingRequest] = None
         batch_data: Optional[List] = None

--- a/tests/litellm/llms/bedrock/embed/test_embedding.py
+++ b/tests/litellm/llms/bedrock/embed/test_embedding.py
@@ -1,0 +1,82 @@
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+from unittest.mock import patch
+
+import pytest
+
+from litellm.types.utils import Embedding
+from litellm.main import bedrock_embedding, embedding, EmbeddingResponse, Usage
+
+
+_mock_model_id = "arn:aws:bedrock:us-east-1:123412341234:application-inference-profile/abc123123"
+_mock_app_ip_url = "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A123412341234%3Aapplication-inference-profile%2Fabc123123/invoke"
+
+
+def _get_mock_embedding_response(model: str) -> EmbeddingResponse:
+    return EmbeddingResponse(
+        model=model,
+        usage=Usage(
+            prompt_tokens=1,
+            completion_tokens=0,
+            total_tokens=1,
+            completion_tokens_details=None,
+            prompt_tokens_details=None
+        ),
+        data=[
+            Embedding(
+                embedding=[-0.671875, 0.291015625, -0.1826171875, 0.8828125],
+                index=0,
+                object="embedding"
+            )
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "amazon.titan-embed-text-v1",
+        "amazon.titan-embed-text-v2:0"
+    ]
+)
+def test_bedrock_embedding_titan_app_profile(model: str):
+    with patch.object(bedrock_embedding, '_single_func_embeddings') as mock_method:
+        mock_method.return_value = _get_mock_embedding_response(model=model)
+        resp = embedding(
+            custom_llm_provider="bedrock",
+            model=model,
+            model_id=_mock_model_id,
+            input=["tester"],
+            aws_region_name="us-east-1",
+            aws_access_key_id="mockaws_access_key_id",
+            aws_secret_access_key="mockaws_secret_access_key"
+        )
+        assert mock_method.call_args.kwargs['endpoint_url'] == _mock_app_ip_url
+        
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "cohere.embed-english-v3",
+        "cohere.embed-multilingual-v3"
+    ]
+)
+def test_bedrock_embedding_cohere_app_profile(model: str):
+    with patch("litellm.llms.bedrock.embed.embedding.cohere_embedding") as mock_cohere_embedding:
+        mock_cohere_embedding.return_value = _get_mock_embedding_response(model=model)
+        resp = embedding(
+            custom_llm_provider="bedrock",
+            model=model,
+            model_id=_mock_model_id,
+            input=["tester"],
+            aws_region_name="us-east-1",
+            aws_access_key_id="mockaws_access_key_id",
+            aws_secret_access_key="mockaws_secret_access_key"
+        )
+        assert mock_cohere_embedding.call_args.kwargs['complete_api_base'] == _mock_app_ip_url
+        


### PR DESCRIPTION
## Title

Fixes bedrock embedding invocations with app inference profiles. 

## Relevant issues

Fixes #9894

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Fixes bedrock embedding invocations with app inference profiles.
Correctly remove model_id from inference params and encodes the model ID for the URL. 

![image](https://github.com/user-attachments/assets/2bb08865-3a7f-4e8d-b388-f4eb3be6addc)

All unit tests did not pass before my change. 

Current main
![image](https://github.com/user-attachments/assets/db9fda92-8cd8-4ee9-9e11-a83dcdf9d72d)


After my changes and tests were added. 
![image](https://github.com/user-attachments/assets/28edf664-9d25-477a-817d-b3cee6cd0757)


