### PR TITLE
[Bug Fix] Always include tool calls in output of trim_messages

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5829,6 +5829,7 @@ def trim_messages(
     """
     # Initialize max_tokens
     # if users pass in max tokens, trim to this amount
+    original_messages = messages
     messages = copy.deepcopy(messages)
     try:
         if max_tokens is None:
@@ -5912,7 +5913,7 @@ def trim_messages(
         verbose_logger.exception(
             "Got exception while token trimming - {}".format(str(e))
         )
-        return messages
+        return original_messages
 
 
 from litellm.caching.in_memory_cache import InMemoryCache

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5867,7 +5867,7 @@ def trim_messages(
 
         # Do nothing if current tokens under messages
         if current_tokens < max_tokens:
-            return messages
+            return messages + tool_messages
 
         #### Trimming messages if current_tokens > max_tokens
         print_verbose(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5857,6 +5857,7 @@ def trim_messages(
             if message["role"] != "tool":
                 break
             tool_messages.append(message)
+        tool_messages.reverse()
         # # Remove the collected tool messages from the original list
         if len(tool_messages):
             messages = messages[: -len(tool_messages)]

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -248,6 +248,10 @@ def test_trimming_with_tool_calls():
     assert len(result) == num_tool_calls
     assert result == messages[-num_tool_calls:]
 
+    result = trim_messages(messages=messages, max_tokens=999)
+    # message length is below max_tokens, so output should match input
+    assert messages == result
+
 
 def test_trimming_should_not_change_original_messages():
     messages = [

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -238,11 +238,15 @@ def test_trimming_with_tool_calls():
             "content": '{"location": "Paris", "temperature": "22", "unit": "celsius"}',
         },
     ]
-    result = trim_messages(messages=messages, max_tokens=1, return_response_tokens=True)
+    num_tool_calls = 3
+
+    result = trim_messages(messages=messages, max_tokens=1)
 
     print(result)
 
-    assert len(result[0]) == 3  # final 3 messages are tool calls
+    # only trailing tool calls are returned
+    assert len(result) == num_tool_calls
+    assert result == messages[-num_tool_calls:]
 
 
 def test_trimming_should_not_change_original_messages():

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import sys
 import time
 from datetime import datetime
@@ -280,6 +281,53 @@ def test_trimming_with_model_cost_max_input_tokens(model):
         get_token_count(trimmed_messages, model=model)
         < litellm.model_cost[model]["max_input_tokens"]
     )
+
+
+def test_trimming_with_untokenizable_field(caplog: pytest.LogCaptureFixture) -> None:
+    from litellm.types.utils import ChatCompletionMessageToolCall, Function, Message
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        },
+        {
+            "role": "user",
+            "content": "What's the weather like in San Francisco?",
+            # non-string values will cause the tokenizer to raise an exception
+            "user_id": 123,
+        },
+        Message(
+            content=None,
+            role="assistant",
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    function=Function(
+                        arguments='{"location": "San Francisco, CA", "unit": "celsius"}',
+                        name="get_current_weather",
+                    ),
+                    id="call_G11shFcS024xEKjiAOSt6Tc9",
+                    type="function",
+                ),
+            ],
+            function_call=None,
+        ),
+        {
+            "tool_call_id": "call_G11shFcS024xEKjiAOSt6Tc9",
+            "role": "tool",
+            "name": "get_current_weather",
+            "content": '{"location": "San Francisco", "temperature": "72", "unit": "fahrenheit"}',
+        },
+    ]
+
+    # trim_messages() catches the exception raised by the tokenizer and logs an error
+    with caplog.at_level(level=logging.ERROR, logger="LiteLLM"):
+        trimmed_messages = trim_messages(messages, max_tokens=999)
+
+    assert trimmed_messages == messages
+
+    assert len(caplog.records) >= 1
+    assert "Got exception while token trimming" in caplog.text
 
 
 def test_aget_valid_models():


### PR DESCRIPTION
## Title

Always include tool calls in output of `trim_messages()`

## Relevant issues

Fixes #6505
Fixes #8261

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Here is a screenshot of the modified test and the new test passing. The warning from Pydantic exists for me on main and is not due to these changes.

<img width="793" alt="image" src="https://github.com/user-attachments/assets/7b3c2eaf-be79-4d10-989d-db6fc03619cf" />

## Type

🐛 Bug Fix

## Changes

### Include tool calls in output of `trim_messages()` if no trimming is needed
- We deliberately do not trim away trailing tool calls since that could lead to downstream problems (see https://github.com/BerriAI/litellm/issues/4931).
- Therefore, we take them out of the message list before doing any trimming.
- However, we need to add them back, even if it turns out that no trimming was required.

### Retain the original order of tool calls.
- Tool calls are identified by iterating backwards over the list of messages.
- This means the first tool call we find is the last one in the original list.
- Therefore, we should reverse the tool calls to match the order they appear in the input.

### Save a reference to the original message list and return that if an exception occurs.
- `trim_messages()` catches any errors and is intended to return the input message list if there's a problem.
- However, the body of `trim_messages()` makes several modifications to (its copy of) the message list as it runs.
- This meant that it could return inconsistent information depending on when the error occurred.
- Now we always return the input messages unaltered if there's an exception.