### PR TITLE
fix template conversion for Llama 4 models in Bedrock

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3633,7 +3633,7 @@ def prompt_factory(
             return mistral_instruct_pt(messages=messages)
         elif "llama2" in model and "chat" in model:
             return llama_2_chat_pt(messages=messages)
-        elif "llama3" in model and "instruct" in model:
+        elif ("llama3" in model or "llama4" in model) and "instruct" in model:
             return hf_chat_template(
                 model="meta-llama/Meta-Llama-3-8B-Instruct",
                 messages=messages,


### PR DESCRIPTION
## Title
Fix chat template conversion for AWS Bedrock Llama 4 models

## Relevant issues
No issues found.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Llama-4-Instruct models use same tokenizer as Llama-3-Instruct models, therefore I leveraged the same template for both.

1. Llama-4-Scout

**Current output**
<img width="520" alt="Screenshot 2025-05-05 at 1 03 22 PM" src="https://github.com/user-attachments/assets/a5d6a04e-29df-407e-9206-9bdf21f307bc" />

**Output with fix**
<img width="521" alt="Screenshot 2025-05-05 at 1 02 42 PM" src="https://github.com/user-attachments/assets/3c3c1229-e14c-42ea-9d8c-fdcdade8d1e7" />

2. Llama-4-Maverick

**Current output**
<img width="522" alt="Screenshot 2025-05-05 at 1 03 13 PM" src="https://github.com/user-attachments/assets/08f89eb8-7d93-4a10-8951-b2feba7008aa" />

**Output with fix**
<img width="533" alt="Screenshot 2025-05-05 at 1 02 50 PM" src="https://github.com/user-attachments/assets/4012327e-27e1-4a95-b40d-bdf3542bc233" />



