### PR TITLE
added support to credential delete to support slashes in the curl

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -4,7 +4,7 @@ CRUD endpoints for storing reusable credentials.
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, Path
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -203,14 +203,14 @@ async def get_credential(
 
 
 @router.delete(
-    "/credentials/{credential_name}",
+    "/credentials/{credential_name:path}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["credential management"],
 )
 async def delete_credential(
     request: Request,
     fastapi_response: Response,
-    credential_name: str,
+    credential_name: str = Path(..., description="The credential name, percent-decoded; may contain slashes"),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -131,7 +131,7 @@ async def get_credentials(
 
 
 @router.get(
-    "/credentials/by_name/{credential_name}",
+    "/credentials/by_name/{credential_name:path}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["credential management"],
     response_model=CredentialItem,
@@ -145,7 +145,7 @@ async def get_credentials(
 async def get_credential(
     request: Request,
     fastapi_response: Response,
-    credential_name: Optional[str] = None,
+    credential_name: str = Path(..., description="The credential name, percent-decoded; may contain slashes"),
     model_id: Optional[str] = None,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
@@ -278,15 +278,15 @@ def update_db_credential(
 
 
 @router.patch(
-    "/credentials/{credential_name}",
+    "/credentials/{credential_name:path}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["credential management"],
 )
 async def update_credential(
     request: Request,
     fastapi_response: Response,
-    credential_name: str,
     credential: CredentialItem,
+    credential_name: str = Path(..., description="The credential name, percent-decoded; may contain slashes"),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """


### PR DESCRIPTION
## Title

Fixes the credential router to support slashes when dealing with deletion

## Relevant issues

Fixes #10975 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


