### PR TITLE
Fix Health Check on the --health comment

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import click
 import httpx
 from dotenv import load_dotenv
-
+import urllib.parse
 if TYPE_CHECKING:
     from fastapi import FastAPI
 else:
@@ -664,8 +664,14 @@ def run_server(  # noqa: PLR0915
                     and database_password
                     and database_name
                 ):
+                    # Handle the problem of special character escaping in the database URL
+                    database_username_enc = urllib.parse.quote_plus(database_username)
+                    database_password_enc = urllib.parse.quote_plus(database_password)
+                    database_name_enc = urllib.parse.quote_plus(database_name)
+
                     # Construct DATABASE_URL from the provided variables
-                    database_url = f"postgresql://{database_username}:{database_password}@{database_host}/{database_name}"
+                    database_url = f"postgresql://{database_username_enc}:{database_password_enc}@{database_host}/{database_name_enc}"
+
                     os.environ["DATABASE_URL"] = database_url
             db_connection_pool_limit = general_settings.get(
                 "database_connection_pool_limit",

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -55,7 +55,14 @@ class ProxyInitializationHelpers:
     @staticmethod
     def _run_health_check(host, port):
         print("\nLiteLLM: Health Testing models in config")  # noqa
-        response = httpx.get(url=f"http://{host}:{port}/health")
+        headers = {
+            "x-litellm-api-key":os.getenv("LITELLM_MASTER_KEY")
+        }
+        response = httpx.get(url=f"http://{host}:{port}/health" , headers=headers)
+        if response.status_code != 200:
+            raise Exception(
+                f"LiteLLM: Health check failed with status code {response.status_code}"
+            )
         print(json.dumps(response.json(), indent=4))  # noqa
 
     @staticmethod

--- a/tests/litellm/proxy/test_proxy_cli.py
+++ b/tests/litellm/proxy/test_proxy_cli.py
@@ -12,6 +12,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from litellm.llms.custom_httpx.http_handler import headers
+
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system-path
@@ -42,6 +44,7 @@ class TestProxyInitializationHelpers:
         # Setup
         mock_response = MagicMock()
         mock_response.json.return_value = {"status": "healthy"}
+        mock_response.status_code = 200
         mock_get.return_value = mock_response
         mock_dumps.return_value = '{"status": "healthy"}'
 
@@ -49,7 +52,7 @@ class TestProxyInitializationHelpers:
         ProxyInitializationHelpers._run_health_check("localhost", 8000)
 
         # Assert
-        mock_get.assert_called_once_with(url="http://localhost:8000/health")
+        mock_get.assert_called_once_with(url="http://localhost:8000/health", headers = {"x-litellm-api-key":os.getenv("LITELLM_MASTER_KEY")})
         mock_response.json.assert_called_once()
         mock_dumps.assert_called_once_with({"status": "healthy"}, indent=4)
 


### PR DESCRIPTION
## Title

Fix the problem on the function _run_health_check

## Relevant issues

#10683

## Pre-Submission checklist

Check all these


## Type

🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
I have change the _run_health_check , add raising error logic and also updated the test.
Currently the API call will use LITELLM_MASTER_KEY to auth



