### PR TITLE
[Refactor - Filtering Spend Logs] Add `status` to root of SpendLogs table

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20250508072103_add_status_to_spendlogs/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20250508072103_add_status_to_spendlogs/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_SpendLogs" ADD COLUMN     "status" TEXT;
+

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_SpendLogs {
   messages            Json?     @default("{}")
   response            Json?     @default("{}")
   session_id          String?
+  status              String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2035,6 +2035,7 @@ class SpendLogsPayload(TypedDict):
     response: Optional[Union[str, list, dict]]
     proxy_server_request: Optional[str]
     session_id: Optional[str]
+    status: Literal["success", "failure"]
 
 
 class SpanAttributes(str, enum.Enum):

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_SpendLogs {
   messages            Json?     @default("{}")
   response            Json?     @default("{}")
   session_id          String?
+  status              String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/schema.prisma
+++ b/schema.prisma
@@ -260,6 +260,7 @@ model LiteLLM_SpendLogs {
   messages            Json?     @default("{}")
   response            Json?     @default("{}")
   session_id          String?
+  status              String?
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([end_user])

--- a/tests/litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -485,6 +485,7 @@ class TestSpendLogsPayload:
                     "messages": "{}",
                     "response": "{}",
                     "proxy_server_request": "{}",
+                    "status": "success",
                 }
             )
 
@@ -576,6 +577,7 @@ class TestSpendLogsPayload:
                     "messages": "{}",
                     "response": "{}",
                     "proxy_server_request": "{}",
+                    "status": "success",
                 }
             )
 
@@ -665,6 +667,7 @@ class TestSpendLogsPayload:
                     "messages": "{}",
                     "response": "{}",
                     "proxy_server_request": "{}",
+                    "status": "success",
                 }
             )
 

--- a/tests/logging_callback_tests/gcs_pub_sub_body/spend_logs_payload.json
+++ b/tests/logging_callback_tests/gcs_pub_sub_body/spend_logs_payload.json
@@ -25,5 +25,6 @@
     "custom_llm_provider": "openai",
     "messages": "{}",
     "response": "{}",
-    "proxy_server_request": "{}"
+    "proxy_server_request": "{}",
+    "status": "success"
 }


### PR DESCRIPTION
## [Refactor - Filtering Spend Logs] Add `status` to root of SpendLogs table

- Add `status` to root of the SpendLogs Table
- This allows easily filtering the Logs table by status

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
✅ Test

## Changes


