### PR TITLE
Removing duplicated cache get

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -475,7 +475,6 @@ class Cache:
                     or float("inf")
                 )
                 cached_result = self.cache.get_cache(cache_key, messages=messages)
-                cached_result = self.cache.get_cache(cache_key, messages=messages)
                 return self._get_cache_logic(
                     cached_result=cached_result, max_age=max_age
                 )


### PR DESCRIPTION
## Removing duplicated cache get as the value is fetched twice consecutively

<!-- e.g. "Implement user authentication feature" -->
Reading the code to understand how nuts n bolts of response caching works, found out that there are 2 consecutive get cache calls fetching potentially the same value twice.
Seems like a typo rather than intended behaviour, but could be wrong.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
🧹 Refactoring

## Changes
Removing duplicated get cache 

