### PR TITLE
[Feat] Add Tracing for guardrails in StandardLoggingPayload, Langfuse

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -190,8 +190,8 @@ class CustomGuardrail(CustomLogger):
         guardrail_json_response: Union[Exception, str, dict, List[dict]],
         request_data: dict,
         guardrail_status: Literal["success", "failure"],
-        start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
         duration: Optional[float] = None,
         masked_entity_count: Optional[Dict[str, int]] = None,
     ) -> None:
@@ -250,8 +250,8 @@ class CustomGuardrail(CustomLogger):
         self,
         response: Optional[Dict],
         request_data: dict,
-        start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
         duration: Optional[float] = None,
     ):
         """
@@ -275,8 +275,8 @@ class CustomGuardrail(CustomLogger):
         self,
         e: Exception,
         request_data: dict,
-        start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
         duration: Optional[float] = None,
     ):
         """
@@ -322,16 +322,16 @@ def log_guardrail_information(func):
             return self._process_response(
                 response=response,
                 request_data=request_data,
-                start_time=start_time,
-                end_time=datetime.now(),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
                 duration=(datetime.now() - start_time).total_seconds(),
             )
         except Exception as e:
             return self._process_error(
                 e=e,
                 request_data=request_data,
-                start_time=start_time,
-                end_time=datetime.now(),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
                 duration=(datetime.now() - start_time).total_seconds(),
             )
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -190,6 +190,8 @@ class CustomGuardrail(CustomLogger):
         guardrail_json_response: Union[Exception, str, dict, List[dict]],
         request_data: dict,
         guardrail_status: Literal["success", "failure"],
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
         duration: Optional[float] = None,
         masked_entity_count: Optional[Dict[str, int]] = None,
     ) -> None:
@@ -203,6 +205,8 @@ class CustomGuardrail(CustomLogger):
             guardrail_mode=self.event_hook,
             guardrail_response=guardrail_json_response,
             guardrail_status=guardrail_status,
+            start_time=start_time,
+            end_time=end_time,
             duration=duration,
             masked_entity_count=masked_entity_count,
         )
@@ -246,6 +250,8 @@ class CustomGuardrail(CustomLogger):
         self,
         response: Optional[Dict],
         request_data: dict,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
         duration: Optional[float] = None,
     ):
         """
@@ -260,6 +266,8 @@ class CustomGuardrail(CustomLogger):
             request_data=request_data,
             guardrail_status="success",
             duration=duration,
+            start_time=start_time,
+            end_time=end_time,
         )
         return response
 
@@ -267,6 +275,8 @@ class CustomGuardrail(CustomLogger):
         self,
         e: Exception,
         request_data: dict,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
         duration: Optional[float] = None,
     ):
         """
@@ -279,6 +289,8 @@ class CustomGuardrail(CustomLogger):
             request_data=request_data,
             guardrail_status="failure",
             duration=duration,
+            start_time=start_time,
+            end_time=end_time,
         )
         raise e
 
@@ -310,12 +322,16 @@ def log_guardrail_information(func):
             return self._process_response(
                 response=response,
                 request_data=request_data,
+                start_time=start_time,
+                end_time=datetime.now(),
                 duration=(datetime.now() - start_time).total_seconds(),
             )
         except Exception as e:
             return self._process_error(
                 e=e,
                 request_data=request_data,
+                start_time=start_time,
+                end_time=datetime.now(),
                 duration=(datetime.now() - start_time).total_seconds(),
             )
 

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -822,16 +822,22 @@ class LangFuseLogger:
         Log guardrail information as a span
         """
         if standard_logging_object is None:
+            verbose_logger.debug(
+                "Not logging guardrail information as span because standard_logging_object is None"
+            )
             return
 
         guardrail_information = standard_logging_object.get(
             "guardrail_information", None
         )
         if guardrail_information is None:
+            verbose_logger.debug(
+                "Not logging guardrail information as span because guardrail_information is None"
+            )
             return
 
-        trace.span(
-            name="guardrail_information",
+        span = trace.span(
+            name="guardrail",
             input=guardrail_information.get("guardrail_request", None),
             output=guardrail_information.get("guardrail_response", None),
             metadata={
@@ -841,13 +847,12 @@ class LangFuseLogger:
                     "masked_entity_count", None
                 ),
             },
-            # start_time=datetime.fromtimestamp(
-            #     guardrail_information.get("start_time", datetime.now().timestamp())
-            # ),
-            # end_time=datetime.fromtimestamp(
-            #     guardrail_information.get("end_time", datetime.now().timestamp())
-            # ),
+            start_time=guardrail_information.get("start_time", None),  # type: ignore
+            end_time=guardrail_information.get("end_time", None),  # type: ignore
         )
+
+        verbose_logger.debug(f"Logged guardrail information as span: {span}")
+        span.end()
 
 
 def _add_prompt_to_generation_params(

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -841,10 +841,12 @@ class LangFuseLogger:
                     "masked_entity_count", None
                 ),
             },
-            # The Langfuse SDK expects datetime objects for start_time and end_time but it does not render them correctly
-            # It seems to only work when start_time and end_time are floats :)
-            start_time=guardrail_information.get("start_time", None),  # type: ignore
-            end_time=guardrail_information.get("end_time", None),  # type: ignore
+            # start_time=datetime.fromtimestamp(
+            #     guardrail_information.get("start_time", datetime.now().timestamp())
+            # ),
+            # end_time=datetime.fromtimestamp(
+            #     guardrail_information.get("end_time", datetime.now().timestamp())
+            # ),
         )
 
 

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -6,7 +6,6 @@ import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
-from langfuse.client import StatefulTraceClient
 from packaging.version import Version
 
 import litellm
@@ -28,9 +27,12 @@ from litellm.types.utils import (
 )
 
 if TYPE_CHECKING:
+    from langfuse.client import StatefulTraceClient
+
     from litellm.litellm_core_utils.litellm_logging import DynamicLoggingCache
 else:
     DynamicLoggingCache = Any
+    StatefulTraceClient = Any
 
 
 class LangFuseLogger:
@@ -830,8 +832,6 @@ class LangFuseLogger:
 
         trace.span(
             name="guardrail_information",
-            start_time=guardrail_information.get("start_time", None),
-            end_time=guardrail_information.get("end_time", None),
             input=guardrail_information.get("guardrail_request", None),
             output=guardrail_information.get("guardrail_response", None),
             metadata={
@@ -841,6 +841,10 @@ class LangFuseLogger:
                     "masked_entity_count", None
                 ),
             },
+            # The Langfuse SDK expects datetime objects for start_time and end_time but it does not render them correctly
+            # It seems to only work when start_time and end_time are floats :)
+            start_time=guardrail_information.get("start_time", None),  # type: ignore
+            end_time=guardrail_information.get("end_time", None),  # type: ignore
         )
 
 

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -830,6 +830,9 @@ class LangFuseLogger:
 
         trace.span(
             name="guardrail_information",
+            start_time=guardrail_information.get("start_time", None),
+            end_time=guardrail_information.get("end_time", None),
+            input=guardrail_information.get("guardrail_request", None),
             output=guardrail_information.get("guardrail_response", None),
             metadata={
                 "guardrail_name": guardrail_information.get("guardrail_name", None),

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -358,8 +358,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 guardrail_json_response=guardrail_json_response,
                 request_data=request_data,
                 guardrail_status=status,
-                start_time=start_time,
-                end_time=datetime.now(),
+                start_time=start_time.timestamp(),
+                end_time=datetime.now().timestamp(),
                 duration=(datetime.now() - start_time).total_seconds(),
                 masked_entity_count=masked_entity_count,
             )

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -11,7 +11,8 @@
 import asyncio
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import aiohttp
 
@@ -20,10 +21,8 @@ from litellm import get_secret
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.exceptions import BlockedPiiEntityError
-from litellm.integrations.custom_guardrail import (
-    CustomGuardrail,
-    log_guardrail_information,
-)
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import (
     GuardrailEventHooks,
@@ -218,7 +217,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             raise e
 
     async def anonymize_text(
-        self, text: str, analyze_results: Any, output_parse_pii: bool
+        self,
+        text: str,
+        analyze_results: Any,
+        output_parse_pii: bool,
+        masked_entity_count: Dict[str, int],
     ) -> str:
         """
         Send analysis results to the Presidio anonymizer endpoint to get redacted text
@@ -256,6 +259,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                             ]  # get text it'll replace
 
                         new_text = new_text[:start] + replacement + new_text[end:]
+                        entity_type = item.get("entity_type", None)
+                        if entity_type is not None:
+                            masked_entity_count[entity_type] = (
+                                masked_entity_count.get(entity_type, 0) + 1
+                            )
                     return redacted_text["text"]
                 else:
                     raise Exception(f"Invalid anonymizer response: {redacted_text}")
@@ -300,6 +308,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         """
         Calls Presidio Analyze + Anonymize endpoints for PII Analysis + Masking
         """
+        start_time = datetime.now()
+        analyze_results: Optional[Union[List[PresidioAnalyzeResponseItem], Dict]] = None
+        status: Literal["success", "failure"] = "success"
+        masked_entity_count: Dict[str, int] = {}
+        exception_str: str = ""
         try:
             if self.mock_redacted_text is not None:
                 redacted_text = self.mock_redacted_text
@@ -324,13 +337,31 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     text=text,
                     analyze_results=analyze_results,
                     output_parse_pii=output_parse_pii,
+                    masked_entity_count=masked_entity_count,
                 )
-
             return redacted_text["text"]
         except Exception as e:
+            status = "failure"
+            exception_str = str(e)
             raise e
+        finally:
+            ####################################################
+            # Create Guardrail Trace for logging on Langfuse, Datadog, etc.
+            ####################################################
+            guardrail_json_response: Union[Exception, str, dict, List[dict]] = {}
+            if status == "success":
+                if isinstance(analyze_results, List):
+                    guardrail_json_response = [dict(item) for item in analyze_results]
+            else:
+                guardrail_json_response = exception_str
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_json_response=guardrail_json_response,
+                request_data=request_data,
+                guardrail_status=status,
+                duration=(datetime.now() - start_time).total_seconds(),
+                masked_entity_count=masked_entity_count,
+            )
 
-    @log_guardrail_information
     async def async_pre_call_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -394,7 +425,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         except Exception as e:
             raise e
 
-    @log_guardrail_information
     def logging_hook(
         self, kwargs: dict, result: Any, call_type: str
     ) -> Tuple[dict, Any]:
@@ -427,7 +457,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # No running event loop, we can safely run in this thread
             return run_in_new_loop()
 
-    @log_guardrail_information
     async def async_logging_hook(
         self, kwargs: dict, result: Any, call_type: str
     ) -> Tuple[dict, Any]:
@@ -476,7 +505,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         return kwargs, result
 
-    @log_guardrail_information
     async def async_post_call_success_hook(  # type: ignore
         self,
         data: dict,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -22,7 +22,6 @@ from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.exceptions import BlockedPiiEntityError
 from litellm.integrations.custom_guardrail import CustomGuardrail
-from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import (
     GuardrailEventHooks,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -358,6 +358,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 guardrail_json_response=guardrail_json_response,
                 request_data=request_data,
                 guardrail_status=status,
+                start_time=start_time,
+                end_time=datetime.now(),
                 duration=(datetime.now() - start_time).total_seconds(),
                 masked_entity_count=masked_entity_count,
             )

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -633,23 +633,23 @@ class Message(OpenAIObject):
         if audio is None:
             # delete audio from self
             # OpenAI compatible APIs like mistral API will raise an error if audio is passed in
-            if hasattr(self, 'audio'):
+            if hasattr(self, "audio"):
                 del self.audio
 
         if annotations is None:
             # ensure default response matches OpenAI spec
             # Some OpenAI compatible APIs raise an error if annotations are passed in
-            if hasattr(self, 'annotations'):
+            if hasattr(self, "annotations"):
                 del self.annotations
 
         if reasoning_content is None:
             # ensure default response matches OpenAI spec
-            if hasattr(self, 'reasoning_content'):
+            if hasattr(self, "reasoning_content"):
                 del self.reasoning_content
 
         if thinking_blocks is None:
             # ensure default response matches OpenAI spec
-            if hasattr(self, 'thinking_blocks'):
+            if hasattr(self, "thinking_blocks"):
                 del self.thinking_blocks
 
         add_provider_specific_fields(self, provider_specific_fields)
@@ -1870,8 +1870,21 @@ class StandardLoggingPayloadErrorInformation(TypedDict, total=False):
 class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: Optional[str]
     guardrail_mode: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks]]]
-    guardrail_response: Optional[Union[dict, str]]
+    guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: Literal["success", "failure"]
+    duration: Optional[float]
+    """
+    Duration of the guardrail in seconds
+    """
+
+    masked_entity_count: Optional[Dict[str, int]]
+    """
+    Count of masked entities
+    {
+        "CREDIT_CARD": 2,
+        "PHONE": 1
+    }
+    """
 
 
 StandardLoggingPayloadStatus = Literal["success", "failure"]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1,7 +1,6 @@
 import json
 import time
 import uuid
-from datetime import datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -1874,8 +1873,8 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: Literal["success", "failure"]
-    start_time: Optional[datetime]
-    end_time: Optional[datetime]
+    start_time: Optional[float]
+    end_time: Optional[float]
     duration: Optional[float]
     """
     Duration of the guardrail in seconds

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1,6 +1,7 @@
 import json
 import time
 import uuid
+from datetime import datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -1870,8 +1871,11 @@ class StandardLoggingPayloadErrorInformation(TypedDict, total=False):
 class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: Optional[str]
     guardrail_mode: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks]]]
+    guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: Literal["success", "failure"]
+    start_time: Optional[datetime]
+    end_time: Optional[datetime]
     duration: Optional[float]
     """
     Duration of the guardrail in seconds

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -236,20 +236,24 @@ async def test_presidio_pre_call_hook_with_different_call_types(call_type):
 def test_validate_environment_missing_http(base_url):
     pii_masking = _OPTIONAL_PresidioPIIMasking(mock_testing=True)
 
-    os.environ["PRESIDIO_ANALYZER_API_BASE"] = f"{base_url}/analyze"
-    os.environ["PRESIDIO_ANONYMIZER_API_BASE"] = f"{base_url}/anonymize"
-    pii_masking.validate_environment()
+    # Use patch.dict to temporarily modify environment variables only for this test
+    env_vars = {
+        "PRESIDIO_ANALYZER_API_BASE": f"{base_url}/analyze",
+        "PRESIDIO_ANONYMIZER_API_BASE": f"{base_url}/anonymize"
+    }
+    with patch.dict(os.environ, env_vars):
+        pii_masking.validate_environment()
 
-    expected_url = base_url
-    if not (base_url.startswith("https://") or base_url.startswith("http://")):
-        expected_url = "http://" + base_url
+        expected_url = base_url
+        if not (base_url.startswith("https://") or base_url.startswith("http://")):
+            expected_url = "http://" + base_url
 
-    assert (
-        pii_masking.presidio_anonymizer_api_base == f"{expected_url}/anonymize/"
-    ), "Got={}, Expected={}".format(
-        pii_masking.presidio_anonymizer_api_base, f"{expected_url}/anonymize/"
-    )
-    assert pii_masking.presidio_analyzer_api_base == f"{expected_url}/analyze/"
+        assert (
+            pii_masking.presidio_anonymizer_api_base == f"{expected_url}/anonymize/"
+        ), "Got={}, Expected={}".format(
+            pii_masking.presidio_anonymizer_api_base, f"{expected_url}/anonymize/"
+        )
+        assert pii_masking.presidio_analyzer_api_base == f"{expected_url}/analyze/"
 
 
 @pytest.mark.asyncio

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -433,6 +433,10 @@ async def test_presidio_pii_masking_logging_output_only_no_pre_api_hook():
 
 
 @pytest.mark.asyncio
+@patch.dict(os.environ, {
+    "PRESIDIO_ANALYZER_API_BASE": "http://localhost:5002",
+    "PRESIDIO_ANONYMIZER_API_BASE": "http://localhost:5001"
+})
 async def test_presidio_pii_masking_logging_output_only_logged_response_guardrails_config():
     from typing import Dict, List, Optional
 
@@ -445,9 +449,8 @@ async def test_presidio_pii_masking_logging_output_only_logged_response_guardrai
     )
 
     litellm.set_verbose = True
-    os.environ["PRESIDIO_ANALYZER_API_BASE"] = "http://localhost:5002"
-    os.environ["PRESIDIO_ANONYMIZER_API_BASE"] = "http://localhost:5001"
-
+    # Environment variables are now patched via the decorator instead of setting them directly
+    
     guardrails_config: List[Dict[str, GuardrailItemSpec]] = [
         {
             "pii_masking": {

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -1,0 +1,86 @@
+import sys
+import os
+import io, asyncio
+import json
+import pytest
+import time
+from litellm import mock_completion
+from unittest.mock import MagicMock, AsyncMock, patch
+sys.path.insert(0, os.path.abspath("../.."))
+import litellm
+from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking, PresidioPerRequestConfig
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.types.utils import StandardLoggingPayload, StandardLoggingGuardrailInformation
+from litellm.types.guardrails import GuardrailEventHooks
+from typing import Optional
+
+
+class TestCustomLogger(CustomLogger):
+    def __init__(self, *args, **kwargs):
+        self.standard_logging_payload: Optional[StandardLoggingPayload] = None
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.standard_logging_payload = kwargs.get("standard_logging_object")
+        pass
+
+@pytest.mark.asyncio
+async def test_standard_logging_payload_includes_guardrail_information():
+    """
+    Test that the standard logging payload includes the guardrail information when a guardrail is applied
+    """
+    test_custom_logger = TestCustomLogger()
+    litellm.callbacks = [test_custom_logger]
+    presidio_guard = _OPTIONAL_PresidioPIIMasking(
+        guardrail_name="presidio_guard",
+        event_hook=GuardrailEventHooks.pre_call,
+        presidio_analyzer_api_base=os.getenv("PRESIDIO_ANALYZER_API_BASE"),
+        presidio_anonymizer_api_base=os.getenv("PRESIDIO_ANONYMIZER_API_BASE"),
+    )
+    # 1. call the pre call hook with guardrail
+    request_data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Hello, my phone number is +1 412 555 1212"},
+        ],
+        "mock_response": "Hello",
+        "guardrails": ["presidio_guard"],
+        "metadata": {},
+    }
+    await presidio_guard.async_pre_call_hook(
+        user_api_key_dict={},
+        cache=None,
+        data=request_data,
+        call_type="acompletion"
+    )
+
+    # 2. call litellm.acompletion
+    response = await litellm.acompletion(**request_data)
+
+    # 3. assert that the standard logging payload includes the guardrail information
+    await asyncio.sleep(1)
+    print("got standard logging payload=", json.dumps(test_custom_logger.standard_logging_payload, indent=4, default=str))
+    assert test_custom_logger.standard_logging_payload is not None
+    assert test_custom_logger.standard_logging_payload["guardrail_information"] is not None
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["guardrail_name"] == "presidio_guard"
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["guardrail_mode"] == GuardrailEventHooks.pre_call
+
+    # assert that the guardrail_response is a response from presidio analyze
+    presidio_response = test_custom_logger.standard_logging_payload["guardrail_information"]["guardrail_response"]
+    assert isinstance(presidio_response, list)
+    for response_item in presidio_response:
+        assert "analysis_explanation" in response_item
+        assert "start" in response_item
+        assert "end" in response_item
+        assert "score" in response_item
+        assert "entity_type" in response_item
+        assert "recognition_metadata" in response_item
+    
+
+    # assert that the duration is not None
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["duration"] is not None
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["duration"] > 0
+
+    # assert that we get the count of masked entities
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["masked_entity_count"] is not None
+    assert test_custom_logger.standard_logging_payload["guardrail_information"]["masked_entity_count"]["PHONE_NUMBER"] == 1
+

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -88,6 +88,7 @@ async def test_standard_logging_payload_includes_guardrail_information():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Local only test")
 async def test_langfuse_trace_includes_guardrail_information():
     """
     Test that the langfuse trace includes the guardrail information when a guardrail is applied

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -135,7 +135,7 @@ async def test_langfuse_trace_includes_guardrail_information():
         response = await litellm.acompletion(**request_data)
 
         # 3. Wait for async logging operations to complete
-        await asyncio.sleep(3)
+        await asyncio.sleep(5)
         
         # 4. Verify the Langfuse payload
         assert mock_post.call_count >= 1


### PR DESCRIPTION
## [Feat] Add Tracing for guardrails in StandardLoggingPayload, Langfuse

- This PR adds tracing for guardrails in the StandardLoggingPayload by updating the logging payload structure and the related guardrail processing logic as well as adding test coverage.
- Adds guardrail tracing in Langfuse

<img width="934" alt="Xnapper-2025-05-16-09 46 51" src="https://github.com/user-attachments/assets/dd394add-aeb3-48b1-a49c-ced13e5296e4" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


