### PR TITLE
fix(gemini): append empty choice to model response when there are no …

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -949,6 +949,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 ) = self._process_candidates(
                     _candidates, model_response, litellm_params
                 )
+            else:
+                model_response.choices.append(litellm.Choices())
 
             usage = self._calculate_usage(completion_response=completion_response)
             setattr(model_response, "usage", usage)

--- a/tests/litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -310,3 +310,40 @@ def test_vertex_ai_candidate_token_count_inclusive(
     assert usage.prompt_tokens == expected_usage.prompt_tokens
     assert usage.completion_tokens == expected_usage.completion_tokens
     assert usage.total_tokens == expected_usage.total_tokens
+
+def test_empty_candidates_response():
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
+    import litellm
+    import httpx
+
+    model_response = litellm.ModelResponse()
+
+    completion_response = {
+        "usageMetadata": {
+            "promptTokenCount": 9291,
+            "totalTokenCount": 9291,
+            "promptTokensDetails": [{
+                "modality": "TEXT",
+                "tokenCount": 9291
+            }]
+        },
+        "modelVersion": "gemini-2.5-pro-preview-03-25"
+    }
+
+    raw_response = httpx.Response(200, json=completion_response)
+
+    config = VertexGeminiConfig()
+    result = config.transform_response(
+        model="gemini-2.5-pro-preview-03-25",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=MagicMock(),
+        request_data={},
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        encoding=None
+    )
+
+    assert len(result.choices) == 1
+    assert isinstance(result.choices[0], litellm.Choices)


### PR DESCRIPTION
## Title

make sure response has at least one choice

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

gemini-2.5-pro-preview-03-25 at some cases will respond with a non-error message that has neither candidates nor promptFeedback, like this:
```json
{
  "usageMetadata": {
    "promptTokenCount": 9291,
    "totalTokenCount": 9291,
    "promptTokensDetails": [
      {
        "modality": "TEXT",
        "tokenCount": 9291
      }
    ]
  },
  "modelVersion": "gemini-2.5-pro-preview-03-25"
}
```

this breaks apps like smolagents,  this is a related [issue](https://github.com/huggingface/smolagents/issues/1127) on smolagents.

