### PR TITLE
Support OTLP standard environment variables for configuration

### DIFF
--- a/docs/my-website/docs/observability/opentelemetry_integration.md
+++ b/docs/my-website/docs/observability/opentelemetry_integration.md
@@ -34,8 +34,9 @@ OTEL_HEADERS="Authorization=Bearer%20<your-api-key>"
 <TabItem value="otel-col" label="Log to OTEL HTTP Collector">
 
 ```shell
-OTEL_EXPORTER="otlp_http"
-OTEL_ENDPOINT="http://0.0.0.0:4318"
+OTEL_EXPORTER_OTLP_ENDPOINT="http://0.0.0.0:4318"
+OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+OTEL_EXPORTER_OTLP_HEADERS="api-key=key,other-config-value=value"
 ```
 
 </TabItem>
@@ -43,8 +44,9 @@ OTEL_ENDPOINT="http://0.0.0.0:4318"
 <TabItem value="otel-col-grpc" label="Log to OTEL GRPC Collector">
 
 ```shell
-OTEL_EXPORTER="otlp_grpc"
-OTEL_ENDPOINT="http://0.0.0.0:4317"
+OTEL_EXPORTER_OTLP_ENDPOINT="http://0.0.0.0:4318"
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_HEADERS="api-key=key,other-config-value=value"
 ```
 
 </TabItem>
@@ -98,7 +100,7 @@ LiteLLM emits the user_api_key_metadata
 - user_id
 - team_id
 
-for successful + failed requests 
+for successful + failed requests
 
 click under `litellm_request` in the trace
 

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -63,14 +63,16 @@ class OpenTelemetryConfig:
             InMemorySpanExporter,
         )
 
-        if os.getenv("OTEL_EXPORTER") == "in_memory":
+        exporter=os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", os.getenv("OTEL_EXPORTER", "console"))
+        endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", os.getenv("OTEL_ENDPOINT"))
+        headers=os.getenv("OTEL_EXPORTER_OTLP_HEADERS", os.getenv("OTEL_HEADERS"))  # example: OTEL_HEADERS=x-honeycomb-team=B85YgLm96***"
+
+        if exporter == "in_memory":
             return cls(exporter=InMemorySpanExporter())
         return cls(
-            exporter=os.getenv("OTEL_EXPORTER", "console"),
-            endpoint=os.getenv("OTEL_ENDPOINT"),
-            headers=os.getenv(
-                "OTEL_HEADERS"
-            ),  # example: OTEL_HEADERS=x-honeycomb-team=B85YgLm96***"
+            exporter=exporter,
+            endpoint=endpoint,
+            headers=headers,  # example: OTEL_HEADERS=x-honeycomb-team=B85YgLm96***"
         )
 
 
@@ -854,7 +856,7 @@ class OpenTelemetry(CustomLogger):
                 self.OTEL_EXPORTER,
             )
             return BatchSpanProcessor(ConsoleSpanExporter())
-        elif self.OTEL_EXPORTER == "otlp_http":
+        elif self.OTEL_EXPORTER == "otlp_http" or self.OTEL_EXPORTER == "http/protobuf" or self.OTEL_EXPORTER == "http/json":
             verbose_logger.debug(
                 "OpenTelemetry: intiializing http exporter. Value of OTEL_EXPORTER: %s",
                 self.OTEL_EXPORTER,
@@ -864,7 +866,7 @@ class OpenTelemetry(CustomLogger):
                     endpoint=self.OTEL_ENDPOINT, headers=_split_otel_headers
                 ),
             )
-        elif self.OTEL_EXPORTER == "otlp_grpc":
+        elif self.OTEL_EXPORTER == "otlp_grpc" or self.OTEL_EXPORTER == "grpc":
             verbose_logger.debug(
                 "OpenTelemetry: intiializing grpc exporter. Value of OTEL_EXPORTER: %s",
                 self.OTEL_EXPORTER,


### PR DESCRIPTION
## Support open telemetry standard environment variables for OTLP exporter

Systems often inject these variables, or equally developers expect to have a consistent set of configuration options when relating to opentelemetry. Environment variables for the open telemetry OTLP exporter are outlined at https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/ for their standards.

This adds in the option to utilise those environment variables, without introducing a breaking change, by falling back to the currently documented process.

## Relevant issues

Relates to #9901

Also relates to PR #9972 but I had confusion on that PR, as it doesn't reference environment variables such as `OTEL_EXPORTER_OTLP_PROTOCOL`, or `OTEL_EXPORTER_OTLP_ENDPOINT` as I had expected

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation

## Changes
- Default to OTLP standard, but fallback to existing so as to not break backwards compatibility
- Also allow/match the values expected in `OTEL_EXPORTER_OTLP_PROTOCOL` of `grpc`, `http/protobuf`, or `http/json` as outlined at https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_protocol
- Changed documentation on the "Log to OTEL HTTP Collector" and "Log to OTEL GRPC Collector" tabs as they seem more related to OTLP standards than the other documented tabs