### PR TITLE
WIP: refactor remote client ip address retrieval

### DIFF
--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, Request, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
+from litellm.proxy._types import ProxyErrorTypes, ProxyException
 from litellm.proxy.auth.auth_utils import UserAPIKeyAuth
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.ip_helper import get_client_ip_address

--- a/litellm/proxy/ip_helper.py
+++ b/litellm/proxy/ip_helper.py
@@ -1,0 +1,11 @@
+from fastapi import Request
+from typing import Dict
+
+def get_client_ip_address(request: Request, general_settings: Dict[str, any]) -> str:
+    """
+    Determines the client IP address.
+    Relies on Uvicorn (or a similar ASGI server) being correctly configured
+    with 'forwarded_allow_ips' to set request.client.host accurately
+    when behind trusted proxies.
+    """
+    return request.client.host if request.client else ""

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -597,7 +597,7 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         user_api_key_dict.api_key
     )  # this is just the hashed token. [TODO]: replace variable name in repo.
 
-    data[_metadata_variable_name]["user_api_key_end_user_max_budget"] = getattr(
+    data[_metadata_variable_name]["user_api_end_user_max_budget"] = getattr(
         user_api_key_dict, "end_user_max_budget", None
     )
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -764,6 +764,7 @@ def run_server(  # noqa: PLR0915
 
         # DO NOT DELETE - enables global variables to work across files
         from litellm.proxy.proxy_server import app  # noqa
+        from litellm.proxy.proxy_server import _run_background_health_check # Add this import
 
         # Skip server startup if requested (after all setup is done)
         if skip_server_startup:
@@ -798,9 +799,9 @@ def run_server(  # noqa: PLR0915
 
             if litellm.proxy.proxy_server.premium_user is True: # Updated access
                 # if premium user, print the config file path
-                if user_config_file_path is not None:
+                if config is not None: # Replace user_config_file_path with config
                     click.secho(
-                        f"\nLiteLLM: Using config file at {user_config_file_path}\n",
+                        f"\nLiteLLM: Using config file at {config}\n", # Replace user_config_file_path with config
                         fg="green",
                     )
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2009,9 +2009,7 @@ class PrismaClient:
                 if "members_with_roles" in db_data and isinstance(
                     db_data["members_with_roles"], list
                 ):
-                    db_data["members_with_roles"] = json.dumps(
-                        db_data["members_with_roles"]
-                    )
+                    db_data["members_with_roles"] = json.dumps(db_data["members_with_roles"])
                 if "members_with_roles" in update_key_values and isinstance(
                     update_key_values["members_with_roles"], list
                 ):


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

This PR targets a vulnerability in LiteLLM, where a client is able to spoof the IP being logged.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

Extend the `general_settings.use_x_forwarded_for` setting to cover setting up processing of x_forwarded_for in Uvicorn. Additionally introducing `general_settings.trusted_proxies`, which is an array of IP's that is trusted to set the x-forwarded-for header. If x-forwarded-for is set, uvicorn will read the left-most IP in the x-forwarded-for header and report that as the remote clients IP. Otherwise the header will be ignored and the actual remote clients IP will be logged.

This also refactors a couple of pieces of code that also deals with getting the users IP. Instead of having custom logic to parse the x-forwarded-for header, we now offload that to the WSGI layer (uvicorn) and read it directory from `request.client.host`. `request.client.host` will be set by uvicorn to the either the x-forwarded-for IP if the remote IP is a trusted proxy, or directly to the remote IP if `general_settings.use_x_forwarded_for` is set. If not set, the remote IP will be used.