### PR TITLE
Put "all proxy models" if no models are selected

### DIFF
--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -226,11 +226,15 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
             <Card>
                 <Text>Models</Text>
                 <div className="mt-2 flex flex-wrap gap-2">
-                {orgData.models.map((model, index) => (
+                {orgData.models.length === 0 ? (
+                  <Badge color="red">All proxy models</Badge>
+                ) : (
+                  orgData.models.map((model, index) => (
                     <Badge key={index} color="red">
-                    {model}
+                      {model}
                     </Badge>
-                ))}
+                  ))
+                )}
                 </div>
             </Card>
             <Card>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -295,11 +295,15 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
               <Card>
                 <Text>Models</Text>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {info.models.map((model, index) => (
-                    <Badge key={index} color="red">
-                      {model}
-                    </Badge>
-                  ))}
+                  {info.models.length === 0 ? (
+                    <Badge color="red">All proxy models</Badge>
+                  ) : (
+                    info.models.map((model, index) => (
+                      <Badge key={index} color="red">
+                        {model}
+                      </Badge>
+                    ))
+                  )}
                 </div>
               </Card>
             </Grid>


### PR DESCRIPTION
## Put all proxy models if no models are selected
[Regression] If no model is specified it used to say (correctly) All proxy models, it now says no models specified after creating teams and organizations.

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Added `All proxy models` badge for when we create a new team and organization.
<img width="1470" alt="Screenshot 2025-05-28 at 3 28 55 AM" src="https://github.com/user-attachments/assets/0b4ea38e-bd3e-41f0-bb36-db0a264ef0ed" />

<img width="1470" alt="Screenshot 2025-05-28 at 3 29 13 AM" src="https://github.com/user-attachments/assets/4cffd103-4a67-4073-b43e-0f1ba14634ef" />

