### PR TITLE
Add presidio_language yaml configuration support for guardrails

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -69,6 +69,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         presidio_ad_hoc_recognizers: Optional[str] = None,
         logging_only: Optional[bool] = None,
         pii_entities_config: Optional[Dict[PiiEntityType, PiiAction]] = None,
+        presidio_language: Optional[str] = None,
         **kwargs,
     ):
         if logging_only is True:
@@ -83,6 +84,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         self.pii_entities_config: Dict[PiiEntityType, PiiAction] = (
             pii_entities_config or {}
         )
+        self.presidio_language = presidio_language or "en"
         if mock_testing is True:  # for testing purposes only
             return
 
@@ -161,7 +163,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         """
         analyze_payload: PresidioAnalyzeRequest = PresidioAnalyzeRequest(
             text=text,
-            language="en",
+            language=self.presidio_language,
         )
         ##################################################################
         ###### Check if user has configured any params for this guardrail

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -113,6 +113,7 @@ def initialize_presidio(litellm_params: LitellmParams, guardrail: Guardrail):
         pii_entities_config=litellm_params.pii_entities_config,
         presidio_analyzer_api_base=litellm_params.presidio_analyzer_api_base,
         presidio_anonymizer_api_base=litellm_params.presidio_anonymizer_api_base,
+        presidio_language=litellm_params.presidio_language,
     )
     litellm.logging_callback_manager.add_litellm_callback(_presidio_callback)
 
@@ -125,6 +126,7 @@ def initialize_presidio(litellm_params: LitellmParams, guardrail: Guardrail):
             default_on=litellm_params.default_on,
             presidio_analyzer_api_base=litellm_params.presidio_analyzer_api_base,
             presidio_anonymizer_api_base=litellm_params.presidio_anonymizer_api_base,
+            presidio_language=litellm_params.presidio_language,
         )
         litellm.logging_callback_manager.add_litellm_callback(_success_callback)
 

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -234,6 +234,10 @@ class PresidioPresidioConfigModelUserInterface(BaseModel):
         # extra param to let the ui know this is a boolean
         json_schema_extra={"ui_type": GuardrailParamUITypes.BOOL},
     )
+    presidio_language: Optional[str] = Field(
+        default="en",
+        description="Language code for Presidio PII analysis (e.g., 'en', 'de', 'es', 'fr')",
+    )
 
 
 class PresidioConfigModel(PresidioPresidioConfigModelUserInterface):


### PR DESCRIPTION
## Title

Add presidio_language yaml configuration support for guardrails

## Relevant issues

Fixes #11026

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Summary
Added support for configuring Presidio language in guardrail YAML configurations. This allows users from non-English speaking countries (e.g., Germany, Spain) to configure Presidio PII detection to use their native language instead of being limited to English only.

### Problem Solved
Issue #11026: Users from Germany and other non-English speaking countries needed the ability to implement DLP based on Presidio with their native language instead of being hardcoded to English verification only.

### What's Changed

**New Configuration Parameter:**
- Added `presidio_language` field to `PresidioPresidioConfigModelUserInterface` and `PresidioConfigModel` classes
- Defaults to `"en"` for full backward compatibility
- Supports standard language codes for languages supported by Microsoft Presidio

**Core Implementation:**
- Modified `_OPTIONAL_PresidioPIIMasking.__init__()` to accept `presidio_language` parameter
- Updated `_get_presidio_analyze_request_payload()` to use configured language instead of hardcoded "en"
- Updated `initialize_presidio()` function to pass language parameter from YAML configuration
- Preserved existing per-request language override functionality (takes precedence over configured default)

**Testing Coverage:**
- Added `test_presidio_language_configuration()` - Tests language configuration with German, Spanish, and default English
- Added `test_presidio_language_configuration_with_per_request_override()` - Tests per-request language override functionality
- Verified existing `test_initialize_presidio_guardrail` continues to pass

### Usage Example

```yaml
guardrails:
  - guardrail_name: "presidio-pre-guard"
    litellm_params:
      guardrail: presidio
      mode: "pre_call"
      output_parse_pii: True
      default_on: true
      presidio_language: "de"  # German language for PII detection
      presidio_analyzer_api_base: "https://your-presidio-analyzer-endpoint.com/"
      presidio_anonymizer_api_base: "https://your-presidio-anonymizer-endpoint.com/"
      pii_entities_config:
        PHONE_NUMBER: "MASK"
        EMAIL_ADDRESS: "MASK"
        PERSON: "MASK"
```

### Supported Language Codes
- `"en"` - English (default)
- `"de"` - German  
- `"es"` - Spanish
- Other languages as supported by Microsoft Presidio

### Backward Compatibility
- ✅ **Fully backward compatible** - existing configurations without `presidio_language` continue to work
- ✅ **Default behavior preserved** - English remains the default when not specified
- ✅ **Per-request override maintained** - runtime language switching still works and takes precedence

### Files Modified
- `litellm/types/guardrails.py` - Added `presidio_language` configuration field
- `litellm/proxy/guardrails/guardrail_hooks/presidio.py` - Updated to accept and use language parameter  
- `litellm/proxy/guardrails/guardrail_initializers.py` - Updated to pass language parameter from config
- `tests/guardrails_tests/test_presidio_pii.py` - Added comprehensive test coverage

### Test Results
<img width="862" alt="Screenshot 2025-06-02 at 12 33 38 PM" src="https://github.com/user-attachments/assets/c67bafab-97c4-4f2b-a06f-268cdf22b321" />


### Impact
This change directly addresses the specific need expressed in issue #11026, enabling German users and other non-English speaking users to configure Presidio language via yaml config. The implementation maintains full backward compatibility while adding the requested functionality for the confirmed supported languages.
