### PR TITLE
Fix azure_ad_token_provider initialization for azure openai

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -320,7 +320,7 @@ class BaseAzureLLM(BaseOpenAILLM):
         api_version: Optional[str],
         is_async: bool,
     ) -> dict:
-        azure_ad_token_provider: Optional[Callable[[], str]] = None
+        azure_ad_token_provider: Optional[Callable[[], str]] = litellm_params.get("azure_ad_token_provider", None)
         # If we have api_key, then we have higher priority
         azure_ad_token = litellm_params.get("azure_ad_token")
         tenant_id = litellm_params.get("tenant_id", os.getenv("AZURE_TENANT_ID"))


### PR DESCRIPTION
## Title

Fix azure_ad_token_provider initialization in initialize_azure_sdk_client.

## Relevant issues

Fixes #6790 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR addresses a bug where azure_ad_token_provider was not being correctly assigned during the initialization of the client in the initialize_azure_sdk_client function. The root cause was that the value of azure_ad_token_provider defaulted to None, instead of retrieving the correct value from the litellm_params.

Fix
The fix ensures that azure_ad_token_provider is now correctly fetched from litellm_params if available. If it is not found, it will still default to None.

Updated code snippet:
```python
azure_ad_token_provider: Optional[Callable[[], str]] = litellm_params.get("azure_ad_token_provider", None)
```

