### PR TITLE
fixbug(router.py): add original_messages handling in Router class

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3211,6 +3211,7 @@ class Router:
         model_group: Optional[str] = kwargs.get("model")
         disable_fallbacks: Optional[bool] = kwargs.pop("disable_fallbacks", False)
         fallbacks: Optional[List] = kwargs.get("fallbacks", self.fallbacks)
+        original_messages: Optional[List] = copy.deepcopy(kwargs.get("messages", None))
         context_window_fallbacks: Optional[List] = kwargs.get(
             "context_window_fallbacks", self.context_window_fallbacks
         )
@@ -3261,6 +3262,8 @@ class Router:
                 input_kwargs["max_fallbacks"] = self.max_fallbacks
             if "fallback_depth" not in input_kwargs:
                 input_kwargs["fallback_depth"] = 0
+            if original_messages is not None:
+                input_kwargs["messages"] = original_messages
 
             try:
                 verbose_router_logger.info("Trying to fallback b/w models")

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3252,6 +3252,12 @@ class Router:
             if disable_fallbacks is True or original_model_group is None:
                 raise e
 
+            if original_messages is not None:
+                modify_in_place = kwargs["messages"]
+                modify_in_place.clear()
+                for item in original_messages:
+                    modify_in_place.append(copy.deepcopy(item))
+                
             input_kwargs = {
                 "litellm_router": self,
                 "original_exception": original_exception,
@@ -3262,8 +3268,7 @@ class Router:
                 input_kwargs["max_fallbacks"] = self.max_fallbacks
             if "fallback_depth" not in input_kwargs:
                 input_kwargs["fallback_depth"] = 0
-            if original_messages is not None:
-                input_kwargs["messages"] = original_messages
+            
 
             try:
                 verbose_router_logger.info("Trying to fallback b/w models")


### PR DESCRIPTION
to fixbug in https://github.com/BerriAI/litellm/issues/9816
Introduces original_messages to store a deep copy of input messages. This change allows for better management of message states during fallback operations, ensuring that the original messages are preserved and can be reused when necessary.

I have already conducted tests in my own project. I'm sorry that due to certain reasons, I can't access OpenAI or Gemini locally.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


