### PR TITLE
fixes: expose flag to disable token counter

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -216,6 +216,7 @@ use_client: bool = False
 ssl_verify: Union[str, bool] = True
 ssl_certificate: Optional[str] = None
 disable_streaming_logging: bool = False
+disable_token_counter: bool = False
 disable_add_transform_inline_image_block: bool = False
 in_memory_llm_clients_cache: LLMClientCache = LLMClientCache()
 safe_memory_mode: bool = False

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -362,6 +362,15 @@ def token_counter(
     """
     from litellm.utils import convert_list_message_to_dict
 
+    #########################################################
+    # Flag to disable token counter
+    # We've gotten reports of this consuming CPU cycles,
+    # exposing this flag to allow users to disable
+    # it to confirm if this is indeed the issue
+    #########################################################
+    if litellm.disable_token_counter is True:
+        return 0
+
     verbose_logger.debug(
         f"messages in token_counter: {messages}, text in token_counter: {text}"
     )

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -4,6 +4,5 @@ model_list:
       model: openai/*
 
 
-
-
-
+litellm_settings:
+  disable_token_counter: True

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1697,6 +1697,16 @@ def token_counter(
 
     Kept for backwards compatibility.
     """
+
+    #########################################################
+    # Flag to disable token counter
+    # We've gotten reports of this consuming CPU cycles,
+    # exposing this flag to allow users to disable
+    # it to confirm if this is indeed the issue
+    #########################################################
+    if litellm.disable_token_counter is True:
+        return 0
+
     return token_counter_new(
         model,
         custom_tokenizer,


### PR DESCRIPTION
## Fix: expose flag to disable token counter

We've gotten reports of this consuming CPU cycles. Exposing this flag to allow users to disable token counter. 

```yaml
model_list:
  - model_name: openai/*
    litellm_params:
      model: openai/*


litellm_settings:
  disable_token_counter: True

```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


