### PR TITLE
Update prisma to 0.15.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2632,14 +2632,14 @@ files = [
 
 [[package]]
 name = "prisma"
-version = "0.11.0"
+version = "0.15.0"
 description = "Prisma Client Python is an auto-generated and fully type-safe database client"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 groups = ["main", "proxy-dev"]
 files = [
-    {file = "prisma-0.11.0-py3-none-any.whl", hash = "sha256:22bb869e59a2968b99f3483bb417717273ffbc569fd1e9ceed95e5614cbaf53a"},
-    {file = "prisma-0.11.0.tar.gz", hash = "sha256:3f2f2fd2361e1ec5ff655f2a04c7860c2f2a5bc4c91f78ca9c5c6349735bf693"},
+    {file = "prisma-0.15.0-py3-none-any.whl", hash = "sha256:de949cc94d3d91243615f22ff64490aa6e2d7cb81aabffce53d92bd3977c09a4"},
+    {file = "prisma-0.15.0.tar.gz", hash = "sha256:5cd6402aa8322625db3fc1152040404e7fc471fe7f8fa3a314fa8a99529ca107"},
 ]
 
 [package.dependencies]
@@ -2647,10 +2647,11 @@ click = ">=7.1.2"
 httpx = ">=0.19.0"
 jinja2 = ">=2.11.2"
 nodeenv = "*"
-pydantic = ">=1.8.0,<3"
+pydantic = ">=1.10.0,<3"
 python-dotenv = ">=0.12.0"
+StrEnum = {version = "*", markers = "python_version < \"3.11\""}
 tomlkit = "*"
-typing-extensions = ">=4.0.1"
+typing-extensions = ">=4.5.0"
 
 [package.extras]
 all = ["nodejs-bin"]
@@ -3798,6 +3799,24 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "strenum"
+version = "0.4.15"
+description = "An Enum that inherits from str."
+optional = false
+python-versions = "*"
+groups = ["main", "proxy-dev"]
+markers = "python_version <= \"3.10\""
+files = [
+    {file = "StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659"},
+    {file = "StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff"},
+]
+
+[package.extras]
+docs = ["myst-parser[linkify]", "sphinx", "sphinx-rtd-theme"]
+release = ["twine"]
+test = ["pylint", "pytest", "pytest-black", "pytest-cov", "pytest-pylint"]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
@@ -4623,4 +4642,4 @@ proxy = ["PyJWT", "apscheduler", "backoff", "boto3", "cryptography", "fastapi", 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<4.0, !=3.9.7"
-content-hash = "ba7691ffdf305d212bf661fbe0f2a6919043852d993721189c6b7b92d4a127c0"
+content-hash = "dc16cabb4229d4d982d48ce67840091cb15886f26d2853bbb295fb044f9ca93f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ fastapi-sso = { version = "^0.16.0", optional = true }
 PyJWT = { version = "^2.8.0", optional = true }
 python-multipart = { version = "^0.0.18", optional = true}
 cryptography = {version = "^43.0.1", optional = true}
-prisma = {version = "0.11.0", optional = true}
+prisma = {version = "^0.15.0", optional = true}
 azure-identity = {version = "^1.15.0", optional = true}
 azure-keyvault-secrets = {version = "^4.8.0", optional = true}
 google-cloud-kms = {version = "^2.21.3", optional = true}
@@ -113,7 +113,7 @@ opentelemetry-sdk = "1.25.0"
 opentelemetry-exporter-otlp = "1.25.0"
 
 [tool.poetry.group.proxy-dev.dependencies]
-prisma = "0.11.0"
+prisma = "^0.15.0"
 hypercorn = "^0.15.0"
 prometheus-client = "0.20.0"
 opentelemetry-api = "1.25.0"


### PR DESCRIPTION
With older versions of prisma, I get various errors when running `make test-unit`. For example with prisma 0.11.0, I get:

![Screenshot 2025-04-30 at 7 23 27 PM](https://github.com/user-attachments/assets/beba7389-e132-457e-a95a-dc7ac0f4c626)

```
====================================== short test summary info =======================================
ERROR tests/litellm/proxy/auth/test_auth_exception_handler.py - AttributeError: module 'prisma._types'
  has no attribute 'SortMode'
ERROR tests/litellm/proxy/db/test_exception_handler.py - AttributeError: module 'prisma._types'
  has no attribute 'SortMode'
!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!
=================================== 4 warnings, 2 errors in 2.35s ====================================
```

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


