### PR TITLE
[Fix] - Duplicate maxTokens parameter being sent to Bedrock/Claude model with thinking

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -110,6 +110,15 @@ class BaseConfig(ABC):
             or non_default_params.get("reasoning_effort") is not None
         )
 
+    def is_max_tokens_in_request(self, non_default_params: dict) -> bool:
+        """
+        OpenAI spec allows max_tokens or max_completion_tokens to be specified.
+        """
+        return (
+            "max_tokens" in non_default_params
+            or "max_completion_tokens" in non_default_params
+        )
+
     def update_optional_params_with_thinking_tokens(
         self, non_default_params: dict, optional_params: dict
     ):

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -374,7 +374,8 @@ class AmazonConverseConfig(BaseConfig):
         from litellm.constants import DEFAULT_MAX_TOKENS
 
         is_thinking_enabled = self.is_thinking_enabled(optional_params)
-        if is_thinking_enabled and "maxTokens" not in non_default_params:
+        is_max_tokens_in_request = self.is_max_tokens_in_request(non_default_params)
+        if is_thinking_enabled and not is_max_tokens_in_request:
             thinking_token_budget = cast(dict, optional_params["thinking"]).get(
                 "budget_tokens", None
             )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -146,9 +146,14 @@ class AmazonConverseConfig(BaseConfig):
             # only anthropic and mistral support tool choice config. otherwise (E.g. cohere) will fail the call - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             supported_params.append("tool_choice")
 
-        if "claude-3-7" in model or "claude-sonnet-4" in model or "claude-opus-4" in model or supports_reasoning(
-            model=model,
-            custom_llm_provider=self.custom_llm_provider,
+        if (
+            "claude-3-7" in model
+            or "claude-sonnet-4" in model
+            or "claude-opus-4" in model
+            or supports_reasoning(
+                model=model,
+                custom_llm_provider=self.custom_llm_provider,
+            )
         ):
             supported_params.append("thinking")
             supported_params.append("reasoning_effort")
@@ -195,7 +200,11 @@ class AmazonConverseConfig(BaseConfig):
         return ["mp4", "mov", "mkv", "webm", "flv", "mpeg", "mpg", "wmv", "3gp"]
 
     def get_all_supported_content_types(self) -> List[str]:
-        return self.get_supported_image_types() + self.get_supported_document_types() + self.get_supported_video_types()
+        return (
+            self.get_supported_image_types()
+            + self.get_supported_document_types()
+            + self.get_supported_video_types()
+        )
 
     def _create_json_tool_call_for_response_format(
         self,
@@ -351,6 +360,28 @@ class AmazonConverseConfig(BaseConfig):
         )
 
         return optional_params
+
+    def update_optional_params_with_thinking_tokens(
+        self, non_default_params: dict, optional_params: dict
+    ):
+        """
+        Handles scenario where max tokens is not specified. For anthropic models (anthropic api/bedrock/vertex ai), this requires having the max tokens being set and being greater than the thinking token budget.
+
+        Checks 'non_default_params' for 'thinking' and 'max_tokens'
+
+        if 'thinking' is enabled and 'max_tokens' is not specified, set 'max_tokens' to the thinking token budget + DEFAULT_MAX_TOKENS
+        """
+        from litellm.constants import DEFAULT_MAX_TOKENS
+
+        is_thinking_enabled = self.is_thinking_enabled(optional_params)
+        if is_thinking_enabled and "maxTokens" not in non_default_params:
+            thinking_token_budget = cast(dict, optional_params["thinking"]).get(
+                "budget_tokens", None
+            )
+            if thinking_token_budget is not None:
+                optional_params["maxTokens"] = (
+                    thinking_token_budget + DEFAULT_MAX_TOKENS
+                )
 
     @overload
     def _get_cache_point_block(

--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -1436,6 +1436,36 @@ class BaseAnthropicChatTest(ABC):
         )
 
         print(response)
+    
+    def test_completion_thinking_with_max_tokens(self):
+        from pydantic import BaseModel
+        litellm._turn_on_debug()
+
+        base_completion_call_args = self.get_base_completion_call_args_with_thinking()
+
+        messages = [{"role": "user", "content": "Generate 5 question + answer pairs"}]
+        response = self.completion_function(
+            **base_completion_call_args,
+            messages=messages,
+            max_completion_tokens=20000,
+        )
+
+        print(response)
+    
+        
+    def test_completion_thinking_without_max_tokens(self):
+        from pydantic import BaseModel
+        litellm._turn_on_debug()
+
+        base_completion_call_args = self.get_base_completion_call_args_with_thinking()
+
+        messages = [{"role": "user", "content": "Generate 5 question + answer pairs"}]
+        response = self.completion_function(
+            **base_completion_call_args,
+            messages=messages,
+        )
+
+        print(response)
 
     def test_completion_with_thinking_basic(self):
         litellm._turn_on_debug()

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -91,6 +91,28 @@ def test_completion_bedrock_claude_completion_auth():
 
 # test_completion_bedrock_claude_completion_auth()
 
+def test_completion_bedrock_claude_completion_max_tokens():
+    try:
+        litellm._turn_on_debug()
+        response = completion(
+            model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            messages=messages,
+            max_completion_tokens=10,
+            temperature=1,
+            thinking={
+                "type": "enabled",
+                "budget_tokens": 1024
+            }
+        )
+        # Add any assertions here to check the response
+        print(response)
+    except RateLimitError:
+        pass
+    except Exception as e:
+        pytest.fail(f"Error occurred: {e}")
+
+
+
 
 @pytest.mark.parametrize("streaming", [True, False])
 def test_completion_bedrock_guardrails(streaming):

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -91,28 +91,6 @@ def test_completion_bedrock_claude_completion_auth():
 
 # test_completion_bedrock_claude_completion_auth()
 
-def test_completion_bedrock_claude_completion_max_tokens():
-    try:
-        litellm._turn_on_debug()
-        response = completion(
-            model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-            messages=messages,
-            max_completion_tokens=10,
-            temperature=1,
-            thinking={
-                "type": "enabled",
-                "budget_tokens": 1024
-            }
-        )
-        # Add any assertions here to check the response
-        print(response)
-    except RateLimitError:
-        pass
-    except Exception as e:
-        pytest.fail(f"Error occurred: {e}")
-
-
-
 
 @pytest.mark.parametrize("streaming", [True, False])
 def test_completion_bedrock_guardrails(streaming):


### PR DESCRIPTION
## [Fix] - Duplicate maxTokens parameter being sent to Bedrock/Claude model with thinking

Fixes #10659 

The culprit was `update_optional_params_with_thinking_tokens` that was added, it was sending `max_tokens` to bedrock models 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


