### PR TITLE
fix issue with parsing assistant messages

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -229,7 +229,6 @@ def ollama_pt(
         ## MERGE CONSECUTIVE ASSISTANT CONTENT ##
         while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
             assistant_content_str += convert_content_list_to_str(messages[msg_i])
-            msg_i += 1
 
             tool_calls = messages[msg_i].get("tool_calls")
             ollama_tool_calls = []
@@ -255,7 +254,7 @@ def ollama_pt(
                     f"Tool Calls: {json.dumps(ollama_tool_calls, indent=2)}"
                 )
 
-                msg_i += 1
+            msg_i += 1
 
         if assistant_content_str:
             prompt += f"### Assistant:\n{assistant_content_str}\n\n"

--- a/tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -92,7 +92,7 @@ def test_ollama_pt_consecutive_system_messages():
 
     # Consecutive system messages should be merged
     expected_prompt = "### User:\nHello\n\n### System:\nYou are a helpful assistantBe concise and polite\n\n### Assistant:\nHow can I help you?\n\n"
-    assert result == expected_prompt
+    assert result["prompt"] == expected_prompt
 
 def test_ollama_pt_consecutive_assistant_messages():
     """Test handling consecutive assistant messages"""

--- a/tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -79,35 +79,35 @@ async def test_anthropic_bedrock_thinking_blocks_with_none_content():
 
 
 
-# def test_ollama_pt_consecutive_system_messages():
-#     """Test handling consecutive system messages"""
-#     messages = [
-#         {"role": "user", "content": "Hello"},
-#         {"role": "system", "content": "You are a helpful assistant"},
-#         {"role": "system", "content": "Be concise and polite"},
-#         {"role": "assistant", "content": "How can I help you?"}
-#     ]
+def test_ollama_pt_consecutive_system_messages():
+    """Test handling consecutive system messages"""
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "system", "content": "You are a helpful assistant"},
+        {"role": "system", "content": "Be concise and polite"},
+        {"role": "assistant", "content": "How can I help you?"}
+    ]
 
-#     result = ollama_pt(model="llama2", messages=messages)
+    result = ollama_pt(model="llama2", messages=messages)
 
-#     # Consecutive system messages should be merged
-#     expected_prompt = "### User:\nHello\n\n### System:\nYou are a helpful assistantBe concise and polite\n\n### Assistant:\nHow can I help you?\n\n"
-#     assert result == expected_prompt
+    # Consecutive system messages should be merged
+    expected_prompt = "### User:\nHello\n\n### System:\nYou are a helpful assistantBe concise and polite\n\n### Assistant:\nHow can I help you?\n\n"
+    assert result == expected_prompt
 
-# def test_ollama_pt_consecutive_assistant_messages():
-#     """Test handling consecutive assistant messages"""
-#     messages = [
-#         {"role": "user", "content": "Hello"},
-#         {"role": "assistant", "content": "Hi there!"},
-#         {"role": "assistant", "content": "How can I help you?"},
-#         {"role": "user", "content": "Tell me a joke"}
-#     ]
+def test_ollama_pt_consecutive_assistant_messages():
+    """Test handling consecutive assistant messages"""
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "assistant", "content": "How can I help you?"},
+        {"role": "user", "content": "Tell me a joke"}
+    ]
 
-#     result = ollama_pt(model="llama2", messages=messages)
+    result = ollama_pt(model="llama2", messages=messages)
 
-#     # Consecutive assistant messages should be merged
-#     expected_prompt = "### User:\nHello\n\n### Assistant:\nHi there!How can I help you?\n\n### User:\nTell me a joke\n\n"
-#     assert result["prompt"] == expected_prompt
+    # Consecutive assistant messages should be merged
+    expected_prompt = "### User:\nHello\n\n### Assistant:\nHi there!How can I help you?\n\n### User:\nTell me a joke\n\n"
+    assert result["prompt"] == expected_prompt
 
 # def test_ollama_pt_with_image_urls_as_strings():
 #     """Test handling messages with image URLs as strings"""


### PR DESCRIPTION
## Title
This pull request includes changes to improve the handling of consecutive assistant messages in the `ollama_pt` function and re-enables previously commented-out test cases for better test coverage.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have re-enabled testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - `tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py::test_ollama_pt_consecutive_assistant_messages`
  - `tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py::test_ollama_pt_consecutive_system_messages`
- [x] I have added a screenshot of my new test passing locally (wonder why is this necessary, since we have the CI anyway)
  <img width="1032" alt="Screenshot 2025-05-17 at 21 02 06" src="https://github.com/user-attachments/assets/c5d092fb-9d08-44fd-97aa-cbb230e9bac3" />
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (see CI)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

### Bug Fixes:
* Fixed a bug in the `ollama_pt` function where the `msg_i` index was not incremented in the loop for merging consecutive assistant messages. This ensures proper processing of all messages. (`litellm/litellm_core_utils/prompt_templates/factory.py`, [litellm/litellm_core_utils/prompt_templates/factory.pyL232](diffhunk://#diff-a3c9843a716ad6c49482395f7357e83abc5397168eafc75fa2dba2124619dcebL232))

### Test Updates:
* Re-enabled and updated two tests: `test_ollama_pt_consecutive_system_messages` and `test_ollama_pt_consecutive_assistant_messages`. These tests validate the merging of consecutive system and assistant messages in the `ollama_pt` function and check that the resulting prompt matches the expected format. (`tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py`, [tests/litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.pyL82-R110](diffhunk://#diff-86108d9af47c7a50e0552b35e48ceac7ba10af7fb4800471f562f28fa4622e10L82-R110))
