### PR TITLE
Fix/calling localhost ollama when api base is set

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -39,13 +39,17 @@ class ResponseMetadata:
 
         ## ADD OTHER HIDDEN PARAMS
         model_id = kwargs.get("model_info", {}).get("id", None)
+        if model and str(model).startswith("ollama"):
+            response_cost = 0
+        else:
+            response_cost = logging_obj._response_cost_calculator(
+            result=self.result, litellm_model_name=model, router_model_id=model_id
+            )
         new_params = {
             "litellm_call_id": getattr(logging_obj, "litellm_call_id", None),
             "api_base": get_api_base(model=model or "", optional_params=kwargs),
             "model_id": model_id,
-            "response_cost": logging_obj._response_cost_calculator(
-                result=self.result, litellm_model_name=model, router_model_id=model_id
-            ),
+            "response_cost": response_cost,
             "additional_headers": process_response_headers(
                 self._get_value_from_hidden_params("additional_headers") or {}
             ),

--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -39,8 +39,9 @@ class ResponseMetadata:
 
         ## ADD OTHER HIDDEN PARAMS
         model_id = kwargs.get("model_info", {}).get("id", None)
+        response_cost: float | None
         if model and str(model).startswith("ollama"):
-            response_cost = 0
+            response_cost = 0.0
         else:
             response_cost = logging_obj._response_cost_calculator(
             result=self.result, litellm_model_name=model, router_model_id=model_id

--- a/tests/litellm/test_cost_calculator.py
+++ b/tests/litellm/test_cost_calculator.py
@@ -16,6 +16,7 @@ import litellm
 from litellm.cost_calculator import (
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
+    cost_per_token,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
@@ -239,6 +240,13 @@ def test_azure_realtime_cost_calculator():
 
     assert cost > 0
 
+def test_ollama_cost_per_token():
+    cost = cost_per_token(
+        model="ollama/llama2",
+        prompt_tokens=100,
+        completion_tokens=50,
+    )
+    assert cost == (0, 0)
 
 def test_default_image_cost_calculator(monkeypatch):
     from litellm.cost_calculator import default_image_cost_calculator


### PR DESCRIPTION
## Title

Fix : avoid calling localhost when using a non-localhost Ollama server.

## Relevant issues

#10952 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

To avoid LiteLLM to call localhost when trying to assess cost of request when using Ollama, set cost to 0 as there is no cost to calling a Ollama server.

![image](https://github.com/user-attachments/assets/3737dbb9-6115-4095-af9d-1e0c28d09fd9)

Bug can be reproduce by running : 
```
from litellm import completion
import logging
logging.basicConfig(level=logging.INFO)


response = completion(
            model="ollama/qwen3:0.6b",
            messages = [{ "content": "Hello, how are you?","role": "user"}],
            api_base="http://REMOTE_OLLAMA_IP:11434",
)
```

The log shows : 

```
20:10:47 - LiteLLM:INFO: utils.py:2905 - 
LiteLLM completion() model= qwen3:0.6b; provider = ollama
INFO:LiteLLM:
LiteLLM completion() model= qwen3:0.6b; provider = ollama
INFO:httpx:HTTP Request: POST http://REMOTE_OLLAMA_IP:11434/api/generate "HTTP/1.1 200 OK"
20:10:53 - LiteLLM:INFO: utils.py:1211 - Wrapper: Completed Call, calling success_handler
INFO:LiteLLM:Wrapper: Completed Call, calling success_handler
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: ollama/qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: ollama/qwen3:0.6b
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: ollama/qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: ollama/qwen3:0.6b
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: qwen3:0.6b
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: ollama/qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: ollama/qwen3:0.6b
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: ollama/qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: ollama/qwen3:0.6b
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
20:10:53 - LiteLLM:INFO: cost_calculator.py:655 - selected model name for cost calculation: qwen3:0.6b
INFO:LiteLLM:selected model name for cost calculation: qwen3:0.6b
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
INFO:httpx:HTTP Request: POST http://localhost:11434/api/show "HTTP/1.1 404 Not Found"
```

Of course, I anonymized REMOTE_OLLAMA_IP, it is a working Ollama server.