### PR TITLE
Default jwt role for the user

### DIFF
--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -842,8 +842,10 @@ class JWTAuthManager:
                                 continue
                             elif getattr(user_object, key, None) is None:
                                 user_data[key] = value
-                            elif key == "models" and isinstance(getattr(user_object, key, None), list) and len(getattr(user_object, key, None)) == 0:
-                                user_data[key] = value
+                            elif key == "models":
+                                models = getattr(user_object, key, None)
+                                if isinstance(models, list) and len(models) == 0:
+                                    user_data[key] = value
                     
                     # Set budget based on defaults if not already set
                     if user_object.max_budget is None and litellm.max_internal_user_budget is not None:

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -15,7 +15,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from fastapi import HTTPException
 
-import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.litellm_core_utils.dot_notation_indexing import get_nested_value
@@ -808,16 +807,15 @@ class JWTAuthManager:
 
         user_object: Optional[LiteLLM_UserTable] = None
         if user_id:
-            # Check if we need to upsert the user
-            upsert_user = jwt_handler.is_upsert_user_id(valid_user_email=valid_user_email)
-            
             try:
                 user_object = (
                     await get_user_object(
                         user_id=user_id,
                         prisma_client=prisma_client,
                         user_api_key_cache=user_api_key_cache,
-                        user_id_upsert=upsert_user,
+                        user_id_upsert=jwt_handler.is_upsert_user_id(
+                            valid_user_email=valid_user_email
+                        ),
                         parent_otel_span=parent_otel_span,
                         proxy_logging_obj=proxy_logging_obj,
                         user_email=user_email,
@@ -826,52 +824,6 @@ class JWTAuthManager:
                     if user_id
                     else None
                 )
-                
-                # Apply default internal user params if user was just created
-                # We can check this by seeing if the user was just added to the cache
-                if user_object and upsert_user and litellm.default_internal_user_params:
-                    verbose_proxy_logger.debug(f"Applying default_internal_user_params to JWT user: {user_id}")
-                    
-                    # Update the user with default internal user params
-                    user_data = {}
-                    
-                    # Apply default params for internal users only
-                    if user_object.user_role and user_object.user_role.startswith("internal_user"):
-                        for key, value in litellm.default_internal_user_params.items():
-                            if key == "available_teams":
-                                continue
-                            elif getattr(user_object, key, None) is None:
-                                user_data[key] = value
-                            elif key == "models":
-                                models = getattr(user_object, key, None)
-                                if isinstance(models, list) and len(models) == 0:
-                                    user_data[key] = value
-                    
-                    # Set budget based on defaults if not already set
-                    if user_object.max_budget is None and litellm.max_internal_user_budget is not None:
-                        user_data["max_budget"] = litellm.max_internal_user_budget
-                        
-                    if user_object.budget_duration is None and litellm.internal_user_budget_duration is not None:
-                        user_data["budget_duration"] = litellm.internal_user_budget_duration
-                    
-                    # Only update if there are changes to make
-                    if user_data and prisma_client:
-                        await prisma_client.db.litellm_usertable.update(
-                            where={"user_id": user_id},
-                            data=user_data,
-                        )
-                        
-                        # Refresh the user object after update
-                        user_object = await get_user_object(
-                            user_id=user_id,
-                            prisma_client=prisma_client,
-                            user_api_key_cache=user_api_key_cache,
-                            user_id_upsert=False,
-                            parent_otel_span=parent_otel_span,
-                            proxy_logging_obj=proxy_logging_obj,
-                            check_db_only=True,
-                        )
-                
             except Exception as e:
                 verbose_proxy_logger.error(f"Error getting/creating JWT user: {str(e)}")
                 user_object = None

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -386,7 +386,7 @@ async def test_team_budget_metrics():
         print("first_budget['remaining_hours']", first_budget["remaining_hours"])
         # The budget reset time is now midnight, not exactly 7 days (168 hours) from creation
         # So we'll check if it's within a reasonable range (5-7 days)
-        assert 0 < first_budget["remaining_hours"] <= 168, "Budget should have positive remaining hours, up to 7 days"
+        assert 120 <= first_budget["remaining_hours"] <= 168, "Budget remaining hours should be within a reasonable range (5-7 days)"
 
         # Get team info and verify spend matches prometheus metrics
         team_info = await get_team_info(session, team_id)

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -386,7 +386,7 @@ async def test_team_budget_metrics():
         print("first_budget['remaining_hours']", first_budget["remaining_hours"])
         # The budget reset time is now midnight, not exactly 7 days (168 hours) from creation
         # So we'll check if it's within a reasonable range (5-7 days)
-        assert 120 <= first_budget["remaining_hours"] <= 168, "Budget remaining hours should be within a reasonable range (5-7 days)"
+        assert 0 < first_budget["remaining_hours"] <= 168, "Budget should have positive remaining hours, up to 7 days"
 
         # Get team info and verify spend matches prometheus metrics
         team_info = await get_team_info(session, team_id)


### PR DESCRIPTION
## Title
Added default jwt role for new user

## Relevant issues

Fixes #10286 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ 👍 ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [👍  ] I have added a screenshot of my new test passing locally 
 
![image](https://github.com/user-attachments/assets/e8ad9b82-a085-4a70-904a-fa4ca4c3d207)

- [ 👍 ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ 👍 ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature


## Changes
Enhance JWT user creation process by applying default internal user parameters upon upsert. Added error handling for user retrieval and updated tests to verify default role assignment and parameters for new users created via JWT authentication.

Usage Example:
```
default_internal_user_params: # Default Params used when a new user signs in Via SSO
    user_role: "internal_user" # one of "internal_user", "internal_user_viewer", "proxy_admin", "proxy_admin_viewer". New SSO users not in litellm will be created as this user
    max_budget: 100 # Optional[float], optional): $100 budget for a new SSO sign in user
    budget_duration: 30d # Optional[str], optional): 30 days budget_duration for a new SSO sign in user
    models: ["gpt-4.1-nano"] # Optional[List[str]], optional): models to be used by a new SSO sign in user
```

