### PR TITLE
fix(watsonx): IBM Watsonx - use correct parameter name for tool choice

### DIFF
--- a/litellm/llms/watsonx/chat/transformation.py
+++ b/litellm/llms/watsonx/chat/transformation.py
@@ -25,7 +25,7 @@ class IBMWatsonXChatConfig(IBMWatsonXMixin, OpenAIGPTConfig):
             "seed",  # equivalent to random_seed
             "stream",  # equivalent to stream
             "tools",
-            "tool_choice",  # equivalent to tool_choice + tool_choice_options
+            "tool_choice",  # equivalent to tool_choice + tool_choice_option
             "logprobs",
             "top_logprobs",
             "n",
@@ -61,7 +61,7 @@ class IBMWatsonXChatConfig(IBMWatsonXMixin, OpenAIGPTConfig):
 
         _tool_choice = non_default_params.pop("tool_choice", None)
         if self.is_tool_choice_option(_tool_choice):
-            optional_params["tool_choice_options"] = _tool_choice
+            optional_params["tool_choice_option"] = _tool_choice
         elif _tool_choice is not None:
             optional_params["tool_choice"] = _tool_choice
         return super().map_openai_params(

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -964,7 +964,7 @@ def test_watsonx_tool_choice():
         model="gemini-1.5-pro", custom_llm_provider="watsonx", tool_choice="auto"
     )
     print(optional_params)
-    assert optional_params["tool_choice_options"] == "auto"
+    assert optional_params["tool_choice_option"] == "auto"
 
 
 def test_watsonx_text_top_k():

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -791,7 +791,7 @@ async def test_watsonx_tool_choice(sync_mode):
             mock_completion.assert_called_once()
             print(mock_completion.call_args.kwargs)
             json_data = json.loads(mock_completion.call_args.kwargs["data"])
-            json_data["tool_choice_options"] == "auto"
+            json_data["tool_choice_option"] == "auto"
         except Exception as e:
             print(e)
             if "The read operation timed out" in str(e):


### PR DESCRIPTION
Ref: BerriAI/litellm#9979

