### PR TITLE
fix(streaming_handler): ignore ["DONE"] tokens from streaming responses

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1506,7 +1506,7 @@ class CustomStreamWrapper:
                     chunk = self.completion_stream
                 else:
                     chunk = next(self.completion_stream)
-                if chunk is not None and chunk != b"":
+                if chunk is not None and chunk != b"" and chunk != ["DONE"]:
                     print_verbose(
                         f"PROCESSED CHUNK PRE CHUNK CREATOR: {chunk}; custom_llm_provider: {self.custom_llm_provider}"
                     )


### PR DESCRIPTION
## LiteLLM fails to handle final `["DONE"]` token correctly in streaming chat completions

## Summary

This PR fixes a bug in LiteLLM where the final `["DONE"]` token in streamed chat completions is not handled correctly, leading to an exception. While some providers (e.g., Azure OpenAI and vLLM) may omit the token, this fix ensures that even when it is present, LiteLLM processes it properly without crashing.

## Relevant issues

Haven't found any related issues.

Some Azure OpenAI endpoints (e.g. [1](https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Connectors/Connectors.AzureOpenAI.UnitTests/TestData/chat_completion_streaming_async_filter_response.txt#L13)) and [vLLM inference engines](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/serving_completion.py#L241) omit a final `["DONE"]` token when doing chat completion in streaming mode. This behaviour brakes LiteLLM resulting in this error:

```python
Traceback (most recent call last):
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 1211, in chunk_creator
    response_obj = self.handle_openai_chat_completion_chunk(chunk)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 465, in handle_openai_chat_completion_chunk
    raise e
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 433, in handle_openai_chat_completion_chunk
    if str_line and str_line.choices and len(str_line.choices) > 0:
                    ^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'choices'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/gorosz/.config/JetBrains/PyCharm2024.3/scratches/scratch_5.py", line 13, in <module>
    for chunk in resp:
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 1620, in __next__
    raise exception_type(
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 1513, in __next__
    response: Optional[ModelResponseStream] = self.chunk_creator(
                                              ^^^^^^^^^^^^^^^^^^^
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/streaming_handler.py", line 1405, in chunk_creator
    raise exception_type(
          ^^^^^^^^^^^^^^^
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/exception_mapping_utils.py", line 2219, in exception_type
    raise e  # it's already mapped
    ^^^^^^^
  File "/home/gorosz/workspace/github/litellm/litellm/litellm_core_utils/exception_mapping_utils.py", line 466, in exception_type
    raise APIConnectionError(
litellm.exceptions.APIConnectionError: litellm.APIConnectionError: APIConnectionError: OpenAIException - 'list' object has no attribute 'choices'
```



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![image](https://github.com/user-attachments/assets/db8fd812-d416-4bc7-8a09-71ff6faf58ef)


## Type

🐛 Bug Fix

## Changes

LiteLLM currently fails when it encounters the final `["DONE"]` token during a streamed chat completion, resulting in an AttributeError. This happens because it incorrectly tries to process the `["DONE"]` signal as a normal data chunk. This PR adds proper handling for this token, preventing LiteLLM from attempting to parse it as a response object.