### PR TITLE
Add `--version` flag to `litellm-proxy` CLI

### DIFF
--- a/litellm/proxy/client/__init__.py
+++ b/litellm/proxy/client/__init__.py
@@ -4,5 +4,6 @@ from .models import ModelsManagementClient
 from .model_groups import ModelGroupsManagementClient
 from .exceptions import UnauthorizedError
 from .users import UsersManagementClient
+from .health import HealthManagementClient
 
-__all__ = ["Client", "ChatClient", "ModelsManagementClient", "ModelGroupsManagementClient", "UsersManagementClient", "UnauthorizedError"]
+__all__ = ["Client", "ChatClient", "ModelsManagementClient", "ModelGroupsManagementClient", "UsersManagementClient", "UnauthorizedError", "HealthManagementClient"]

--- a/litellm/proxy/client/cli/README.md
+++ b/litellm/proxy/client/cli/README.md
@@ -17,11 +17,13 @@ The CLI can be configured using environment variables or command-line options:
 
 ## Global Options
 
-- `--version`, `-v`: Print the LiteLLM Proxy CLI version and exit.
+- `--version`, `-v`: Print the LiteLLM Proxy client and server version and exit.
 
 Example:
 
 ```bash
+litellm-proxy version
+# or
 litellm-proxy --version
 # or
 litellm-proxy -v

--- a/litellm/proxy/client/cli/README.md
+++ b/litellm/proxy/client/cli/README.md
@@ -15,6 +15,18 @@ The CLI can be configured using environment variables or command-line options:
 - `LITELLM_PROXY_URL`: Base URL of the LiteLLM proxy server (default: http://localhost:4000)
 - `LITELLM_PROXY_API_KEY`: API key for authentication
 
+## Global Options
+
+- `--version`, `-v`: Print the LiteLLM Proxy CLI version and exit.
+
+Example:
+
+```bash
+litellm-proxy --version
+# or
+litellm-proxy -v
+```
+
 ## Commands
 
 ### Models Management

--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -11,9 +11,11 @@ from .commands.chat import chat
 from .commands.http import http
 from .commands.keys import keys
 from .commands.users import users
+from litellm._version import version as litellm_version
 
 
 @click.group()
+@click.version_option(litellm_version, "--version", "-v", message="litellm-proxy version: %(version)s")
 @click.option(
     "--base-url",
     envvar="LITELLM_PROXY_URL",

--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -12,10 +12,37 @@ from .commands.http import http
 from .commands.keys import keys
 from .commands.users import users
 from litellm._version import version as litellm_version
+from litellm.proxy.client.health import HealthManagementClient
+
+
+def print_version(base_url: str, api_key: Optional[str]):
+    """Print CLI and server version info."""
+    click.echo(f"LiteLLM Proxy CLI Version: {litellm_version}")
+    if base_url:
+        click.echo(f"LiteLLM Proxy Server URL: {base_url}")
+    try:
+        health_client = HealthManagementClient(base_url=base_url, api_key=api_key)
+        server_version = health_client.get_server_version()
+        if server_version:
+            click.echo(f"LiteLLM Proxy Server Version: {server_version}")
+        else:
+            click.echo("LiteLLM Proxy Server Version: (unavailable)")
+    except Exception as e:
+        click.echo(f"Could not retrieve server version: {e}")
 
 
 @click.group()
-@click.version_option(litellm_version, "--version", "-v", message="litellm-proxy version: %(version)s")
+@click.option(
+    "--version", "-v", is_flag=True, is_eager=True, expose_value=False,
+    help="Show the LiteLLM Proxy CLI and server version and exit.",
+    callback=lambda ctx, param, value: (
+        print_version(
+            ctx.params.get("base_url") or "http://localhost:4000",
+            ctx.params.get("api_key")
+        )
+        or ctx.exit()
+    ) if value and not ctx.resilient_parsing else None,
+)
 @click.option(
     "--base-url",
     envvar="LITELLM_PROXY_URL",
@@ -35,6 +62,13 @@ def cli(ctx: click.Context, base_url: str, api_key: Optional[str]) -> None:
     ctx.ensure_object(dict)
     ctx.obj["base_url"] = base_url
     ctx.obj["api_key"] = api_key
+
+
+@cli.command()
+@click.pass_context
+def version(ctx: click.Context):
+    """Show the LiteLLM Proxy CLI and server version."""
+    print_version(ctx.obj.get("base_url"), ctx.obj.get("api_key"))
 
 
 # Add the models command group

--- a/litellm/proxy/client/health.py
+++ b/litellm/proxy/client/health.py
@@ -1,0 +1,40 @@
+from typing import Optional, Dict, Any
+from .http_client import HTTPClient
+
+class HealthManagementClient:
+    """
+    Client for interacting with the health endpoints of the LiteLLM proxy server.
+    """
+    def __init__(self, base_url: str, api_key: Optional[str] = None, timeout: int = 30):
+        """
+        Initialize the HealthManagementClient.
+
+        Args:
+            base_url (str): The base URL of the LiteLLM proxy server (e.g., "http://localhost:4000")
+            api_key (Optional[str]): API key for authentication. If provided, it will be sent as a Bearer token.
+            timeout (int): Request timeout in seconds (default: 30)
+        """
+        self._http = HTTPClient(base_url=base_url, api_key=api_key, timeout=timeout)
+
+    def get_readiness(self) -> Dict[str, Any]:
+        """
+        Check the readiness of the LiteLLM proxy server.
+
+        Returns:
+            Dict[str, Any]: The readiness status and details from the server.
+
+        Raises:
+            requests.exceptions.RequestException: If the request fails
+            ValueError: If the response is not valid JSON
+        """
+        return self._http.request("GET", "/health/readiness")
+
+    def get_server_version(self) -> Optional[str]:
+        """
+        Get the LiteLLM server version from the readiness endpoint.
+
+        Returns:
+            Optional[str]: The server version if available, otherwise None.
+        """
+        readiness = self.get_readiness()
+        return readiness.get("litellm_version") 

--- a/tests/litellm/proxy/client/cli/test_global_options.py
+++ b/tests/litellm/proxy/client/cli/test_global_options.py
@@ -3,6 +3,7 @@ from litellm.proxy.client.cli import cli
 from litellm._version import version as litellm_version
 from click.testing import CliRunner
 import pytest
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -11,7 +12,10 @@ def cli_runner():
 
 
 def test_cli_version_flag(cli_runner):
-    """Test that --version prints the correct version and exits successfully"""
-    result = cli_runner.invoke(cli, ["--version"])
+    """Test that --version prints the correct version, server URL, and server version, and exits successfully"""
+    with patch("litellm.proxy.client.health.HealthManagementClient.get_server_version", return_value="1.2.3"):
+        result = cli_runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert f"litellm-proxy version: {litellm_version}" in result.output
+    assert f"LiteLLM Proxy CLI Version: {litellm_version}" in result.output
+    assert "LiteLLM Proxy Server URL: http://localhost:4000" in result.output
+    assert "LiteLLM Proxy Server Version: 1.2.3" in result.output

--- a/tests/litellm/proxy/client/cli/test_global_options.py
+++ b/tests/litellm/proxy/client/cli/test_global_options.py
@@ -4,6 +4,7 @@ from litellm._version import version as litellm_version
 from click.testing import CliRunner
 import pytest
 from unittest.mock import patch
+import os
 
 
 @pytest.fixture
@@ -13,8 +14,20 @@ def cli_runner():
 
 def test_cli_version_flag(cli_runner):
     """Test that --version prints the correct version, server URL, and server version, and exits successfully"""
-    with patch("litellm.proxy.client.health.HealthManagementClient.get_server_version", return_value="1.2.3"):
+    with patch("litellm.proxy.client.health.HealthManagementClient.get_server_version", return_value="1.2.3"), \
+         patch.dict(os.environ, {"LITELLM_PROXY_URL": "http://localhost:4000"}):
         result = cli_runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert f"LiteLLM Proxy CLI Version: {litellm_version}" in result.output
+    assert "LiteLLM Proxy Server URL: http://localhost:4000" in result.output
+    assert "LiteLLM Proxy Server Version: 1.2.3" in result.output
+
+
+def test_cli_version_command(cli_runner):
+    """Test that 'version' command prints the correct version, server URL, and server version, and exits successfully"""
+    with patch("litellm.proxy.client.health.HealthManagementClient.get_server_version", return_value="1.2.3"), \
+         patch.dict(os.environ, {"LITELLM_PROXY_URL": "http://localhost:4000"}):
+        result = cli_runner.invoke(cli, ["version"])
     assert result.exit_code == 0
     assert f"LiteLLM Proxy CLI Version: {litellm_version}" in result.output
     assert "LiteLLM Proxy Server URL: http://localhost:4000" in result.output

--- a/tests/litellm/proxy/client/cli/test_global_options.py
+++ b/tests/litellm/proxy/client/cli/test_global_options.py
@@ -1,0 +1,17 @@
+# stdlib imports
+from litellm.proxy.client.cli import cli
+from litellm._version import version as litellm_version
+from click.testing import CliRunner
+import pytest
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+def test_cli_version_flag(cli_runner):
+    """Test that --version prints the correct version and exits successfully"""
+    result = cli_runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert f"litellm-proxy version: {litellm_version}" in result.output


### PR DESCRIPTION
```shell
$ litellm-proxy --version
litellm-proxy version: 1.68.1
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
    ![Screenshot 2025-05-09 at 1 08 31 PM](https://github.com/user-attachments/assets/73655a93-5da1-40d5-bf56-7cf0fe8da752)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) **Not without https://github.com/BerriAI/litellm/pull/10606 but with it, yes**
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature