### PR TITLE
Fix Google/Vertex AI Gemini module linting errors - Remove unused imports

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -44,7 +44,6 @@ from litellm.types.llms.openai import (
     ChatCompletionToolCallChunk,
     ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolParamFunctionChunk,
-    ChatCompletionUsageBlock,
     OpenAIChatCompletionFinishReason,
 )
 from litellm.types.llms.vertex_ai import (
@@ -66,7 +65,6 @@ from litellm.types.utils import (
     ChatCompletionTokenLogprob,
     ChoiceLogprobs,
     CompletionTokensDetailsWrapper,
-    GenericStreamingChunk,
     PromptTokensDetailsWrapper,
     TopLogprob,
     Usage,


### PR DESCRIPTION
## Title

Fix Google/Vertex AI Gemini module linting errors - Remove unused imports

## Relevant issues

<!-- No specific issue referenced -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🧹 Refactoring

## Changes

- Removed unused imports `ChatCompletionUsageBlock` and `GenericStreamingChunk` from `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
- This fixes linting errors related to unused imports in the Google/Vertex AI Gemini integration module
- No functional changes, purely cleanup to improve code quality and pass linting checks

**Files changed:**
- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py` (2 lines removed)