### PR TITLE
Wrong parameter mapping for "frequency_penalty" to "repeat_penalty" 

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -173,7 +173,7 @@ class OllamaConfig(BaseConfig):
             if param == "top_p":
                 optional_params["top_p"] = value
             if param == "frequency_penalty":
-                optional_params["repeat_penalty"] = value
+                optional_params["frequency_penalty"] = value
             if param == "stop":
                 optional_params["stop"] = value
             if param == "response_format" and isinstance(value, dict):


### PR DESCRIPTION

## Title

Wrong parameter mapping for "frequency_penalty" to "repeat_penalty" 

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/11269

## Pre-Submission checklist


- [ ] module testing N/A
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
Changes wrong paramter mapping from "repeat_penalty" to "frequency_penalty" in Ollama/completion/transformation.py

**Response:**
```json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "logprobs": null,
      "text": "n):\n   "
    }
  ],
  "created": 1748663995,
  "id": "chatcmpl-33b85fea-5cb4-444b-9805-43b2c82bcd62",
  "model": "ollama/qwen2.5-coder:1.5b",
  "object": "text_completion",
  "usage": {
    "completion_tokens": 3,
    "completion_tokens_details": null,
    "prompt_tokens": 6,
    "prompt_tokens_details": null,
    "total_tokens": 9
  }
} 
````
## Screenshot of output
![Screenshot 2025-05-31 133716](https://github.com/user-attachments/assets/4a2486af-808d-49a5-a9d6-4bbb186d9e61)


