### PR TITLE
Simple fix for #9339 - upgrade the azure storage library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-multipart==0.0.18 # admin UI
 Pillow==11.0.0
 azure-ai-contentsafety==1.0.0 # for azure content safety
 azure-identity==1.16.1 # for azure content safety
-azure-storage-file-datalake==12.15.0 # for azure buck storage logging
+azure-storage-file-datalake==12.20.0 # for azure buck storage logging
 opentelemetry-api==1.25.0
 opentelemetry-sdk==1.25.0
 opentelemetry-exporter-otlp==1.25.0


### PR DESCRIPTION
## Title

Uprades the `azure-storage-file-datalake` library, and retains a single azure client for the azure logging handler.

## Relevant issues

Fixes #9339

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

No unit tests were added, as this is a concurrency bug that's difficult to recreate. I ran manual tests with 400 simultaneous requests to verify the bug no longer occurs (the bug easily occurred with the old v12.15.0 of the `azure-storage-file-datalake`). Script is attached

Script attached. This bug only occurs for shared key auth, and not active directory, as their implementation differs.

Logs from proxy look like this, (with waiting some time after the test for the logs to flush)

<img width="567" alt="image" src="https://github.com/user-attachments/assets/e47049f4-017e-4a70-b933-beaff7611b0c" />



## Type


🐛 Bug Fix

## Changes

The upgrade fixes #9339, and retaining the client prevents annoying verbose logs about the task not having completed from not correctly disposing of the client for each request. (It should also be more efficient to retain a single client).

This is a simpler, but less elegant fix than #9962

Testing script:

```python
import asyncio
import aiohttp
import json
import time

async def make_request(session, request_number):
    url = 'http://localhost:4000/v1/chat/completions'
    headers = {
        'Content-Type': 'application/json',
        'Authorization': 'Bearer sk-1234'
    }
    payload = {
        'model': 'gpt-4o-mini',
        'messages': [
            {
                'role': 'user',
                'content': f'Hello! This is request number {request_number}'
            }
        ]
    }
    
    try:
        start_time = time.time()
        async with session.post(url, headers=headers, json=payload) as response:
            response_text = await response.text()
            end_time = time.time()
            print(f"Request {request_number} completed in {end_time - start_time:.2f}s with status {response.status}")
            return response.status, response_text
    except Exception as e:
        print(f"Request {request_number} failed: {str(e)}")
        return None, str(e)

async def main():
    total_requests = 400
    parallelism = 400
    
    print(f"Starting {total_requests} requests with parallelism of {parallelism}")
    start_time = time.time()
    
    async with aiohttp.ClientSession() as session:
        tasks = []
        for i in range(1, total_requests + 1):
            task = asyncio.create_task(make_request(session, i))
            tasks.append(task)
            
            # Control parallelism
            if len(tasks) >= parallelism:
                # Wait for some tasks to complete before adding more
                completed, pending = await asyncio.wait(
                    tasks, 
                    return_when=asyncio.FIRST_COMPLETED
                )
                tasks = list(pending)  # Convert set of pending tasks back to list
        
        # Wait for remaining tasks
        if tasks:
            await asyncio.gather(*tasks)
    
    end_time = time.time()
    print(f"All requests completed in {end_time - start_time:.2f} seconds")

if __name__ == "__main__":
    asyncio.run(main())
````