### PR TITLE
Fix side effects on `params` instance variables.

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -259,14 +259,14 @@ class LiteLLM:
         timeout: Optional[float] = 600,
         max_retries: Optional[int] = litellm.num_retries,
         default_headers: Optional[Mapping[str, str]] = None,
-    ):
+    ) -> None:
         self.params = locals()
         self.chat = Chat(self.params, router_obj=None)
 
 
 class Chat:
-    def __init__(self, params, router_obj: Optional[Any]):
-        self.params = params
+    def __init__(self, params: Dict[str, Any], router_obj: Optional[Any]) -> None:
+        self.params = dict(params)  # Use a shallow copy to prevent side effects.
         if self.params.get("acompletion", False) is True:
             self.params.pop("acompletion")
             self.completions: Union[AsyncCompletions, Completions] = AsyncCompletions(
@@ -277,38 +277,40 @@ class Chat:
 
 
 class Completions:
-    def __init__(self, params, router_obj: Optional[Any]):
-        self.params = params
+    def __init__(self, params: Dict[str, Any], router_obj: Optional[Any]) -> None:
+        self.params = dict(params)
         self.router_obj = router_obj
 
     def create(self, messages, model=None, **kwargs):
+        params = dict(self.params)
         for k, v in kwargs.items():
-            self.params[k] = v
-        model = model or self.params.get("model")
+            params[k] = v
+        model = model or params.get("model")
         if self.router_obj is not None:
             response = self.router_obj.completion(
-                model=model, messages=messages, **self.params
+                model=model, messages=messages, **params
             )
         else:
-            response = completion(model=model, messages=messages, **self.params)
+            response = completion(model=model, messages=messages, **params)
         return response
 
 
 class AsyncCompletions:
-    def __init__(self, params, router_obj: Optional[Any]):
-        self.params = params
+    def __init__(self, params: Dict[str, Any], router_obj: Optional[Any]) -> None:
+        self.params = dict(params)
         self.router_obj = router_obj
 
     async def create(self, messages, model=None, **kwargs):
+        params = dict(self.params)
         for k, v in kwargs.items():
-            self.params[k] = v
-        model = model or self.params.get("model")
+            params[k] = v
+        model = model or params.get("model")
         if self.router_obj is not None:
             response = await self.router_obj.acompletion(
-                model=model, messages=messages, **self.params
+                model=model, messages=messages, **params
             )
         else:
-            response = await acompletion(model=model, messages=messages, **self.params)
+            response = await acompletion(model=model, messages=messages, **params)
         return response
 
 

--- a/tests/litellm/test_main.py
+++ b/tests/litellm/test_main.py
@@ -454,3 +454,32 @@ class Test_Chat:
             call(model="gemini/gemini-1.5-flash", messages=[{"role": "user", "content": "hello"}], bar="foo"),
         ]
         assert params == {"acompletion": True}
+
+    def test_calls_completion_with_router_obj(self, mocker):
+        router_obj = mocker.MagicMock()
+        chatobj = litellm.main.Chat({}, router_obj=router_obj)
+        chatobj.completions.create(
+            messages=[{"role": "user", "content": "hello"}],
+            model="gemini/gemini-1.5-flash",
+            foo="bar",
+        )
+        router_obj.completion.assert_called_once_with(
+            model="gemini/gemini-1.5-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            foo="bar"
+        )
+
+    @pytest.mark.asyncio
+    async def test_calls_acompletion_with_router_obj(self, mocker):
+        router_obj = mocker.AsyncMock()
+        chatobj = litellm.main.Chat({"acompletion": True}, router_obj=router_obj)
+        await chatobj.completions.create(  # type: ignore
+            messages=[{"role": "user", "content": "hello"}],
+            model="gemini/gemini-1.5-flash",
+            foo="bar",
+        )
+        router_obj.acompletion.assert_called_once_with(
+            model="gemini/gemini-1.5-flash",
+            messages=[{"role": "user", "content": "hello"}],
+            foo="bar"
+        )


### PR DESCRIPTION
## Fix side effects on `params` instance variables.

## Relevant issues
#9928

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes
See files.

Results of added tests.
```
$ poetry run pytest tests/litellm/test_main.py::Test_Chat
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.11.11, pytest-7.4.4, pluggy-1.5.0
rootdir: /workspaces/litellm
plugins: respx-0.22.0, anyio-4.5.2, asyncio-0.21.2, mock-3.14.0
asyncio: mode=Mode.STRICT
collected 4 items                                                                                                                                                                                                         

tests/litellm/test_main.py ....                                                                                                                                                                                     [100%]

==================================================================================================== warnings summary =====================================================================================================
.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295
  /workspaces/litellm/.venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

litellm/utils.py:183
  /workspaces/litellm/litellm/utils.py:183: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with resources.open_text(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 4 passed, 2 warnings in 0.76s ==============================================================================================
```