### PR TITLE
Fix None values in usage field for gpt-image-1 model responses

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -294,6 +294,22 @@ class LiteLLMResponseObjectHandler:
     ) -> ImageResponse:
         response_object.update({"hidden_params": hidden_params})
 
+        # Handle gpt-image-1 usage field with None values
+        if "usage" in response_object and response_object["usage"] is not None:
+            usage = response_object["usage"]
+            # Check if usage fields are None and provide defaults
+            if usage.get("input_tokens") is None:
+                usage["input_tokens"] = 0
+            if usage.get("output_tokens") is None:
+                usage["output_tokens"] = 0
+            if usage.get("total_tokens") is None:
+                usage["total_tokens"] = usage["input_tokens"] + usage["output_tokens"]
+            if usage.get("input_tokens_details") is None:
+                usage["input_tokens_details"] = {
+                    "image_tokens": 0,
+                    "text_tokens": 0,
+                }
+
         if model_response_object is None:
             model_response_object = ImageResponse(**response_object)
             return model_response_object

--- a/tests/llm_translation/test_convert_dict_to_image.py
+++ b/tests/llm_translation/test_convert_dict_to_image.py
@@ -117,3 +117,107 @@ def test_convert_to_image_response_with_extra_fields_2():
 
     assert result.data[0].url == "http://example.com/image1.jpg"
     assert result.data[1].url == "http://example.com/image2.jpg"
+
+
+def test_convert_to_image_response_with_none_usage_fields():
+    """
+    Test handling of None values in usage fields, specifically for gpt-image-1 responses.
+    
+    This test verifies the fix for the bug where gpt-image-1 returns None values
+    for usage statistics fields, which caused Pydantic validation errors.
+    The fix should clean these None values and let ImageResponse constructor
+    handle the default values.
+    """
+    response_dict = {
+        "created": 1234567890,
+        "data": [{"b64_json": "base64encodedstring"}],
+        "usage": {
+            "input_tokens": None,  # gpt-image-1 returns None instead of integer
+            "input_tokens_details": None,  # gpt-image-1 returns None instead of object
+            "output_tokens": None,  # gpt-image-1 returns None instead of integer
+            "total_tokens": None,  # gpt-image-1 returns None instead of integer
+        }
+    }
+
+    # This should not raise a ValidationError
+    result = LiteLLMResponseObjectHandler.convert_to_image_response(response_dict)
+
+    assert isinstance(result, ImageResponse)
+    assert result.created == 1234567890
+    assert result.data[0].b64_json == "base64encodedstring"
+    
+    # Usage should be properly initialized with default values
+    assert result.usage is not None
+    assert result.usage.input_tokens == 0
+    assert result.usage.output_tokens == 0
+    assert result.usage.total_tokens == 0
+    assert result.usage.input_tokens_details is not None
+    assert result.usage.input_tokens_details.image_tokens == 0
+    assert result.usage.input_tokens_details.text_tokens == 0
+
+
+def test_convert_to_image_response_with_partial_none_usage_fields():
+    """
+    Test handling of mixed None and valid values in usage fields.
+    """
+    response_dict = {
+        "created": 1234567890,
+        "data": [{"b64_json": "base64encodedstring"}],
+        "usage": {
+            "input_tokens": 10,  # Valid value
+            "input_tokens_details": None,  # None value (should be cleaned)
+            "output_tokens": None,  # None value (should be cleaned)
+            "total_tokens": 10,  # Valid value
+        }
+    }
+
+    # This should not raise a ValidationError
+    result = LiteLLMResponseObjectHandler.convert_to_image_response(response_dict)
+
+    assert isinstance(result, ImageResponse)
+    assert result.created == 1234567890
+    assert result.data[0].b64_json == "base64encodedstring"
+    
+    # Usage should be properly initialized with defaults where needed
+    # Valid values should be preserved, None values should be cleaned and use defaults
+    assert result.usage is not None
+    assert result.usage.input_tokens == 10  # Valid value should be preserved
+    assert result.usage.output_tokens == 0  # None value should become 0
+    assert result.usage.total_tokens == 10  # Calculated as input_tokens + output_tokens (10 + 0)
+    assert result.usage.input_tokens_details is not None
+    assert result.usage.input_tokens_details.image_tokens == 0
+    assert result.usage.input_tokens_details.text_tokens == 0
+
+
+def test_convert_to_image_response_with_valid_usage_fields():
+    """
+    Test that valid usage fields are preserved correctly.
+    """
+    response_dict = {
+        "created": 1234567890,
+        "data": [{"b64_json": "base64encodedstring"}],
+        "usage": {
+            "input_tokens": 50,
+            "input_tokens_details": {
+                "image_tokens": 30,
+                "text_tokens": 20,
+            },
+            "output_tokens": 10,
+            "total_tokens": 60,
+        }
+    }
+
+    result = LiteLLMResponseObjectHandler.convert_to_image_response(response_dict)
+
+    assert isinstance(result, ImageResponse)
+    assert result.created == 1234567890
+    assert result.data[0].b64_json == "base64encodedstring"
+    
+    # Valid usage fields should be preserved
+    assert result.usage is not None
+    assert result.usage.input_tokens == 50
+    assert result.usage.output_tokens == 10
+    assert result.usage.total_tokens == 60
+    assert result.usage.input_tokens_details is not None
+    assert result.usage.input_tokens_details.image_tokens == 30
+    assert result.usage.input_tokens_details.text_tokens == 20


### PR DESCRIPTION
## Title

Fix None values in usage field for gpt-image-1 model responses

## Relevant issues

<!-- Please link any relevant issues if they exist -->
Fixes parsing bug where gpt-image-1 model responses contained None values in usage fields

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
The gpt-image-1 model was returning usage fields with `None` values, which caused parsing errors when converting response dictionaries to `ImageResponse` objects. This was breaking the response handling pipeline for image generation requests.

### Solution
Added defensive handling in `convert_dict_to_response.py` to check for `None` values in the usage field and provide sensible defaults:

- Set `input_tokens` to 0 if None
- Set `output_tokens` to 0 if None  
- Calculate `total_tokens` as sum of input and output tokens if None
- Provide default `input_tokens_details` structure with image_tokens and text_tokens set to 0 if None

### Files Modified
- `litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py`: Added None value handling for usage fields in `convert_to_image_response_object()` method

### Tests
<img width="916" alt="Screenshot 2025-06-05 at 11 49 36 AM" src="https://github.com/user-attachments/assets/88e0645a-f354-4dc4-983f-a79e33a9266b" />

### Impact
- Prevents crashes when processing gpt-image-1 responses with None usage values
- Maintains backward compatibility by providing sensible defaults
- Ensures consistent response object structure for downstream processing