### PR TITLE
message support for vertex bedrock - 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ config.yaml
 tests/litellm/litellm_core_utils/llm_cost_calc/log.txt
 tests/test_custom_dir/*
 test.py
+task.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "LiteLLM Config Debug",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "litellm.proxy.proxy_cli",
+      "args": ["--config", "config.yaml", "--port", "4000", "--debug"],
+      "justMyCode": false,
+      "env": {
+        "DEBUG": "True"
+      }
+    }
+  ]
+}

--- a/litellm/llms/anthropic/experimental_pass_through/messages/DAY1_SUMMARY.md
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/DAY1_SUMMARY.md
@@ -1,0 +1,46 @@
+# Day 1 Accomplishments
+
+## 1. Updated Test File
+
+Updated `tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py` to include comprehensive validation of Anthropic Messages API responses. The new validation checks:
+
+- All required fields in the Anthropic Messages API format
+- Content structure and types
+- Different response formats for streaming vs non-streaming
+- Proper handling of error cases
+
+## 2. Refactored Transformation Logic
+
+Refactored the `litellm/llms/anthropic/experimental_pass_through/messages/transformation.py` file to split the logic into modular functions:
+
+- `transform_request`: Converts LiteLLM request format to Anthropic's format
+- `transform_response`: Processes the response from Anthropic
+- `map_openai_params`: Maps OpenAI-style parameters to Anthropic parameters
+- `transform_streaming_response`: Handles streaming responses
+
+## 3. Created Implementation Stubs
+
+Created stub implementations for:
+
+- Bedrock Invoke: `litellm/llms/bedrock/anthropic_messages/invoke_transformation.py`
+- Bedrock Converse: `litellm/llms/bedrock/anthropic_messages/converse_transformation.py`
+- Vertex AI: `litellm/llms/vertex_ai/anthropic_messages/transformation.py`
+
+Each stub includes:
+
+- The necessary class definition implementing `BaseAnthropicMessagesConfig`
+- Placeholder methods for the required transformations
+- Comments explaining what each part will do
+
+## 4. Created Implementation Documentation
+
+Created documentation files:
+
+- `README.md`: Overall implementation plan and architecture
+- This summary file tracking progress
+
+## Next Steps (Day 2)
+
+1. Move the current Anthropic handler to use `BaseLLMHTTPHandler`
+2. Complete the implementation of the transformation functions
+3. Test the refactored code with the existing Anthropic API

--- a/litellm/llms/anthropic/experimental_pass_through/messages/README.md
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/README.md
@@ -1,0 +1,94 @@
+# Anthropic /v1/messages API Support for Bedrock and Vertex AI
+
+This implementation provides /v1/messages API support for Anthropic Claude models on Vertex AI and AWS Bedrock (Invoke & Converse).
+
+## Implementation Status
+
+| Provider | Family    | Streaming | Model String Example                                       |
+| -------- | --------- | --------- | ---------------------------------------------------------- |
+| Vertex   | Anthropic | 🔄        | vertex_ai/claude-3-sonnet@20240229                         |
+| Bedrock  | Invoke    | 🔄        | bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0   |
+| Bedrock  | Converse  | 🔄        | bedrock/converse/anthropic.claude-3-5-sonnet-20240620-v1:0 |
+
+Legend:
+
+- ✅ = Implemented and tested
+- 🔄 = In progress
+- ❌ = Not implemented
+
+## Implementation Plan
+
+### Day 1: Setup and Test Updates
+
+- ✅ Update tests to validate proper Anthropic Messages API response structure
+- ✅ Refactor transformation.py to split logic into modular functions
+- ✅ Create stubs for Bedrock and Vertex AI implementations
+
+### Day 2: Refactor Current Implementation
+
+- 🔄 Move Anthropic sync/async calls to use BaseLLMHTTPHandler
+- 🔄 Implement transform_request and transform_response functions
+- 🔄 Ensure streaming response handling works correctly
+
+### Day 3: Implement Bedrock Invoke Support
+
+- 🔄 Complete Bedrock Invoke implementation
+- 🔄 Add support for streaming responses
+- 🔄 Test with real AWS credentials
+
+### Day 4: Implement Bedrock Converse and Vertex AI
+
+- 🔄 Complete Bedrock Converse implementation
+- 🔄 Complete Vertex AI implementation
+- 🔄 Test both implementations with real credentials
+
+### Day 5: Integration Testing and Documentation
+
+- 🔄 Perform integration testing across all implementations
+- 🔄 Update documentation and examples
+- 🔄 Create final changelog
+
+## Usage
+
+Once implemented, users will be able to call Anthropic models through the OpenAI-style `/v1/messages` endpoint:
+
+```python
+# Bedrock Invoke example
+response = await litellm.anthropic.messages.acreate(
+    messages=[{"role": "user", "content": "Hello, Claude!"}],
+    model="bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    max_tokens=100,
+    stream=True,
+)
+
+# Bedrock Converse example
+response = await litellm.anthropic.messages.acreate(
+    messages=[{"role": "user", "content": "Hello, Claude!"}],
+    model="bedrock/converse/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    max_tokens=100,
+)
+
+# Vertex AI example
+response = await litellm.anthropic.messages.acreate(
+    messages=[{"role": "user", "content": "Hello, Claude!"}],
+    model="vertex_ai/claude-3-sonnet@20240229",
+    max_tokens=100,
+)
+```
+
+## Architecture
+
+The implementation uses the following components:
+
+1. `transformation.py` - Contains the core transformation logic for Anthropic Messages
+2. `invoke_transformation.py` - Bedrock Invoke specific transformations
+3. `converse_transformation.py` - Bedrock Converse specific transformations
+4. `vertex_ai/anthropic_messages/transformation.py` - Vertex AI specific transformations
+5. `handler.py` - Entry point for API calls, moved to use BaseLLMHTTPHandler
+
+All implementations follow the same pattern:
+
+- `transform_request` - Transforms the request to the provider's format
+- `transform_response` - Transforms the response back to Anthropic's format
+- `map_openai_params` - Maps OpenAI-style parameters to Anthropic parameters
+- `transform_streaming_response` - Handles streaming responses

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import httpx
 

--- a/litellm/llms/bedrock/anthropic_messages/converse_transformation.py
+++ b/litellm/llms/bedrock/anthropic_messages/converse_transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import httpx
 

--- a/litellm/llms/bedrock/anthropic_messages/converse_transformation.py
+++ b/litellm/llms/bedrock/anthropic_messages/converse_transformation.py
@@ -10,14 +10,13 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
-DEFAULT_ANTHROPIC_API_BASE = "https://api.anthropic.com"
-DEFAULT_ANTHROPIC_API_VERSION = "2023-06-01"
+DEFAULT_ANTHROPIC_API_VERSION = "bedrock-2023-05-31"
 
 
-class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
+class BedrockConverseAnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     def get_supported_anthropic_messages_params(self, model: str) -> list:
         """
-        Return the supported parameters for Anthropic Messages API
+        Return the supported parameters for Bedrock Converse Anthropic Messages API
         """
         return [
             "messages",
@@ -30,14 +29,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             "top_k",
             "tools",
             "tool_choice",
-            "thinking",
-            # TODO: Add Anthropic `metadata` support
-            # "metadata",
+            "anthropic_version"
         ]
     
     def map_openai_params(self, model: str, optional_params: dict) -> dict:
         """
-        Maps OpenAI-style parameters to Anthropic parameters
+        Maps OpenAI-style parameters to Bedrock Anthropic parameters
         """
         mapped_params = {}
         
@@ -59,12 +56,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
     def get_complete_url(self, api_base: Optional[str], model: str) -> str:
         """
-        Get the complete URL for the Anthropic Messages API
+        Get the complete URL for the Bedrock Converse API
+        For Bedrock, this will be handled differently in the main handler
         """
-        api_base = api_base or DEFAULT_ANTHROPIC_API_BASE
-        if not api_base.endswith("/v1/messages"):
-            api_base = f"{api_base}/v1/messages"
-        return api_base
+        return api_base or ""
 
     def validate_environment(
         self,
@@ -74,11 +69,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     ) -> dict:
         """
         Validate and return the environment for the API call
+        Bedrock uses AWS credentials (not API keys), so this is different
         """
-        if "x-api-key" not in headers:
-            headers["x-api-key"] = api_key
-        if "anthropic-version" not in headers:
-            headers["anthropic-version"] = DEFAULT_ANTHROPIC_API_VERSION
+        # For Bedrock, authentication is handled through AWS credentials
+        # We just need to ensure the content-type is set
         if "content-type" not in headers:
             headers["content-type"] = "application/json"
         return headers
@@ -92,7 +86,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         headers: dict,
     ) -> dict:
         """
-        Transform the request to match Anthropic's API format
+        Transform the request to match Bedrock Converse Anthropic format
         """
         # Map OpenAI style parameters to Anthropic parameters
         mapped_params = self.map_openai_params(model, optional_params.copy())
@@ -103,9 +97,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             if k in self.get_supported_anthropic_messages_params(model)
         }
         
-        # Combine the request data
+        # Ensure anthropic_version is set
+        if "anthropic_version" not in anthropic_params:
+            anthropic_params["anthropic_version"] = DEFAULT_ANTHROPIC_API_VERSION
+        
+        # Combine the request data - Converse format might differ slightly from Invoke
         data = {
-            "model": model,
             "messages": messages,
             **anthropic_params,
             **mapped_params,
@@ -128,13 +125,14 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         json_mode: bool = False,
     ) -> AnthropicMessagesResponse:
         """
-        Transform the raw response to match the expected format
+        Transform the raw Bedrock Converse response to match the expected Anthropic format
         """
-        # For Anthropic Messages, the response is already in the correct format
-        # Just parse the JSON response
+        # Parse the Bedrock Converse response
         response_json = raw_response.json()
         
-        # Return the parsed response
+        # Transform to Anthropic Messages format if needed
+        # TODO: Implement the specific transformations needed for Converse
+        
         return response_json
     
     def transform_streaming_response(
@@ -145,8 +143,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         request_body: Dict[str, Any]
     ) -> Any:
         """
-        Transform a streaming response from Anthropic
+        Transform a streaming response from Bedrock Converse Anthropic
         """
-        # The streaming response processing is handled in the handler.py file
-        # This function is a placeholder for completeness
-        return streaming_response
+        # TODO: Implement the streaming response transformation for Converse
+        return streaming_response 

--- a/litellm/llms/bedrock/anthropic_messages/invoke_transformation.py
+++ b/litellm/llms/bedrock/anthropic_messages/invoke_transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import httpx
 

--- a/litellm/llms/bedrock/anthropic_messages/invoke_transformation.py
+++ b/litellm/llms/bedrock/anthropic_messages/invoke_transformation.py
@@ -10,14 +10,13 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
-DEFAULT_ANTHROPIC_API_BASE = "https://api.anthropic.com"
-DEFAULT_ANTHROPIC_API_VERSION = "2023-06-01"
+DEFAULT_ANTHROPIC_API_VERSION = "bedrock-2023-05-31"
 
 
-class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
+class BedrockInvokeAnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     def get_supported_anthropic_messages_params(self, model: str) -> list:
         """
-        Return the supported parameters for Anthropic Messages API
+        Return the supported parameters for Bedrock Invoke Anthropic Messages API
         """
         return [
             "messages",
@@ -30,14 +29,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             "top_k",
             "tools",
             "tool_choice",
-            "thinking",
-            # TODO: Add Anthropic `metadata` support
-            # "metadata",
+            "anthropic_version"
         ]
     
     def map_openai_params(self, model: str, optional_params: dict) -> dict:
         """
-        Maps OpenAI-style parameters to Anthropic parameters
+        Maps OpenAI-style parameters to Bedrock Anthropic parameters
         """
         mapped_params = {}
         
@@ -59,12 +56,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
     def get_complete_url(self, api_base: Optional[str], model: str) -> str:
         """
-        Get the complete URL for the Anthropic Messages API
+        Get the complete URL for the Bedrock Invoke API
+        For Bedrock, this will be handled differently in the main handler
         """
-        api_base = api_base or DEFAULT_ANTHROPIC_API_BASE
-        if not api_base.endswith("/v1/messages"):
-            api_base = f"{api_base}/v1/messages"
-        return api_base
+        return api_base or ""
 
     def validate_environment(
         self,
@@ -74,11 +69,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     ) -> dict:
         """
         Validate and return the environment for the API call
+        Bedrock uses AWS credentials (not API keys), so this is different
         """
-        if "x-api-key" not in headers:
-            headers["x-api-key"] = api_key
-        if "anthropic-version" not in headers:
-            headers["anthropic-version"] = DEFAULT_ANTHROPIC_API_VERSION
+        # For Bedrock, authentication is handled through AWS credentials
+        # We just need to ensure the content-type is set
         if "content-type" not in headers:
             headers["content-type"] = "application/json"
         return headers
@@ -92,7 +86,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         headers: dict,
     ) -> dict:
         """
-        Transform the request to match Anthropic's API format
+        Transform the request to match Bedrock Invoke Anthropic format
         """
         # Map OpenAI style parameters to Anthropic parameters
         mapped_params = self.map_openai_params(model, optional_params.copy())
@@ -103,9 +97,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             if k in self.get_supported_anthropic_messages_params(model)
         }
         
+        # Ensure anthropic_version is set
+        if "anthropic_version" not in anthropic_params:
+            anthropic_params["anthropic_version"] = DEFAULT_ANTHROPIC_API_VERSION
+        
         # Combine the request data
         data = {
-            "model": model,
             "messages": messages,
             **anthropic_params,
             **mapped_params,
@@ -128,13 +125,14 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         json_mode: bool = False,
     ) -> AnthropicMessagesResponse:
         """
-        Transform the raw response to match the expected format
+        Transform the raw Bedrock response to match the expected Anthropic format
         """
-        # For Anthropic Messages, the response is already in the correct format
-        # Just parse the JSON response
+        # Parse the Bedrock response
         response_json = raw_response.json()
         
-        # Return the parsed response
+        # Transform to Anthropic Messages format if needed
+        # TODO: Implement the specific transformations needed
+        
         return response_json
     
     def transform_streaming_response(
@@ -145,8 +143,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         request_body: Dict[str, Any]
     ) -> Any:
         """
-        Transform a streaming response from Anthropic
+        Transform a streaming response from Bedrock Invoke Anthropic
         """
-        # The streaming response processing is handled in the handler.py file
-        # This function is a placeholder for completeness
-        return streaming_response
+        # TODO: Implement the streaming response transformation
+        return streaming_response 

--- a/litellm/llms/vertex_ai/anthropic_messages/transformation.py
+++ b/litellm/llms/vertex_ai/anthropic_messages/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import httpx
 

--- a/tests/anthropic_messages_transformation_test.py
+++ b/tests/anthropic_messages_transformation_test.py
@@ -1,0 +1,134 @@
+import unittest
+import httpx
+from unittest.mock import MagicMock
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import AnthropicMessagesConfig
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+class TestAnthropicMessagesTransformation(unittest.TestCase):
+    def setUp(self):
+        self.config = AnthropicMessagesConfig()
+        self.model = "claude-3-haiku-20240307"
+        self.messages = [{"role": "user", "content": "Hello, world!"}]
+        self.logging_obj = MagicMock(spec=LiteLLMLoggingObj)
+        
+        # Create mock response
+        self.mock_response = MagicMock(spec=httpx.Response)
+        self.mock_response.json.return_value = {
+            "id": "msg_123456",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello! How can I help you today?"
+                }
+            ],
+            "model": self.model,
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 15
+            }
+        }
+    
+    def test_map_openai_params(self):
+        # Test max_tokens mapping
+        params = {"max_completion_tokens": 100}
+        mapped = self.config.map_openai_params(self.model, params)
+        self.assertEqual(mapped["max_tokens"], 100)
+        self.assertEqual(params, {})  # Ensure original param was popped
+        
+        # Test stop sequences mapping
+        params = {"stop": ["END", "STOP"]}
+        mapped = self.config.map_openai_params(self.model, params)
+        self.assertEqual(mapped["stop_sequences"], ["END", "STOP"])
+        self.assertEqual(params, {})  # Ensure original param was popped
+        
+        # Test response_format mapping
+        params = {"response_format": {"type": "json"}}
+        mapped = self.config.map_openai_params(self.model, params)
+        self.assertTrue(mapped["json_mode"])
+        self.assertEqual(params, {})  # Ensure original param was popped
+    
+    def test_get_complete_url(self):
+        # Test with no API base
+        url = self.config.get_complete_url(None, self.model)
+        self.assertEqual(url, "https://api.anthropic.com/v1/messages")
+        
+        # Test with API base without endpoint
+        url = self.config.get_complete_url("https://custom-api.example.com", self.model)
+        self.assertEqual(url, "https://custom-api.example.com/v1/messages")
+        
+        # Test with API base that already includes endpoint
+        url = self.config.get_complete_url("https://custom-api.example.com/v1/messages", self.model)
+        self.assertEqual(url, "https://custom-api.example.com/v1/messages")
+    
+    def test_validate_environment(self):
+        # Test with empty headers
+        headers = {}
+        result = self.config.validate_environment(headers, self.model, "test-api-key")
+        self.assertEqual(result["x-api-key"], "test-api-key")
+        self.assertEqual(result["anthropic-version"], "2023-06-01")
+        self.assertEqual(result["content-type"], "application/json")
+        
+        # Test with existing headers
+        headers = {
+            "x-api-key": "existing-key",
+            "anthropic-version": "custom-version",
+            "content-type": "custom-content-type"
+        }
+        result = self.config.validate_environment(headers, self.model, "test-api-key")
+        self.assertEqual(result["x-api-key"], "existing-key")
+        self.assertEqual(result["anthropic-version"], "custom-version")
+        self.assertEqual(result["content-type"], "custom-content-type")
+    
+    def test_transform_request(self):
+        optional_params = {
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "stop": ["END"],
+            "unsupported_param": "value"  # This should be excluded
+        }
+        litellm_params = {}
+        headers = {}
+        
+        result = self.config.transform_request(
+            model=self.model,
+            messages=self.messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        # Check that expected keys are present
+        self.assertEqual(result["model"], self.model)
+        self.assertEqual(result["messages"], self.messages)
+        self.assertEqual(result["max_tokens"], 100)
+        self.assertEqual(result["temperature"], 0.7)
+        self.assertEqual(result["top_p"], 0.95)
+        self.assertEqual(result["stop_sequences"], ["END"])
+        
+        # Check that unsupported params are excluded
+        self.assertNotIn("unsupported_param", result)
+    
+    def test_transform_response(self):
+        result = self.config.transform_response(
+            model=self.model,
+            raw_response=self.mock_response,
+            model_response=None,
+            logging_obj=self.logging_obj,
+            api_key="test-api-key",
+            request_data={},
+            messages=self.messages,
+            optional_params={},
+            litellm_params={}
+        )
+        
+        # Verify the result is the parsed JSON from the mock response
+        self.assertEqual(result, self.mock_response.json.return_value)
+
+if __name__ == "__main__":
+    unittest.main() 

--- a/tests/bedrock_anthropic_messages_invoke_test.py
+++ b/tests/bedrock_anthropic_messages_invoke_test.py
@@ -1,0 +1,122 @@
+import unittest
+import httpx
+from unittest.mock import MagicMock
+
+from litellm.llms.bedrock.anthropic_messages.invoke_transformation import BedrockInvokeAnthropicMessagesConfig
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+class TestBedrockInvokeAnthropicMessagesTransformation(unittest.TestCase):
+    def setUp(self):
+        self.config = BedrockInvokeAnthropicMessagesConfig()
+        self.model = "bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0"
+        self.messages = [{"role": "user", "content": "Hello, world!"}]
+        self.logging_obj = MagicMock(spec=LiteLLMLoggingObj)
+        
+        # Create mock response
+        self.mock_response = MagicMock(spec=httpx.Response)
+        self.mock_response.json.return_value = {
+            "id": "msg_123456",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello! How can I help you today?"
+                }
+            ],
+            "model": self.model,
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 15
+            }
+        }
+    
+    def test_map_openai_params(self):
+        # Test max_tokens mapping
+        params = {"max_completion_tokens": 100}
+        mapped = self.config.map_openai_params(self.model, params)
+        self.assertEqual(mapped["max_tokens"], 100)
+        self.assertEqual(params, {})  # Ensure original param was popped
+        
+        # Test stop sequences mapping
+        params = {"stop": ["END", "STOP"]}
+        mapped = self.config.map_openai_params(self.model, params)
+        self.assertEqual(mapped["stop_sequences"], ["END", "STOP"])
+        self.assertEqual(params, {})  # Ensure original param was popped
+    
+    def test_get_complete_url(self):
+        # For Bedrock, the URL handling is deferred to the main handler
+        url = self.config.get_complete_url(None, self.model)
+        self.assertEqual(url, "")
+        
+        url = self.config.get_complete_url("https://custom-api.example.com", self.model)
+        self.assertEqual(url, "https://custom-api.example.com")
+    
+    def test_validate_environment(self):
+        # Test with empty headers - Bedrock doesn't use API keys
+        headers = {}
+        result = self.config.validate_environment(headers, self.model, None)
+        self.assertEqual(result["content-type"], "application/json")
+        self.assertNotIn("x-api-key", result)
+        
+        # Test with existing headers
+        headers = {
+            "content-type": "custom-content-type"
+        }
+        result = self.config.validate_environment(headers, self.model, None)
+        self.assertEqual(result["content-type"], "custom-content-type")
+    
+    def test_transform_request(self):
+        optional_params = {
+            "max_tokens": 100,
+            "temperature": 0.7,
+            "top_p": 0.95,
+            "stop": ["END"],
+            "unsupported_param": "value"  # This should be excluded
+        }
+        litellm_params = {}
+        headers = {}
+        
+        result = self.config.transform_request(
+            model=self.model,
+            messages=self.messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        # Check that expected keys are present
+        self.assertEqual(result["messages"], self.messages)
+        self.assertEqual(result["max_tokens"], 100)
+        self.assertEqual(result["temperature"], 0.7)
+        self.assertEqual(result["top_p"], 0.95)
+        self.assertEqual(result["stop_sequences"], ["END"])
+        self.assertEqual(result["anthropic_version"], "bedrock-2023-05-31")
+        
+        # Check that model is not included (handled by Bedrock differently)
+        self.assertNotIn("model", result)
+        
+        # Check that unsupported params are excluded
+        self.assertNotIn("unsupported_param", result)
+    
+    def test_transform_response(self):
+        # This is just testing the placeholder implementation for now
+        result = self.config.transform_response(
+            model=self.model,
+            raw_response=self.mock_response,
+            model_response=None,
+            logging_obj=self.logging_obj,
+            api_key="",
+            request_data={},
+            messages=self.messages,
+            optional_params={},
+            litellm_params={}
+        )
+        
+        # Verify the result is the parsed JSON from the mock response
+        self.assertEqual(result, self.mock_response.json.return_value)
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
## Title

Allow LiteLLM users to call Anthropic models on Vertex AI and AWS Bedrock (Invoke & Converse) through the OpenAI-style /v1/messages endpoint.


## Relevant issues

Allow LiteLLM users to call Anthropic models on Vertex AI and AWS Bedrock (Invoke & Converse) through the OpenAI-style /v1/messages endpoint.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [👍  ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature


## Changes
Enhance AnthropicMessagesConfig with parameter mapping and response transformation methods
    - Added methods to map OpenAI-style parameters to Anthropic parameters.
    - Implemented request transformation to match Anthropic API format.
    - Added response transformation methods for both non-streaming and streaming responses.
    - Updated unit tests to validate response structure against the Anthropic Messages API specificatio
ns.

Add unit tests for Anthropic and Bedrock message transformations
    - Introduced tests for AnthropicMessagesConfig, covering parameter mapping, URL generation, environment validation, request transformation, and response handling.
    - Added tests for BedrockInvokeAnthropicMessagesConfig, focusing on parameter mapping, URL handling, environment validation, request transformation, and response verification.
    - Both test files utilize mock responses to ensure accurate validation of the transformation logic against expected outputs.

