### PR TITLE
Streamline session expiration in UI

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -62,13 +62,8 @@ export interface CredentialsResponse {
   credentials: CredentialItem[];
 }
 
-
-const baseUrl = "/"; // Assuming the base URL is the root
-
-
 let lastErrorTime = 0;
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const handleError = async (errorData: string) => {
   const currentTime = Date.now();
@@ -76,9 +71,8 @@ const handleError = async (errorData: string) => {
     if (errorData.includes("Authentication Error - Expired Key")) {
       message.info("UI Session Expired. Logging out.");
       lastErrorTime = currentTime;
-      await sleep(3000); // 5 second sleep
       document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-      window.location.href = baseUrl;
+      window.location.href = window.location.pathname;
     }
     lastErrorTime = currentTime;
   } else {


### PR DESCRIPTION
## Title

Streamline session expiration in UI

This was driving me insane to the point that I came to the repo just to fix it :)

## Type

Refactoring

## Changes

This PR cleans up the session expiration in the UI. Currently it redirects you to `/` even though by default the UI runs on `/ui`. It also currently sleeps for 3 seconds for no real reason, so I removed that. It just redirects immediately.
