### PR TITLE
fix: remove dupe server_id MCP config servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -72,8 +72,9 @@ class MCPServerManager:
             mcp_info = MCPInfo(**_mcp_info)
             mcp_info["server_name"] = server_name
             mcp_info["description"] = server_config.get("description", None)
+            server_id = str(uuid.uuid4())
             new_server = MCPServer(
-                server_id=str(uuid.uuid4()),
+                server_id=server_id,
                 name=server_name,
                 url=server_config["url"],
                 # TODO: utility fn the default values
@@ -82,7 +83,6 @@ class MCPServerManager:
                 auth_type=server_config.get("auth_type", None),
                 mcp_info=mcp_info,
             )
-            server_id = str(uuid.uuid4())
             self.config_mcp_servers[server_id] = new_server
         verbose_logger.debug(
             f"Loaded MCP Servers: {json.dumps(self.config_mcp_servers, indent=4, default=str)}"


### PR DESCRIPTION
## Title

Removes the dupe server id to fix UI and MCP servers from config file

## Relevant issues

Issue from [discussion](https://github.com/BerriAI/litellm/discussions/11253)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


