### PR TITLE
Fix get_secret function

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1558,7 +1558,12 @@ class ProxyConfig:
         environment_variables = config.get("environment_variables", None)
         if environment_variables:
             for key, value in environment_variables.items():
-                os.environ[key] = str(get_secret(secret_name=key, default_value=value))
+                secret = get_secret(secret_name=key, default_value=value)
+                if isinstance(secret, str):
+                    os.environ[key] = secret
+                else:
+                    from litellm._logging import verbose_logger
+                    verbose_logger.error(f"Warning: Secret value for {key} does not resolve to a string")
 
             # check if litellm_license in general_settings
             if "LITELLM_LICENSE" in environment_variables:

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -327,6 +327,8 @@ def get_secret(  # noqa: PLR0915
                 secret_value_as_bool, bool
             ):
                 return secret_value_as_bool
+            elif secret is None:
+                return default_value
             else:
                 return secret
     except Exception as e:


### PR DESCRIPTION
Previously the guide in https://docs.litellm.ai/docs/observability/phoenix_integration#using-with-litellm-proxy doesn't work — the environment variable is set to the string `"None"`, which causes much error downstream.

p/s. Why all the blanket `except Exception`? Hopefully not AI-promoted bad practice?


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
