### PR TITLE
feat: add Databricks Llama 4 Maverick model cost

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12337,6 +12337,20 @@
         "metadata": {"notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."},
         "supports_tool_choice": true
     },
+    "databricks/databricks-llama-4-maverick": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000, 
+        "input_cost_per_token": 0.000005,
+        "input_dbu_cost_per_token": 0.00007143,
+        "output_cost_per_token": 0.000015,
+        "output_dbu_cost_per_token": 0.00021429,
+        "litellm_provider": "databricks",
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "metadata": {"notes": "Databricks documentation now provides both DBU costs (_dbu_cost_per_token) and dollar costs(_cost_per_token)."},
+        "supports_tool_choice": true
+    },
     "databricks/databricks-dbrx-instruct": {
         "max_tokens": 32768,
         "max_input_tokens": 32768,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12337,6 +12337,20 @@
         "metadata": {"notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."},
         "supports_tool_choice": true
     },
+    "databricks/databricks-llama-4-maverick": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000, 
+        "input_cost_per_token": 0.000005,
+        "input_dbu_cost_per_token": 0.00007143,
+        "output_cost_per_token": 0.000015,
+        "output_dbu_cost_per_token": 0.00021429,
+        "litellm_provider": "databricks",
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "metadata": {"notes": "Databricks documentation now provides both DBU costs (_dbu_cost_per_token) and dollar costs(_cost_per_token)."},
+        "supports_tool_choice": true
+    },
     "databricks/databricks-dbrx-instruct": {
         "max_tokens": 32768,
         "max_input_tokens": 32768,


### PR DESCRIPTION
## Title

Add Databricks Llama 4 Maverick model cost

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature


## Changes

Add configuration and pricing details for databricks-llama-4-maverick model:
- 128k context window
- Input cost: $0.000005 per token (0.00007143 DBU)
- Output cost: $0.000015 per token (0.00021429 DBU)
