### PR TITLE
[Performance] Performance improvements for /v1/messages route

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -125,9 +125,9 @@ class AnthropicPassthroughLoggingHandler:
             litellm_model_response.id = logging_obj.litellm_call_id
             litellm_model_response.model = model
             logging_obj.model_call_details["model"] = model
-            logging_obj.model_call_details[
-                "custom_llm_provider"
-            ] = litellm.LlmProviders.ANTHROPIC.value
+            logging_obj.model_call_details["custom_llm_provider"] = (
+                litellm.LlmProviders.ANTHROPIC.value
+            )
             return kwargs
         except Exception as e:
             verbose_proxy_logger.exception(
@@ -210,10 +210,6 @@ class AnthropicPassthroughLoggingHandler:
                 if transformed_openai_chunk is not None:
                     all_openai_chunks.append(transformed_openai_chunk)
 
-                verbose_proxy_logger.debug(
-                    "all openai chunks= %s",
-                    json.dumps(all_openai_chunks, indent=4, default=str),
-                )
             except (StopIteration, StopAsyncIteration):
                 break
         complete_streaming_response = litellm.stream_chunk_builder(

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import threading
 from datetime import datetime
 from typing import List, Optional
 

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -7,6 +7,7 @@ import httpx
 
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.proxy._types import PassThroughEndpointLoggingResultValues
 from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
 from litellm.types.utils import StandardPassThroughResponseObject
@@ -122,20 +123,23 @@ class PassThroughStreamingHandler:
             standard_logging_response_object = StandardPassThroughResponseObject(
                 response=f"cannot parse chunks to standard response object. Chunks={all_chunks}"
             )
-        threading.Thread(
-            target=litellm_logging_obj.success_handler,
-            args=(
-                standard_logging_response_object,
-                start_time,
-                end_time,
-                False,
-            ),
-        ).start()
+
         await litellm_logging_obj.async_success_handler(
             result=standard_logging_response_object,
             start_time=start_time,
             end_time=end_time,
             cache_hit=False,
+            **kwargs,
+        )
+        if litellm_logging_obj._should_run_sync_callbacks_for_async_calls() is False:
+            return
+
+        executor.submit(
+            litellm_logging_obj.success_handler,
+            result=standard_logging_response_object,
+            end_time=end_time,
+            cache_hit=False,
+            start_time=start_time,
             **kwargs,
         )
 

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,14 +1,13 @@
 model_list:
-  - model_name: openai/*
+  - model_name: fake-openai-endpoint
     litellm_params:
-      model: openai/*
-      api_key: any
-      api_base: http://0.0.0.0:8090/large-stream
+      model: openai/my-fake-model
+      api_key: my-fake-key
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
   - model_name: "anthropic/*"
     litellm_params:
       model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
-      api_base: http://localhost:8093/large-stream
   - model_name: "bedrock/*"
     litellm_params:
       model: "bedrock/*"
@@ -43,57 +42,68 @@ model_list:
       api_key: os.environ/DATABRICKS_API_KEY
       api_base: os.environ/DATABRICKS_API_BASE
 
-# litellm_settings:
-#   request_timeout: 30
-#   allowed_fails: 3
-#   # callbacks:
-#     # - otel
-#     # - prometheus
-#   failure_callback:
-#     - sentry
-#   s3_callback_params:
-#     s3_bucket_name: load-testing-oct
-#   disable_token_counter: True
-#   default_internal_user_params:
-#     user_role: os.environ/DEFAULT_USER_ROLE
+litellm_settings:
+  cache: True
+  cache_params:
+    type: redis
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    password: os.environ/REDIS_PASSWORD
+    supported_call_types:
+      - acompletion
+      - completion
+  request_timeout: 30
+  allowed_fails: 3
+  # callbacks:
+    # - otel
+    # - prometheus
+  failure_callback:
+    - sentry
+  success_callback:
+    - s3_v2
+  s3_callback_params:
+    s3_bucket_name: load-testing-oct
+  disable_token_counter: True
+  default_internal_user_params:
+    user_role: os.environ/DEFAULT_USER_ROLE
 
 callback_settings:
   otel:
     message_logging: False
 
-# router_settings:
-#   routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"
-#   redis_host: os.environ/REDIS_HOST
-#   redis_port: os.environ/REDIS_PORT
-#   redis_password: os.environ/REDIS_PASSWORD
-#   retry_policy: {
-#     # Set the number of retries for each exception type.
-#     # The logic is as follows:
-#     # 1. For anything that is likely to repeat the same outcome, don't retry.
-#     # 2. Internal server errors might be transient, so retry once.
-#     # 3. For rate limit errors, retry twice.
-#     # https://docs.litellm.ai/docs/routing#advanced-custom-retries-cooldowns-based-on-error-type
-#     # Based on that doc, rate limit retries use exponential backoff whereas others are immediate.
-#     "AuthenticationErrorRetries": 0,
-#     "BadRequestErrorRetries": 0,
-#     "ContentPolicyViolationErrorRetries": 0,
-#     "InternalServerErrorRetries": 1,
-#     "RateLimitErrorRetries": 2,
-#     "TimeoutErrorRetries": 0
-#   }
+router_settings:
+  routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+  redis_password: os.environ/REDIS_PASSWORD
+  retry_policy: {
+    # Set the number of retries for each exception type.
+    # The logic is as follows:
+    # 1. For anything that is likely to repeat the same outcome, don't retry.
+    # 2. Internal server errors might be transient, so retry once.
+    # 3. For rate limit errors, retry twice.
+    # https://docs.litellm.ai/docs/routing#advanced-custom-retries-cooldowns-based-on-error-type
+    # Based on that doc, rate limit retries use exponential backoff whereas others are immediate.
+    "AuthenticationErrorRetries": 0,
+    "BadRequestErrorRetries": 0,
+    "ContentPolicyViolationErrorRetries": 0,
+    "InternalServerErrorRetries": 1,
+    "RateLimitErrorRetries": 2,
+    "TimeoutErrorRetries": 0
+  }
 
-# general_settings:
-#   disable_spend_logs: True
-#   proxy_batch_write_at: 60
-#   use_redis_transaction_buffer: true
-#   alert_types: # https://docs.litellm.ai/docs/proxy/alerting#all-possible-alert-types
-#     - db_exceptions
-#     - cooldown_deployment
-#     - failed_tracking_spend
-#     - fallback_reports
-#     # - llm_requests_hanging
-#     - llm_too_slow
-#     - new_model_added
-#     - outage_alerts
-#     - region_outage_alerts
-#   alerting: ["slack"]
+general_settings:
+  disable_spend_logs: True
+  proxy_batch_write_at: 60
+  use_redis_transaction_buffer: true
+  alert_types: # https://docs.litellm.ai/docs/proxy/alerting#all-possible-alert-types
+    - db_exceptions
+    - cooldown_deployment
+    - failed_tracking_spend
+    - fallback_reports
+    # - llm_requests_hanging
+    - llm_too_slow
+    - new_model_added
+    - outage_alerts
+    - region_outage_alerts
+  alerting: ["slack"]

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,13 +1,14 @@
 model_list:
-  - model_name: fake-openai-endpoint
+  - model_name: openai/*
     litellm_params:
-      model: openai/my-fake-model
-      api_key: my-fake-key
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      model: openai/*
+      api_key: any
+      api_base: http://0.0.0.0:8090/large-stream
   - model_name: "anthropic/*"
     litellm_params:
       model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
+      api_base: http://localhost:8093/large-stream
   - model_name: "bedrock/*"
     litellm_params:
       model: "bedrock/*"
@@ -42,68 +43,57 @@ model_list:
       api_key: os.environ/DATABRICKS_API_KEY
       api_base: os.environ/DATABRICKS_API_BASE
 
-litellm_settings:
-  cache: True
-  cache_params:
-    type: redis
-    host: os.environ/REDIS_HOST
-    port: os.environ/REDIS_PORT
-    password: os.environ/REDIS_PASSWORD
-    supported_call_types:
-      - acompletion
-      - completion
-  request_timeout: 30
-  allowed_fails: 3
-  # callbacks:
-    # - otel
-    # - prometheus
-  failure_callback:
-    - sentry
-  success_callback:
-    - s3_v2
-  s3_callback_params:
-    s3_bucket_name: load-testing-oct
-  disable_token_counter: True
-  default_internal_user_params:
-    user_role: os.environ/DEFAULT_USER_ROLE
+# litellm_settings:
+#   request_timeout: 30
+#   allowed_fails: 3
+#   # callbacks:
+#     # - otel
+#     # - prometheus
+#   failure_callback:
+#     - sentry
+#   s3_callback_params:
+#     s3_bucket_name: load-testing-oct
+#   disable_token_counter: True
+#   default_internal_user_params:
+#     user_role: os.environ/DEFAULT_USER_ROLE
 
 callback_settings:
   otel:
     message_logging: False
 
-router_settings:
-  routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"
-  redis_host: os.environ/REDIS_HOST
-  redis_port: os.environ/REDIS_PORT
-  redis_password: os.environ/REDIS_PASSWORD
-  retry_policy: {
-    # Set the number of retries for each exception type.
-    # The logic is as follows:
-    # 1. For anything that is likely to repeat the same outcome, don't retry.
-    # 2. Internal server errors might be transient, so retry once.
-    # 3. For rate limit errors, retry twice.
-    # https://docs.litellm.ai/docs/routing#advanced-custom-retries-cooldowns-based-on-error-type
-    # Based on that doc, rate limit retries use exponential backoff whereas others are immediate.
-    "AuthenticationErrorRetries": 0,
-    "BadRequestErrorRetries": 0,
-    "ContentPolicyViolationErrorRetries": 0,
-    "InternalServerErrorRetries": 1,
-    "RateLimitErrorRetries": 2,
-    "TimeoutErrorRetries": 0
-  }
+# router_settings:
+#   routing_strategy: simple-shuffle # Literal["simple-shuffle", "least-busy", "usage-based-routing","latency-based-routing"], default="simple-shuffle"
+#   redis_host: os.environ/REDIS_HOST
+#   redis_port: os.environ/REDIS_PORT
+#   redis_password: os.environ/REDIS_PASSWORD
+#   retry_policy: {
+#     # Set the number of retries for each exception type.
+#     # The logic is as follows:
+#     # 1. For anything that is likely to repeat the same outcome, don't retry.
+#     # 2. Internal server errors might be transient, so retry once.
+#     # 3. For rate limit errors, retry twice.
+#     # https://docs.litellm.ai/docs/routing#advanced-custom-retries-cooldowns-based-on-error-type
+#     # Based on that doc, rate limit retries use exponential backoff whereas others are immediate.
+#     "AuthenticationErrorRetries": 0,
+#     "BadRequestErrorRetries": 0,
+#     "ContentPolicyViolationErrorRetries": 0,
+#     "InternalServerErrorRetries": 1,
+#     "RateLimitErrorRetries": 2,
+#     "TimeoutErrorRetries": 0
+#   }
 
-general_settings:
-  disable_spend_logs: True
-  proxy_batch_write_at: 60
-  use_redis_transaction_buffer: true
-  alert_types: # https://docs.litellm.ai/docs/proxy/alerting#all-possible-alert-types
-    - db_exceptions
-    - cooldown_deployment
-    - failed_tracking_spend
-    - fallback_reports
-    # - llm_requests_hanging
-    - llm_too_slow
-    - new_model_added
-    - outage_alerts
-    - region_outage_alerts
-  alerting: ["slack"]
+# general_settings:
+#   disable_spend_logs: True
+#   proxy_batch_write_at: 60
+#   use_redis_transaction_buffer: true
+#   alert_types: # https://docs.litellm.ai/docs/proxy/alerting#all-possible-alert-types
+#     - db_exceptions
+#     - cooldown_deployment
+#     - failed_tracking_spend
+#     - fallback_reports
+#     # - llm_requests_hanging
+#     - llm_too_slow
+#     - new_model_added
+#     - outage_alerts
+#     - region_outage_alerts
+#   alerting: ["slack"]


### PR DESCRIPTION
## [Performance] Performance improvements for /v1/messages route

Performance improvements for using /v1/messages with large streams. These are performance improvements for using /v1/messages with large streaming responses on litellm. The graph below shows the RPS before and after.  Before was 16 RPS, After 100+ RPS 

Key changes

- Reformatted a logging payload assignment and removed an expensive debug log in the Anthropic handler. (This was consuming most of our CPU %) 
- Replaced threading.Thread invocations in streaming_handler.py with a shared thread pool executor.

![Group 6698](https://github.com/user-attachments/assets/4fcd4262-8765-447f-ae4c-fc2a0243e9cb)

## Testing
- This will be added to LiteLLM Load Testing CI/CD before we put out stable releases. 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Changes


