### PR TITLE
adding support for cohere command-a-03-2025

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7058,6 +7058,17 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
         "supports_tool_choice": true
     },
+    "command-a-03-2025": {
+        "max_tokens": 8000,
+        "max_input_tokens": 256000,
+        "max_output_tokens": 8000,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.00001,
+        "litellm_provider": "cohere_chat",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
     "command-r": {
         "max_tokens": 4096,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## adding support for cohere command-a-03-2025

adding model details for cohere's command-a-03-2025 model in model_prices_and_context_window_backup.json

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshots of completed tests

![completed-make-test-unit](https://github.com/user-attachments/assets/4e327f86-67fe-45a9-adb8-67aa31dadb95)
![completed-make-lint](https://github.com/user-attachments/assets/b6838196-46a7-4216-9808-9f9244eb02c3)

## Type

🆕 New Feature



