### PR TITLE
Removed teamInfo call and used existing teamsList call

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { keyListCall, Organization } from '../networking';
+import { keyListCall, Member, Organization } from '../networking';
 import { Setter } from '@/types';
 
 export interface Team {
@@ -13,13 +13,7 @@ export interface Team {
     organization_id: string;
     created_at: string;
     keys: KeyResponse[];
-    members_with_roles: MemberWithRoles[];
-}
-
-interface MemberWithRoles {
-    user_id: string;
-    user_email: string;
-    role: string;
+    members_with_roles: Member[];
 }
 
 export interface KeyResponse {

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -12,6 +12,14 @@ export interface Team {
     rpm_limit: number | null;
     organization_id: string;
     created_at: string;
+    keys: KeyResponse[];
+    members_with_roles: MemberWithRoles[];
+}
+
+interface MemberWithRoles {
+    user_id: string;
+    user_email: string;
+    role: string;
 }
 
 export interface KeyResponse {

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -202,26 +202,24 @@ const Teams: React.FC<TeamProps> = ({
   }, [accessToken]);
 
   useEffect(() => {
-    const fetchTeamInfo = async () => {
-      if (!teams || !accessToken) return;
+    const fetchTeamInfo = () => {
+      if (!teams) return;
       
-      const teamInfoPromises = teams.map(async (team) => {
-        try {
-          const info = await teamInfoCall(accessToken, team.team_id);
-          return { [team.team_id]: info };
-        } catch (error) {
-          console.error(`Error fetching info for team ${team.team_id}:`, error);
-          return { [team.team_id]: null };
-        }
-      });
-
-      const results = await Promise.all(teamInfoPromises);
-      const newPerTeamInfo = results.reduce((acc, curr) => ({ ...acc, ...curr }), {});
+      const newPerTeamInfo = teams.reduce((acc, team) => {
+        acc[team.team_id] = {
+          keys: team.keys || [],
+          team_info: {
+            members_with_roles: team.members_with_roles || []
+          }
+        };
+        return acc;
+      }, {} as Record<string, any>);
+      
       setPerTeamInfo(newPerTeamInfo);
     };
 
     fetchTeamInfo();
-  }, [teams, accessToken]);
+  }, [teams]);
 
   const handleOk = () => {
     setIsTeamModalVisible(false);

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -26,7 +26,7 @@ import { fetchAvailableModelsForTeamOrKey, getModelDisplayName, unfurlWildcardMo
 import { Select, SelectItem } from "@tremor/react";
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { getGuardrailsList } from "./networking";
-import TeamInfoView from "@/components/team/team_info";
+import TeamInfoView, { TeamData } from "@/components/team/team_info";
 import TeamSSOSettings from "@/components/TeamSSOSettings";
 import { isAdminRole } from "@/utils/roles";
 import {
@@ -55,7 +55,7 @@ import {
 } from "@tremor/react";
 import { CogIcon } from "@heroicons/react/outline";
 import AvailableTeamsPanel from "@/components/team/available_teams";
-import type { Team } from "./key_team_helpers/key_list";
+import type { KeyResponse, Team } from "./key_team_helpers/key_list";
 const isLocal = process.env.NODE_ENV === "development";
 const proxyBaseUrl = isLocal ? "http://localhost:4000" : null;
 if (isLocal != true) {
@@ -95,6 +95,15 @@ import {
   v2TeamListCall
 } from "./networking";
 import { updateExistingKeys } from "@/utils/dataUtils";
+
+interface TeamInfo {
+  members_with_roles: Member[];
+}
+
+interface PerTeamInfo {
+  keys: KeyResponse[];
+  team_info: TeamInfo;
+}
 
 const getOrganizationModels = (organization: Organization | null, userModels: string[]) => {
   let tempModelsToPick = [];
@@ -164,10 +173,7 @@ const Teams: React.FC<TeamProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [teamToDelete, setTeamToDelete] = useState<string | null>(null);
   const [modelsToPick, setModelsToPick] = useState<string[]>([]);
-  
-
-
-  const [perTeamInfo, setPerTeamInfo] = useState<Record<string, any>>({});
+  const [perTeamInfo, setPerTeamInfo] = useState<Record<string, PerTeamInfo>>({});
 
   // Add this state near the other useState declarations
   const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
@@ -213,7 +219,7 @@ const Teams: React.FC<TeamProps> = ({
           }
         };
         return acc;
-      }, {} as Record<string, any>);
+      }, {} as Record<string, PerTeamInfo>);
       
       setPerTeamInfo(newPerTeamInfo);
     };


### PR DESCRIPTION
## Avoid spamming /team/info try using /team/list instead
Related PR -> https://github.com/BerriAI/litellm/pull/10950
The `team/info` call added in this PR was being invoked redundantly, which affected the processing speed of the key list and teams list calls. It should be removed, and the existing `team/list` call should be used instead.

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

Refactor

## Changes
- Removed the `team/info` call in favor of using the existing `team/list` call. 
- Added `members_with_roles` and `keys ` properties to the existing `Team` type to get these properties from existing `team/list` call.


https://www.loom.com/share/14b7f1a30edf4089be78df65de6661cc?sid=71d36952-b1fd-46d9-a615-cf49bcdd1a54