### PR TITLE
fix: enhance AzureOpenAIResponsesAPIConfig to support different Azure auth method like we have for completions api.

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -409,9 +409,11 @@ class BaseAzureLLM(BaseOpenAILLM):
         }
         # init http client + SSL Verification settings
         if is_async is True:
-            azure_client_params["http_client"] = self._get_async_http_client()
+            # Type annotation to fix incompatible types error
+            azure_client_params["http_client"] = self._get_async_http_client()  # type: ignore
         else:
-            azure_client_params["http_client"] = self._get_sync_http_client()
+            # Type annotation to fix incompatible types error
+            azure_client_params["http_client"] = self._get_sync_http_client()  # type: ignore
 
         if max_retries is not None:
             azure_client_params["max_retries"] = max_retries

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Callable, Dict, Optional, Union, Tuple
+from typing import Any, Callable, Dict, Optional, Union
 
 import httpx
 from openai import AsyncAzureOpenAI, AzureOpenAI

--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -29,10 +29,13 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_key: Optional[str] = None,
     ) -> dict:
         
-        api_key, azure_ad_token_provider, azure_ad_token = get_azure_api_key_or_token(
+        auth_response = get_azure_api_key_or_token(
             litellm_params=litellm_params,
             api_key=api_key,
         )
+        api_key = auth_response.api_key
+        azure_ad_token_provider = auth_response.azure_ad_token_provider
+        azure_ad_token = auth_response.azure_ad_token
 
         if azure_ad_token_provider:
             azure_ad_token = azure_ad_token_provider()

--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
-import os 
 import httpx
 
 import litellm

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -66,6 +66,7 @@ class BaseResponsesAPIConfig(ABC):
         self,
         headers: dict,
         model: str,
+        litellm_params: dict,
         api_key: Optional[str] = None,
     ) -> dict:
         return {}

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1271,6 +1271,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=response_api_optional_request_params.get("extra_headers", {}) or {},
             model=model,
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:
@@ -1391,6 +1392,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=response_api_optional_request_params.get("extra_headers", {}) or {},
             model=model,
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:
@@ -1512,6 +1514,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=extra_headers or {},
             model="None",
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:
@@ -1596,6 +1599,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=extra_headers or {},
             model="None",
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:
@@ -1681,6 +1685,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=extra_headers or {},
             model="None",
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:
@@ -1749,6 +1754,7 @@ class BaseLLMHTTPHandler:
             api_key=litellm_params.api_key,
             headers=extra_headers or {},
             model="None",
+            litellm_params=dict(litellm_params)
         )
 
         if extra_headers:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -93,6 +93,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         self,
         headers: dict,
         model: str,
+        litellm_params: dict,
         api_key: Optional[str] = None,
     ) -> dict:
         api_key = (

--- a/tests/litellm/llms/azure/response/test_azure_responses_transformation.py
+++ b/tests/litellm/llms/azure/response/test_azure_responses_transformation.py
@@ -94,7 +94,7 @@ class TestAzureOpenAIResponsesAPIConfig:
         
         mock_token_provider = MagicMock(return_value="entra_id_token")
         
-        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_entra_id",
+        with patch("litellm.llms.azure.common_utils.get_azure_ad_token_from_entra_id",
                   return_value=mock_token_provider) as mock_get_token:
             result = self.config.validate_environment(
                 headers=headers,
@@ -121,7 +121,7 @@ class TestAzureOpenAIResponsesAPIConfig:
         
         mock_token_provider = MagicMock(return_value="username_password_token")
         
-        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_username_password",
+        with patch("litellm.llms.azure.common_utils.get_azure_ad_token_from_username_password",
                   return_value=mock_token_provider) as mock_get_token:
             result = self.config.validate_environment(
                 headers=headers,
@@ -146,7 +146,7 @@ class TestAzureOpenAIResponsesAPIConfig:
             "tenant_id": "test_tenant_id"
         }
         
-        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_oidc",
+        with patch("litellm.llms.azure.common_utils.get_azure_ad_token_from_oidc",
                   return_value="processed_oidc_token") as mock_get_token:
             result = self.config.validate_environment(
                 headers=headers,
@@ -175,7 +175,7 @@ class TestAzureOpenAIResponsesAPIConfig:
             with patch("litellm.azure_key", None):
                 with patch("litellm.enable_azure_ad_token_refresh", True):
                     # Mock the get_azure_ad_token_provider function in the module
-                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_provider",
+                    with patch("litellm.llms.azure.common_utils.get_azure_ad_token_provider",
                               return_value=mock_token) as mock_get_provider:
                         # Call the method
                         result = self.config.validate_environment(
@@ -199,7 +199,7 @@ class TestAzureOpenAIResponsesAPIConfig:
         with patch("litellm.api_key", None):
             with patch("litellm.azure_key", None):
                 with patch("litellm.enable_azure_ad_token_refresh", True):
-                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_provider",
+                    with patch("litellm.llms.azure.common_utils.get_azure_ad_token_provider",
                               side_effect=ValueError("Token provider error")):
                         with patch("litellm.llms.azure.responses.transformation.get_secret_str",
                                   return_value="fallback_api_key"):
@@ -306,7 +306,7 @@ class TestAzureOpenAIResponsesAPIConfig:
             
             mock_token_provider = MagicMock(return_value="env_entra_id_token")
             
-            with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_entra_id", 
+            with patch("litellm.llms.azure.common_utils.get_azure_ad_token_from_entra_id", 
                       return_value=mock_token_provider) as mock_get_token:
                 result = self.config.validate_environment(
                     headers=headers,
@@ -333,7 +333,7 @@ class TestAzureOpenAIResponsesAPIConfig:
             
             with patch("litellm.api_key", None):
                 with patch("litellm.azure_key", None):
-                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_username_password", 
+                    with patch("litellm.llms.azure.common_utils.get_azure_ad_token_from_username_password", 
                               return_value=mock_token_provider) as mock_get_token:
                         result = self.config.validate_environment(
                             headers=headers,

--- a/tests/litellm/llms/azure/response/test_azure_responses_transformation.py
+++ b/tests/litellm/llms/azure/response/test_azure_responses_transformation.py
@@ -1,0 +1,389 @@
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
+
+
+
+class TestAzureOpenAIResponsesAPIConfig:
+
+    def setup_method(self):
+        self.config = AzureOpenAIResponsesAPIConfig()
+        self.model = "gpt-4o"
+        self.logging_obj = MagicMock()
+
+    def test_validate_environment(self):
+        """Test that validate_environment correctly sets the Authorization header"""
+        # Test with provided API key
+        headers = {}
+        litellm_params = {}
+        api_key = "test_api_key"
+
+        result = self.config.validate_environment(
+            headers=headers,
+            model=self.model,
+            api_key=api_key,
+            litellm_params=litellm_params
+        )
+
+        assert "Authorization" in result
+        assert result["Authorization"] == f"Bearer {api_key}"
+
+        # Test with empty headers
+        headers = {}
+
+        with patch("litellm.api_key", "litellm_api_key"):
+            result = self.config.validate_environment(
+                headers=headers,
+                model=self.model,
+                litellm_params=litellm_params
+            )
+
+            assert "Authorization" in result
+            assert result["Authorization"] == "Bearer litellm_api_key"
+
+        # Test with existing headers
+        headers = {"Content-Type": "application/json"}
+
+        with patch("litellm.azure_key", "azure_key"):
+            with patch("litellm.api_key", None):
+                result = self.config.validate_environment(
+                    headers=headers,
+                    model=self.model,
+                    litellm_params=litellm_params
+                )
+
+                assert "Authorization" in result
+                assert result["Authorization"] == "Bearer azure_key"
+                assert "Content-Type" in result
+                assert result["Content-Type"] == "application/json"
+
+        # Test with environment variable
+        headers = {}
+
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", None):
+                with patch(
+                    "litellm.llms.azure.responses.transformation.get_secret_str",
+                    return_value="env_api_key",
+                ):
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        litellm_params=litellm_params
+                    )
+
+                    assert "Authorization" in result
+                    assert result["Authorization"] == "Bearer env_api_key"
+    
+    def test_validate_environment_with_azure_ad_token_from_entra_id(self):
+        """Test validate_environment with Azure AD Token from Entra ID"""
+        headers = {}
+        litellm_params = {
+            "tenant_id": "test_tenant_id",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret"
+        }
+        
+        mock_token_provider = MagicMock(return_value="entra_id_token")
+        
+        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_entra_id",
+                  return_value=mock_token_provider) as mock_get_token:
+            result = self.config.validate_environment(
+                headers=headers,
+                model=self.model,
+                litellm_params=litellm_params
+            )
+            
+            mock_get_token.assert_called_once_with(
+                tenant_id="test_tenant_id",
+                client_id="test_client_id",
+                client_secret="test_client_secret"
+            )
+            assert "Authorization" in result
+            assert result["Authorization"] == "Bearer entra_id_token"
+    
+    def test_validate_environment_with_azure_username_password(self):
+        """Test validate_environment with Azure username and password"""
+        headers = {}
+        litellm_params = {
+            "azure_username": "test_username",
+            "azure_password": "test_password",
+            "client_id": "test_client_id"
+        }
+        
+        mock_token_provider = MagicMock(return_value="username_password_token")
+        
+        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_username_password",
+                  return_value=mock_token_provider) as mock_get_token:
+            result = self.config.validate_environment(
+                headers=headers,
+                model=self.model,
+                litellm_params=litellm_params
+            )
+            
+            mock_get_token.assert_called_once_with(
+                azure_username="test_username",
+                azure_password="test_password",
+                client_id="test_client_id"
+            )
+            assert "Authorization" in result
+            assert result["Authorization"] == "Bearer username_password_token"
+    
+    def test_validate_environment_with_oidc_token(self):
+        """Test validate_environment with OIDC token"""
+        headers = {}
+        litellm_params = {
+            "azure_ad_token": "oidc/test_token",
+            "client_id": "test_client_id",
+            "tenant_id": "test_tenant_id"
+        }
+        
+        with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_oidc",
+                  return_value="processed_oidc_token") as mock_get_token:
+            result = self.config.validate_environment(
+                headers=headers,
+                model=self.model,
+                litellm_params=litellm_params
+            )
+            
+            mock_get_token.assert_called_once_with(
+                azure_ad_token="oidc/test_token",
+                azure_client_id="test_client_id",
+                azure_tenant_id="test_tenant_id"
+            )
+            assert "Authorization" in result
+            assert result["Authorization"] == "Bearer processed_oidc_token"
+    
+    def test_validate_environment_with_service_principal(self):
+        """Test validate_environment with Service Principal"""
+        headers = {}
+        litellm_params = {}
+        
+        # Create a token provider that returns a token when called
+        mock_token = "service_principal_token"
+        
+        
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", None):
+                with patch("litellm.enable_azure_ad_token_refresh", True):
+                    # Mock the get_azure_ad_token_provider function in the module
+                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_provider",
+                              return_value=mock_token) as mock_get_provider:
+                        # Call the method
+                        result = self.config.validate_environment(
+                            headers=headers,
+                            model=self.model,
+                            litellm_params=litellm_params
+                        )
+                        
+                        # Verify the token provider was retrieved
+                        mock_get_provider.assert_called_once()
+                        
+                        # Verify the result contains the expected Authorization header
+                        assert "Authorization" in result
+                        assert result["Authorization"] == f"Bearer {mock_token}"
+    
+    def test_validate_environment_service_principal_error(self):
+        """Test validate_environment when Service Principal raises ValueError"""
+        headers = {}
+        litellm_params = {}
+        
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", None):
+                with patch("litellm.enable_azure_ad_token_refresh", True):
+                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_provider",
+                              side_effect=ValueError("Token provider error")):
+                        with patch("litellm.llms.azure.responses.transformation.get_secret_str",
+                                  return_value="fallback_api_key"):
+                            result = self.config.validate_environment(
+                                headers=headers,
+                                model=self.model,
+                                litellm_params=litellm_params
+                            )
+                            
+                            assert "Authorization" in result
+                            assert result["Authorization"] == "Bearer fallback_api_key"
+    
+    def test_validate_environment_priority_order(self):
+        """Test the priority order of token sources"""
+        headers = {}
+        
+        # Test 1: azure_ad_token has highest priority
+        litellm_params = {
+            "azure_ad_token": "ad_token_from_params"
+        }
+        api_key = "direct_api_key"
+        
+        # All sources available - should use azure_ad_token (highest priority)
+        with patch("litellm.api_key", "litellm_api_key"):
+            with patch("litellm.azure_key", "azure_key"):
+                with patch("litellm.llms.azure.responses.transformation.get_secret_str",
+                          return_value="env_api_key"):
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        api_key=api_key,
+                        litellm_params=litellm_params
+                    )
+                    
+                    assert result["Authorization"] == "Bearer ad_token_from_params"
+        
+        # Test 2: Without azure_ad_token, api_key has next highest priority
+        litellm_params = {}  # No azure_ad_token
+        api_key = "direct_api_key"
+        
+        with patch("litellm.api_key", "litellm_api_key"):
+            with patch("litellm.azure_key", "azure_key"):
+                with patch("litellm.llms.azure.responses.transformation.get_secret_str",
+                          return_value="env_api_key"):
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        api_key=api_key,
+                        litellm_params=litellm_params
+                    )
+                    
+                    assert result["Authorization"] == "Bearer direct_api_key"
+        
+        # No direct api_key - should use litellm_api_key since no azure_ad_token in params
+        with patch("litellm.api_key", "litellm_api_key"):
+            with patch("litellm.azure_key", "azure_key"):
+                with patch("litellm.llms.azure.responses.transformation.get_secret_str",
+                          return_value="env_api_key"):
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        litellm_params=litellm_params
+                    )
+                    
+                    assert result["Authorization"] == "Bearer litellm_api_key"
+        
+        # Test the complete fallback chain
+        litellm_params = {}  # No azure_ad_token
+        
+        # Should use litellm.api_key
+        with patch("litellm.api_key", "litellm_api_key"):
+            with patch("litellm.azure_key", "azure_key"):
+                result = self.config.validate_environment(
+                    headers=headers,
+                    model=self.model,
+                    litellm_params=litellm_params
+                )
+                
+                assert result["Authorization"] == "Bearer litellm_api_key"
+        
+        # Should use litellm.azure_key
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", "azure_key"):
+                result = self.config.validate_environment(
+                    headers=headers,
+                    model=self.model,
+                    litellm_params=litellm_params
+                )
+                
+                assert result["Authorization"] == "Bearer azure_key"
+
+    def test_validate_environment_with_env_variables(self):
+        """Test validate_environment with environment variables"""
+        headers = {}
+        litellm_params = {}
+        
+        # Test with environment variables for Entra ID
+        with patch("os.getenv") as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                "AZURE_TENANT_ID": "env_tenant_id",
+                "AZURE_CLIENT_ID": "env_client_id",
+                "AZURE_CLIENT_SECRET": "env_client_secret"
+            }.get(key, default)
+            
+            mock_token_provider = MagicMock(return_value="env_entra_id_token")
+            
+            with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_entra_id", 
+                      return_value=mock_token_provider) as mock_get_token:
+                result = self.config.validate_environment(
+                    headers=headers,
+                    model=self.model,
+                    litellm_params=litellm_params
+                )
+                
+                mock_get_token.assert_called_once_with(
+                    tenant_id="env_tenant_id",
+                    client_id="env_client_id",
+                    client_secret="env_client_secret"
+                )
+                assert result["Authorization"] == "Bearer env_entra_id_token"
+        
+        # Test with environment variables for username/password
+        with patch("os.getenv") as mock_getenv:
+            mock_getenv.side_effect = lambda key, default=None: {
+                "AZURE_USERNAME": "env_username",
+                "AZURE_PASSWORD": "env_password",
+                "AZURE_CLIENT_ID": "env_client_id"
+            }.get(key, default)
+            
+            mock_token_provider = MagicMock(return_value="env_username_token")
+            
+            with patch("litellm.api_key", None):
+                with patch("litellm.azure_key", None):
+                    with patch("litellm.llms.azure.responses.transformation.get_azure_ad_token_from_username_password", 
+                              return_value=mock_token_provider) as mock_get_token:
+                        result = self.config.validate_environment(
+                            headers=headers,
+                            model=self.model,
+                            litellm_params=litellm_params
+                        )
+                        
+                        mock_get_token.assert_called_once_with(
+                            azure_username="env_username",
+                            azure_password="env_password",
+                            client_id="env_client_id"
+                        )
+                        assert result["Authorization"] == "Bearer env_username_token"
+
+    def test_validate_environment_with_azure_api_key_env_vars(self):
+        """Test validate_environment with specific Azure API key environment variables"""
+        headers = {}
+        litellm_params = {}
+        
+        # Test with AZURE_OPENAI_API_KEY environment variable
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", None):
+                with patch("litellm.llms.azure.responses.transformation.get_secret_str") as mock_get_secret:
+                    # Set up the mock to return different values based on the input key
+                    mock_get_secret.side_effect = lambda key: "azure_openai_key" if key == "AZURE_OPENAI_API_KEY" else None
+                    
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        litellm_params=litellm_params
+                    )
+                    
+                    assert "Authorization" in result
+                    assert result["Authorization"] == "Bearer azure_openai_key"
+                    mock_get_secret.assert_called_with("AZURE_OPENAI_API_KEY")
+        
+        # Test with AZURE_API_KEY environment variable (fallback)
+        with patch("litellm.api_key", None):
+            with patch("litellm.azure_key", None):
+                with patch("litellm.llms.azure.responses.transformation.get_secret_str") as mock_get_secret:
+                    # First call returns None (for AZURE_OPENAI_API_KEY), second call returns a value (for AZURE_API_KEY)
+                    mock_get_secret.side_effect = lambda key: None if key == "AZURE_OPENAI_API_KEY" else "azure_api_key"
+                    
+                    result = self.config.validate_environment(
+                        headers=headers,
+                        model=self.model,
+                        litellm_params=litellm_params
+                    )
+                    
+                    assert "Authorization" in result
+                    assert result["Authorization"] == "Bearer azure_api_key"
+                    # Should be called twice, once for each environment variable
+                    assert mock_get_secret.call_count == 2

--- a/tests/litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -148,10 +148,14 @@ class TestOpenAIResponsesAPIConfig:
         """Test that validate_environment correctly sets the Authorization header"""
         # Test with provided API key
         headers = {}
+        litellm_params = {}
         api_key = "test_api_key"
 
         result = self.config.validate_environment(
-            headers=headers, model=self.model, api_key=api_key
+            headers=headers, 
+            model=self.model, 
+            api_key=api_key, 
+            litellm_params=litellm_params
         )
 
         assert "Authorization" in result
@@ -161,7 +165,11 @@ class TestOpenAIResponsesAPIConfig:
         headers = {}
 
         with patch("litellm.api_key", "litellm_api_key"):
-            result = self.config.validate_environment(headers=headers, model=self.model)
+            result = self.config.validate_environment(
+                headers=headers, 
+                model=self.model,
+                litellm_params=litellm_params
+            )
 
             assert "Authorization" in result
             assert result["Authorization"] == "Bearer litellm_api_key"
@@ -172,7 +180,9 @@ class TestOpenAIResponsesAPIConfig:
         with patch("litellm.openai_key", "openai_key"):
             with patch("litellm.api_key", None):
                 result = self.config.validate_environment(
-                    headers=headers, model=self.model
+                    headers=headers, 
+                    model=self.model,
+                    litellm_params=litellm_params
                 )
 
                 assert "Authorization" in result
@@ -190,7 +200,9 @@ class TestOpenAIResponsesAPIConfig:
                     return_value="env_api_key",
                 ):
                     result = self.config.validate_environment(
-                        headers=headers, model=self.model
+                        headers=headers, 
+                        model=self.model,
+                        litellm_params=litellm_params
                     )
 
                     assert "Authorization" in result


### PR DESCRIPTION
Auth method like we have for completions api.

## Enhance AzureOpenAIResponsesAPIConfig to support different Azure auth method 
support  Entra ID for Azure Auth /  Azure Username and Password for Azure Auth /  Azure OIDC Token / Azure AD token provider based on Service Principal with Secret workflow for Azure Auth


## Relevant issues

Reference to issue https://github.com/BerriAI/litellm/issues/10868

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [✓] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [✓] I have added a screenshot of my new test passing locally 
- [✓] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [✓] My PR's scope is as isolated as possible, it only solves 1 specific problem



## Test reuslt
```

## Result of make test-unit 
Those 3 error is not coming from my change
```
(.venv) user@abehsu-us-vscode-med:~/abehsu/litellm_clone$ make test-unit
poetry run pytest tests/litellm/
============================================ test session starts ============================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0
rootdir: /home/user/abehsu/litellm_clone
plugins: requests-mock-1.12.1, asyncio-0.21.2, anyio-4.5.2, respx-0.22.0, mock-3.14.0
asyncio: mode=strict
collected 800 items / 3 errors                                                                              

================================================== ERRORS ===================================================
____________________ ERROR collecting tests/litellm/enterprise/test_enterprise_routes.py ____________________
ImportError while importing test module '/home/user/abehsu/litellm_clone/tests/litellm/enterprise/test_enterprise_routes.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/litellm/enterprise/test_enterprise_routes.py:13: in <module>
    from litellm_enterprise.proxy.enterprise_routes import router
E   ModuleNotFoundError: No module named 'litellm_enterprise.proxy'
__________________ ERROR collecting tests/litellm/litellm_core_utils/test_token_counter.py __________________
ImportError while importing test module '/home/user/abehsu/litellm_clone/tests/litellm/litellm_core_utils/test_token_counter.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/litellm/litellm_core_utils/test_token_counter.py:26: in <module>
    from tests.large_text import text
E   ModuleNotFoundError: No module named 'tests.large_text'
_______________ ERROR collecting tests/litellm/litellm_core_utils/test_token_counter_tool.py ________________
ImportError while importing test module '/home/user/abehsu/litellm_clone/tests/litellm/litellm_core_utils/test_token_counter_tool.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/litellm/litellm_core_utils/test_token_counter_tool.py:13: in <module>
    from test_token_counter import token_counter
tests/litellm/litellm_core_utils/test_token_counter.py:26: in <module>
    from tests.large_text import text
E   ModuleNotFoundError: No module named 'tests.large_text'
============================================= warnings summary ==============================================
tests/litellm/integrations/test_custom_prompt_management.py:27
  /home/user/abehsu/litellm_clone/tests/litellm/integrations/test_custom_prompt_management.py:27: PytestCollectionWarning: cannot collect test class 'TestCustomPromptManagement' because it has a __init__ constructor (from: tests/litellm/integrations/test_custom_prompt_management.py)
    class TestCustomPromptManagement(CustomPromptManagement):

tests/litellm/integrations/arize/test_arize_utils.py:181
  /home/user/abehsu/litellm_clone/tests/litellm/integrations/arize/test_arize_utils.py:181: PytestCollectionWarning: cannot collect test class 'TestArizeLogger' because it has a __init__ constructor (from: tests/litellm/integrations/arize/test_arize_utils.py)
    class TestArizeLogger(CustomLogger):

tests/litellm/litellm_core_utils/test_streaming_handler.py:505
  /home/user/abehsu/litellm_clone/tests/litellm/litellm_core_utils/test_streaming_handler.py:505: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=3)

tests/litellm/llms/ollama/test_ollama_chat_transformation.py:16
  /home/user/abehsu/litellm_clone/tests/litellm/llms/ollama/test_ollama_chat_transformation.py:16: PytestCollectionWarning: cannot collect test class 'TestEvent' because it has a __init__ constructor (from: tests/litellm/llms/ollama/test_ollama_chat_transformation.py)
    class TestEvent(BaseModel):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== short test summary info ==========================================
ERROR tests/litellm/enterprise/test_enterprise_routes.py
ERROR tests/litellm/litellm_core_utils/test_token_counter.py
ERROR tests/litellm/litellm_core_utils/test_token_counter_tool.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================= 4 warnings, 3 errors in 4.24s =======================================
make: *** [Makefile:29: test-unit] Error 2
```


## Type

🐛 Bug Fix

## Changes


