### PR TITLE
Add price for gpt4o mini audio preview without date

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -421,6 +421,23 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "gpt-4o-mini-audio-preview": {
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 0.00000015,
+        "input_cost_per_audio_token": 0.00001,
+        "output_cost_per_token": 0.0000006,
+        "output_cost_per_audio_token": 0.00002,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "gpt-4o-mini-audio-preview-2024-12-17": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Add price for gpt4o mini audio preview without date at the end of the name, just like for the non mini model.

📖 Documentation
💰 Cost map

## Changes

Adding the gpt4o mini audio preview to the cost map without a date suffix, just like the gpt4o audio preview model.