### PR TITLE
[Fix] Invitation Email does not include the invitation link

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -169,7 +169,13 @@ class BaseEmailLogger(CustomLogger):
 
         from litellm.proxy.proxy_server import prisma_client
 
-        await asyncio.sleep(5)
+        ################################################################################
+        ########## Sleep for 10 seconds to wait for the invitation link to be created ###
+        ################################################################################
+        # The UI, calls /invitation/new to generate the invitation link
+        # We wait 10 seconds to ensure the link is created
+        ################################################################################
+        await asyncio.sleep(10)
 
         if prisma_client is None:
             verbose_proxy_logger.debug(

--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -18,6 +18,7 @@ from litellm.integrations.email_templates.user_invitation_email import (
 )
 from litellm.proxy._types import WebhookEvent
 from litellm.types.enterprise.enterprise_callbacks.send_emails import (
+    EmailEvent,
     EmailParams,
     SendKeyCreatedEmailEvent,
 )
@@ -33,7 +34,9 @@ class BaseEmailLogger(CustomLogger):
         Send email to user after inviting them to the team
         """
         email_params = await self._get_email_params(
-            user_id=event.user_id, user_email=getattr(event, "user_email", None)
+            email_event=EmailEvent.new_user_invitation,
+            user_id=event.user_id,
+            user_email=getattr(event, "user_email", None),
         )
         # Implement invitation email logic using email_params
 
@@ -68,6 +71,7 @@ class BaseEmailLogger(CustomLogger):
         email_params = await self._get_email_params(
             user_id=send_key_created_email_event.user_id,
             user_email=send_key_created_email_event.user_email,
+            email_event=EmailEvent.virtual_key_created,
         )
 
         verbose_proxy_logger.debug(
@@ -93,7 +97,10 @@ class BaseEmailLogger(CustomLogger):
         pass
 
     async def _get_email_params(
-        self, user_id: Optional[str] = None, user_email: Optional[str] = None
+        self,
+        email_event: EmailEvent,
+        user_id: Optional[str] = None,
+        user_email: Optional[str] = None,
     ) -> EmailParams:
         """
         Get common email parameters used across different email sending methods
@@ -111,6 +118,12 @@ class BaseEmailLogger(CustomLogger):
         if recipient_email is None:
             raise ValueError(
                 f"User email not found for user_id: {user_id}. User email is required to send email."
+            )
+
+        # if user invited event then send invitation link
+        if email_event == EmailEvent.new_user_invitation:
+            base_url = await self._get_invitation_link(
+                user_id=user_id, base_url=base_url
             )
 
         return EmailParams(
@@ -147,6 +160,46 @@ class BaseEmailLogger(CustomLogger):
         if user_row is not None:
             return user_row.user_email
         return None
+
+    async def _get_invitation_link(self, user_id: Optional[str], base_url: str) -> str:
+        """
+        Get invitation link for the user
+        """
+        import asyncio
+
+        from litellm.proxy.proxy_server import prisma_client
+
+        await asyncio.sleep(5)
+
+        if prisma_client is None:
+            verbose_proxy_logger.debug(
+                f"Prisma client not found. Unable to lookup user email for user_id: {user_id}"
+            )
+            return base_url
+
+        if user_id is None:
+            return base_url
+
+        # get the latest invitation link for the user
+        invitation_rows = await prisma_client.db.litellm_invitationlink.find_many(
+            where={"user_id": user_id},
+            orderBy={"created_at": "desc"},
+        )
+        if len(invitation_rows) > 0:
+            invitation_row = invitation_rows[0]
+            return self._construct_invitation_link(
+                invitation_id=invitation_row.id, base_url=base_url
+            )
+
+        return base_url
+
+    def _construct_invitation_link(self, invitation_id: str, base_url: str) -> str:
+        """
+        Construct invitation link for the user
+
+        # http://localhost:4000/ui?invitation_id=7a096b3a-37c6-440f-9dd1-ba22e8043f6b
+        """
+        return f"{base_url}/ui?invitation_id={invitation_id}"
 
     async def send_email(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12731,5 +12731,19 @@
             "/v1/images/generations"
         ],
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#image-models"
+    },
+    "featherless_ai/featherless-ai/Qwerky-72B": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "litellm_provider": "featherless_ai",
+        "mode": "chat"
+    },
+    "featherless_ai/featherless-ai/Qwerky-QwQ-32B": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "litellm_provider": "featherless_ai",
+        "mode": "chat"
     }
 }


### PR DESCRIPTION
## [Fix] Invitation Email should include the invitation link 

Fixes #10942 

A fix for the invitation email to include the invitation link.

Added tests to verify invitation link creation and proper email parameters.
Updated email sending logic to conditionally fetch the invitation link based on the email event.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


