### PR TITLE
Fix Cohere Rerank Provider

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6477,7 +6477,10 @@ class ProviderConfigManager:
         api_base: Optional[str],
         present_version_params: List[str],
     ) -> BaseRerankConfig:
-        if litellm.LlmProviders.COHERE == provider:
+        if (
+            litellm.LlmProviders.COHERE == provider
+            or litellm.LlmProviders.COHERE_CHAT == provider
+        ):
             if should_use_cohere_v1_client(api_base, present_version_params):
                 return litellm.CohereRerankConfig()
             else:


### PR DESCRIPTION
## Title

Cohere models added via the UI gets the provider cohere_chat. While the embeddings model checks if the provider is cohere_chat as well, there is no such check for reranking models, resulting in an error.

Here's the relevant stacktrace:
```
9:14:33 - LiteLLM Proxy:ERROR: endpoints.py:110 - litellm.proxy.proxy_server.rerank(): Exception occured - litellm.APIConnectionError: Unsupported provider: cohere_chat
Traceback (most recent call last):
File "/usr/local/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 1462, in exception_type
raise original_exception
File "/usr/local/lib/python3.13/site-packages/litellm/rerank_api/main.py", line 327, in rerank
raise ValueError(f"Unsupported provider: {_custom_llm_provider}")
ValueError: Unsupported provider: cohere_chat
No fallback model group found for original model_group=cohere/rerank-v3.5. Fallbacks=[]. Received Model Group=cohere/rerank-v3.5
Available Model Group Fallbacks=None
Error doing the fallback: litellm.APIConnectionError: Unsupported provider: cohere_chat
Traceback (most recent call last):
File "/usr/local/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 1462, in exception_type
raise original_exception
File "/usr/local/lib/python3.13/site-packages/litellm/rerank_api/main.py", line 327, in rerank
raise ValueError(f"Unsupported provider: {_custom_llm_provider}")
ValueError: Unsupported provider: cohere_chat
No fallback model group found for original model_group=cohere/rerank-v3.5. Fallbacks=[] LiteLLM Retried: 1 times, LiteLLM Max Retries: 2 LiteLLM Retried: 1 times, LiteLLM Max Retries: 2
```

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

- added a check for cohere_chat for reranker
