### PR TITLE
Add devstral-small-2505 model to pricing and context window configuration

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2888,6 +2888,19 @@
         "supports_assistant_prefill": true,
         "supports_tool_choice": true
     },
+    "mistral/devstral-small-2505": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 0.0000001,
+        "output_cost_per_token": 0.0000003,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/devstral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-embed": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,


### PR DESCRIPTION
## Summary
This PR adds support for the new `devstral-small-2505` model from Mistral AI to the model pricing and context window configuration.

## Changes
- Added `mistral/devstral-small-2505` entry to `model_prices_and_context_window.json`
- Configured with 128K context window (128,000 tokens)
- Set pricing to match Mistral Small 3.1: $0.1/M input tokens, $0.3/M output tokens
- Enabled support for function calling, assistant prefill, and tool choice
- Added source reference to the official Mistral AI announcement

## Model Details
- **Model**: devstral-small-2505
- **Provider**: mistral
- **Context Window**: 128K tokens
- **Input Cost**: $0.1 per million tokens
- **Output Cost**: $0.3 per million tokens
- **Capabilities**: Function calling, assistant prefill, tool choice
- **Source**: https://mistral.ai/news/devstral

## Background
Devstral is an agentic LLM for software engineering tasks built under a collaboration between Mistral AI and All Hands AI. It's fine-tuned from Mistral-Small-3.1 and achieves 46.8% on SWE-Bench Verified, outperforming prior open-source models by 6%.

The model is available on Mistral's API under the name `devstral-small-2505` at the same pricing as Mistral Small 3.1.