### PR TITLE
[Bug Fix] Responses API - fix for handling multiturn responses API sessions 

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,7 +1,10 @@
 model_list:
-  - model_name: anthropic/*
+  - model_name: computer-user-agent
     litellm_params:
-      model: anthropic/*
-      api_key: os.environ/ANTHROPIC_API_KEY
+      model: azure/computer-use-preview
+      truncation: auto
+      api_key: os.environ/AZURE_RESPONSES_OPENAI_API_KEY
+      api_base: os.environ/AZURE_RESPONSES_OPENAI_ENDPOINT
+      api_version: os.environ/AZURE_RESPONSES_OPENAI_API_VERSION
 general_settings:
   store_prompts_in_spend_logs: true

--- a/tests/litellm/responses/test_responses_utils.py
+++ b/tests/litellm/responses/test_responses_utils.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import os
 import sys
@@ -83,6 +84,35 @@ class TestResponsesAPIRequestUtils:
         assert "model" not in result
         assert result["temperature"] == 0.7
         assert result["max_output_tokens"] == 100
+
+    def test_decode_previous_response_id_to_original_previous_response_id(self):
+        """Test decoding a LiteLLM encoded previous_response_id to the original previous_response_id"""
+        # Setup
+        test_provider = "openai"
+        test_model_id = "gpt-4o"
+        original_response_id = "resp_abc123"
+
+        # Use the helper method to build an encoded response ID
+        encoded_id = ResponsesAPIRequestUtils._build_responses_api_response_id(
+            custom_llm_provider=test_provider,
+            model_id=test_model_id,
+            response_id=original_response_id,
+        )
+
+        # Execute
+        result = ResponsesAPIRequestUtils.decode_previous_response_id_to_original_previous_response_id(
+            encoded_id
+        )
+
+        # Assert
+        assert result == original_response_id
+
+        # Test with a non-encoded ID
+        plain_id = "resp_xyz789"
+        result_plain = ResponsesAPIRequestUtils.decode_previous_response_id_to_original_previous_response_id(
+            plain_id
+        )
+        assert result_plain == plain_id
 
 
 class TestResponseAPILoggingUtils:

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -314,4 +314,24 @@ class BaseResponsesAPITest(ABC):
             else:
                 raise ValueError("response is not a ResponsesAPIResponse")
     
+    @pytest.mark.asyncio
+    async def test_multiturn_responses_api(self):
+        litellm._turn_on_debug()
+        litellm.set_verbose = True
+        base_completion_call_args = self.get_base_completion_call_args()
+        response_1 = await litellm.aresponses(
+            input="Basic ping", max_output_tokens=20, **base_completion_call_args
+        )
 
+        # follow up with a second request
+        response_1_id = response_1.id
+        response_2 = await litellm.aresponses(
+            input="Basic ping", 
+            max_output_tokens=20, 
+            previous_response_id=response_1_id,
+            **base_completion_call_args
+        )
+
+        # assert the response is not None
+        assert response_1 is not None
+        assert response_2 is not None


### PR DESCRIPTION
## [Bug Fix] Responses API - fix for handling multiturn responses API sessions 

This PR fixes an issue with multi-turn conversations in the Responses API. LiteLLM encodes additional metadata in response IDs (including custom_llm_provider and model_id) to ensure we can maintain sticky sessions when load balancing. However, when this encoded ID is passed as previous_response_id to upstream LLM providers, they reject it as invalid.

The fix adds a decoder that extracts the original response ID before sending requests upstream, maintaining compatibility while preserving LiteLLM's enhanced ID format for internal use.

If unable to decode, then use the previous_response_id passed in 

<!-- e.g. "Implement user authentication feature" -->

## Testing 
- Unit tests confirm proper decoding of both encoded and plain response IDs
- Integration test verifies end-to-end functionality for multi-turn conversations


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on (`make test-unit`)[https://docs.litellm.ai/docs/extras/contributing_code]
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


