### PR TITLE
[Refactor] Make Pagerduty a free feature

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -57,7 +57,7 @@ class PagerDutyAlerting(SlackAlerting):
 
         self.api_key: str = _api_key
         alerting_args = alerting_args or {}
-        self.alerting_args: AlertingConfig = AlertingConfig(
+        self.pagerduty_alerting_args: AlertingConfig = AlertingConfig(
             failure_threshold=alerting_args.get(
                 "failure_threshold", PAGERDUTY_DEFAULT_FAILURE_THRESHOLD
             ),
@@ -119,8 +119,10 @@ class PagerDutyAlerting(SlackAlerting):
         )
 
         # Prune + Possibly alert
-        window_seconds = self.alerting_args.get("failure_threshold_window_seconds", 60)
-        threshold = self.alerting_args.get("failure_threshold", 1)
+        window_seconds = self.pagerduty_alerting_args.get(
+            "failure_threshold_window_seconds", 60
+        )
+        threshold = self.pagerduty_alerting_args.get("failure_threshold", 1)
 
         # If threshold is crossed, send PD alert for failures
         await self._send_alert_if_thresholds_crossed(
@@ -166,10 +168,10 @@ class PagerDutyAlerting(SlackAlerting):
         If not, we classify it as a hanging request.
         """
         verbose_logger.debug(
-            f"Inside Hanging Response Handler!..sleeping for {self.alerting_args.get('hanging_threshold_seconds', PAGERDUTY_DEFAULT_HANGING_THRESHOLD_SECONDS)} seconds"
+            f"Inside Hanging Response Handler!..sleeping for {self.pagerduty_alerting_args.get('hanging_threshold_seconds', PAGERDUTY_DEFAULT_HANGING_THRESHOLD_SECONDS)} seconds"
         )
         await asyncio.sleep(
-            self.alerting_args.get(
+            self.pagerduty_alerting_args.get(
                 "hanging_threshold_seconds", PAGERDUTY_DEFAULT_HANGING_THRESHOLD_SECONDS
             )
         )
@@ -197,11 +199,11 @@ class PagerDutyAlerting(SlackAlerting):
         )
 
         # Prune + Possibly alert
-        window_seconds = self.alerting_args.get(
+        window_seconds = self.pagerduty_alerting_args.get(
             "hanging_threshold_window_seconds",
             PAGERDUTY_DEFAULT_HANGING_THRESHOLD_WINDOW_SECONDS,
         )
-        threshold: int = self.alerting_args.get(
+        threshold: int = self.pagerduty_alerting_args.get(
             "hanging_threshold_fails", PAGERDUTY_DEFAULT_HANGING_THRESHOLD_SECONDS
         )
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/pagerduty/pagerduty.py
@@ -4,6 +4,10 @@ PagerDuty Alerting Integration
 Handles two types of alerts:
 - High LLM API Failure Rate. Configure X fails in Y seconds to trigger an alert.
 - High Number of Hanging LLM Requests. Configure X hangs in Y seconds to trigger an alert.
+
+Note: This is a Free feature on the regular litellm docker image.
+
+However, this is under the enterprise license
 """
 
 import asyncio

--- a/litellm/integrations/pagerduty/pagerduty.py
+++ b/litellm/integrations/pagerduty/pagerduty.py
@@ -46,8 +46,6 @@ class PagerDutyAlerting(SlackAlerting):
     def __init__(
         self, alerting_args: Optional[Union[AlertingConfig, dict]] = None, **kwargs
     ):
-        from litellm.proxy.proxy_server import CommonProxyErrors, premium_user
-
         super().__init__()
         _api_key = os.getenv("PAGERDUTY_API_KEY")
         if not _api_key:
@@ -75,12 +73,6 @@ class PagerDutyAlerting(SlackAlerting):
         # Separate storage for failures vs. hangs
         self._failure_events: List[PagerDutyInternalEvent] = []
         self._hanging_events: List[PagerDutyInternalEvent] = []
-
-        # premium user check
-        if premium_user is not True:
-            raise ValueError(
-                f"PagerDutyAlerting is only available for LiteLLM Enterprise users. {CommonProxyErrors.not_premium_user.value}"
-            )
 
     # ------------------ MAIN LOGIC ------------------ #
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -53,7 +53,6 @@ from litellm.integrations.arize.arize import ArizeLogger
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.mlflow import MlflowLogger
-from litellm.integrations.pagerduty.pagerduty import PagerDutyAlerting
 from litellm.integrations.vector_stores.bedrock_vector_store import BedrockVectorStore
 from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
@@ -148,6 +147,9 @@ try:
     from litellm_enterprise.enterprise_callbacks.generic_api_callback import (
         GenericAPILogger,
     )
+    from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
+        PagerDutyAlerting,
+    )
     from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
         ResendEmailLogger,
     )
@@ -168,6 +170,7 @@ except Exception as e:
     GenericAPILogger = CustomLogger  # type: ignore
     ResendEmailLogger = CustomLogger  # type: ignore
     SMTPEmailLogger = CustomLogger  # type: ignore
+    PagerDutyAlerting = CustomLogger  # type: ignore
     EnterpriseStandardLoggingPayloadSetupVAR = None
 _in_memory_loggers: List[Any] = []
 

--- a/tests/logging_callback_tests/test_pagerduty_alerting.py
+++ b/tests/logging_callback_tests/test_pagerduty_alerting.py
@@ -8,7 +8,11 @@ from typing import Optional
 sys.path.insert(0, os.path.abspath("../.."))
 import pytest
 import litellm
-from litellm.integrations.pagerduty.pagerduty import PagerDutyAlerting, AlertingConfig
+
+from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
+    PagerDutyAlerting,
+    AlertingConfig,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 
 

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -20,7 +20,6 @@ from prometheus_client import REGISTRY, CollectorRegistry
 from litellm.integrations.lago import LagoLogger
 from litellm.integrations.openmeter import OpenMeterLogger
 from litellm.integrations.braintrust_logging import BraintrustLogger
-from litellm.integrations.pagerduty.pagerduty import PagerDutyAlerting
 from litellm.integrations.galileo import GalileoObserve
 from litellm.integrations.langsmith import LangsmithLogger
 from litellm.integrations.literal_ai import LiteralAILogger
@@ -45,6 +44,7 @@ from litellm.proxy.hooks.dynamic_rate_limiter import _PROXY_DynamicRateLimitHand
 from litellm_enterprise.enterprise_callbacks.generic_api_callback import GenericAPILogger
 from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import ResendEmailLogger
 from litellm_enterprise.enterprise_callbacks.send_emails.smtp_email import SMTPEmailLogger
+from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import PagerDutyAlerting
 from unittest.mock import patch
 
 # clear prometheus collectors / registry


### PR DESCRIPTION
## [Refactor] Make Pagerduty a free feature

This PR refactors the PagerDuty integration to remove the premium user check, effectively making the feature free.

Key changes:
- This can now be used for free on the regular litellm docker 
- This will be under the enterprise/ folder license, but can be used for free. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


