### PR TITLE
[Fix] Responses API - Session management 

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/session_handler.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/session_handler.py
@@ -124,7 +124,7 @@ class _ENTERPRISE_ResponsesSessionHandler:
         """
         from litellm.proxy.proxy_server import prisma_client
 
-        verbose_proxy_logger.debug("decoding response id=", previous_response_id)
+        verbose_proxy_logger.debug("decoding response id=%s", previous_response_id)
 
         decoded_response_id = (
             ResponsesAPIRequestUtils._decode_responses_api_response_id(

--- a/enterprise/litellm_enterprise/enterprise_callbacks/session_handler.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/session_handler.py
@@ -1,17 +1,19 @@
-from litellm.proxy._types import SpendLogsPayload
-from litellm._logging import verbose_proxy_logger
-from typing import Optional, List, Union
 import json
-from litellm.types.utils import ModelResponse, Message
+from typing import List, Optional, Union, cast
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import SpendLogsPayload
+from litellm.responses.litellm_completion_transformation.transformation import (
+    ChatCompletionSession,
+)
+from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionResponseMessage,
     GenericChatCompletionMessage,
     ResponseInputParam,
 )
-from litellm.types.utils import ChatCompletionMessageToolCall
-from litellm.responses.utils import ResponsesAPIRequestUtils
-from litellm.responses.litellm_completion_transformation.transformation import ChatCompletionSession
+from litellm.types.utils import ChatCompletionMessageToolCall, Message, ModelResponse
 
 
 class _ENTERPRISE_ResponsesSessionHandler:
@@ -22,9 +24,16 @@ class _ENTERPRISE_ResponsesSessionHandler:
         """
         Return the chat completion message history for a previous response id
         """
-        from litellm.responses.litellm_completion_transformation.transformation import LiteLLMCompletionResponsesConfig
-        all_spend_logs: List[SpendLogsPayload] = await _ENTERPRISE_ResponsesSessionHandler.get_all_spend_logs_for_previous_response_id(previous_response_id)
-        
+        from litellm.responses.litellm_completion_transformation.transformation import (
+            LiteLLMCompletionResponsesConfig,
+        )
+
+        all_spend_logs: List[
+            SpendLogsPayload
+        ] = await _ENTERPRISE_ResponsesSessionHandler.get_all_spend_logs_for_previous_response_id(
+            previous_response_id
+        )
+
         litellm_session_id: Optional[str] = None
         if len(all_spend_logs) > 0:
             litellm_session_id = all_spend_logs[0].get("session_id")
@@ -39,14 +48,16 @@ class _ENTERPRISE_ResponsesSessionHandler:
             ]
         ] = []
         for spend_log in all_spend_logs:
-            proxy_server_request: Union[str, dict] = spend_log.get("proxy_server_request") or "{}"
+            proxy_server_request: Union[str, dict] = (
+                spend_log.get("proxy_server_request") or "{}"
+            )
             proxy_server_request_dict: Optional[dict] = None
             response_input_param: Optional[Union[str, ResponseInputParam]] = None
             if isinstance(proxy_server_request, dict):
                 proxy_server_request_dict = proxy_server_request
             else:
                 proxy_server_request_dict = json.loads(proxy_server_request)
-            
+
             ############################################################
             # Add Input messages for this Spend Log
             ############################################################
@@ -55,15 +66,17 @@ class _ENTERPRISE_ResponsesSessionHandler:
                 if isinstance(_response_input_param, str):
                     response_input_param = _response_input_param
                 elif isinstance(_response_input_param, dict):
-                    response_input_param = ResponseInputParam(**_response_input_param)
-            
+                    response_input_param = cast(
+                        ResponseInputParam, _response_input_param
+                    )
+
             if response_input_param:
                 chat_completion_messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
                     input=response_input_param,
-                    responses_api_request=proxy_server_request_dict or {}
+                    responses_api_request=proxy_server_request_dict or {},
                 )
                 chat_completion_message_history.extend(chat_completion_messages)
-            
+
             ############################################################
             # Add Output messages for this Spend Log
             ############################################################
@@ -73,17 +86,22 @@ class _ENTERPRISE_ResponsesSessionHandler:
                 model_response = ModelResponse(**_response_output)
                 for choice in model_response.choices:
                     if hasattr(choice, "message"):
-                        chat_completion_message_history.append(choice.message)
-        
-        verbose_proxy_logger.debug("chat_completion_message_history %s", json.dumps(chat_completion_message_history, indent=4, default=str))
+                        chat_completion_message_history.append(
+                            getattr(choice, "message")
+                        )
+
+        verbose_proxy_logger.debug(
+            "chat_completion_message_history %s",
+            json.dumps(chat_completion_message_history, indent=4, default=str),
+        )
         return ChatCompletionSession(
             messages=chat_completion_message_history,
-            litellm_session_id=litellm_session_id
+            litellm_session_id=litellm_session_id,
         )
 
     @staticmethod
     async def get_all_spend_logs_for_previous_response_id(
-        previous_response_id: str
+        previous_response_id: str,
     ) -> List[SpendLogsPayload]:
         """
         Get all spend logs for a previous response id
@@ -94,8 +112,15 @@ class _ENTERPRISE_ResponsesSessionHandler:
         SELECT session_id FROM spend_logs WHERE response_id = previous_response_id, SELECT * FROM spend_logs WHERE session_id = session_id
         """
         from litellm.proxy.proxy_server import prisma_client
-        decoded_response_id = ResponsesAPIRequestUtils._decode_responses_api_response_id(previous_response_id)
-        previous_response_id = decoded_response_id.get("response_id", previous_response_id)
+
+        decoded_response_id = (
+            ResponsesAPIRequestUtils._decode_responses_api_response_id(
+                previous_response_id
+            )
+        )
+        previous_response_id = decoded_response_id.get(
+            "response_id", previous_response_id
+        )
         if prisma_client is None:
             return []
 
@@ -111,21 +136,12 @@ class _ENTERPRISE_ResponsesSessionHandler:
             ORDER BY "endTime" ASC;
         """
 
-        spend_logs = await prisma_client.db.query_raw(
-            query,
-            previous_response_id
-        )
+        spend_logs = await prisma_client.db.query_raw(query, previous_response_id)
 
         verbose_proxy_logger.debug(
             "Found the following spend logs for previous response id %s: %s",
             previous_response_id,
-            json.dumps(spend_logs, indent=4, default=str)
+            json.dumps(spend_logs, indent=4, default=str),
         )
 
-
         return spend_logs
-        
-
-    
-    
-    

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,4 +1,8 @@
 model_list:
-  - model_name: openai/*
+  - model_name: anthropic/*
     litellm_params:
-      model: openai/*
+      model: anthropic/*
+  
+
+general_settings:
+  store_prompts_in_spend_logs: true

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -7,16 +7,17 @@ from typing import Any, Dict, List, Optional, Union
 from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
 
-HAS_ENTERPRISE_DIRECTORY = False
+from litellm._logging import verbose_logger
+
 try:
-    from enterprise.enterprise_hooks.session_handler import (
+    from litellm_enterprise.enterprise_callbacks.session_handler import (
         _ENTERPRISE_ResponsesSessionHandler,
     )
-
-    HAS_ENTERPRISE_DIRECTORY = True
-except ImportError:
-    _ENTERPRISE_ResponsesSessionHandler = None  # type: ignore
-    HAS_ENTERPRISE_DIRECTORY = False
+except Exception as e:
+    verbose_logger.debug(
+        f"[Non-Blocking] Unable to import _ENTERPRISE_ResponsesSessionHandler - LiteLLM Enterprise Feature - {str(e)}"
+    )
+    _ENTERPRISE_ResponsesSessionHandler = None
 
 from litellm.caching import InMemoryCache
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -197,10 +198,7 @@ class LiteLLMCompletionResponsesConfig:
         """
         Async hook to get the chain of previous input and output pairs and return a list of Chat Completion messages
         """
-        if (
-            HAS_ENTERPRISE_DIRECTORY is True
-            and _ENTERPRISE_ResponsesSessionHandler is not None
-        ):
+        if _ENTERPRISE_ResponsesSessionHandler is not None:
             chat_completion_session = ChatCompletionSession(
                 messages=[], litellm_session_id=None
             )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -18,7 +18,6 @@ except Exception as e:
         f"[Non-Blocking] Unable to import _ENTERPRISE_ResponsesSessionHandler - LiteLLM Enterprise Feature - {str(e)}"
     )
     _ENTERPRISE_ResponsesSessionHandler = None
-
 from litellm.caching import InMemoryCache
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.types.llms.openai import (

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_session_handler.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_session_handler.py
@@ -1,0 +1,182 @@
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+
+from enterprise.litellm_enterprise.enterprise_callbacks.session_handler import (
+    _ENTERPRISE_ResponsesSessionHandler,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_chat_completion_message_history_for_previous_response_id():
+    """
+    Test get_chat_completion_message_history_for_previous_response_id with mock data
+    """
+    # Mock data based on the provided spend logs (simplified version)
+    mock_spend_logs = [
+        {
+            "request_id": "chatcmpl-935b8dad-fdc2-466e-a8ca-e26e5a8a21bb",
+            "call_type": "aresponses",
+            "api_key": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
+            "spend": 0.004803,
+            "total_tokens": 329,
+            "prompt_tokens": 11,
+            "completion_tokens": 318,
+            "startTime": "2025-05-30T03:17:06.703+00:00",
+            "endTime": "2025-05-30T03:17:11.894+00:00",
+            "model": "claude-3-5-sonnet-latest",
+            "session_id": "a96757c4-c6dc-4c76-b37e-e7dfa526b701",
+            "proxy_server_request": {
+                "input": "who is Michael Jordan",
+                "model": "anthropic/claude-3-5-sonnet-latest",
+            },
+            "response": {
+                "id": "chatcmpl-935b8dad-fdc2-466e-a8ca-e26e5a8a21bb",
+                "model": "claude-3-5-sonnet-20241022",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Michael Jordan (born February 17, 1963) is widely considered the greatest basketball player of all time. Here are some key points about him...",
+                            "tool_calls": None,
+                            "function_call": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "created": 1748575031,
+                "usage": {
+                    "total_tokens": 329,
+                    "prompt_tokens": 11,
+                    "completion_tokens": 318,
+                },
+            },
+            "status": "success",
+        },
+        {
+            "request_id": "chatcmpl-370760c9-39fa-4db7-b034-d1f8d933c935",
+            "call_type": "aresponses",
+            "api_key": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
+            "spend": 0.010437,
+            "total_tokens": 967,
+            "prompt_tokens": 339,
+            "completion_tokens": 628,
+            "startTime": "2025-05-30T03:17:28.600+00:00",
+            "endTime": "2025-05-30T03:17:39.921+00:00",
+            "model": "claude-3-5-sonnet-latest",
+            "session_id": "a96757c4-c6dc-4c76-b37e-e7dfa526b701",
+            "proxy_server_request": {
+                "input": "can you tell me more about him",
+                "model": "anthropic/claude-3-5-sonnet-latest",
+                "previous_response_id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmFudGhyb3BpYzttb2RlbF9pZDplMGYzMDJhMTQxMmU3ODQ3MGViYjI4Y2JlZDAxZmZmNWY4OGMwZDMzMWM2NjdlOWYyYmE0YjQxM2M2ZmJkMjgyO3Jlc3BvbnNlX2lkOmNoYXRjbXBsLTkzNWI4ZGFkLWZkYzItNDY2ZS1hOGNhLWUyNmU1YThhMjFiYg==",
+            },
+            "response": {
+                "id": "chatcmpl-370760c9-39fa-4db7-b034-d1f8d933c935",
+                "model": "claude-3-5-sonnet-20241022",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here's more detailed information about Michael Jordan...",
+                            "tool_calls": None,
+                            "function_call": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "created": 1748575059,
+                "usage": {
+                    "total_tokens": 967,
+                    "prompt_tokens": 339,
+                    "completion_tokens": 628,
+                },
+            },
+            "status": "success",
+        },
+    ]
+
+    # Mock the get_all_spend_logs_for_previous_response_id method
+    with patch.object(
+        _ENTERPRISE_ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+
+        # Test the function
+        previous_response_id = "chatcmpl-935b8dad-fdc2-466e-a8ca-e26e5a8a21bb"
+        result = await _ENTERPRISE_ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            previous_response_id
+        )
+
+        # Verify the mock was called with correct parameters
+        mock_get_spend_logs.assert_called_once_with(previous_response_id)
+
+        # Verify the returned ChatCompletionSession structure
+        assert "messages" in result
+        assert "litellm_session_id" in result
+
+        # Verify session_id is extracted correctly
+        assert result["litellm_session_id"] == "a96757c4-c6dc-4c76-b37e-e7dfa526b701"
+
+        # Verify messages structure
+        messages = result["messages"]
+        assert len(messages) == 4  # 2 user messages + 2 assistant messages
+
+        # Check the message sequence
+        # First user message
+        assert messages[0].get("role") == "user"
+        assert messages[0].get("content") == "who is Michael Jordan"
+
+        # First assistant response
+        assert messages[1].get("role") == "assistant"
+        content_1 = messages[1].get("content", "")
+        if isinstance(content_1, str):
+            assert "Michael Jordan" in content_1
+            assert content_1.startswith("Michael Jordan (born February 17, 1963)")
+
+        # Second user message
+        assert messages[2].get("role") == "user"
+        assert messages[2].get("content") == "can you tell me more about him"
+
+        # Second assistant response
+        assert messages[3].get("role") == "assistant"
+        content_3 = messages[3].get("content", "")
+        if isinstance(content_3, str):
+            assert "Here's more detailed information about Michael Jordan" in content_3
+
+
+@pytest.mark.asyncio
+async def test_get_chat_completion_message_history_empty_spend_logs():
+    """
+    Test get_chat_completion_message_history_for_previous_response_id with empty spend logs
+    """
+    with patch.object(
+        _ENTERPRISE_ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = []
+
+        previous_response_id = "non-existent-id"
+        result = await _ENTERPRISE_ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            previous_response_id
+        )
+
+        # Verify empty result structure
+        assert result.get("messages") == []
+        assert result.get("litellm_session_id") is None


### PR DESCRIPTION
## [Fix] Responses API - Session management 

This PR fixes an import error affecting session management in the Responses API by relocating logic and updating exception handling and logging. This was not working because of an import error. 

Updated import paths and exception handling in transformation.py.

Fixes https://github.com/BerriAI/litellm/issues/11204

https://www.loom.com/share/06d86a32ab394230a6b31926eb74f11f?sid=0b2b0534-09f5-4633-b494-d6b7bed84c6c

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


