### PR TITLE
When using multiple workers with uvicorn, use `MultiProcessCollector` for Prometheus

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -570,6 +570,7 @@ router_settings:
 | PRESIDIO_ANONYMIZER_API_BASE | Base URL for Presidio Anonymizer service
 | PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES | Refresh interval in minutes for Prometheus budget metrics. Default is 5
 | PROMETHEUS_FALLBACK_STATS_SEND_TIME_HOURS | Fallback time in hours for sending stats to Prometheus. Default is 9
+| PROMETHEUS_MULTIPROC_DIR | Temp directory for Prometheus multiprocess collector
 | PROMETHEUS_URL | URL for Prometheus service
 | PROMPTLAYER_API_KEY | API key for PromptLayer integration
 | PROXY_ADMIN_ID | Admin identifier for proxy server

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -261,7 +261,12 @@ Use these metrics to monitor the health of the DB Transaction Queue. Eg. Monitor
 | `litellm_in_memory_spend_update_queue_size`         | In-memory aggregate spend values for keys, users, teams, team members, etc.| In-Memory    |
 | `litellm_redis_spend_update_queue_size`             | Redis aggregate spend values for keys, users, teams, etc.                  | Redis        |
 
+## Multiple Workers
+When using multiple workers, a special temporary directory is used to store metrics across workers.
+By default a temporary directory is created and deleted at when litellm closes.
 
+You can manually specify the directory by setting the environment variable `PROMETHEUS_MULTIPROC_DIR`.
+Do note that it needs to be cleared manually before litellm starts.
 
 ## **🔥 LiteLLM Maintained Grafana Dashboards **
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1823,14 +1823,13 @@ class PrometheusLogger(CustomLogger):
             metrics_app = make_asgi_app()
         else:
             metrics_app = FastAPI()
-            @metrics_app.get("/", include_in_schema=False)
             def metrics_endpoint():
                 """Multiprocess-aware metrics endpoint"""
                 registry = CollectorRegistry()
                 multiprocess.MultiProcessCollector(registry)
                 data = generate_latest(registry)
                 return Response(content=data, media_type=CONTENT_TYPE_LATEST, status_code=200)
-
+            metrics_app.add_api_route("/", metrics_endpoint, methods=["GET"])
         app.mount("/metrics", metrics_app)
         verbose_proxy_logger.debug(
             "Starting Prometheus Metrics on /metrics (no authentication)"

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -794,13 +794,13 @@ def run_server(  # noqa: PLR0915
                 # See https://prometheus.github.io/client_python/multiprocess/
                 if num_workers > 1 and "prometheus" in  _config.get("litellm_settings", {}).get("callbacks", []):
                     if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
-                        print(f"Using existing dir: {os.environ['PROMETHEUS_MULTIPROC_DIR']}")
+                        print(f"LITELLM: Using PROMETHEUS_MULTIPROC_DIR dir: {os.environ['PROMETHEUS_MULTIPROC_DIR']}")
                     else:
-                        # We're the first process to set this up
-                        shared_dir = tempfile.mkdtemp(prefix="prometheus_multiproc_")
+                        # Setup the temp dir for prometheus
+                        shared_dir = tempfile.mkdtemp(prefix="litellm_prometheus_")
                         os.environ['PROMETHEUS_MULTIPROC_DIR'] = shared_dir
 
-                        print(f"Created new dir: {shared_dir}")
+                        print(f"LITELLM: Using PROMETHEUS_MULTIPROC_DIR dir: {os.environ['PROMETHEUS_MULTIPROC_DIR']}")
 
                         def cleanup():
                             if os.path.exists(shared_dir):


### PR DESCRIPTION

## When using multiple workers with uvicorn, use `MultiProcessCollector` for prometheus

## Relevant issues
Fixes #10595

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes

When using multiple workers with uvicorn, we need to use the `MultiProcessCollector` with prometheus. If we don't then each worker will have it's own metrics and uvicorn is going to round-robin meaning metrics will be changing as you bounce around different workers

### How it works:

According to the docs: https://prometheus.github.io/client_python/multiprocess/
We must set `PROMETHEUS_MULTIPROC_DIR` before starting our application. Luckily this is possible in `proxy_cli.py`. 
I wasn't sure how to check if we're going to be using prometheus, so I just used `"prometheus" in  _config.get("litellm_settings", {}).get("callbacks", [])`

If we're using prometheus and multiple workers, and gunicorn, and the user does not specify `PROMETHEUS_MULTIPROC_DIR` - then a random directory is selected with `tempfile.mkdtemp(prefix="litellm_prometheus_")`


### Uvicorn
I only tested with `uvicorn`. I saw references in the code to `gunicorn` but no references in the docs.

I did see `hypercorn` but haven't had a chance to test it. 
However based on the changes, `hypercorn` will likely still have this same bug, and this PR only fixes `uvicorn`. I can fix `hypercorn` when I have time.

### Testing

I wasn't sure how you'd like tests written for this. I could not find many examples of tests involving either `run_server` or `prometheus`.

https://github.com/search?q=repo%3ABerriAI%2Flitellm+path%3A%2F%5Etests%5C%2Flitellm%5C%2F%2F++run_server&type=code

https://github.com/search?q=repo%3ABerriAI%2Flitellm+path%3A%2F%5Etests%5C%2Flitellm%5C%2F%2F++prometheus&type=code


All tests pass, although `tests/litellm/proxy/hooks/test_parallel_request_limiter_v2.py::test_normal_router_call_rpm` is being flaky. I don't think anything in my PR would impact this test? It does pass and sometimes fails?

Screenshot of them all passing as requested:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/44bc459c-ce0e-4fd3-8725-b7d9900356a7" />


### Verifying
I've discovered this issue is made more complex because of connection keep alives. 
To make it more obvious that the metrics are not being shared across workers, I used nginx to make sure the connections weren't reused. The problem still exists without this, but it's less obvious on the graphs. 

See below for a basic docker setup.

Before
1. Start litellm with `--num_workers 8`
2. Run nginx and prometheus (see below)
3. Send several basic requests to gpt4o - the contents don't matter we're just watching `litellm_total_tokens_total`
4. Observe that `litellm_total_tokens_total` bounces all over the place in prometheus
<img width="1065" alt="Screenshot 2025-05-22 at 6 21 33 PM" src="https://github.com/user-attachments/assets/698433b9-db85-44b6-88a3-51c404c86ee6" />

After
1. Start litellm with `--num_workers 8`
2. Run nginx and prometheus (see below)
3. Send several basic requests to gpt4o 
4. Observe that `litellm_total_tokens_total` only goes up in prometheus
<img width="1405" alt="Screenshot 2025-05-22 at 6 25 39 PM" src="https://github.com/user-attachments/assets/29ba1494-1001-47f1-aba3-196c1138fd5a" />

### Docker setup
Here is a basic setup for testing prometheus/nginx if you'd like to graph the numbers. 
You can also spam refresh in the browser, but without nginx the browser will reuse the connection so it won't change as frequently, and it can be difficult to see the numbers change.

```sh
# Stop containers
docker stop nginx-proxy prometheus 2>/dev/null
docker rm nginx-proxy prometheus 2>/dev/null

# Create a custom network
docker network create prom-network

# Create nginx config
echo 'events { worker_connections 1024; }
http {
  upstream backend {
    server host.docker.internal:4000;
  }
  server {
    listen 8081;
    location /metrics {
      proxy_pass http://backend/metrics;
      proxy_http_version 1.0;
      proxy_set_header Connection "close";
      proxy_set_header Host $host;
      proxy_buffering off;
      proxy_connect_timeout 5s;
      proxy_send_timeout 5s;
      proxy_read_timeout 5s;
    }
  }
}' > nginx.conf

# Run nginx on custom network
docker run -d --name nginx-proxy \
  --network prom-network \
  --add-host=host.docker.internal:host-gateway \
  -p 8081:8081 \
  -v $(pwd)/nginx.conf:/etc/nginx/nginx.conf \
  nginx

# Create Prometheus config using container name (not host.docker.internal)
echo 'global:
  scrape_interval: 5s
scrape_configs:
  - job_name: "target-4000"
    scrape_interval: 5s
    scrape_timeout: 4s
    params:
      connection: ["close"]
    metric_relabel_configs:
      - source_labels: [__name__]
        target_label: scrape_time
        replacement: "{{ .Timestamp }}"
    static_configs:
      - targets: ["nginx-proxy:8081"]' > prometheus.yml

# Run Prometheus on same custom network
docker run -d \
  --name prometheus \
  --network prom-network \
  -p 9090:9090 \
  -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml \
  prom/prometheus

```