### PR TITLE
[Feat] Add endpoints to manage email settings

### DIFF
--- a/enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -64,6 +64,7 @@ class BaseEmailLogger(CustomLogger):
         """
         Send email to user after creating key for the user
         """
+
         email_params = await self._get_email_params(
             user_id=send_key_created_email_event.user_id,
             user_email=send_key_created_email_event.user_email,

--- a/enterprise/enterprise_callbacks/send_emails/endpoints.py
+++ b/enterprise/enterprise_callbacks/send_emails/endpoints.py
@@ -2,56 +2,23 @@
 Endpoints for managing email alerts on litellm
 """
 
-import enum
 import json
-from typing import Dict, List
+from typing import Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.types.enterprise.enterprise_callbacks.send_emails import (
+    DefaultEmailSettings,
+    EmailEvent,
+    EmailEventSettings,
+    EmailEventSettingsResponse,
+    EmailEventSettingsUpdateRequest,
+)
 
 router = APIRouter()
-
-
-class EmailEvent(str, enum.Enum):
-    virtual_key_created = "Virtual Key Created"
-    new_user_invitation = "New User Invitation"
-
-
-class EmailEventSettings(BaseModel):
-    event: EmailEvent
-    enabled: bool
-
-
-class EmailEventSettingsUpdateRequest(BaseModel):
-    settings: List[EmailEventSettings]
-
-
-class EmailEventSettingsResponse(BaseModel):
-    settings: List[EmailEventSettings]
-
-
-class DefaultEmailSettings(BaseModel):
-    """Default settings for email events"""
-
-    settings: Dict[EmailEvent, bool] = Field(
-        default_factory=lambda: {
-            EmailEvent.virtual_key_created: False,  # Off by default
-            EmailEvent.new_user_invitation: True,  # On by default
-        }
-    )
-
-    def to_dict(self) -> Dict[str, bool]:
-        """Convert to dictionary with string keys for storage"""
-        return {event.value: enabled for event, enabled in self.settings.items()}
-
-    @classmethod
-    def get_defaults(cls) -> Dict[str, bool]:
-        """Get the default settings as a dictionary with string keys"""
-        return cls().to_dict()
 
 
 async def _get_email_settings(prisma_client) -> Dict[str, bool]:

--- a/enterprise/proxy/enterprise_routes.py
+++ b/enterprise/proxy/enterprise_routes.py
@@ -1,10 +1,13 @@
 from fastapi import APIRouter
 from fastapi.responses import Response
+
+from ..enterprise_callbacks.send_emails.endpoints import router as email_events_router
 from .utils import _should_block_robots
 from .vector_stores.endpoints import router as vector_stores_router
 
 router = APIRouter()
 router.include_router(vector_stores_router)
+router.include_router(email_events_router)
 
 
 @router.get("/robots.txt")

--- a/litellm/types/enterprise/enterprise_callbacks/send_emails.py
+++ b/litellm/types/enterprise/enterprise_callbacks/send_emails.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel
+import enum
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
 
 from litellm.proxy._types import WebhookEvent
 
@@ -17,3 +20,41 @@ class SendKeyCreatedEmailEvent(WebhookEvent):
 
     this will be sk-123xxx, since we will be emailing this to the user to start using the key
     """
+
+
+class EmailEvent(str, enum.Enum):
+    virtual_key_created = "Virtual Key Created"
+    new_user_invitation = "New User Invitation"
+
+
+class EmailEventSettings(BaseModel):
+    event: EmailEvent
+    enabled: bool
+
+
+class EmailEventSettingsUpdateRequest(BaseModel):
+    settings: List[EmailEventSettings]
+
+
+class EmailEventSettingsResponse(BaseModel):
+    settings: List[EmailEventSettings]
+
+
+class DefaultEmailSettings(BaseModel):
+    """Default settings for email events"""
+
+    settings: Dict[EmailEvent, bool] = Field(
+        default_factory=lambda: {
+            EmailEvent.virtual_key_created: False,  # Off by default
+            EmailEvent.new_user_invitation: True,  # On by default
+        }
+    )
+
+    def to_dict(self) -> Dict[str, bool]:
+        """Convert to dictionary with string keys for storage"""
+        return {event.value: enabled for event, enabled in self.settings.items()}
+
+    @classmethod
+    def get_defaults(cls) -> Dict[str, bool]:
+        """Get the default settings as a dictionary with string keys"""
+        return cls().to_dict()

--- a/tests/litellm/enterprise/enterprise_callbacks/send_emails/test_endpoints.py
+++ b/tests/litellm/enterprise/enterprise_callbacks/send_emails/test_endpoints.py
@@ -1,0 +1,265 @@
+import json
+import os
+import sys
+import unittest.mock as mock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from enterprise.enterprise_callbacks.send_emails.endpoints import (
+    _get_email_settings,
+    _save_email_settings,
+    get_email_event_settings,
+    reset_event_settings,
+    router,
+    update_event_settings,
+)
+from litellm.types.enterprise.enterprise_callbacks.send_emails import (
+    DefaultEmailSettings,
+    EmailEvent,
+    EmailEventSettings,
+    EmailEventSettingsUpdateRequest,
+)
+
+
+# Mock user_api_key_auth dependency
+@pytest.fixture
+def mock_user_api_key_auth():
+    return {"user_id": "test_user"}
+
+
+# Mock prisma client
+@pytest.fixture
+def mock_prisma_client():
+    mock_client = mock.MagicMock()
+
+    # Setup mock for async methods to work properly
+    mock_db = mock.MagicMock()
+    mock_config = mock.MagicMock()
+
+    # Make find_unique return a coroutine mock
+    async def mock_find_unique(*args, **kwargs):
+        return None
+
+    mock_config.find_unique = mock_find_unique
+
+    # Make upsert return a coroutine mock
+    async def mock_upsert(*args, **kwargs):
+        return None
+
+    mock_config.upsert = mock_upsert
+
+    mock_db.litellm_config = mock_config
+    mock_client.db = mock_db
+
+    return mock_client
+
+
+# Test _get_email_settings helper function
+@pytest.mark.asyncio
+async def test_get_email_settings_empty_db(mock_prisma_client):
+    """Test that default settings are returned when database has no email settings."""
+
+    # Setup mock find_unique to return None
+    async def mock_find_unique(*args, **kwargs):
+        return None
+
+    mock_prisma_client.db.litellm_config.find_unique = mock_find_unique
+
+    # Call the function
+    result = await _get_email_settings(mock_prisma_client)
+
+    # Assert that default settings are returned
+    assert result == DefaultEmailSettings.get_defaults()
+
+
+@pytest.mark.asyncio
+async def test_get_email_settings_with_existing_settings(mock_prisma_client):
+    """Test that existing email settings are correctly retrieved from the database."""
+    # Setup mock find_unique to return existing settings
+    mock_settings = {
+        "email_settings": {
+            EmailEvent.virtual_key_created.value: True,
+            EmailEvent.new_user_invitation.value: False,
+        }
+    }
+
+    mock_entry = mock.MagicMock()
+    mock_entry.param_value = json.dumps(mock_settings)
+
+    async def mock_find_unique(*args, **kwargs):
+        return mock_entry
+
+    mock_prisma_client.db.litellm_config.find_unique = mock_find_unique
+
+    # Call the function
+    result = await _get_email_settings(mock_prisma_client)
+
+    # Assert correct settings are returned
+    assert result[EmailEvent.virtual_key_created.value] is True
+    assert result[EmailEvent.new_user_invitation.value] is False
+
+
+@pytest.mark.asyncio
+async def test_save_email_settings_new_entry(mock_prisma_client):
+    """Test that email settings are properly saved to database when no previous settings exist."""
+
+    # Setup mock find_unique to return None
+    async def mock_find_unique(*args, **kwargs):
+        return None
+
+    mock_prisma_client.db.litellm_config.find_unique = mock_find_unique
+
+    # Setup mock upsert to return None
+    async def mock_upsert(*args, **kwargs):
+        return None
+
+    mock_prisma_client.db.litellm_config.upsert = mock_upsert
+
+    # Settings to save
+    settings = {
+        EmailEvent.virtual_key_created.value: True,
+        EmailEvent.new_user_invitation.value: False,
+    }
+
+    # Call the function
+    await _save_email_settings(mock_prisma_client, settings)
+
+    # Success if no exception was raised
+
+
+# Test the GET endpoint
+@pytest.mark.asyncio
+async def test_get_email_event_settings(mock_prisma_client, mock_user_api_key_auth):
+    """Test that the GET endpoint returns the correct email event settings."""
+
+    # Mock _get_email_settings to return test data
+    async def mock_get_settings(*args, **kwargs):
+        return {
+            EmailEvent.virtual_key_created.value: True,
+            EmailEvent.new_user_invitation.value: False,
+        }
+
+    # Setup mocks
+    with mock.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        with mock.patch(
+            "enterprise.enterprise_callbacks.send_emails.endpoints._get_email_settings",
+            side_effect=mock_get_settings,
+        ):
+            # Call the endpoint function directly
+            response = await get_email_event_settings(
+                user_api_key_dict=mock_user_api_key_auth
+            )
+
+            # Assert response contains correct settings
+            assert isinstance(response.dict(), dict)
+            assert "settings" in response.dict()
+            settings = response.dict()["settings"]
+            assert len(settings) == len(EmailEvent)
+
+            # Find the setting for virtual_key_created and check its value
+            virtual_key_setting = next(
+                (s for s in settings if s["event"] == EmailEvent.virtual_key_created),
+                None,
+            )
+            assert virtual_key_setting is not None
+            assert virtual_key_setting["enabled"] is True
+
+
+# Test the PATCH endpoint
+@pytest.mark.asyncio
+async def test_update_event_settings(mock_prisma_client, mock_user_api_key_auth):
+    """Test that the PATCH endpoint correctly updates email event settings."""
+
+    # Mock _get_email_settings to return default settings
+    async def mock_get_settings(*args, **kwargs):
+        return DefaultEmailSettings.get_defaults()
+
+    # Mock _save_email_settings to do nothing
+    async def mock_save_settings(*args, **kwargs):
+        return None
+
+    # Setup mocks
+    with mock.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        with mock.patch(
+            "enterprise.enterprise_callbacks.send_emails.endpoints._get_email_settings",
+            side_effect=mock_get_settings,
+        ):
+            with mock.patch(
+                "enterprise.enterprise_callbacks.send_emails.endpoints._save_email_settings",
+                side_effect=mock_save_settings,
+            ):
+                # Create request with updated settings
+                request = EmailEventSettingsUpdateRequest(
+                    settings=[
+                        EmailEventSettings(
+                            event=EmailEvent.virtual_key_created, enabled=True
+                        ),
+                        EmailEventSettings(
+                            event=EmailEvent.new_user_invitation, enabled=False
+                        ),
+                    ]
+                )
+
+                # Call the endpoint function directly
+                response = await update_event_settings(
+                    request=request, user_api_key_dict=mock_user_api_key_auth
+                )
+
+                # Assert response is success
+                assert (
+                    response["message"] == "Email event settings updated successfully"
+                )
+
+
+# Test the reset endpoint
+@pytest.mark.asyncio
+async def test_reset_event_settings(mock_prisma_client, mock_user_api_key_auth):
+    """Test that the reset endpoint correctly restores default email event settings."""
+
+    # Mock _save_email_settings to do nothing
+    async def mock_save_settings(*args, **kwargs):
+        return None
+
+    # Setup mocks
+    with mock.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        with mock.patch(
+            "enterprise.enterprise_callbacks.send_emails.endpoints._save_email_settings",
+            side_effect=mock_save_settings,
+        ):
+            # Call the endpoint function directly
+            response = await reset_event_settings(
+                user_api_key_dict=mock_user_api_key_auth
+            )
+
+            # Assert response is success
+            assert response["message"] == "Email event settings reset to defaults"
+
+
+# Test handling of prisma client None
+@pytest.mark.asyncio
+async def test_endpoint_with_no_prisma_client(mock_user_api_key_auth):
+    """Test that all endpoints properly handle the case when the database is not connected."""
+    # Setup mock to return None for prisma_client
+    with mock.patch("litellm.proxy.proxy_server.prisma_client", None):
+        # Test get endpoint
+        with pytest.raises(HTTPException) as exc_info:
+            await get_email_event_settings(user_api_key_dict=mock_user_api_key_auth)
+        assert exc_info.value.status_code == 500
+        assert "Database not connected" in exc_info.value.detail
+
+        # Test update endpoint
+        request = EmailEventSettingsUpdateRequest(settings=[])
+        with pytest.raises(HTTPException) as exc_info:
+            await update_event_settings(
+                request=request, user_api_key_dict=mock_user_api_key_auth
+            )
+        assert exc_info.value.status_code == 500
+
+        # Test reset endpoint
+        with pytest.raises(HTTPException) as exc_info:
+            await reset_event_settings(user_api_key_dict=mock_user_api_key_auth)
+        assert exc_info.value.status_code == 500

--- a/ui/litellm-dashboard/src/components/email_events/email_event_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_events/email_event_settings.tsx
@@ -74,9 +74,9 @@ const EmailEventSettings: React.FC<EmailEventSettingsProps> = ({
   const getEventDescription = (event: EmailEvent): string => {
     // Convert event name to a sentence with more context
     if (event.includes("Virtual Key Created")) {
-      return "Receive an email notification when a new virtual key is created";
+      return "An email will be sent to the user when a new virtual key is created with their user ID";
     } else if (event.includes("New User Invitation")) {
-      return "Receive an email notification when a new user is invited";
+      return "An email will be sent to the email address of the user when a new user is created";
     } else {
       // Handle any other event type from the API
       const words = event.split(/(?=[A-Z])/).join(' ').toLowerCase();

--- a/ui/litellm-dashboard/src/components/email_events/email_event_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_events/email_event_settings.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect } from "react";
+import { Card, Text, Grid, Button } from "@tremor/react";
+import { Typography, message, Divider, Spin, Checkbox } from "antd";
+import { getEmailEventSettings, updateEmailEventSettings, resetEmailEventSettings } from "../networking";
+import { EmailEvent } from "../../types";
+import { EmailEventSetting } from "./types";
+
+const { Title } = Typography;
+
+interface EmailEventSettingsProps {
+  accessToken: string | null;
+}
+
+const EmailEventSettings: React.FC<EmailEventSettingsProps> = ({
+  accessToken,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [eventSettings, setEventSettings] = useState<EmailEventSetting[]>([]);
+
+  // Fetch email event settings on component mount
+  useEffect(() => {
+    fetchEventSettings();
+  }, [accessToken]);
+
+  const fetchEventSettings = async () => {
+    if (!accessToken) return;
+
+    setLoading(true);
+    try {
+      const response = await getEmailEventSettings(accessToken);
+      setEventSettings(response.settings);
+    } catch (error) {
+      console.error("Failed to fetch email event settings:", error);
+      message.error("Failed to fetch email event settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCheckboxChange = (event: EmailEvent, checked: boolean) => {
+    const updatedSettings = eventSettings.map(setting => 
+      setting.event === event ? { ...setting, enabled: checked } : setting
+    );
+    setEventSettings(updatedSettings);
+  };
+
+  const handleSaveSettings = async () => {
+    if (!accessToken) return;
+
+    try {
+      await updateEmailEventSettings(accessToken, { settings: eventSettings });
+      message.success("Email event settings updated successfully");
+    } catch (error) {
+      console.error("Failed to update email event settings:", error);
+      message.error("Failed to update email event settings");
+    }
+  };
+
+  const handleResetSettings = async () => {
+    if (!accessToken) return;
+
+    try {
+      await resetEmailEventSettings(accessToken);
+      message.success("Email event settings reset to defaults");
+      // Refresh settings after reset
+      fetchEventSettings();
+    } catch (error) {
+      console.error("Failed to reset email event settings:", error);
+      message.error("Failed to reset email event settings");
+    }
+  };
+
+  // Helper function to get a description for each event type
+  const getEventDescription = (event: EmailEvent): string => {
+    // Convert event name to a sentence with more context
+    if (event.includes("Virtual Key Created")) {
+      return "Receive an email notification when a new virtual key is created";
+    } else if (event.includes("New User Invitation")) {
+      return "Receive an email notification when a new user is invited";
+    } else {
+      // Handle any other event type from the API
+      const words = event.split(/(?=[A-Z])/).join(' ').toLowerCase();
+      return `Receive an email notification when ${words}`;
+    }
+  };
+
+  return (
+    <Card>
+      <Title level={4}>Email Notifications</Title>
+      <Text>
+        Select which events should trigger email notifications.
+      </Text>
+      <Divider />
+
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: '20px' }}>
+          <Spin size="large" />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {eventSettings.map((setting) => (
+            <div key={setting.event} className="flex items-center">
+              <Checkbox 
+                checked={setting.enabled}
+                onChange={(e) => handleCheckboxChange(setting.event, e.target.checked)}
+              />
+              <div className="ml-3">
+                <Text>{setting.event}</Text>
+                <div className="text-sm text-gray-500 block">
+                  {getEventDescription(setting.event)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-6 flex space-x-4">
+        <Button
+          onClick={handleSaveSettings}
+          disabled={loading}
+        >
+          Save Changes
+        </Button>
+        <Button
+          onClick={handleResetSettings}
+          variant="secondary"
+          disabled={loading}
+        >
+          Reset to Defaults
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default EmailEventSettings; 

--- a/ui/litellm-dashboard/src/components/email_events/index.ts
+++ b/ui/litellm-dashboard/src/components/email_events/index.ts
@@ -1,0 +1,2 @@
+export { default as EmailEventSettings } from './email_event_settings';
+export * from './types'; 

--- a/ui/litellm-dashboard/src/components/email_events/types.ts
+++ b/ui/litellm-dashboard/src/components/email_events/types.ts
@@ -1,0 +1,14 @@
+import { EmailEvent } from "../../types";
+
+export interface EmailEventSetting {
+  event: EmailEvent;
+  enabled: boolean;
+}
+
+export interface EmailEventSettingsUpdateRequest {
+  settings: EmailEventSetting[];
+}
+
+export interface EmailEventSettingsResponse {
+  settings: EmailEventSetting[];
+} 

--- a/ui/litellm-dashboard/src/components/email_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.tsx
@@ -7,8 +7,9 @@ import {
   TextInput,
   TableCell,
 } from "@tremor/react";
-import { Typography, message } from "antd";
+import { Typography, message, Divider } from "antd";
 import { serviceHealthCheck, setCallbacksCall } from "./networking";
+import { EmailEventSettings } from "./email_events";
 
 const { Title } = Typography;
 
@@ -60,11 +61,12 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({
   }
 
   return (
-    <Card>
-      <Title level={4}>Email Settings</Title>
-      <Text>
-      <a href="https://docs.litellm.ai/docs/proxy/email" target="_blank" style={{ color: "blue" }}> LiteLLM Docs: email alerts</a> <br/>        
-      </Text>
+    <>
+      <Card>
+        <Title level={4}>Email Server Settings</Title>
+        <Text>
+        <a href="https://docs.litellm.ai/docs/proxy/email" target="_blank" style={{ color: "blue" }}> LiteLLM Docs: email alerts</a> <br/>        
+        </Text>
 <div className="flex w-full">
   {alerts
     .filter((alert) => alert.name === "email")
@@ -186,13 +188,18 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({
             </Button>
             <Button
               onClick={() =>
-                serviceHealthCheck(accessToken, "email")
+                accessToken && serviceHealthCheck(accessToken, "email")
               }
               className="mx-2"
             >
               Test Email Alerts
             </Button>
-    </Card>
+      </Card>
+
+      <div className="mt-6">
+        <EmailEventSettings accessToken={accessToken} />
+      </div>
+    </>
   );
 };
 

--- a/ui/litellm-dashboard/src/components/email_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.tsx
@@ -62,11 +62,15 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({
 
   return (
     <>
+    <div className="mt-6 mb-6">
+        <EmailEventSettings accessToken={accessToken} />
+      </div>
       <Card>
         <Title level={4}>Email Server Settings</Title>
         <Text>
         <a href="https://docs.litellm.ai/docs/proxy/email" target="_blank" style={{ color: "blue" }}> LiteLLM Docs: email alerts</a> <br/>        
         </Text>
+        
 <div className="flex w-full">
   {alerts
     .filter((alert) => alert.name === "email")
@@ -196,9 +200,6 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({
             </Button>
       </Card>
 
-      <div className="mt-6">
-        <EmailEventSettings accessToken={accessToken} />
-      </div>
     </>
   );
 };

--- a/ui/litellm-dashboard/src/components/email_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.tsx
@@ -1,0 +1,199 @@
+import React, { useState, useEffect } from "react";
+import {
+  Card,
+  Text,
+  Grid,
+  Button,
+  TextInput,
+  TableCell,
+} from "@tremor/react";
+import { Typography, message } from "antd";
+import { serviceHealthCheck, setCallbacksCall } from "./networking";
+
+const { Title } = Typography;
+
+interface EmailSettingsProps {
+  accessToken: string | null;
+  premiumUser: boolean;
+  alerts: any[];
+}
+
+const EmailSettings: React.FC<EmailSettingsProps> = ({
+  accessToken,
+  premiumUser,
+  alerts,
+}) => {
+  const handleSaveEmailSettings = () => {
+    if (!accessToken) {
+      return;
+    }
+
+    let updatedVariables: Record<string, string> = {};
+
+    alerts
+      .filter((alert) => alert.name === "email")
+      .forEach((alert) => {
+        Object.entries(alert.variables ?? {}).forEach(([key, value]) => {
+          const inputElement = document.querySelector(`input[name="${key}"]`) as HTMLInputElement;
+          if (inputElement && inputElement.value) {
+            updatedVariables[key] = inputElement?.value;
+          }
+        });
+      });
+
+    console.log("updatedVariables", updatedVariables);
+    //filter out null / undefined values for updatedVariables
+
+    const payload = {
+      general_settings: {
+        alerting: ["email"],
+      },
+      environment_variables: updatedVariables,
+    };
+    try {
+      setCallbacksCall(accessToken, payload);
+    } catch (error) {
+      message.error("Failed to update alerts: " + error, 20);
+    }
+
+    message.success("Email settings updated successfully");
+  }
+
+  return (
+    <Card>
+      <Title level={4}>Email Settings</Title>
+      <Text>
+      <a href="https://docs.litellm.ai/docs/proxy/email" target="_blank" style={{ color: "blue" }}> LiteLLM Docs: email alerts</a> <br/>        
+      </Text>
+<div className="flex w-full">
+  {alerts
+    .filter((alert) => alert.name === "email")
+    .map((alert, index) => (
+      <TableCell key={index}>
+
+        <ul>
+        <Grid numItems={2}>
+          {Object.entries(alert.variables ?? {}).map(([key, value]) => (
+            <li key={key} className="mx-2 my-2">
+              
+              { premiumUser!= true && (key === "EMAIL_LOGO_URL" || key === "EMAIL_SUPPORT_CONTACT") ? (
+                <div>
+                  <a
+                  href="https://forms.gle/W3U4PZpJGFHWtHyA9"
+                  target="_blank"
+                >
+                  <Text className="mt-2">
+                  {" "}
+                  ✨ {key}
+
+                  </Text>
+                 
+                </a>
+                <TextInput
+                name={key}
+                defaultValue={value as string}
+                type="password"
+                disabled={true}
+                style={{ width: "400px" }}
+              />
+                </div>
+                
+              ) : (
+                <div>
+                  <Text className="mt-2">{key}</Text>
+                  <TextInput
+                name={key}
+                defaultValue={value as string}
+                type="password"
+                style={{ width: "400px" }}
+              />
+                </div>
+                
+              )}
+              
+              {/* Added descriptions for input fields */}
+              <p style={{ fontSize: "small", fontStyle: "italic" }}>
+                {key === "SMTP_HOST" && (
+                  <div style={{ color: "gray" }}>
+                    Enter the SMTP host address, e.g. `smtp.resend.com`
+                    <span style={{ color: "red" }}> Required * </span>
+                  </div>
+                  
+                )}
+
+                {key === "SMTP_PORT" && (
+                  <div style={{ color: "gray" }}>
+                    Enter the SMTP port number, e.g. `587`
+                     <span style={{ color: "red" }}> Required * </span>
+
+                  </div>
+                 
+                )}
+                
+                {key === "SMTP_USERNAME" && (
+                  <div style={{ color: "gray" }}>
+                    Enter the SMTP username, e.g. `username`
+                    <span style={{ color: "red" }}> Required * </span>
+                  </div>
+                  
+                )}
+                
+                {key === "SMTP_PASSWORD" && (
+                  <span style={{ color: "red" }}> Required * </span>
+                )}
+
+                {key === "SMTP_SENDER_EMAIL" && (
+                  <div style={{ color: "gray" }}>
+                    Enter the sender email address, e.g. `sender@berri.ai`
+                  <span style={{ color: "red" }}> Required * </span>
+
+                  </div>
+                )}
+
+                {key === "TEST_EMAIL_ADDRESS" && (
+                  <div style={{ color: "gray" }}>
+                  Email Address to send `Test Email Alert` to. example: `info@berri.ai`
+                  <span style={{ color: "red" }}> Required * </span>
+                  </div>
+                )
+                }
+                {key === "EMAIL_LOGO_URL" && (
+                  <div style={{ color: "gray" }}>
+                   (Optional) Customize the Logo that appears in the email, pass a url to your logo
+                  </div>
+                )
+                }
+                {key === "EMAIL_SUPPORT_CONTACT" && (
+                  <div style={{ color: "gray" }}>
+                   (Optional) Customize the support email address that appears in the email. Default is support@berri.ai
+                  </div>
+                )
+                   }
+              </p>
+            </li>
+          ))}
+                  </Grid>
+        </ul>
+      </TableCell>
+    ))}
+</div>
+
+            <Button
+              className="mt-2"
+              onClick={() => handleSaveEmailSettings()}
+            >
+              Save Changes
+            </Button>
+            <Button
+              onClick={() =>
+                serviceHealthCheck(accessToken, "email")
+              }
+              className="mx-2"
+            >
+              Test Email Alerts
+            </Button>
+    </Card>
+  );
+};
+
+export default EmailSettings; 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6,6 +6,7 @@ import { message } from "antd";
 import { TagNewRequest, TagUpdateRequest, TagDeleteRequest, TagInfoRequest, TagListResponse, TagInfoResponse } from "./tag_management/types";
 import { Team } from "./key_team_helpers/key_list";
 import { UserInfo } from "./view_users/types";
+import { EmailEventSettingsResponse, EmailEventSettingsUpdateRequest } from "./email_events/types";
 
 const isLocal = process.env.NODE_ENV === "development";
 export const proxyBaseUrl = isLocal ? "http://localhost:4000" : null;
@@ -4920,6 +4921,91 @@ export const vectorStoreInfoCall = async (
     return await response.json();
   } catch (error) {
     console.error('Error getting vector store info:', error);
+    throw error;
+  }
+};
+
+export const getEmailEventSettings = async (accessToken: string): Promise<EmailEventSettingsResponse> => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/email/event_settings` : `/email/event_settings`;
+    
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Failed to get email event settings");
+    }
+
+    const data = await response.json();
+    console.log("Email event settings response:", data);
+    return data;
+  } catch (error) {
+    console.error("Failed to get email event settings:", error);
+    throw error;
+  }
+};
+
+export const updateEmailEventSettings = async (
+  accessToken: string,
+  settings: EmailEventSettingsUpdateRequest
+) => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/email/event_settings` : `/email/event_settings`;
+    
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(settings),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Failed to update email event settings");
+    }
+
+    const data = await response.json();
+    console.log("Update email event settings response:", data);
+    return data;
+  } catch (error) {
+    console.error("Failed to update email event settings:", error);
+    throw error;
+  }
+};
+
+export const resetEmailEventSettings = async (accessToken: string) => {
+  try {
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/email/event_settings/reset` : `/email/event_settings/reset`;
+    
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      }
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Failed to reset email event settings");
+    }
+
+    const data = await response.json();
+    console.log("Reset email event settings response:", data);
+    return data;
+  } catch (error) {
+    console.error("Failed to reset email event settings:", error);
     throw error;
   }
 };

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -32,6 +32,7 @@ import {
 } from "@heroicons/react/outline";
 
 import { Modal, Typography, Form, Input, Select, Button as Button2, message } from "antd";
+import EmailSettings from "./email_settings";
 
 const { Title, Paragraph } = Typography;
 const isLocal = process.env.NODE_ENV === "development";
@@ -205,43 +206,6 @@ const Settings: React.FC<SettingsPageProps> = ({
     // Here, you can perform any additional logic with the selected values
     console.log("Selected values:", values);
   };
-
-  const handleSaveEmailSettings = () => {
-    if (!accessToken) {
-      return;
-    }
-
-
-    let updatedVariables: Record<string, string> = {};
-
-    alerts
-      .filter((alert) => alert.name === "email")
-      .forEach((alert) => {
-        Object.entries(alert.variables ?? {}).forEach(([key, value]) => {
-          const inputElement = document.querySelector(`input[name="${key}"]`) as HTMLInputElement;
-          if (inputElement && inputElement.value) {
-            updatedVariables[key] = inputElement?.value;
-          }
-        });
-      });
-
-    console.log("updatedVariables", updatedVariables);
-    //filter out null / undefined values for updatedVariables
-
-    const payload = {
-      general_settings: {
-        alerting: ["email"],
-      },
-      environment_variables: updatedVariables,
-    };
-    try {
-      setCallbacksCall(accessToken, payload);
-    } catch (error) {
-      message.error("Failed to update alerts: " + error, 20);
-    }
-
-    message.success("Email settings updated successfully");
-  }
 
   const updateCallbackCall = async (formValues: Record<string, any>) => {
     if (!accessToken) {
@@ -653,141 +617,12 @@ const Settings: React.FC<SettingsPageProps> = ({
               />
             </TabPanel>
             <TabPanel>
-              <Card>
-      <Title level={4}>Email Settings</Title>
-      <Text>
-      <a href="https://docs.litellm.ai/docs/proxy/email" target="_blank" style={{ color: "blue" }}> LiteLLM Docs: email alerts</a> <br/>        
-      </Text>
-<div className="flex w-full">
-  {alerts
-    .filter((alert) => alert.name === "email")
-    .map((alert, index) => (
-      <TableCell key={index}>
-
-        <ul>
-        <Grid numItems={2}>
-          {Object.entries(alert.variables ?? {}).map(([key, value]) => (
-            <li key={key} className="mx-2 my-2">
-              
-              { premiumUser!= true && (key === "EMAIL_LOGO_URL" || key === "EMAIL_SUPPORT_CONTACT") ? (
-                <div>
-                  <a
-                  href="https://forms.gle/W3U4PZpJGFHWtHyA9"
-                  target="_blank"
-                >
-                  <Text className="mt-2">
-                  {" "}
-                  ✨ {key}
-
-                  </Text>
-                 
-                </a>
-                <TextInput
-                name={key}
-                defaultValue={value as string}
-                type="password"
-                disabled={true}
-                style={{ width: "400px" }}
+              <EmailSettings 
+                accessToken={accessToken}
+                premiumUser={premiumUser}
+                alerts={alerts}
               />
-                </div>
-                
-              ) : (
-                <div>
-                  <Text className="mt-2">{key}</Text>
-                  <TextInput
-                name={key}
-                defaultValue={value as string}
-                type="password"
-                style={{ width: "400px" }}
-              />
-                </div>
-                
-              )}
-              
-              {/* Added descriptions for input fields */}
-              <p style={{ fontSize: "small", fontStyle: "italic" }}>
-                {key === "SMTP_HOST" && (
-                  <div style={{ color: "gray" }}>
-                    Enter the SMTP host address, e.g. `smtp.resend.com`
-                    <span style={{ color: "red" }}> Required * </span>
-                  </div>
-                  
-                )}
-
-                {key === "SMTP_PORT" && (
-                  <div style={{ color: "gray" }}>
-                    Enter the SMTP port number, e.g. `587`
-                     <span style={{ color: "red" }}> Required * </span>
-
-                  </div>
-                 
-                )}
-                
-                {key === "SMTP_USERNAME" && (
-                  <div style={{ color: "gray" }}>
-                    Enter the SMTP username, e.g. `username`
-                    <span style={{ color: "red" }}> Required * </span>
-                  </div>
-                  
-                )}
-                
-                {key === "SMTP_PASSWORD" && (
-                  <span style={{ color: "red" }}> Required * </span>
-                )}
-
-                {key === "SMTP_SENDER_EMAIL" && (
-                  <div style={{ color: "gray" }}>
-                    Enter the sender email address, e.g. `sender@berri.ai`
-                  <span style={{ color: "red" }}> Required * </span>
-
-                  </div>
-                )}
-
-                {key === "TEST_EMAIL_ADDRESS" && (
-                  <div style={{ color: "gray" }}>
-                  Email Address to send `Test Email Alert` to. example: `info@berri.ai`
-                  <span style={{ color: "red" }}> Required * </span>
-                  </div>
-                )
-                }
-                {key === "EMAIL_LOGO_URL" && (
-                  <div style={{ color: "gray" }}>
-                   (Optional) Customize the Logo that appears in the email, pass a url to your logo
-                  </div>
-                )
-                }
-                {key === "EMAIL_SUPPORT_CONTACT" && (
-                  <div style={{ color: "gray" }}>
-                   (Optional) Customize the support email address that appears in the email. Default is support@berri.ai
-                  </div>
-                )
-                   }
-              </p>
-            </li>
-          ))}
-                  </Grid>
-        </ul>
-      </TableCell>
-    ))}
-</div>
-
-            <Button
-              className="mt-2"
-              onClick={() => handleSaveEmailSettings()}
-            >
-              Save Changes
-            </Button>
-            <Button
-              onClick={() =>
-                serviceHealthCheck(accessToken, "email")
-              }
-              className="mx-2"
-            >
-              Test Email Alerts
-            </Button>
-            
-              </Card>
-          </TabPanel>
+            </TabPanel>
           </TabPanels>
         </TabGroup>
       </Grid>

--- a/ui/litellm-dashboard/src/types.ts
+++ b/ui/litellm-dashboard/src/types.ts
@@ -1,1 +1,4 @@
 export type Setter<T> = (newValueOrUpdater: T | ((previousValue: T) => T)) => void
+
+// We'll get the email event types from the endpoint
+export type EmailEvent = string;


### PR DESCRIPTION
## [Feat] Add endpoints to manage email settings

<img width="1088" alt="Screenshot 2025-05-07 at 6 31 12 PM" src="https://github.com/user-attachments/assets/23eebebc-bb70-4519-aa3c-9b9a7b7e1c41" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


