### PR TITLE
Enable structured JSON schema outputs in LM Studio

### DIFF
--- a/docs/my-website/docs/providers/lm_studio.md
+++ b/docs/my-website/docs/providers/lm_studio.md
@@ -153,3 +153,26 @@ response = embedding(
 )
 print(response)
 ```
+
+
+## Structured Output
+
+LM Studio supports structured outputs via JSON Schema. You can pass a pydantic model or a raw schema using `response_format`.
+LiteLLM sends the schema as `{ "type": "json_schema", "json_schema": {"schema": <your schema>} }`.
+
+```python
+from pydantic import BaseModel
+from litellm import completion
+
+class Book(BaseModel):
+    title: str
+    author: str
+    year: int
+
+response = completion(
+    model="lm_studio/llama-3-8b-instruct",
+    messages=[{"role": "user", "content": "Tell me about The Hobbit"}],
+    response_format=Book,
+)
+print(response.choices[0].message.content)
+```

--- a/litellm/llms/lm_studio/chat/transformation.py
+++ b/litellm/llms/lm_studio/chat/transformation.py
@@ -18,3 +18,32 @@ class LMStudioChatConfig(OpenAIGPTConfig):
             api_key or get_secret_str("LM_STUDIO_API_KEY") or " "
         )  # vllm does not require an api key
         return api_base, dynamic_api_key
+    
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        for param, value in list(non_default_params.items()):
+            if param == "response_format" and isinstance(value, dict):
+                if value.get("type") == "json_schema":
+                    if "json_schema" not in value and "schema" in value:
+                        optional_params["response_format"] = {
+                            "type": "json_schema",
+                            "json_schema": {"schema": value.get("schema")},
+                        }
+                    else:
+                        optional_params["response_format"] = value
+                    non_default_params.pop(param, None)
+                elif value.get("type") == "json_object":
+                    optional_params["response_format"] = value
+                    non_default_params.pop(param, None)
+
+        return super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1824,6 +1824,7 @@ def supports_response_schema(
     PROVIDERS_GLOBALLY_SUPPORT_RESPONSE_SCHEMA = [
         litellm.LlmProviders.PREDIBASE,
         litellm.LlmProviders.FIREWORKS_AI,
+        litellm.LlmProviders.LM_STUDIO,
     ]
 
     if custom_llm_provider in PROVIDERS_GLOBALLY_SUPPORT_RESPONSE_SCHEMA:

--- a/tests/litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
+++ b/tests/litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
@@ -1,0 +1,51 @@
+import os
+import sys
+
+from pydantic import BaseModel
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")))
+
+from litellm.llms.lm_studio.chat.transformation import LMStudioChatConfig
+from litellm.utils import get_optional_params
+
+
+class Book(BaseModel):
+    title: str
+    author: str
+    year: int
+
+
+class TestLMStudioChatConfigResponseFormat:
+    def test_get_optional_params_with_pydantic_model(self):
+        optional_params = get_optional_params(
+            model="lm_studio/test-model",
+            response_format=Book,
+            custom_llm_provider="lm_studio",
+        )
+
+        assert "response_format" in optional_params
+        transformed = optional_params["response_format"]
+        assert transformed.get("type") == "json_schema"
+        schema = transformed.get("json_schema", {}).get("schema")
+        assert schema["properties"] == Book.model_json_schema()["properties"]
+
+    def test_map_openai_params_with_dict_json_schema(self):
+        config = LMStudioChatConfig()
+        schema = Book.model_json_schema()
+        response_format_dict = {
+            "type": "json_schema",
+            "json_schema": {"schema": schema},
+        }
+
+        non_default_params = {"response_format": response_format_dict}
+        optional_params = get_optional_params(
+            model="lm_studio/test-model",
+            response_format=response_format_dict,
+            custom_llm_provider="lm_studio",
+        )
+
+        mapped = config.map_openai_params(non_default_params, {}, "lm_studio/test-model", False)
+        mapped_schema = mapped["response_format"]["json_schema"]["schema"]
+        assert mapped_schema["properties"] == schema["properties"]
+        opt_schema = optional_params["response_format"]["json_schema"]["schema"]
+        assert opt_schema["properties"] == schema["properties"]


### PR DESCRIPTION

## Title

Enable structured JSON schema outputs in LM Studio

## Relevant issues

#10851 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] I have added a screenshot of my new test passing locally 

![Screenshot 2025-05-18 at 17 22 49](https://github.com/user-attachments/assets/1c76d1ff-a4d3-4c4e-b818-6822ad24bac6)
- [ _ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

My unit tests didn't all pass, but they don't seem affected and my tests don't pass on main. 

```
====================================================================== short test summary info ======================================================================
FAILED tests/litellm/proxy/auth/test_auth_checks.py::test_get_experimental_ui_login_jwt_auth_token_valid - TypeError: can't compare offset-naive and offset-aware datetimes
FAILED tests/litellm/proxy/guardrails/test_init_guardrails.py::test_initialize_presidio_guardrail - Exception: Missing `PRESIDIO_ANALYZER_API_BASE` from environment
FAILED tests/litellm/proxy/test_proxy_server.py::test_initialize_scheduled_jobs_credentials - TypeError: 'Mock' object is not subscriptable
FAILED tests/litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_web_search_tool_transformation - KeyError: 'approximate'
================================================= 4 failed, 899 passed, 10 skipped, 7 warnings in 278.67s (0:04:38) =================================================
```

- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- docs/my-website/docs/providers/lm_studio.md: add Structured Output section with JSON schema and Pydantic examples
- litellm/llms/lm_studio/chat/transformation.py: extend map_openai_params to handle `response_format` mappings (`json_schema`, `json_object`) and move them to optional_params
- litellm/utils.py: include `LM_STUDIO` in `supports_response_schema` list
- tests/litellm/llms/lm_studio/test_lm_studio_chat_transformation.py: add tests for Pydantic model and dict-based JSON schema handling
