### PR TITLE
feat: Make gemini accept the openai parameter parallel_tool_calls

### DIFF
--- a/litellm/llms/gemini/chat/transformation.py
+++ b/litellm/llms/gemini/chat/transformation.py
@@ -83,6 +83,7 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
             "logprobs",
             "frequency_penalty",
             "modalities",
+            "parallel_tool_calls",
         ]
         if supports_reasoning(model):
             supported_params.append("reasoning_effort")

--- a/tests/litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/litellm/llms/vertex_ai/test_vertex.py
@@ -12,8 +12,7 @@ import litellm.litellm_core_utils.prompt_templates
 import litellm.litellm_core_utils.prompt_templates.factory
 
 load_dotenv()
-import io
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -21,10 +20,8 @@ sys.path.insert(
 import pytest
 import litellm
 from litellm import get_optional_params
-from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.vertex_ai.gemini.transformation import _process_gemini_image
-from litellm.types.llms.vertex_ai import PartType, BlobType
-import httpx
+from litellm.types.llms.vertex_ai import BlobType
 
 
 def encode_image_to_base64(image_path):
@@ -1146,7 +1143,7 @@ def test_process_gemini_image():
     from litellm.llms.vertex_ai.gemini.transformation import (
         _process_gemini_image,
     )
-    from litellm.types.llms.vertex_ai import PartType, FileDataType, BlobType
+    from litellm.types.llms.vertex_ai import FileDataType
 
     # Test GCS URI
     gcs_result = _process_gemini_image("gs://bucket/image.png")
@@ -1271,10 +1268,6 @@ def test_vertex_embedding_url(model, expected_url):
 
 import pytest
 from unittest.mock import Mock, patch
-from typing import Dict, Any
-
-# Import your actual module here
-# from your_module import _process_gemini_image, PartType, FileDataType, BlobType
 
 
 # Add these fixtures below existing fixtures


### PR DESCRIPTION
When mapping, allow the parameter: True because that is the intrinsic behavior of Gemini. Allow False, but reject if there are multiple tools because there's no actual equivalent in Gemini.

fixes #9686

ref: issues/9686

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
fixes #9686

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
![image](https://github.com/user-attachments/assets/c6aa49eb-4a62-41e9-8035-a0ebd4da84c9)

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix

## Changes
When mapping, allow the parameter: True because that is the intrinsic behavior of Gemini. Allow False, but reject if there are multiple tools because there's no actual equivalent in Gemini.

