### PR TITLE
Make all commands show server URL

### DIFF
--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -1,4 +1,5 @@
 # stdlib imports
+import sys
 from typing import Optional
 
 # third party imports
@@ -60,7 +61,8 @@ def print_version(base_url: str, api_key: Optional[str]):
 def cli(ctx: click.Context, base_url: str, api_key: Optional[str]) -> None:
     """LiteLLM Proxy CLI - Manage your LiteLLM proxy server"""
     ctx.ensure_object(dict)
-    click.secho(f"Accessing LiteLLM server: {base_url} ...\n", fg="yellow")
+    if sys.stderr.isatty():
+        click.secho(f"Accessing LiteLLM server: {base_url} ...\n", fg="yellow", err=True)
     ctx.obj["base_url"] = base_url
     ctx.obj["api_key"] = api_key
 

--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -60,6 +60,7 @@ def print_version(base_url: str, api_key: Optional[str]):
 def cli(ctx: click.Context, base_url: str, api_key: Optional[str]) -> None:
     """LiteLLM Proxy CLI - Manage your LiteLLM proxy server"""
     ctx.ensure_object(dict)
+    click.secho(f"Accessing LiteLLM server: {base_url} ...\n", fg="yellow")
     ctx.obj["base_url"] = base_url
     ctx.obj["api_key"] = api_key
 


### PR DESCRIPTION
so users know which server they're accessing

<img width="1114" alt="Screenshot 2025-05-13 at 10 56 14 AM" src="https://github.com/user-attachments/assets/1ca77bc3-ac9a-43d9-964e-273a4e7a5d93" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature