### PR TITLE
[Fixes] Azure OpenAI OIDC - allow using litellm defined params for OIDC Auth 

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -125,22 +125,6 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     def __init__(self) -> None:
         super().__init__()
 
-    def validate_environment(self, api_key, azure_ad_token, azure_ad_token_provider):
-        headers = {
-            "content-type": "application/json",
-        }
-        if api_key is not None:
-            headers["api-key"] = api_key
-        elif azure_ad_token is not None:
-            if azure_ad_token.startswith("oidc/"):
-                azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)
-            headers["Authorization"] = f"Bearer {azure_ad_token}"
-        elif azure_ad_token_provider is not None:
-            azure_ad_token = azure_ad_token_provider()
-            headers["Authorization"] = f"Bearer {azure_ad_token}"
-
-        return headers
-
     def make_sync_azure_openai_chat_completion_request(
         self,
         azure_client: AzureOpenAI,
@@ -242,6 +226,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     azure_ad_token_provider=azure_ad_token_provider,
                     acompletion=acompletion,
                     client=client,
+                    litellm_params=litellm_params,
                 )
 
                 data = {"model": None, "messages": messages, **optional_params}

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -158,9 +158,22 @@ def get_azure_ad_token_from_username_password(
     return token_provider
 
 
-def get_azure_ad_token_from_oidc(azure_ad_token: str):
-    azure_client_id = os.getenv("AZURE_CLIENT_ID", None)
-    azure_tenant_id = os.getenv("AZURE_TENANT_ID", None)
+def get_azure_ad_token_from_oidc(
+    azure_ad_token: str,
+    azure_client_id: Optional[str],
+    azure_tenant_id: Optional[str],
+) -> str:
+    """
+    Get Azure AD token from OIDC token
+
+    Args:
+        azure_ad_token: str
+        azure_client_id: Optional[str]
+        azure_tenant_id: Optional[str]
+
+    Returns:
+        `azure_ad_token_access_token` - str
+    """
     azure_authority_host = os.getenv(
         "AZURE_AUTHORITY_HOST", "https://login.microsoftonline.com"
     )
@@ -341,7 +354,11 @@ class BaseAzureLLM(BaseOpenAILLM):
 
         if azure_ad_token is not None and azure_ad_token.startswith("oidc/"):
             verbose_logger.debug("Using Azure OIDC Token for Azure Auth")
-            azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)
+            azure_ad_token = get_azure_ad_token_from_oidc(
+                azure_ad_token=azure_ad_token,
+                azure_client_id=client_id,
+                azure_tenant_id=tenant_id,
+            )
         elif (
             not api_key
             and azure_ad_token_provider is None
@@ -402,6 +419,7 @@ class BaseAzureLLM(BaseOpenAILLM):
         api_version: str,
         max_retries: int,
         timeout: Union[float, httpx.Timeout],
+        litellm_params: dict,
         api_key: Optional[str],
         azure_ad_token: Optional[str],
         azure_ad_token_provider: Optional[Callable[[], str]],
@@ -409,6 +427,8 @@ class BaseAzureLLM(BaseOpenAILLM):
         client: Optional[Union[AzureOpenAI, AsyncAzureOpenAI]] = None,
     ) -> Union[AzureOpenAI, AsyncAzureOpenAI]:
         ## build base url - assume api base includes resource name
+        tenant_id = litellm_params.get("tenant_id", os.getenv("AZURE_TENANT_ID"))
+        client_id = litellm_params.get("client_id", os.getenv("AZURE_CLIENT_ID"))
         if client is None:
             if not api_base.endswith("/"):
                 api_base += "/"
@@ -425,7 +445,11 @@ class BaseAzureLLM(BaseOpenAILLM):
                 azure_client_params["api_key"] = api_key
             elif azure_ad_token is not None:
                 if azure_ad_token.startswith("oidc/"):
-                    azure_ad_token = get_azure_ad_token_from_oidc(azure_ad_token)
+                    azure_ad_token = get_azure_ad_token_from_oidc(
+                        azure_ad_token=azure_ad_token,
+                        azure_client_id=client_id,
+                        azure_tenant_id=tenant_id,
+                    )
 
                 azure_client_params["azure_ad_token"] = azure_ad_token
             if azure_ad_token_provider is not None:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -177,7 +177,8 @@ def get_azure_ad_token_from_oidc(
     azure_authority_host = os.getenv(
         "AZURE_AUTHORITY_HOST", "https://login.microsoftonline.com"
     )
-
+    azure_client_id = azure_client_id or os.getenv("AZURE_CLIENT_ID")
+    azure_tenant_id = azure_tenant_id or os.getenv("AZURE_TENANT_ID")
     if azure_client_id is None or azure_tenant_id is None:
         raise AzureOpenAIError(
             status_code=422,

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -72,6 +72,7 @@ class AzureTextCompletion(BaseAzureLLM):
                     azure_ad_token=azure_ad_token,
                     azure_ad_token_provider=azure_ad_token_provider,
                     acompletion=acompletion,
+                    litellm_params=litellm_params,
                 )
 
                 data = {"model": None, "prompt": prompt, **optional_params}

--- a/tests/litellm_utils_tests/test_secret_manager.py
+++ b/tests/litellm_utils_tests/test_secret_manager.py
@@ -140,7 +140,11 @@ def test_oidc_circleci_with_azure():
     # TODO: Switch to our own Azure account, currently using ai.moda's account
     os.environ["AZURE_TENANT_ID"] = "17c0a27a-1246-4aa1-a3b6-d294e80e783c"
     os.environ["AZURE_CLIENT_ID"] = "4faf5422-b2bd-45e8-a6d7-46543a38acd0"
-    azure_ad_token = get_azure_ad_token_from_oidc("oidc/circleci/")
+    azure_ad_token = get_azure_ad_token_from_oidc(
+        azure_ad_token="oidc/circleci/",
+        azure_client_id=None,
+        azure_tenant_id=None,
+    )
 
     print(f"secret_val: {redact_oidc_signature(azure_ad_token)}")
 


### PR DESCRIPTION
## [Bug Fix] Azure OpenAI OIDC - allow using litellm defined params for OIDC Auth 

Bug fix, using OIDC for auth to Azure, you needed to set the client and tenant id as env vars, litellm was not reading the vars defined on the config.yaml

How to repro

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: azure/gpt-4o-2024-05-13
      api_base: https://xxxx.xxxx.xxxx/
      tenant_id: 72f988bf-86f1-41af-91ab-2d7cd011db47
      client_id: 00000000-0000-0000-0000-000000000000
      azure_ad_token: oidc/google/api://AzureADTokenExchange
```


## Key changes

- get_azure_ad_token_from_oidc() takes azure_client_id, azure_tenant_id.
- litellm_params now accepted in Azure SDK client builders; values flow from AzureChatCompletion / AzureTextCompletion → BaseAzureLLM.initialize_azure_sdk_client.
- order of checking params: dynamic parameters → environment → None.

## Testing 
Unit-test suite expanded to cover all paths.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


