### PR TITLE
fix: pass application/json for GenericAPILogger

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
@@ -74,7 +74,9 @@ class GenericAPILogger(CustomBatchLogger):
             headers: Optional[dict] = None
         """
         # Process headers from different sources
-        headers_dict = {}
+        headers_dict = {
+            "Content-Type": "application/json",
+        }
 
         # 1. First check for headers from env var
         env_headers = os.getenv("GENERIC_LOGGER_HEADERS")

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -78,6 +78,9 @@ async def test_generic_api_callback():
     print("##########\n")
     print("logs were flushed to URL", actual_url, "with the following headers", mock_post.call_args[1]["headers"])
     assert actual_url == test_endpoint, f"Expected URL {test_endpoint}, got {actual_url}"
+
+    # Validate headers
+    assert mock_post.call_args[1]["headers"]["Content-Type"] == "application/json", "Content-Type should be application/json"
     
     # For the GenericAPILogger, it sends the payload directly as JSON in the data field
     json_data = mock_post.call_args[1]["data"]


### PR DESCRIPTION
## fix: pass application/json for GenericAPILogger

This PR fixes the header issue for the GenericAPILogger by ensuring that the "Content-Type" is set to "application/json" in API calls.

Added an assertion in the unit test to validate the header value.
Updated the default headers in the callback to include "Content-Type": "application/json".

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


