### PR TITLE
Fix case where only system messages are passed to Gemini

### DIFF
--- a/tests/litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -8,6 +8,7 @@ from litellm import ModelResponse
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     VertexGeminiConfig,
 )
+from litellm.llms.vertex_ai.gemini.transformation import _transform_request_body
 from litellm.types.utils import ChoiceLogprobs
 
 
@@ -62,3 +63,71 @@ def test_get_model_name_from_gemini_spec_model():
     model = "gemini/ft-uuid-123"
     result = VertexGeminiConfig._get_model_name_from_gemini_spec_model(model)
     assert result == "ft-uuid-123"
+
+def test_system_message_conversion_gemini():
+    """Test that system-only messages are properly handled for Gemini"""
+    # Case 1: Default behavior - duplicate system as user
+    messages = [{"role": "system", "content": "You are a helpful assistant"}]
+    
+    # Create mock objects for the test
+    model = "gemini-2.0-flash"
+    custom_llm_provider = "gemini"
+    optional_params = {}
+    litellm_params = {}
+    
+    result = _transform_request_body(
+        messages=messages, # type: ignore
+        model=model,
+        optional_params=optional_params,
+        custom_llm_provider=custom_llm_provider,
+        litellm_params=litellm_params,
+        cached_content=None
+    )
+    
+    # Verify that contents has user message
+    assert len(result["contents"]) > 0
+    assert result["contents"][0]["role"] == "user" # type: ignore
+    assert "system_instruction" in result
+    
+    # Case 2: Disable duplication
+    optional_params = {"duplicate_system_as_user_for_gemini": False}
+    
+    # Save original modify_params value
+    original_modify_params = litellm.modify_params
+    litellm.modify_params = False
+    
+    result_no_duplicate = _transform_request_body(
+        messages=messages.copy(), # type: ignore
+        model=model,
+        optional_params=optional_params,
+        custom_llm_provider=custom_llm_provider,
+        litellm_params={},
+        cached_content=None
+    )
+    
+    # Restore original modify_params value
+    litellm.modify_params = original_modify_params
+    
+    # With duplication disabled and modify_params False,
+    # we'd expect an empty contents field
+    # This might actually raise an exception in practice
+    assert "system_instruction" in result_no_duplicate
+    
+    # Case 3: With litellm.modify_params=True it should duplicate even with parameter set to False
+    litellm.modify_params = True
+    
+    result_with_modify_params = _transform_request_body(
+        messages=messages.copy(), # type: ignore
+        model=model,
+        optional_params={"duplicate_system_as_user_for_gemini": False},
+        custom_llm_provider=custom_llm_provider,
+        litellm_params={},
+        cached_content=None
+    )
+    
+    # Restore original modify_params value
+    litellm.modify_params = original_modify_params
+    
+    # Verify that contents has user message due to modify_params=True
+    assert len(result_with_modify_params["contents"]) > 0
+    assert result_with_modify_params["contents"][0]["role"] == "user" # type: ignore


### PR DESCRIPTION
Currently, When you call the Gemini API with only system messages, LiteLLM extracts those messages for the `system_instruction` field but leaves nothing for the required `contents` field.

Passing message content such as `messages=[{"role": "system", "content": "Generate a hypothetical document about artificial intelligence."}]` will do the following:

1. The message is identified as a system message
2. It's extracted and placed in `system_instruction`
3. The `messages` list becomes empty
4. When trying to create the `contents` field, there are no messages to convert
5. The request is sent to Gemini with a missing `contents` field

Causing:
```
VertexAIException BadRequestError - {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.contents: contents is not specified\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

With this patch:
1. The system messages are extracted for `system_instruction`
2. But there's now a user message (with the same content) that remains in the messages list
3. This gets converted properly for the `contents` field
4. The request to Gemini is valid with both fields populated


**Internal Transformation (Before Fix):**
```json
{
  "system_instruction": {
    "parts": [{"text": "Generate a hypothetical document about AI."}]
  },
  "contents": []  // Empty contents field! This causes the error
}
```

**Internal Transformation (After Fix):**
```json
{
  "system_instruction": {
    "parts": [{"text": "Generate a hypothetical document about AI."}]
  },
  "contents": [
    {
      "role": "user",
      "parts": [{"text": "Generate a hypothetical document about AI."}]
    }
  ]  // Now contents has a valid value
}
```

This fix ensures the required fields are always populated correctly while maintaining the intended functionality of system messages.