### PR TITLE
Return 404 when `delete_verification_tokens` (`POST /key/delete`) fails to find keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1486,6 +1486,12 @@ async def delete_verification_tokens(
                 where={"token": {"in": tokens}}
             )
 
+            if len(_keys_being_deleted) == 0:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail={"error": "No keys found"},
+                )
+
             # Assuming 'db' is your Prisma Client instance
             # check if admin making request - don't filter by user-id
             if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -4056,3 +4056,38 @@ async def test_reset_budget_job(prisma_client, entity_type):
 
     assert entity_after is not None
     assert entity_after.spend == 0.0
+
+def test_delete_nonexistent_key_returns_404(prisma_client):
+    # Try to delete a key that does not exist, expect a 404 error
+    import random, string
+    from litellm.proxy._types import KeyRequest, UserAPIKeyAuth, LitellmUserRoles, ProxyException
+    from litellm.proxy.management_endpoints.key_management_endpoints import delete_key_fn
+    from starlette.datastructures import URL
+    from fastapi import Request
+
+    print("prisma client=", prisma_client)
+    setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
+    try:
+        async def test():
+            await litellm.proxy.proxy_server.prisma_client.connect()
+            # Generate a random key that does not exist
+            random_key = "sk-" + ''.join(random.choices(string.ascii_letters + string.digits, k=24))
+            delete_key_request = KeyRequest(keys=[random_key])
+            bearer_token = "Bearer sk-1234"
+            request = Request(scope={"type": "http"})
+            request._url = URL(url="/key/delete")
+            # use admin to auth in
+            result = await litellm.proxy.proxy_server.user_api_key_auth(request=request, api_key=bearer_token)
+            result.user_role = LitellmUserRoles.PROXY_ADMIN
+            try:
+                await delete_key_fn(data=delete_key_request, user_api_key_dict=result)
+                pytest.fail("Expected ProxyException 404 for non-existent key, but delete_key_fn did not raise.")
+            except ProxyException as e:
+                print("Caught ProxyException:", e)
+                assert str(e.code) == "404"
+                assert "No keys found" in str(e.message) or "No matching keys or aliases found to delete" in str(e.message)
+        import asyncio
+        asyncio.run(test())
+    except Exception as e:
+        pytest.fail(f"An exception occurred - {str(e)}")


### PR DESCRIPTION
## Title

Return 404 when `delete_verification_tokens` (`POST /key/delete`) fails to find keys

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
    <img width="1728" alt="Screenshot 2025-05-06 at 4 15 51 PM" src="https://github.com/user-attachments/assets/45dde156-3a29-4a8f-932b-0e794c748665" />
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


