### PR TITLE
[Feat] handle multi-pod deployment for SpendLogs Retention

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -95,6 +95,7 @@ general_settings:
   key_management_system: google_kms  # either google_kms or azure_kms
   master_key: string
   maximum_spend_logs_retention_period: 30d # The maximum time to retain spend logs before deletion.
+  maximum_spend_logs_retention_interval: 1d # interval in which the spend log cleanup task should run in.
 
   # Database Settings
   database_url: string
@@ -212,7 +213,7 @@ general_settings:
 | forward_openai_org_id | boolean | If true, forwards the OpenAI Organization ID to the backend LLM call (if it's OpenAI). |
 | forward_client_headers_to_llm_api | boolean | If true, forwards the client headers (any `x-` headers) to the backend LLM call |
 | maximum_spend_logs_retention_period               | str                   | Used to set the max retention time for spend logs in the db, after which they will be auto-purged                                                                                                                                                                                                                             |
-
+| maximum_spend_logs_retention_interval | str | Used to set the interval in which the spend log cleanup task should run in.                                                                                                                                                                                                                                                   |
 ### router_settings - Reference
 
 :::info

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -618,7 +618,7 @@ LITELLM_PROXY_ADMIN_NAME = "default_user_id"
 DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"
 PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics"
 SPEND_LOG_CLEANUP_JOB_NAME = "spend_log_cleanup"
-SPEND_LOG_RUN_LOOPS = int(100)
+SPEND_LOG_RUN_LOOPS = int(os.getenv("SPEND_LOG_RUN_LOOPS", 100))
 DEFAULT_CRON_JOB_LOCK_TTL_SECONDS = int(
     os.getenv("DEFAULT_CRON_JOB_LOCK_TTL_SECONDS", 60)
 )  # 1 minute

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -618,6 +618,7 @@ LITELLM_PROXY_ADMIN_NAME = "default_user_id"
 DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"
 PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics"
 SPEND_LOG_CLEANUP_JOB_NAME = "spend_log_cleanup"
+SPEND_LOG_RUN_LOOPS = int(100)
 DEFAULT_CRON_JOB_LOCK_TTL_SECONDS = int(
     os.getenv("DEFAULT_CRON_JOB_LOCK_TTL_SECONDS", 60)
 )  # 1 minute

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -616,7 +616,8 @@ LITELLM_PROXY_ADMIN_NAME = "default_user_id"
 
 ########################### DB CRON JOB NAMES ###########################
 DB_SPEND_UPDATE_JOB_NAME = "db_spend_update_job"
-PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics_job"
+PROMETHEUS_EMIT_BUDGET_METRICS_JOB_NAME = "prometheus_emit_budget_metrics"
+SPEND_LOG_CLEANUP_JOB_NAME = "spend_log_cleanup"
 DEFAULT_CRON_JOB_LOCK_TTL_SECONDS = int(
     os.getenv("DEFAULT_CRON_JOB_LOCK_TTL_SECONDS", 60)
 )  # 1 minute

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -46,7 +46,11 @@ class PodLockManager:
             verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")
             return None
         try:
-            verbose_proxy_logger.debug(f"attempting to acquire Redis lock for cronjob_id={cronjob_id}")
+            verbose_proxy_logger.debug(
+                "Pod %s attempting to acquire Redis lock for cronjob_id=%s",
+                self.pod_id,
+                cronjob_id,
+            )
             # Try to set the lock key with the pod_id as its value, only if it doesn't exist (NX)
             # and with an expiration (EX) to avoid deadlocks.
             lock_key = PodLockManager.get_redis_lock_key(cronjob_id)

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -39,7 +39,6 @@ class PodLockManager:
         
         Args:
             cronjob_id: The ID of the cron job to lock
-            lock_expiry_seconds: Optional duration in seconds for the lock to expire. If not provided, uses DEFAULT_CRON_JOB_LOCK_TTL_SECONDS.
         """
         if self.redis_cache is None:
             verbose_proxy_logger.debug("redis_cache is None, skipping acquire_lock")

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -32,7 +32,6 @@ class PodLockManager:
     async def acquire_lock(
         self,
         cronjob_id: str,
-        lock_expiry_seconds: Optional[int] = None,
     ) -> Optional[bool]:
         """
         Attempt to acquire the lock for a specific cron job using Redis.
@@ -54,12 +53,11 @@ class PodLockManager:
             # Try to set the lock key with the pod_id as its value, only if it doesn't exist (NX)
             # and with an expiration (EX) to avoid deadlocks.
             lock_key = PodLockManager.get_redis_lock_key(cronjob_id)
-            ttl = lock_expiry_seconds if lock_expiry_seconds is not None else DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
             acquired = await self.redis_cache.async_set_cache(
                 lock_key,
                 self.pod_id,
                 nx=True,
-                ttl=ttl,
+                ttl=DEFAULT_CRON_JOB_LOCK_TTL_SECONDS,
             )
             if acquired:
                 verbose_proxy_logger.info(

--- a/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
@@ -4,7 +4,7 @@ from litellm.proxy.utils import PrismaClient
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import RedisCache
-from litellm.constants import SPEND_LOG_CLEANUP_JOB_NAME
+from litellm.constants import DEFAULT_CRON_JOB_LOCK_TTL_SECONDS, SPEND_LOG_CLEANUP_JOB_NAME
 
 
 class SpendLogCleanup:
@@ -48,27 +48,61 @@ class SpendLogCleanup:
             )
             return False
 
-    def _get_lock_duration(self) -> Optional[int]:
-        """
-        Gets the lock duration from config settings.
-        Returns the duration in seconds.
-        """
-        retention_interval = self.general_settings.get("maximum_spend_logs_retention_interval")
-        if retention_interval is None:
-            verbose_proxy_logger.info("No retention interval found, using default 24 hours")
-            return 86400  # Default to 24 hours
+    # def _get_lock_duration(self) -> Optional[int]: // TODO: uncomment this when we have a way to set the lock duration
+    #     """
+    #     Gets the lock duration from config settings.
+    #     Returns the duration in seconds.
+    #     """
+    #     retention_interval = self.general_settings.get("maximum_spend_logs_retention_interval")
+    #     if retention_interval is None:
+    #         verbose_proxy_logger.info("No retention interval found, using default 24 hours")
+    #         return DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
 
-        try:
-            if isinstance(retention_interval, int):
-                retention_interval = str(retention_interval)
-            lock_duration = duration_in_seconds(retention_interval)
-            verbose_proxy_logger.info(f"Lock duration set to {lock_duration} seconds")
-            return lock_duration
-        except ValueError as e:
-            verbose_proxy_logger.error(
-                f"Invalid maximum_spend_logs_retention_interval value: {retention_interval}, error: {str(e)}"
+    #     try:
+    #         if isinstance(retention_interval, int):
+    #             retention_interval = str(retention_interval)
+    #         lock_duration = duration_in_seconds(retention_interval)
+    #         verbose_proxy_logger.info(f"Lock duration set to {lock_duration} seconds")
+    #         return lock_duration
+    #     except ValueError as e:
+    #         verbose_proxy_logger.error(
+    #             f"Invalid maximum_spend_logs_retention_interval value: {retention_interval}, error: {str(e)}"
+    #         )
+    #         return DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
+
+    async def _delete_old_logs(self, prisma_client: PrismaClient, cutoff_date: datetime) -> int:
+        """
+        Helper method to delete old logs in batches.
+        Returns the total number of logs deleted.
+        """
+        total_deleted = 0
+        run_count = 0
+        while True:
+            if run_count > 100:
+                verbose_proxy_logger.info("Max logs deleted - 1,00,000, rest of the logs will be deleted in next run")
+                break
+            # Step 1: Find logs to delete
+            logs_to_delete = await prisma_client.db.litellm_spendlogs.find_many(
+                where={"startTime": {"lt": cutoff_date}},
+                take=self.batch_size,
             )
-            return 86400  # Default to 24 hours on error
+            verbose_proxy_logger.info(f"Found {len(logs_to_delete)} logs in this batch")
+
+            if not logs_to_delete:
+                verbose_proxy_logger.info(f"No more logs to delete. Total deleted: {total_deleted}")
+                break
+
+            request_ids = [log.request_id for log in logs_to_delete]
+
+            # Step 2: Delete them in one go
+            await prisma_client.db.litellm_spendlogs.delete_many(
+                where={"request_id": {"in": request_ids}}
+            )
+
+            total_deleted += len(logs_to_delete)
+            run_count += 1
+
+        return total_deleted
 
     async def cleanup_old_spend_logs(self, prisma_client: PrismaClient) -> None:
         """
@@ -93,14 +127,14 @@ class SpendLogCleanup:
                 return
 
             # Get lock duration from config
-            lock_duration = self._get_lock_duration()
+            lock_duration = DEFAULT_CRON_JOB_LOCK_TTL_SECONDS
 
             # Try to acquire the distributed lock with the configured duration
             lock_acquired = await self.pod_lock_manager.acquire_lock(
                 cronjob_id=SPEND_LOG_CLEANUP_JOB_NAME,
                 lock_expiry_seconds=lock_duration
             )
-            verbose_proxy_logger.info(f"Lock acquisition attempt: {'successful' if lock_acquired else 'failed'}")
+            verbose_proxy_logger.info(f"Lock acquisition attempt: {'successful' if lock_acquired else 'failed'}  at {datetime.now()}")
             
             if not lock_acquired:
                 verbose_proxy_logger.info("Another pod is already running cleanup")
@@ -110,37 +144,14 @@ class SpendLogCleanup:
                 cutoff_date = datetime.now(timezone.utc) - timedelta(seconds=float(self.retention_seconds))
                 verbose_proxy_logger.info(f"Deleting logs older than {cutoff_date.isoformat()}")
 
-                total_deleted = 0
-                run_count = 0
-                while True:
-                    if run_count > 100:
-                        verbose_proxy_logger.info("Max logs deleted - 1,00,000, rest of the logs will be deleted in next run")
-                        break
-                    # Step 1: Find logs to delete
-                    logs_to_delete = await prisma_client.db.litellm_spendlogs.find_many(
-                        where={"startTime": {"lt": cutoff_date}},
-                        take=self.batch_size,
-                    )
-                    verbose_proxy_logger.info(f"🗑️ Found {len(logs_to_delete)} logs in this batch")
+                # Perform the actual deletion
+                total_deleted = await self._delete_old_logs(prisma_client, cutoff_date)
 
-                    if not logs_to_delete:
-                        verbose_proxy_logger.info(f"No more logs to delete. Total deleted: {total_deleted}")
-                        break
-
-                    request_ids = [log.request_id for log in logs_to_delete]
-
-                    # Step 2: Delete them in one go
-                    await prisma_client.db.litellm_spendlogs.delete_many(
-                        where={"request_id": {"in": request_ids}}
-                    )
-
-                    total_deleted += len(logs_to_delete)
-                    verbose_proxy_logger.info(f"Deleted {len(logs_to_delete)} logs in this batch")
-                    run_count += 1
+                verbose_proxy_logger.info(f"Deleted {total_deleted} logs")
 
                 # After cleanup is complete, release the lock and return
                 await self.pod_lock_manager.release_lock(cronjob_id=SPEND_LOG_CLEANUP_JOB_NAME)
-                verbose_proxy_logger.info("Released cleanup lock")
+                verbose_proxy_logger.info(f"Released cleanup lock {datetime.now()}")
                 return  # Explicitly return after cleanup is complete
 
             except Exception as e:

--- a/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
@@ -3,37 +3,46 @@ from typing import Optional
 from litellm.proxy.utils import PrismaClient
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm._logging import verbose_proxy_logger
+from litellm.caching import RedisCache
+from litellm.proxy.db.db_transaction_queue.pod_lock_manager import PodLockManager
+from litellm.constants import SPEND_LOG_CLEANUP_JOB_NAME
+import os
 
 
 class SpendLogCleanup:
     """
     Handles cleaning up old spend logs based on maximum retention period.
     Deletes logs in batches to prevent timeouts.
+    Uses PodLockManager to ensure only one pod runs cleanup in multi-pod deployments.
     """
 
-    def __init__(self, general_settings=None):
+    def __init__(self, general_settings=None, redis_cache: Optional[RedisCache] = None):
         self.batch_size = 1000
         self.retention_seconds: Optional[int] = None
         from litellm.proxy.proxy_server import general_settings as default_settings
         self.general_settings = general_settings or default_settings
-        verbose_proxy_logger.info("SpendLogCleanup initialized with batch size: %d", self.batch_size)
+        from litellm.proxy.proxy_server import proxy_logging_obj
+
+        pod_lock_manager = proxy_logging_obj.db_spend_update_writer.pod_lock_manager
+        self.pod_lock_manager = pod_lock_manager
+        verbose_proxy_logger.info(f"SpendLogCleanup initialized with batch size: {self.batch_size}")
 
     def _should_delete_spend_logs(self) -> bool:
         """
         Determines if logs should be deleted based on the max retention period in settings.
         """
         retention_setting = self.general_settings.get("maximum_spend_logs_retention_period")
-        verbose_proxy_logger.info("Checking retention setting: %s", retention_setting)
+        verbose_proxy_logger.info(f"Checking retention setting: {retention_setting}")
 
         if retention_setting is None:
-            verbose_proxy_logger.info("No retention setting found")
+            verbose_proxy_logger.info(f"No retention setting found")
             return False
 
         try:
             if isinstance(retention_setting, int):
                 retention_setting = str(retention_setting)
             self.retention_seconds = duration_in_seconds(retention_setting)
-            verbose_proxy_logger.info("Retention period set to %d seconds", self.retention_seconds)
+            verbose_proxy_logger.info(f"Retention period set to {self.retention_seconds} seconds")
             return True
         except ValueError as e:
             verbose_proxy_logger.error(
@@ -44,47 +53,76 @@ class SpendLogCleanup:
     async def cleanup_old_spend_logs(self, prisma_client: PrismaClient) -> None:
         """
         Main cleanup function. Deletes old spend logs in batches.
+        Only runs on the pod that acquires the distributed lock.
         """
         try:
             verbose_proxy_logger.info(f"Cleanup job triggered at {datetime.now()}")
 
             if not self._should_delete_spend_logs():
-                verbose_proxy_logger.info("Skipping cleanup — invalid or missing retention setting.")
+                verbose_proxy_logger.info(f"Skipping cleanup — invalid or missing retention setting.")
                 return
 
             if self.retention_seconds is None:
-                verbose_proxy_logger.error("Retention seconds is None, cannot proceed with cleanup")
+                verbose_proxy_logger.error(f"Retention seconds is None, cannot proceed with cleanup")
                 return
 
-            cutoff_date = datetime.now(UTC) - timedelta(seconds=float(self.retention_seconds))
-            verbose_proxy_logger.info(f"Deleting logs older than {cutoff_date.isoformat()}")
+            # Check if pod_lock_manager and redis_cache exist
+            if not self.pod_lock_manager or not self.pod_lock_manager.redis_cache:
+                verbose_proxy_logger.info(f"Pod lock manager or redis cache not initialized, skipping cleanup")
+                return
 
-            total_deleted = 0
-            run_count = 0
-            while True:
-                if run_count > 100:
-                    verbose_proxy_logger.info("Max logs deleted - 1,00,000, rest of the logs will be deleted in next run")
-                    break
-                # Step 1: Find logs to delete
-                logs_to_delete = await prisma_client.db.litellm_spendlogs.find_many(
-                    where={"startTime": {"lt": cutoff_date}},
-                    take=self.batch_size,
-                )
-                verbose_proxy_logger.info(f"🗑️ Found {len(logs_to_delete)} logs in this batch")
+            # Try to acquire the distributed lock
+            lock_acquired = await self.pod_lock_manager.acquire_lock(cronjob_id=SPEND_LOG_CLEANUP_JOB_NAME)
+            verbose_proxy_logger.info(f"Lock acquisition attempt: {'successful' if lock_acquired else 'failed'}")
+            
+            if not lock_acquired:
+                verbose_proxy_logger.info(f"Another pod is already running cleanup")
+                return
 
-                if not logs_to_delete:
-                    verbose_proxy_logger.info(f"No more logs to delete. Total deleted: {total_deleted}")
-                    break
+            try:
+                cutoff_date = datetime.now(UTC) - timedelta(seconds=float(self.retention_seconds))
+                verbose_proxy_logger.info(f"Deleting logs older than {cutoff_date.isoformat()}")
 
-                request_ids = [log.request_id for log in logs_to_delete]
+                total_deleted = 0
+                run_count = 0
+                while True:
+                    if run_count > 100:
+                        verbose_proxy_logger.info(f"Max logs deleted - 1,00,000, rest of the logs will be deleted in next run")
+                        break
+                    # Step 1: Find logs to delete
+                    logs_to_delete = await prisma_client.db.litellm_spendlogs.find_many(
+                        where={"startTime": {"lt": cutoff_date}},
+                        take=self.batch_size,
+                    )
+                    verbose_proxy_logger.info(f"🗑️ Found {len(logs_to_delete)} logs in this batch")
 
-                # Step 2: Delete them in one go
-                await prisma_client.db.litellm_spendlogs.delete_many(
-                    where={"request_id": {"in": request_ids}}
-                )
+                    if not logs_to_delete:
+                        verbose_proxy_logger.info(f"No more logs to delete. Total deleted: {total_deleted}")
+                        break
 
-                total_deleted += len(logs_to_delete)
-                verbose_proxy_logger.info(f"Deleted {len(logs_to_delete)} logs in this batch")
-                run_count += 1
+                    request_ids = [log.request_id for log in logs_to_delete]
+
+                    # Step 2: Delete them in one go
+                    await prisma_client.db.litellm_spendlogs.delete_many(
+                        where={"request_id": {"in": request_ids}}
+                    )
+
+                    total_deleted += len(logs_to_delete)
+                    verbose_proxy_logger.info(f"Deleted {len(logs_to_delete)} logs in this batch")
+                    run_count += 1
+
+                # After cleanup is complete, release the lock and return
+                await self.pod_lock_manager.release_lock(cronjob_id=SPEND_LOG_CLEANUP_JOB_NAME)
+                verbose_proxy_logger.info(f"Released cleanup lock")
+                return  # Explicitly return after cleanup is complete
+
+            except Exception as e:
+                verbose_proxy_logger.error(f"Error during cleanup: {str(e)}")
+                # Ensure lock is released even if an error occurs
+                await self.pod_lock_manager.release_lock(cronjob_id=SPEND_LOG_CLEANUP_JOB_NAME)
+                verbose_proxy_logger.info(f"Released cleanup lock after error")
+                return  # Return after error handling
+
         except Exception as e:
             verbose_proxy_logger.error(f"Error during cleanup: {str(e)}")
+            return  # Return after error handling

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3312,8 +3312,7 @@ class ProxyStartupEvent:
                     args=[prisma_client],
                 )
             except ValueError:
-                verbose_proxy_logger.error(f"Invalid maximum_spend_logs_retention_interval value: {retention_interval}, defaulting to 60 seconds")
-                interval_seconds = 60
+                verbose_proxy_logger.error(f"Invalid maximum_spend_logs_retention_interval value")
 
         scheduler.start()
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3312,7 +3312,7 @@ class ProxyStartupEvent:
                     args=[prisma_client],
                 )
             except ValueError:
-                verbose_proxy_logger.error(f"Invalid maximum_spend_logs_retention_interval value")
+                verbose_proxy_logger.error("Invalid maximum_spend_logs_retention_interval value")
 
         scheduler.start()
 


### PR DESCRIPTION
## Title

Handle multi-pod deployment on spend_log_retention_cleanup

## Relevant issues



## Pre-Submission checklist



- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🆕 New Feature

## Changes


