### PR TITLE
Schedule budget resets at expectable times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ litellm/proxy/migrations/*config.yaml
 litellm/proxy/migrations/*
 config.yaml
 tests/litellm/litellm_core_utils/llm_cost_calc/log.txt
+test.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,23 +16,28 @@ services:
     ports:
       - "4000:4000" # Map the container port to the host, change the host port if necessary
     environment:
-        DATABASE_URL: "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
-        STORE_MODEL_IN_DB: "True" # allows adding models to proxy via UI
+      DATABASE_URL: "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
+      STORE_MODEL_IN_DB: "True" # allows adding models to proxy via UI
     env_file:
       - .env # Load local .env file
     depends_on:
-      - db  # Indicates that this service depends on the 'db' service, ensuring 'db' starts first
-    healthcheck:  # Defines the health check configuration for the container
-      test: [ "CMD", "curl", "-f", "http://localhost:4000/health/liveliness || exit 1" ]  # Command to execute for health check
-      interval: 30s  # Perform health check every 30 seconds
-      timeout: 10s   # Health check command times out after 10 seconds
-      retries: 3     # Retry up to 3 times if health check fails
-      start_period: 40s  # Wait 40 seconds after container start before beginning health checks
+      - db # Indicates that this service depends on the 'db' service, ensuring 'db' starts first
+    healthcheck: # Defines the health check configuration for the container
+      test: [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:4000/health/liveliness || exit 1",
+        ] # Command to execute for health check
+      interval: 30s # Perform health check every 30 seconds
+      timeout: 10s # Health check command times out after 10 seconds
+      retries: 3 # Retry up to 3 times if health check fails
+      start_period: 40s # Wait 40 seconds after container start before beginning health checks
 
- 
   db:
     image: postgres:16
     restart: always
+    container_name: litellm_db
     environment:
       POSTGRES_DB: litellm
       POSTGRES_USER: llmproxy
@@ -40,13 +45,13 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data  # Persists Postgres data across container restarts
+      - postgres_data:/var/lib/postgresql/data # Persists Postgres data across container restarts
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d litellm -U llmproxy"]
       interval: 1s
       timeout: 5s
       retries: 10
-  
+
   prometheus:
     image: prom/prometheus
     volumes:
@@ -55,14 +60,14 @@ services:
     ports:
       - "9090:9090"
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=15d'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
     restart: always
 
 volumes:
   prometheus_data:
     driver: local
   postgres_data:
-    name: litellm_postgres_data  # Named volume for Postgres data persistence
+    name: litellm_postgres_data # Named volume for Postgres data persistence
 

--- a/docs/my-website/docs/proxy/budget_reset_and_tz.md
+++ b/docs/my-website/docs/proxy/budget_reset_and_tz.md
@@ -1,0 +1,33 @@
+## Budget Reset Times and Timezones
+
+LiteLLM now supports predictable budget reset times that align with natural calendar boundaries:
+
+- All budgets reset at midnight (00:00:00) in the configured timezone
+- Special handling for common durations:
+  - Daily (24h/1d): Reset at midnight every day
+  - Weekly (7d): Reset on Monday at midnight
+  - Monthly (30d): Reset on the 1st of each month at midnight
+
+### Configuring the Timezone
+
+You can specify the timezone for all budget resets in your configuration file:
+
+```yaml
+litellm_settings:
+  max_budget: 100 # (float) sets max budget as $100 USD
+  budget_duration: 30d # (number)(s/m/h/d)
+  timezone: "US/Eastern" # Any valid timezone string
+```
+
+This ensures that all budget resets happen at midnight in your specified timezone rather than in UTC.
+If no timezone is specified, UTC will be used by default.
+
+Common timezone values:
+
+- `UTC` - Coordinated Universal Time
+- `US/Eastern` - Eastern Time
+- `US/Pacific` - Pacific Time
+- `Europe/London` - UK Time
+- `Asia/Kolkata` - Indian Standard Time (IST)
+- `Asia/Tokyo` - Japan Standard Time
+- `Australia/Sydney` - Australian Eastern Time

--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -10,7 +10,7 @@ import re
 import time
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
-from typing import Tuple
+from typing import Tuple, Optional
 
 
 def _extract_from_regex(duration: str) -> Tuple[int, str]:
@@ -164,7 +164,7 @@ def _setup_timezone(current_time: datetime, timezone_str: str = "UTC") -> Tuple[
     
     return current_time, timezone
 
-def _parse_duration(duration: str) -> Tuple[int, str]:
+def _parse_duration(duration: str) -> Tuple[Optional[int], Optional[str]]:
     """Parse the duration string into value and unit."""
     match = re.match(r"(\d+)([a-z]+)", duration)
     if not match:

--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -9,6 +9,7 @@ duration_in_seconds is used in diff parts of the code base, example
 import re
 import time
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import Tuple
 
 
@@ -93,3 +94,178 @@ def duration_in_seconds(duration: str) -> int:
 
     else:
         raise ValueError(f"Unsupported duration unit, passed duration: {duration}")
+
+def get_next_standardized_reset_time(
+    duration: str, 
+    current_time: datetime,
+    timezone_str: str = "UTC"
+) -> datetime:
+    """
+    Get the next standardized reset time based on the duration.
+    
+    All durations will reset at predictable intervals, aligned from the current time:
+    - Nd: If N=1, reset at next midnight; if N>1, reset every N days from now
+    - Nh: Every N hours, aligned to hour boundaries (e.g., 1:00, 2:00)
+    - Nm: Every N minutes, aligned to minute boundaries (e.g., 1:05, 1:10)
+    - Ns: Every N seconds, aligned to second boundaries
+    
+    Parameters:
+    - duration: Duration string (e.g. "30s", "30m", "30h", "30d")
+    - current_time: Current datetime
+    - timezone_str: Timezone string (e.g. "UTC", "US/Eastern", "Asia/Kolkata")
+    
+    Returns:
+    - Next reset time at a standardized interval in the specified timezone
+    """
+    # Set up the timezone
+    try:
+        if timezone_str is None:
+            timezone = ZoneInfo("UTC")
+        else:
+            timezone = ZoneInfo(timezone_str)
+    except (ImportError, KeyError):
+        # If timezone is invalid, fall back to UTC
+        timezone = ZoneInfo("UTC")
+    
+    # Convert current_time to the target timezone
+    if current_time.tzinfo is None:
+        # Naive datetime - assume it's UTC
+        utc_time = current_time.replace(tzinfo=ZoneInfo("UTC"))
+        current_time = utc_time.astimezone(timezone)
+    else:
+        # Already has timezone - convert to target timezone
+        current_time = current_time.astimezone(timezone)
+    
+    match = re.match(r"(\d+)([a-z]+)", duration)
+    if not match:
+        # Fall back to default if format is invalid
+        return current_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    
+    value, unit = match.groups()
+    value = int(value)
+    
+    # Midnight of the current day in the specified timezone
+    base_midnight = current_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    
+    # Handle days
+    if unit == "d":
+        if value == 1:  # Daily reset at midnight
+            return base_midnight + timedelta(days=1)
+        elif value == 7:  # Weekly reset on Monday at midnight
+            days_until_monday = (7 - current_time.weekday()) % 7
+            if days_until_monday == 0:  # If today is Monday
+                days_until_monday = 7
+            return base_midnight + timedelta(days=days_until_monday)
+        elif value == 30:  # Monthly reset on 1st at midnight
+            # Get 1st of next month at midnight
+            if current_time.month == 12:
+                next_reset = datetime(
+                    year=current_time.year + 1, 
+                    month=1, 
+                    day=1, 
+                    hour=0, 
+                    minute=0, 
+                    second=0, 
+                    microsecond=0,
+                    tzinfo=timezone
+                )
+            else:
+                next_reset = datetime(
+                    year=current_time.year, 
+                    month=current_time.month + 1, 
+                    day=1, 
+                    hour=0, 
+                    minute=0, 
+                    second=0, 
+                    microsecond=0,
+                    tzinfo=timezone
+                )
+            return next_reset
+        else:  # Custom day value - next interval is value days from current
+            return current_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=value)
+    
+    # Handle hours - find next hour boundary aligned with the frequency
+    elif unit == "h":
+        current_hour = current_time.hour
+        current_minute = current_time.minute
+        current_second = current_time.second
+        current_microsecond = current_time.microsecond
+        
+        # If exactly on the hour and no minutes/seconds/microseconds, use the next interval
+        if current_minute == 0 and current_second == 0 and current_microsecond == 0:
+            # Calculate next hour aligned with the value
+            next_hour = current_hour + value - (current_hour % value) if current_hour % value != 0 else current_hour + value
+        else:
+            # Not on the hour boundary, round up to next aligned hour
+            next_hour = current_hour + value - (current_hour % value) if current_hour % value != 0 else current_hour + value
+        
+        # Handle overnight case
+        if next_hour >= 24:
+            next_hour = next_hour % 24
+            next_day = base_midnight + timedelta(days=1)
+            return next_day.replace(hour=next_hour)
+        
+        return current_time.replace(hour=next_hour, minute=0, second=0, microsecond=0)
+    
+    # Handle minutes - find next minute boundary aligned with the frequency
+    elif unit == "m":
+        current_hour = current_time.hour
+        current_minute = current_time.minute
+        current_second = current_time.second
+        current_microsecond = current_time.microsecond
+        
+        # If exactly on the minute and no seconds/microseconds, use the next interval
+        if current_second == 0 and current_microsecond == 0:
+            # Calculate next minute aligned with the value
+            next_minute = current_minute + value - (current_minute % value) if current_minute % value != 0 else current_minute + value
+        else:
+            # Not on the minute boundary, round up to next aligned minute
+            next_minute = current_minute + value - (current_minute % value) if current_minute % value != 0 else current_minute + value
+        
+        # Handle hour rollover
+        next_hour = current_hour + (next_minute // 60)
+        next_minute = next_minute % 60
+        
+        # Handle overnight case
+        if next_hour >= 24:
+            next_hour = next_hour % 24
+            next_day = base_midnight + timedelta(days=1)
+            return next_day.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
+        
+        return current_time.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
+    
+    # Handle seconds - find next second boundary aligned with the frequency
+    elif unit == "s":
+        current_hour = current_time.hour
+        current_minute = current_time.minute
+        current_second = current_time.second
+        current_microsecond = current_time.microsecond
+        
+        # If exactly on the second and no microseconds, use the next interval
+        if current_microsecond == 0:
+            # Calculate next second aligned with the value
+            next_second = current_second + value - (current_second % value) if current_second % value != 0 else current_second + value
+        else:
+            # Not on the second boundary, round up to next aligned second
+            next_second = current_second + value - (current_second % value) if current_second % value != 0 else current_second + value
+        
+        # Handle minute rollover
+        additional_minutes = next_second // 60
+        next_second = next_second % 60
+        next_minute = current_minute + additional_minutes
+        
+        # Handle hour rollover
+        next_hour = current_hour + (next_minute // 60)
+        next_minute = next_minute % 60
+        
+        # Handle overnight case
+        if next_hour >= 24:
+            next_hour = next_hour % 24
+            next_day = base_midnight + timedelta(days=1)
+            return next_day.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)
+        
+        return current_time.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)
+    
+    else:
+        # Unrecognized unit, default to next midnight
+        return base_midnight + timedelta(days=1)

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -328,8 +328,11 @@ class ResetBudgetJob:
         try:
             item.spend = 0.0
             if hasattr(item, "budget_duration") and item.budget_duration is not None:
-                duration_s = duration_in_seconds(duration=item.budget_duration)
-                item.budget_reset_at = current_time + timedelta(seconds=duration_s)
+                # Get standardized reset time based on budget duration
+                from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+                item.budget_reset_at = get_budget_reset_time(
+                    budget_duration=item.budget_duration
+                )
             return item
         except Exception as e:
             verbose_proxy_logger.exception(

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -1,11 +1,10 @@
 import asyncio
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Literal, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
-from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import (
     LiteLLM_TeamTable,
     LiteLLM_UserTable,

--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -1,0 +1,29 @@
+from litellm.litellm_core_utils.duration_parser import get_next_standardized_reset_time
+
+from datetime import datetime, timezone
+def get_budget_reset_timezone():
+    """
+    Get the budget reset timezone from general_settings.
+    Falls back to UTC if not specified.
+    """
+    # Import at function level to avoid circular imports
+    from litellm.proxy.proxy_server import general_settings
+    if general_settings:
+        litellm_settings = general_settings.get("litellm_settings", {})
+        if litellm_settings and "timezone" in litellm_settings:
+            return litellm_settings["timezone"]
+    
+    return "UTC"
+
+
+def get_budget_reset_time(budget_duration: str):
+    """
+    Get the budget reset time from general_settings.
+    Falls back to UTC if not specified.
+    """
+    reset_at = get_next_standardized_reset_time(
+        duration=budget_duration, 
+        current_time=datetime.now(timezone.utc),
+        timezone_str=get_budget_reset_timezone()
+    )
+    return reset_at

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -14,7 +14,7 @@ These are members of a Team on LiteLLM
 import asyncio
 import traceback
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union, cast
 
 import fastapi
@@ -22,7 +22,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -651,9 +651,10 @@ def _update_internal_user_params(data_json: dict, data: UpdateUserRequest) -> di
         is_internal_user = True
 
     if "budget_duration" in non_default_values:
-        duration_s = duration_in_seconds(duration=non_default_values["budget_duration"])
-        user_reset_at = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
-        non_default_values["budget_reset_at"] = user_reset_at
+        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+        non_default_values["budget_reset_at"] = get_budget_reset_time(
+            budget_duration=non_default_values["budget_duration"]
+        )
 
     if "max_budget" not in non_default_values:
         if (
@@ -668,11 +669,10 @@ def _update_internal_user_params(data_json: dict, data: UpdateUserRequest) -> di
             non_default_values[
                 "budget_duration"
             ] = litellm.internal_user_budget_duration
-            duration_s = duration_in_seconds(
-                duration=non_default_values["budget_duration"]
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+            non_default_values["budget_reset_at"] = get_budget_reset_time(
+                budget_duration=non_default_values["budget_duration"]
             )
-            user_reset_at = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
-            non_default_values["budget_reset_at"] = user_reset_at
 
     return non_default_values
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -663,8 +663,8 @@ def prepare_key_update_data(
             and (isinstance(budget_duration, str))
             and len(budget_duration) > 0
         ):
-            duration_s = duration_in_seconds(duration=budget_duration)
-            key_reset_at = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+            key_reset_at = get_budget_reset_time(budget_duration=budget_duration)
             non_default_values["budget_reset_at"] = key_reset_at
             non_default_values["budget_duration"] = budget_duration
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -313,11 +313,10 @@ async def new_team(  # noqa: PLR0915
 
         # If budget_duration is set, set `budget_reset_at`
         if complete_team_data.budget_duration is not None:
-            duration_s = duration_in_seconds(
-                duration=complete_team_data.budget_duration
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+            complete_team_data.budget_reset_at = get_budget_reset_time(
+                budget_duration=complete_team_data.budget_duration, 
             )
-            reset_at = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
-            complete_team_data.budget_reset_at = reset_at
 
         complete_team_data_dict = complete_team_data.model_dump(exclude_none=True)
         complete_team_data_dict = prisma_client.jsonify_team_object(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -198,7 +198,6 @@ async def new_team(  # noqa: PLR0915
     try:
         from litellm.proxy.proxy_server import (
             create_audit_log_for_update,
-            duration_in_seconds,
             litellm_proxy_admin_name,
             prisma_client,
         )

--- a/tests/litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/litellm/litellm_core_utils/test_duration_parser.py
@@ -1,0 +1,113 @@
+import unittest
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+from litellm.litellm_core_utils.duration_parser import get_next_standardized_reset_time
+
+class TestStandardizedResetTime(unittest.TestCase):
+    def test_day_based_resets(self):
+        """Test day-based reset durations (1d, 7d, 30d)"""
+        # Base time: 2023-05-15 10:30:00 UTC
+        base_time = datetime(2023, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
+        
+        # Daily reset (1d) - should reset at next midnight
+        daily_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc)
+        daily_result = get_next_standardized_reset_time("1d", base_time, "UTC")
+        self.assertEqual(daily_result, daily_expected)
+        
+        # Weekly reset (7d) - should reset on next Monday
+        wednesday = datetime(2023, 5, 17, 15, 45, 0, tzinfo=timezone.utc)  # A Wednesday
+        weekly_expected = datetime(2023, 5, 22, 0, 0, 0, tzinfo=timezone.utc)  # Next Monday
+        weekly_result = get_next_standardized_reset_time("7d", wednesday, "UTC")
+        self.assertEqual(weekly_result, weekly_expected)
+        
+        # Monthly reset (30d) - should reset on 1st of next month
+        monthly_expected = datetime(2023, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+        monthly_result = get_next_standardized_reset_time("30d", base_time, "UTC")
+        self.assertEqual(monthly_result, monthly_expected)
+        
+        # Custom day reset (3d) - should reset after 3 days
+        custom_day_expected = datetime(2023, 5, 18, 0, 0, 0, tzinfo=timezone.utc)
+        custom_day_result = get_next_standardized_reset_time("3d", base_time, "UTC")
+        self.assertEqual(custom_day_result, custom_day_expected)
+
+    def test_hour_minute_second_resets(self):
+        """Test hour, minute, and second based reset durations"""
+        # Base time: 2023-05-15 15:20:30 UTC (3:20:30 PM)
+        base_time = datetime(2023, 5, 15, 15, 20, 30, tzinfo=timezone.utc)
+        
+        # 2-hour reset - should reset at next even hour (16:00)
+        hour_expected = datetime(2023, 5, 15, 16, 0, 0, tzinfo=timezone.utc)
+        hour_result = get_next_standardized_reset_time("2h", base_time, "UTC")
+        self.assertEqual(hour_result, hour_expected)
+        
+        # 30-minute reset - should reset at next 30-minute mark (15:30)
+        minute_expected = datetime(2023, 5, 15, 15, 30, 0, tzinfo=timezone.utc)
+        minute_result = get_next_standardized_reset_time("30m", base_time, "UTC")
+        self.assertEqual(minute_result, minute_expected)
+        
+        # 15-second reset - should reset at next 15-second mark (15:20:45)
+        second_expected = datetime(2023, 5, 15, 15, 20, 45, tzinfo=timezone.utc)
+        second_result = get_next_standardized_reset_time("15s", base_time, "UTC")
+        self.assertEqual(second_result, second_expected)
+
+    def test_timezone_handling(self):
+        """Test timezone handling with different regions"""
+        # Base time: 2023-05-15 22:30:00 UTC (late in UTC day)
+        base_time = datetime(2023, 5, 15, 22, 30, 0, tzinfo=timezone.utc)
+        
+        # Test daily reset in different timezones
+        # US/Eastern (UTC-4): 6:30 PM, so next reset is midnight same day
+        eastern = ZoneInfo("US/Eastern")
+        eastern_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=eastern)
+        eastern_result = get_next_standardized_reset_time("1d", base_time, "US/Eastern")
+        self.assertEqual(eastern_result, eastern_expected)
+        
+        # Asia/Kolkata (UTC+5:30): 4:00 AM next day, so next reset is midnight the day after
+        ist = ZoneInfo("Asia/Kolkata")
+        ist_expected = datetime(2023, 5, 17, 0, 0, 0, tzinfo=ist)
+        ist_result = get_next_standardized_reset_time("1d", base_time, "Asia/Kolkata")
+        self.assertEqual(ist_result, ist_expected)
+        
+        # Test hourly reset in different timezones
+        # US/Pacific (UTC-7): 3:30 PM, so next 2h reset is 4:00 PM
+        pacific = ZoneInfo("US/Pacific")
+        pacific_expected = datetime(2023, 5, 15, 16, 0, 0, tzinfo=pacific)
+        pacific_result = get_next_standardized_reset_time("2h", base_time, "US/Pacific")
+        self.assertEqual(pacific_result, pacific_expected)
+        
+        # Test minute reset in different timezones
+        # Europe/London (UTC+1): 11:30 PM, so next 15m reset is 11:45 PM
+        london = ZoneInfo("Europe/London")
+        london_expected = datetime(2023, 5, 15, 23, 45, 0, tzinfo=london)
+        london_result = get_next_standardized_reset_time("15m", base_time, "Europe/London")
+        self.assertEqual(london_result, london_expected)
+
+    def test_edge_cases(self):
+        """Test edge cases and boundary conditions"""
+        # Exactly on hour boundary
+        on_hour = datetime(2023, 5, 15, 14, 0, 0, tzinfo=timezone.utc)
+        hour_expected = datetime(2023, 5, 15, 16, 0, 0, tzinfo=timezone.utc)
+        hour_result = get_next_standardized_reset_time("2h", on_hour, "UTC")
+        self.assertEqual(hour_result, hour_expected)
+        
+        # Exactly on minute boundary
+        on_minute = datetime(2023, 5, 15, 14, 30, 0, tzinfo=timezone.utc)
+        minute_expected = datetime(2023, 5, 15, 15, 0, 0, tzinfo=timezone.utc)
+        minute_result = get_next_standardized_reset_time("30m", on_minute, "UTC")
+        self.assertEqual(minute_result, minute_expected)
+        
+        # Near day boundary
+        near_midnight = datetime(2023, 5, 15, 23, 50, 0, tzinfo=timezone.utc)
+        
+        # 30m near midnight - should roll over to next day
+        midnight_minute_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc)
+        midnight_minute_result = get_next_standardized_reset_time("30m", near_midnight, "UTC")
+        self.assertEqual(midnight_minute_result, midnight_minute_expected)
+        
+        # Invalid timezone - should fall back to UTC
+        invalid_tz_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc)
+        invalid_tz_result = get_next_standardized_reset_time("1d", on_hour, "NonExistentTimeZone")
+        self.assertEqual(invalid_tz_result, invalid_tz_expected)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/litellm/proxy/common_utils/test_reset_budget_job.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
@@ -68,8 +68,8 @@ async def run_async_test(coro):
 
 # Tests
 def test_reset_budget_for_key(reset_budget_job, mock_prisma_client):
-    # Setup test data
-    now = datetime.utcnow()
+    # Setup test data with timezone-aware datetime
+    now = datetime.now(timezone.utc)
     test_key = type(
         "LiteLLM_VerificationToken",
         (),
@@ -94,8 +94,8 @@ def test_reset_budget_for_key(reset_budget_job, mock_prisma_client):
 
 
 def test_reset_budget_for_user(reset_budget_job, mock_prisma_client):
-    # Setup test data
-    now = datetime.utcnow()
+    # Setup test data with timezone-aware datetime
+    now = datetime.now(timezone.utc)
     test_user = type(
         "LiteLLM_UserTable",
         (),
@@ -120,8 +120,8 @@ def test_reset_budget_for_user(reset_budget_job, mock_prisma_client):
 
 
 def test_reset_budget_for_team(reset_budget_job, mock_prisma_client):
-    # Setup test data
-    now = datetime.utcnow()
+    # Setup test data with timezone-aware datetime
+    now = datetime.now(timezone.utc)
     test_team = type(
         "LiteLLM_TeamTable",
         (),
@@ -146,8 +146,8 @@ def test_reset_budget_for_team(reset_budget_job, mock_prisma_client):
 
 
 def test_reset_budget_all(reset_budget_job, mock_prisma_client):
-    # Setup test data
-    now = datetime.utcnow()
+    # Setup test data with timezone-aware datetime
+    now = datetime.now(timezone.utc)
 
     # Create test objects for all three types
     test_key = type(


### PR DESCRIPTION
## Title
Enhance budget reset functionality with timezone support and standardized reset times

## Relevant issues
Fixes 10288

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ 👍 ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [👍  ] I have added a screenshot of my new test passing locally 
- [ 👍 ] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [ 👍 ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 Enhancement

## Changes
- Added `get_next_standardized_reset_time` function to calculate budget reset times based on specified durations and timezones.
- Introduced `timezone_utils.py` to manage timezone retrieval and budget reset time calculations.
- Updated budget reset logic in `reset_budget_job.py`, `internal_user_endpoints.py`, `key_management_endpoints.py`, and `team_endpoints.py` to utilize the new timezone-aware reset time calculations.
- Added unit tests for the new reset time functionality in `test_duration_parser.py`.
- Updated `.gitignore` to include `test.py` and made minor formatting adjustments in `docker-compose.yml` for consistency.


