### PR TITLE
[Bug fix] - allow using credentials for /moderations

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3107,6 +3107,13 @@ class Router:
                 request_kwargs=kwargs,
             )
             kwargs["model"] = deployment["litellm_params"]["model"]
+            data = deployment["litellm_params"].copy()
+            self._update_kwargs_with_deployment(
+                deployment=deployment,
+                kwargs=kwargs,
+            )
+            kwargs.update(data)
+
         return await original_function(**kwargs)
 
     def factory_function(


### PR DESCRIPTION
## [Bug fix] - allow using credentials for /moderations

This PR fixes a bug where credentials (specifically the litellm_credential_name) were not being passed along in the /moderations endpoint. Key changes include updating the pass‐through moderation endpoint factory to copy and merge the entire litellm_params (including credentials) into kwargs and adding a test case to confirm the credential is propagated.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


