### PR TITLE
fix: remove --accept-data-loss flag from prisma db push command

### DIFF
--- a/litellm/proxy/prisma_migration.py
+++ b/litellm/proxy/prisma_migration.py
@@ -79,10 +79,8 @@ while retry_count < max_retries and exit_code != 0:
         )  # Log stderr
 
     # Run the Prisma db push command
-    verbose_proxy_logger.info("Running 'prisma db push --accept-data-loss'...")
-    result = subprocess.run(
-        ["prisma", "db", "push", "--accept-data-loss"], capture_output=True, text=True
-    )
+    verbose_proxy_logger.info("Running 'prisma db push'...")
+    result = subprocess.run(["prisma", "db", "push"], capture_output=True, text=True)
     verbose_proxy_logger.info(f"'prisma db push' stdout: {result.stdout}")  # Log stdout
     exit_code = result.returncode
 


### PR DESCRIPTION
## Title

Fix remove --accept-data-loss flag from prisma db push command

## Relevant issues

This change is critically important because it removes the --accept-data-loss flag from the prisma db push command. By default, this command will now fail or prompt for confirmation if the schema changes could lead to data loss. 

Allowing for data loss with no warning is a **MAJOR** footgun.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

- [fix: remove --accept-data-loss flag from prisma db push command](https://github.com/BerriAI/litellm/commit/ef0ffc05d592c4145064f8055409778c3b42c449)
