### PR TITLE
fix: detect and return status codes in streaming responses

### DIFF
--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -8,13 +8,15 @@ import time
 import traceback
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
-from fastapi.responses import StreamingResponse
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_request_processing import (
+    ProxyBaseLLMRequestProcessing,
+    create_streaming_response,
+)
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
 from litellm.proxy.utils import ProxyLogging
@@ -227,9 +229,10 @@ async def anthropic_response(  # noqa: PLR0915
                 proxy_logging_obj=proxy_logging_obj,
             )
 
-            return StreamingResponse(
-                selected_data_generator,  # type: ignore
+            return await create_streaming_response(
+                generator=selected_data_generator,
                 media_type="text/event-stream",
+                headers=dict(fastapi_response.headers),
             )
 
         verbose_proxy_logger.info("\nResponse from Litellm:\n{}".format(response))

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2,9 +2,10 @@ import asyncio
 import json
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Tuple, Union, AsyncGenerator
 
 import httpx
+import orjson
 from fastapi import HTTPException, Request, status
 from fastapi.responses import Response, StreamingResponse
 
@@ -28,6 +29,88 @@ if TYPE_CHECKING:
 else:
     ProxyConfig = Any
 from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+
+async def _parse_event_data_for_error(event_line: str) -> Optional[int]:
+    """Parses an event line and returns an error code if present, else None."""
+    if event_line.startswith("data: "):
+        json_str = event_line[len("data: "):].strip()
+        if not json_str or json_str == "[DONE]": # handle empty data or [DONE] message
+            return None
+        try:
+            data = orjson.loads(json_str)
+            if isinstance(data, dict) and "error" in data and isinstance(data["error"], dict):
+                error_code_raw = data["error"].get("code")
+                error_code: Optional[int] = None
+
+                if isinstance(error_code_raw, int):
+                    error_code = error_code_raw
+                elif isinstance(error_code_raw, str):
+                    try:
+                        error_code = int(error_code_raw)
+                    except ValueError:
+                        verbose_proxy_logger.warning(f"Error code is a string but not a valid integer: {error_code_raw}")
+                        # Not a valid integer string, treat as if no valid code was found for this check
+                        pass
+
+                # Ensure error_code is a valid HTTP status code
+                if error_code is not None and 100 <= error_code <= 599:
+                    return error_code
+                elif error_code_raw is not None : # Log if original code was present but not valid
+                    verbose_proxy_logger.warning(f"Error has invalid or non-convertible code: {error_code_raw}")
+        except (orjson.JSONDecodeError, json.JSONDecodeError):
+            # not a known error chunk
+            pass
+    return None
+
+async def create_streaming_response(
+    generator: AsyncGenerator[str, None],
+    media_type: str,
+    headers: dict,
+    default_status_code: int = status.HTTP_200_OK,
+) -> StreamingResponse:
+    """
+    Creates a StreamingResponse by inspecting the first chunk for an error code.
+    The entire original generator content is streamed, but the HTTP status code
+    of the response is set based on the first chunk if it's a recognized error.
+    """
+    first_chunk_value: Optional[str] = None
+    final_status_code = default_status_code
+
+    try:
+        first_chunk_value = await generator.__anext__()
+        if first_chunk_value is not None:
+            error_code_from_chunk = await _parse_event_data_for_error(first_chunk_value)
+            if error_code_from_chunk is not None:
+                final_status_code = error_code_from_chunk
+                verbose_proxy_logger.debug(f"Error detected in first stream chunk. Status code set to: {final_status_code}")
+
+    except StopAsyncIteration:
+        # Generator was empty. Default status
+        async def empty_gen() -> AsyncGenerator[str, None]:
+            if False: yield # type: ignore
+        return StreamingResponse(empty_gen(), media_type=media_type, headers=headers, status_code=default_status_code)
+    except Exception as e:
+        # Unexpected error consuming first chunk.
+        verbose_proxy_logger.error(f"Error consuming first chunk from generator: {e}")
+        # Fallback to a generic error stream
+        async def error_gen_message() -> AsyncGenerator[str, None]:
+            yield f"data: {json.dumps({'error': {'message': 'Error processing stream start', 'code': status.HTTP_500_INTERNAL_SERVER_ERROR}})}\n\n"
+            yield "data: [DONE]\n\n"
+        return StreamingResponse(error_gen_message(), media_type=media_type, headers=headers, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    async def combined_generator() -> AsyncGenerator[str, None]:
+        if first_chunk_value is not None:
+            yield first_chunk_value
+        async for chunk in generator:
+            yield chunk
+
+    return StreamingResponse(
+        combined_generator(),
+        media_type=media_type,
+        headers=headers,
+        status_code=final_status_code,
+    )
 
 
 class ProxyBaseLLMRequestProcessing:
@@ -300,8 +383,8 @@ class ProxyBaseLLMRequestProcessing:
                 user_api_key_dict=user_api_key_dict,
                 request_data=self.data,
             )
-            return StreamingResponse(
-                selected_data_generator,
+            return await create_streaming_response(
+                generator=selected_data_generator,
                 media_type="text/event-stream",
                 headers=custom_headers,
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -171,7 +171,7 @@ from litellm.proxy.batches_endpoints.endpoints import router as batches_router
 
 ## Import All Misc routes here ##
 from litellm.proxy.caching_routes import router as caching_router
-from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing, create_streaming_response
 from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
@@ -3491,6 +3491,7 @@ async def chat_completion(  # noqa: PLR0915
             return StreamingResponse(
                 selected_data_generator,
                 media_type="text/event-stream",
+                status_code=e.status_code if hasattr(e, "status_code") else status.HTTP_400_BAD_REQUEST,
             )
         _usage = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
         _chat_response.usage = _usage  # type: ignore
@@ -3633,8 +3634,8 @@ async def completion(  # noqa: PLR0915
                 request_data=data,
             )
 
-            return StreamingResponse(
-                selected_data_generator,
+            return await create_streaming_response(
+                generator=selected_data_generator,
                 media_type="text/event-stream",
                 headers=custom_headers,
             )
@@ -3692,6 +3693,7 @@ async def completion(  # noqa: PLR0915
                 selected_data_generator,
                 media_type="text/event-stream",
                 headers={},
+                status_code=e.status_code if hasattr(e, "status_code") else status.HTTP_400_BAD_REQUEST,
             )
         else:
             _response = litellm.TextCompletionResponse()
@@ -5124,13 +5126,14 @@ async def run_thread(
         if (
             "stream" in data and data["stream"] is True
         ):  # use generate_responses to stream responses
-            return StreamingResponse(
-                async_assistants_data_generator(
+            return await create_streaming_response(
+                generator=async_assistants_data_generator(
                     user_api_key_dict=user_api_key_dict,
                     response=response,
                     request_data=data,
                 ),
                 media_type="text/event-stream",
+                headers={}, # Added empty headers dict, original call missed this argument
             )
 
         ### ALERTING ###


### PR DESCRIPTION
For streaming requests, the remote request is triggered and first chunk inspected for an error code as emitted by async_data_generator.

Potential fix for #9035

## Title
initiate streaming requests to derive correct return status code

## Relevant issues
Fixes #9035 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
![image](https://github.com/user-attachments/assets/f9f46345-f977-435e-8830-e1f826705180)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
For streaming requests, the remote request is triggered and first chunk inspected for an error code as emitted by async_data_generator.

