### PR TITLE
[Fix] Allow using dynamic aws_region with /messages on Bedrock

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -91,9 +91,11 @@ class BaseLLMHTTPHandler:
                 response = await async_httpx_client.post(
                     url=api_base,
                     headers=headers,
-                    data=signed_json_body
-                    if signed_json_body is not None
-                    else json.dumps(data),
+                    data=(
+                        signed_json_body
+                        if signed_json_body is not None
+                        else json.dumps(data)
+                    ),
                     timeout=timeout,
                     stream=stream,
                     logging_obj=logging_obj,
@@ -149,9 +151,11 @@ class BaseLLMHTTPHandler:
                 response = sync_httpx_client.post(
                     url=api_base,
                     headers=headers,
-                    data=signed_json_body
-                    if signed_json_body is not None
-                    else json.dumps(data),
+                    data=(
+                        signed_json_body
+                        if signed_json_body is not None
+                        else json.dumps(data)
+                    ),
                     timeout=timeout,
                     stream=stream,
                     logging_obj=logging_obj,
@@ -1111,7 +1115,9 @@ class BaseLLMHTTPHandler:
             api_base=api_base,
             api_key=api_key,
             model=model,
-            optional_params=anthropic_messages_optional_request_params,
+            optional_params=dict(
+                litellm_params
+            ),  # this uses the invoke config, which expects aws_* params in optional_params
             litellm_params=dict(litellm_params),
             stream=stream,
         )


### PR DESCRIPTION
## [Fix] Allow using dynamic aws_region with /messages on Bedrock

This PR adds support for dynamically specifying the AWS region when calling the Bedrock /messages endpoint and includes a new unit test to validate that behavior.

Adds test_anthropic_messages_bedrock_dynamic_region to verify the region in the request URL and credential call.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


