### PR TITLE
Add Columns widget to `DataTable`

### DIFF
--- a/ui/litellm-dashboard/src/components/all_keys_table.tsx
+++ b/ui/litellm-dashboard/src/components/all_keys_table.tsx
@@ -205,15 +205,18 @@ export function AllKeysTable({
     },
     {
       header: "Team Alias",
-      accessorKey: "team_id", // Change to access the team_id
-      cell: ({ row, getValue }) => {
-        const teamId = getValue() as string;
-        const team = allTeams?.find(t => t.team_id === teamId);
+      id: "team_alias",
+      accessorFn: (row) => {
+        const team = allTeams?.find(t => t.team_id === row.team_id);
         return team?.team_alias || "Unknown";
+      },
+      cell: (info) => {
+        return <span>{info.getValue() as string}</span>;
       },
     },
     {
       header: "Team ID",
+      id: "team_id",
       accessorKey: "team_id",
       cell: (info) => <Tooltip title={info.getValue() as string}>{info.getValue() ? `${(info.getValue() as string).slice(0, 7)}...` : "-"}</Tooltip>
     },
@@ -224,15 +227,18 @@ export function AllKeysTable({
     },
     {
       header: "User Email",
-      accessorKey: "user_id",
+      id: "user_email",
+      accessorFn: (row) => {
+        const user = userList.find(u => u.user_id === row.user_id);
+        return user?.user_email || "-";
+      },
       cell: (info) => {
-        const userId = info.getValue() as string;
-        const user = userList.find(u => u.user_id === userId);
-        return user?.user_email ? user.user_email : "-";
+        return <span>{info.getValue() as string}</span>;
       },
     },
     {
       header: "User ID",
+      id: "user_id",
       accessorKey: "user_id",
       cell: (info) => {
         const userId = info.getValue() as string;

--- a/ui/litellm-dashboard/src/components/view_logs/table.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/table.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect } from "react";
+import { Fragment } from "react";
 import {
   ColumnDef,
   flexRender,
@@ -6,8 +6,9 @@ import {
   getExpandedRowModel,
   Row,
   useReactTable,
+  VisibilityState,
 } from "@tanstack/react-table";
-
+import React from "react";
 import {
   Table,
   TableHead,
@@ -16,6 +17,7 @@ import {
   TableRow,
   TableCell,
 } from "@tremor/react";
+import { TableIcon } from "@heroicons/react/outline";
 
 interface DataTableProps<TData, TValue> {
   data: TData[];
@@ -37,6 +39,21 @@ export function DataTable<TData extends { request_id: string }, TValue>({
   expandedRequestId,
   onRowExpand,
 }: DataTableProps<TData, TValue>) {
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const dropdownRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   const table = useReactTable({
     data,
     columns,
@@ -52,11 +69,11 @@ export function DataTable<TData extends { request_id: string }, TValue>({
             return acc;
           }, {} as Record<string, boolean>)
         : {},
+      columnVisibility,
     },
     onExpandedChange: (updater) => {
       if (!onRowExpand) return;
       
-      // Get current expanded state
       const currentExpanded = expandedRequestId 
         ? data.reduce((acc, row, index) => {
             if (row.request_id === expandedRequestId) {
@@ -66,94 +83,145 @@ export function DataTable<TData extends { request_id: string }, TValue>({
           }, {} as Record<string, boolean>)
         : {};
       
-      // Calculate new expanded state
       const newExpanded = typeof updater === 'function' 
         ? updater(currentExpanded) 
         : updater;
       
-      // If empty, it means we're closing the expanded row
       if (Object.keys(newExpanded).length === 0) {
         onRowExpand(null);
         return;
       }
       
-      // Find the request_id of the expanded row
       const expandedIndex = Object.keys(newExpanded)[0];
       const expandedRow = expandedIndex !== undefined ? data[parseInt(expandedIndex)] : null;
       
-      // Call the onRowExpand callback with the request_id
       onRowExpand(expandedRow ? expandedRow.request_id : null);
     },
+    onColumnVisibilityChange: setColumnVisibility,
   });
 
-  // No need for the useEffect here as we're handling everything in onExpandedChange
-  
+  const getHeaderText = (header: any): string => {
+    if (typeof header === 'string') {
+      return header;
+    }
+    if (typeof header === 'function') {
+      const headerElement = header();
+      if (headerElement && headerElement.props && headerElement.props.children) {
+        const children = headerElement.props.children;
+        if (typeof children === 'string') {
+          return children;
+        }
+        if (children.props && children.props.children) {
+          return children.props.children;
+        }
+      }
+    }
+    return '';
+  };
+
   return (
-    <div className="rounded-lg custom-border">
-      <Table className="[&_td]:py-0.5 [&_th]:py-1">
-        <TableHead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
+    <div className="relative w-full">
+      {/* Column visibility toggle */}
+      <div className="my-2" ref={dropdownRef}>
+        <button
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        >
+          <TableIcon className="h-4 w-4" />
+          Columns
+        </button>
+        {isDropdownOpen && (
+          <div className="absolute left-0 mt-2 w-56 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-50">
+            <div className="py-1 max-h-[60vh] overflow-y-auto">
+              {table.getAllLeafColumns().map((column) => {
+                if (column.id === 'expander') return null;
                 return (
-                  <TableHeaderCell key={header.id} className="py-1 h-8">
-                    {header.isPlaceholder ? null : (
-                      flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )
-                    )}
-                  </TableHeaderCell>
+                  <div
+                    key={column.id}
+                    className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer"
+                    onClick={() => column.toggleVisibility()}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={column.getIsVisible()}
+                      onChange={() => column.toggleVisibility()}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="ml-2">{getHeaderText(column.columnDef.header)}</span>
+                  </div>
                 );
               })}
-            </TableRow>
-          ))}
-        </TableHead>
-        <TableBody>
-          {isLoading ?
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-8 text-center">
-                <div className="text-center text-gray-500">
-                  <p>🚅 Loading logs...</p>
-                </div>
-              </TableCell>
-            </TableRow>
-          : table.getRowModel().rows.length > 0 ?
-            table.getRowModel().rows.map((row) => (
-              <Fragment key={row.id}>
-                <TableRow className="h-8">
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell 
-                      key={cell.id} 
-                      className="py-0.5 max-h-8 overflow-hidden text-ellipsis whitespace-nowrap"
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
+            </div>
+          </div>
+        )}
+      </div>
 
-                {row.getIsExpanded() && (
-                  <TableRow>
-                    <TableCell colSpan={row.getVisibleCells().length}>
-                      {renderSubComponent({ row })}
-                    </TableCell>
+      <div className="rounded-lg custom-border clear-both">
+        <Table className="[&_td]:py-0.5 [&_th]:py-1">
+          <TableHead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHeaderCell key={header.id} className="py-1 h-8">
+                      {header.isPlaceholder ? null : (
+                        flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )
+                      )}
+                    </TableHeaderCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHead>
+          <TableBody>
+            {isLoading ?
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-8 text-center">
+                  <div className="text-center text-gray-500">
+                    <p>🚅 Loading logs...</p>
+                  </div>
+                </TableCell>
+              </TableRow>
+            : table.getRowModel().rows.length > 0 ?
+              table.getRowModel().rows.map((row) => (
+                <Fragment key={row.id}>
+                  <TableRow className="h-8">
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell 
+                        key={cell.id} 
+                        className="py-0.5 max-h-8 overflow-hidden text-ellipsis whitespace-nowrap"
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
-              </Fragment>
-            ))
-          : <TableRow>
-              <TableCell colSpan={columns.length} className="h-8 text-center">
-                <div className="text-center text-gray-500">
-                  <p>No logs found</p>
-                </div>
-              </TableCell>
-            </TableRow>
-          }
-        </TableBody>
-      </Table>
+
+                  {row.getIsExpanded() && (
+                    <TableRow>
+                      <TableCell colSpan={row.getVisibleCells().length}>
+                        {renderSubComponent({ row })}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              ))
+            : <TableRow>
+                <TableCell colSpan={columns.length} className="h-8 text-center">
+                  <div className="text-center text-gray-500">
+                    <p>No logs found</p>
+                  </div>
+                </TableCell>
+              </TableRow>
+            }
+          </TableBody>
+        </Table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This adds a widget for controlling column visibility to the `DataTable` component, which is used by Virtual Keys and Logs pages. Perhaps in the future, other pages like Teams and Users could be made to use `DataTable` to get the same benefits.

![Screenshot 2025-04-24 at 1 49 00 PM](https://github.com/user-attachments/assets/95a7409a-c055-4043-b834-c151aac81736)
![Screenshot 2025-04-24 at 1 48 47 PM](https://github.com/user-attachments/assets/0bef6759-f01c-4885-81fd-d02c6838f856)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes


