### PR TITLE
[Fix]: Performance - Don't run auth on /health/liveliness

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -567,12 +567,10 @@ async def health_readiness():
 @router.get(
     "/health/liveliness",  # Historical LiteLLM name; doesn't match k8s terminology but kept for backwards compatibility
     tags=["health"],
-    dependencies=[Depends(user_api_key_auth)],
 )
 @router.get(
     "/health/liveness",  # Kubernetes has "liveness" probes (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
     tags=["health"],
-    dependencies=[Depends(user_api_key_auth)],
 )
 async def health_liveliness():
     """
@@ -601,12 +599,10 @@ async def health_readiness_options():
 @router.options(
     "/health/liveliness",
     tags=["health"],
-    dependencies=[Depends(user_api_key_auth)],
 )
 @router.options(
     "/health/liveness",  # Kubernetes has "liveness" probes (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
     tags=["health"],
-    dependencies=[Depends(user_api_key_auth)],
 )
 async def health_liveliness_options():
     """


### PR DESCRIPTION
## [Fix]: Performance - Don't run auth on /health/liveliness

This is already an unprotected route, there's no need for the auth dependency on this route. 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes


