### PR TITLE
fix: URL encode OTEL_EXPORTER_OTLP_TRACES_HEADERS for Phoenix Integration

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 from typing import TYPE_CHECKING, Any, Union
 
 from litellm._logging import verbose_logger
@@ -69,7 +70,7 @@ class ArizePhoenixLogger:
             otlp_auth_headers = f"api_key={api_key}"
         elif api_key is not None:
             # api_key/auth is optional for self hosted phoenix
-            otlp_auth_headers = f"Authorization=Bearer {api_key}"
+            otlp_auth_headers = f"Authorization={urllib.parse.quote(f'Bearer {api_key}')}"
 
         return ArizePhoenixConfig(
             otlp_auth_headers=otlp_auth_headers, protocol=protocol, endpoint=endpoint

--- a/tests/litellm/integrations/arize/test_arize_phoenix.py
+++ b/tests/litellm/integrations/arize/test_arize_phoenix.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+from litellm.integrations.arize.arize_phoenix import ArizePhoenixLogger
+
+class TestArizePhoenixConfig(unittest.TestCase):
+
+    @patch.dict('os.environ', {
+        'PHOENIX_API_KEY': 'test_api_key',
+        'PHOENIX_COLLECTOR_HTTP_ENDPOINT': 'http://test.endpoint'
+    })
+    def test_get_arize_phoenix_config_http(self):
+        # Call the function to get the configuration
+        config = ArizePhoenixLogger.get_arize_phoenix_config()
+        
+        # Verify the configuration
+        self.assertEqual(config.otlp_auth_headers, 'Authorization=Bearer%20test_api_key')
+        self.assertEqual(config.endpoint, 'http://test.endpoint')
+        self.assertEqual(config.protocol, 'otlp_http')
+
+    @patch.dict('os.environ', {
+        'PHOENIX_API_KEY': 'test_api_key',
+        'PHOENIX_COLLECTOR_ENDPOINT': 'grpc://test.endpoint'
+    })
+    def test_get_arize_phoenix_config_grpc(self):
+        # Call the function to get the configuration
+        config = ArizePhoenixLogger.get_arize_phoenix_config()
+        
+        # Verify the configuration
+        self.assertEqual(config.otlp_auth_headers, 'Authorization=Bearer%20test_api_key')
+        self.assertEqual(config.endpoint, 'grpc://test.endpoint')
+        self.assertEqual(config.protocol, 'otlp_grpc')
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION

- Add URL encoding for Bearer token in authorization header
- Follow OpenTelemetry Protocol Exporter specification
- Fix header format validation error in Phoenix integration

## Title

## Relevant issues

Fixes #10569 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


