### PR TITLE
Add `nixpacks.toml` that specifies python provider

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+# This file exists to tell nixpacks to use the python provider.
+# This helps PaaS system like Coolify that use nixpacks to build the app corectly.
+# nixpacks gets confused because the project has both a `pyproject.toml` and a
+# `package.json` file so it thinks the app is a Node app.
+providers = ["python"]


### PR DESCRIPTION
Without this, [Nixpacks](https://nixpacks.com/docs) thinks this is a Node project:

```
$ nixpacks plan . | jq '.phases.install'
{
  "dependsOn": [
    "setup"
  ],
  "cmds": [
    "npm ci"
  ],
  "cacheDirectories": [
    "/root/.npm"
  ],
  "paths": [
    "/app/node_modules/.bin"
  ]
}
```

With this, it recognizes it as a Python project:

```
$ nixpacks plan . | jq '.phases.install'
{
  "dependsOn": [
    "setup"
  ],
  "cmds": [
    "python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt"
  ],
  "cacheDirectories": [
    "/root/.cache/pip"
  ],
  "paths": [
    "/opt/venv/bin"
  ]
}
```

Reference: https://nixpacks.com/docs/guides/configuring-builds#change-what-providers-are-run

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
