### PR TITLE
update GCSBucketBase to handle GSM project ID if passed

### DIFF
--- a/litellm/integrations/gcs_bucket/gcs_bucket_base.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket_base.py
@@ -66,11 +66,19 @@ class GCSBucketBase(CustomBatchLogger):
         return headers
 
     def sync_construct_request_headers(self) -> Dict[str, str]:
+        """
+        Construct request headers for GCS API calls
+        """
         from litellm import vertex_chat_completion
 
+        # Get project_id from environment if available, otherwise None
+        # This helps support use of this library to auth to pull secrets 
+        # from Secret Manager.
+        project_id = os.getenv("GOOGLE_SECRET_MANAGER_PROJECT_ID")
+        
         _auth_header, vertex_project = vertex_chat_completion._ensure_access_token(
             credentials=self.path_service_account_json,
-            project_id=None,
+            project_id=project_id,
             custom_llm_provider="vertex_ai",
         )
 

--- a/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
+++ b/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
@@ -1,0 +1,82 @@
+import os
+from unittest.mock import patch
+from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
+
+
+class TestGCSBucketBase:
+    def test_construct_request_headers_with_project_id(self):
+        """Test that construct_request_headers correctly uses project_id if passed from env"""
+        test_project_id = "test-project"
+        os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"] = test_project_id
+
+        try:
+            # Create handler
+            handler = GCSBucketBase(bucket_name="test-bucket")
+
+            # Mock the Vertex AI auth calls
+            mock_auth_header = "mock-auth-header"
+            mock_token = "mock-token"
+
+            with patch(
+                "litellm.vertex_chat_completion._ensure_access_token"
+            ) as mock_ensure_token, patch(
+                "litellm.vertex_chat_completion._get_token_and_url"
+            ) as mock_get_token:
+                mock_ensure_token.return_value = (mock_auth_header, test_project_id)
+                mock_get_token.return_value = (mock_token, "mock-url")
+
+                # Call construct_request_headers
+                headers = handler.sync_construct_request_headers()
+
+                # Verify headers
+                assert headers == {
+                    "Authorization": f"Bearer {mock_token}",
+                    "Content-Type": "application/json",
+                }
+
+                # Verify _ensure_access_token was called with correct project_id
+                mock_ensure_token.assert_called_once_with(
+                    credentials=None,  # No service account in this test
+                    project_id=test_project_id,  # Should use project_id from env
+                    custom_llm_provider="vertex_ai",
+                )
+        finally:
+            # Clean up environment variable
+            del os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"]
+
+    def test_construct_request_headers_without_project_id(self):
+        """Test that construct_request_headers works when no project_id is in env"""
+        # Ensure environment variable is not set
+        if "GOOGLE_SECRET_MANAGER_PROJECT_ID" in os.environ:
+            del os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"]
+
+        # Create handler
+        handler = GCSBucketBase(bucket_name="test-bucket")
+
+        # Mock the Vertex AI auth calls
+        mock_auth_header = "mock-auth-header"
+        mock_token = "mock-token"
+
+        with patch(
+            "litellm.vertex_chat_completion._ensure_access_token"
+        ) as mock_ensure_token, patch(
+            "litellm.vertex_chat_completion._get_token_and_url"
+        ) as mock_get_token:
+            mock_ensure_token.return_value = (mock_auth_header, None)
+            mock_get_token.return_value = (mock_token, "mock-url")
+
+            # Call construct_request_headers
+            headers = handler.sync_construct_request_headers()
+
+            # Verify headers
+            assert headers == {
+                "Authorization": f"Bearer {mock_token}",
+                "Content-Type": "application/json",
+            }
+
+            # Verify _ensure_access_token was called with project_id as None
+            mock_ensure_token.assert_called_once_with(
+                credentials=None,  # No service account in this test
+                project_id=None,  # Should be None when no env var is set
+                custom_llm_provider="vertex_ai",
+            )


### PR DESCRIPTION
## Title

When using the Enterprise feature to pull secrets from Google Secret Manager, the dance to initially pull keys depends on credentials that are passed in `GOOGLE_APPLICATION_CREDENTIALS` where `project_id` is available. however, when running from Cloud Run, the auth dance is modified a bit since Cloud Run uses a service account workflow.   

Here we update the associated library to check for the environment variable we need for the GSM dance and use it, if populated. 

An example of how this fails when trying to pull secrets is: 
```
DEFAULT 2025-06-04T14:49:44.723745Z Google Secret Manager retrieval response status code: 200
DEFAULT 2025-06-04T14:49:44.723836Z Checking cached credentials for project_id: None
DEFAULT 2025-06-04T14:49:44.723841Z Cached credentials found for project_id: None.
DEFAULT 2025-06-04T14:49:44.723845Z Using cached credentials
DEFAULT 2025-06-04T14:49:44.723929Z Validating credentials for project_id: None
DEFAULT 2025-06-04T14:49:44.741606Z Defaulting to os.environ value for key=example_api_key. An exception occurred - Could not resolve project_id. Traceback (most recent call last): File "/usr/lib/python3.13/site-packages/litellm/secret_managers/main.py", line 292, in get_secret raise e File "/usr/lib/python3.13/site-packages/litellm/secret_managers/main.py", line 286, in get_secret secret = client.get_secret_from_google_secret_manager(secret_name) File "/usr/lib/python3.13/site-packages/litellm/secret_managers/google_secret_manager.py", line 82, in get_secret_from_google_secret_manager headers = self.sync_construct_request_headers() File "/usr/lib/python3.13/site-packages/litellm/integrations/gcs_bucket/gcs_bucket_base.py", line 71, in sync_construct_request_headers _auth_header, vertex_project = vertex_chat_completion._ensure_access_token( ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ credentials=self.path_service_account_json, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ project_id=None, ^^^^^^^^^^^^^^^^ custom_llm_provider="vertex_ai", ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ) ^ File "/usr/lib/python3.13/site-packages/litellm/llms/vertex_ai/vertex_llm_base.py", line 242, in _ensure_access_token return self.get_access_token( ~~~~~~~~~~~~~~~~~~~~~^ credentials=credentials, ^^^^^^^^^^^^^^^^^^^^^^^^ project_id=project_id, ^^^^^^^^^^^^^^^^^^^^^^ ) ^ File "/usr/lib/python3.13/site-packages/litellm/llms/vertex_ai/vertex_llm_base.py", line 432, in get_access_token raise ValueError("Could not resolve project_id") ValueError: Could not resolve project_id
```



To test, I built a new local docker container from my forked branch, built a custom container with our configuration, and then deployed to Cloud Run.   All initial secrets were pulled correctly when the project_id was set. 
```
DEFAULT 2025-06-04T16:08:07.324786Z litellm.proxy.proxy_server.py::startup() - CHECKING PREMIUM USER - True
DEFAULT 2025-06-04T16:08:07.325056Z worker_config: {"model": null, "alias": null, "api_base": null, "api_version": "2024-07-01-preview", "debug": false, "detailed_debug": true, "temperature": null, "max_tokens": null, "request_timeout": null, "max_budget": null, "telemetry": true, "drop_params": false, "add_function_to_prompt": false, "headers": null, "save": false, "config": "config.yaml", "use_queue": false}
DEFAULT 2025-06-04T16:08:07.330975Z Checking cached credentials for project_id: my-secret-project-id
DEFAULT 2025-06-04T16:08:07.330997Z Credential cache key not found for project_id: my-secret-project-id, loading new credentials
DEFAULT 2025-06-04T16:08:07.481428Z Validating credentials for project_id: my-secret-project-id
DEFAULT 2025-06-04T16:08:07.481555Z constructed auth_header <AUTH-HASH>
```

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 

![Screenshot 2025-06-04 at 12 15 44 PM](https://github.com/user-attachments/assets/4742df62-803d-4578-b048-95ae87c72627)

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


