### PR TITLE
Fix deprecation_date value for llama groq models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4392,7 +4392,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "deprecation_date": "2025-1-6"
+        "deprecation_date": "2025-01-06"
     },
     "groq/llama3-groq-8b-8192-tool-use-preview": {
         "max_tokens": 8192,
@@ -4405,7 +4405,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "deprecation_date": "2025-1-6"
+        "deprecation_date": "2025-01-06"
     },
     "groq/qwen-qwq-32b": {
         "max_tokens": 128000,


### PR DESCRIPTION
The fixed dates didn't follow the expected format of YYYY-MM-DD.