### PR TITLE
fix: 'role' incorrectly duplicated in multiple deltas

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1326,7 +1326,10 @@ class CustomStreamWrapper:
                                                 t.function.arguments = ""
                             _json_delta = delta.model_dump()
                             print_verbose(f"_json_delta: {_json_delta}")
-                            if "role" not in _json_delta or _json_delta["role"] is None:
+                            if not self.sent_first_chunk and (
+                                "role" not in _json_delta
+                                or _json_delta["role"] is None
+                            ):
                                 _json_delta[
                                     "role"
                                 ] = "assistant"  # mistral's api returns role as None

--- a/tests/litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/litellm/litellm_core_utils/test_streaming_handler.py
@@ -276,6 +276,39 @@ def test_optional_combine_thinking_block_in_choices(
     assert not hasattr(final_response.choices[0].delta, "reasoning_content")
 
 
+def test_missing_role_in_not_first_delta(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.sent_first_chunk = False
+    delta_json = {"content": "Hello world"}
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta = MagicMock()
+    mock_chunk.choices[0].delta.model_dump.return_value = delta_json
+
+    with patch.object(initialized_custom_stream_wrapper, 'return_processed_chunk_logic', return_value=None):
+        initialized_custom_stream_wrapper.chunk_creator(mock_chunk)
+
+    assert delta_json["role"] == "assistant"
+
+
+def test_missing_role_in_first_delta(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.sent_first_chunk = True
+    delta_json = {"content": "Hello world", "role": None}
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta = MagicMock()
+    mock_chunk.choices[0].delta.model_dump.return_value = delta_json
+
+    with patch.object(initialized_custom_stream_wrapper, 'return_processed_chunk_logic', return_value=None):
+        initialized_custom_stream_wrapper.chunk_creator(mock_chunk)
+
+    assert delta_json["role"] is None
+
+
 def test_multi_chunk_reasoning_and_content(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
 ):


### PR DESCRIPTION
## Fix: 'role' incorrectly is duplicated in multiple deltas

The role="assistant" gets duplicated across multiple delta chunks, meaning that when the chunks get [merged together](https://github.com/openai/openai-python/blob/main/src/openai/lib/streaming/_deltas.py#L27-L28) by openai libraries, the role ends up being concatenated into `assistantassistantassistant...`

[Example output before the change](https://github.com/user-attachments/files/19740558/stream_before.txt) (`assistant` gets added to every delta chunk)

[Example output after the change](https://github.com/user-attachments/files/19753525/stream_after.txt) (`assistant` is only on the first chunk)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![image](https://github.com/user-attachments/assets/739b4bcd-3f5b-4d01-aca4-489a0aa18c9f)

## Type

🐛 Bug Fix


