### PR TITLE
[Feat]: Add Bedrock InvokeAgents as a /chat/completions route on LiteLLM

### DIFF
--- a/docs/my-website/docs/providers/bedrock_agents.md
+++ b/docs/my-website/docs/providers/bedrock_agents.md
@@ -1,0 +1,202 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Bedrock Agents
+
+Call Bedrock Agents in the OpenAI Request/Response format.
+
+
+| Property | Details |
+|----------|---------|
+| Description | Amazon Bedrock Agents use the reasoning of foundation models (FMs), APIs, and data to break down user requests, gather relevant information, and efficiently complete tasks. |
+| Provider Route on LiteLLM | `bedrock/agent/{AGENT_ID}/{ALIAS_ID}` |
+| Provider Doc | [AWS Bedrock Agents ↗](https://aws.amazon.com/bedrock/agents/) |
+
+## Quick Start
+
+### Model Format to LiteLLM
+
+To call a bedrock agent through LiteLLM, you need to use the following model format to call the agent.
+
+Here the `model=bedrock/agent/` tells LiteLLM to call the bedrock `InvokeAgent` API.
+
+```shell showLineNumbers title="Model Format to LiteLLM"
+bedrock/agent/{AGENT_ID}/{ALIAS_ID}
+```
+
+**Example:**
+- `bedrock/agent/L1RT58GYRW/MFPSBCXYTW`
+- `bedrock/agent/ABCD1234/LIVE`
+
+You can find these IDs in your AWS Bedrock console under Agents.
+
+
+### LiteLLM Python SDK
+
+```python showLineNumbers title="Basic Agent Completion"
+import litellm
+
+# Make a completion request to your Bedrock Agent
+response = litellm.completion(
+    model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",  # agent/{AGENT_ID}/{ALIAS_ID}
+    messages=[
+        {
+            "role": "user", 
+            "content": "Hi, I need help with analyzing our Q3 sales data and generating a summary report"
+        }
+    ],
+)
+
+print(response.choices[0].message.content)
+print(f"Response cost: ${response._hidden_params['response_cost']}")
+```
+
+```python showLineNumbers title="Streaming Agent Responses"
+import litellm
+
+# Stream responses from your Bedrock Agent
+response = litellm.completion(
+    model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",
+    messages=[
+        {
+            "role": "user",
+            "content": "Can you help me plan a marketing campaign and provide step-by-step execution details?"
+        }
+    ],
+    stream=True,
+)
+
+for chunk in response:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+
+### LiteLLM Proxy
+
+#### 1. Configure your model in config.yaml
+
+<Tabs>
+<TabItem value="config-yaml" label="config.yaml">
+
+```yaml showLineNumbers title="LiteLLM Proxy Configuration"
+model_list:
+  - model_name: bedrock-agent-1
+    litellm_params:
+      model: bedrock/agent/L1RT58GYRW/MFPSBCXYTW
+      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_region_name: us-west-2
+
+  - model_name: bedrock-agent-2  
+    litellm_params:
+      model: bedrock/agent/AGENT456/ALIAS789
+      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_region_name: us-east-1
+```
+
+</TabItem>
+</Tabs>
+
+#### 2. Start the LiteLLM Proxy
+
+```bash showLineNumbers title="Start LiteLLM Proxy"
+litellm --config config.yaml
+```
+
+#### 3. Make requests to your Bedrock Agents
+
+<Tabs>
+<TabItem value="curl" label="Curl">
+
+```bash showLineNumbers title="Basic Agent Request"
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "bedrock-agent-1",
+    "messages": [
+      {
+        "role": "user", 
+        "content": "Analyze our customer data and suggest retention strategies"
+      }
+    ]
+  }'
+```
+
+```bash showLineNumbers title="Streaming Agent Request"
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $LITELLM_API_KEY" \
+  -d '{
+    "model": "bedrock-agent-2",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Create a comprehensive social media strategy for our new product"
+      }
+    ],
+    "stream": true
+  }'
+```
+
+</TabItem>
+
+<TabItem value="openai-sdk" label="OpenAI Python SDK">
+
+```python showLineNumbers title="Using OpenAI SDK with LiteLLM Proxy"
+from openai import OpenAI
+
+# Initialize client with your LiteLLM proxy URL
+client = OpenAI(
+    base_url="http://localhost:4000",
+    api_key="your-litellm-api-key"
+)
+
+# Make a completion request to your agent
+response = client.chat.completions.create(
+    model="bedrock-agent-1",
+    messages=[
+      {
+        "role": "user",
+        "content": "Help me prepare for the quarterly business review meeting"
+      }
+    ]
+)
+
+print(response.choices[0].message.content)
+```
+
+```python showLineNumbers title="Streaming with OpenAI SDK"
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:4000", 
+    api_key="your-litellm-api-key"
+)
+
+# Stream agent responses
+stream = client.chat.completions.create(
+    model="bedrock-agent-2",
+    messages=[
+      {
+        "role": "user",
+        "content": "Walk me through launching a new feature beta program"
+      }
+    ],
+    stream=True
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content is not None:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+</TabItem>
+</Tabs>
+
+## Further Reading
+
+- [AWS Bedrock Agents Documentation](https://aws.amazon.com/bedrock/agents/)
+- [LiteLLM Authentication to Bedrock](https://docs.litellm.ai/docs/providers/bedrock#boto3---authentication)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -328,6 +328,7 @@ const sidebars = {
           label: "Bedrock",
           items: [
             "providers/bedrock",
+            "providers/bedrock_agents",
             "providers/bedrock_vector_store",
           ]
         },

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -527,6 +527,7 @@ class BaseAWSLLM:
         api_base: Optional[str],
         aws_bedrock_runtime_endpoint: Optional[str],
         aws_region_name: str,
+        endpoint_type: Optional[Literal["runtime", "agent"]] = "runtime",
     ) -> Tuple[str, str]:
         env_aws_bedrock_runtime_endpoint = get_secret("AWS_BEDROCK_RUNTIME_ENDPOINT")
         if api_base is not None:
@@ -540,7 +541,10 @@ class BaseAWSLLM:
         ):
             endpoint_url = env_aws_bedrock_runtime_endpoint
         else:
-            endpoint_url = f"https://bedrock-runtime.{aws_region_name}.amazonaws.com"
+            endpoint_url = self._select_default_endpoint_url(
+                endpoint_type=endpoint_type,
+                aws_region_name=aws_region_name,
+            )
 
         # Determine proxy_endpoint_url
         if env_aws_bedrock_runtime_endpoint and isinstance(
@@ -555,6 +559,19 @@ class BaseAWSLLM:
             proxy_endpoint_url = endpoint_url
 
         return endpoint_url, proxy_endpoint_url
+
+    def _select_default_endpoint_url(
+        self, endpoint_type: Optional[Literal["runtime", "agent"]], aws_region_name: str
+    ) -> str:
+        """
+        Select the default endpoint url based on the endpoint type
+
+        Default endpoint url is https://bedrock-runtime.{aws_region_name}.amazonaws.com
+        """
+        if endpoint_type == "agent":
+            return f"https://bedrock-agent.{aws_region_name}.amazonaws.com"
+        else:
+            return f"https://bedrock-runtime.{aws_region_name}.amazonaws.com"
 
     def _get_boto_credentials_from_optional_params(
         self, optional_params: dict, model: Optional[str] = None

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -569,7 +569,7 @@ class BaseAWSLLM:
         Default endpoint url is https://bedrock-runtime.{aws_region_name}.amazonaws.com
         """
         if endpoint_type == "agent":
-            return f"https://bedrock-agent.{aws_region_name}.amazonaws.com"
+            return f"https://bedrock-agent-runtime.{aws_region_name}.amazonaws.com"
         else:
             return f"https://bedrock-runtime.{aws_region_name}.amazonaws.com"
 

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -6,7 +6,7 @@ https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Invoke
 import base64
 import json
 import uuid
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
@@ -180,10 +180,10 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
                 if event_type == "chunk":
                     # Handle chunk events specially - they contain decoded content, not JSON
                     message = self._parse_message_from_event(event, parser)
-
+                    parsed_event: InvokeAgentEvent = InvokeAgentEvent()
                     if message:
                         # For chunk events, create a payload with the decoded content
-                        parsed_event: InvokeAgentEvent = {
+                        parsed_event = {
                             "headers": headers,
                             "payload": {
                                 "bytes": base64.b64encode(
@@ -200,7 +200,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
                     if message:
                         try:
                             event_data = json.loads(message)
-                            parsed_event: InvokeAgentEvent = {
+                            parsed_event = {
                                 "headers": headers,
                                 "payload": event_data,
                             }
@@ -399,7 +399,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
         if not metadata:
             return
 
-        usage = metadata.get("usage", {})
+        usage: Optional[Union[InvokeAgentUsage, Dict]] = metadata.get("usage", {})
         if not usage:
             return
 

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -1,0 +1,75 @@
+"""
+Transformation for Bedrock Invoke Agent
+
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html
+"""
+
+from typing import List, Optional
+
+from litellm.llms.base_llm.chat.transformation import BaseConfig
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+
+class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
+    def __init__(self, **kwargs):
+        BaseConfig.__init__(self, **kwargs)
+        BaseAWSLLM.__init__(self, **kwargs)
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        """
+        This is a base invoke model mapping. For Invoke - define a bedrock provider specific config that extends this class.
+        """
+        return [
+            "max_tokens",
+            "max_completion_tokens",
+            "stream",
+        ]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        This is a base invoke model mapping. For Invoke - define a bedrock provider specific config that extends this class.
+        """
+        for param, value in non_default_params.items():
+            if param == "max_tokens" or param == "max_completion_tokens":
+                optional_params["max_tokens"] = value
+            if param == "stream":
+                optional_params["stream"] = value
+        return optional_params
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        """
+        Get the complete url for the request
+        """
+        ### SET RUNTIME ENDPOINT ###
+        aws_bedrock_runtime_endpoint = optional_params.get(
+            "aws_bedrock_runtime_endpoint", None
+        )  # https://bedrock-runtime.{region_name}.amazonaws.com
+        endpoint_url, _ = self.get_runtime_endpoint(
+            api_base=api_base,
+            aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
+            aws_region_name=self._get_aws_region_name(
+                optional_params=optional_params, model=model
+            ),
+            endpoint_type="agent",
+        )
+
+        agentAliasID = optional_params.get("agentAliasID", None)
+        sessionID = optional_params.get("sessionID", None)
+
+        endpoint_url = f"{endpoint_url}/agents/{model}/agentAliases/{agentAliasID}/sessions/{sessionID}/text"
+
+        return endpoint_url

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -402,7 +402,9 @@ class BedrockModelInfo(BaseLLMModelInfo):
         return ["us", "eu", "apac"]
 
     @staticmethod
-    def get_bedrock_route(model: str) -> Literal["converse", "invoke", "converse_like"]:
+    def get_bedrock_route(
+        model: str,
+    ) -> Literal["converse", "invoke", "converse_like", "agent"]:
         """
         Get the bedrock route for the given model.
         """
@@ -414,6 +416,8 @@ class BedrockModelInfo(BaseLLMModelInfo):
             return "converse_like"
         elif "converse/" in model:
             return "converse"
+        elif "agent/" in model:
+            return "agent"
         elif (
             base_model in litellm.bedrock_converse_models
             or alt_model in litellm.bedrock_converse_models

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -271,7 +271,6 @@ class BaseLLMHTTPHandler:
     ):
         json_mode: bool = optional_params.pop("json_mode", False)
         extra_body: Optional[dict] = optional_params.pop("extra_body", None)
-        fake_stream = fake_stream or optional_params.pop("fake_stream", False)
 
         provider_config = (
             provider_config
@@ -283,6 +282,14 @@ class BaseLLMHTTPHandler:
             raise ValueError(
                 f"Provider config not found for model: {model} and provider: {custom_llm_provider}"
             )
+
+        fake_stream = (
+            fake_stream
+            or optional_params.pop("fake_stream", False)
+            or provider_config.should_fake_stream(
+                model=model, custom_llm_provider=custom_llm_provider, stream=stream
+            )
+        )
 
         # get config from model, custom llm provider
         headers = provider_config.validate_environment(

--- a/litellm/types/llms/bedrock_invoke_agents.py
+++ b/litellm/types/llms/bedrock_invoke_agents.py
@@ -15,11 +15,12 @@ class InvokeAgentEventHeaders(TypedDict, total=False):
     message_type: str  # 'event', etc.
 
 
-class InvokeAgentUsage(TypedDict, total=False):
+class InvokeAgentUsage(TypedDict):
     """Token usage information from trace events."""
 
     inputTokens: int
     outputTokens: int
+    model: Optional[str]
 
 
 class InvokeAgentMetadata(TypedDict, total=False):

--- a/litellm/types/llms/bedrock_invoke_agents.py
+++ b/litellm/types/llms/bedrock_invoke_agents.py
@@ -1,0 +1,118 @@
+"""
+Type definitions for AWS Bedrock Invoke Agent API responses.
+
+https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html
+"""
+
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+
+class InvokeAgentEventHeaders(TypedDict, total=False):
+    """Headers for AWS Invoke Agent events."""
+
+    event_type: str  # 'trace', 'chunk', etc.
+    content_type: str  # 'application/json', etc.
+    message_type: str  # 'event', etc.
+
+
+class InvokeAgentUsage(TypedDict, total=False):
+    """Token usage information from trace events."""
+
+    inputTokens: int
+    outputTokens: int
+
+
+class InvokeAgentMetadata(TypedDict, total=False):
+    """Metadata from model invocation."""
+
+    clientRequestId: Optional[str]
+    endTime: Optional[str]
+    startTime: Optional[str]
+    totalTimeMs: Optional[int]
+    usage: Optional[InvokeAgentUsage]
+
+
+class InvokeAgentModelInvocationInput(TypedDict, total=False):
+    """Model invocation input details."""
+
+    foundationModel: Optional[str]
+    inferenceConfiguration: Optional[Dict[str, Any]]
+    text: Optional[str]
+    traceId: Optional[str]
+    type: Optional[str]
+
+
+class InvokeAgentModelInvocationOutput(TypedDict, total=False):
+    """Model invocation output details."""
+
+    metadata: Optional[InvokeAgentMetadata]
+    parsedResponse: Optional[Dict[str, Any]]
+    rawResponse: Optional[Dict[str, Any]]
+    reasoningContent: Optional[Dict[str, Any]]
+    traceId: Optional[str]
+
+
+class InvokeAgentPreProcessingTrace(TypedDict, total=False):
+    """Pre-processing trace information."""
+
+    modelInvocationInput: Optional[InvokeAgentModelInvocationInput]
+    modelInvocationOutput: Optional[InvokeAgentModelInvocationOutput]
+
+
+class InvokeAgentTrace(TypedDict, total=False):
+    """Trace information container."""
+
+    preProcessingTrace: Optional[InvokeAgentPreProcessingTrace]
+
+
+class InvokeAgentCallerChain(TypedDict, total=False):
+    """Caller chain information."""
+
+    agentAliasArn: str
+
+
+class InvokeAgentTracePayload(TypedDict, total=False):
+    """Payload for trace events."""
+
+    agentAliasId: str
+    agentId: str
+    agentVersion: str
+    callerChain: List[InvokeAgentCallerChain]
+    eventTime: str
+    sessionId: str
+    trace: InvokeAgentTrace
+
+
+class InvokeAgentChunkPayload(TypedDict, total=False):
+    """Payload for chunk events containing response content."""
+
+    bytes: str  # Base64 encoded response content
+
+
+class InvokeAgentEventPayload(TypedDict, total=False):
+    """Union type for different event payload types."""
+
+    # Trace event fields
+    agentAliasId: Optional[str]
+    agentId: Optional[str]
+    agentVersion: Optional[str]
+    callerChain: Optional[List[InvokeAgentCallerChain]]
+    eventTime: Optional[str]
+    sessionId: Optional[str]
+    trace: Optional[InvokeAgentTrace]
+
+    # Chunk event fields
+    bytes: Optional[str]
+
+
+class InvokeAgentEvent(TypedDict, total=False):
+    """Complete event structure for AWS Invoke Agent responses."""
+
+    headers: InvokeAgentEventHeaders
+    payload: Optional[InvokeAgentEventPayload]
+
+
+# Type aliases for convenience
+InvokeAgentEventList = List[InvokeAgentEvent]
+InvokeAgentTraceEvent = InvokeAgentEvent  # When headers.event_type == 'trace'
+InvokeAgentChunkEvent = InvokeAgentEvent  # When headers.event_type == 'chunk'

--- a/litellm/types/llms/bedrock_invoke_agents.py
+++ b/litellm/types/llms/bedrock_invoke_agents.py
@@ -53,6 +53,13 @@ class InvokeAgentModelInvocationOutput(TypedDict, total=False):
     traceId: Optional[str]
 
 
+class InvokeAgentOrchestrationTrace(TypedDict, total=False):
+    """Orchestration trace information."""
+
+    modelInvocationInput: Optional[InvokeAgentModelInvocationInput]
+    modelInvocationOutput: Optional[InvokeAgentModelInvocationOutput]
+
+
 class InvokeAgentPreProcessingTrace(TypedDict, total=False):
     """Pre-processing trace information."""
 
@@ -63,6 +70,7 @@ class InvokeAgentPreProcessingTrace(TypedDict, total=False):
 class InvokeAgentTrace(TypedDict, total=False):
     """Trace information container."""
 
+    orchestrationTrace: Optional[InvokeAgentOrchestrationTrace]
     preProcessingTrace: Optional[InvokeAgentPreProcessingTrace]
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6515,6 +6515,12 @@ class ProviderConfigManager:
 
             if bedrock_route == "converse" or bedrock_route == "converse_like":
                 return litellm.AmazonConverseConfig()
+            elif bedrock_route == "agent":
+                from litellm.llms.bedrock.chat.invoke_agent.transformation import (
+                    AmazonInvokeAgentConfig,
+                )
+
+                return AmazonInvokeAgentConfig()
             elif bedrock_invoke_provider == "amazon":  # amazon titan llms
                 return litellm.AmazonTitanConfig()
             elif bedrock_invoke_provider == "anthropic":

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import traceback
+
+from dotenv import load_dotenv
+
+import litellm.types
+
+load_dotenv()
+import io
+import os
+import json
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+async def test_bedrock_agents():
+    response = litellm.completion(
+            model="bedrock/agents/<>",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "What is the capital of France?"
+                }
+            ],
+        )
+    pass

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -20,7 +20,7 @@ import pytest
 
 async def test_bedrock_agents():
     response = litellm.completion(
-            model="bedrock/agents/<>",
+            model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",
             messages=[
                 {
                     "role": "user",

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -18,7 +18,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+@pytest.mark.asyncio
 async def test_bedrock_agents():
+    litellm._turn_on_debug()
     response = litellm.completion(
             model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",
             messages=[

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -39,3 +39,22 @@ async def test_bedrock_agents():
     assert len(response.choices[0].message.content) > 0
 
     pass
+
+@pytest.mark.asyncio
+async def test_bedrock_agents_with_streaming():
+    # litellm._turn_on_debug()
+    response = litellm.completion(
+        model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",
+        messages=[
+            {
+                "role": "user",
+                "content": "Hi who is ishaan cto of litellm, tell me 10 things about him"
+            }
+        ],
+        stream=True,
+    )
+
+    for chunk in response:
+        print("final chunk=", chunk)
+
+    pass

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -38,6 +38,10 @@ async def test_bedrock_agents():
     # assert that the message content has a response with some length
     assert len(response.choices[0].message.content) > 0
 
+
+    # assert we were able to get the response cost
+    assert response._hidden_params["response_cost"] is not None and response._hidden_params["response_cost"] > 0
+
     pass
 
 @pytest.mark.asyncio

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -26,8 +26,16 @@ async def test_bedrock_agents():
             messages=[
                 {
                     "role": "user",
-                    "content": "What is the capital of France?"
+                    "content": "Hi just respond with a ping message"
                 }
             ],
         )
+
+    #########################################################
+    #########################################################
+    print("response from agent=", response.model_dump_json(indent=4))
+
+    # assert that the message content has a response with some length
+    assert len(response.choices[0].message.content) > 0
+
     pass

--- a/tests/test_litellm/llms/bedrock/invoke_agent/test_bedrock_agent_transformation.py
+++ b/tests/test_litellm/llms/bedrock/invoke_agent/test_bedrock_agent_transformation.py
@@ -1,0 +1,272 @@
+import base64
+import json
+import os
+import sys
+import uuid
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.bedrock.chat.invoke_agent.transformation import (
+    AmazonInvokeAgentConfig,
+)
+from litellm.types.llms.bedrock_invoke_agents import (
+    InvokeAgentEvent,
+    InvokeAgentEventHeaders,
+    InvokeAgentUsage,
+)
+from litellm.types.utils import Message, ModelResponse, Usage
+
+
+class TestAmazonInvokeAgentConfig:
+    """Test suite for AmazonInvokeAgentConfig methods"""
+
+    @pytest.fixture
+    def config(self):
+        """Create a test instance of AmazonInvokeAgentConfig"""
+        return AmazonInvokeAgentConfig()
+
+    @pytest.fixture
+    def sample_messages(self):
+        """Sample messages for testing"""
+        return [
+            {"role": "user", "content": "Hello, how can you help me?"},
+            {"role": "assistant", "content": "I can help with various tasks."},
+            {"role": "user", "content": "What is the weather like?"},
+        ]
+
+    @pytest.fixture
+    def sample_events(self):
+        """Sample events for testing event parsing"""
+        return [
+            {
+                "headers": {"event_type": "chunk"},
+                "payload": {
+                    "bytes": base64.b64encode("Hello ".encode("utf-8")).decode("utf-8")
+                },
+            },
+            {
+                "headers": {"event_type": "chunk"},
+                "payload": {
+                    "bytes": base64.b64encode("world!".encode("utf-8")).decode("utf-8")
+                },
+            },
+            {
+                "headers": {"event_type": "trace"},
+                "payload": {
+                    "trace": {
+                        "preProcessingTrace": {
+                            "modelInvocationOutput": {
+                                "metadata": {
+                                    "usage": {"inputTokens": 10, "outputTokens": 20}
+                                }
+                            }
+                        },
+                        "orchestrationTrace": {
+                            "modelInvocationInput": {
+                                "foundationModel": "anthropic.claude-v2"
+                            }
+                        },
+                    }
+                },
+            },
+        ]
+
+    def test_get_agent_id_and_alias_id_valid(self, config):
+        """Test parsing valid agent model string"""
+        model = "agent/L1RT58GYRW/MFPSBCXYTW"
+        agent_id, agent_alias_id = config._get_agent_id_and_alias_id(model)
+
+        assert agent_id == "L1RT58GYRW"
+        assert agent_alias_id == "MFPSBCXYTW"
+
+    def test_get_agent_id_and_alias_id_invalid_format(self, config):
+        """Test parsing invalid agent model string"""
+        invalid_models = [
+            "invalid/L1RT58GYRW/MFPSBCXYTW",  # Wrong prefix
+            "agent/L1RT58GYRW",  # Missing alias
+            "agent/L1RT58GYRW/MFPSBCXYTW/extra",  # Too many parts
+            "L1RT58GYRW/MFPSBCXYTW",  # Missing prefix
+        ]
+
+        for invalid_model in invalid_models:
+            with pytest.raises(ValueError, match="Invalid model format"):
+                config._get_agent_id_and_alias_id(invalid_model)
+
+    @patch(
+        "litellm.llms.bedrock.chat.invoke_agent.transformation.convert_content_list_to_str"
+    )
+    def test_transform_request(self, mock_convert, config, sample_messages):
+        """Test transform_request method"""
+        mock_convert.return_value = "What is the weather like?"
+
+        model = "agent/TEST123/ALIAS456"
+        optional_params = {}
+        litellm_params = {}
+        headers = {}
+
+        result = config.transform_request(
+            model, sample_messages, optional_params, litellm_params, headers
+        )
+
+        expected = {
+            "inputText": "What is the weather like?",
+            "enableTrace": True,
+        }
+        assert result == expected
+        mock_convert.assert_called_once_with(sample_messages[-1])
+
+    def test_extract_response_content(self, config, sample_events):
+        """Test _extract_response_content method"""
+        result = config._extract_response_content(sample_events)
+        assert result == "Hello world!"
+
+    def test_extract_response_content_empty_events(self, config):
+        """Test _extract_response_content with empty events"""
+        result = config._extract_response_content([])
+        assert result == ""
+
+    def test_extract_response_content_no_chunk_events(self, config):
+        """Test _extract_response_content with no chunk events"""
+        events = [{"headers": {"event_type": "trace"}, "payload": {"some": "data"}}]
+        result = config._extract_response_content(events)
+        assert result == ""
+
+    def test_is_trace_event(self, config):
+        """Test _is_trace_event method"""
+        trace_event = {"headers": {"event_type": "trace"}, "payload": {"some": "data"}}
+        chunk_event = {"headers": {"event_type": "chunk"}, "payload": {"bytes": "data"}}
+        invalid_event = {"headers": {"event_type": "trace"}, "payload": None}
+
+        assert config._is_trace_event(trace_event) is True
+        assert config._is_trace_event(chunk_event) is False
+        assert config._is_trace_event(invalid_event) is False
+
+    def test_get_trace_data(self, config):
+        """Test _get_trace_data method"""
+        event = {"payload": {"trace": {"preProcessingTrace": {"some": "data"}}}}
+        result = config._get_trace_data(event)
+        assert result == {"preProcessingTrace": {"some": "data"}}
+
+    def test_get_trace_data_no_payload(self, config):
+        """Test _get_trace_data with no payload"""
+        event = {"payload": None}
+        result = config._get_trace_data(event)
+        assert result is None
+
+    def test_extract_usage_info(self, config, sample_events):
+        """Test _extract_usage_info method"""
+        result = config._extract_usage_info(sample_events)
+
+        assert result["inputTokens"] == 10
+        assert result["outputTokens"] == 20
+        assert result["model"] == "anthropic.claude-v2"
+
+    def test_extract_usage_info_empty_events(self, config):
+        """Test _extract_usage_info with empty events"""
+        result = config._extract_usage_info([])
+
+        assert result["inputTokens"] == 0
+        assert result["outputTokens"] == 0
+        assert result["model"] is None
+
+    def test_extract_and_update_preprocessing_usage(self, config):
+        """Test _extract_and_update_preprocessing_usage method"""
+        trace_data = {
+            "preProcessingTrace": {
+                "modelInvocationOutput": {
+                    "metadata": {"usage": {"inputTokens": 15, "outputTokens": 25}}
+                }
+            }
+        }
+        usage_info = {"inputTokens": 5, "outputTokens": 10, "model": None}
+
+        config._extract_and_update_preprocessing_usage(trace_data, usage_info)
+
+        assert usage_info["inputTokens"] == 20  # 5 + 15
+        assert usage_info["outputTokens"] == 35  # 10 + 25
+
+    def test_extract_and_update_preprocessing_usage_no_data(self, config):
+        """Test _extract_and_update_preprocessing_usage with missing data"""
+        trace_data = {}
+        usage_info = {"inputTokens": 5, "outputTokens": 10, "model": None}
+
+        config._extract_and_update_preprocessing_usage(trace_data, usage_info)
+
+        # Should remain unchanged
+        assert usage_info["inputTokens"] == 5
+        assert usage_info["outputTokens"] == 10
+
+    def test_extract_orchestration_model(self, config):
+        """Test _extract_orchestration_model method"""
+        trace_data = {
+            "orchestrationTrace": {
+                "modelInvocationInput": {"foundationModel": "anthropic.claude-v2"}
+            }
+        }
+        result = config._extract_orchestration_model(trace_data)
+        assert result == "anthropic.claude-v2"
+
+    def test_extract_orchestration_model_no_data(self, config):
+        """Test _extract_orchestration_model with missing data"""
+        trace_data = {}
+        result = config._extract_orchestration_model(trace_data)
+        assert result is None
+
+    def test_build_model_response(self, config):
+        """Test _build_model_response method"""
+        content = "Hello, world!"
+        model = "agent/TEST123/ALIAS456"
+        usage_info = {
+            "inputTokens": 10,
+            "outputTokens": 20,
+            "model": "anthropic.claude-v2",
+        }
+        model_response = ModelResponse()
+
+        result = config._build_model_response(
+            content, model, usage_info, model_response
+        )
+
+        assert len(result.choices) == 1
+        assert result.choices[0].message.content == content
+        assert result.choices[0].message.role == "assistant"
+        assert result.choices[0].finish_reason == "stop"
+        assert result.model == "anthropic.claude-v2"
+        assert hasattr(result, "usage")
+        assert result.usage.prompt_tokens == 10
+        assert result.usage.completion_tokens == 20
+        assert result.usage.total_tokens == 30
+
+    @patch(
+        "litellm.llms.bedrock.chat.invoke_agent.transformation.convert_content_list_to_str"
+    )
+    @patch.object(AmazonInvokeAgentConfig, "get_runtime_endpoint")
+    @patch.object(AmazonInvokeAgentConfig, "_get_aws_region_name")
+    def test_get_complete_url(self, mock_region, mock_endpoint, mock_convert, config):
+        """Test get_complete_url method"""
+        mock_endpoint.return_value = (
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            None,
+        )
+        mock_region.return_value = "us-east-1"
+
+        api_base = None
+        api_key = None
+        model = "agent/L1RT58GYRW/MFPSBCXYTW"
+        optional_params = {}
+        litellm_params = {}
+
+        result = config.get_complete_url(
+            api_base, api_key, model, optional_params, litellm_params
+        )
+
+        assert (
+            "https://bedrock-runtime.us-east-1.amazonaws.com/agents/L1RT58GYRW/agentAliases/MFPSBCXYTW/sessions"
+            in result
+        )


### PR DESCRIPTION
## [Feat]: Add Bedrock InvokeAgents as a /chat/completions route on LiteLLM


Call Bedrock Agents in the OpenAI Request/Response format.


| Property | Details |
|----------|---------|
| Description | Amazon Bedrock Agents use the reasoning of foundation models (FMs), APIs, and data to break down user requests, gather relevant information, and efficiently complete tasks. |
| Provider Route on LiteLLM | `bedrock/agent/{AGENT_ID}/{ALIAS_ID}` |
| Provider Doc | [AWS Bedrock Agents ↗](https://aws.amazon.com/bedrock/agents/) |

## Quick Start

### Model Format to LiteLLM

To call a bedrock agent through LiteLLM, you need to use the following model format to call the agent.

Here the `model=bedrock/agent/` tells LiteLLM to call the bedrock `InvokeAgent` API.

```shell showLineNumbers title="Model Format to LiteLLM"
bedrock/agent/{AGENT_ID}/{ALIAS_ID}
```

**Example:**
- `bedrock/agent/L1RT58GYRW/MFPSBCXYTW`
- `bedrock/agent/ABCD1234/LIVE`

You can find these IDs in your AWS Bedrock console under Agents.


### LiteLLM Python SDK

```python showLineNumbers title="Basic Agent Completion"
import litellm

# Make a completion request to your Bedrock Agent
response = litellm.completion(
    model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",  # agent/{AGENT_ID}/{ALIAS_ID}
    messages=[
        {
            "role": "user", 
            "content": "Hi, I need help with analyzing our Q3 sales data and generating a summary report"
        }
    ],
)

print(response.choices[0].message.content)
print(f"Response cost: ${response._hidden_params['response_cost']}")
```

```python showLineNumbers title="Streaming Agent Responses"
import litellm

# Stream responses from your Bedrock Agent
response = litellm.completion(
    model="bedrock/agent/L1RT58GYRW/MFPSBCXYTW",
    messages=[
        {
            "role": "user",
            "content": "Can you help me plan a marketing campaign and provide step-by-step execution details?"
        }
    ],
    stream=True,
)

for chunk in response:
    if chunk.choices[0].delta.content:
        print(chunk.choices[0].delta.content, end="")
```


### LiteLLM Proxy

#### 1. Configure your model in config.yaml

<Tabs>
<TabItem value="config-yaml" label="config.yaml">

```yaml showLineNumbers title="LiteLLM Proxy Configuration"
model_list:
  - model_name: bedrock-agent-1
    litellm_params:
      model: bedrock/agent/L1RT58GYRW/MFPSBCXYTW
      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
      aws_region_name: us-west-2

  - model_name: bedrock-agent-2  
    litellm_params:
      model: bedrock/agent/AGENT456/ALIAS789
      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
      aws_region_name: us-east-1
```

</TabItem>
</Tabs>

#### 2. Start the LiteLLM Proxy

```bash showLineNumbers title="Start LiteLLM Proxy"
litellm --config config.yaml
```

#### 3. Make requests to your Bedrock Agents

<Tabs>
<TabItem value="curl" label="Curl">

```bash showLineNumbers title="Basic Agent Request"
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -d '{
    "model": "bedrock-agent-1",
    "messages": [
      {
        "role": "user", 
        "content": "Analyze our customer data and suggest retention strategies"
      }
    ]
  }'
```

```bash showLineNumbers title="Streaming Agent Request"
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -d '{
    "model": "bedrock-agent-2",
    "messages": [
      {
        "role": "user",
        "content": "Create a comprehensive social media strategy for our new product"
      }
    ],
    "stream": true
  }'
```

</TabItem>

<TabItem value="openai-sdk" label="OpenAI Python SDK">

```python showLineNumbers title="Using OpenAI SDK with LiteLLM Proxy"
from openai import OpenAI

# Initialize client with your LiteLLM proxy URL
client = OpenAI(
    base_url="http://localhost:4000",
    api_key="your-litellm-api-key"
)

# Make a completion request to your agent
response = client.chat.completions.create(
    model="bedrock-agent-1",
    messages=[
      {
        "role": "user",
        "content": "Help me prepare for the quarterly business review meeting"
      }
    ]
)

print(response.choices[0].message.content)
```

```python showLineNumbers title="Streaming with OpenAI SDK"
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:4000", 
    api_key="your-litellm-api-key"
)

# Stream agent responses
stream = client.chat.completions.create(
    model="bedrock-agent-2",
    messages=[
      {
        "role": "user",
        "content": "Walk me through launching a new feature beta program"
      }
    ],
    stream=True
)

for chunk in stream:
    if chunk.choices[0].delta.content is not None:
        print(chunk.choices[0].delta.content, end="")
```

</TabItem>
</Tabs>


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


