### PR TITLE
fix: migrate to ConfigDict

### DIFF
--- a/litellm/integrations/deepeval/types.py
+++ b/litellm/integrations/deepeval/types.py
@@ -1,7 +1,7 @@
 # Duplicate -> https://github.com/confident-ai/deepeval/blob/main/deepeval/tracing/api.py
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SpanApiType(Enum):
@@ -21,6 +21,8 @@ class TraceSpanApiStatus(Enum):
 
 
 class BaseApiSpan(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     uuid: str
     name: Optional[str] = None
     status: TraceSpanApiStatus
@@ -39,9 +41,6 @@ class BaseApiSpan(BaseModel):
     output_token_count: Optional[int] = Field(None, alias="outputTokenCount")
     cost_per_input_token: Optional[float] = Field(None, alias="costPerInputToken")
     cost_per_output_token: Optional[float] = Field(None, alias="costPerOutputToken")
-
-    class Config:
-        use_enum_values = True
 
 
 class TraceApi(BaseModel):

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -878,11 +878,9 @@ class FineTuningJobCreate(BaseModel):
 
 
 class LiteLLMFineTuningJobCreate(FineTuningJobCreate):
-    custom_llm_provider: Optional[Literal["openai", "azure", "vertex_ai"]] = None
+    model_config = ConfigDict(extra="allow")  # This allows the model to accept additional fields
 
-    model_config = {
-        "extra": "allow"
-    }  # This allows the model to accept additional fields
+    custom_llm_provider: Optional[Literal["openai", "azure", "vertex_ai"]] = None
 
 
 AllEmbeddingInputValues = Union[str, List[str], List[int], List[List[int]]]

--- a/litellm/types/mcp_server/tool_registry.py
+++ b/litellm/types/mcp_server/tool_registry.py
@@ -1,16 +1,15 @@
 from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class MCPTool(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     name: str
     description: str
     input_schema: Dict[str, Any]
     handler: Callable
-
-    class Config:
-        arbitrary_types_allowed = True
 
 
 class ToolSchema(BaseModel):


### PR DESCRIPTION
## Title

This migrates model configuration to `ConfigDict`. Support for class-based `config` is deprecated.
Deprecated in Pydantic V2.0 to be removed in V3.0.

https://docs.pydantic.dev/dev/migration/#changes-to-config

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes


