### PR TITLE
docs: add openrouter/qwen/qwen3-235b-a22b model & update openrouter/qwen/qwen-2.5-coder-32b-instruct

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8235,7 +8235,7 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-		"openrouter/qwen/qwen3-235b-a22b": {
+    "openrouter/qwen/qwen3-235b-a22b": {
 			"max_tokens": 40959,
 			"max_input_tokens": 40959,
 			"max_output_tokens": 41000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8229,12 +8229,22 @@
         "max_tokens": 33792,
         "max_input_tokens": 33792,
         "max_output_tokens": 33792,
-        "input_cost_per_token": 0.00000018,
+        "input_cost_per_token": 0.00000006,
         "output_cost_per_token": 0.00000018,
         "litellm_provider": "openrouter",
         "mode": "chat",
         "supports_tool_choice": true
     },
+		"openrouter/qwen/qwen3-235b-a22b": {
+			"max_tokens": 40959,
+			"max_input_tokens": 40959,
+			"max_output_tokens": 41000,
+			"input_cost_per_token": 0.0000001,
+			"output_cost_per_token": 0.0000001,
+			"litellm_provider": "openrouter",
+			"mode": "chat",
+			"support_tool_choice": true
+		},
     "j2-ultra": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,


### PR DESCRIPTION
… input price

## Add openrouter/qwen-3-235b-a22b model in list

Information took from [Qwen: Qwen3 235B A22B – Run with an API | OpenRouter](https://openrouter.ai/qwen/qwen3-235b-a22b/api)


## Type
📖 Documentation

## Changes
```json
{
	"openrouter/qwen/qwen3-235b-a22b": {
		"max_tokens": 40960,
		"max_output": 40000,
		"input_cost_per_token": 0.0000001,
		"output_cost_per_token": 0.0000001,
		"litellm_provider": "openrouter",
                 "mode": "chat",
		"support_tool_choice": true
	}
}
```

Update price of `openrouter/qwen/qwen-2.5-coder-32b-instruct` with last price: $0.06/M input tokens
<img width="589" alt="05-04-2025 Prices with description from openrouter" src="https://github.com/user-attachments/assets/63d5ef5a-3952-4a77-af71-ee72d240474e" />

