### PR TITLE
Fix issue 10264 unicode docode error

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -184,7 +184,7 @@ try:
     # Python 3.9+
     with resources.files("litellm.litellm_core_utils.tokenizers").joinpath(
         "anthropic_tokenizer.json"
-    ).open("r") as f:
+    ).open("r", encoding="utf-8") as f:
         json_data = json.load(f)
 except (ImportError, AttributeError, TypeError):
     with resources.open_text(


### PR DESCRIPTION
## Title

Fix UnicodeDecodeError on non-English OS by specifying UTF-8 encoding when opening files

## Relevant issues

Fixes #10264

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added testing in the [`tests/litellm_utils_tests/test_utils.py`](https://github.com/BerriAI/litellm/tree/main/tests/litellm_utils_tests) directory, **Adding at least 1 test is a hard requirement** – see details at https://docs.litellm.ai/docs/extras/contributing_code  
- [x] I have added a screenshot/log of my new test passing locally  
- [x] My PR passes all unit tests on (`make test-unit`)  
- [x] My PR’s scope is as isolated as possible; it only solves 1 specific problem  

## Type

🐛 Bug Fix

## Changes

- Changed all occurrences of `open("r")` to `open("r", encoding="utf-8")` to ensure files are read as UTF-8 rather than the platform default, preventing `UnicodeDecodeError` on non-English OSes.  
- Added a unit test at `tests/litellm_utils_tests/test_utils.py` to verify that `anthropic_tokenizer.json` is read correctly with UTF-8 encoding.  

## screenshot
![image](https://github.com/user-attachments/assets/142b36a7-7e5e-42c8-8a88-c6b4391c7017)
