### PR TITLE
Address deprecation of open_text

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -180,9 +180,9 @@ from litellm.types.utils import (
     all_litellm_params,
 )
 
-with resources.open_text(
-    "litellm.litellm_core_utils.tokenizers", "anthropic_tokenizer.json"
-) as f:
+with resources.files("litellm.litellm_core_utils.tokenizers") \
+    .joinpath("anthropic_tokenizer.json") \
+    .open("r") as f:
     json_data = json.load(f)
 # Convert to str (if necessary)
 claude_json_str = json.dumps(json_data)


### PR DESCRIPTION
## Title

I was getting a warning about open_text getting deprecated.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
I'll call it a bug fix but it's not really a bug

🐛 Bug Fix
🧹 Refactoring

## Changes


