### PR TITLE
Fix test imports

### DIFF
--- a/tests/litellm/litellm_core_utils/test_token_counter_tool.py
+++ b/tests/litellm/litellm_core_utils/test_token_counter_tool.py
@@ -5,14 +5,10 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+# Use the same token_counter as the main test.
+from tests.litellm.litellm_core_utils.test_token_counter import token_counter
 
-#Use the same token_counter as the main test. 
-from test_token_counter import token_counter
-
-from test_token_counter_tool_data import *
+from tests.litellm.litellm_core_utils.test_token_counter_tool_data import *
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[Workflow](https://github.com/BerriAI/litellm/actions/runs/15229372377/job/42835368960?pr=9079) from PR #9079

`poetry run pytest tests/litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py` did not fail in local

But `poetry run pytest tests/litellm/litellm_core_utils/test_token_counter_tool.py -v`

```
_ ERROR collecting tests/litellm/litellm_core_utils/test_token_counter_tool.py __ 
ImportError while importing test module 'C:\Users\smart\Desktop\GD\litellm\tests\litellm\litellm_core_utils\test_token_counter_tool.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests\litellm\litellm_core_utils\test_token_counter_tool.py:13: in <module>       
    from test_token_counter import token_counter
E   ModuleNotFoundError: No module named 'test_token_counter'
```

---

Full test `poetry run pytest tests/litellm -x -vv -n 4` hangs at 95% (interrupted after 1 hour)

![image](https://github.com/user-attachments/assets/55e08b6d-ef6b-4e9e-b507-f35b34cff5bc)

![image](https://github.com/user-attachments/assets/df978a4f-2a15-489a-87b9-487f93fb58bc)
