### PR TITLE
make openai model O series conditional accept provider/model

### DIFF
--- a/litellm/llms/openai/chat/o_series_transformation.py
+++ b/litellm/llms/openai/chat/o_series_transformation.py
@@ -130,14 +130,9 @@ class OpenAIOSeriesConfig(OpenAIGPTConfig):
         )
 
     def is_model_o_series_model(self, model: str) -> bool:
-        if model in litellm.open_ai_chat_completion_models and (
-            "o1" in model
-            or "o3" in model
-            or "o4"
-            in model  # [TODO] make this a more generic check (e.g. using `openai-o-series` as provider like gemini)
-        ):
-            return True
-        return False
+        model = model.split("/")[-1] # could be "openai/o3" or "o3"
+        return model in litellm.open_ai_chat_completion_models and any(
+            model.startswith(pfx) for pfx in ("o1", "o3", "o4"))
 
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str

--- a/tests/litellm/llms/openai/test_o_series_transformation.py
+++ b/tests/litellm/llms/openai/test_o_series_transformation.py
@@ -1,0 +1,49 @@
+import pytest
+from litellm.llms.openai.chat.o_series_transformation import OpenAIOSeriesConfig
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        # Valid O-series models
+        ("o1", True),
+        ("o3", True),
+        ("o4-mini", True),
+        ("o1-preview", True),
+        ("o3-mini", True),
+        
+        # Valid O-series models with provider prefix
+        ("openai/o1", True),
+        ("openai/o3", True),
+        ("openai/o4-mini", True),
+        ("openai/o1-preview", True),
+        ("openai/o3-mini", True),
+        
+        # Non-O-series models
+        ("gpt-4", False),
+        ("gpt-3.5-turbo", False),
+        ("claude-3-opus", False),
+        
+        # Non-O-series models with provider prefix
+        ("openai/gpt-4", False),
+        ("openai/gpt-3.5-turbo", False),
+        ("anthropic/claude-3-opus", False),
+        
+        # Edge cases
+        ("o", False),  # Too short
+        ("o5", False),  # Not a valid O-series model
+        ("o1-", False),  # Invalid suffix
+        ("o3_", False),  # Invalid suffix
+    ],
+)
+def test_is_model_o_series_model(model_name: str, expected: bool):
+    """
+    Test that is_model_o_series_model correctly identifies O-series models.
+    
+    Args:
+        model_name: The model name to test
+        expected: The expected result (True if it should be identified as an O-series model)
+    """
+    config = OpenAIOSeriesConfig()
+    assert config.is_model_o_series_model(model_name) == expected, \
+        f"Expected {model_name} to be {'an O-series model' if expected else 'not an O-series model'}"


### PR DESCRIPTION
Registration and calls within the project are not consistent. This accepts either form.

ref: #10566

## Title

make openai model O series conditional accept provider/model

## Relevant issues

Fixes #10566 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
![image](https://github.com/user-attachments/assets/4715507d-ba16-4e38-a08b-9177a0c3dfc6)

- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test

## Changes
make openai model O series conditional accept provider/model

