### PR TITLE
[Models/ LLM Credentials] Fix edit credentials modal

### DIFF
--- a/ui/litellm-dashboard/src/components/model_add/add_credentials_tab.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/add_credentials_tab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { 
   Card, 
   Form, 
@@ -41,8 +41,6 @@ const AddCredentialsModal: React.FC<AddCredentialsModalProps> = ({
   const [selectedProvider, setSelectedProvider] = useState<Providers>(Providers.OpenAI);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
 
-  console.log(`existingCredential in add credentials tab: ${JSON.stringify(existingCredential)}`);
-
   const handleSubmit = (values: any) => {
     if (addOrEdit === "add") {
       onAddCredential(values);
@@ -51,6 +49,20 @@ const AddCredentialsModal: React.FC<AddCredentialsModalProps> = ({
     }
     form.resetFields();
   };
+
+  useEffect(() => {
+    if (existingCredential) {
+      form.setFieldsValue({
+        credential_name: existingCredential.credential_name,
+        custom_llm_provider: existingCredential.credential_info.custom_llm_provider,
+        api_base: existingCredential.credential_values.api_base,
+        api_version: existingCredential.credential_values.api_version,
+        base_model: existingCredential.credential_values.base_model,
+        api_key: existingCredential.credential_values.api_key,
+      });
+      setSelectedProvider(existingCredential.credential_info.custom_llm_provider as Providers);
+    }
+  }, [existingCredential]);
 
   return (
     <Modal
@@ -89,9 +101,9 @@ const AddCredentialsModal: React.FC<AddCredentialsModalProps> = ({
           tooltip="Helper to auto-populate provider specific fields"
         >
           <AntdSelect
-            value={existingCredential?.credential_info.custom_llm_provider || selectedProvider}
             onChange={(value) => {
               setSelectedProvider(value as Providers);
+              form.setFieldValue("custom_llm_provider", value);
             }}
           >
             {Object.entries(Providers).map(([providerEnum, providerDisplayName]) => (
@@ -108,8 +120,9 @@ const AddCredentialsModal: React.FC<AddCredentialsModalProps> = ({
                       const target = e.target as HTMLImageElement;
                       const parent = target.parentElement;
                       if (parent) {
-                        const fallbackDiv = document.createElement('div');
-                        fallbackDiv.className = 'w-5 h-5 rounded-full bg-gray-200 flex items-center justify-center text-xs';
+                        const fallbackDiv = document.createElement("div");
+                        fallbackDiv.className =
+                          "w-5 h-5 rounded-full bg-gray-200 flex items-center justify-center text-xs";
                         fallbackDiv.textContent = providerDisplayName.charAt(0);
                         parent.replaceChild(fallbackDiv, target);
                       }

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -38,12 +38,10 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ accessToken, upload
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
   const [selectedCredential, setSelectedCredential] = useState<CredentialItem | null>(null);
   const [form] = Form.useForm();
-  console.log(`selectedCredential in credentials panel: ${JSON.stringify(selectedCredential)}`);
 
   const restrictedFields = ['credential_name', 'custom_llm_provider'];
   const handleUpdateCredential = async (values: any) => {
     if (!accessToken) {
-      console.error('No access token found');
       return;
     }
 
@@ -61,14 +59,12 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ accessToken, upload
 
     const response = await credentialUpdateCall(accessToken, values.credential_name, newCredential);
     message.success('Credential updated successfully');
-    console.log(`response: ${JSON.stringify(response)}`);
     setIsUpdateModalOpen(false);
     fetchCredentials(accessToken);
   }
 
   const handleAddCredential = async (values: any) => {
     if (!accessToken) {
-      console.error('No access token found');
       return;
     }
 
@@ -87,7 +83,6 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ accessToken, upload
     // Add to list and close modal
     const response = await credentialCreateCall(accessToken, newCredential);
     message.success('Credential added successfully');
-    console.log(`response: ${JSON.stringify(response)}`);
     setIsAddModalOpen(false);
     fetchCredentials(accessToken);
   };
@@ -120,11 +115,9 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ accessToken, upload
 
   const handleDeleteCredential = async (credentialName: string) => {
     if (!accessToken) {
-      console.error('No access token found');
       return;
     }
     const response = await credentialDeleteCall(accessToken, credentialName);
-    console.log(`response: ${JSON.stringify(response)}`);
     message.success('Credential deleted successfully');
     fetchCredentials(accessToken);
   };
@@ -175,7 +168,6 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ accessToken, upload
                       variant="light" 
                       size="sm"
                       onClick={() => {
-                        console.log(`credential being set: ${JSON.stringify(credential)}`);
                         setSelectedCredential(credential);
                         setIsUpdateModalOpen(true);
                       }}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -42,7 +42,7 @@ export interface Organization {
 
 export interface CredentialItem {
   credential_name: string;
-  credential_values: object;
+  credential_values: any;
   credential_info: {
     custom_llm_provider?: string;
     description?: string;


### PR DESCRIPTION
## Fix edit credentials modal
Credentials not showing up on edit. This PR fixes broken controlled form behavior.

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes

- Remove the value prop from AntdSelect.
- Move setSelectedProvider(...) logic into onChange in a way that does not interfere with AntD's form control.
- To ensure the field is prefilled on edit add useEffect after Form.useForm().
<img width="1470" alt="Screenshot 2025-05-03 at 9 12 10 AM" src="https://github.com/user-attachments/assets/c1c312d8-3d57-495c-83f8-f5b5ed08d490" />
