### PR TITLE
[UI] Render Reasoning content, ttft, usage metrics on test key page

### DIFF
--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -15,6 +15,7 @@ Supported Providers:
 - Bedrock (Anthropic + Deepseek) (`bedrock/`)
 - Vertex AI (Anthropic) (`vertexai/`)
 - OpenRouter (`openrouter/`)
+- XAI (`xai/`)
 
 LiteLLM will standardize the `reasoning_content` in the response and `thinking_blocks` in the assistant message.
 

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, Tuple
 
+import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     strip_name_from_messages,
 )
@@ -12,6 +14,10 @@ XAI_API_BASE = "https://api.x.ai/v1"
 
 
 class XAIChatConfig(OpenAIGPTConfig):
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "xai"
+
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
@@ -20,7 +26,7 @@ class XAIChatConfig(OpenAIGPTConfig):
         return api_base, dynamic_api_key
 
     def get_supported_openai_params(self, model: str) -> list:
-        return [
+        base_openai_params = [
             "frequency_penalty",
             "logit_bias",
             "logprobs",
@@ -39,6 +45,15 @@ class XAIChatConfig(OpenAIGPTConfig):
             "top_p",
             "user",
         ]
+        try:
+            if litellm.supports_reasoning(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            ):
+                base_openai_params.append("reasoning_effort")
+        except Exception as e:
+            verbose_logger.debug(f"Error checking if model supports reasoning: {e}")
+
+        return base_openai_params
 
     def map_openai_params(
         self,

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -18,6 +18,7 @@ from litellm import Choices, Message, ModelResponse, EmbeddingResponse, Usage
 from litellm import completion
 from unittest.mock import patch
 from litellm.llms.xai.chat.transformation import XAIChatConfig, XAI_API_BASE
+from base_llm_unit_tests import BaseReasoningEffortTests
 
 
 def test_xai_chat_config_get_openai_compatible_provider_info():
@@ -162,22 +163,9 @@ def test_xai_message_name_filtering():
     assert response.choices[0].message.content is not None
 
 
-def test_xai_reasoning_effort():
-    litellm._turn_on_debug()
-    messages = [
-        {
-            "role": "system",
-            "content": "*I press the green button*",
-            "name": "example_user"
-        },
-        {"role": "user", "content": "Hello", "name": "John"},
-        {"role": "assistant", "content": "Hello", "name": "Jane"},
-    ]
-    response = completion(
-        model="xai/grok-3",
-        messages=messages,
-        reasoning_effort="high",
-        stream=True,
-    )
-    for chunk in response:
-        print(chunk)
+class TestXAIReasoningEffort(BaseReasoningEffortTests):
+    def get_base_completion_call_args(self):
+        return {
+            "model": "xai/grok-3-mini-beta",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -18,7 +18,7 @@ from litellm import Choices, Message, ModelResponse, EmbeddingResponse, Usage
 from litellm import completion
 from unittest.mock import patch
 from litellm.llms.xai.chat.transformation import XAIChatConfig, XAI_API_BASE
-from base_llm_unit_tests import BaseReasoningEffortTests
+from base_llm_unit_tests import BaseReasoningLLMTests
 
 
 def test_xai_chat_config_get_openai_compatible_provider_info():
@@ -163,7 +163,7 @@ def test_xai_message_name_filtering():
     assert response.choices[0].message.content is not None
 
 
-class TestXAIReasoningEffort(BaseReasoningEffortTests):
+class TestXAIReasoningEffort(BaseReasoningLLMTests):
     def get_base_completion_call_args(self):
         return {
             "model": "xai/grok-3-mini-beta",

--- a/ui/litellm-dashboard/src/components/chat_ui.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui.tsx
@@ -455,7 +455,13 @@ const ChatUI: React.FC<ChatUIProps> = ({
                   {message.reasoningContent && (
                     <ReasoningContent reasoningContent={message.reasoningContent} />
                   )}
-                  <div className="whitespace-pre-wrap break-words max-w-full message-content">
+                  <div className="whitespace-pre-wrap break-words max-w-full message-content" 
+                       style={{ 
+                         wordWrap: 'break-word', 
+                         overflowWrap: 'break-word',
+                         wordBreak: 'break-word',
+                         hyphens: 'auto'
+                       }}>
                     {message.isImage ? (
                       <img 
                         src={message.content} 
@@ -477,16 +483,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
                                 language={match[1]}
                                 PreTag="div"
                                 className="rounded-md my-2"
+                                wrapLines={true}
+                                wrapLongLines={true}
                                 {...props}
                               >
                                 {String(children).replace(/\n$/, '')}
                               </SyntaxHighlighter>
                             ) : (
-                              <code className={`${className} px-1.5 py-0.5 rounded bg-gray-100 text-sm font-mono`} {...props}>
+                              <code className={`${className} px-1.5 py-0.5 rounded bg-gray-100 text-sm font-mono`} style={{ wordBreak: 'break-word' }} {...props}>
                                 {children}
                               </code>
                             );
-                          }
+                          },
+                          pre: ({ node, ...props }) => (
+                            <pre style={{ overflowX: 'auto', maxWidth: '100%' }} {...props} />
+                          )
                         }}
                       >
                         {message.content}

--- a/ui/litellm-dashboard/src/components/chat_ui.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui.tsx
@@ -23,7 +23,7 @@ import {
   Divider,
 } from "@tremor/react";
 
-import { message, Select, Spin, Typography, Tooltip } from "antd";
+import { message, Select, Spin, Typography, Tooltip, Input } from "antd";
 import { makeOpenAIChatCompletionRequest } from "./chat_ui/llm_calls/chat_completion";
 import { makeOpenAIImageGenerationRequest } from "./chat_ui/llm_calls/image_generation";
 import { fetchAvailableModels, ModelGroup  } from "./chat_ui/llm_calls/fetch_models";
@@ -46,6 +46,8 @@ import {
   LoadingOutlined,
   TagsOutlined
 } from "@ant-design/icons";
+
+const { TextArea } = Input;
 
 interface ChatUIProps {
   accessToken: string | null;
@@ -190,10 +192,12 @@ const ChatUI: React.FC<ChatUIProps> = ({
     ]);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault(); // Prevent default to avoid newline
       handleSendMessage();
     }
+    // If Shift+Enter is pressed, the default behavior (inserting a newline) will occur
   };
 
   const handleCancelRequest = () => {
@@ -502,18 +506,19 @@ const ChatUI: React.FC<ChatUIProps> = ({
           
           <div className="p-4 border-t border-gray-200 bg-white">
             <div className="flex items-center">
-              <TextInput
-                type="text"
+              <TextArea
                 value={inputMessage}
                 onChange={(e) => setInputMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={
                   endpointType === EndpointType.CHAT 
-                    ? "Type your message..." 
+                    ? "Type your message... (Shift+Enter for new line)" 
                     : "Describe the image you want to generate..."
                 }
                 disabled={isLoading}
                 className="flex-1"
+                autoSize={{ minRows: 1, maxRows: 6 }}
+                style={{ resize: 'none', paddingRight: '10px', paddingLeft: '10px' }}
               />
               {isLoading ? (
                 <Button

--- a/ui/litellm-dashboard/src/components/chat_ui.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui.tsx
@@ -187,19 +187,38 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const updateTimingData = (timeToFirstToken: number) => {
+    console.log("updateTimingData called with:", timeToFirstToken);
     setChatHistory((prevHistory) => {
       const lastMessage = prevHistory[prevHistory.length - 1];
+      console.log("Current last message:", lastMessage);
       
       if (lastMessage && lastMessage.role === "assistant") {
-        return [
+        console.log("Updating assistant message with timeToFirstToken:", timeToFirstToken);
+        const updatedHistory = [
           ...prevHistory.slice(0, prevHistory.length - 1),
           { 
             ...lastMessage,
             timeToFirstToken
           },
         ];
+        console.log("Updated chat history:", updatedHistory);
+        return updatedHistory;
+      } 
+      // If the last message is a user message and no assistant message exists yet,
+      // create a new assistant message with empty content
+      else if (lastMessage && lastMessage.role === "user") {
+        console.log("Creating new assistant message with timeToFirstToken:", timeToFirstToken);
+        return [
+          ...prevHistory,
+          { 
+            role: "assistant", 
+            content: "", 
+            timeToFirstToken 
+          }
+        ];
       }
       
+      console.log("No appropriate message found to update timing");
       return prevHistory;
     });
   };

--- a/ui/litellm-dashboard/src/components/chat_ui/ReasoningContent.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ReasoningContent.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { Button, Collapse } from "antd";
+import ReactMarkdown from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { coy } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { DownOutlined, RightOutlined, BulbOutlined } from "@ant-design/icons";
+
+interface ReasoningContentProps {
+  reasoningContent: string;
+}
+
+const ReasoningContent: React.FC<ReasoningContentProps> = ({ reasoningContent }) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  if (!reasoningContent) return null;
+
+  return (
+    <div className="reasoning-content mt-1 mb-2">
+      <Button 
+        type="text" 
+        className="flex items-center text-xs text-gray-500 hover:text-gray-700"
+        onClick={() => setIsExpanded(!isExpanded)}
+        icon={<BulbOutlined />}
+      >
+        {isExpanded ? "Hide reasoning" : "Show reasoning"}
+        {isExpanded ? <DownOutlined className="ml-1" /> : <RightOutlined className="ml-1" />}
+      </Button>
+      
+      {isExpanded && (
+        <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-md text-sm text-gray-700">
+          <ReactMarkdown
+            components={{
+              code({node, inline, className, children, ...props}: React.ComponentPropsWithoutRef<'code'> & {
+                inline?: boolean;
+                node?: any;
+              }) {
+                const match = /language-(\w+)/.exec(className || '');
+                return !inline && match ? (
+                  <SyntaxHighlighter
+                    style={coy as any}
+                    language={match[1]}
+                    PreTag="div"
+                    className="rounded-md my-2"
+                    {...props}
+                  >
+                    {String(children).replace(/\n$/, '')}
+                  </SyntaxHighlighter>
+                ) : (
+                  <code className={`${className} px-1.5 py-0.5 rounded bg-gray-100 text-sm font-mono`} {...props}>
+                    {children}
+                  </code>
+                );
+              }
+            }}
+          >
+            {reasoningContent}
+          </ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReasoningContent; 

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Tooltip } from "antd";
+import { 
+  ClockCircleOutlined, 
+  NumberOutlined, 
+  ImportOutlined, 
+  ExportOutlined,
+  ThunderboltOutlined,
+  BulbOutlined
+} from "@ant-design/icons";
+
+export interface TokenUsage {
+  completionTokens?: number;
+  promptTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+}
+
+interface ResponseMetricsProps {
+  timeToFirstToken?: number; // in milliseconds
+  usage?: TokenUsage;
+}
+
+const ResponseMetrics: React.FC<ResponseMetricsProps> = ({ 
+  timeToFirstToken, 
+  usage 
+}) => {
+  if (!timeToFirstToken && !usage) return null;
+
+  return (
+    <div className="response-metrics mt-2 pt-2 border-t border-gray-100 text-xs text-gray-500 flex flex-wrap gap-3">
+      {timeToFirstToken !== undefined && (
+        <Tooltip title="Time to first token">
+          <div className="flex items-center">
+            <ClockCircleOutlined className="mr-1" />
+            <span>{(timeToFirstToken / 1000).toFixed(2)}s</span>
+          </div>
+        </Tooltip>
+      )}
+      
+      {usage?.promptTokens !== undefined && (
+        <Tooltip title="Prompt tokens">
+          <div className="flex items-center">
+            <ImportOutlined className="mr-1" />
+            <span>In: {usage.promptTokens}</span>
+          </div>
+        </Tooltip>
+      )}
+      
+      {usage?.completionTokens !== undefined && (
+        <Tooltip title="Completion tokens">
+          <div className="flex items-center">
+            <ExportOutlined className="mr-1" />
+            <span>Out: {usage.completionTokens}</span>
+          </div>
+        </Tooltip>
+      )}
+      
+      {usage?.reasoningTokens !== undefined && (
+        <Tooltip title="Reasoning tokens">
+          <div className="flex items-center">
+            <BulbOutlined className="mr-1" />
+            <span>Reasoning: {usage.reasoningTokens}</span>
+          </div>
+        </Tooltip>
+      )}
+      
+      {usage?.totalTokens !== undefined && (
+        <Tooltip title="Total tokens">
+          <div className="flex items-center">
+            <NumberOutlined className="mr-1" />
+            <span>Total: {usage.totalTokens}</span>
+          </div>
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
+export default ResponseMetrics; 

--- a/ui/litellm-dashboard/src/components/chat_ui/llm_calls/process_stream.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/llm_calls/process_stream.tsx
@@ -1,8 +1,59 @@
-import { StreamingResponse } from "../types";
+import { TokenUsage } from "../ResponseMetrics";
+
+export interface StreamingResponse {
+  id: string;
+  created: number;
+  model: string;
+  object: string;
+  system_fingerprint?: string;
+  choices: StreamingChoices[];
+  provider_specific_fields?: any;
+  stream_options?: any;
+  citations?: any;
+  usage?: Usage;
+}
+
+export interface StreamingChoices {
+  finish_reason?: string | null;
+  index: number;
+  delta: Delta;
+  logprobs?: any;
+}
+
+export interface Delta {
+  content?: string;
+  reasoning_content?: string;
+  role?: string;
+  function_call?: any;
+  tool_calls?: any;
+  audio?: any;
+  refusal?: any;
+  provider_specific_fields?: any;
+}
+
+export interface Usage {
+  completion_tokens: number;
+  prompt_tokens: number;
+  total_tokens: number;
+  completion_tokens_details?: {
+    accepted_prediction_tokens?: number;
+    audio_tokens?: number;
+    reasoning_tokens?: number;
+    rejected_prediction_tokens?: number;
+    text_tokens?: number | null;
+  };
+  prompt_tokens_details?: {
+    audio_tokens?: number;
+    cached_tokens?: number;
+    text_tokens?: number;
+    image_tokens?: number;
+  };
+}
 
 export interface StreamProcessCallbacks {
   onContent: (content: string, model?: string) => void;
   onReasoningContent: (content: string) => void;
+  onUsage?: (usage: TokenUsage) => void;
 }
 
 export const processStreamingResponse = (
@@ -24,5 +75,22 @@ export const processStreamingResponse = (
     if (choice.delta?.reasoning_content) {
       callbacks.onReasoningContent(choice.delta.reasoning_content);
     }
+  }
+  
+  // Process usage information if it exists and we have a handler
+  if (response.usage && callbacks.onUsage) {
+    console.log("Processing usage data:", response.usage);
+    const usageData: TokenUsage = {
+      completionTokens: response.usage.completion_tokens,
+      promptTokens: response.usage.prompt_tokens,
+      totalTokens: response.usage.total_tokens,
+    };
+    
+    // Extract reasoning tokens if available
+    if (response.usage.completion_tokens_details?.reasoning_tokens) {
+      usageData.reasoningTokens = response.usage.completion_tokens_details.reasoning_tokens;
+    }
+    
+    callbacks.onUsage(usageData);
   }
 }; 

--- a/ui/litellm-dashboard/src/components/chat_ui/llm_calls/process_stream.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/llm_calls/process_stream.tsx
@@ -1,0 +1,28 @@
+import { StreamingResponse } from "../types";
+
+export interface StreamProcessCallbacks {
+  onContent: (content: string, model?: string) => void;
+  onReasoningContent: (content: string) => void;
+}
+
+export const processStreamingResponse = (
+  response: StreamingResponse, 
+  callbacks: StreamProcessCallbacks
+) => {
+  // Extract model information if available
+  const model = response.model;
+  
+  // Process regular content
+  if (response.choices && response.choices.length > 0) {
+    const choice = response.choices[0];
+    
+    if (choice.delta?.content) {
+      callbacks.onContent(choice.delta.content, model);
+    }
+    
+    // Process reasoning content if it exists
+    if (choice.delta?.reasoning_content) {
+      callbacks.onReasoningContent(choice.delta.reasoning_content);
+    }
+  }
+}; 

--- a/ui/litellm-dashboard/src/components/chat_ui/types.ts
+++ b/ui/litellm-dashboard/src/components/chat_ui/types.ts
@@ -1,0 +1,37 @@
+export interface Delta {
+  content?: string;
+  reasoning_content?: string;
+  role?: string;
+  function_call?: any;
+  tool_calls?: any;
+  audio?: any;
+  refusal?: any;
+  provider_specific_fields?: any;
+}
+
+export interface StreamingChoices {
+  finish_reason?: string | null;
+  index: number;
+  delta: Delta;
+  logprobs?: any;
+}
+
+export interface StreamingResponse {
+  id: string;
+  created: number;
+  model: string;
+  object: string;
+  system_fingerprint?: string;
+  choices: StreamingChoices[];
+  provider_specific_fields?: any;
+  stream_options?: any;
+  citations?: any;
+}
+
+export interface MessageType {
+  role: string;
+  content: string;
+  model?: string;
+  isImage?: boolean;
+  reasoningContent?: string;
+} 

--- a/ui/litellm-dashboard/src/components/chat_ui/types.ts
+++ b/ui/litellm-dashboard/src/components/chat_ui/types.ts
@@ -9,6 +9,29 @@ export interface Delta {
   provider_specific_fields?: any;
 }
 
+export interface CompletionTokensDetails {
+  accepted_prediction_tokens?: number;
+  audio_tokens?: number;
+  reasoning_tokens?: number;
+  rejected_prediction_tokens?: number;
+  text_tokens?: number | null;
+}
+
+export interface PromptTokensDetails {
+  audio_tokens?: number;
+  cached_tokens?: number;
+  text_tokens?: number;
+  image_tokens?: number;
+}
+
+export interface Usage {
+  completion_tokens: number;
+  prompt_tokens: number;
+  total_tokens: number;
+  completion_tokens_details?: CompletionTokensDetails;
+  prompt_tokens_details?: PromptTokensDetails;
+}
+
 export interface StreamingChoices {
   finish_reason?: string | null;
   index: number;
@@ -26,6 +49,7 @@ export interface StreamingResponse {
   provider_specific_fields?: any;
   stream_options?: any;
   citations?: any;
+  usage?: Usage;
 }
 
 export interface MessageType {
@@ -34,4 +58,11 @@ export interface MessageType {
   model?: string;
   isImage?: boolean;
   reasoningContent?: string;
+  timeToFirstToken?: number;
+  usage?: {
+    completionTokens?: number;
+    promptTokens?: number;
+    totalTokens?: number;
+    reasoningTokens?: number;
+  };
 } 


### PR DESCRIPTION
## [UI] Render Reasoning content, ttft, usage metrics on test key page

<img width="1328" alt="Xnapper-2025-04-11-19 12 11" src="https://github.com/user-attachments/assets/2c1ba289-66cb-4db5-9457-2dd63ff90c04" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


