### PR TITLE
[UI QA Fix] Fix width of the model_id on Models Page

### DIFF
--- a/ui/litellm-dashboard/src/components/model_dashboard/columns.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/columns.tsx
@@ -25,7 +25,7 @@ export const columns = (
       return (
         <Tooltip title={model.model_info.id}>
           <div 
-            className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left w-full truncate whitespace-nowrap cursor-pointer"
+            className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left w-full truncate whitespace-nowrap cursor-pointer max-w-[15ch]"
             onClick={() => setSelectedModelId(model.model_info.id)}
           >
             {model.model_info.id}


### PR DESCRIPTION
## [UI QA Fix] Fix width of the model_id on Models Page

Ensure models page has a upper bound on col width 

<img width="674" alt="Screenshot 2025-04-26 at 4 25 01 PM" src="https://github.com/user-attachments/assets/a881ff04-95ae-4ce0-bb13-e99d4a4bcf1c" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


