### PR TITLE
quick fix to enable Cloudflare Gateway in google-ai-studio

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -172,12 +172,16 @@ class VertexBase:
             if custom_llm_provider == "gemini":
                 url = "{}:{}".format(api_base, endpoint)
                 if gemini_api_key is None:
-                    raise ValueError(
-                        "Missing gemini_api_key, please set `GEMINI_API_KEY`"
+                    # Do not raise error as google-ai-studio expect header 'x-goog-api-key' instead of 'Authorization',
+                    #     https://developers.cloudflare.com/ai-gateway/providers/google-ai-studio/#curl
+                    # raise ValueError(
+                    #     "Missing gemini_api_key, please set `GEMINI_API_KEY`"
+                    # )
+                    pass
+                else:
+                    auth_header = (
+                        gemini_api_key  # cloudflare expects api key as bearer token
                     )
-                auth_header = (
-                    gemini_api_key  # cloudflare expects api key as bearer token
-                )
             else:
                 url = "{}:{}".format(api_base, endpoint)
 


### PR DESCRIPTION
## Title

quick fix to enable Cloudflare Gateway in google-ai-studio resolving #9975 

## Relevant issues

The Cloudflare Gateway with google-ai-studio do not expect normal Auth, missing the normal api-key will raise error in current codebase

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
With this quick fix, it will not hurt the current cases. Error will pop up in later http.post stage if normal Auth api-key really needed.

When key in 'x-goog-api-key' format needed, user can manually set `extra_header` for it, like the solution commented out in [this example](https://github.com/BerriAI/litellm/issues/9975#issue-2992558297).

A more smart solution to #9975 is needed by the official developers, or, I can create a full solution after discussion.

