### PR TITLE
Fix AzureChatCompletion adding stream_options when stream is False

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -207,6 +207,8 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     status_code=422, message="Missing model or messages"
                 )
 
+            self.maybe_remove_stream_options(optional_params)
+
             max_retries = optional_params.pop("max_retries", None)
             if max_retries is None:
                 max_retries = DEFAULT_MAX_RETRIES
@@ -361,6 +363,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 headers=error_headers,
                 body=error_body,
             )
+
+    def maybe_remove_stream_options(self, optional_params):
+        if "stream_options" in optional_params and not optional_params["stream"]:
+            del optional_params["stream_options"]
 
     async def acompletion(
         self,

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -589,3 +589,19 @@ async def test_azure_embedding_max_retries_0(
         ]
         == max_retries
     )
+
+
+@pytest.mark.parametrize(
+    "optional_params, keep_stream_options",
+    [
+        ({"stream": False}, False),
+        ({"stream_options": {"key1": "value1"}, "stream": True}, True),
+        ({"stream_options": {"key1": "value1"}, "stream": False}, False), # Remove stream_options when stream is False
+        ({"stream_options": {"key1": "value1"}, "stream": None}, False),  # Remove stream_options when stream is missing
+    ],
+)
+def test_maybe_remove_stream_options(optional_params, keep_stream_options):
+    from litellm.llms.azure.azure import AzureChatCompletion
+    azure_chat_completion = AzureChatCompletion()
+    azure_chat_completion.maybe_remove_stream_options(optional_params)
+    assert ("stream_options" in optional_params) == keep_stream_options


### PR DESCRIPTION
AzureChatCompletion is adding `"include_usage: True"` to `stream_options` despite `stream` being False. 

```
litellm.BadRequestError: AzureException BadRequestError - The 'stream_options' parameter is only allowed when 'stream' is enabled.
```


This PR fixes that by deleting the `stream_options` key when `stream` is False.


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
![image](https://github.com/user-attachments/assets/30e4c902-ed30-46ba-83f6-19121610f9b9)

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

