### PR TITLE
Attempt to avoid the encoding error when loading the json file.

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -184,11 +184,11 @@ try:
     # Python 3.9+
     with resources.files("litellm.litellm_core_utils.tokenizers").joinpath(
         "anthropic_tokenizer.json"
-    ).open("r") as f:
+    ).open("r", encoding="utf-8") as f:
         json_data = json.load(f)
 except (ImportError, AttributeError, TypeError):
     with resources.open_text(
-        "litellm.litellm_core_utils.tokenizers", "anthropic_tokenizer.json"
+        "litellm.litellm_core_utils.tokenizers", "anthropic_tokenizer.json", encoding="utf-8"
     ) as f:
         json_data = json.load(f)
 


### PR DESCRIPTION
## Title

Hopefully fix issues 10340 / 10272

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

Sorry, but this is a trivial change in an existing loading code line where a fixed encoding is being added. Adding a unit test does not make sense in this case in my opinion. 
Take it or leave it.

This was tested on Windows 10 / German where `import litellm` failed previously to now work. 

## Type

🐛 Bug Fix

## Changes

Make both ways to load the anthropic_tokenizer.json file in utils.py explicitly use encoding utf-8. 

