### PR TITLE
fix issue when databrick use external model, the delta could be empty…

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -543,7 +543,7 @@ class DatabricksChatResponseIterator(BaseModelResponseIterator):
                     reasoning_content,
                     thinking_blocks,
                 ) = DatabricksConfig.extract_reasoning_content(
-                    choice["delta"]["content"]
+                    choice["delta"].get("content")
                 )
 
                 choice["delta"]["content"] = content_str


### PR DESCRIPTION
… content

## When databrick use external model, the delta could be empty, and the choice["delta"]["content"] would throw exception

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [* ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [*] I have added a screenshot of my new test passing locally 
- [*] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [*] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


