### PR TITLE
Edit member - don't allow changing user email/id - just role

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2348,6 +2348,7 @@ class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
 
 class TeamMemberUpdateResponse(MemberUpdateResponse):
     team_id: str
+    role: Optional[Literal["admin", "user"]] = None
     max_budget_in_team: Optional[float] = None
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1020,7 +1020,7 @@ async def team_member_update(
             status_code=403,
             detail={
                 "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
-                    "/team/member_delete", existing_team_row.team_id
+                    "/team/member_update", existing_team_row.team_id
                 )
             },
         )
@@ -1050,6 +1050,14 @@ async def team_member_update(
                 "error": "User id doesn't exist in team table. Data={}".format(data)
             },
         )
+    
+    user_email = data.user_email
+    if user_email is None:
+        for member in returned_team_info["team_info"].members_with_roles:
+            if member.user_id == received_user_id:
+                user_email = member.user_email
+                break
+            
     ## find the relevant team membership
     identified_budget_id: Optional[str] = None
     for tm in returned_team_info["team_memberships"]:
@@ -1107,8 +1115,9 @@ async def team_member_update(
     return TeamMemberUpdateResponse(
         team_id=data.team_id,
         user_id=received_user_id,
-        user_email=data.user_email,
+        user_email=user_email,
         max_budget_in_team=data.max_budget_in_team,
+        role=data.role
     )
 
 

--- a/ui/litellm-dashboard/src/components/team/edit_membership.tsx
+++ b/ui/litellm-dashboard/src/components/team/edit_membership.tsx
@@ -46,8 +46,6 @@ const MemberModal = <T extends BaseMember>({
 }: MemberModalProps<T>) => {
   const [form] = Form.useForm();
 
-  console.log("Initial Data:", initialData);
-
   // Reset form and set initial values when modal becomes visible or initialData changes
   useEffect(() => {
     if (visible) {
@@ -81,7 +79,6 @@ const MemberModal = <T extends BaseMember>({
       message.success(`Successfully ${mode === 'add' ? 'added' : 'updated'} member`);
     } catch (error) {
       message.error('Failed to submit form');
-      console.error('Form submission error:', error);
     }
   };
 
@@ -152,6 +149,7 @@ const MemberModal = <T extends BaseMember>({
               onChange={(e) => {
                 e.target.value = e.target.value.trim();
               }}
+              disabled={mode === 'edit'}
             />
           </Form.Item>
         )}
@@ -174,6 +172,7 @@ const MemberModal = <T extends BaseMember>({
               onChange={(e) => {
                 e.target.value = e.target.value.trim();
               }}
+              disabled={mode === 'edit'}
             />
           </Form.Item>
         )}


### PR DESCRIPTION
## Edit member - don't allow changing user email/id - just role
This PR enhances the team member update functionality in the `/team/member_update` endpoint. Key improvements include stricter controls around identity fields and expanded support for role management.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) 

**_->  I have added test in the existing tests/test_team.py_** 

- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test

## Changes

- Made `user_id` and `user_email` read-only during member updates. User must be able to update only the `role`.
<img width="1447" alt="Screenshot 2025-04-29 at 7 36 50 PM" src="https://github.com/user-attachments/assets/9a0c6908-6a47-4435-897c-920f2ef3c37f" />

- Enabled updating the role field for a team member via the API.
- Ensured `user_email` is always included in the response for consistency.
- Added role to the `/team/member_update` response to reflect updated values.
- Added a backend test to verify that the member’s role is correctly updated in the database.
<img width="999" alt="Screenshot 2025-04-29 at 8 53 31 PM" src="https://github.com/user-attachments/assets/34b4f678-788e-452b-bec8-e312b8991054" />


