### PR TITLE
[UI] SCIM fixes SCIM token exposed on UI

### DIFF
--- a/ui/litellm-dashboard/src/components/SCIM.tsx
+++ b/ui/litellm-dashboard/src/components/SCIM.tsx
@@ -175,13 +175,13 @@ const SCIMConfig: React.FC<SCIMConfigProps> = ({ accessToken, userID, proxySetti
                 </Text>
                 <div className="flex items-center">
                   <TextInput
-                    value={tokenData.token}
+                    value={tokenData.key}
                     className="flex-grow mr-2 bg-white"
                     type="password"
                     disabled={true}
                   />
                   <CopyToClipboard
-                    text={tokenData.token}
+                    text={tokenData.key}
                     onCopy={() => message.success("Token copied to clipboard")}
                   >
                     <TremorButton variant="primary" className="flex items-center">


### PR DESCRIPTION
## [UI] SCIM fixes SCIM token exposed on UI

Ensure SCIM token shown on UI is sk-* prefixed

Ensures the SCIM UI shows the correctly prefixed token by switching from tokenData.token to tokenData.key.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


