### PR TITLE
(#10265) fix caching soft_budget

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -615,6 +615,7 @@ class SlackAlerting(CustomBatchLogger):
         elif type == "soft_budget":
             event_group = "proxy"
             event_message += "Soft Budget Crossed: "
+            _id = user_info.team_id or user_info.user_id or _id
         elif type == "user_budget":
             event_group = "internal_user"
             event_message += "User Budget: "


### PR DESCRIPTION
##  fix caching soft_budget

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

 - #10265 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

I think keys in different team or user have to send each alert if they exceed soft_budget 

ex) team1 with virtual key1 / team2 with virtual key2
if virtual key1 exceed soft budget, send alert
if virtual key2 exceed soft budget, send alert too, because they are in different team.
but current logic, it sends alert only once since they might have same cache key