### PR TITLE
Fix proxy_cli.py: avoid overriding DATABASE_URL when it’s already provided

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -659,7 +659,7 @@ def run_server(  # noqa: PLR0915
                     **key_management_settings
                 )
             database_url = general_settings.get("database_url", None)
-            if database_url is None:
+            if database_url is None and os.getenv("DATABASE_URL") is None:
                 # Check if all required variables are provided
                 database_host = os.getenv("DATABASE_HOST")
                 database_username = os.getenv("DATABASE_USERNAME")


### PR DESCRIPTION
## Summary
<!-- e.g. "Implement user authentication feature" -->
Fix a bug introduced in https://github.com/BerriAI/litellm/pull/10842. This bug may cause the environment variable `DATABASE_URL` to be updated to an incorrect value when `DATABASE_USERNAME/DATABASE_PASSWORD/DATABASE_NAME` is already URL-encoded.

In my case, I use the litellm helm chart in K8S with an existing PostgreSQL database from AWS Aurora. I simply provided the environment variable already URL-encoded, and now it fails when I upgrade to the latest version.

The code has two main issues:
1. When overriding an environment variable, it’s crucial to first check if it exists.
2. Before URL-encoding any data, it’s essential to ensure that it’s not already URL-encoded.

The proposed change in this PR addresses issue 1, which is a quick fix to unblock situations like mine since I have limited time. Perhaps @unrealandychan could create another PR to address issue 2?

cc @krrishdholakia 
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


