### PR TITLE
[Build] Bump dd trace version 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8824,20 +8824,6 @@
             "notes": "'supports_image_input' is a deprecated field. Use 'supports_embedding_image_input' instead."
         }
     },
-    "embed-v4.0": {
-        "max_tokens": 1024,
-        "max_input_tokens": 1024,
-        "input_cost_per_token": 1.2e-07,
-        "input_cost_per_image": 4.7e-07,
-        "output_cost_per_token": 0.0,
-        "litellm_provider": "cohere",
-        "mode": "embedding",
-        "supports_image_input": true,
-        "supports_embedding_image_input": true,
-        "metadata": {
-            "notes": "'supports_image_input' is a deprecated field. Use 'supports_embedding_image_input' instead."
-        }
-    },
     "replicate/meta/llama-2-13b": {
         "max_tokens": 4096,
         "max_input_tokens": 4096,

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls
 langfuse==2.45.0 # for langfuse self-hosted logging
 prometheus_client==0.20.0 # for /metrics endpoint on proxy
-ddtrace==2.19.0      # for advanced DD tracing / profiling
+ddtrace==3.8.0      # for advanced DD tracing / profiling
 orjson==3.10.12 # fast /embedding responses
 apscheduler==3.10.4 # for resetting budget in background 
 fastapi-sso==0.16.0 # admin UI, SSO


### PR DESCRIPTION
## [Build] Bump dd trace version 

Bump dd trace to ddtrace==3.8.0. This is done to ensure compatibility with python 3.13 and dd trace. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure

## Changes


