### PR TITLE
Add New Perplexity Models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11223,12 +11223,11 @@
         "supports_reasoning": true
     },
     "perplexity/sonar-deep-research": {
-        "max_tokens": 12000,
-        "max_input_tokens": 12000,
-        "max_output_tokens": 12000,
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
         "input_cost_per_token": 2e-6,
         "output_cost_per_token": 8e-6,
-        "output_cost_per_reasoning_token": 3e-5,
+        "output_cost_per_reasoning_token": 3e-6,
         "litellm_provider": "perplexity",
         "mode": "chat",
         "search_context_cost_per_query": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4257,7 +4257,7 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
-    "cerebras/llama3.3-70b": {
+    "cerebras/llama-3.3-70b": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -11162,6 +11162,65 @@
         "input_cost_per_request": 0.005,
         "litellm_provider": "perplexity",
         "mode": "chat"
+    },
+    "perplexity/sonar": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 1e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 5e-3,
+            "search_context_size_medium": 8e-3,
+            "search_context_size_high": 12e-3
+        },
+        "supports_web_search": true
+    },
+    "perplexity/sonar-pro": {
+        "max_tokens": 8000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "input_cost_per_token": 3e-6,
+        "output_cost_per_token": 15e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 6e-3,
+            "search_context_size_medium": 10e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true
+    },
+    "perplexity/sonar-reasoning": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 5e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 5e-3,
+            "search_context_size_medium": 8e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true,
+        "supports_reasoning": true
+    },
+    "perplexity/sonar-reasoning-pro": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 2e-6,
+        "output_cost_per_token": 8e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 6e-3,
+            "search_context_size_medium": 10e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true,
+        "supports_reasoning": true
     },
     "perplexity/sonar-deep-research": {
         "max_tokens": 12000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11223,12 +11223,11 @@
         "supports_reasoning": true
     },
     "perplexity/sonar-deep-research": {
-        "max_tokens": 12000,
-        "max_input_tokens": 12000,
-        "max_output_tokens": 12000,
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
         "input_cost_per_token": 2e-6,
         "output_cost_per_token": 8e-6,
-        "output_cost_per_reasoning_token": 3e-5,
+        "output_cost_per_reasoning_token": 3e-6,
         "litellm_provider": "perplexity",
         "mode": "chat",
         "search_context_cost_per_query": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11163,6 +11163,65 @@
         "litellm_provider": "perplexity",
         "mode": "chat"
     },
+    "perplexity/sonar": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 1e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 5e-3,
+            "search_context_size_medium": 8e-3,
+            "search_context_size_high": 12e-3
+        },
+        "supports_web_search": true
+    },
+    "perplexity/sonar-pro": {
+        "max_tokens": 8000,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "input_cost_per_token": 3e-6,
+        "output_cost_per_token": 15e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 6e-3,
+            "search_context_size_medium": 10e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true
+    },
+    "perplexity/sonar-reasoning": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 1e-6,
+        "output_cost_per_token": 5e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 5e-3,
+            "search_context_size_medium": 8e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true,
+        "supports_reasoning": true
+    },
+    "perplexity/sonar-reasoning-pro": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "input_cost_per_token": 2e-6,
+        "output_cost_per_token": 8e-6,
+        "litellm_provider": "perplexity",
+        "mode": "chat",
+        "search_context_cost_per_query": {
+            "search_context_size_low": 6e-3,
+            "search_context_size_medium": 10e-3,
+            "search_context_size_high": 14e-3
+        },
+        "supports_web_search": true,
+        "supports_reasoning": true
+    },
     "perplexity/sonar-deep-research": {
         "max_tokens": 12000,
         "max_input_tokens": 12000,


### PR DESCRIPTION
## Title

Adds more perplexity models such as Sonar, Sonar Pro, Sonar Reasoning and Sonar Reasoning Pro

## Relevant issues

#10537 has removed some perplexity models which I use and I have added it back with more accurate pricing and numbers using the format from Sonar Reasoning Pro

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
- Added Sonar, Sonar Pro, Sonar Reasoning and Sonar Reasoning Pro models using the pattern from Sonar Deep Research
