### PR TITLE
[Docs] Change llama-api link for litellm

### DIFF
--- a/docs/my-website/docs/providers/meta_llama.md
+++ b/docs/my-website/docs/providers/meta_llama.md
@@ -15,6 +15,22 @@ import TabItem from '@theme/TabItem';
 ```python showLineNumbers title="Environment Variables"
 os.environ["LLAMA_API_KEY"] = ""  # your Meta Llama API key
 ```
+
+## Supported Models
+
+:::info
+All models listed here https://llama.developer.meta.com/docs/models/ are supported. We actively maintain the list of models, token window, etc. [here](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).
+
+:::
+
+
+| Model ID | Input context length | Output context length | Input Modalities | Output Modalities |
+| --- | --- | --- | --- | --- |
+| `Llama-4-Scout-17B-16E-Instruct-FP8` | 128k | 4028 | Text, Image | Text |
+| `Llama-4-Maverick-17B-128E-Instruct-FP8` | 128k | 4028 | Text, Image | Text |
+| `Llama-3.3-70B-Instruct` | 128k | 4028 | Text | Text |
+| `Llama-3.3-8B-Instruct` | 128k | 4028 | Text | Text |
+
 ## Usage - LiteLLM Python SDK
 
 ### Non-streaming

--- a/docs/my-website/docs/providers/meta_llama.md
+++ b/docs/my-website/docs/providers/meta_llama.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 | Description | Meta's Llama API provides access to Meta's family of large language models. |
 | Provider Route on LiteLLM | `meta_llama/` |
 | Supported Endpoints | `/chat/completions`, `/completions`, `/responses` |
-| API Reference | [Llama API Reference ↗](https://www.llama.com/products/llama-api/) |
+| API Reference | [Llama API Reference ↗](https://llama.developer.meta.com?utm_source=partner-litellm&utm_medium=website) |
 
 ## Required Variables
 
@@ -45,7 +45,7 @@ messages = [{"content": "Hello, how are you?", "role": "user"}]
 
 # Meta Llama call with streaming
 response = completion(
-    model="meta_llama/Llama-3.3-70B-Instruct", 
+    model="meta_llama/Llama-3.3-70B-Instruct",
     messages=messages,
     stream=True
 )
@@ -66,7 +66,7 @@ model_list:
     litellm_params:
       model: meta_llama/Llama-3.3-70B-Instruct
       api_key: os.environ/LLAMA_API_KEY
-      
+
   - model_name: meta_llama/Llama-3.3-8B-Instruct
     litellm_params:
       model: meta_llama/Llama-3.3-8B-Instruct


### PR DESCRIPTION
## Documentation updates:

* Updated the API reference link to include UTM parameters for tracking, pointing to the Meta developer site.
* Added a new "Supported Models" section, including a table with details such as model IDs, input/output context lengths, and modalities.

## Type
📖 Documentation