### PR TITLE
Fix pytest event loop warning (#9641)

### DIFF
--- a/litellm/caching/llm_caching_handler.py
+++ b/litellm/caching/llm_caching_handler.py
@@ -14,10 +14,10 @@ class LLMClientCache(InMemoryCache):
         If none, use the key as is.
         """
         try:
-            event_loop = asyncio.get_event_loop()
+            event_loop = asyncio.get_running_loop()
             stringified_event_loop = str(id(event_loop))
             return f"{key}-{stringified_event_loop}"
-        except Exception:  # handle no current event loop
+        except RuntimeError:  # handle no current running event loop
             return key
 
     def set_cache(self, key, value, **kwargs):


### PR DESCRIPTION
Fixes: GH-9641

This is a Cursor-generated fix for the following warning from pytest:

```pytb
litellm/caching/llm_caching_handler.py:17
  /Users/abramowi/Code/OpenSource/litellm/litellm/caching/llm_caching_handler.py:17: DeprecationWarning: There is no current event loop
    event_loop = asyncio.get_event_loop()
```

Cursor prompt:

    Fix this pytest warning
    ```
    litellm/caching/llm_caching_handler.py:17
      /Users/abramowi/Code/OpenSource/litellm/litellm/caching/llm_caching_handler.py:17: DeprecationWarning: There is no current event loop
        event_loop = asyncio.get_event_loop()
    ```

![Screenshot 2025-05-02 at 11 12 16 AM](https://github.com/user-attachments/assets/b3e4199a-229a-438b-bd02-189eff9643d2)

Fixes https://github.com/BerriAI/litellm/issues/9641

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Fixes #9641 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


