### PR TITLE
Fix mcp.md in documentation

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -47,14 +47,10 @@ model_list:
       api_key: sk-xxxxxxx
 
 mcp_servers:
-  {
-    "zapier_mcp": {
-      "url": "https://actions.zapier.com/mcp/sk-akxxxxx/sse"
-    },
-    "fetch": {
-      "url": "http://localhost:8000/sse"
-    }
-  }
+  zapier_mcp:
+    url: "https://actions.zapier.com/mcp/sk-akxxxxx/sse"
+  fetch:
+    url: "http://localhost:8000/sse"
 ```
 
 


### PR DESCRIPTION
## Title

The `config.yaml` in the `mcp.md` was wrong and has both yaml and json in a same file.

## Type

📖 Documentation

## Changes

Update `config.yaml` to only contains yaml content.
