### PR TITLE
[Organization] Include litellm_budget_table in /organization/list response

### DIFF
--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -320,7 +320,7 @@ async def list_organization(
     # if proxy admin - get all orgs
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
         response = await prisma_client.db.litellm_organizationtable.find_many(
-            include={"members": True, "teams": True}
+            include={"litellm_budget_table": True, "members": True, "teams": True}
         )
     # if internal user - get orgs they are a member of
     else:
@@ -335,7 +335,7 @@ async def list_organization(
                     "in": [membership.organization_id for membership in org_memberships]
                 }
             },
-            include={"members": True, "teams": True},
+            include={"litellm_budget_table": True, "members": True, "teams": True},
         )
 
         response = org_objects

--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -180,6 +180,12 @@ async def list_organization(session, i):
         if status != 200:
             raise Exception(f"Request {i} did not return a 200 status code: {status}")
 
+        # Assert that budget info is returned for each organization
+        for org in response_json:
+            assert "litellm_budget_table" in org, "Missing budget info in organization response"
+            # Optionally also check that it's not null
+            assert org["litellm_budget_table"] is not None, "Budget info is None"
+
         return response_json
 
 


### PR DESCRIPTION
## Include litellm_budget_table in /organization/list response

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="1076" alt="Screenshot 2025-05-02 at 8 45 54 AM" src="https://github.com/user-attachments/assets/00410e5a-c47c-4555-98bb-020ff36dc54c" />
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test

## Changes
This PR ensures that the `/organization/list` endpoint returns complete organization data by including the related `litellm_budget_table` in the Prisma query.

- Updated the find_many calls in the `list_organization` route to include `litellm_budget_table` along with members and teams.

Tested:
Verified locally that `litellm_budget_table` now appears correctly in the response.
<img width="1464" alt="Screenshot 2025-05-02 at 8 45 16 AM" src="https://github.com/user-attachments/assets/4a3e1cd0-647f-421d-9010-aaee6a3454f0" />

