### PR TITLE
feat: add cerebras/qwen-3-32b model pricing and context window

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4737,6 +4737,18 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "cerebras/qwen-3-32b": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 8e-07,
+        "litellm_provider": "cerebras",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://inference-docs.cerebras.ai/support/pricing"
+    },
     "friendliai/meta-llama-3.1-8b-instruct": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,


### PR DESCRIPTION
## Title

feat: add cerebras/qwen-3-32b model pricing and context window

## Relevant issues

Fixes #11326

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- Added cerebras/qwen-3-32b model configuration to `model_prices_and_context_window.json`
- Documentation source: https://inference-docs.cerebras.ai/support/pricing

This addition enables users to utilize the Cerebras Qwen-3-32B model through LiteLLM with proper cost tracking and context window awareness.