### PR TITLE
[Fix] [Bug]: Knowledge Base Call returning error

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Helper utilities
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
 import httpx
 
@@ -68,6 +68,15 @@ def remove_index_from_tool_calls(
                         tool_call.pop("index", None)
 
     return
+
+
+def remove_items_at_indices(items: Optional[List[Any]], indices: Iterable[int]) -> None:
+    """Remove items from a list in-place by index"""
+    if items is None:
+        return
+    for index in sorted(set(indices), reverse=True):
+        if 0 <= index < len(items):
+            items.pop(index)
 
 
 def add_missing_spend_metadata_to_litellm_metadata(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -437,6 +437,10 @@ async def acompletion(
             prompt_label=kwargs.get("prompt_label", None),
         )
 
+        # if the chat completion logging hook removed all tools, set tools to None
+        if tools is not None and len(tools) == 0:
+            tools = None
+
     #########################################################
     #########################################################
 
@@ -2769,9 +2773,9 @@ def completion(  # type: ignore # noqa: PLR0915
                     "aws_region_name" not in optional_params
                     or optional_params["aws_region_name"] is None
                 ):
-                    optional_params[
-                        "aws_region_name"
-                    ] = aws_bedrock_client.meta.region_name
+                    optional_params["aws_region_name"] = (
+                        aws_bedrock_client.meta.region_name
+                    )
 
             bedrock_route = BedrockModelInfo.get_bedrock_route(model)
             if bedrock_route == "converse":
@@ -4545,9 +4549,9 @@ def adapter_completion(
     new_kwargs = translation_obj.translate_completion_input_params(kwargs=kwargs)
 
     response: Union[ModelResponse, CustomStreamWrapper] = completion(**new_kwargs)  # type: ignore
-    translated_response: Optional[
-        Union[BaseModel, AdapterCompletionStreamWrapper]
-    ] = None
+    translated_response: Optional[Union[BaseModel, AdapterCompletionStreamWrapper]] = (
+        None
+    )
     if isinstance(response, ModelResponse):
         translated_response = translation_obj.translate_completion_output_params(
             response=response
@@ -5505,9 +5509,9 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(content_chunks) > 0:
-            response["choices"][0]["message"][
-                "content"
-            ] = processor.get_combined_content(content_chunks)
+            response["choices"][0]["message"]["content"] = (
+                processor.get_combined_content(content_chunks)
+            )
 
         reasoning_chunks = [
             chunk
@@ -5518,9 +5522,9 @@ def stream_chunk_builder(  # noqa: PLR0915
         ]
 
         if len(reasoning_chunks) > 0:
-            response["choices"][0]["message"][
-                "reasoning_content"
-            ] = processor.get_combined_reasoning_content(reasoning_chunks)
+            response["choices"][0]["message"]["reasoning_content"] = (
+                processor.get_combined_reasoning_content(reasoning_chunks)
+            )
 
         audio_chunks = [
             chunk

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -436,8 +436,13 @@ async def acompletion(
             tools=tools,
             prompt_label=kwargs.get("prompt_label", None),
         )
-
-        # if the chat completion logging hook removed all tools, set tools to None
+        #########################################################
+        # if the chat completion logging hook removed all tools,
+        # set tools to None
+        # eg. in certain cases when users send vector stores as tools
+        # we don't want the tools to go to the upstream llm
+        # relevant issue: https://github.com/BerriAI/litellm/issues/11404
+        #########################################################
         if tools is not None and len(tools) == 0:
             tools = None
 

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.core_helpers import remove_items_at_indices
 from litellm.types.vector_stores import (
     LiteLLM_ManagedVectorStore,
     LiteLLM_ManagedVectorStoreListResponse,
@@ -55,9 +56,44 @@ class VectorStoreRegistry:
         vector_store_ids = non_default_params.pop("vector_store_ids", None) or []
 
         # 2. check if vector_store_ids is provided as a tool in the request
-        vector_store_ids = self._get_vector_store_ids_from_tool_calls(
-            tools=tools, vector_store_ids=vector_store_ids
+        vector_store_ids = self.get_and_pop_recognised_vector_store_tools(
+            tools=tools,
         )
+
+        return vector_store_ids
+
+    def get_and_pop_recognised_vector_store_tools(
+        self, tools: Optional[List[Dict]] = None
+    ) -> List[str]:
+        """
+        Returns and pops the vector store ids from the tool calls
+
+        It only pops the recognised vector store tools from the tools list.
+        """
+        vector_store_ids: List[str] = []
+        if tools:
+            tools_to_remove: List[int] = []
+            for i, tool in enumerate(tools):
+                tool_vector_store_ids: List[str] = tool.get("vector_store_ids", [])
+                if len(tool_vector_store_ids) == 0:
+                    continue
+
+                vector_store_ids.extend(tool_vector_store_ids)
+
+                # remove the tool if all vector_store_ids are recognised in the registry
+                recognised = all(
+                    any(vs.get("vector_store_id") == vs_id for vs in self.vector_stores)
+                    for vs_id in tool_vector_store_ids
+                )
+                if recognised:
+                    tools_to_remove.append(i)
+
+            # remove recognised tools from the original list
+            remove_items_at_indices(
+                items=tools,
+                indices=tools_to_remove,
+            )
+
         return vector_store_ids
 
     def get_vector_store_to_run(

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -58,28 +58,32 @@ class VectorStoreRegistry:
         # 2. check if vector_store_ids is provided as a tool in the request
         vector_store_ids = self.get_and_pop_recognised_vector_store_tools(
             tools=tools,
+            vector_store_ids=vector_store_ids,
         )
 
         return vector_store_ids
 
     def get_and_pop_recognised_vector_store_tools(
-        self, tools: Optional[List[Dict]] = None
+        self, tools: Optional[List[Dict]] = None, vector_store_ids: List[str] = []
     ) -> List[str]:
         """
         Returns and pops the vector store ids from the tool calls
 
         It only pops the recognised vector store tools from the tools list.
+
+        Args:
+            tools: The tools to pop the vector store ids from
+            vector_store_ids: The list of vector store IDs the user provided
+
+        Returns:
+            The vector store ids that were popped
         """
-        vector_store_ids: List[str] = []
         if tools:
             tools_to_remove: List[int] = []
             for i, tool in enumerate(tools):
                 tool_vector_store_ids: List[str] = tool.get("vector_store_ids", [])
                 if len(tool_vector_store_ids) == 0:
                     continue
-
-                vector_store_ids.extend(tool_vector_store_ids)
-
                 # remove the tool if all vector_store_ids are recognised in the registry
                 recognised = all(
                     any(vs.get("vector_store_id") == vs_id for vs in self.vector_stores)
@@ -87,6 +91,7 @@ class VectorStoreRegistry:
                 )
                 if recognised:
                     tools_to_remove.append(i)
+                    vector_store_ids.extend(tool_vector_store_ids)
 
             # remove recognised tools from the original list
             remove_items_at_indices(

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -210,6 +210,7 @@ async def test_openai_with_vector_store_ids_in_tool_call_mock_openai(setup_vecto
         # Verify the API was called
         mock_client.assert_called_once()
         request_body = mock_client.call_args.kwargs
+        print("request body:", json.dumps(request_body, indent=4, default=str))
         
         # Verify the request contains messages with knowledge base context
         assert "messages" in request_body
@@ -225,6 +226,9 @@ async def test_openai_with_vector_store_ids_in_tool_call_mock_openai(setup_vecto
         # assert message[1] is the user message with the knowledge base context
         assert messages[1]["role"] == "user"
         assert BedrockVectorStore.CONTENT_PREFIX_STRING in messages[1]["content"]
+
+        # assert that the tool call was not sent to the upstream llm API if it's a litellm vector store
+        assert "tools" not in request_body
 
 
 @pytest.mark.asyncio

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -232,6 +232,45 @@ async def test_openai_with_vector_store_ids_in_tool_call_mock_openai(setup_vecto
 
 
 @pytest.mark.asyncio
+async def test_openai_with_mixed_tool_call_mock_openai(setup_vector_store_registry):
+    """Ensure unrecognized vector store tools are forwarded to the provider"""
+    litellm.callbacks = [BedrockVectorStore(aws_region_name="us-west-2")]
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key="fake-api-key")
+
+    with patch.object(
+        client.chat.completions.with_raw_response, "create"
+    ) as mock_client:
+        try:
+            await litellm.acompletion(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "what is litellm?"}],
+                tools=[
+                    {"type": "file_search", "vector_store_ids": ["T37J8R4WTM"]},
+                    {"type": "file_search", "vector_store_ids": ["unknownVS"]},
+                ],
+                client=client,
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        mock_client.assert_called_once()
+        request_body = mock_client.call_args.kwargs
+
+        assert "messages" in request_body
+        messages = request_body["messages"]
+        assert len(messages) >= 2
+        assert messages[1]["role"] == "user"
+        assert BedrockVectorStore.CONTENT_PREFIX_STRING in messages[1]["content"]
+
+        assert "tools" in request_body
+        tools = request_body["tools"]
+        assert len(tools) == 1
+        assert tools[0]["vector_store_ids"] == ["unknownVS"]
+
+
+@pytest.mark.asyncio
 async def test_logging_with_knowledge_base_hook(setup_vector_store_registry):
     """
     Test that the knowledge base request was logged in standard logging payload


### PR DESCRIPTION
## [Fix] [Bug]: Knowledge Base Call returning error

Fixes https://github.com/BerriAI/litellm/issues/11404

Refactoring the vector store registry to extract and remove recognized vector store tool calls.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


