### PR TITLE
[Fix] Fix SCIM running patch operation case sensitivity 

### DIFF
--- a/litellm/types/proxy/management_endpoints/scim_v2.py
+++ b/litellm/types/proxy/management_endpoints/scim_v2.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from fastapi import HTTPException
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 
 
 class LiteLLM_UserScimMetadata(BaseModel):
@@ -72,9 +72,19 @@ class SCIMListResponse(BaseModel):
 
 # SCIM PATCH Operation Models
 class SCIMPatchOperation(BaseModel):
-    op: Literal["add", "remove", "replace"]
+    op: str
     path: Optional[str] = None
     value: Optional[Any] = None
+
+    @field_validator("op", mode="before")
+    @classmethod
+    def normalize_op(cls, v):
+        if isinstance(v, str):
+            v_lower = v.lower()
+            if v_lower not in {"add", "remove", "replace"}:
+                raise ValueError("op must be add, remove, or replace")
+            return v_lower
+        return v
 
 
 class SCIMPatchOp(BaseModel):


### PR DESCRIPTION
## [Fix] Fix SCIM running patch operation case sensitivity 

This PR fixes a case sensitivity bug in handling SCIM PATCH operations by normalizing the operation values. Key changes include:

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


