### PR TITLE
Fix variable redefinition linting error in vertex_and_google_ai_studio_gemini.py

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1234,7 +1234,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         url_context_metadata: List[dict] = []
         try:
             grounding_metadata: List[dict] = []
-            url_context_metadata: List[dict] = []
             safety_ratings: List[dict] = []
             citation_metadata: List[dict] = []
             if _candidates:


### PR DESCRIPTION
## Title

Fix variable redefinition linting error in vertex_and_google_ai_studio_gemini.py

## Relevant issues

Fixes linting error: `Name "url_context_metadata" already defined` at lines 1234 and 1237

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- **Fixed variable redefinition linting error**: Removed duplicate declaration of `url_context_metadata` variable in the `transform_response` method
- **Root cause**: The variable `url_context_metadata` was declared twice - once on line 1234 and again on line 1237, causing a linting error about variable shadowing
- **Solution**: Removed the redundant second declaration while preserving the original initialization and subsequent tuple unpacking logic
- **Impact**: No functional changes - the variable is still properly initialized and used throughout the method. This is purely a code quality improvement that resolves the linting error.

**Files changed:**
- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`: Removed duplicate `url_context_metadata` declaration

**Verification:**
- Confirmed the fix resolves the linting error by running `ruff check` on the file
- Verified no new linting issues were introduced
- Logic flow remains unchanged - variable is still properly assigned from `_process_candidates()` and used to set model response attributes