### PR TITLE
[Feat] Add support for using Bedrock Knowledge Bases with LiteLLM /chat/completions requests

### DIFF
--- a/docs/my-website/docs/completion/knowledgebase.md
+++ b/docs/my-website/docs/completion/knowledgebase.md
@@ -38,16 +38,48 @@ model_list:
 
 #### 2. Make a request with knowledge_bases parameter
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="curl" label="Curl">
+
 ```bash showLineNumbers title="Curl Request to LiteLLM Proxy"
 curl http://localhost:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $LITELLM_API_KEY" \
   -d '{
-    "model": "claude-with-kb",
+    "model": "claude-3-5-sonnet",
     "messages": [{"role": "user", "content": "What is litellm?"}],
     "knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]
   }'
 ```
+
+</TabItem>
+
+<TabItem value="openai-sdk" label="OpenAI Python SDK">
+
+```python showLineNumbers title="OpenAI Python SDK Request"
+from openai import OpenAI
+
+# Initialize client with your LiteLLM proxy URL
+client = OpenAI(
+    base_url="http://localhost:4000",
+    api_key="your-litellm-api-key"
+)
+
+# Make a completion request with knowledge_bases parameter
+response = client.chat.completions.create(
+    model="claude-3-5-sonnet",
+    messages=[{"role": "user", "content": "What is litellm?"}],
+    extra_body={"knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]}
+)
+
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+</Tabs>
 
 ## How It Works
 

--- a/docs/my-website/docs/completion/knowledgebase.md
+++ b/docs/my-website/docs/completion/knowledgebase.md
@@ -1,0 +1,108 @@
+# Using Knowledge Bases with LiteLLM
+
+LiteLLM integrates with AWS Bedrock Knowledge Bases, allowing your models to access your organization's data for more accurate and contextually relevant responses.
+
+## Quick Start
+
+In order to use a Bedrock Knowledge Base with LiteLLM, you need to pass `knowledge_bases` as a parameter to the completion request. Where `knowledge_bases` is a list of Bedrock Knowledge Base IDs.
+
+### LiteLLM Python SDK
+
+```python showLineNumbers title="Basic Bedrock Knowledge Base Usage"
+import os
+import litellm
+
+
+# Make a completion request with knowledge_bases parameter
+response = await litellm.acompletion(
+    model="anthropic/claude-3-5-sonnet", 
+    messages=[{"role": "user", "content": "What is litellm?"}],
+    knowledge_bases=["YOUR_KNOWLEDGE_BASE_ID"]  # e.g., "T37J8R4WTM"
+)
+
+print(response.choices[0].message.content)
+```
+
+### LiteLLM Proxy
+
+#### 1. Configure your proxy
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+```
+
+#### 2. Make a request with knowledge_bases parameter
+
+```bash showLineNumbers title="Curl Request to LiteLLM Proxy"
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "claude-with-kb",
+    "messages": [{"role": "user", "content": "What is litellm?"}],
+    "knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]
+  }'
+```
+
+## How It Works
+
+LiteLLM implements a `BedrockKnowledgeBaseHook` that intercepts your completion requests for handling the integration with Bedrock Knowledge Bases.
+
+1. You make a completion request with the `knowledge_bases` parameter
+2. LiteLLM automatically:
+   - Uses your last message as the query to retrieve relevant information from the Knowledge Base
+   - Adds the retrieved context to your conversation
+   - Sends the augmented messages to the model
+
+### Example Transformation
+
+When you pass `knowledge_bases=["YOUR_KNOWLEDGE_BASE_ID"]`, your request flows through these steps:
+
+**1. Original Request to LiteLLM:**
+```json
+{
+    "model": "anthropic/claude-3-5-sonnet",
+    "messages": [
+        {"role": "user", "content": "What is litellm?"}
+    ],
+    "knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]
+}
+```
+
+**2. Request to AWS Bedrock Knowledge Base:**
+```json
+{
+    "retrievalQuery": {
+        "text": "What is litellm?"
+    }
+}
+```
+This is sent to: `https://bedrock-agent-runtime.{aws_region}.amazonaws.com/knowledgebases/YOUR_KNOWLEDGE_BASE_ID/retrieve`
+
+**3. Final Request to LiteLLM:**
+```json
+{
+    "model": "anthropic/claude-3-5-sonnet",
+    "messages": [
+        {"role": "user", "content": "What is litellm?"},
+        {"role": "user", "content": "Context: \n\nLiteLLM is an open-source SDK to simplify LLM API calls across providers (OpenAI, Claude, etc). It provides a standardized interface with robust error handling, streaming, and observability tools."}
+    ]
+}
+```
+
+This process happens automatically whenever you include the `knowledge_bases` parameter in your request.
+
+## API Reference
+
+### LiteLLM Completion Knowledge Base Parameters
+
+When using the Knowledge Base integration with LiteLLM, you can include the following parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `knowledge_bases` | List[str] | List of Bedrock Knowledge Base IDs to query |

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -271,6 +271,7 @@ const sidebars = {
         "reasoning_content",
         "completion/prompt_caching",
         "completion/predict_outputs",
+        "completion/knowledgebase",
         "completion/prefix",
         "completion/drop_params",
         "completion/prompt_formatting",

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -115,6 +115,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "gcs_pubsub",
     "agentops",
     "anthropic_cache_control_hook",
+    "bedrock_knowledgebase_hook",
 ]
 logged_real_time_event_types: Optional[Union[List[str], Literal["*"]]] = None
 _known_custom_logger_compatible_callbacks: List = list(

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -77,7 +77,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         model: str,
         messages: List[AllMessageValues],
         non_default_params: dict,
-        prompt_id: str,
+        prompt_id: Optional[str],
         prompt_variables: Optional[dict],
         dynamic_callback_params: StandardCallbackDynamicParams,
     ) -> Tuple[str, List[AllMessageValues], dict]:

--- a/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
+++ b/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
@@ -1,0 +1,185 @@
+# +-------------------------------------------------------------+
+#
+#           Use Bedrock Guardrails for your LLM calls
+#
+# +-------------------------------------------------------------+
+#  Thank you users! We ❤️ you! - Krrish & Ishaan
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+import json
+import sys
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+from fastapi import HTTPException
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    convert_content_list_to_str,
+)
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.integrations.rag.bedrock_knowledgebase import (
+    BedrockKBGuardrailConfiguration,
+    BedrockKBRequest,
+    BedrockKBResponse,
+    BedrockKBRetrievalConfiguration,
+    BedrockKBRetrievalQuery,
+)
+from litellm.types.llms.openai import AllMessageValues
+from litellm.types.utils import ModelResponse
+
+GUARDRAIL_NAME = "bedrock"
+
+
+class BedrockKnowledgeBaseHook(CustomLogger, BaseAWSLLM):
+    def __init__(
+        self,
+        **kwargs,
+    ):
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback
+        )
+
+        # store kwargs as optional_params
+        self.optional_params = kwargs
+
+        super().__init__(**kwargs)
+        BaseAWSLLM.__init__(self)
+
+    def _prepare_request(
+        self,
+        credentials: Any,
+        data: BedrockKBRequest,
+        optional_params: dict,
+        aws_region_name: str,
+        api_base: str,
+        extra_headers: Optional[dict] = None,
+    ) -> Any:
+        """
+        Prepare a signed AWS request.
+
+        Args:
+            credentials: AWS credentials
+            data: Request data
+            optional_params: Additional parameters
+            aws_region_name: AWS region name
+            api_base: Base API URL
+            extra_headers: Additional headers
+
+        Returns:
+            AWSRequest: A signed AWS request
+        """
+        try:
+            from botocore.auth import SigV4Auth
+            from botocore.awsrequest import AWSRequest
+        except ImportError:
+            raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
+
+        sigv4 = SigV4Auth(credentials, "bedrock", aws_region_name)
+
+        encoded_data = json.dumps(data).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if extra_headers is not None:
+            headers = {"Content-Type": "application/json", **extra_headers}
+
+        request = AWSRequest(
+            method="POST", url=api_base, data=encoded_data, headers=headers
+        )
+        sigv4.add_auth(request)
+        if extra_headers is not None and "Authorization" in extra_headers:
+            # prevent sigv4 from overwriting the auth header
+            request.headers["Authorization"] = extra_headers["Authorization"]
+
+        return request.prepare()
+
+    async def make_bedrock_kb_retrieve_request(
+        self,
+        knowledge_base_id: str,
+        query: str,
+        guardrail_id: Optional[str] = None,
+        guardrail_version: Optional[str] = None,
+        next_token: Optional[str] = None,
+        retrieval_configuration: Optional[BedrockKBRetrievalConfiguration] = None,
+    ) -> BedrockKBResponse:
+        """
+        Make a Bedrock Knowledge Base retrieve request.
+
+        Args:
+            knowledge_base_id (str): The unique identifier of the knowledge base to query
+            query (str): The query text to search for
+            guardrail_id (Optional[str]): The guardrail ID to apply
+            guardrail_version (Optional[str]): The version of the guardrail to apply
+            next_token (Optional[str]): Token for pagination
+            retrieval_configuration (Optional[BedrockKBRetrievalConfiguration]): Configuration for the retrieval process
+
+        Returns:
+            BedrockKBRetrievalResponse: A typed response object containing the retrieval results
+        """
+        credentials = self.get_credentials()
+        aws_region_name = self._get_aws_region_name(
+            optional_params=self.optional_params
+        )
+
+        # Prepare request data
+        request_data: BedrockKBRequest = BedrockKBRequest(
+            retrievalQuery=BedrockKBRetrievalQuery(text=query),
+            nextToken=next_token,
+            retrievalConfiguration=retrieval_configuration,
+            guardrailConfiguration=BedrockKBGuardrailConfiguration(
+                guardrailId=guardrail_id, guardrailVersion=guardrail_version
+            ),
+        )
+
+        # Prepare the request
+        api_base = f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com/knowledgebases/{knowledge_base_id}/retrieve"
+
+        prepared_request = self._prepare_request(
+            credentials=credentials,
+            data=request_data,
+            optional_params=self.optional_params,
+            aws_region_name=aws_region_name,
+            api_base=api_base,
+        )
+
+        verbose_proxy_logger.debug(
+            "Bedrock Knowledge Base request body: %s, url %s, headers: %s",
+            request_data,
+            prepared_request.url,
+            prepared_request.headers,
+        )
+
+        response = await self.async_handler.post(
+            url=prepared_request.url,
+            data=prepared_request.body,  # type: ignore
+            headers=prepared_request.headers,  # type: ignore
+        )
+
+        verbose_proxy_logger.debug("Bedrock Knowledge Base response: %s", response.text)
+
+        if response.status_code == 200:
+            response_data = response.json()
+            return BedrockKBResponse(response_data)
+        else:
+            verbose_proxy_logger.error(
+                "Bedrock Knowledge Base: error in response. Status code: %s, response: %s",
+                response.status_code,
+                response.text,
+            )
+            raise HTTPException(
+                status_code=response.status_code,
+                detail={
+                    "error": "Error calling Bedrock Knowledge Base",
+                    "response": response.text,
+                },
+            )

--- a/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
+++ b/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
@@ -1,6 +1,6 @@
 # +-------------------------------------------------------------+
 #
-#           Use Bedrock Guardrails for your LLM calls
+#           Add Bedrock Knowledge Base Context to your LLM calls
 #
 # +-------------------------------------------------------------+
 #  Thank you users! We ❤️ you! - Krrish & Ishaan
@@ -42,6 +42,8 @@ else:
 
 
 class BedrockKnowledgeBaseHook(CustomLogger, BaseAWSLLM):
+    CONTENT_PREFIX_STRING = "Context: \n\n"
+
     def __init__(
         self,
         **kwargs,
@@ -267,7 +269,7 @@ class BedrockKnowledgeBaseHook(CustomLogger, BaseAWSLLM):
         retrieval_results: Optional[List[BedrockKBRetrievalResult]] = response.get(
             "retrievalResults", None
         )
-        context_string: str = "Context: \n\n"
+        context_string: str = BedrockKnowledgeBaseHook.CONTENT_PREFIX_STRING
         for retrieval_result in retrieval_results:
             retrieval_result_content: Optional[BedrockKBContent] = (
                 retrieval_result.get("content", None) or {}

--- a/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
+++ b/litellm/integrations/rag_hooks/bedrock_knowledgebase.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
@@ -32,7 +33,7 @@ else:
     StandardCallbackDynamicParams = Any
 
 
-class BedrockKnowledgeBaseHook(CustomLogger, BaseAWSLLM):
+class BedrockKnowledgeBaseHook(CustomPromptManagement, BaseAWSLLM):
     CONTENT_PREFIX_STRING = "Context: \n\n"
 
     def __init__(
@@ -40,7 +41,7 @@ class BedrockKnowledgeBaseHook(CustomLogger, BaseAWSLLM):
         **kwargs,
     ):
         self.async_handler = get_async_httpx_client(
-            llm_provider=httpxSpecialProvider.GuardrailCallback
+            llm_provider=httpxSpecialProvider.LoggingCallback
         )
 
         # store kwargs as optional_params

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -471,7 +471,7 @@ class Logging(LiteLLMLoggingBaseClass):
             return True
 
         if self._should_run_prompt_management_hooks_without_prompt_id(
-            non_default_params
+            non_default_params=non_default_params
         ):
             return True
 
@@ -487,7 +487,7 @@ class Logging(LiteLLMLoggingBaseClass):
         eg. AnthropicCacheControlHook and BedrockKnowledgeBaseHook both don't require a `prompt_id` to be passed in, they are triggered by dynamic params
         """
         for param in non_default_params:
-            if param in DynamicPromptManagementParamLiteral:
+            if param in DynamicPromptManagementParamLiteral.list_all_params():
                 return True
         return False
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -405,6 +405,31 @@ async def acompletion(
 
     loop = asyncio.get_event_loop()
     custom_llm_provider = kwargs.get("custom_llm_provider", None)
+
+    ## PROMPT MANAGEMENT HOOKS ##
+    #########################################################
+    #########################################################
+    litellm_logging_obj = kwargs.get("litellm_logging_obj", None)
+    if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
+        litellm_logging_obj.should_run_prompt_management_hooks(
+            prompt_id=kwargs.get("prompt_id", None), non_default_params=kwargs
+        )
+    ):
+        (
+            model,
+            messages,
+            _,
+        ) = await litellm_logging_obj.async_get_chat_completion_prompt(
+            model=model,
+            messages=messages,
+            non_default_params=kwargs,
+            prompt_id=kwargs.get("prompt_id", None),
+            prompt_variables=kwargs.get("prompt_variables", None),
+        )
+
+    #########################################################
+    #########################################################
+
     # Adjusted to use explicit arguments instead of *args and **kwargs
     completion_kwargs = {
         "model": model,

--- a/litellm/types/integrations/rag/bedrock_knowledgebase.py
+++ b/litellm/types/integrations/rag/bedrock_knowledgebase.py
@@ -1,0 +1,141 @@
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+
+
+class BedrockKBLocation(TypedDict, total=False):
+    """Location information for a retrieved document."""
+
+    type: str
+    s3Location: Optional[dict]
+    webLocation: Optional[dict]
+    kendraDocumentLocation: Optional[dict]
+    salesforceLocation: Optional[dict]
+    sharePointLocation: Optional[dict]
+    confluenceLocation: Optional[dict]
+    customDocumentLocation: Optional[dict]
+    sqlLocation: Optional[dict]
+
+
+class BedrockKBRowValue(TypedDict):
+    """Row value in a retrieved document."""
+
+    columnName: str
+    columnValue: str
+    type: str
+
+
+class BedrockKBContent(TypedDict, total=False):
+    """Content of a retrieved document."""
+
+    type: str
+    text: Optional[str]
+    byteContent: Optional[str]
+    row: Optional[List[BedrockKBRowValue]]
+
+
+class BedrockKBRetrievalResult(TypedDict):
+    """Individual result from a knowledge base retrieval."""
+
+    content: BedrockKBContent
+    location: BedrockKBLocation
+    score: float
+    metadata: Optional[Dict[str, Any]]
+
+
+class BedrockKBResponse(TypedDict):
+    """Response from a Bedrock Knowledge Base retrieval request."""
+
+    guardrailAction: Literal["INTERVENED", "NONE"]
+    nextToken: Optional[str]
+    retrievalResults: List[BedrockKBRetrievalResult]
+
+
+################ Bedrock Knowledge Base Request Types #################
+#########################################################################
+#########################################################################
+
+
+class BedrockKBMetadataAttribute(TypedDict, total=False):
+    """Metadata attribute configuration for implicit filtering."""
+
+    description: Optional[str]
+    key: Optional[str]
+    type: Optional[str]
+
+
+class BedrockKBImplicitFilterConfiguration(TypedDict, total=False):
+    """Configuration for implicit filtering."""
+
+    metadataAttributes: Optional[List[BedrockKBMetadataAttribute]]
+    modelArn: Optional[str]
+
+
+class BedrockKBSelectiveModeConfiguration(TypedDict, total=False):
+    """Configuration for selective mode in reranking."""
+
+    pass  # This can be expanded based on actual requirements
+
+
+class BedrockKBMetadataConfiguration(TypedDict, total=False):
+    """Metadata configuration for reranking."""
+
+    selectionMode: Optional[str]
+    selectiveModeConfiguration: Optional[BedrockKBSelectiveModeConfiguration]
+
+
+class BedrockKBModelConfiguration(TypedDict, total=False):
+    """Model configuration for reranking."""
+
+    additionalModelRequestFields: Optional[Dict[str, Any]]
+    modelArn: Optional[str]
+
+
+class BedrockKBRerankingConfiguration(TypedDict, total=False):
+    """Configuration for reranking in vector search."""
+
+    bedrockRerankingConfiguration: Optional[
+        Dict[str, Any]
+    ]  # This could be further typed if needed
+    type: Optional[str]
+
+
+class BedrockKBVectorSearchConfiguration(TypedDict, total=False):
+    """Configuration for vector search."""
+
+    filter: Optional[Dict[str, Any]]
+    implicitFilterConfiguration: Optional[BedrockKBImplicitFilterConfiguration]
+    numberOfResults: Optional[int]
+    overrideSearchType: Optional[str]
+    rerankingConfiguration: Optional[BedrockKBRerankingConfiguration]
+
+
+class BedrockKBRetrievalConfiguration(TypedDict, total=False):
+    """Configuration for retrieval."""
+
+    vectorSearchConfiguration: Optional[BedrockKBVectorSearchConfiguration]
+
+
+class BedrockKBRetrievalQuery(TypedDict, total=False):
+    """Query structure for retrieval."""
+
+    text: Optional[str]
+
+
+class BedrockKBGuardrailConfiguration(TypedDict, total=False):
+    """Configuration for guardrails."""
+
+    guardrailId: Optional[str]
+    guardrailVersion: Optional[str]
+
+
+class BedrockKBRequest(TypedDict, total=False):
+    """Complete request structure for Bedrock Knowledge Base retrieval."""
+
+    guardrailConfiguration: Optional[BedrockKBGuardrailConfiguration]
+    nextToken: Optional[str]
+    retrievalConfiguration: Optional[BedrockKBRetrievalConfiguration]
+    retrievalQuery: BedrockKBRetrievalQuery
+
+
+#########################################################################
+#########################################################################
+#########################################################################

--- a/litellm/types/integrations/rag/bedrock_knowledgebase.py
+++ b/litellm/types/integrations/rag/bedrock_knowledgebase.py
@@ -32,21 +32,21 @@ class BedrockKBContent(TypedDict, total=False):
     row: Optional[List[BedrockKBRowValue]]
 
 
-class BedrockKBRetrievalResult(TypedDict):
+class BedrockKBRetrievalResult(TypedDict, total=False):
     """Individual result from a knowledge base retrieval."""
 
-    content: BedrockKBContent
-    location: BedrockKBLocation
-    score: float
+    content: Optional[BedrockKBContent]
+    location: Optional[BedrockKBLocation]
+    score: Optional[float]
     metadata: Optional[Dict[str, Any]]
 
 
-class BedrockKBResponse(TypedDict):
+class BedrockKBResponse(TypedDict, total=False):
     """Response from a Bedrock Knowledge Base retrieval request."""
 
-    guardrailAction: Literal["INTERVENED", "NONE"]
+    guardrailAction: Optional[Literal["INTERVENED", "NONE"]]
     nextToken: Optional[str]
-    retrievalResults: List[BedrockKBRetrievalResult]
+    retrievalResults: Optional[List[BedrockKBRetrievalResult]]
 
 
 ################ Bedrock Knowledge Base Request Types #################

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2265,10 +2265,14 @@ LLMResponseTypes = Union[
 ]
 
 
-DynamicPromptManagementParamLiteral = Literal[
-    "cache_control_injection_points",
-    "knowledge_bases",
-]
-"""
-If any of these params are passed, the user is trying to use dynamic prompt management
-"""
+class DynamicPromptManagementParamLiteral(str, Enum):
+    """
+    If any of these params are passed, the user is trying to use dynamic prompt management
+    """
+
+    CACHE_CONTROL_INJECTION_POINTS = "cache_control_injection_points"
+    KNOWLEDGE_BASES = "knowledge_bases"
+
+    @classmethod
+    def list_all_params(cls):
+        return [param.value for param in cls]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2263,3 +2263,12 @@ class SpecialEnums(Enum):
 LLMResponseTypes = Union[
     ModelResponse, EmbeddingResponse, ImageResponse, OpenAIFileObject
 ]
+
+
+DynamicPromptManagementParamLiteral = Literal[
+    "cache_control_injection_points",
+    "knowledge_bases",
+]
+"""
+If any of these params are passed, the user is trying to use dynamic prompt management
+"""

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -95,3 +95,49 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call():
     )
     assert response is not None
 
+
+@pytest.mark.asyncio
+async def test_openai_with_knowledge_base_mock_openai():
+    """
+    Tests that knowledge base content is correctly passed to the OpenAI API call
+    """
+    litellm.set_verbose = True
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key="fake-api-key")
+
+    with patch.object(
+        client.chat.completions.with_raw_response, "create"
+    ) as mock_client:
+        try:
+            await litellm.acompletion(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "what is litellm?"}],
+                knowledge_bases = [
+                    "T37J8R4WTM"
+                ],
+                client=client,
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        # Verify the API was called
+        mock_client.assert_called_once()
+        request_body = mock_client.call_args.kwargs
+        
+        # Verify the request contains messages with knowledge base context
+        assert "messages" in request_body
+        messages = request_body["messages"]
+        
+        # We expect at least 2 messages:
+        # 1. User message with the question
+        # 2. User message with the knowledge base context
+        assert len(messages) >= 2
+        
+        print("request messages:", json.dumps(messages, indent=4, default=str))
+
+        # assert message[1] is the user message with the knowledge base context
+        assert messages[1]["role"] == "user"
+        assert BedrockKnowledgeBaseHook.CONTENT_PREFIX_STRING in messages[1]["content"]
+
+

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -84,16 +84,16 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call():
     """
     Test that the Bedrock Knowledge Base Hook works when making a real llm api call
     """
-    from openai import AsyncOpenAI
     litellm._turn_on_debug()
-    client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    async_client = AsyncHTTPHandler()
+    litellm.callbacks = [BedrockKnowledgeBaseHook()]
     response = await litellm.acompletion(
-        model="gpt-4o",
+        model="anthropic/claude-3-5-haiku-latest",
         messages=[{"role": "user", "content": "what is litellm?"}],
         knowledge_bases = [
             "T37J8R4WTM"
         ],
-        client=client
+        client=async_client
     )
     assert response is not None
 
@@ -103,6 +103,7 @@ async def test_openai_with_knowledge_base_mock_openai():
     """
     Tests that knowledge base content is correctly passed to the OpenAI API call
     """
+    litellm.callbacks = [BedrockKnowledgeBaseHook()]
     litellm.set_verbose = True
     from openai import AsyncOpenAI
 

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -31,3 +31,17 @@ async def test_basic_bedrock_knowledgebase_retrieval():
     )
     assert response is not None
 
+
+@pytest.mark.asyncio
+async def test_e2e_bedrock_knowledgebase_retrieval_with_completion():
+    litellm._turn_on_debug()
+    response = await litellm.acompletion(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "what is litellm?"}],
+        knowledge_bases = [
+            "T37J8R4WTM"
+        ]
+        
+    )
+    assert response is not None
+

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -27,7 +27,7 @@ async def test_basic_bedrock_knowledgebase_retrieval():
 
     bedrock_knowledgebase_hook = BedrockKnowledgeBaseHook()
     response = await bedrock_knowledgebase_hook.make_bedrock_kb_retrieve_request(
-        knowledge_base_id="test_knowledge_base_id",
+        knowledge_base_id="T37J8R4WTM",
         query="what is litellm?",
     )
     assert response is not None
@@ -84,14 +84,16 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call():
     """
     Test that the Bedrock Knowledge Base Hook works when making a real llm api call
     """
+    from openai import AsyncOpenAI
     litellm._turn_on_debug()
+    client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
     response = await litellm.acompletion(
         model="gpt-4o",
         messages=[{"role": "user", "content": "what is litellm?"}],
         knowledge_bases = [
             "T37J8R4WTM"
-        ]
-        
+        ],
+        client=client
     )
     assert response is not None
 

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -11,7 +11,7 @@ import gzip
 import json
 import logging
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, Mock
 
 import pytest
 
@@ -19,6 +19,7 @@ import litellm
 from litellm import completion
 from litellm._logging import verbose_logger
 from litellm.integrations.rag_hooks.bedrock_knowledgebase import BedrockKnowledgeBaseHook
+from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler
 
 
 @pytest.mark.asyncio
@@ -34,6 +35,55 @@ async def test_basic_bedrock_knowledgebase_retrieval():
 
 @pytest.mark.asyncio
 async def test_e2e_bedrock_knowledgebase_retrieval_with_completion():
+    litellm._turn_on_debug()
+    client = AsyncHTTPHandler()
+
+    with patch.object(client, "post") as mock_post:
+        # Mock the response for the LLM call
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_post.return_value = mock_response
+        try:
+            response = await litellm.acompletion(
+                model="anthropic/claude-3.5-sonnet",
+                messages=[{"role": "user", "content": "what is litellm?"}],
+                knowledge_bases = [
+                    "T37J8R4WTM"
+                ],
+                client=client
+        )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        # Verify the LLM request was made
+        mock_post.assert_called_once()
+        
+        # Verify the request body
+        print("call args:", mock_post.call_args)
+        request_body = mock_post.call_args.kwargs["json"]
+        print("Request body:", json.dumps(request_body, indent=4, default=str))
+        
+        # Assert content from the knowedge base was applied to the request
+        
+        # 1. we should have 2 content blocks, the first is the user message, the second is the context from the knowledge base
+        content = request_body["messages"][0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "text"
+        assert content[1]["type"] == "text"
+
+        # 2. the message with the context should have the bedrock knowledge base prefix string
+        # this helps confirm that the context from the knowledge base was applied to the request
+        assert BedrockKnowledgeBaseHook.CONTENT_PREFIX_STRING in content[1]["text"]
+        
+
+
+@pytest.mark.asyncio
+async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call():
+    """
+    Test that the Bedrock Knowledge Base Hook works when making a real llm api call
+    """
     litellm._turn_on_debug()
     response = await litellm.acompletion(
         model="gpt-4o",

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -1,0 +1,33 @@
+import io
+import os
+import sys
+
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import asyncio
+import litellm
+import gzip
+import json
+import logging
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import litellm
+from litellm import completion
+from litellm._logging import verbose_logger
+from litellm.integrations.rag_hooks.bedrock_knowledgebase import BedrockKnowledgeBaseHook
+
+
+@pytest.mark.asyncio
+async def test_basic_bedrock_knowledgebase_retrieval():
+
+    bedrock_knowledgebase_hook = BedrockKnowledgeBaseHook()
+    response = await bedrock_knowledgebase_hook.make_bedrock_kb_retrieve_request(
+        knowledge_base_id="test_knowledge_base_id",
+        query="what is litellm?",
+    )
+    assert response is not None
+

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -34,6 +34,7 @@ from litellm.integrations.opentelemetry import OpenTelemetry
 from litellm.integrations.mlflow import MlflowLogger
 from litellm.integrations.argilla import ArgillaLogger
 from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
+from litellm.integrations.rag_hooks.bedrock_knowledgebase import BedrockKnowledgeBaseHook
 from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,
 )
@@ -77,6 +78,7 @@ callback_class_str_to_classType = {
     "gcs_pubsub": GcsPubSubLogger,
     "anthropic_cache_control_hook": AnthropicCacheControlHook,
     "agentops": AgentOps,
+    "bedrock_knowledgebase": BedrockKnowledgeBaseHook,
 }
 
 expected_env_vars = {

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -78,7 +78,7 @@ callback_class_str_to_classType = {
     "gcs_pubsub": GcsPubSubLogger,
     "anthropic_cache_control_hook": AnthropicCacheControlHook,
     "agentops": AgentOps,
-    "bedrock_knowledgebase": BedrockKnowledgeBaseHook,
+    "bedrock_knowledgebase_hook": BedrockKnowledgeBaseHook,
 }
 
 expected_env_vars = {


### PR DESCRIPTION
## [Feat] Add support for using Bedrock Knowledge Bases with LiteLLM /chat/completions requests

# Using Knowledge Bases with LiteLLM

LiteLLM integrates with AWS Bedrock Knowledge Bases, allowing your models to access your organization's data for more accurate and contextually relevant responses.

## Quick Start

In order to use a Bedrock Knowledge Base with LiteLLM, you need to pass `knowledge_bases` as a parameter to the completion request. Where `knowledge_bases` is a list of Bedrock Knowledge Base IDs.

### LiteLLM Python SDK

```python showLineNumbers title="Basic Bedrock Knowledge Base Usage"
import os
import litellm


# Make a completion request with knowledge_bases parameter
response = await litellm.acompletion(
    model="anthropic/claude-3-5-sonnet", 
    messages=[{"role": "user", "content": "What is litellm?"}],
    knowledge_bases=["YOUR_KNOWLEDGE_BASE_ID"]  # e.g., "T37J8R4WTM"
)

print(response.choices[0].message.content)
```

### LiteLLM Proxy

#### 1. Configure your proxy

```yaml showLineNumbers title="config.yaml"
model_list:
  - model_name: claude-3-5-sonnet
    litellm_params:
      model: anthropic/claude-3-5-sonnet
      api_key: os.environ/ANTHROPIC_API_KEY

```

#### 2. Make a request with knowledge_bases parameter


<Tabs>
<TabItem value="curl" label="Curl">

```bash showLineNumbers title="Curl Request to LiteLLM Proxy"
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -d '{
    "model": "claude-3-5-sonnet",
    "messages": [{"role": "user", "content": "What is litellm?"}],
    "knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]
  }'
```

</TabItem>

<TabItem value="openai-sdk" label="OpenAI Python SDK">

```python showLineNumbers title="OpenAI Python SDK Request"
from openai import OpenAI

# Initialize client with your LiteLLM proxy URL
client = OpenAI(
    base_url="http://localhost:4000",
    api_key="your-litellm-api-key"
)

# Make a completion request with knowledge_bases parameter
response = client.chat.completions.create(
    model="claude-3-5-sonnet",
    messages=[{"role": "user", "content": "What is litellm?"}],
    extra_body={"knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]}
)

print(response.choices[0].message.content)
```

</TabItem>
</Tabs>

## How It Works

LiteLLM implements a `BedrockKnowledgeBaseHook` that intercepts your completion requests for handling the integration with Bedrock Knowledge Bases.

1. You make a completion request with the `knowledge_bases` parameter
2. LiteLLM automatically:
   - Uses your last message as the query to retrieve relevant information from the Knowledge Base
   - Adds the retrieved context to your conversation
   - Sends the augmented messages to the model

### Example Transformation

When you pass `knowledge_bases=["YOUR_KNOWLEDGE_BASE_ID"]`, your request flows through these steps:

**1. Original Request to LiteLLM:**
```json
{
    "model": "anthropic/claude-3-5-sonnet",
    "messages": [
        {"role": "user", "content": "What is litellm?"}
    ],
    "knowledge_bases": ["YOUR_KNOWLEDGE_BASE_ID"]
}
```

**2. Request to AWS Bedrock Knowledge Base:**
```json
{
    "retrievalQuery": {
        "text": "What is litellm?"
    }
}
```
This is sent to: `https://bedrock-agent-runtime.{aws_region}.amazonaws.com/knowledgebases/YOUR_KNOWLEDGE_BASE_ID/retrieve`

**3. Final Request to LiteLLM:**
```json
{
    "model": "anthropic/claude-3-5-sonnet",
    "messages": [
        {"role": "user", "content": "What is litellm?"},
        {"role": "user", "content": "Context: \n\nLiteLLM is an open-source SDK to simplify LLM API calls across providers (OpenAI, Claude, etc). It provides a standardized interface with robust error handling, streaming, and observability tools."}
    ]
}
```

This process happens automatically whenever you include the `knowledge_bases` parameter in your request.

## API Reference

### LiteLLM Completion Knowledge Base Parameters

When using the Knowledge Base integration with LiteLLM, you can include the following parameters:

| Parameter | Type | Description |
|-----------|------|-------------|
| `knowledge_bases` | List[str] | List of Bedrock Knowledge Base IDs to query |


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


