### PR TITLE
[Fix]: /v1/messages -  return streaming usage statistics when using litellm with bedrock models

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 import httpx
@@ -13,6 +14,7 @@ from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation
     AmazonInvokeConfig,
 )
 from litellm.types.router import GenericLiteLLMParams
+from litellm.types.utils import GenericStreamingChunk
 from litellm.types.utils import GenericStreamingChunk as GChunk
 from litellm.types.utils import ModelResponseStream
 
@@ -139,7 +141,26 @@ class AmazonAnthropicClaude3MessagesConfig(
         completion_stream = aws_decoder.aiter_bytes(
             httpx_response.aiter_bytes(chunk_size=aws_decoder.DEFAULT_CHUNK_SIZE)
         )
-        return completion_stream
+        # Convert decoded Bedrock events to Server-Sent Events expected by Anthropic clients.
+        return self.bedrock_sse_wrapper(completion_stream)
+
+    async def bedrock_sse_wrapper(
+        self,
+        completion_stream: AsyncIterator[
+            Union[bytes, GenericStreamingChunk, ModelResponseStream, dict]
+        ],
+    ):
+        """
+        Bedrock invoke does not return SSE formatted data. This function is a wrapper to ensure litellm chunks are SSE formatted.
+        """
+        async for chunk in completion_stream:
+            if isinstance(chunk, dict):
+                event_type: str = str(chunk.get("type", "message"))
+                payload = f"event: {event_type}\n" f"data: {json.dumps(chunk)}\n\n"
+                yield payload.encode()
+            else:
+                # For non-dict chunks, forward the original value unchanged so callers can leverage the richer Python objects if they wish.
+                yield chunk
 
 
 class AmazonAnthropicClaudeMessagesStreamDecoder(AWSEventStreamDecoder):

--- a/tests/llm_translation/test_bedrock_invoke_tests.py
+++ b/tests/llm_translation/test_bedrock_invoke_tests.py
@@ -145,26 +145,3 @@ def test_nova_invoke_streaming_chunk_parsing():
     result = decoder._chunk_parser(nova_stop_chunk)
     print(result)
     assert result.choices[0].finish_reason == "tool_calls"
-
-
-def test_anthropic_messages_streaming_usage_transformation():
-    """Ensure Bedrock usage keys are converted to Anthropic spec."""
-    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
-        AmazonAnthropicClaudeMessagesStreamDecoder,
-    )
-
-    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0")
-    chunk = {
-        "type": "message_delta",
-        "usage": {
-            "inputTokens": 5,
-            "outputTokens": 3,
-            "cacheReadInputTokens": 1,
-            "cacheWriteInputTokens": 0,
-        },
-    }
-    result = decoder._chunk_parser(chunk)
-    assert "usage" in result
-    assert result["usage"]["input_tokens"] == 6
-    assert result["usage"]["output_tokens"] == 3
-    assert result["usage"]["cache_read_input_tokens"] == 1

--- a/tests/llm_translation/test_bedrock_invoke_tests.py
+++ b/tests/llm_translation/test_bedrock_invoke_tests.py
@@ -145,3 +145,26 @@ def test_nova_invoke_streaming_chunk_parsing():
     result = decoder._chunk_parser(nova_stop_chunk)
     print(result)
     assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_anthropic_messages_streaming_usage_transformation():
+    """Ensure Bedrock usage keys are converted to Anthropic spec."""
+    from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+        AmazonAnthropicClaudeMessagesStreamDecoder,
+    )
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0")
+    chunk = {
+        "type": "message_delta",
+        "usage": {
+            "inputTokens": 5,
+            "outputTokens": 3,
+            "cacheReadInputTokens": 1,
+            "cacheWriteInputTokens": 0,
+        },
+    }
+    result = decoder._chunk_parser(chunk)
+    assert "usage" in result
+    assert result["usage"]["input_tokens"] == 6
+    assert result["usage"]["output_tokens"] == 3
+    assert result["usage"]["cache_read_input_tokens"] == 1

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1,0 +1,67 @@
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+# Ensure the project root is on the import path so `litellm` can be imported when
+# tests are executed from any working directory.
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
+    AmazonAnthropicClaude3MessagesConfig,
+    AmazonAnthropicClaudeMessagesStreamDecoder,
+)
+
+
+@pytest.mark.asyncio
+async def test_bedrock_sse_wrapper_encodes_dict_chunks():
+    """Verify that `bedrock_sse_wrapper` converts dictionary chunks to properly formatted Server-Sent Events and forwards non-dict chunks unchanged."""
+
+    cfg = AmazonAnthropicClaude3MessagesConfig()
+
+    async def _dummy_stream():  # type: ignore[return-type]
+        yield {"type": "message_delta", "text": "hello"}
+        yield b"raw-bytes"
+
+    # Collect all chunks returned by the wrapper
+    collected: list[bytes] = []
+    async for chunk in cfg.bedrock_sse_wrapper(_dummy_stream()):
+        collected.append(chunk)
+
+    assert collected, "No chunks returned from wrapper"
+
+    # First chunk should be SSE encoded
+    first_chunk = collected[0]
+    assert first_chunk.startswith(b"event: message_delta\n"), first_chunk
+    assert first_chunk.endswith(b"\n\n"), first_chunk
+    # Ensure the JSON payload is present in the SSE data line
+    assert b'"hello"' in first_chunk  # payload contains the text
+
+    # Second chunk should be forwarded unchanged
+    assert collected[1] == b"raw-bytes"
+
+
+def test_chunk_parser_usage_transformation():
+    """Ensure Bedrock invocation metrics are transformed to Anthropic usage keys."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0"
+    )
+
+    chunk = {
+        "type": "message_delta",
+        "amazon-bedrock-invocationMetrics": {
+            "inputTokenCount": 10,
+            "outputTokenCount": 5,
+        },
+    }
+
+    parsed = decoder._chunk_parser(chunk.copy())  # use copy to avoid side-effects
+
+    # The invocation metrics key should be removed and replaced by `usage`
+    assert "amazon-bedrock-invocationMetrics" not in parsed
+    assert "usage" in parsed
+    assert parsed["usage"]["input_tokens"] == 10
+    assert parsed["usage"]["output_tokens"] == 5


### PR DESCRIPTION
## [Fix]: /v1/messages -  return streaming usage statistics when using litellm with bedrock models

https://www.loom.com/share/14639244068b478e807e46bc2a0735a8?sid=bf8dbb08-1509-4c25-85b5-be0872f91eb3

Ensure tools like claude code see the correct token counts when using litellm with bedrock messages 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


