### PR TITLE
fix #9339, rewrite azure storage to consolidate the authentication implementation

### DIFF
--- a/litellm/integrations/azure_storage/_azure_storage_auth.py
+++ b/litellm/integrations/azure_storage/_azure_storage_auth.py
@@ -1,0 +1,242 @@
+import base64
+import hashlib
+import hmac
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Optional
+from httpx import Request
+from litellm._logging import verbose_logger
+from urllib.parse import urlparse, parse_qs
+
+from litellm.llms.azure.common_utils import get_azure_ad_token_from_entrata_id
+
+
+def _get_now_utc_str():
+    return datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+
+class AzureAuthSharedKey:
+    def __init__(
+        self,
+        account_name: str,
+        account_key: str,
+        get_date_str: Callable[[], str] = _get_now_utc_str,
+    ):
+        self.account_name = account_name
+        try:
+            self.account_key = base64.b64decode(account_key)
+        except Exception:
+            raise ValueError(
+                f"Invalid account key: '{account_key}' - must be a valid base64 encoded string"
+            )
+        self.get_date_str = get_date_str
+
+    def __call__(self, request: Request) -> Request:
+        return sign_httpx_request_with_shared_key(
+            request, self.account_name, self.account_key, self.get_date_str
+        )
+
+
+class AzureADTokenAuth:
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str):
+        self.tenant_id = tenant_id
+        self.client_id = client_id
+        self.client_secret = client_secret
+        # Internal variables used for Token based authentication
+        self.azure_auth_token: Optional[
+            str
+        ] = None  # the Azure AD token to use for Azure Storage API requests
+        self.token_expiry: Optional[
+            datetime
+        ] = None  # the expiry time of the currentAzure AD token
+
+    def __call__(self, request: Request) -> Request:
+        self.set_valid_azure_ad_token()
+        if not self.azure_auth_token:
+            raise ValueError("Failed to get Azure AD token")
+        request.headers["Authorization"] = f"Bearer {self.azure_auth_token}"
+        return request
+
+    ####### Helper methods to managing Authentication to Azure Storage #######
+    ##########################################################################
+
+    def set_valid_azure_ad_token(self):
+        """
+        Wrapper to set self.azure_auth_token to a valid Azure AD token, refreshing if necessary
+
+        Refreshes the token when:
+        - Token is expired
+        - Token is not set
+        """
+        # Check if token needs refresh
+        if self._azure_ad_token_is_expired() or self.azure_auth_token is None:
+            verbose_logger.debug("Azure AD token needs refresh")
+            self.azure_auth_token = self.get_azure_ad_token_from_azure_storage(
+                tenant_id=self.tenant_id,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+            )
+            # Token typically expires in 1 hour
+            self.token_expiry = datetime.now() + timedelta(hours=1)
+            verbose_logger.debug(f"New token will expire at {self.token_expiry}")
+
+    def get_azure_ad_token_from_azure_storage(
+        self,
+        tenant_id: Optional[str],
+        client_id: Optional[str],
+        client_secret: Optional[str],
+    ) -> str:
+        """
+        Gets Azure AD token to use for Azure Storage API requests
+        """
+        verbose_logger.debug("Getting Azure AD Token from Azure Storage")
+        verbose_logger.debug(
+            "tenant_id %s, client_id %s, client_secret %s",
+            tenant_id,
+            client_id,
+            client_secret,
+        )
+        if tenant_id is None:
+            raise ValueError(
+                "Missing required environment variable: AZURE_STORAGE_TENANT_ID"
+            )
+        if client_id is None:
+            raise ValueError(
+                "Missing required environment variable: AZURE_STORAGE_CLIENT_ID"
+            )
+        if client_secret is None:
+            raise ValueError(
+                "Missing required environment variable: AZURE_STORAGE_CLIENT_SECRET"
+            )
+
+        token_provider = get_azure_ad_token_from_entrata_id(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+            scope="https://storage.azure.com/.default",
+        )
+        token = token_provider()
+
+        verbose_logger.debug("azure auth token %s", token)
+
+        return token
+
+    def _azure_ad_token_is_expired(self):
+        """
+        Returns True if Azure AD token is expired, False otherwise
+        """
+        if self.azure_auth_token and self.token_expiry:
+            if datetime.now() + timedelta(minutes=5) >= self.token_expiry:
+                verbose_logger.debug("Azure AD token is expired. Requesting new token")
+                return True
+        return False
+
+
+def build_shared_key_signature(
+    account_name: str,
+    account_key: bytes,
+    method: str,
+    url_resource: str,
+    headers: Dict[str, str],
+) -> str:
+    """
+    Stateless function to compute Shared Key authorization header for Azure Data Lake Storage Gen2
+    using the signature format for SharedKey (not SharedKeyLite).
+    """
+
+    # Ensure headers are case-insensitive
+    headers = {k.lower(): v for k, v in headers.items()}
+
+    # Required headers for SharedKey
+    content_encoding = headers.get("content-encoding", "")
+    content_language = headers.get("content-language", "")
+    content_length = headers.get("content-length", "")
+    if_modified_since = headers.get("if-modified-since", "")
+    if_match = headers.get("if-match", "")
+    if_none_match = headers.get("if-none-match", "")
+    if_unmodified_since = headers.get("if-unmodified-since", "")
+    range = headers.get("range", "")
+    if content_length == "0":
+        content_length = ""
+    content_md5 = headers.get("content-md5", "")
+    content_type = headers.get("content-type", "")
+    date = "" if "x-ms-date" in headers else headers.get("date", "")
+    if not date and "x-ms-date" not in headers:
+        raise ValueError("Date header or x-ms-date header is required")
+
+    # Construct CanonicalizedHeaders
+    canonicalized_headers = ""
+    ms_headers = [
+        (k.lower(), v.strip())
+        for k, v in headers.items()
+        if k.lower().startswith("x-ms-")
+    ]
+
+    for key, value in sorted(ms_headers):
+        canonicalized_headers += f"{key}:{value}\n"
+
+    # Construct CanonicalizedResource
+    parsed_url = urlparse(url_resource)
+    url_params = parse_qs(parsed_url.query)
+    url_resource = parsed_url.path
+
+    canonicalized_resource = f"/{account_name}{url_resource}"
+    for key in sorted(url_params.keys()):
+        values = url_params[key]
+        sorted_values = sorted(values)
+        canonicalized_resource += f"\n{key}:{','.join(sorted_values)}"
+
+    # Build the signature string as per SharedKey documentation
+    string_to_sign = (
+        f"{method}\n"
+        f"{content_encoding}\n"
+        f"{content_language}\n"
+        f"{content_length}\n"
+        f"{content_md5}\n"
+        f"{content_type}\n"
+        f"{date}\n"
+        f"{if_modified_since}\n"
+        f"{if_match}\n"
+        f"{if_none_match}\n"
+        f"{if_unmodified_since}\n"
+        f"{range}\n"
+        f"{canonicalized_headers}"
+        f"{canonicalized_resource}"
+    )
+
+    signed_hmac_sha256 = hmac.new(
+        account_key, string_to_sign.encode("utf-8"), hashlib.sha256
+    ).digest()
+    signature = base64.b64encode(signed_hmac_sha256).decode()
+
+    auth_header = f"SharedKey {account_name}:{signature}"
+    return auth_header
+
+
+def sign_httpx_request_with_shared_key(
+    request: Request,
+    account_name: str,
+    account_key: bytes,
+    get_date_str: Callable[[], str] = _get_now_utc_str,
+) -> Request:
+    """
+    Mutates the given httpx.Request to include a Shared Key Authorization header.
+    """
+    # Ensure required headers
+    request.headers.setdefault("x-ms-date", get_date_str())
+    request.headers.setdefault("x-ms-version", "2021-04-10")
+
+    # Add content-length header if not present
+    if "content-length" not in request.headers:
+        request.headers["content-length"] = "0"
+
+    url_resource = request.url.raw_path.decode("utf-8")
+
+    signature = build_shared_key_signature(
+        account_name=account_name,
+        account_key=account_key,
+        method=request.method.upper(),
+        url_resource=url_resource,
+        headers=dict(request.headers),
+    )
+    request.headers["Authorization"] = signature
+    return request

--- a/litellm/integrations/azure_storage/azure_storage.py
+++ b/litellm/integrations/azure_storage/azure_storage.py
@@ -1,27 +1,37 @@
 import asyncio
+from datetime import datetime
 import json
 import os
 import uuid
-from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import Callable, List, Optional
+
+import httpx
 
 from litellm._logging import verbose_logger
 from litellm.constants import AZURE_STORAGE_MSFT_VERSION
-from litellm.integrations.custom_batch_logger import CustomBatchLogger
-from litellm.llms.azure.common_utils import get_azure_ad_token_from_entrata_id
-from litellm.llms.custom_httpx.http_handler import (
-    AsyncHTTPHandler,
-    get_async_httpx_client,
-    httpxSpecialProvider,
+from litellm.integrations.azure_storage._azure_storage_auth import (
+    AzureADTokenAuth,
+    AzureAuthSharedKey,
 )
+from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.types.utils import StandardLoggingPayload
 
 
 class AzureBlobStorageLogger(CustomBatchLogger):
     def __init__(
         self,
+        upload_to_daily_dir: Optional[bool] = None,
         **kwargs,
     ):
+        """
+        Initialize the Azure Blob Storage Logger
+
+        Args:
+            upload_to_dir - if true, uploads logs to %Y-%m-%d based directories. If not specified, defaults to
+               true only if AZURE_STORAGE_ACCOUNT_KEY is set, for historical compatibility. May also be set via
+               environment variable LITELLM_AZURE_STORAGE_UPLOAD_TO_DAILY_DIR.
+            **kwargs: Additional keyword arguments for CustomBatchLogger, passed through
+        """
         try:
             verbose_logger.debug(
                 "AzureBlobStorageLogger: in init azure blob storage logger"
@@ -34,6 +44,24 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             self.azure_storage_account_key: Optional[str] = os.getenv(
                 "AZURE_STORAGE_ACCOUNT_KEY"
             )
+
+            if self.azure_storage_account_key is None and (
+                self.tenant_id is None
+                or self.client_id is None
+                or self.client_secret is None
+            ):
+                raise ValueError(
+                    "Either Azure Storage Account Key is required (AZURE_STORAGE_ACCOUNT_KEY) or Azure AD authentication is required all of (AZURE_STORAGE_TENANT_ID, AZURE_STORAGE_CLIENT_ID, AZURE_STORAGE_CLIENT_SECRET)"
+                )
+
+            if upload_to_daily_dir is None:
+                daily_dir_env = os.getenv("LITELLM_AZURE_STORAGE_UPLOAD_TO_DAILY_DIR")
+                if daily_dir_env is not None:
+                    upload_to_daily_dir = daily_dir_env.lower() == "true"
+                else:
+                    upload_to_daily_dir = self.azure_storage_account_key is not None
+            self.upload_to_daily_dir = upload_to_daily_dir
+            self.ensured_dir: Optional[str] = None
 
             # Required Env Variables for Azure Storage
             _azure_storage_account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
@@ -49,23 +77,34 @@ class AzureBlobStorageLogger(CustomBatchLogger):
                 )
             self.azure_storage_file_system: str = _azure_storage_file_system
 
-            # Internal variables used for Token based authentication
-            self.azure_auth_token: Optional[
-                str
-            ] = None  # the Azure AD token to use for Azure Storage API requests
-            self.token_expiry: Optional[
-                datetime
-            ] = None  # the expiry time of the currentAzure AD token
-
+            self.service_client = None
             asyncio.create_task(self.periodic_flush())
             self.flush_lock = asyncio.Lock()
             self.log_queue: List[StandardLoggingPayload] = []
+            self._client: Optional[httpx.AsyncClient] = None
             super().__init__(**kwargs, flush_lock=self.flush_lock)
         except Exception as e:
             verbose_logger.exception(
                 f"AzureBlobStorageLogger: Got exception on init AzureBlobStorageLogger client {str(e)}"
             )
             raise e
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            auth: Callable[[httpx.Request], httpx.Request]
+            if self.azure_storage_account_key:
+                auth = AzureAuthSharedKey(
+                    self.azure_storage_account_name, self.azure_storage_account_key
+                )
+            elif self.tenant_id and self.client_id and self.client_secret:
+                auth = AzureADTokenAuth(
+                    self.tenant_id, self.client_id, self.client_secret
+                )
+            else:
+                raise ValueError("Missing required authentication parameters")
+            self._client = httpx.AsyncClient(auth=auth)
+        return self._client
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -153,165 +192,102 @@ class AzureBlobStorageLogger(CustomBatchLogger):
         3. Flush the data
         """
         try:
-            if self.azure_storage_account_key:
-                await self.upload_to_azure_data_lake_with_azure_account_key(
-                    payload=payload
-                )
-            else:
-                # Get a valid token instead of always requesting a new one
-                await self.set_valid_azure_ad_token()
-                async_client = get_async_httpx_client(
-                    llm_provider=httpxSpecialProvider.LoggingCallback
-                )
-                json_payload = (
-                    json.dumps(payload) + "\n"
-                )  # Add newline for each log entry
-                payload_bytes = json_payload.encode("utf-8")
-                filename = f"{payload.get('id') or str(uuid.uuid4())}.json"
-                base_url = f"https://{self.azure_storage_account_name}.dfs.core.windows.net/{self.azure_storage_file_system}/{filename}"
+            json_payload = json.dumps(payload) + "\n"  # Add newline for each log entry
+            payload_bytes = json_payload.encode("utf-8")
+            filename = f"{payload.get('id') or str(uuid.uuid4())}.json"
 
-                # Execute the 3-step upload process
-                await self._create_file(async_client, base_url)
-                await self._append_data(async_client, base_url, json_payload)
-                await self._flush_data(async_client, base_url, len(payload_bytes))
+            if self.upload_to_daily_dir:
+                dir_name = datetime.now().strftime("%Y-%m-%d")
+                filename = f"{dir_name}/{filename}"
+            base_url = f"https://{self.azure_storage_account_name}.dfs.core.windows.net/{self.azure_storage_file_system}/{filename}"
 
-                verbose_logger.debug(
-                    f"Successfully uploaded log to Azure Blob Storage: {filename}"
-                )
+            # Execute the 3-step upload process
+            await self._create_file(base_url)
+            await self._append_data(base_url, json_payload)
+            await self._flush_data(base_url, len(payload_bytes))
+
+            verbose_logger.debug(
+                f"Successfully uploaded log to Azure Blob Storage: {filename}"
+            )
 
         except Exception as e:
             verbose_logger.exception(f"Error uploading to Azure Blob Storage: {str(e)}")
             raise e
 
-    async def _create_file(self, client: AsyncHTTPHandler, base_url: str):
+    async def _create_dir(self, base_url: str):
+        """Helper method to create the directory"""
+        try:
+            verbose_logger.debug(f"Creating directory: {base_url}")
+            headers = {
+                "x-ms-version": AZURE_STORAGE_MSFT_VERSION,
+                "Content-Length": "0",
+            }
+            request = self.client.build_request(
+                "PUT", f"{base_url}?resource=directory", headers=headers
+            )
+            response = await self.client.send(request)
+            response.raise_for_status()
+            verbose_logger.debug("Successfully created directory")
+        except Exception as e:
+            verbose_logger.exception(f"Error creating directory: {str(e)}")
+            raise
+
+    async def _create_file(self, base_url: str):
         """Helper method to create the file resource"""
         try:
             verbose_logger.debug(f"Creating file resource at: {base_url}")
             headers = {
                 "x-ms-version": AZURE_STORAGE_MSFT_VERSION,
                 "Content-Length": "0",
-                "Authorization": f"Bearer {self.azure_auth_token}",
             }
-            response = await client.put(f"{base_url}?resource=file", headers=headers)
+            request = self.client.build_request(
+                "PUT", f"{base_url}?resource=file", headers=headers
+            )
+            response = await self.client.send(request)
             response.raise_for_status()
             verbose_logger.debug("Successfully created file resource")
         except Exception as e:
             verbose_logger.exception(f"Error creating file resource: {str(e)}")
             raise
 
-    async def _append_data(
-        self, client: AsyncHTTPHandler, base_url: str, json_payload: str
-    ):
+    async def _append_data(self, base_url: str, json_payload: str):
         """Helper method to append data to the file"""
         try:
             verbose_logger.debug(f"Appending data to file: {base_url}")
             headers = {
                 "x-ms-version": AZURE_STORAGE_MSFT_VERSION,
                 "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.azure_auth_token}",
             }
-            response = await client.patch(
+            request = self.client.build_request(
+                "PATCH",
                 f"{base_url}?action=append&position=0",
                 headers=headers,
-                data=json_payload,
+                content=json_payload,
             )
+            response = await self.client.send(request)
             response.raise_for_status()
             verbose_logger.debug("Successfully appended data")
         except Exception as e:
             verbose_logger.exception(f"Error appending data: {str(e)}")
             raise
 
-    async def _flush_data(self, client: AsyncHTTPHandler, base_url: str, position: int):
+    async def _flush_data(self, base_url: str, position: int):
         """Helper method to flush the data"""
         try:
             verbose_logger.debug(f"Flushing data at position {position}")
             headers = {
                 "x-ms-version": AZURE_STORAGE_MSFT_VERSION,
                 "Content-Length": "0",
-                "Authorization": f"Bearer {self.azure_auth_token}",
             }
-            response = await client.patch(
-                f"{base_url}?action=flush&position={position}", headers=headers
+            request = self.client.build_request(
+                "PATCH", f"{base_url}?action=flush&position={position}", headers=headers
             )
+            response = await self.client.send(request)
             response.raise_for_status()
             verbose_logger.debug("Successfully flushed data")
         except Exception as e:
             verbose_logger.exception(f"Error flushing data: {str(e)}")
             raise
-
-    ####### Helper methods to managing Authentication to Azure Storage #######
-    ##########################################################################
-
-    async def set_valid_azure_ad_token(self):
-        """
-        Wrapper to set self.azure_auth_token to a valid Azure AD token, refreshing if necessary
-
-        Refreshes the token when:
-        - Token is expired
-        - Token is not set
-        """
-        # Check if token needs refresh
-        if self._azure_ad_token_is_expired() or self.azure_auth_token is None:
-            verbose_logger.debug("Azure AD token needs refresh")
-            self.azure_auth_token = self.get_azure_ad_token_from_azure_storage(
-                tenant_id=self.tenant_id,
-                client_id=self.client_id,
-                client_secret=self.client_secret,
-            )
-            # Token typically expires in 1 hour
-            self.token_expiry = datetime.now() + timedelta(hours=1)
-            verbose_logger.debug(f"New token will expire at {self.token_expiry}")
-
-    def get_azure_ad_token_from_azure_storage(
-        self,
-        tenant_id: Optional[str],
-        client_id: Optional[str],
-        client_secret: Optional[str],
-    ) -> str:
-        """
-        Gets Azure AD token to use for Azure Storage API requests
-        """
-        verbose_logger.debug("Getting Azure AD Token from Azure Storage")
-        verbose_logger.debug(
-            "tenant_id %s, client_id %s, client_secret %s",
-            tenant_id,
-            client_id,
-            client_secret,
-        )
-        if tenant_id is None:
-            raise ValueError(
-                "Missing required environment variable: AZURE_STORAGE_TENANT_ID"
-            )
-        if client_id is None:
-            raise ValueError(
-                "Missing required environment variable: AZURE_STORAGE_CLIENT_ID"
-            )
-        if client_secret is None:
-            raise ValueError(
-                "Missing required environment variable: AZURE_STORAGE_CLIENT_SECRET"
-            )
-
-        token_provider = get_azure_ad_token_from_entrata_id(
-            tenant_id=tenant_id,
-            client_id=client_id,
-            client_secret=client_secret,
-            scope="https://storage.azure.com/.default",
-        )
-        token = token_provider()
-
-        verbose_logger.debug("azure auth token %s", token)
-
-        return token
-
-    def _azure_ad_token_is_expired(self):
-        """
-        Returns True if Azure AD token is expired, False otherwise
-        """
-        if self.azure_auth_token and self.token_expiry:
-            if datetime.now() + timedelta(minutes=5) >= self.token_expiry:
-                verbose_logger.debug("Azure AD token is expired. Requesting new token")
-                return True
-        return False
 
     def _premium_user_check(self):
         """
@@ -323,58 +299,3 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             raise ValueError(
                 f"AzureBlobStorageLogger is only available for premium users. {CommonProxyErrors.not_premium_user}"
             )
-
-    async def upload_to_azure_data_lake_with_azure_account_key(
-        self, payload: StandardLoggingPayload
-    ):
-        """
-        Uploads the payload to Azure Data Lake using the Azure SDK
-
-        This is used when Azure Storage Account Key is set - Azure Storage Account Key does not work directly with Azure Rest API
-        """
-        from azure.storage.filedatalake.aio import DataLakeServiceClient
-
-        # Create an async service client
-        service_client = DataLakeServiceClient(
-            account_url=f"https://{self.azure_storage_account_name}.dfs.core.windows.net",
-            credential=self.azure_storage_account_key,
-        )
-        # Get file system client
-        file_system_client = service_client.get_file_system_client(
-            file_system=self.azure_storage_file_system
-        )
-
-        try:
-            # Create directory with today's date
-            from datetime import datetime
-
-            today = datetime.now().strftime("%Y-%m-%d")
-            directory_client = file_system_client.get_directory_client(today)
-
-            # check if the directory exists
-            if not await directory_client.exists():
-                await directory_client.create_directory()
-                verbose_logger.debug(f"Created directory: {today}")
-
-            # Create a file client
-            file_name = f"{payload.get('id') or str(uuid.uuid4())}.json"
-            file_client = directory_client.get_file_client(file_name)
-
-            # Create the file
-            await file_client.create_file()
-
-            # Content to append
-            content = json.dumps(payload).encode("utf-8")
-
-            # Append content to the file
-            await file_client.append_data(data=content, offset=0, length=len(content))
-
-            # Flush the content to finalize the file
-            await file_client.flush_data(position=len(content), offset=0)
-
-            verbose_logger.debug(
-                f"Successfully uploaded and wrote to {today}/{file_name}"
-            )
-
-        except Exception as e:
-            verbose_logger.exception(f"Error occurred: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ python-multipart==0.0.18 # admin UI
 Pillow==11.0.0
 azure-ai-contentsafety==1.0.0 # for azure content safety
 azure-identity==1.16.1 # for azure content safety
-azure-storage-file-datalake==12.15.0 # for azure buck storage logging
 opentelemetry-api==1.25.0
 opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0

--- a/tests/logging_callback_tests/test_azure_blob_storage.py
+++ b/tests/logging_callback_tests/test_azure_blob_storage.py
@@ -1,45 +1,434 @@
-import io
+import base64
+import hashlib
+import hmac
 import os
 import sys
+from datetime import datetime, timedelta
 
+from _pytest.monkeypatch import MonkeyPatch
+import httpx
+
+from litellm.integrations.azure_storage._azure_storage_auth import AzureAuthSharedKey, AzureADTokenAuth
 
 sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
-import gzip
-import json
-import logging
-import time
 from unittest.mock import AsyncMock, patch
+import re
 
 import pytest
 
 import litellm
-from litellm import completion
-from litellm._logging import verbose_logger
-from litellm.integrations.datadog.datadog import *
-from datetime import datetime, timedelta
-from litellm.types.utils import (
-    StandardLoggingPayload,
-    StandardLoggingModelInformation,
-    StandardLoggingMetadata,
-    StandardLoggingHiddenParams,
-)
+
 from litellm.integrations.azure_storage.azure_storage import AzureBlobStorageLogger
 
-verbose_logger.setLevel(logging.DEBUG)
+import respx
+
+
+def test_azure_shared_key_auth_simple_get():
+
+    def get_date_str():
+        return "Mon, 13 Apr 2025 12:00:00 GMT"
+
+    key_bytes = "testkey".encode("utf-8")
+    key = base64.b64encode(key_bytes)
+    auth = AzureAuthSharedKey("testaccount", key, get_date_str)
+    request = httpx.Request(
+        "GET", "https://testaccount.dfs.core.windows.net/testfilesystem/testfile.json?some_query_param=1"
+    )
+    request = auth(request)
+
+    expected_signature = hmac_sign(
+        "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:Mon, 13 Apr 2025 12:00:00 GMT\nx-ms-version:2021-04-10\n/testaccount/testfilesystem/testfile.json\nsome_query_param:1",
+        key_bytes,
+    )
+
+    # then validate the signing uses the same signature
+    assert request.headers["x-ms-date"] == "Mon, 13 Apr 2025 12:00:00 GMT"
+    assert request.headers["x-ms-version"] == "2021-04-10"
+    assert (
+        request.headers["Authorization"]
+        == f"SharedKey testaccount:{expected_signature}"
+    )
+
+
+def test_azure_shared_key_auth_complex_post():
+    def get_date_str():
+        return "Mon, 13 Apr 2025 12:00:00 GMT"
+
+    key_bytes = "testkey".encode("utf-8")
+    key = base64.b64encode(key_bytes)
+    auth = AzureAuthSharedKey("testaccount", key, get_date_str)
+
+    request = httpx.Request(
+        "POST",
+        "https://testaccount.dfs.core.windows.net/testfilesystem/testfile.json",
+        headers={
+            "hi": "there",
+            "Content-Type": "application/json",
+            "Content-MD5": "testmd5",
+        },
+        content=b'{"hello": "world"}',
+    )
+    request = auth(request)
+
+    expected_signature = hmac_sign(
+        "POST\n\n\n18\ntestmd5\napplication/json\n\n\n\n\n\n\nx-ms-date:Mon, 13 Apr 2025 12:00:00 GMT\nx-ms-version:2021-04-10\n/testaccount/testfilesystem/testfile.json",
+        key_bytes,
+    )
+
+    assert (
+        request.headers["Authorization"]
+        == f"SharedKey testaccount:{expected_signature}"
+    )
+    
+def test_azure_shared_key_query_parameter_sorting():
+    def get_date_str():
+        return "Mon, 13 Apr 2025 12:00:00 GMT"
+
+    key_bytes = "testkey".encode("utf-8")
+    key = base64.b64encode(key_bytes)
+    auth = AzureAuthSharedKey("testaccount", key, get_date_str)
+
+    # Create a request with unsorted query parameters
+    request = httpx.Request(
+        "GET", "https://testaccount.dfs.core.windows.net/testfilesystem/testfile.json?b=2&b=1&a=1"
+    )
+    request = auth(request)
+
+    expected_signature = hmac_sign(
+        "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:Mon, 13 Apr 2025 12:00:00 GMT\nx-ms-version:2021-04-10\n/testaccount/testfilesystem/testfile.json\na:1\nb:1,2",
+        key_bytes,
+    )
+
+    # Validate that the signature is correct and the query parameters are sorted
+    assert (
+        request.headers["Authorization"]
+        == f"SharedKey testaccount:{expected_signature}"
+    )
+
+def test_azure_shared_key_all_the_headers():
+    x_ms_date = "Mon, 13 Apr 2025 12:00:00 GMT"
+    def get_date_str():
+        return x_ms_date
+
+    key_bytes = "testkey".encode("utf-8")
+    key = base64.b64encode(key_bytes)
+    auth = AzureAuthSharedKey("testaccount", key, get_date_str)
+    content_encoding = "gzip"
+    content_language = "en-US"
+    content_length = "0"
+    if_modified_since = "Mon, 13 Apr 2025 12:00:00 GMT"
+    if_match = "*"
+    if_none_match = "*"
+    if_unmodified_since = "Sun, 12 Apr 2025 12:00:00 GMT"
+    range = "0-123"
+    content_md5 = "testmd5"
+    content_type = "application/json"
+    date = "Tue, 14 Apr 2025 12:00:00 GMT"
+    if content_length == "0":
+        content_length = ""
+    # Create a request with unsorted query parameters
+    request = httpx.Request(
+        "GET", "https://testaccount.dfs.core.windows.net/testfilesystem/testfile.json",
+        headers={
+            "Content-Encoding": content_encoding,
+            "Content-Language": content_language,
+            "Content-Length": content_length,
+            "Date": date,
+            "If-Modified-Since": if_modified_since,
+            "If-Match": if_match,
+            "If-None-Match": if_none_match,
+            "If-Unmodified-Since": if_unmodified_since,
+            "Range": range,
+            "Content-MD5": content_md5,
+            "Content-Type": content_type,
+        }
+    )
+    request = auth(request)
+
+    expected_string_to_sign = f"GET\n{content_encoding}\n{content_language}\n\n{content_md5}\n{content_type}\n\n{if_modified_since}\n{if_match}\n{if_none_match}\n{if_unmodified_since}\n{range}\nx-ms-date:{x_ms_date}\nx-ms-version:2021-04-10\n/testaccount/testfilesystem/testfile.json"
+    expected_signature = hmac_sign(
+        expected_string_to_sign,
+        key_bytes,
+    )
+
+    # Validate that the signature is correct and the query parameters are sorted
+    assert (
+        request.headers["Authorization"]
+        == f"SharedKey testaccount:{expected_signature}"
+    )
+
+def hmac_sign(string: str, key: bytes) -> str:
+    signed_hmac_sha256 = hmac.new(key, string.encode("utf-8"), hashlib.sha256).digest()
+    return base64.b64encode(signed_hmac_sha256).decode()
+
+
+def test_test_hmac_sign():
+    # double check assumptions about the signing here in the test. Kind of just testing the test here.
+    key_bytes = "testkey".encode("utf-8")
+    expected_string_to_sign = "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:Mon, 13 Apr 2025 12:00:00 GMT\nx-ms-version:2021-04-10\n/testaccount/testfilesystem/testfile.json"
+    signed_hmac_sha256 = hmac.new(
+        key_bytes, expected_string_to_sign.encode("utf-8"), hashlib.sha256
+    ).digest()
+    signature = base64.b64encode(signed_hmac_sha256).decode()
+    assert signature == "iNSUkZfnd0VgI/bl8qyx1MiH01O/yA9vYfl2KNQLnRE="
+
+
+def setup_azure_storage_mocks(
+    respx_mock: respx.MockRouter,
+    account_name: str,
+    file_system: str,
+) -> None:
+    """
+    Sets up common mocks for Azure Storage API calls and OpenAI completion.
+    
+    Args:
+        respx_mock: The respx mock router
+        account_name: Azure storage account name
+        file_system: Azure storage file system name
+    """
+    # Regex to match the base URL structure and filename
+    base_pattern = re.compile(
+        rf"https://{account_name}\.dfs\.core\.windows\.net/{file_system}/.+\.json.*"
+    )
+
+    # Mock PUT request for file creation
+    respx_mock.put(base_pattern, params={"resource": "file"}).respond(
+        status_code=201  # Created
+    )
+
+    # Mock PATCH request for appending data
+    respx_mock.patch(
+        base_pattern, params={"action": "append", "position": "0"}
+    ).respond(
+        status_code=202
+    )  # Accepted
+
+    # Mock PATCH request for flushing data - allow any position value
+    respx_mock.patch(base_pattern, params={"action": "flush"}).respond(
+        status_code=202
+    )  # Accepted
+
+    # Mock OpenAI call - Ensure it returns an ID for filename generation
+    respx_mock.post("https://api.openai.com/v1/chat/completions").respond(
+        json={
+            "id": "chatcmpl-123",
+            "choices": [{"message": {"content": "Hello, world!"}}],
+        }
+    )
 
 
 @pytest.mark.asyncio
-async def test_azure_blob_storage():
-    azure_storage_logger = AzureBlobStorageLogger(flush_interval=1)
-    litellm.callbacks = [azure_storage_logger]
+@patch("litellm.proxy.proxy_server.premium_user", True)
+async def test_azure_blob_storage_shared_key(
+    respx_mock: respx.MockRouter,
+    monkeypatch,
+):
+    # Mock Azure Blob Storage API calls
+    account_name = "testaccount"
+    file_system = "testfilesystem"
+    test_key_bytes = "testkey".encode("utf-8")
+    test_key = base64.b64encode(test_key_bytes)
+
+    # Mock environment variables for Shared Key Auth
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", account_name)
+    monkeypatch.setenv("AZURE_STORAGE_FILE_SYSTEM", file_system)
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", test_key)
+
+    setup_azure_storage_mocks(respx_mock, account_name, file_system)
+
+    azure_storage_logger = AzureBlobStorageLogger(flush_interval=0.1)
+    monkeypatch.setattr(litellm, "callbacks", [azure_storage_logger])
 
     response = await litellm.acompletion(
-        model="gpt-4o",
+        model="gpt-4o-mini",  # Use a model litellm recognizes by default
         messages=[{"role": "user", "content": "Hello, world!"}],
+        api_key="sk-12345",  # Dummy key
     )
-    print(response)
 
-    await asyncio.sleep(3)
-    pass
+    # Wait up to 1.5 seconds for the call count to increase to 3
+    for _ in range(150):  # Check every 0.1 seconds
+        if respx_mock.calls.call_count >= 3:
+            break
+        await asyncio.sleep(0.01)
+
+    # Assert that the mocked Azure endpoints were called (at least create, append, flush)
+    assert respx_mock.calls.call_count >= 3
+    call_log: list[respx.models.Call] = list(respx_mock.calls)
+
+    put_calls = [call for call in call_log if call.request.method == "PUT"]
+    patch_calls = [call for call in call_log if call.request.method == "PATCH"]
+
+    assert len(put_calls) == 1
+    assert "resource=file" in str(put_calls[0].request.url)
+
+    assert len(patch_calls) == 2
+    append_call_found = any(
+        "action=append" in str(call.request.url) for call in patch_calls
+    )
+    flush_call_found = any(
+        "action=flush" in str(call.request.url) for call in patch_calls
+    )
+    assert append_call_found
+    assert flush_call_found
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.premium_user", True)
+async def test_azure_blob_storage_ad_auth(
+    respx_mock: respx.MockRouter,
+    monkeypatch: MonkeyPatch,
+):
+    # Mock Azure Blob Storage API calls
+    account_name = "testaccount"
+    file_system = "testfilesystem"
+    test_token = "test_azure_ad_token"
+
+    # Mock environment variables for AD Auth
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", account_name)
+    monkeypatch.setenv("AZURE_STORAGE_FILE_SYSTEM", file_system)
+    monkeypatch.setenv("AZURE_STORAGE_TENANT_ID", "test-tenant-id")
+    monkeypatch.setenv("AZURE_STORAGE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_STORAGE_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_KEY", raising=False)
+
+    # Mock the Azure AD token provider
+    def mock_token_provider():
+        return test_token
+
+    with patch(
+        "litellm.integrations.azure_storage._azure_storage_auth.get_azure_ad_token_from_entrata_id",
+        return_value=mock_token_provider,
+    ):
+        setup_azure_storage_mocks(respx_mock, account_name, file_system)
+
+        azure_storage_logger = AzureBlobStorageLogger(flush_interval=0.1)
+        monkeypatch.setattr(litellm, "callbacks", [azure_storage_logger])
+
+        response = await litellm.acompletion(
+            model="gpt-4o-mini",  # Use a model litellm recognizes by default
+            messages=[{"role": "user", "content": "Hello, world!"}],
+            api_key="sk-12345",  # Dummy key
+        )
+
+        # Wait up to 1.5 seconds for the call count to increase to 3
+        for _ in range(150):  # Check every 0.1 seconds
+            if respx_mock.calls.call_count >= 3:
+                break
+            await asyncio.sleep(0.01)
+
+        # Assert that the mocked Azure endpoints were called (at least create, append, flush)
+        assert respx_mock.calls.call_count == 4
+        call_log: list[respx.models.Call] = list(respx_mock.calls)
+        azure_calls = [call for call in call_log if call.request.url.host == f"{account_name}.dfs.core.windows.net"]
+        assert len(azure_calls) == 3
+        
+        for call in azure_calls:
+            assert call.request.headers.get("Authorization") == f"Bearer {test_token}", f"call {call.request.url} with headers {call.request.headers} missing the correct token"
+
+        put_calls = [call for call in call_log if call.request.method == "PUT"]
+        patch_calls = [call for call in call_log if call.request.method == "PATCH"]
+
+        assert len(put_calls) >= 1
+        assert "resource=file" in str(put_calls[0].request.url)
+
+        assert len(patch_calls) >= 2
+        append_call_found = any(
+            "action=append" in str(call.request.url) for call in patch_calls
+        )
+        flush_call_found = any(
+            "action=flush" in str(call.request.url) for call in patch_calls
+        )
+        assert append_call_found
+        assert flush_call_found
+
+
+@pytest.mark.asyncio
+async def test_azure_ad_token_caching():
+    """Test that the Azure AD token is cached and reused for multiple requests"""
+    account_name = "testaccount"
+    test_token = "test_azure_ad_token"
+    token_fetch_count = 0
+
+    def mock_token_provider():
+        nonlocal token_fetch_count
+        token_fetch_count += 1
+        return test_token
+
+    with patch(
+        "litellm.integrations.azure_storage._azure_storage_auth.get_azure_ad_token_from_entrata_id",
+        return_value=mock_token_provider,
+    ) as mock_get_token:
+        auth1 = AzureADTokenAuth(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        # Make requests with both auth instances
+        request1 = httpx.Request("GET", f"https://{account_name}.dfs.core.windows.net/test")
+        request2 = httpx.Request("GET", f"https://{account_name}.dfs.core.windows.net/test")
+
+        auth1(request1)
+        auth1(request2)
+
+        # Verify token was only fetched once
+        assert token_fetch_count == 1
+        assert request1.headers["Authorization"] == f"Bearer {test_token}"
+        assert request2.headers["Authorization"] == f"Bearer {test_token}"
+
+
+@pytest.mark.asyncio
+async def test_azure_ad_token_expiry():
+    """Test that the Azure AD token is refreshed after expiry"""
+    account_name = "testaccount"
+    test_token_1 = "test_azure_ad_token_1"
+    test_token_2 = "test_azure_ad_token_2"
+    token_fetch_count = 0
+    
+    # Use a mutable object to track time
+    mock_time = {"now": datetime(2024, 1, 1, 12, 0, 0)}
+
+    def mock_token_provider():
+        nonlocal token_fetch_count
+        token_fetch_count += 1
+        # Return different tokens to verify refresh
+        return test_token_1 if token_fetch_count == 1 else test_token_2
+
+    def get_mock_now():
+        return mock_time["now"]
+
+    # Mock time to control token expiry
+    with patch(
+        "litellm.integrations.azure_storage._azure_storage_auth.get_azure_ad_token_from_entrata_id",
+        return_value=mock_token_provider,
+    ) as mock_get_token, patch(
+        "litellm.integrations.azure_storage._azure_storage_auth.datetime"
+    ) as mock_datetime:
+        # Setup datetime mock
+        mock_datetime.now.side_effect = get_mock_now
+
+        auth = AzureADTokenAuth(
+            tenant_id="test-tenant",
+            client_id="test-client",
+            client_secret="test-secret",
+        )
+
+        # First request at t=0
+        request1 = httpx.Request("GET", f"https://{account_name}.dfs.core.windows.net/test")
+        auth(request1)
+        assert token_fetch_count == 1
+        assert request1.headers["Authorization"] == f"Bearer {test_token_1}"
+
+        # Move time forward past token expiry (default 1 hour)
+        mock_time["now"] = mock_time["now"] + timedelta(hours=1, minutes=6)
+
+        # Second request after expiry
+        request2 = httpx.Request("GET", f"https://{account_name}.dfs.core.windows.net/test")
+        auth(request2)
+
+        # Verify new token was fetched
+        assert token_fetch_count == 2
+        assert request2.headers["Authorization"] == f"Bearer {test_token_2}"
+


### PR DESCRIPTION

## Title

rewrite azure storage to consolidate the authentication implementation

## Relevant issues

Fixes #9339

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/71bbcba6-806e-4b12-ac6f-d98f11a0ea32" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

the azure storage datalake was failing under certain high throughput scenarios. v12.15.0 seems like it had api changes causing failure scenarios. This fixes it by entirely removing the code branching around the 2 auth methods, and just uses the AD auth manually written httpx API 


