### PR TITLE
[Feat - Guardrails] Expose /apply_guardrail endpoint for directly calling guardrail

### DIFF
--- a/enterprise/litellm_enterprise/proxy/guardrails/endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/guardrails/endpoints.py
@@ -1,0 +1,41 @@
+"""
+Enterprise Guardrail Routes on LiteLLM Proxy
+
+To see all free guardrails see litellm/proxy/guardrails/*
+
+
+Exposed Routes:
+- /mask_pii
+"""
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.guardrails.guardrail_endpoints import GUARDRAIL_REGISTRY
+from litellm.types.guardrails import ApplyGuardrailRequest, ApplyGuardrailResponse
+
+router = APIRouter(tags=["guardrails"], prefix="/guardrails")
+
+
+@router.post("/apply_guardrail", response_model=ApplyGuardrailResponse)
+async def apply_guardrail(
+    request: ApplyGuardrailRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Mask PII from a given text, requires a guardrail to be added to litellm.
+    """
+    active_guardrail: Optional[
+        CustomGuardrail
+    ] = GUARDRAIL_REGISTRY.get_initialized_guardrail_callback(
+        guardrail_name=request.guardrail_name
+    )
+    if active_guardrail is None:
+        raise Exception(f"Guardrail {request.guardrail_name} not found")
+
+    return await active_guardrail.apply_guardrail(
+        text=request.text, language=request.language, entities=request.entities
+    )

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -2,7 +2,11 @@ from typing import Dict, List, Literal, Optional, Union
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.types.guardrails import DynamicGuardrailParams, GuardrailEventHooks
+from litellm.types.guardrails import (
+    DynamicGuardrailParams,
+    GuardrailEventHooks,
+    PiiEntityType,
+)
 from litellm.types.utils import StandardLoggingGuardrailInformation
 
 
@@ -214,6 +218,24 @@ class CustomGuardrail(CustomLogger):
             verbose_logger.warning(
                 "unable to log guardrail information. No metadata found in request_data"
             )
+
+    def mask_pii(
+        self,
+        text: str,
+        language: Optional[str] = None,
+        entities: Optional[List[PiiEntityType]] = None,
+    ) -> str:
+        """
+        Mask PII from a given text
+
+        Args:
+            text: The text to mask
+            language: The language of the text
+            entities: The entities to mask, optional
+
+        Any of the custom guardrails can override this method to provide custom masking logic
+        """
+        return text
 
 
 def log_guardrail_information(func):

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -219,21 +219,28 @@ class CustomGuardrail(CustomLogger):
                 "unable to log guardrail information. No metadata found in request_data"
             )
 
-    def mask_pii(
+    async def apply_guardrail(
         self,
         text: str,
         language: Optional[str] = None,
         entities: Optional[List[PiiEntityType]] = None,
     ) -> str:
         """
-        Mask PII from a given text
+        Apply your guardrail logic to the given text
 
         Args:
-            text: The text to mask
+            text: The text to apply the guardrail to
             language: The language of the text
             entities: The entities to mask, optional
 
-        Any of the custom guardrails can override this method to provide custom masking logic
+        Any of the custom guardrails can override this method to provide custom guardrail logic
+
+        Returns the text with the guardrail applied
+
+        Raises:
+            Exception:
+                - If the guardrail raises an exception
+
         """
         return text
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -334,7 +334,16 @@ class LiteLLMRoutes(enum.Enum):
         "/mcp/tools/call",
     ]
 
-    llm_api_routes = openai_routes + anthropic_routes + mapped_pass_through_routes
+    apply_guardrail_routes = [
+        "/guardrails/apply_guardrail",
+    ]
+
+    llm_api_routes = (
+        openai_routes
+        + anthropic_routes
+        + mapped_pass_through_routes
+        + apply_guardrail_routes
+    )
     info_routes = [
         "/key/info",
         "/key/health",

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -529,14 +529,19 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         except Exception:
             pass
 
-    async def apply_guardrail(self, input_text: str) -> str:
+    async def apply_guardrail(
+        self,
+        text: str,
+        language: Optional[str] = None,
+        entities: Optional[List[PiiEntityType]] = None,
+    ) -> str:
         """
         UI will call this function to check:
             1. If the connection to the guardrail is working
             2. When Testing the guardrail with some text, this function will be called with the input text and returns a text after applying the guardrail
         """
         text = await self.check_pii(
-            text=input_text,
+            text=text,
             output_parse_pii=self.output_parse_pii,
             presidio_config=None,
             request_data={},

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -26,7 +26,12 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.types.guardrails import GuardrailEventHooks, PiiAction, PiiEntityType
+from litellm.types.guardrails import (
+    GuardrailEventHooks,
+    PiiAction,
+    PiiEntityType,
+    PresidioPerRequestConfig,
+)
 from litellm.types.proxy.guardrails.guardrail_hooks.presidio import (
     PresidioAnalyzeRequest,
     PresidioAnalyzeResponseItem,
@@ -38,15 +43,6 @@ from litellm.utils import (
     ModelResponse,
     StreamingChoices,
 )
-
-
-class PresidioPerRequestConfig(BaseModel):
-    """
-    presdio params that can be controlled per request, api key
-    """
-
-    language: Optional[str] = None
-    entities: Optional[List[PiiEntityType]] = None
 
 
 class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -14,7 +14,6 @@ import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import aiohttp
-from pydantic import BaseModel
 
 import litellm  # noqa: E401
 from litellm import get_secret

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timezone
 from typing import List, Optional
 
+import litellm
+from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy.utils import PrismaClient
 from litellm.types.guardrails import Guardrail, SupportedGuardrailIntegrations
@@ -37,6 +39,26 @@ class GuardrailRegistry:
 
     def __init__(self):
         pass
+
+    ###########################################################
+    ########### In memory management helpers for guardrails ###########
+    ############################################################
+    def get_initialized_guardrail_callback(
+        self, guardrail_name: str
+    ) -> Optional[CustomGuardrail]:
+        """
+        Returns the initialized guardrail callback for a given guardrail name
+        """
+        active_guardrails = (
+            litellm.logging_callback_manager.get_custom_loggers_for_type(
+                callback_type=CustomGuardrail
+            )
+        )
+        for active_guardrail in active_guardrails:
+            if isinstance(active_guardrail, CustomGuardrail):
+                if active_guardrail.guardrail_name == guardrail_name:
+                    return active_guardrail
+        return None
 
     ###########################################################
     ########### DB management helpers for guardrails ###########

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -393,9 +393,11 @@ except Exception:
 ###################
 # Import enterprise routes
 try:
-    from litellm_enterprise.proxy.enterprise_routes import router as enterprise_router
+    from litellm_enterprise.proxy.enterprise_routes import router as _enterprise_router
+
+    enterprise_router = _enterprise_router
 except ImportError:
-    enterprise_router = APIRouter()
+    pass
 ###################
 
 server_root_path = os.getenv("SERVER_ROOT_PATH", "")

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -316,10 +316,12 @@ class PresidioPerRequestConfig(BaseModel):
     entities: Optional[List[PiiEntityType]] = None
 
 
-class MaskPIIRequest(BaseModel):
+class ApplyGuardrailRequest(BaseModel):
+    guardrail_name: str
     text: str
-    presidio_config: Optional[PresidioPerRequestConfig] = None
+    language: Optional[str] = None
+    entities: Optional[List[PiiEntityType]] = None
 
 
-class MaskPIIResponse(BaseModel):
-    redacted_text: str
+class ApplyGuardrailResponse(BaseModel):
+    response_text: str

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -305,3 +305,21 @@ class GuardrailUIAddGuardrailSettings(BaseModel):
     supported_actions: List[PiiAction]
     supported_modes: List[GuardrailEventHooks]
     pii_entity_categories: List[PiiEntityCategoryMap]
+
+
+class PresidioPerRequestConfig(BaseModel):
+    """
+    presdio params that can be controlled per request, api key
+    """
+
+    language: Optional[str] = None
+    entities: Optional[List[PiiEntityType]] = None
+
+
+class MaskPIIRequest(BaseModel):
+    text: str
+    presidio_config: Optional[PresidioPerRequestConfig] = None
+
+
+class MaskPIIResponse(BaseModel):
+    redacted_text: str

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -67,6 +67,27 @@ async def test_presidio_with_entities_config():
 
 
 @pytest.mark.asyncio
+async def test_presidio_apply_guardrail():
+    """Test for Presidio guardrail apply guardrail - requires actual Presidio API"""
+    litellm._turn_on_debug()
+    presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
+        pii_entities_config={},
+        presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+    )
+
+
+    response = await presidio_guardrail.apply_guardrail(
+        text="My credit card number is 4111-1111-1111-1111 and my email is test@example.com",
+        language="en",
+    )
+    print("response from apply guardrail for presidio: ", response)
+
+    # assert tthe default config masks the credit card and email
+    assert "4111-1111-1111-1111" not in response
+    assert "test@example.com" not in response
+
+@pytest.mark.asyncio
 async def test_presidio_with_blocked_entities():
     """Test for Presidio guardrail with blocked entities - requires actual Presidio API"""
     # Setup the guardrail with specific entities config - BLOCK for credit card


### PR DESCRIPTION
## [Feat - Guardrails] Expose /apply_guardrail endpoint for directly calling guardrail

This PR introduces a new endpoint (/apply_guardrail) to allow clients to directly call the guardrail logic for PII masking, with a corresponding test and supporting type changes.

# Request
```
curl -X POST "https://your-litellm-proxy-url/guardrails/apply_guardrail" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer your_api_key_here" \
  -d '{
    "guardrail_name": "pii-masker",
    "text": "My name is John Doe and my email is john.doe@example.com. My credit card number is 4111-1111-1111-1111.",
    "language": "en",
    "entities": ["PERSON", "EMAIL_ADDRESS", "CREDIT_CARD"]
  }'
```

# Response
```
{
  "response_text": "My name is [PERSON] and my email is [EMAIL_ADDRESS]. My credit card number is [CREDIT_CARD]."
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


