### PR TITLE
[Feat] Prometheus - Track `route` on proxy_* metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -832,6 +832,7 @@ class PrometheusLogger(CustomLogger):
                 exception_status=str(getattr(original_exception, "status_code", None)),
                 exception_class=self._get_exception_class_name(original_exception),
                 tags=_tags,
+                route=user_api_key_dict.request_route,
             )
             _labels = prometheus_label_factory(
                 supported_enum_labels=PrometheusMetricLabels.get_labels(
@@ -872,6 +873,7 @@ class PrometheusLogger(CustomLogger):
                 user=user_api_key_dict.user_id,
                 user_email=user_api_key_dict.user_email,
                 status_code="200",
+                route=user_api_key_dict.request_route,
             )
             _labels = prometheus_label_factory(
                 supported_enum_labels=PrometheusMetricLabels.get_labels(

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -295,3 +295,6 @@ class UserAPIKeyLabelValues(BaseModel):
     fallback_model: Annotated[
         Optional[str], Field(..., alias=UserAPIKeyLabelNames.FALLBACK_MODEL.value)
     ] = None
+    route: Annotated[
+        Optional[str], Field(..., alias=UserAPIKeyLabelNames.ROUTE.value)
+    ] = None

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -70,6 +70,7 @@ class UserAPIKeyLabelNames(Enum):
     EXCEPTION_CLASS = EXCEPTION_CLASS
     STATUS_CODE = "status_code"
     FALLBACK_MODEL = "fallback_model"
+    ROUTE = "route"
 
 
 DEFINED_PROMETHEUS_METRICS = Literal[
@@ -125,6 +126,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.STATUS_CODE.value,
         UserAPIKeyLabelNames.USER_EMAIL.value,
+        UserAPIKeyLabelNames.ROUTE.value,
     ]
 
     litellm_proxy_failed_requests_metric = [
@@ -137,6 +139,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.EXCEPTION_STATUS.value,
         UserAPIKeyLabelNames.EXCEPTION_CLASS.value,
+        UserAPIKeyLabelNames.ROUTE.value,
     ]
 
     litellm_deployment_latency_per_output_token = [

--- a/tests/logging_callback_tests/test_prometheus_unit_tests.py
+++ b/tests/logging_callback_tests/test_prometheus_unit_tests.py
@@ -694,6 +694,7 @@ async def test_async_post_call_failure_hook(prometheus_logger):
         team_alias="test_team_alias",
         user_id="test_user",
         end_user_id="test_end_user",
+        request_route="/chat/completions",
     )
 
     # Call the function
@@ -714,6 +715,7 @@ async def test_async_post_call_failure_hook(prometheus_logger):
         user="test_user",
         exception_status="429",
         exception_class="Openai.RateLimitError",
+        route=user_api_key_dict.request_route,
     )
     prometheus_logger.litellm_proxy_failed_requests_metric.labels().inc.assert_called_once()
 
@@ -728,6 +730,7 @@ async def test_async_post_call_failure_hook(prometheus_logger):
         user="test_user",
         status_code="429",
         user_email=None,
+        route=user_api_key_dict.request_route,
     )
     prometheus_logger.litellm_proxy_total_requests_metric.labels().inc.assert_called_once()
 
@@ -752,6 +755,7 @@ async def test_async_post_call_success_hook(prometheus_logger):
         team_alias="test_team_alias",
         user_id="test_user",
         end_user_id="test_end_user",
+        request_route="/chat/completions",
     )
 
     response = {"choices": [{"message": {"content": "test response"}}]}
@@ -772,6 +776,7 @@ async def test_async_post_call_success_hook(prometheus_logger):
         user="test_user",
         status_code="200",
         user_email=None,
+        route=user_api_key_dict.request_route,
     )
     prometheus_logger.litellm_proxy_total_requests_metric.labels().inc.assert_called_once()
 

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -106,7 +106,7 @@ async def test_proxy_failure_metrics():
         print("/metrics", metrics)
 
         # Check if the failure metric is present and correct
-        expected_metric = 'litellm_proxy_failed_requests_metric_total{api_key_alias="None",end_user="None",exception_class="Openai.RateLimitError",exception_status="429",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",team="None",team_alias="None",user="default_user_id"} 1.0'
+        expected_metric = 'litellm_proxy_failed_requests_metric_total{api_key_alias="None",end_user="None",exception_class="Openai.RateLimitError",exception_status="429",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/v1/chat/completions",team="None",team_alias="None",user="default_user_id"} 1.0'
 
         assert (
             expected_metric in metrics
@@ -115,7 +115,7 @@ async def test_proxy_failure_metrics():
         assert expected_llm_deployment_failure
 
         assert (
-            'litellm_proxy_total_requests_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",status_code="429",team="None",team_alias="None",user="default_user_id",user_email="None"} 1.0'
+            'litellm_proxy_total_requests_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/v1/chat/completions",status_code="429",team="None",team_alias="None",user="default_user_id",user_email="None"} 1.0'
             in metrics
         )
 

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -106,7 +106,7 @@ async def test_proxy_failure_metrics():
         print("/metrics", metrics)
 
         # Check if the failure metric is present and correct
-        expected_metric = 'litellm_proxy_failed_requests_metric_total{api_key_alias="None",end_user="None",exception_class="Openai.RateLimitError",exception_status="429",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/v1/chat/completions",team="None",team_alias="None",user="default_user_id"} 1.0'
+        expected_metric = 'litellm_proxy_failed_requests_metric_total{api_key_alias="None",end_user="None",exception_class="Openai.RateLimitError",exception_status="429",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/chat/completions",team="None",team_alias="None",user="default_user_id"} 1.0'
 
         assert (
             expected_metric in metrics

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -115,7 +115,7 @@ async def test_proxy_failure_metrics():
         assert expected_llm_deployment_failure
 
         assert (
-            'litellm_proxy_total_requests_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/v1/chat/completions",status_code="429",team="None",team_alias="None",user="default_user_id",user_email="None"} 1.0'
+            'litellm_proxy_total_requests_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="fake-azure-endpoint",route="/chat/completions",status_code="429",team="None",team_alias="None",user="default_user_id",user_email="None"} 1.0'
             in metrics
         )
 


### PR DESCRIPTION
## [Feat] Prometheus - Track `route` on proxy_* metrics

- Improved error monitoring, this will allow us to track how many errors for a specific route we are seeing on grafana 

```json
litellm_proxy_total_requests_metric_total{api_key_alias="None",end_user="None",hashed_api_key="88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",requested_model="openai/gpt-4sso",route="/chat/completions",status_code="400",team="None",team_alias="None",user="default_user_id",user_email="None"} 1.0
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


