### PR TITLE
chore: increase livenessProbe and readinessProbe timeouts

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -120,10 +120,12 @@ spec:
             httpGet:
               path: /health/liveliness
               port: http
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: http
+            timeoutSeconds: 10
           # Give the container time to start up.  Up to 5 minutes (10 * 30 seconds)
           startupProbe:
             httpGet:


### PR DESCRIPTION
## Increase readinessProbe and livenessProbe for litellm deployment

- our litellm deployment keeps restarting because the pods fail readiness and liveness probes
- the default in k8s is 1s, the pod isn't always able to respond it time
- it seems to happen particularly often when the process flushes spend logs to the database

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix