### PR TITLE
Fix/openrouter stream usage id 8913

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -695,10 +695,13 @@ class CustomStreamWrapper:
 
         Ensure model id is always the same across all chunks.
 
-        If first chunk sent + id set, use that id for all chunks.
+        If a valid ID is received in any chunk, use it for the response.
         """
-        if self.response_id is None:
+        if id and isinstance(id, str) and id.strip():
             self.response_id = id
+        elif self.response_id is None:
+            self.response_id = id
+
         if self.response_id is not None and isinstance(self.response_id, str):
             model_response.id = self.response_id
         return model_response

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -695,11 +695,9 @@ class CustomStreamWrapper:
 
         Ensure model id is always the same across all chunks.
 
-        If a valid ID is received in any chunk, use it for the response.
+        If first chunk sent + id set, use that id for all chunks.
         """
-        if id and isinstance(id, str) and id.strip():
-            self.response_id = id
-        elif self.response_id is None:
+        if self.response_id is None:
             self.response_id = id
 
         if self.response_id is not None and isinstance(self.response_id, str):

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -699,7 +699,6 @@ class CustomStreamWrapper:
         """
         if self.response_id is None:
             self.response_id = id
-
         if self.response_id is not None and isinstance(self.response_id, str):
             model_response.id = self.response_id
         return model_response

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -120,7 +120,7 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                 id=chunk["id"],
                 object="chat.completion.chunk",
                 created=chunk["created"],
-                usage=chunk.get("usage"),  # Usage is only included in the last SSE message
+                usage=chunk.get("usage"),
                 model=chunk["model"],
                 choices=new_choices,
             )

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -120,6 +120,7 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                 id=chunk["id"],
                 object="chat.completion.chunk",
                 created=chunk["created"],
+                usage=chunk.get("usage"),  # Usage is only included in the last SSE message
                 model=chunk["model"],
                 choices=new_choices,
             )

--- a/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -26,6 +26,11 @@ class TestOpenRouterChatCompletionStreamingHandler:
             "id": "test_id",
             "created": 1234567890,
             "model": "test_model",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30
+            },
             "choices": [
                 {"delta": {"content": "test content", "reasoning": "test reasoning"}}
             ],
@@ -39,6 +44,10 @@ class TestOpenRouterChatCompletionStreamingHandler:
         assert result.object == "chat.completion.chunk"
         assert result.created == 1234567890
         assert result.model == "test_model"
+        # Verify usage is passed correctly
+        assert result.usage.prompt_tokens == chunk["usage"]["prompt_tokens"]
+        assert result.usage.completion_tokens == chunk["usage"]["completion_tokens"]
+        assert result.usage.total_tokens == chunk["usage"]["total_tokens"]
         assert len(result.choices) == 1
         assert result.choices[0]["delta"]["reasoning_content"] == "test reasoning"
 
@@ -95,3 +104,7 @@ def test_openrouter_extra_body_transformation():
     assert transformed_request["messages"] == [
         {"role": "user", "content": "Hello, world!"}
     ]
+
+    # Verify usage parameter is included for OpenRouter usage accounting
+    assert "usage" in transformed_request
+    assert transformed_request["usage"] == {"include": True}

--- a/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -44,7 +44,6 @@ class TestOpenRouterChatCompletionStreamingHandler:
         assert result.object == "chat.completion.chunk"
         assert result.created == 1234567890
         assert result.model == "test_model"
-        # Verify usage is passed correctly
         assert result.usage.prompt_tokens == chunk["usage"]["prompt_tokens"]
         assert result.usage.completion_tokens == chunk["usage"]["completion_tokens"]
         assert result.usage.total_tokens == chunk["usage"]["total_tokens"]
@@ -105,6 +104,5 @@ def test_openrouter_extra_body_transformation():
         {"role": "user", "content": "Hello, world!"}
     ]
 
-    # Verify usage parameter is included for OpenRouter usage accounting
     assert "usage" in transformed_request
     assert transformed_request["usage"] == {"include": True}

--- a/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -103,6 +103,3 @@ def test_openrouter_extra_body_transformation():
     assert transformed_request["messages"] == [
         {"role": "user", "content": "Hello, world!"}
     ]
-
-    assert "usage" in transformed_request
-    assert transformed_request["usage"] == {"include": True}


### PR DESCRIPTION
## Title

Surface Streaming Usage When Using OpenRouter (#8913)

## Relevant issues

Fixes #8913

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** – [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix  
✅ Test

## Changes

- Emit OpenRouter’s `usage` block for every SSE chunk in `OpenRouterChatCompletionStreamingHandler.chunk_parser`.
- Document that you must pass `stream_options={"include_usage": True}` when calling 
  ```python
  completion(..., stream=True, stream_options={"include_usage": True})
  in order to receive usage data in streaming mode.
  
<img width="1633" alt="image" src="https://github.com/user-attachments/assets/c9b3ecd4-fb72-4f60-811d-2d3f7d0f1e04" />

