### PR TITLE
More robust import of `tests.large_text` module

### DIFF
--- a/tests/litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/litellm/litellm_core_utils/test_token_counter.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 sys.path.insert(
-    0, os.path.abspath("../../..")
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 )  # Adds the parent directory to the system path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,7 +23,7 @@ import litellm
 from litellm import create_pretrained_tokenizer, decode, encode, get_modified_max_tokens
 from litellm import token_counter as token_counter_old
 from litellm.litellm_core_utils.token_counter import token_counter as token_counter_new
-from tests.large_text import text
+from large_text import text
 
 
 def token_counter_both_assert_same(**args):


### PR DESCRIPTION
Maybe this is just something in my environment; maybe not. When trying to run `make test-unit` today, I kept getting an error:
```
ModuleNotFoundError: No module named 'tests.large_text'
```

E.g.:

<img width="1728" alt="Screenshot 2025-05-06 at 5 04 01 PM" src="https://github.com/user-attachments/assets/f8d857c5-4396-40ee-b106-5314c32e0e3d" />
<img width="1728" alt="Screenshot 2025-05-06 at 5 04 13 PM" src="https://github.com/user-attachments/assets/a3d42a94-69ae-46b6-a34e-c9965583e9a7" />

```python
(.venv)
abramowi at Marcs-MBP-3 in ~/Code/OpenSource/litellm (main●●)
$ make test-unit
poetry run pytest tests/litellm/
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.9, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/abramowi/Code/OpenSource/litellm
plugins: respx-0.22.0, postgresql-7.0.1, anyio-4.5.2, asyncio-0.21.2, mock-3.14.0, requests-mock-1.12.1
asyncio: mode=Mode.STRICT
collected 662 items / 2 errors

=================================================================== ERRORS ====================================================================
___________________________________ ERROR collecting tests/litellm/litellm_core_utils/test_token_counter.py ___________________________________
ImportError while importing test module '/Users/abramowi/Code/OpenSource/litellm/tests/litellm/litellm_core_utils/test_token_counter.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/litellm/litellm_core_utils/test_token_counter.py:26: in <module>
    from tests.large_text import text
E   ModuleNotFoundError: No module named 'tests.large_text'
________________________________ ERROR collecting tests/litellm/litellm_core_utils/test_token_counter_tool.py _________________________________
ImportError while importing test module '/Users/abramowi/Code/OpenSource/litellm/tests/litellm/litellm_core_utils/test_token_counter_tool.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/litellm/litellm_core_utils/test_token_counter_tool.py:13: in <module>
    from test_token_counter import token_counter
tests/litellm/litellm_core_utils/test_token_counter.py:26: in <module>
    from tests.large_text import text
E   ModuleNotFoundError: No module named 'tests.large_text'
============================================================== warnings summary ===============================================================
tests/litellm/integrations/test_custom_prompt_management.py:27
  /Users/abramowi/Code/OpenSource/litellm/tests/litellm/integrations/test_custom_prompt_management.py:27: PytestCollectionWarning: cannot collect test class 'TestCustomPromptManagement' because it has a __init__ constructor (from: tests/litellm/integrations/test_custom_prompt_management.py)
    class TestCustomPromptManagement(CustomPromptManagement):

tests/litellm/integrations/arize/test_arize_utils.py:181
  /Users/abramowi/Code/OpenSource/litellm/tests/litellm/integrations/arize/test_arize_utils.py:181: PytestCollectionWarning: cannot collect test class 'TestArizeLogger' because it has a __init__ constructor (from: tests/litellm/integrations/arize/test_arize_utils.py)
    class TestArizeLogger(CustomLogger):

tests/litellm/litellm_core_utils/test_streaming_handler.py:505
  /Users/abramowi/Code/OpenSource/litellm/tests/litellm/litellm_core_utils/test_streaming_handler.py:505: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=3)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== short test summary info ===========================================================
ERROR tests/litellm/litellm_core_utils/test_token_counter.py
ERROR tests/litellm/litellm_core_utils/test_token_counter_tool.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================== 3 warnings, 2 errors in 1.75s ========================================================
make: *** [test-unit] Error 2
```

I think it's because the existing `sys.path.insert` hack depends on what directory the user is in (it depends on the user's current directory when running `pytest`; it's not related to the location of the test file, though I often make that mistake myself).

For example if I'm in `~/Code/OpenSource/litellm` when I run `make test-unit` then `os.path.abspath("../../..")` evaluates to `'/Users/abramowi'`.

<img width="1728" alt="Screenshot 2025-05-06 at 5 07 59 PM" src="https://github.com/user-attachments/assets/0cdf51df-8a6b-4411-bc96-ea7a3e1cc50a" />

I changed it to actually make the path relative to the current file, which should be more robust than having it depend on the user's current directory.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
    
    <img width="1840" alt="Screenshot 2025-05-06 at 4 57 32 PM" src="https://github.com/user-attachments/assets/0d43a969-e790-453a-8813-d6a519f88186" />
    <img width="1840" alt="Screenshot 2025-05-06 at 5 01 49 PM" src="https://github.com/user-attachments/assets/2fa19f31-284d-4af3-ae3a-3827cd5a3db5" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


