### PR TITLE
Support max_completion_tokens on Sagemaker

### DIFF
--- a/litellm/llms/sagemaker/completion/transformation.py
+++ b/litellm/llms/sagemaker/completion/transformation.py
@@ -37,6 +37,7 @@ class SagemakerConfig(BaseConfig):
     """
 
     max_new_tokens: Optional[int] = None
+    max_completion_tokens: Optional[int] = None
     top_p: Optional[float] = None
     temperature: Optional[float] = None
     return_full_text: Optional[bool] = None
@@ -44,6 +45,7 @@ class SagemakerConfig(BaseConfig):
     def __init__(
         self,
         max_new_tokens: Optional[int] = None,
+        max_completion_tokens: Optional[int] = None,
         top_p: Optional[float] = None,
         temperature: Optional[float] = None,
         return_full_text: Optional[bool] = None,
@@ -65,7 +67,7 @@ class SagemakerConfig(BaseConfig):
         )
 
     def get_supported_openai_params(self, model: str) -> List:
-        return ["stream", "temperature", "max_tokens", "top_p", "stop", "n"]
+        return ["stream", "temperature", "max_tokens", "max_completion_tokens", "top_p", "stop", "n"]
 
     def map_openai_params(
         self,
@@ -101,6 +103,8 @@ class SagemakerConfig(BaseConfig):
                 # Failed: Error occurred: HuggingfaceException - Input validation error: `max_new_tokens` must be strictly positive
                 if value == 0:
                     value = 1
+                optional_params["max_new_tokens"] = value
+            if param == "max_completion_tokens":
                 optional_params["max_new_tokens"] = value
         non_default_params.pop("aws_sagemaker_allow_zero_temp", None)
         return optional_params


### PR DESCRIPTION
## Support max_completion_tokens on Sagemaker

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixes #10243
<!-- e.g. "Fixes" -->

## Pre-Submission checklist
![image](https://github.com/user-attachments/assets/907078a2-5fbf-4ae9-80c7-6a8ad3200a24)
![image](https://github.com/user-attachments/assets/28b98a94-6f15-46db-a231-e22ac6960203)

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes


