### PR TITLE
[Chore]: feature flag aiohttp transport - users should opt into using aiohttp transport

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -300,7 +300,7 @@ custom_prometheus_metadata_labels: List[str] = []
 priority_reservation: Optional[Dict[str, float]] = None
 
 ######## Networking Settings ########
-use_aiohttp_transport: bool = True
+use_aiohttp_transport: bool = False
 force_ipv4: bool = False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
 module_level_aclient = AsyncHTTPHandler(
     timeout=request_timeout, client_alias="module level aclient"

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -13,6 +13,7 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.constants import _DEFAULT_TTL_FOR_HTTPX_CLIENTS
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
+from litellm.secret_managers.main import str_to_bool
 from litellm.types.llms.custom_http import *
 
 if TYPE_CHECKING:
@@ -494,7 +495,7 @@ class AsyncHTTPHandler:
         # httpx_aiohttp is included in litellm docker images and pip when python 3.9+ is used
         #########################################################
         if (
-            litellm.use_aiohttp_transport
+            AsyncHTTPHandler._should_use_aiohttp_transport()
             and AsyncHTTPHandler.aiohttp_transport_exists()
         ):
             return AsyncHTTPHandler._create_aiohttp_transport(
@@ -505,6 +506,22 @@ class AsyncHTTPHandler:
         # HTTPX TRANSPORT is used when aiohttp is not installed
         #########################################################
         return AsyncHTTPHandler._create_httpx_transport()
+
+    @staticmethod
+    def _should_use_aiohttp_transport() -> bool:
+        """
+        This is feature flagged for now and is opt in as we roll out to all users.
+
+        Controlled by either
+        - litellm.use_aiohttp_transport or os.getenv("USE_AIOHTTP_TRANSPORT") = "True"
+        """
+        if (
+            str_to_bool(os.getenv("USE_AIOHTTP_TRANSPORT", "False"))
+            or litellm.use_aiohttp_transport
+        ):
+            verbose_logger.debug("Using AiohttpTransport...")
+            return True
+        return False
 
     @staticmethod
     def _create_aiohttp_transport(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -13,7 +13,6 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.constants import _DEFAULT_TTL_FOR_HTTPX_CLIENTS
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
-from litellm.secret_managers.main import str_to_bool
 from litellm.types.llms.custom_http import *
 
 if TYPE_CHECKING:
@@ -515,6 +514,8 @@ class AsyncHTTPHandler:
         Controlled by either
         - litellm.use_aiohttp_transport or os.getenv("USE_AIOHTTP_TRANSPORT") = "True"
         """
+        from litellm.secret_managers.main import str_to_bool
+
         if (
             str_to_bool(os.getenv("USE_AIOHTTP_TRANSPORT", "False"))
             or litellm.use_aiohttp_transport

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import HEALTH_CHECK_TIMEOUT_SECONDS
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.proxy._types import (
     AlertType,
     CallInfo,
@@ -547,6 +548,7 @@ async def health_readiness():
                 "cache": cache_type,
                 "litellm_version": version,
                 "success_callbacks": success_callback_names,
+                "use_aiohttp_transport": AsyncHTTPHandler._should_use_aiohttp_transport(),
                 **db_health_status,
             }
         else:
@@ -556,6 +558,7 @@ async def health_readiness():
                 "cache": cache_type,
                 "litellm_version": version,
                 "success_callbacks": success_callback_names,
+                "use_aiohttp_transport": AsyncHTTPHandler._should_use_aiohttp_transport(),
             }
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Service Unhealthy ({str(e)})")


### PR DESCRIPTION
## [Chore]: feature flag aiohttp transport - user should opt into using aiohttp transport

Introduces an opt-in feature flag for selecting the aiohttp transport in the AsyncHTTPHandler.

Adds a _should_use_aiohttp_transport() helper that reads from litellm.use_aiohttp_transport or USE_AIOHTTP_TRANSPORT env var

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


