### PR TITLE
Fix dropped redacted thinking blocks in streaming response chunks from Claude 3.7 Sonnet

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -564,7 +564,7 @@ class ModelResponseIterator:
                 reasoning_content += thinking_content
         return reasoning_content
 
-    def chunk_parser(self, chunk: dict) -> ModelResponseStream:
+    def chunk_parser(self, chunk: dict) -> ModelResponseStream:  # noqa: PLR0915
         try:
             type_chunk = chunk.get("type", "") or ""
 
@@ -627,6 +627,7 @@ class ModelResponseIterator:
                             data=content_block_start["content_block"]["data"],
                         )
                     ]
+                    provider_specific_fields["thinking_blocks"] = thinking_blocks
             elif type_chunk == "content_block_stop":
                 ContentBlockStop(**chunk)  # type: ignore
                 # check if tool call content block

--- a/tests/llm_translation/test_anthropic_thinking_blocks.py
+++ b/tests/llm_translation/test_anthropic_thinking_blocks.py
@@ -1,0 +1,58 @@
+"""
+Test for checking Anthropic thinking blocks in streaming responses
+"""
+
+import asyncio
+import pytest
+import litellm
+
+MODEL = "anthropic/claude-3-7-sonnet-20250219"
+MAGIC_STRING = "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB"
+
+
+@pytest.mark.asyncio
+async def test_has_chunks_with_thinking_blocks_regular_prompt():
+    """Test that regular prompts have thinking blocks in streaming chunks"""
+    # Test with a regular prompt
+    block_exists, block_type = await has_chunks_with_thinking_blocks("How are you?")
+    assert block_exists, "Regular prompts should have thinking blocks in stream chunks"
+    assert block_type == "thinking", "Regular prompts should have thinking blocks in stream chunks"
+
+
+@pytest.mark.asyncio
+async def test_has_chunks_with_thinking_blocks_magic_string():
+    """Test that the magic string prompt has thinking blocks in streaming chunks"""
+    # Test with the magic string that should also have thinking blocks
+    block_exists, block_type = await has_chunks_with_thinking_blocks(MAGIC_STRING)
+    assert block_exists, "Magic string prompt should have thinking blocks in stream chunks"
+    assert block_type == "redacted_thinking", "Magic string prompt should have redacted thinking blocks in stream chunks"
+
+async def has_chunks_with_thinking_blocks(query: str):
+    """
+    Check if the streaming response from Claude contains thinking blocks
+    
+    Args:
+        query: The query to send to Claude
+        
+    Returns:
+        bool: True if thinking blocks were found in the streaming response
+    """
+    stream = await litellm.acompletion(
+        model=MODEL,
+        messages=[{"role": "user", "content": query}],
+        stream=True,
+        reasoning_effort="low",
+    )
+
+    has_thinking_blocks = False
+
+    async for chunk in stream:
+        chunk_delta = chunk.choices[0].delta                        
+        if hasattr(chunk_delta, "thinking_blocks") and chunk_delta.thinking_blocks:
+            return True, chunk_delta.thinking_blocks[0]["type"]
+
+    return False, None
+
+if __name__ == "__main__":
+    asyncio.run(test_has_chunks_with_thinking_blocks_regular_prompt())
+    asyncio.run(test_has_chunks_with_thinking_blocks_magic_string())

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from unittest.mock import MagicMock
+from typing import Optional
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,6 +12,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+from litellm.types.llms.openai import ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock
 
 
 def test_redacted_thinking_content_block_delta():
@@ -36,3 +38,7 @@ def test_redacted_thinking_content_block_delta():
         model_response.choices[0].delta.thinking_blocks[0]["type"]
         == "redacted_thinking"
     )
+    
+    # Verify the fix from commit 59f457d79
+    assert model_response.choices[0].delta.provider_specific_fields is not None
+    assert "thinking_blocks" in model_response.choices[0].delta.provider_specific_fields

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -2,7 +2,6 @@ import json
 import os
 import sys
 from unittest.mock import MagicMock
-from typing import Optional
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,7 +11,6 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.llms.anthropic.chat.handler import ModelResponseIterator
-from litellm.types.llms.openai import ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock
 
 
 def test_redacted_thinking_content_block_delta():


### PR DESCRIPTION
- fixes #10328

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Screenshot

<img width="2106" alt="Screenshot 2025-04-26 at 13 47 17" src="https://github.com/user-attachments/assets/f2ccfd85-3112-4f81-8579-12462096185e" />

## Type

🐛 Bug Fix