### PR TITLE
avoid error `AttributeError: 'Message' object has no attribute 'audio'`

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -633,20 +633,24 @@ class Message(OpenAIObject):
         if audio is None:
             # delete audio from self
             # OpenAI compatible APIs like mistral API will raise an error if audio is passed in
-            del self.audio
+            if hasattr(self, 'audio'):
+                del self.audio
 
         if annotations is None:
             # ensure default response matches OpenAI spec
             # Some OpenAI compatible APIs raise an error if annotations are passed in
-            del self.annotations
+            if hasattr(self, 'annotations'):
+                del self.annotations
 
         if reasoning_content is None:
             # ensure default response matches OpenAI spec
-            del self.reasoning_content
+            if hasattr(self, 'reasoning_content'):
+                del self.reasoning_content
 
         if thinking_blocks is None:
             # ensure default response matches OpenAI spec
-            del self.thinking_blocks
+            if hasattr(self, 'thinking_blocks'):
+                del self.thinking_blocks
 
         add_provider_specific_fields(self, provider_specific_fields)
 


### PR DESCRIPTION
## Title

avoid error `AttributeError: 'Message' object has no attribute 'audio'`

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/10622

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

i got this error when using bedrock claude model. so i changed the code safer.
```
  File "/venv/lib/python3.12/site-packages/litellm/utils.py", line 1460, in wrapper_async
    raise e
  File "/venv/lib/python3.12/site-packages/litellm/utils.py", line 1321, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/main.py", line 523, in acompletion
    raise exception_type(
  File "/venv/lib/python3.12/site-packages/litellm/main.py", line 496, in acompletion
    init_response = await loop.run_in_executor(None, func_with_context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/utils.py", line 990, in wrapper
    result = original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/main.py", line 3210, in completion
    raise exception_type(
          ^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2217, in exception_type
    raise e
  File "/venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2193, in exception_type
    raise APIConnectionError(
litellm.exceptions.APIConnectionError: litellm.APIConnectionError: 'Message' object has no attribute 'audio'
Traceback (most recent call last):
  File "/venv/lib/python3.12/site-packages/litellm/main.py", line 1019, in completion
    model_response = ModelResponse()
                     ^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/types/utils.py", line 1153, in __init__
    choices = [Choices()]
               ^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/types/utils.py", line 763, in __init__
    self.message = Message()
                   ^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/litellm/types/utils.py", line 621, in __init__
    del self.audio
        ^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/pydantic/main.py", line 1077, in __delattr__
    object.__delattr__(self, item)
AttributeError: 'Message' object has no attribute 'audio'
```
