### PR TITLE
Better handling of Sagemaker models

### DIFF
--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -614,7 +614,7 @@ class SagemakerLLM(BaseAWSLLM):
             )
 
         # Make it possible to customize the input key depending on the model deployed
-        input_key = optional_params.pop("input_key", "text_inputs")
+        input_key = optional_params.pop("sagemaker_input_key", "text_inputs")
 
         # pop streaming if it's in the optional params as 'stream' raises an error with sagemaker
         inference_params = deepcopy(optional_params)
@@ -679,8 +679,11 @@ class SagemakerLLM(BaseAWSLLM):
         elif isinstance(response, dict):
             embeddings = response["embedding"]
         else:
+            maybe_keys = getattr(response, "keys", lambda: "not-a-dict")()
+            if maybe_keys:
+                maybe_keys = list(maybe_keys)
             raise SagemakerError(
-                status_code=500, message="Response is not a list nor a dict with 'embedding' key"
+                status_code=500, message=f'Unable to parse response: was not a list nor a dict with key "embedding". Found type "{type(response)}" with keys {maybe_keys}'
             )
 
         if not isinstance(embeddings, list):

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -614,7 +614,7 @@ class SagemakerLLM(BaseAWSLLM):
             )
 
         # Make it possible to customize the input key depending on the model deployed
-        input_key = optional_params.pop("sagemaker_input_key", "text_inputs")
+        input_key = optional_params.pop("sagemaker_input_key", "inputs")
 
         # pop streaming if it's in the optional params as 'stream' raises an error with sagemaker
         inference_params = deepcopy(optional_params)


### PR DESCRIPTION
## Dynamic key for request body and handle response being embeddings directly

First stab at fixing https://github.com/BerriAI/litellm/issues/11019 as well as better handling of the response format from Sagemaker.

This makes it possible to dynamically select what the key should be for the request body for embedding models. It defaults to the existing value for backwards compatability.

Also handles the response a bit better by allowing the embeddings to be directly the response (which it is for some models e.g. the https://huggingface.co/nomic-ai/nomic-embed-text-v1 one) and not only a dict with a key. 

**Not included yet:** This only handles the LiteLLM cli part, but for myself I'd like this to be supported to set on a per-model basis in the proxy as well. Any hints on how to do this would be highly appreciated! 

## Relevant issues

#11019 

## Type

🆕 New Feature
🐛 Bug Fix
