### PR TITLE
adding cache delete keys for in-memory cache

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -669,7 +669,11 @@ class Cache:
     async def delete_cache_keys(self, keys):
         cache_delete_cache_keys = getattr(self.cache, "delete_cache_keys")
         if cache_delete_cache_keys:
-            return await cache_delete_cache_keys(keys)
+            if self.type == LiteLLMCacheType.LOCAL:
+                cache_delete_cache_keys(keys)
+            else:
+                await cache_delete_cache_keys(keys)
+
         return None
 
     async def disconnect(self):

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -192,9 +192,11 @@ class InMemoryCache(BaseCache):
     async def disconnect(self):
         pass
 
-    def delete_cache(self, key):
-        self.cache_dict.pop(key, None)
-        self.ttl_dict.pop(key, None)
+    def delete_cache_keys(self, keys: List[str]):
+        for key in keys:
+            self.cache_dict.pop(key, None)
+            self.ttl_dict.pop(key, None)
+        
 
     async def async_get_ttl(self, key: str) -> Optional[int]:
         """

--- a/litellm/proxy/caching_routes.py
+++ b/litellm/proxy/caching_routes.py
@@ -145,12 +145,7 @@ async def cache_delete(request: Request):
         request_data = await _read_request_body(request=request)
         keys = request_data.get("keys", None)
         
-        if litellm.cache.type == LiteLLMCacheType.REDIS:
-            await litellm.cache.delete_cache_keys(keys=keys)
-            return {
-                "status": "success",
-            }
-        elif litellm.cache.type == LiteLLMCacheType.LOCAL:
+        if litellm.cache.type == LiteLLMCacheType.REDIS or litellm.cache.type == LiteLLMCacheType.LOCAL:
             await litellm.cache.delete_cache_keys(keys=keys)
             return {
                 "status": "success",


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## How to reproduce the issue

Git checkout and build the image prior to the proposed changes:

```bash
git checkout 914ab0080594299591d64fecefb7a23c3ac9931f # <-- commit before proposed changes
docker build --platform linux/amd64 -f Dockerfile -t litellm-test:latest .
```

To reproduce the issue, you need to set up a `docker-compose.yaml` file.

```yaml
services:
  litellm:
    image: litellm-test:latest
    container_name: litellm
    environment:
      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
      LITELLM_SALT_KEY: ${LITELLM_SALT_KEY}
      DATABASE_URL: "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
    ports:
      - "4000:4000"
    volumes:
      - ./proxy_server_config.yaml:/app/config.yaml
    command: --config /app/config.yaml --detailed_debug
    restart: unless-stopped

  db:
    image: postgres:16
    restart: always
    environment:
      POSTGRES_DB: litellm
      POSTGRES_USER: llmproxy
      POSTGRES_PASSWORD: dbpassword9090
    ports:
      - "5432:5432"
    volumes:
      - postgres_data:/var/lib/postgresql/data
    healthcheck:
      test: ["CMD", "pg_isready"]
      interval: 1s
      timeout: 5s
      retries: 10

volumes:
  postgres_data:
    name: litellm_postgres_data
```

Here is the `config.yaml` file I am using:

```yaml
model_list:
  - model_name: claude-3-7-sonnet-thinking
    litellm_params:
      model: anthropic/claude-3-7-sonnet-20250219
      api_key: os.environ/ANTHROPIC_API_KEY
      temperature: 1
      thinking: { "type": "enabled", "budget_tokens": 1024 }

general_settings:
  proxy_batch_write_at: 60 # Batch write spend updates every 60s
  database_connection_pool_limit: 10 # limit the number of database connections to = MAX Number of DB Connections/Number of instances of litellm proxy (Around 10-20 is good number)
  store_model_in_db: true
  store_prompts_in_spend_logs: true

litellm_settings:
  success_callback: ["langfuse"] # list of success callbacks
  callbacks: ["langfuse"] # list of callbacks - runs on success and failure
  request_timeout: 180 # raise Timeout error if call takes longer than 180 seconds. Default value is 6000seconds if not set
  set_verbose: False # Switch off Debug Logging, ensure your logs do not have any debugging on
  json_logs: true # Get logs in json format
  turn_off_message_logging: False
  redact_user_api_key_info: False
  num_retries: 3
  cache: True
  cache_params: # set cache params for redis
    type: local
    supported_call_types:
      ["acompletion", "atext_completion", "aembedding", "atranscription"]
    ttl: 36000 # 60 minutes caching
```

Here is the curl requests I am making:

```bash
# Call litellm
curl -i http://0.0.0.0:4000/v1/chat/completions -H 'x-api-key: $LITELLM_API_KEY' -H "Content-Type: application/json" -d '{
     "model": "claude-3-7-sonnet-thinking",
     "messages": [{"role": "user", "content": "write a poem about litellm!"}],
     "temperature": 1.0
   }'

# Call the /cache/delete endpoint
curl --location 'http://localhost:4000/cache/delete' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer $LITELLM_API_KEY' \
--data '{
    "keys": [
        "7c134b368318118f2c64f0593a77fd9eb38102b7cd3a6c38ef753129c5e50796"
    ]
}'
> Cache Delete Failed(500: Cache type local does not support deleting a key. only `redis` is supported)
```

Then re-run everything with my latest commit.

Then if you:

1. Run the first curl command of `write a poem about litellm!` <-- this takes some time
2. Re-run the same command <-- this is instant
3. Run the second curl command to delete the cache key
4. Re-run the curl command of `write a poem about litellm!` and you will see that it takes some time.
5. Re-run the same command <-- this is instant

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes