### PR TITLE
Update production doc

### DIFF
--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -67,7 +67,13 @@ If you decide to use Redis, DO NOT use 'redis_url'. We recommend using redis por
 
 This is still something we're investigating. Keep track of it [here](https://github.com/BerriAI/litellm/issues/3188)
 
-Recommended to do this for prod: 
+### Redis Version Requirement
+
+| Component | Minimum Version |
+|-----------|-----------------|
+| Redis     | 7.0+            |
+
+Recommended to do this for prod:
 
 ```yaml
 router_settings:


### PR DESCRIPTION
## Summary
- document using Redis 7.0 or higher in production best practices

## Testing
- `make test-unit` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68435b099f8c832194cb3485174546a2