### PR TITLE
fix: remove redundant condition in is_chunk_non_empty

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -747,10 +747,6 @@ class CustomStreamWrapper:
             )
             or (model_response.choices[0].delta.provider_specific_fields is not None)
             or (
-                "provider_specific_fields" in model_response
-                and model_response.choices[0].delta.provider_specific_fields is not None
-            )
-            or (
                 "provider_specific_fields" in response_obj
                 and response_obj["provider_specific_fields"] is not None
             )


### PR DESCRIPTION
## Title

remove redundant condition in `CustomStreamWrapper.is_chunk_non_empty`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🧹 Refactoring

## Changes
remove redundant condition in `CustomStreamWrapper.is_chunk_non_empty`
- before: `A or (A and B)`
- after: `A`