### PR TITLE
[QA Bug fix] fix: ensure model info does not get overwritten when editing a model on UI

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -79,6 +79,7 @@ def update_db_model(
         litellm_params=LiteLLMParamsTypedDict(
             **db_model.litellm_params.model_dump(exclude_none=True)  # type: ignore
         ),
+        model_info=db_model.model_info.model_dump(exclude_none=True),
     )
     # update model name
     if updated_patch.model_name:


### PR DESCRIPTION
## [QA Bug fix] fix: ensure model info does not get overwritten when editing a model on UI

This PR addresses a bug that caused the model information to be overwritten when editing a model via the UI by ensuring that the existing model_info is retained and merged with any updates.

Introduces initialization of model_info in the deployment dictionary in update_db_model.
Ensures that any updates from updated_patch.model_info are merged on top of the existing model_info.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


