### PR TITLE
fix: add enterprise feature gating to RegenerateKeyModal in KeyInfoView

### DIFF
--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -18,7 +18,7 @@ import {
 import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
 import { keyDeleteCall, keyUpdateCall } from "./networking";
 import { KeyResponse } from "./key_team_helpers/key_list";
-import { Form, Input, InputNumber, message, Select } from "antd";
+import { Form, Input, InputNumber, message, Select, Tooltip } from "antd";
 import { KeyEditView } from "./key_edit_view";
 import { RegenerateKeyModal } from "./regenerate_key_modal";
 import { rolesWithWriteAccess } from '../utils/roles';
@@ -34,9 +34,10 @@ interface KeyInfoViewProps {
   userID: string | null;
   userRole: string | null;
   teams: any[] | null;
+  premiumUser: boolean;
 }
 
-export default function KeyInfoView({ keyId, onClose, keyData, accessToken, userID, userRole, teams, onKeyDataUpdate, onDelete }: KeyInfoViewProps) {
+export default function KeyInfoView({ keyId, onClose, keyData, accessToken, userID, userRole, teams, onKeyDataUpdate, onDelete, premiumUser }: KeyInfoViewProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [form] = Form.useForm();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -150,14 +151,19 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
           <div className="flex gap-2">
-            <Button
-              icon={RefreshIcon}
-              variant="secondary"
-              onClick={() => setIsRegenerateModalOpen(true)}
-              className="flex items-center"
-            >
-              Regenerate Key
-            </Button>
+            <Tooltip title={!premiumUser ? "This is a LiteLLM Enterprise feature, and requires a valid key to use." : ""}>
+              <span className="inline-block">
+                <Button
+                  icon={RefreshIcon}
+                  variant="secondary"
+                  onClick={() => setIsRegenerateModalOpen(true)}
+                  className="flex items-center"
+                  disabled={!premiumUser}
+                >
+                  Regenerate Key
+                </Button>
+              </span>
+            </Tooltip>
             <Button
               icon={TrashIcon}
               variant="secondary"
@@ -176,6 +182,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
         visible={isRegenerateModalOpen}
         onClose={() => setIsRegenerateModalOpen(false)}
         accessToken={accessToken}
+        premiumUser={premiumUser}
       />
 
       {/* Delete Confirmation Modal */}


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Add enterprise feature gating to RegenerateKeyModal in KeyInfoView

![screenshot-1749038052851](https://github.com/user-attachments/assets/e80f88fd-3ebd-4d78-9cc7-a9160febd11a)

This PR adds enterprise feature gating to the RegenerateKeyModal component within KeyInfoView.

- Provides a better user experience by clearly communicating the reason for the regeneration failure.
- Reduces user confusion and frustration.
- Encourages users to explore enterprise plan options if they need this feature.

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #9883 

When a user attempts to regenerate a virtual key in the UI, and this feature is only available for enterprise users, the UI displays a generic "Failed to regenerate API Key" message. This message doesn't clearly communicate that the feature is part of the enterprise tier.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

This PR implements a check to determine if the user has access to the enterprise feature. If not, a more informative message is displayed, explaining that the feature requires an enterprise plan upgrade.

**Enhanced UX for Regenerate Key Button:**

- Added a tooltip to the "Regenerate Key" button to inform users why the button is disabled if `premiumUser` is `false`.
- Tooltip message: "This is a LiteLLM Enterprise feature, and requires a valid key to use."

**Behavioral Control Based on User Tier:**

- The "Regenerate Key" button is disabled when `premiumUser` is `false`.
- This prevents non-premium users from accessing enterprise-only functionality.
- Tooltip is always shown for the button, even when disabled, via span wrapper pattern to ensure accessibility.
