### PR TITLE
Fix transcription model name mapping

### DIFF
--- a/litellm/llms/azure/audio_transcriptions.py
+++ b/litellm/llms/azure/audio_transcriptions.py
@@ -94,7 +94,7 @@ class AzureAudioTranscription(AzureChatCompletion):
             additional_args={"complete_input_dict": data},
             original_response=stringified_response,
         )
-        hidden_params = {"model": "whisper-1", "custom_llm_provider": "azure"}
+        hidden_params = {"model": model, "custom_llm_provider": "azure"}
         final_response: TranscriptionResponse = convert_to_model_response_object(response_object=stringified_response, model_response_object=model_response, hidden_params=hidden_params, response_type="audio_transcription")  # type: ignore
         return final_response
 
@@ -174,7 +174,7 @@ class AzureAudioTranscription(AzureChatCompletion):
                 },
                 original_response=stringified_response,
             )
-            hidden_params = {"model": "whisper-1", "custom_llm_provider": "azure"}
+            hidden_params = {"model": model, "custom_llm_provider": "azure"}
             response = convert_to_model_response_object(
                 _response_headers=headers,
                 response_object=stringified_response,

--- a/litellm/llms/openai/transcriptions/handler.py
+++ b/litellm/llms/openai/transcriptions/handler.py
@@ -155,7 +155,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
             additional_args={"complete_input_dict": data},
             original_response=stringified_response,
         )
-        hidden_params = {"model": "whisper-1", "custom_llm_provider": "openai"}
+        hidden_params = {"model": model, "custom_llm_provider": "openai"}
         final_response: TranscriptionResponse = convert_to_model_response_object(response_object=stringified_response, model_response_object=model_response, hidden_params=hidden_params, response_type="audio_transcription")  # type: ignore
         return final_response
 
@@ -210,7 +210,9 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
                 additional_args={"complete_input_dict": data},
                 original_response=stringified_response,
             )
-            hidden_params = {"model": "whisper-1", "custom_llm_provider": "openai"}
+            # Extract the actual model from data instead of hardcoding "whisper-1"
+            actual_model = data.get("model", "whisper-1")
+            hidden_params = {"model": actual_model, "custom_llm_provider": "openai"}
             return convert_to_model_response_object(response_object=stringified_response, model_response_object=model_response, hidden_params=hidden_params, response_type="audio_transcription")  # type: ignore
         except Exception as e:
             ## LOGGING

--- a/tests/local_testing/test_whisper.py
+++ b/tests/local_testing/test_whisper.py
@@ -164,3 +164,72 @@ async def test_gpt_4o_transcribe():
     await litellm.atranscription(
         model="openai/gpt-4o-transcribe", file=audio_file, response_format="json"
     )
+
+
+@pytest.mark.asyncio
+async def test_gpt_4o_transcribe_model_mapping():
+    """Test that GPT-4o transcription models are correctly mapped and not hardcoded to whisper-1"""
+    
+    # Test GPT-4o mini transcribe
+    response = await litellm.atranscription(
+        model="openai/gpt-4o-mini-transcribe", 
+        file=audio_file, 
+        response_format="json"
+    )
+    
+    # Check that the response contains the correct model in hidden params
+    assert response._hidden_params is not None
+    assert response._hidden_params["model"] == "gpt-4o-mini-transcribe"
+    assert response._hidden_params["custom_llm_provider"] == "openai"
+    assert response.text is not None
+    
+    # Test GPT-4o transcribe
+    response2 = await litellm.atranscription(
+        model="openai/gpt-4o-transcribe", 
+        file=audio_file, 
+        response_format="json"
+    )
+    
+    # Check that the response contains the correct model in hidden params
+    assert response2._hidden_params is not None
+    assert response2._hidden_params["model"] == "gpt-4o-transcribe"
+    assert response2._hidden_params["custom_llm_provider"] == "openai"
+    assert response2.text is not None
+    
+    # Test traditional whisper-1 still works
+    response3 = await litellm.atranscription(
+        model="openai/whisper-1", 
+        file=audio_file, 
+        response_format="json"
+    )
+    
+    # Check that the response contains the correct model in hidden params
+    assert response3._hidden_params is not None
+    assert response3._hidden_params["model"] == "whisper-1"
+    assert response3._hidden_params["custom_llm_provider"] == "openai"
+    assert response3.text is not None
+
+
+@pytest.mark.asyncio
+async def test_azure_transcribe_model_mapping():
+    """Test that Azure transcription models are correctly mapped and not hardcoded to whisper-1"""
+    
+    # Test Azure whisper-1
+    try:
+        response = await litellm.atranscription(
+            model="azure/whisper-1", 
+            file=audio_file, 
+            response_format="json",
+            api_key=os.getenv("AZURE_EUROPE_API_KEY"),
+            api_base="https://my-endpoint-europe-berri-992.openai.azure.com/",
+            drop_params=True
+        )
+        
+        # Check that the response contains the correct model in hidden params
+        assert response._hidden_params is not None
+        assert response._hidden_params["model"] == "whisper-1"
+        assert response._hidden_params["custom_llm_provider"] == "azure"
+        assert response.text is not None
+    except Exception as e:
+        # If Azure credentials are not available, skip this test
+        pytest.skip(f"Azure credentials not available: {str(e)}")


### PR DESCRIPTION

## Title

Fix transcription model name mapping

## Relevant issues
https://github.com/BerriAI/litellm/issues/11263

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
The transcription handlers for both OpenAI and Azure were hardcoding the model name to "whisper-1" in the response's `_hidden_params["model"]` field, regardless of the actual model used. This caused issues when using newer transcription models like:
- `gpt-4o-transcribe`
- `gpt-4o-mini-transcribe` 
- Custom Azure transcription deployments

### Solution
**Modified Files:**
1. **`litellm/llms/openai/transcriptions/handler.py`**
   - Changed line 188: `"model": "whisper-1"` → `"model": actual_model`
   - Now extracts the actual model from the request data: `actual_model = data.get("model", "whisper-1")`

2. **`litellm/llms/azure/audio_transcriptions.py`**
   - Updated both sync and async methods to use the actual model parameter instead of hardcoded "whisper-1"
   - Ensures consistent behavior between OpenAI and Azure providers

**Tests:**
3. **`tests/local_testing/test_whisper.py`**
   - `test_gpt_4o_transcribe_model_mapping()`: Verifies GPT-4o transcription models preserve correct model names
   - `test_azure_transcribe_model_mapping()`: Verifies Azure transcription models preserve correct model names
   - Tests confirm `_hidden_params["model"]` contains the actual model used, not "whisper-1"

<img width="837" alt="Screenshot 2025-06-02 at 1 46 34 PM" src="https://github.com/user-attachments/assets/89856a94-ea77-48b7-8df1-8d829d896dab" />


### Testing
All tests pass, including the new model mapping tests that specifically verify the fix works for both OpenAI GPT-4o models and Azure deployments.
