### PR TITLE
fix: Do not add default model on tag based-routing when valid tag

### DIFF
--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -69,6 +69,7 @@ async def get_deployments_for_tag(
         request_tags = metadata.get("tags")
 
         new_healthy_deployments = []
+        default_deployments = []
         if request_tags:
             verbose_logger.debug(
                 "get_deployments_for_tag routing: router_keys: %s", request_tags
@@ -90,13 +91,15 @@ async def get_deployments_for_tag(
 
                 if is_valid_deployment_tag(deployment_tags, request_tags):
                     new_healthy_deployments.append(deployment)
+                elif "default" in deployment_tags:
+                    default_deployments.append(deployment)
 
-            if len(new_healthy_deployments) == 0:
+            if len(new_healthy_deployments) == 0 and len(default_deployments) == 0:
                 raise ValueError(
                     f"{RouterErrors.no_deployments_with_tag_routing.value}. Passed model={model} and tags={request_tags}"
                 )
 
-            return new_healthy_deployments
+            return new_healthy_deployments if len(new_healthy_deployments) > 0 else default_deployments
 
     # for Untagged requests use default deployments if set
     _default_deployments_with_tags = []

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -91,7 +91,8 @@ async def get_deployments_for_tag(
 
                 if is_valid_deployment_tag(deployment_tags, request_tags):
                     new_healthy_deployments.append(deployment)
-                elif "default" in deployment_tags:
+
+                if "default" in deployment_tags:
                     default_deployments.append(deployment)
 
             if len(new_healthy_deployments) == 0 and len(default_deployments) == 0:

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -33,13 +33,6 @@ def is_valid_deployment_tag(
             request_tags,
         )
         return True
-    elif "default" in deployment_tags:
-        verbose_logger.debug(
-            "adding default deployment with tags: %s, request tags: %s",
-            deployment_tags,
-            request_tags,
-        )
-        return True
     return False
 
 

--- a/tests/local_testing/test_router_tag_routing.py
+++ b/tests/local_testing/test_router_tag_routing.py
@@ -116,11 +116,21 @@ async def test_router_free_paid_tier_embeddings():
                 },
                 "model_info": {"id": "very-expensive-model"},
             },
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4o-mini",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "tags": ["default"],
+                    "mock_response": ["1", "2", "3"],
+                },
+                "model_info": {"id": "default-model"},
+            },
         ],
         enable_tag_filtering=True,
     )
 
-    for _ in range(1):
+    for _ in range(5):
         # this should pick model with id == very-cheap-model
         response = await router.aembedding(
             model="gpt-4",
@@ -136,7 +146,7 @@ async def test_router_free_paid_tier_embeddings():
         assert response_extra_info["model_id"] == "very-cheap-model"
 
     for _ in range(5):
-        # this should pick model with id == very-cheap-model
+        # this should pick model with id == very-expensive-model
         response = await router.aembedding(
             model="gpt-4",
             input="Tell me a joke.",
@@ -218,6 +228,22 @@ async def test_default_tagged_deployments():
         print("response_extra_info: ", response_extra_info)
 
         assert response_extra_info["model_id"] == "default-model"
+
+    for _ in range(5):
+        # requests with invalid tags, this should pick model with id == "default-model"
+        response = await router.acompletion(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Tell me a joke."}],
+            metadata={"tags": ["invalid-tag"]},
+        )
+
+        print("Response: ", response)
+
+        response_extra_info = response._hidden_params
+        print("response_extra_info: ", response_extra_info)
+
+        assert response_extra_info["model_id"] == "default-model"
+
 
 
 @pytest.mark.asyncio()

--- a/tests/local_testing/test_router_tag_routing.py
+++ b/tests/local_testing/test_router_tag_routing.py
@@ -288,3 +288,4 @@ def test_tag_routing_with_list_of_tags():
     assert is_valid_deployment_tag(["teamA", "teamB"], ["teamA", "teamC"])
     assert not is_valid_deployment_tag(["teamA", "teamB"], ["teamC"])
     assert not is_valid_deployment_tag(["teamA", "teamB"], [])
+    assert not is_valid_deployment_tag(["default"], ["teamA"])


### PR DESCRIPTION
##  Do not add default model on tag based-routing when valid tag

When you have something like this in your config

```
  - model_name: "*"
    litellm_params:
      model: openai/*
      api_key: os.environ/OPENAI_API_KEY
      tags: ["default"]
  - model_name: "*"
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      tags: ["my_tag"]
```

The requests that you send with the tag `my_tag` can either be routed to the default model OR to the model tagged with my_tag. It is super counter-intuitive as when you have tag-based routing you only expect the default models to be used in cases where you don't have a matching tag OR in cases where you don't have any tag at all.


## Relevant issues

Fixes #6770 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Removes the logic that always add the default models to the list of valid deployments on tagged requests. Instead, we are now keeping track of all default deployments and after we loop through all the deployments we check if we have at least one deployment with an exact tag match and if so we return those deployments, otherwise we return the default deployments.

If we don't have anything, then raises an error

