### PR TITLE
fix:Databricks Claude 3.7 Sonnet output token cost: $17.85/M

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12284,7 +12284,7 @@
         "max_output_tokens": 128000, 
         "input_cost_per_token": 0.0000025,
         "input_dbu_cost_per_token": 0.00003571,
-        "output_cost_per_token": 0.00017857,
+        "output_cost_per_token": 0.000017857,
         "output_db_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
         "mode": "chat",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12284,7 +12284,7 @@
         "max_output_tokens": 128000, 
         "input_cost_per_token": 0.0000025,
         "input_dbu_cost_per_token": 0.00003571,
-        "output_cost_per_token": 0.00017857,
+        "output_cost_per_token": 0.000017857,
         "output_db_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
         "mode": "chat",


### PR DESCRIPTION
## Title

Fix Databricks Claude 3.7 Sonnet output token cost: $17.85/M instead of $178.5/M

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes

Fixes the output_cost_per_token for Databricks Claude 3.7 Sonnet model by adding an extra 0, changing from 0.00017857 to 0.000017857

