### PR TITLE
Fix config.yaml environment_variables never got loaded to os.env

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1558,7 +1558,10 @@ class ProxyConfig:
         environment_variables = config.get("environment_variables", None)
         if environment_variables:
             for key, value in environment_variables.items():
-                os.environ[key] = str(get_secret(secret_name=key, default_value=value))
+                str_data=str(get_secret(secret_name=key, default_value=value))
+                if str_data is None:
+                    str_data = value
+                os.environ[key] = str_data
 
             # check if litellm_license in general_settings
             if "LITELLM_LICENSE" in environment_variables:


### PR DESCRIPTION
## Fix: config.yaml environment_variables never got loaded

In load_config, logic is below
```
for key, value in environment_variables.items():
    os.environ[key] = str(get_secret(secret_name=key, default_value=value))
```

But get_secret doesn't use default_value unless os.environ.get(key) throw exception, which it doesn't (it return None for non-existing variable).
So above logic is useless. It only overrides enviromment IF os.environ.get(key) throw exception.
This cause almost all setting is environment_variables not being loaded (STORE_MODEL_IN_DB, UI_PASSWORD etc)


relate to #10399

🐛 Bug Fix