### PR TITLE
Upgrade langfuse sdk and enable passing generation params thru metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             pip install langchain
             pip install lunary==0.2.5
             pip install "azure-identity==1.16.1"
-            pip install "langfuse==2.45.0"
+            pip install "langfuse==2.60.4"
             pip install "logfire==0.29.0"
             pip install numpydoc
             pip install traceloop-sdk==0.21.1
@@ -199,7 +199,7 @@ jobs:
             pip install langchain
             pip install lunary==0.2.5
             pip install "azure-identity==1.16.1"
-            pip install "langfuse==2.45.0"
+            pip install "langfuse==2.60.4"
             pip install "logfire==0.29.0"
             pip install numpydoc
             pip install traceloop-sdk==0.21.1
@@ -305,7 +305,7 @@ jobs:
             pip install langchain
             pip install lunary==0.2.5
             pip install "azure-identity==1.16.1"
-            pip install "langfuse==2.45.0"
+            pip install "langfuse==2.60.4"
             pip install "logfire==0.29.0"
             pip install numpydoc
             pip install traceloop-sdk==0.21.1
@@ -559,7 +559,7 @@ jobs:
             pip install langchain
             pip install lunary==0.2.5
             pip install "azure-identity==1.16.1"
-            pip install "langfuse==2.45.0"
+            pip install "langfuse==2.60.4"
             pip install "logfire==0.29.0"
             pip install numpydoc
             pip install traceloop-sdk==0.21.1

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -691,6 +691,18 @@ class LangFuseLogger:
                 "version": clean_metadata.pop("version", None),
             }
 
+            # Promote every metadata entry whose key starts with "generation_"
+            for key in list(
+                filter(lambda k: k.startswith("generation_"), clean_metadata.keys())
+            ):
+                stripped = key.replace("generation_", "")
+                # don’t silently overwrite an explicit field that was already set
+                if stripped not in generation_params:
+                    generation_params[stripped] = clean_metadata[key]
+                # whether or not you pop() depends on whether you still want the value
+                # inside metadata; most people pop it to avoid duplication:
+                clean_metadata.pop(key, None)
+
             parent_observation_id = metadata.get("parent_observation_id", None)
             if parent_observation_id is not None:
                 generation_params["parent_observation_id"] = parent_observation_id

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -696,12 +696,8 @@ class LangFuseLogger:
                 filter(lambda k: k.startswith("generation_"), clean_metadata.keys())
             ):
                 stripped = key.replace("generation_", "")
-                # don’t silently overwrite an explicit field that was already set
                 if stripped not in generation_params:
                     generation_params[stripped] = clean_metadata[key]
-                # whether or not you pop() depends on whether you still want the value
-                # inside metadata; most people pop it to avoid duplication:
-                clean_metadata.pop(key, None)
 
             parent_observation_id = metadata.get("parent_observation_id", None)
             if parent_observation_id is not None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1084,15 +1084,15 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.39.0"
+version = "2.40.0"
 description = "Google Authentication Library"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "extra == \"extra-proxy\""
 files = [
-    {file = "google_auth-2.39.0-py2.py3-none-any.whl", hash = "sha256:0150b6711e97fb9f52fe599f55648950cc4540015565d8fbb31be2ad6e1548a2"},
-    {file = "google_auth-2.39.0.tar.gz", hash = "sha256:73222d43cdc35a3aeacbfdcaf73142a97839f10de930550d89ebfe1d0a00cde7"},
+    {file = "google_auth-2.40.0-py2.py3-none-any.whl", hash = "sha256:dc3a5078acb1043c3e43685c22d628afe40af8559cf561de388e0c939280fcc8"},
+    {file = "google_auth-2.40.0.tar.gz", hash = "sha256:c277cf39f7c192d8540eb6331c08b5a0796e8041af8343ae73dd6b269732ca6c"},
 ]
 
 [package.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ anthropic[vertex]==0.21.3
 mcp==1.5.0    # for MCP server
 google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
-langfuse==2.45.0 # for langfuse self-hosted logging
+langfuse==2.60.4 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
 ddtrace==2.19.0      # for advanced DD tracing / profiling
 orjson==3.10.12 # fast /embedding responses


### PR DESCRIPTION
## Title

This first upgrade langfuse (https://github.com/BerriAI/litellm/issues/9867) so we can pass in environment variable. It also adds the ability to set generation params via setting metadata like `generation_environment`. This [will enable setting the langfuse environment](https://langfuse.com/docs/tracing-features/environments).

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


