### PR TITLE
Add User ID validation to ensure it is not an email or phone number

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1,5 +1,6 @@
 import json
 import time
+import re
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import httpx
@@ -527,6 +528,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _litellm_metadata
             and isinstance(_litellm_metadata, dict)
             and "user_id" in _litellm_metadata
+            and not _valid_user_id(_litellm_metadata.get("user_id", None))
         ):
             optional_params["metadata"] = {"user_id": _litellm_metadata["user_id"]}
 
@@ -784,3 +786,19 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             message=error_message,
             headers=cast(httpx.Headers, headers),
         )
+
+
+def _valid_user_id(user_id: str) -> bool:
+    """
+    Validate that user_id is not an email or phone number.
+    Returns: bool: True if valid (not email or phone), False otherwise
+    """
+    email_pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    phone_pattern = r"^\+?[\d\s\(\)-]{7,}$"
+
+    if re.match(email_pattern, user_id):
+        return False
+    if re.match(phone_pattern, user_id):
+        return False
+
+    return True


### PR DESCRIPTION
## Title

Add validation to exclude invalid `user_id` (e.g. email or phone number) from Anthropic metadata

## Relevant issues

Fixes #10106 


## Type
🐛 Bug Fix

## Changes

This PR introduces a validation check for the `user_id` field in the `_litellm_metadata` dictionary to ensure it does not contain personally identifiable information (PII) such as emails or phone numbers.

## Rationale
Anthropic **requires** that the `user_id` in metadata must be a UUID, hash value, or other opaque, non-identifying identifier. It **must not** contain any personally identifiable information such as names, email addresses, or phone numbers. Including such data can lead to the API rejecting the request with a `400 Bad Request error`. [View](https://docs.anthropic.com/en/api/messages#body-metadata-user-id)

This update ensures that if an invalid user_id is provided (e.g. an email), it will simply be excluded from the metadata, preventing avoidable request failures.
