### PR TITLE
fix: Use proper attribute for Sagemaker request for embeddings

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -626,7 +626,7 @@ class SagemakerLLM(BaseAWSLLM):
                 inference_params[k] = v
 
         #### HF EMBEDDING LOGIC
-        data = json.dumps({"text_inputs": input}).encode("utf-8")
+        data = json.dumps({"inputs": input}).encode("utf-8")
 
         ## LOGGING
         request_str = f"""


### PR DESCRIPTION
Fixes a bug with Sagemaker where sagemaker embeddings can not be used

References:
* example in AWS docs https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-test-endpoints.html
* implementation in langchain (also uses `inputs` rather than `text_inputs`) https://python.langchain.com/docs/integrations/text_embedding/sagemaker-endpoint/

Fixes https://github.com/BerriAI/litellm/issues/2608