### PR TITLE
Capturing gemini usage details in streaming mode with inferred reasoning tokens

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -983,13 +983,16 @@ class CustomStreamWrapper:
 
                     if self.custom_llm_provider in ("vertex_ai", "vertex_ai_beta"):
 
-                        prompt_tokens = generic_response_obj["usage"].get("prompt_tokens")
-                        completion_tokens = generic_response_obj["usage"].get("completion_tokens")
-                        total_tokens = generic_response_obj["usage"].get("total_tokens")
-                                                                           
-                        # Gemini may not return reasoning_tokens in stream mode separately but it includes them in total_tokens                                                                           )
-                        reasoning_tokens = total_tokens - (prompt_tokens + completion_tokens) if total_tokens and prompt_tokens and completion_tokens else 0
+                        prompt_tokens = generic_response_obj["usage"].get("prompt_tokens") or 0
+                        completion_tokens = generic_response_obj["usage"].get("completion_tokens") or 0
+                        total_tokens = generic_response_obj["usage"].get("total_tokens") or 0
 
+                        if total_tokens > prompt_tokens + completion_tokens:
+                            reasoning_tokens = total_tokens - (prompt_tokens + completion_tokens)
+                            completion_tokens = completion_tokens + reasoning_tokens
+                        else:
+                            reasoning_tokens = 0
+                                                                           
                         model_response.usage = litellm.Usage(
                             prompt_tokens=prompt_tokens,
                             completion_tokens=completion_tokens,

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -997,7 +997,7 @@ class CustomStreamWrapper:
                             reasoning_tokens=reasoning_tokens
                         )
                     else:
-                        model_response.usage = litellm.Usage(**generic_response_obj.usage)
+                        model_response.usage = litellm.Usage(**generic_response_obj["usage"])
 
                 if (
                     "tool_use" in generic_response_obj


### PR DESCRIPTION
## Title

Capturing gemini usage details in streaming mode with inferred reasoning tokens

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/10554

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Capturing gemini (vertex_ai) usage tokens in streaming mode. Reasoning tokens can be inferred as total_tokens - prompt - completion. Also a small refac, renamed variable (was called "anthropic_response_obj" while being on a generic path.

Currently (before this PR), gemini reasoning tokens were ignore in streaming mode.

