### PR TITLE
fix(secret-managers): Break AzureCredentialType restriction on AZURE_CREDENTIAL

### DIFF
--- a/litellm/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/secret_managers/get_azure_ad_token_provider.py
@@ -34,9 +34,7 @@ def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[
     if azure_scope is None:
         azure_scope = os.environ.get("AZURE_SCOPE", "https://cognitiveservices.azure.com/.default")
 
-    cred: Union[AzureCredentialType, str] = AzureCredentialType(
-        os.environ.get("AZURE_CREDENTIAL", AzureCredentialType.ClientSecretCredential)
-    )
+    cred: str = os.environ.get("AZURE_CREDENTIAL", AzureCredentialType.ClientSecretCredential)
     credential: Optional[
         Union[
             ClientSecretCredential,

--- a/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
+++ b/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
@@ -136,3 +136,37 @@ class TestGetAzureAdTokenProvider:
         # Test that the returned callable works
         token = result()
         assert token == "mock-certificate-token"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_CREDENTIAL": "DefaultAzureCredential",
+        },
+    )
+    @patch("azure.identity.get_bearer_token_provider")
+    @patch("azure.identity.DefaultAzureCredential")
+    def test_get_azure_ad_token_provider_default_azure_credential(
+        self, mock_certificate_credential, mock_get_bearer_token_provider
+    ):
+        """Test get_azure_ad_token_provider with DefaultAzureCredential."""
+        # Mock the Azure identity credential instance
+        mock_credential_instance = MagicMock()
+        mock_certificate_credential.return_value = mock_credential_instance
+
+        # Mock the bearer token provider
+        mock_token_provider = MagicMock(return_value="mock-certificate-token")
+        mock_get_bearer_token_provider.return_value = mock_token_provider
+
+        # Call the function
+        result = get_azure_ad_token_provider()
+
+        # Assertions
+        assert callable(result)
+        mock_certificate_credential.assert_called_once_with()
+        mock_get_bearer_token_provider.assert_called_once_with(
+            mock_credential_instance, "https://cognitiveservices.azure.com/.default"
+        )
+
+        # Test that the returned callable works
+        token = result()
+        assert token == "mock-certificate-token"


### PR DESCRIPTION
## Title

Break `AzureCredentialType` restriction on `AZURE_CREDENTIAL`.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/11271

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

![image](https://github.com/user-attachments/assets/ede70d20-0a61-46e1-95c1-ce9c7cf6b16e)

