### PR TITLE
fix: health check failure when mode is set to 'batch'

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5301,6 +5301,9 @@ async def ahealth_check(
                 **_filter_model_params(model_params),
                 prompt=prompt,
             ),
+            "batch": lambda: litellm.acompletion(
+                **model_params,
+            ),
             "rerank": lambda: litellm.arerank(
                 **_filter_model_params(model_params),
                 query=prompt or "",


### PR DESCRIPTION
## Title

Fix health check failure when mode is set to 'batch'

## Relevant issues

Fixes #8040

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Added a missing handler for `'batch'` mode in `ahealth_check`'s `mode_handlers`
- Ensured `mode='batch'` is now properly handled during health checks

<img width="1639" alt="image" src="https://github.com/user-attachments/assets/272ffbc2-31b0-4ccd-bdfd-7b6563924596" />
