### PR TITLE
Mutable default arguments on embeddings/completion headers parameters breaks watsonx

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -245,7 +245,7 @@ class BaseLLMHTTPHandler:
         stream: Optional[bool] = False,
         fake_stream: bool = False,
         api_key: Optional[str] = None,
-        headers: Optional[dict] = {},
+        headers: Optional[Dict[str, Any]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         provider_config: Optional[BaseConfig] = None,
     ):
@@ -680,7 +680,7 @@ class BaseLLMHTTPHandler:
         api_key: Optional[str] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         aembedding: bool = False,
-        headers={},
+        headers: Optional[Dict[str, Any]] = None,
     ) -> EmbeddingResponse:
         provider_config = ProviderConfigManager.get_provider_embedding_config(
             model=model, provider=litellm.LlmProviders(custom_llm_provider)
@@ -688,7 +688,7 @@ class BaseLLMHTTPHandler:
         # get config from model, custom llm provider
         headers = provider_config.validate_environment(
             api_key=api_key,
-            headers=headers,
+            headers=headers or {},
             model=model,
             messages=[],
             optional_params=optional_params,
@@ -821,7 +821,7 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]],
         model_response: RerankResponse,
         _is_async: bool = False,
-        headers: dict = {},
+        headers: Optional[Dict[str, Any]] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
@@ -829,7 +829,7 @@ class BaseLLMHTTPHandler:
         # get config from model, custom llm provider
         headers = provider_config.validate_environment(
             api_key=api_key,
-            headers=headers,
+            headers=headers or {},
             model=model,
         )
 
@@ -951,7 +951,7 @@ class BaseLLMHTTPHandler:
         custom_llm_provider: str,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         atranscription: bool = False,
-        headers: dict = {},
+        headers: Optional[Dict[str, Any]] = None,
         provider_config: Optional[BaseAudioTranscriptionConfig] = None,
     ) -> TranscriptionResponse:
         if provider_config is None:
@@ -960,7 +960,7 @@ class BaseLLMHTTPHandler:
             )
         headers = provider_config.validate_environment(
             api_key=api_key,
-            headers=headers,
+            headers=headers or {},
             model=model,
             messages=[],
             optional_params=optional_params,


### PR DESCRIPTION
## Mutable default arguments in BaseLLMHTTPHandler->completion/embedding disallows WatsonX token from being updated.

Mutable default arguments are an issue in litellm as indicated by Bug #9827 and should likely be fixed more broadly.   This is a specific instance where use of such constructs breaks the functionality of litellm.   

WatsonX generates a credential token every hour and that token is stored in a litellm cache, and passed to WatsonX through an HTTP Header.  Since the `headers` parameter defaults to `{}` in the embedding function of BaseLLMHTTPHandler, and that parameter is also overwritten in the body of the function, the `headers` parameter gets set to the initial token for WatsonX and can never get updated due to the default assignment.   This causes connections to WatsonX to fail after a time period with the error:

litellm.exceptions.AuthenticationError: litellm.AuthenticationError: watsonxException - {"errors":[{"code":"authentication_token_expired","message":"Failed to authenticate the request due to an expired token","more_info":"https://cloud.ibm.com/apidocs/watsonx-ai"}],"trace":"redacted","status_code":401}. Received

This issue may affect other providers as well, but I only have access to WatsonX.

## Relevant issues

This seems to be a broader issue across the library as noted in Bug #9827 .

Fixes #9219 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

The code updates default parameters of functions.  I'm not sure how to build a relevant use case for it. 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

litellm/llms/custom_httpx/llm_http_handler.py


