### PR TITLE
patch: validate_team_org_change

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -423,6 +423,11 @@ def validate_team_org_change(
     - The team's tpm/rpm limit must be less than the org's tpm/rpm limit
     """
 
+    # If the team's organization is the same as the new organization, return True
+    # Since no changes are being made
+    if team.organization_id == organization.organization_id:
+        return True
+
     # Check if the org has access to the team's models
     if len(organization.models) > 0:
         if SpecialModelNames.all_proxy_models.value in organization.models:


### PR DESCRIPTION
## fix: validate_team_org_change

This fixes a user issue, a user was editing their team and this function raised an exception even when they were not changing the organization of the team. This fix ensure the team org validation only runs if the team's org is being changed.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


