### PR TITLE
fix(factory.py): Add reasoning content handling for missing assistant…

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3040,6 +3040,18 @@ class BedrockConverseMessagesProcessor:
                     )
                 )
                 _assistant_content = assistant_message_block.get("content", None)
+                if _assistant_content is None:
+                    thinking_blocks = assistant_message_block.get("thinking_blocks", None)
+                    if (
+                            thinking_blocks is not None
+                    ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
+                        for block in thinking_blocks:
+                            thinking_block = BedrockConverseMessagesProcessor.translate_thinking_blocks_to_reasoning_content_blocks(
+                                thinking_blocks=[
+                                    cast(ChatCompletionThinkingBlock, block)
+                                ]
+                            )
+                            assistant_content.extend(thinking_block)
 
                 if _assistant_content is not None and isinstance(
                     _assistant_content, list

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3040,18 +3040,19 @@ class BedrockConverseMessagesProcessor:
                     )
                 )
                 _assistant_content = assistant_message_block.get("content", None)
-                if _assistant_content is None:
-                    thinking_blocks = assistant_message_block.get("thinking_blocks", None)
-                    if (
-                            thinking_blocks is not None
-                    ):  # IMPORTANT: ADD THIS FIRST, ELSE ANTHROPIC WILL RAISE AN ERROR
-                        for block in thinking_blocks:
-                            thinking_block = BedrockConverseMessagesProcessor.translate_thinking_blocks_to_reasoning_content_blocks(
-                                thinking_blocks=[
-                                    cast(ChatCompletionThinkingBlock, block)
-                                ]
-                            )
-                            assistant_content.extend(thinking_block)
+                thinking_blocks = cast(
+                    Optional[List[ChatCompletionThinkingBlock]],
+                    assistant_message_block.get("thinking_blocks"),
+                )
+
+                if thinking_blocks is not None:
+                    converted_thinking_blocks = BedrockConverseMessagesProcessor.translate_thinking_blocks_to_reasoning_content_blocks(
+                        thinking_blocks
+                    )
+                    assistant_content = BedrockConverseMessagesProcessor.add_thinking_blocks_to_assistant_content(
+                        thinking_blocks=converted_thinking_blocks,
+                        assistant_parts=assistant_content,
+                    )
 
                 if _assistant_content is not None and isinstance(
                     _assistant_content, list
@@ -3065,7 +3066,10 @@ class BedrockConverseMessagesProcessor:
                                         cast(ChatCompletionThinkingBlock, element)
                                     ]
                                 )
-                                assistants_parts.extend(thinking_block)
+                                assistants_parts = BedrockConverseMessagesProcessor.add_thinking_blocks_to_assistant_content(
+                                    thinking_blocks=thinking_block,
+                                    assistant_parts=assistants_parts,
+                                )
                             elif element["type"] == "text":
                                 assistants_part = BedrockContentBlock(
                                     text=element["text"]


### PR DESCRIPTION
When LiteLLM is used in proxy mode, configured with the Bedrock model ⁠bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0 and with 'thinking' mode enabled, an issue arises. During the second turn of a conversation, if the assistant's message is returned with its ⁠content field as ⁠None, LiteLLM fails to correctly process the ⁠thinking_blocks when converting messages from the OpenAI format to the Converse API message format.

## Title

**bedrock**: mishandles ⁠thinking_blocks when ⁠assistant.content is ⁠None.

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
<img width="1809" alt="Screenshot 2025-05-12 at 16 12 06" src="https://github.com/user-attachments/assets/7a0a1416-a334-476f-bf35-888422b3ab93" />

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Changes


