### PR TITLE
[Feat] Expose Responses API on LiteLLM UI Test Key Page

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -5,7 +5,6 @@ Handler for transforming responses api requests to litellm.completion requests
 from typing import Any, Coroutine, Optional, Union
 
 import litellm
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -5,6 +5,7 @@ Handler for transforming responses api requests to litellm.completion requests
 from typing import Any, Coroutine, Optional, Union
 
 import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 from openai.types.responses.tool_param import FunctionToolParam
 
 from litellm.caching import InMemoryCache
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesAPISessionElement,
     SessionHandler,
@@ -87,6 +88,18 @@ class LiteLLMCompletionResponsesConfig:
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,
         }
+
+        # Responses API `Completed` events require usage, we pass `stream_options` to litellm.completion to include usage
+        if stream is True:
+            stream_options = {
+                "include_usage": True,
+            }
+            litellm_completion_request["stream_options"] = stream_options
+            litellm_logging_obj: Optional[LiteLLMLoggingObj] = kwargs.get(
+                "litellm_logging_obj"
+            )
+            if litellm_logging_obj:
+                litellm_logging_obj.stream_options = stream_options
 
         # only pass non-None values
         litellm_completion_request = {

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -11,7 +11,9 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.types.llms.openai import (
+    OutputTextDeltaEvent,
     ResponseCompletedEvent,
+    ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
     ResponsesAPIStreamingResponse,
 )
@@ -212,8 +214,13 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
 
 class MockResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
     """
-    mock iterator - some models like o1-pro do not support streaming, we need to fake a stream
+    Mock iterator—fake a stream by slicing the full response text into
+    5 char deltas, then emit a completed event.
+
+    Models like o1-pro don't support streaming, so we fake it.
     """
+
+    CHUNK_SIZE = 5
 
     def __init__(
         self,
@@ -222,49 +229,68 @@ class MockResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         responses_api_provider_config: BaseResponsesAPIConfig,
         logging_obj: LiteLLMLoggingObj,
     ):
-        self.raw_http_response = response
         super().__init__(
             response=response,
             model=model,
             responses_api_provider_config=responses_api_provider_config,
             logging_obj=logging_obj,
         )
-        self.is_done = False
+
+        # one-time transform
+        transformed = (
+            self.responses_api_provider_config.transform_response_api_response(
+                model=self.model,
+                raw_response=response,
+                logging_obj=logging_obj,
+            )
+        )
+        full_text = self._collect_text(transformed)
+
+        # build a list of 5‑char delta events
+        deltas = [
+            OutputTextDeltaEvent(
+                type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA,
+                delta=full_text[i : i + self.CHUNK_SIZE],
+                item_id=transformed.id,
+                output_index=0,
+                content_index=0,
+            )
+            for i in range(0, len(full_text), self.CHUNK_SIZE)
+        ]
+
+        # append the completed event
+        self._events = deltas + [
+            ResponseCompletedEvent(
+                type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+                response=transformed,
+            )
+        ]
+        self._idx = 0
 
     def __aiter__(self):
         return self
 
     async def __anext__(self) -> ResponsesAPIStreamingResponse:
-        if self.is_done:
+        if self._idx >= len(self._events):
             raise StopAsyncIteration
-        self.is_done = True
-        transformed_response = (
-            self.responses_api_provider_config.transform_response_api_response(
-                model=self.model,
-                raw_response=self.raw_http_response,
-                logging_obj=self.logging_obj,
-            )
-        )
-        return ResponseCompletedEvent(
-            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
-            response=transformed_response,
-        )
+        evt = self._events[self._idx]
+        self._idx += 1
+        return evt
 
     def __iter__(self):
         return self
 
     def __next__(self) -> ResponsesAPIStreamingResponse:
-        if self.is_done:
+        if self._idx >= len(self._events):
             raise StopIteration
-        self.is_done = True
-        transformed_response = (
-            self.responses_api_provider_config.transform_response_api_response(
-                model=self.model,
-                raw_response=self.raw_http_response,
-                logging_obj=self.logging_obj,
-            )
-        )
-        return ResponseCompletedEvent(
-            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
-            response=transformed_response,
-        )
+        evt = self._events[self._idx]
+        self._idx += 1
+        return evt
+
+    def _collect_text(self, resp: ResponsesAPIResponse) -> str:
+        out = ""
+        for out_item in resp.output:
+            if out_item.type == "message":
+                for c in getattr(out_item, "content", []):
+                    out += c.text
+        return out

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -181,7 +181,7 @@ class BaseResponsesAPITest(ABC):
         # basic test assert the usage seems reasonable
         print("response_completed_event.response.usage=", response_completed_event.response.usage)
         assert response_completed_event.response.usage.input_tokens > 0 and response_completed_event.response.usage.input_tokens < 100
-        assert response_completed_event.response.usage.output_tokens > 0 and response_completed_event.response.usage.output_tokens < 100
+        assert response_completed_event.response.usage.output_tokens > 0 and response_completed_event.response.usage.output_tokens < 1000
         assert response_completed_event.response.usage.total_tokens > 0 and response_completed_event.response.usage.total_tokens < 1000
 
         # total tokens should be the sum of input and output tokens

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -133,7 +133,7 @@ class BaseResponsesAPITest(ABC):
         validate_responses_api_response(response, final_chunk=True)
 
 
-    @pytest.mark.parametrize("sync_mode", [True])
+    @pytest.mark.parametrize("sync_mode", [True, False])
     @pytest.mark.asyncio
     async def test_basic_openai_responses_api_streaming(self, sync_mode):
         litellm._turn_on_debug()
@@ -177,6 +177,15 @@ class BaseResponsesAPITest(ABC):
 
         # assert the response completed event includes the usage
         assert response_completed_event.response.usage is not None
+
+        # basic test assert the usage seems reasonable
+        print("response_completed_event.response.usage=", response_completed_event.response.usage)
+        assert response_completed_event.response.usage.input_tokens > 0 and response_completed_event.response.usage.input_tokens < 100
+        assert response_completed_event.response.usage.output_tokens > 0 and response_completed_event.response.usage.output_tokens < 100
+        assert response_completed_event.response.usage.total_tokens > 0 and response_completed_event.response.usage.total_tokens < 1000
+
+        # total tokens should be the sum of input and output tokens
+        assert response_completed_event.response.usage.total_tokens == response_completed_event.response.usage.input_tokens + response_completed_event.response.usage.output_tokens
 
 
 

--- a/ui/litellm-dashboard/src/components/chat_ui.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui.tsx
@@ -26,6 +26,7 @@ import {
 import { message, Select, Spin, Typography, Tooltip, Input } from "antd";
 import { makeOpenAIChatCompletionRequest } from "./chat_ui/llm_calls/chat_completion";
 import { makeOpenAIImageGenerationRequest } from "./chat_ui/llm_calls/image_generation";
+import { makeOpenAIResponsesRequest } from "./chat_ui/llm_calls/responses_api";
 import { fetchAvailableModels, ModelGroup  } from "./chat_ui/llm_calls/fetch_models";
 import { litellmModeMapping, ModelMode, EndpointType, getEndpointType } from "./chat_ui/mode_endpoint_mapping";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -297,7 +298,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
 
     try {
       if (selectedModel) {
-        // Use EndpointType enum for comparison
         if (endpointType === EndpointType.CHAT) {
           // Create chat history for API call - strip out model field and isImage field
           const apiChatHistory = [...chatHistory.filter(msg => !msg.isImage).map(({ role, content }) => ({ role, content })), newUserMessage];
@@ -322,6 +322,21 @@ const ChatUI: React.FC<ChatUIProps> = ({
             effectiveApiKey,
             selectedTags,
             signal
+          );
+        } else if (endpointType === EndpointType.RESPONSES) {
+          // Create chat history for API call - strip out model field and isImage field
+          const apiChatHistory = [...chatHistory.filter(msg => !msg.isImage).map(({ role, content }) => ({ role, content })), newUserMessage];
+          
+          await makeOpenAIResponsesRequest(
+            apiChatHistory,
+            (chunk, model) => updateTextUI("assistant", chunk, model),
+            selectedModel,
+            effectiveApiKey,
+            selectedTags,
+            signal,
+            updateReasoningContent,
+            updateTimingData,
+            updateUsageData
           );
         }
       }

--- a/ui/litellm-dashboard/src/components/chat_ui.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui.tsx
@@ -615,7 +615,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                 onChange={(e) => setInputMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={
-                  endpointType === EndpointType.CHAT 
+                  endpointType === EndpointType.CHAT || endpointType === EndpointType.RESPONSES
                     ? "Type your message... (Shift+Enter for new line)" 
                     : "Describe the image you want to generate..."
                 }

--- a/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
@@ -19,9 +19,9 @@ const EndpointSelector: React.FC<EndpointSelectorProps> = ({
 }) => {
   // Map endpoint types to their display labels
   const endpointOptions = [
-    { value: EndpointType.CHAT, label: '/chat/completions' },
-    { value: EndpointType.IMAGE, label: '/images/generations' },
-    { value: EndpointType.RESPONSES, label: '/responses' }
+    { value: EndpointType.CHAT, label: '/v1/chat/completions' },
+    { value: EndpointType.RESPONSES, label: '/v1/responses' },
+    { value: EndpointType.IMAGE, label: '/v1/images/generations' },
   ];
 
   return (

--- a/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
@@ -20,7 +20,8 @@ const EndpointSelector: React.FC<EndpointSelectorProps> = ({
   // Map endpoint types to their display labels
   const endpointOptions = [
     { value: EndpointType.CHAT, label: '/chat/completions' },
-    { value: EndpointType.IMAGE, label: '/images/generations' }
+    { value: EndpointType.IMAGE, label: '/images/generations' },
+    { value: EndpointType.RESPONSES, label: '/responses' }
   ];
 
   return (

--- a/ui/litellm-dashboard/src/components/chat_ui/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/llm_calls/responses_api.tsx
@@ -95,17 +95,19 @@ export async function makeOpenAIResponsesRequest(
           }
         }
         
-        // Handle usage data at the end
-        if (event.type === "response.end" && 'usage' in event) {
-          const usage = event.usage;
+        // Handle usage data at the response.completed event
+        if (event.type === "response.completed" && 'response' in event) {
+          const response_obj = event.response;
+          const usage = response_obj.usage;
+          console.log("Usage data:", usage);
           if (usage && onUsageData) {
             console.log("Usage data:", usage);
             
             // Extract usage data safely
             const usageData: TokenUsage = {
-              completionTokens: typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
-              promptTokens: typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0,
-              totalTokens: typeof usage.total_tokens === 'number' ? usage.total_tokens : 0
+              completionTokens: usage.output_tokens,
+              promptTokens: usage.input_tokens,
+              totalTokens: usage.total_tokens
             };
             
             // Add reasoning tokens if available

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -4,6 +4,7 @@
 export enum ModelMode {
     IMAGE_GENERATION = "image_generation",
     CHAT = "chat",
+    RESPONSES = "responses",
     // add additional modes as needed
   }
   
@@ -11,6 +12,7 @@ export enum ModelMode {
   export enum EndpointType {
     IMAGE = "image",
     CHAT = "chat",
+    RESPONSES = "responses",
     // add additional endpoint types if required
   }
   
@@ -18,6 +20,7 @@ export enum ModelMode {
   export const litellmModeMapping: Record<ModelMode, EndpointType> = {
     [ModelMode.IMAGE_GENERATION]: EndpointType.IMAGE,
     [ModelMode.CHAT]: EndpointType.CHAT,
+    [ModelMode.RESPONSES]: EndpointType.RESPONSES,
   };
 
   export const getEndpointType = (mode: string): EndpointType => {


### PR DESCRIPTION
## [Feat] Expose Responses API on LiteLLM UI Test Key Page
<img width="1335" alt="Xnapper-2025-04-19-13 11 48" src="https://github.com/user-attachments/assets/73241e4e-cc29-4d81-b950-0ee3f9ae14e9" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


