### PR TITLE
Fix: Remove duplicate object_permission field in LiteLLM_TeamTable

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1272,7 +1272,6 @@ class LiteLLM_TeamTable(TeamBase):
     # Object Permission - MCP, Vector Stores etc.
     #########################################################
     object_permission_id: Optional[str] = None
-    object_permission: Optional[LiteLLM_ObjectPermissionTable] = None
 
     model_config = ConfigDict(protected_namespaces=())
 


### PR DESCRIPTION
## Summary
- Fixed mypy error where 'object_permission' field was defined twice in the LiteLLM_TeamTable class
- Removed the duplicate declaration at line 1275

## Test plan
- Verified the fix by running mypy with the type check passing

🤖 Generated with [Claude Code](https://claude.ai/code)