### PR TITLE
feat(grafana_dashboard): enable datasource selection via templating

### DIFF
--- a/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_1/grafana_dashboard.json
+++ b/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_1/grafana_dashboard.json
@@ -32,7 +32,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -110,7 +110,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "histogram_quantile(0.99, sum(rate(litellm_self_latency_bucket{self=\"self\"}[1m])) by (le))",
@@ -125,7 +125,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -216,7 +216,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(increase(litellm_spend_metric_total[30d])) by (hashed_api_key)",
@@ -232,7 +232,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -309,7 +309,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum by (model) (increase(litellm_requests_metric_total[5m]))",
@@ -324,7 +324,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -375,7 +375,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(increase(litellm_llm_api_failed_requests_metric_total[1h]))",
@@ -390,7 +390,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -468,7 +468,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(increase(litellm_spend_metric_total[30d])) by (model)",
@@ -483,7 +483,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "rMzWaBvIk"
+          "uid": "${DS_PROMETHEUS}"
         },
         "fieldConfig": {
           "defaults": {
@@ -560,7 +560,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "rMzWaBvIk"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(increase(litellm_total_tokens_total[5m])) by (model)",
@@ -579,7 +579,27 @@
     "style": "dark",
     "tags": [],
     "templating": {
-      "list": []
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "prometheus",
+            "value": "edx8memhpd9tsa"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "datasource",
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        }
+      ]
     },
     "time": {
       "from": "now-1h",

--- a/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json
+++ b/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json
@@ -37,7 +37,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "Total requests per second made to proxy - success + failure ",
         "fieldConfig": {
@@ -119,7 +119,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -138,7 +138,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "Failures per second by Exception Class",
         "fieldConfig": {
@@ -220,7 +220,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -239,7 +239,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "Average Response latency (seconds)",
         "fieldConfig": {
@@ -346,7 +346,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -361,7 +361,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "histogram_quantile(0.5, sum(rate(litellm_request_total_latency_metric_bucket[2m])) by (le))",
@@ -391,7 +391,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "x-ratelimit-remaining-requests returning from LLM APIs",
         "fieldConfig": {
@@ -473,7 +473,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "topk(5, sort(litellm_remaining_requests))",
@@ -488,7 +488,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "x-ratelimit-remaining-tokens from LLM API ",
         "fieldConfig": {
@@ -570,7 +570,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "topk(5, sort(litellm_remaining_tokens))",
@@ -598,7 +598,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "Requests per second by Key Alias (keys are LiteLLM Virtual Keys). If key is None - means no Alias Set ",
         "fieldConfig": {
@@ -679,7 +679,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (api_key_alias)\n",
@@ -694,7 +694,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "bdiyc60dco54we"
+          "uid": "${DS_PROMETHEUS}"
         },
         "description": "Requests per second by Team Alias. If team is None - means no team alias Set ",
         "fieldConfig": {
@@ -775,7 +775,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "bdiyc60dco54we"
+              "uid": "${DS_PROMETHEUS}"
             },
             "editorMode": "code",
             "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (team_alias)\n",
@@ -792,7 +792,27 @@
     "schemaVersion": 40,
     "tags": [],
     "templating": {
-      "list": []
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "prometheus",
+            "value": "edx8memhpd9tsb"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "datasource",
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        }
+      ]
     },
     "time": {
       "from": "now-6h",


### PR DESCRIPTION
This commit updates the Grafana dashboard configuration to include a datasource template variable. This allows users to dynamically select the datasource directly within the Grafana dashboard, improving flexibility and user experience.

## Title

Enable datasource selection via templating

## Relevant issues

N/A (This introduces a new feature)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

This Pull Request introduces a new feature to the Grafana dashboard configuration, enabling users to dynamically select the datasource directly within the dashboard. This is achieved by adding a datasource template variable (e.g., `$datasource`) to the dashboard configuration. Subsequently, the panel configurations that utilize the datasource are updated to reference this template variable.

Before:
![image](https://github.com/user-attachments/assets/6843f84b-8577-46bd-9144-bba357f845e7)

After:
![image](https://github.com/user-attachments/assets/20b1ebea-3945-49b7-ac7c-88063811da3f)



**Benefits:**

* **Increased Flexibility:** Users can now switch between datasources on the dashboard without modifying configuration files, improving adaptability across different environments (development, testing, production).
* **Improved User Experience:** The ability to select datasources via a user-friendly dropdown menu enhances the overall experience.
* **Simplified Management:** This reduces the need to maintain multiple dashboard configurations tailored to specific datasources.

**Testing:**

* Successfully tested the addition of the `$datasource` template variable on a local Grafana instance.
* Verified that dashboard panels correctly display data after selecting different datasources via the template variable.


