### PR TITLE
[UI] Bug Fix - Allow Copying Request / Response on Logs Page

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/RequestResponsePanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestResponsePanel.tsx
@@ -1,0 +1,94 @@
+import { LogEntry } from "./columns";
+import { message } from "antd";
+
+interface RequestResponsePanelProps {
+  row: {
+    original: LogEntry;
+  };
+  hasMessages: string | boolean;
+  hasResponse: string | boolean;
+  hasError: boolean;
+  errorInfo: any;
+  getRawRequest: () => any;
+  formattedResponse: () => any;
+}
+
+export function RequestResponsePanel({
+  row,
+  hasMessages,
+  hasResponse,
+  hasError,
+  errorInfo,
+  getRawRequest,
+  formattedResponse,
+}: RequestResponsePanelProps) {
+  const handleCopyRequest = () => {
+    try {
+      navigator.clipboard.writeText(JSON.stringify(getRawRequest(), null, 2));
+      message.success('Request copied to clipboard');
+    } catch (error) {
+      message.error('Failed to copy request');
+    }
+  };
+
+  const handleCopyResponse = () => {
+    navigator.clipboard.writeText(JSON.stringify(formattedResponse(), null, 2));
+    message.success('Response copied to clipboard');
+  };
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {/* Request Side */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="flex justify-between items-center p-4 border-b">
+          <h3 className="text-lg font-medium">Request</h3>
+          <button 
+            onClick={handleCopyRequest}
+            className="p-1 hover:bg-gray-200 rounded"
+            title="Copy request"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+          </button>
+        </div>
+        <div className="p-4 overflow-auto max-h-96">
+          <pre className="text-xs font-mono whitespace-pre-wrap break-all">{JSON.stringify(getRawRequest(), null, 2)}</pre>
+        </div>
+      </div>
+
+      {/* Response Side */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="flex justify-between items-center p-4 border-b">
+          <h3 className="text-lg font-medium">
+            Response
+            {hasError && (
+              <span className="ml-2 text-sm text-red-600">
+                • HTTP code {errorInfo?.error_code || 400}
+              </span>
+            )}
+          </h3>
+          <button 
+            onClick={handleCopyResponse}
+            className="p-1 hover:bg-gray-200 rounded"
+            title="Copy response"
+            disabled={!hasResponse}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+          </button>
+        </div>
+        <div className="p-4 overflow-auto max-h-96 bg-gray-50">
+          {hasResponse ? (
+            <pre className="text-xs font-mono whitespace-pre-wrap break-all">{JSON.stringify(formattedResponse(), null, 2)}</pre>
+          ) : (
+            <div className="text-gray-500 text-sm italic text-center py-4">Response data not available</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -162,11 +162,6 @@ export const columns: ColumnDef<LogEntry>[] = [
     ),
   },
   {
-    header: "Country",
-    accessorKey: "requester_ip_address",
-    cell: (info: any) => <CountryCell ipAddress={info.getValue()} />,
-  },
-  {
     header: "Team Name",
     accessorKey: "metadata.user_api_key_team_alias",
     cell: (info: any) => (
@@ -319,8 +314,12 @@ export const RequestResponsePanel = ({ request, response }: { request: any; resp
   const requestStr = typeof request === 'object' ? JSON.stringify(request, null, 2) : String(request || '{}');
   const responseStr = typeof response === 'object' ? JSON.stringify(response, null, 2) : String(response || '{}');
   
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
   };
   
   return (

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -8,7 +8,7 @@ import { DataTable } from "./table";
 import { columns, LogEntry } from "./columns";
 import { Row } from "@tanstack/react-table";
 import { prefetchLogDetails } from "./prefetch";
-import { RequestResponsePanel } from "./columns";
+import { RequestResponsePanel } from './RequestResponsePanel';
 import { ErrorViewer } from './ErrorViewer';
 import { internalUserRoles } from "../../utils/roles";
 import { ConfigInfoMessage } from './ConfigInfoMessage';
@@ -837,63 +837,18 @@ export function RequestViewer({ row }: { row: Row<LogEntry> }) {
       <ConfigInfoMessage show={missingData} />
 
       {/* Request/Response Panel */}
-      <div className="grid grid-cols-2 gap-4">
-        {/* Request Side */}
-        <div className="bg-white rounded-lg shadow">
-          <div className="flex justify-between items-center p-4 border-b">
-            <h3 className="text-lg font-medium">Request</h3>
-            <button 
-              onClick={() => navigator.clipboard.writeText(JSON.stringify(getRawRequest(), null, 2))}
-              className="p-1 hover:bg-gray-200 rounded"
-              title="Copy request"
-              disabled={!hasMessages}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-            </button>
-          </div>
-          <div className="p-4 overflow-auto max-h-96">
-            <pre className="text-xs font-mono whitespace-pre-wrap break-all">{JSON.stringify(getRawRequest(), null, 2)}</pre>
-          </div>
-        </div>
-
-        {/* Response Side */}
-        <div className="bg-white rounded-lg shadow">
-          <div className="flex justify-between items-center p-4 border-b">
-            <h3 className="text-lg font-medium">
-              Response
-              {hasError && (
-                <span className="ml-2 text-sm text-red-600">
-                  • HTTP code {errorInfo?.error_code || 400}
-                </span>
-              )}
-            </h3>
-            <button 
-              onClick={() => navigator.clipboard.writeText(JSON.stringify(formattedResponse(), null, 2))}
-              className="p-1 hover:bg-gray-200 rounded"
-              title="Copy response"
-              disabled={!hasResponse}
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-            </button>
-          </div>
-          <div className="p-4 overflow-auto max-h-96 bg-gray-50">
-            {hasResponse ? (
-              <pre className="text-xs font-mono whitespace-pre-wrap break-all">{JSON.stringify(formattedResponse(), null, 2)}</pre>
-            ) : (
-              <div className="text-gray-500 text-sm italic text-center py-4">Response data not available</div>
-            )}
-          </div>
-        </div>
-      </div>
+      <RequestResponsePanel
+        row={row}
+        hasMessages={hasMessages}
+        hasResponse={hasResponse}
+        hasError={hasError}
+        errorInfo={errorInfo}
+        getRawRequest={getRawRequest}
+        formattedResponse={formattedResponse}
+      />
 
       {/* Vector Store Request Data - Show only if present */}
-            {hasVectorStoreData && (
+      {hasVectorStoreData && (
         <VectorStoreViewer data={metadata.vector_store_request_metadata} />
       )}
 


### PR DESCRIPTION
## [UI] Bug Fix - Allow Copying Request / Response on Logs Page

- Ensure users are able to copy the request from the logs page 
- Remove the Country Cell Rendering on logs page (security fix, ensure extra API call is not made) 

<img width="710" alt="Screenshot 2025-05-10 at 11 25 12 AM" src="https://github.com/user-attachments/assets/a99ed7f4-68e3-46fa-b9f8-39be82c35f80" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


