### PR TITLE
[Feat] Add reasoning_effort support for `xai/grok-3-mini-beta` model family 

### DIFF
--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -15,6 +15,7 @@ Supported Providers:
 - Bedrock (Anthropic + Deepseek) (`bedrock/`)
 - Vertex AI (Anthropic) (`vertexai/`)
 - OpenRouter (`openrouter/`)
+- XAI (`xai/`)
 
 LiteLLM will standardize the `reasoning_content` in the response and `thinking_blocks` in the assistant message.
 

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, Tuple
 
+import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     strip_name_from_messages,
 )
@@ -12,6 +14,10 @@ XAI_API_BASE = "https://api.x.ai/v1"
 
 
 class XAIChatConfig(OpenAIGPTConfig):
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "xai"
+
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
@@ -20,7 +26,7 @@ class XAIChatConfig(OpenAIGPTConfig):
         return api_base, dynamic_api_key
 
     def get_supported_openai_params(self, model: str) -> list:
-        return [
+        base_openai_params = [
             "frequency_penalty",
             "logit_bias",
             "logprobs",
@@ -39,6 +45,15 @@ class XAIChatConfig(OpenAIGPTConfig):
             "top_p",
             "user",
         ]
+        try:
+            if litellm.supports_reasoning(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            ):
+                base_openai_params.append("reasoning_effort")
+        except Exception as e:
+            verbose_logger.debug(f"Error checking if model supports reasoning: {e}")
+
+        return base_openai_params
 
     def map_openai_params(
         self,

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -18,6 +18,7 @@ from litellm import Choices, Message, ModelResponse, EmbeddingResponse, Usage
 from litellm import completion
 from unittest.mock import patch
 from litellm.llms.xai.chat.transformation import XAIChatConfig, XAI_API_BASE
+from base_llm_unit_tests import BaseReasoningEffortTests
 
 
 def test_xai_chat_config_get_openai_compatible_provider_info():
@@ -162,22 +163,9 @@ def test_xai_message_name_filtering():
     assert response.choices[0].message.content is not None
 
 
-def test_xai_reasoning_effort():
-    litellm._turn_on_debug()
-    messages = [
-        {
-            "role": "system",
-            "content": "*I press the green button*",
-            "name": "example_user"
-        },
-        {"role": "user", "content": "Hello", "name": "John"},
-        {"role": "assistant", "content": "Hello", "name": "Jane"},
-    ]
-    response = completion(
-        model="xai/grok-3",
-        messages=messages,
-        reasoning_effort="high",
-        stream=True,
-    )
-    for chunk in response:
-        print(chunk)
+class TestXAIReasoningEffort(BaseReasoningEffortTests):
+    def get_base_completion_call_args(self):
+        return {
+            "model": "xai/grok-3-mini-beta",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -18,7 +18,7 @@ from litellm import Choices, Message, ModelResponse, EmbeddingResponse, Usage
 from litellm import completion
 from unittest.mock import patch
 from litellm.llms.xai.chat.transformation import XAIChatConfig, XAI_API_BASE
-from base_llm_unit_tests import BaseReasoningEffortTests
+from base_llm_unit_tests import BaseReasoningLLMTests
 
 
 def test_xai_chat_config_get_openai_compatible_provider_info():
@@ -163,7 +163,7 @@ def test_xai_message_name_filtering():
     assert response.choices[0].message.content is not None
 
 
-class TestXAIReasoningEffort(BaseReasoningEffortTests):
+class TestXAIReasoningEffort(BaseReasoningLLMTests):
     def get_base_completion_call_args(self):
         return {
             "model": "xai/grok-3-mini-beta",


### PR DESCRIPTION
## [Feat] Add reasoning_effort support for `xai/grok-3-mini-beta` model family 

- Added support for the reasoning_effort parameter in xAI models 
- Ensure `reasoning_content` returned in messages and `reasoning_tokens` in usage metrics
- E2E test suite for reasoning content 
- Supports both streaming and non-streaming response formats


These changes ensure consistent access to model reasoning across providers, improving developer experience when working with multi-step reasoning features.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


