### PR TITLE
Fixes the InvitationLink Prisma find_many query

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -189,7 +189,7 @@ class BaseEmailLogger(CustomLogger):
         # get the latest invitation link for the user
         invitation_rows = await prisma_client.db.litellm_invitationlink.find_many(
             where={"user_id": user_id},
-            orderBy={"created_at": "desc"},
+            order={"created_at": "desc"},
         )
         if len(invitation_rows) > 0:
             invitation_row = invitation_rows[0]


### PR DESCRIPTION


## Title

Fixes the InvitationLink Prisma find_many query

## Relevant issues

Related: https://github.com/BerriAI/litellm/commit/3b6c6d05dd8f8bcd83f776cdc1c8fc64d3d85d13#r157675103

We should use "order", according to the prisma python docs https://prisma-client-py.readthedocs.io/en/stable/reference/limitations/#order-argument 

Also we are using "order" in other files of the project:  https://github.com/search?q=repo%3ABerriAI%2Flitellm%20order%3D%7B&type=code

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


