### PR TITLE
Github: Increase timeout of litellm tests

### DIFF
--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Title
Increase timeout of litellm unit tests

## Relevant issues

Multiple PRs with failing at 5 min.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test


