### PR TITLE
[Bug Fix ] : KeyError: 'name' when using function calling with Ollama models - Gemma3 or Llama3.2

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -282,13 +282,11 @@ class OllamaConfig(BaseConfig):
                 else:
                     # Parsed JSON doesn't have "name"/"arguments" - treat as plain text
                     # Fallback: Use the original JSON string as the text content
-                    print("\n--- DEBUG: Ollama JSON format received, but not a valid tool call. Treating as text. ---\n")
                     model_response.choices[0].message.content = response_json["response"]
                     model_response.choices[0].finish_reason = "stop"
 
             except json.JSONDecodeError:
                 # If response_json["response"] wasn't valid JSON, treat as plain text
-                print("\n--- DEBUG: Ollama JSON format received, but failed to parse. Treating as text. ---\n")
                 model_response.choices[0].message.content = response_json["response"]
                 model_response.choices[0].finish_reason = "stop"
         else:

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -270,8 +270,8 @@ class OllamaConfig(BaseConfig):
                             {
                                 "id": f"call_{str(uuid.uuid4())}",
                                 "function": {
-                                    "name": function_call["name"], # Now safe to access
-                                    "arguments": json.dumps(function_call["arguments"]),
+                                    "name": function_call["name"],  # type: ignore
+                                    "arguments": json.dumps(function_call["arguments"]),  # type: ignore
                                 },
                                 "type": "function",
                             }


### PR DESCRIPTION
Issue 
**fix(ollama): Handle non-tool-call JSON response when format=json**
Issue occurs while using from google.adk.models.lite_llm import LiteLlm with llama3.2 , gemma3:27b 

Error
```
venv/lib/python3.12/site-packages/litellm/llms/ollama/completion/transformation.py", line 266, in transform_response
    "name": function_call["name"],
            ~~~~~~~~~~~~~^^^^^^^^
KeyError: 'name'
```


Changes
This PR addresses a KeyError: 'name' that occurs in litellm/llms/ollama/completion/transformation.py when using certain Ollama models (e.g., ollama/llama3.2:latest, ollama/gemma3:27b) with tool calling enabled (format="json").
Problem:

When LiteLLM expects a tool call response, it requests format="json" from Ollama. However, some models return a valid JSON string in the response field, but the structure of this JSON does not match the expected tool call format ({"name": ..., "arguments": ...}). Instead, it might contain other structures (e.g., Schema.org JSON as seen with llama3.2). When transformation.py parses this JSON and attempts to access function_call["name"], it results in a KeyError.
![adk-litellm-issue](https://github.com/user-attachments/assets/d9938740-1423-46c3-ba3f-954a740871eb)
