### PR TITLE
If json_logs: true, the proxy server will outputs access logs in JSON

### DIFF
--- a/litellm/proxy/json_logging.py
+++ b/litellm/proxy/json_logging.py
@@ -1,0 +1,69 @@
+import logging
+import traceback
+from datetime import datetime, UTC
+import json
+
+from uvicorn.config import LOGGING_CONFIG
+
+# Override uvicorn's default logging config to use our JSON formatter
+def uvicorn_json_log_config():
+    config = LOGGING_CONFIG.copy()
+    config['formatters'] = {
+        'default': {
+            '()': 'litellm.proxy.json_logging.JsonFormatter'
+        },
+        'access': {
+            '()': 'litellm.proxy.json_logging.AccessJsonFormatter'
+        }
+    }
+    return config
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        log_entry = {
+            "timestamp": datetime.fromtimestamp(record.created, UTC).isoformat(timespec='milliseconds') + 'Z',
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "logger_name": record.name,
+            "process": record.process,
+            "thread": record.threadName,
+        }
+        # Add exception information
+        if record.exc_info:
+            log_entry['exception'] = "".join(traceback.format_exception(*record.exc_info))
+            exc_type, exc_value, exc_traceback = record.exc_info
+            log_entry['exception'] = {
+                'type': str(exc_type.__name__),
+                'message': str(exc_value),
+                'traceback': traceback.format_tb(exc_traceback)
+            }
+
+        # Add extra data
+        if hasattr(record, 'extra_data') and isinstance(record.extra_data, dict):
+             log_entry.update(record.extra_data) # extra データの処理例
+
+        return json.dumps(log_entry, ensure_ascii=False)
+
+# ref: https://github.com/encode/uvicorn/blob/0.34.1/uvicorn/logging.py#L73
+class AccessJsonFormatter(logging.Formatter):
+    def format(self, record):
+        (
+            client_addr,
+            method,
+            full_path,
+            http_version,
+            status_code,
+        ) = record.args
+        log_entry = {
+            'timestamp': datetime.fromtimestamp(record.created, UTC).isoformat(timespec='milliseconds') + 'Z',
+            'level': record.levelname,
+            'logger_name': record.name,
+            'process': record.process,
+            'thread': record.threadName,
+            'client_addr': client_addr,
+            'method': method,
+            'full_path': full_path,
+            'http_version': http_version,
+            'status_code': status_code,
+        }
+        return json.dumps(log_entry, ensure_ascii=False)

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -132,8 +132,8 @@ class ProxyInitializationHelpers:
             print(f"Using log_config: {log_config}")  # noqa
             uvicorn_args["log_config"] = log_config
         elif litellm.json_logs:
-            print("Using json logs. Setting log_config to None.")  # noqa
-            uvicorn_args["log_config"] = None
+            from litellm.proxy.json_logging import uvicorn_json_log_config
+            uvicorn_args["log_config"] = uvicorn_json_log_config()
         return uvicorn_args
 
     @staticmethod

--- a/tests/litellm/proxy/test_proxy_cli.py
+++ b/tests/litellm/proxy/test_proxy_cli.py
@@ -108,7 +108,8 @@ class TestProxyInitializationHelpers:
             args = ProxyInitializationHelpers._get_default_unvicorn_init_args(
                 "localhost", 8000
             )
-            assert args["log_config"] is None
+            assert args["log_config"]["formatters"]["default"]["()"] == "litellm.proxy.json_logging.JsonFormatter"
+            assert args["log_config"]["formatters"]["access"]["()"] == "litellm.proxy.json_logging.AccessJsonFormatter"
 
     @patch("asyncio.run")
     @patch("builtins.print")

--- a/tests/proxy_unit_tests/test_json_logging.py
+++ b/tests/proxy_unit_tests/test_json_logging.py
@@ -1,0 +1,96 @@
+import unittest
+import logging
+import json
+from datetime import datetime
+from litellm.proxy.json_logging import JsonFormatter, AccessJsonFormatter
+
+class TestJsonFormatter(unittest.TestCase):
+    def setUp(self):
+        self.formatter = JsonFormatter()
+
+    def test_basic_log_format(self):
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+        formatted = self.formatter.format(record)
+        log_entry = json.loads(formatted)
+
+        self.assertEqual(log_entry["level"], "INFO")
+        self.assertEqual(log_entry["message"], "Test message")
+        self.assertEqual(log_entry["logger_name"], "test_logger")
+        self.assertIn("timestamp", log_entry)
+        self.assertIn("process", log_entry)
+        self.assertIn("thread", log_entry)
+
+    def test_log_with_exception(self):
+        try:
+            raise ValueError("Test error")
+        except ValueError as e:
+            record = logging.LogRecord(
+                name="test_logger",
+                level=logging.ERROR,
+                pathname="test.py",
+                lineno=1,
+                msg="Test error occurred",
+                args=(),
+                exc_info=(type(e), e, e.__traceback__)
+            )
+            formatted = self.formatter.format(record)
+            log_entry = json.loads(formatted)
+
+            self.assertEqual(log_entry["level"], "ERROR")
+            self.assertEqual(log_entry["message"], "Test error occurred")
+            self.assertIn("exception", log_entry)
+            self.assertEqual(log_entry["exception"]["type"], "ValueError")
+            self.assertEqual(log_entry["exception"]["message"], "Test error")
+            self.assertIsInstance(log_entry["exception"]["traceback"], list)
+
+    def test_log_with_extra_data(self):
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+        record.extra_data = {"user_id": "123", "action": "login"}
+        formatted = self.formatter.format(record)
+        log_entry = json.loads(formatted)
+
+        self.assertEqual(log_entry["user_id"], "123")
+        self.assertEqual(log_entry["action"], "login")
+
+class TestAccessJsonFormatter(unittest.TestCase):
+    def setUp(self):
+        self.formatter = AccessJsonFormatter()
+
+    def test_access_log_format(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="%s - %s %s HTTP/%s %d",
+            args=("127.0.0.1", "GET", "/test", "1.1", 200),
+            exc_info=None
+        )
+        formatted = self.formatter.format(record)
+        log_entry = json.loads(formatted)
+
+        self.assertEqual(log_entry["level"], "INFO")
+        self.assertEqual(log_entry["client_addr"], "127.0.0.1")
+        self.assertEqual(log_entry["method"], "GET")
+        self.assertEqual(log_entry["full_path"], "/test")
+        self.assertEqual(log_entry["http_version"], "1.1")
+        self.assertEqual(log_entry["status_code"], 200)
+        self.assertIn("timestamp", log_entry)
+        self.assertIn("process", log_entry)
+        self.assertIn("thread", log_entry)


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

If json_logs: true, the proxy server will outputs access logs in JSON

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #9906

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
- Added a new file json_logging.py that implements JSON-formatted logging for the proxy server
  - Created a custom JSON log formatter for general logs and access logs
  - Logs include timestamp, log level, message, and other metadata in JSON format
  - Added support for exception handling and extra data in logs
- Modified proxy_cli.py to:
  - Replace the previous JSON logging setup with the new custom JSON formatter Instead of setting `log_config` to None, it now uses the new `uvicorn_json_log_config`.
  - This change provides more structured and detailed JSON logs for better observability

The main purpose is to improve logging capabilities by providing a more structured JSON format for logs, making it easier to parse and analyze log data.

In fact, the following log is output:

```
{"timestamp": "2025-04-15T18:24:25.982Z", "level": "INFO", "message": "Application startup complete.", "logger_name": "uvicorn.error", "process": 55706, "thread": "MainThread"}
{"timestamp": "2025-04-15T18:24:25.983Z", "level": "INFO", "message": "Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)", "logger_name": "uvicorn.error", "process": 55706, "thread": "MainThread"}
{"timestamp": "2025-04-15T18:24:28.314Z", "level": "INFO", "logger_name": "uvicorn.access", "process": 55706, "thread": "MainThread", "client_addr": "127.0.0.1:62232", "method": "GET", "full_path": "/health", "http_version": "1.1", "status_code": 200}
```

### ScreenShots

`poetry run pytest tests/proxy_unit_tests/test_json_logging.py`:

<img width="1211" alt="スクリーンショット 2025-04-16 4 27 45" src="https://github.com/user-attachments/assets/2441a73c-2efb-4741-9af6-c7d3e462da8a" />
