### PR TITLE
Add keys and members count in team info

### DIFF
--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -201,6 +201,27 @@ const Teams: React.FC<TeamProps> = ({
     fetchGuardrails();
   }, [accessToken]);
 
+  useEffect(() => {
+    const fetchTeamInfo = async () => {
+      if (!teams || !accessToken) return;
+      
+      const teamInfoPromises = teams.map(async (team) => {
+        try {
+          const info = await teamInfoCall(accessToken, team.team_id);
+          return { [team.team_id]: info };
+        } catch (error) {
+          console.error(`Error fetching info for team ${team.team_id}:`, error);
+          return { [team.team_id]: null };
+        }
+      });
+
+      const results = await Promise.all(teamInfoPromises);
+      const newPerTeamInfo = results.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+      setPerTeamInfo(newPerTeamInfo);
+    };
+
+    fetchTeamInfo();
+  }, [teams, accessToken]);
 
   const handleOk = () => {
     setIsTeamModalVisible(false);
@@ -721,8 +742,9 @@ const Teams: React.FC<TeamProps> = ({
                             {perTeamInfo &&
                               team.team_id &&
                               perTeamInfo[team.team_id] &&
-                              perTeamInfo[team.team_id].members_with_roles &&
-                              perTeamInfo[team.team_id].members_with_roles.length}{" "}
+                              perTeamInfo[team.team_id].team_info &&
+                              perTeamInfo[team.team_id].team_info.members_with_roles &&
+                              perTeamInfo[team.team_id].team_info.members_with_roles.length}{" "}
                             Members
                           </Text>
                         </TableCell>


### PR DESCRIPTION
## Add keys and members count in team info

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Used `teamInfoCall()` to get keys and members teamInfo and show them on the UI.
<img width="1470" alt="Screenshot 2025-05-20 at 1 32 07 AM" src="https://github.com/user-attachments/assets/36ae5ef7-3b9b-48ce-9b37-9a9421cc0d8f" />



