### PR TITLE
[Bug fix] JSON logs - Ensure only 1 log is emitted (previously duplicate json logs were getting emitted)

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -4,6 +4,6 @@ model_list:
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
 
-litellm_settings:
-  success_callback: ["generic_api"]
 
+litellm_settings:
+    json_logs: true

--- a/tests/litellm/test_logging.py
+++ b/tests/litellm/test_logging.py
@@ -1,0 +1,51 @@
+import datetime
+import json
+import os
+import sys
+import unittest
+from typing import List, Optional, Tuple
+from unittest.mock import ANY, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system-path
+import io
+import logging
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+import litellm
+from litellm._logging import verbose_logger, verbose_proxy_logger, verbose_router_logger
+
+
+def test_json_mode_emits_one_record_per_logger(capfd):
+    # Turn on JSON logging
+    litellm._logging._turn_on_json()
+    # Make sure our loggers will emit INFO-level records
+    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger):
+        lg.setLevel(logging.INFO)
+
+    # Log one message from each logger at different levels
+    verbose_logger.info("first info")
+    verbose_router_logger.info("second info from router")
+    verbose_proxy_logger.info("third info from proxy")
+
+    # Capture stdout
+    out, err = capfd.readouterr()
+    print("out", out)
+    print("err", err)
+    lines = [l for l in err.splitlines() if l.strip()]
+
+    # Expect exactly three JSON lines
+    assert len(lines) == 3, f"got {len(lines)} lines, want 3: {lines!r}"
+
+    # Each line must be valid JSON with the required fields
+    for line in lines:
+        obj = json.loads(line)
+        assert "message" in obj, "`message` key missing"
+        assert "level" in obj, "`level` key missing"
+        assert "timestamp" in obj, "`timestamp` key missing"

--- a/tests/litellm/test_logging.py
+++ b/tests/litellm/test_logging.py
@@ -19,7 +19,13 @@ import unittest
 from contextlib import redirect_stdout
 
 import litellm
-from litellm._logging import verbose_logger, verbose_proxy_logger, verbose_router_logger
+from litellm._logging import (
+    ALL_LOGGERS,
+    _initialize_loggers_with_handler,
+    verbose_logger,
+    verbose_proxy_logger,
+    verbose_router_logger,
+)
 
 
 def test_json_mode_emits_one_record_per_logger(capfd):
@@ -49,3 +55,17 @@ def test_json_mode_emits_one_record_per_logger(capfd):
         assert "message" in obj, "`message` key missing"
         assert "level" in obj, "`level` key missing"
         assert "timestamp" in obj, "`timestamp` key missing"
+
+
+def test_initialize_loggers_with_handler_sets_propagate_false():
+    """
+    Test that the initialize_loggers_with_handler function sets propagate to False for all loggers
+    """
+    # Initialize loggers with the test handler
+    _initialize_loggers_with_handler(logging.StreamHandler())
+
+    # Check that propagate is set to False for all loggers
+    for logger in ALL_LOGGERS:
+        assert (
+            logger.propagate is False
+        ), f"Logger {logger.name} has propagate set to {logger.propagate}, expected False"


### PR DESCRIPTION
## [Bug fix] JSON logs - Ensure only 1 log is emitted (previously duplicate json logs were getting emitted)

## Problem
When JSON logging is enabled, each log message was emitted twice: once by the named logger and again via propagation to the root logger. This resulted in duplicate JSON records and cluttered log streams.

## Solution

- Consolidate all relevant loggers (root, LiteLLM, LiteLLM Router, LiteLLM Proxy) into a single ALL_LOGGERS list.
- Introduce _initialize_loggers_with_handler(handler) to:
  - Clear any pre-existing handlers on each logger
  - Attach the JSON handler exactly once
  - Set propagate = False to stop bubbling to the root logger

## Testing
Add unit tests to verify:

- Exactly one JSON line per logger when JSON mode is active
- propagate is disabled on all loggers after initialization

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


