### PR TITLE
Fix/issue 10113 embeddings use non default tokenizer

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -164,6 +164,12 @@ LITELLM_CHAT_PROVIDERS = [
     "meta_llama",
 ]
 
+LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS = [
+    "openai",
+    "azure",
+    "hosted_vllm"
+]
+
 
 OPENAI_CHAT_COMPLETION_PARAMS = [
     "functions",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -28,6 +28,7 @@ from typing import (
 from litellm.constants import (
     DEFAULT_MAX_RECURSE_DEPTH,
     DEFAULT_SLACK_ALERTING_THRESHOLD,
+    LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
 )
 from litellm.types.utils import (
     ModelResponse,
@@ -3808,13 +3809,15 @@ async def embeddings(  # noqa: PLR0915
             and isinstance(data["input"][0], list)
             and isinstance(data["input"][0][0], int)
         ):  # check if array of tokens passed in
-            # check if non-openai/azure model called - e.g. for langchain integration
+            # check if provider accept list of tokens as input - e.g. for langchain integration
             if llm_model_list is not None and data["model"] in router_model_names:
                 for m in llm_model_list:
                     if m["model_name"] == data["model"] and (
                         m["litellm_params"]["model"] in litellm.open_ai_embedding_models
-                        or m["litellm_params"]["model"].startswith("azure/")
-                        or m["litellm_params"]["model"].startswith("hosted_vllm/")
+                        or any(
+                            m["litellm_params"]["model"].startswith(provider)
+                            for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
+                        )
                     ):
                         pass
                     else:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3812,23 +3812,23 @@ async def embeddings(  # noqa: PLR0915
             # check if provider accept list of tokens as input - e.g. for langchain integration
             if llm_model_list is not None and data["model"] in router_model_names:
                 for m in llm_model_list:
-                    if m["model_name"] == data["model"] and (
-                        m["litellm_params"]["model"] in litellm.open_ai_embedding_models
-                        or any(
-                            m["litellm_params"]["model"].startswith(provider)
-                            for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
-                        )
-                    ):
-                        pass
-                    else:
-                        # non-openai/azure embedding model called with token input
-                        input_list = []
-                        for i in data["input"]:
-                            input_list.append(
-                                litellm.decode(model="gpt-3.5-turbo", tokens=i)
-                            )
-                        data["input"] = input_list
-                        break
+                    if m["model_name"] == data["model"]:
+                        if (m["litellm_params"]["model"] in litellm.open_ai_embedding_models
+                                or any(
+                                    m["litellm_params"]["model"].startswith(provider)
+                                    for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
+                                )
+                        ):
+                            pass
+                        else:
+                            # non-openai/azure embedding model called with token input
+                            input_list = []
+                            for i in data["input"]:
+                                input_list.append(
+                                    litellm.decode(model="gpt-3.5-turbo", tokens=i)
+                                )
+                            data["input"] = input_list
+                            break
 
         ### CALL HOOKS ### - modify incoming data / reject request before calling the model
         data = await proxy_logging_obj.pre_call_hook(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3814,6 +3814,7 @@ async def embeddings(  # noqa: PLR0915
                     if m["model_name"] == data["model"] and (
                         m["litellm_params"]["model"] in litellm.open_ai_embedding_models
                         or m["litellm_params"]["model"].startswith("azure/")
+                        or m["litellm_params"]["model"].startswith("hosted_vllm/")
                     ):
                         pass
                     else:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3821,7 +3821,7 @@ async def embeddings(  # noqa: PLR0915
                         input_list = []
                         for i in data["input"]:
                             input_list.append(
-                                litellm.decode(model="gpt-3.5-turbo", tokens=i)
+                                litellm.decode(model=m["model_name"], tokens=i)
                             )
                         data["input"] = input_list
                         break

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3822,7 +3822,7 @@ async def embeddings(  # noqa: PLR0915
                         input_list = []
                         for i in data["input"]:
                             input_list.append(
-                                litellm.decode(model=m["model_name"], tokens=i)
+                                litellm.decode(model="gpt-3.5-turbo", tokens=i)
                             )
                         data["input"] = input_list
                         break

--- a/tests/litellm/proxy/test_configs/test_config_no_auth.yaml
+++ b/tests/litellm/proxy/test_configs/test_config_no_auth.yaml
@@ -1,0 +1,6 @@
+model_list:
+- litellm_params:
+    model: hosted_vllm/embed_model
+  model_info:
+    description: this is a test embedding hosted_vllm model
+  model_name: vllm_embed_model


### PR DESCRIPTION
## Title

Embeddings: Not use default `gpt-3.5-turbo`'s tokenizer

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/10113

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
- embeddings: allow for passthrough of list of lists of tokens to self hosted vllm models

![litellm_issue_10113_unit_test_local](https://github.com/user-attachments/assets/5ed1e3d7-794b-472f-8204-dc655b740843)
