### PR TITLE
[Feat] Add well known MCP servers to LiteLLM

### DIFF
--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -1,16 +1,18 @@
 {
-    "brave-search": {
-        "command": "docker",
-        "args": [
-            "run",
-            "-i",
-            "--rm",
-            "-e",
-            "BRAVE_API_KEY",
-            "mcp/brave-search"
-        ],
-        "env": {
-            "BRAVE_API_KEY": "YOUR_API_KEY_HERE"
-        }
+    "zapier": {
+        "sse_url": "https://mcp.zapier.com/api/mcp"
+    },
+    "deepwiki": {
+        "http_url": "https://mcp.deepwiki.com/mcp",
+        "sse_url": "https://mcp.deepwiki.com/sse",
+        "description": "The DeepWiki MCP server provides programmatic access to DeepWiki's repository documentation (Devin Wiki) and search capabilities (Devin Search)."
+    },
+    "jira": {
+        "sse_url": "https://mcp.atlassian.com/v1/sse",
+        "description": "The Jira MCP server provides programmatic access to Jira's issue tracking capabilities."
+    },
+    "linear": {
+        "sse_url": "https://mcp.linear.app/sse",
+        "description": "The Linear MCP server provides programmatic access to Linear's issue tracking capabilities."
     }
 }


### PR DESCRIPTION
## [Feat] Add well known MCP servers to LiteLLM

This PR adds configurations for well-known MCP servers to LiteLLM by updating the mcp_servers.json file.

Added new MCP server entries: zapier, deepwiki, jira, and linear.


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


