### PR TITLE
feat(devcontainer): add database in devcontainer for easier development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
 	"name": "Python 3.11",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
+	"dockerComposeFile": "./docker-compose.yaml",
+	"service": "workspace",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
 	// https://github.com/devcontainers/images/tree/main/src/python
 	// https://mcr.microsoft.com/en-us/product/devcontainers/python/tags
 
@@ -23,19 +26,21 @@
 				"ms-python.vscode-pylance",
 				"GitHub.copilot",
 				"GitHub.copilot-chat",
-				"ms-python.autopep8"
+				"ms-python.autopep8",
+				"ms-ossdata.vscode-pgsql"
 			]
 		}
 	},
-	
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [4000],
 
 	"containerEnv": {
-		"LITELLM_LOG": "DEBUG"
+		"LITELLM_LOG": "DEBUG",
+		"DATABASE_URL": "postgresql://postgres:postgres@db:5432/litellm"
 	},
 
-	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// Use 'portsAttributes' to set default properties for specific forwarded ports.
 	// More info: https://containers.dev/implementors/json_reference/#port-attributes
 	"portsAttributes": {
 		"4000": {

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  workspace:
+    image: mcr.microsoft.com/devcontainers/python:3.11-bookworm
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    network_mode: service:db
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: litellm
+
+volumes:
+  postgres-data:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+	"pgsql.serverGroups": [
+		{
+			"name": "Servers",
+			"id": "98E70987-2BC3-42A8-9A52-D5FFDBCCDE40",
+			"isDefault": true
+		}
+	],
+	"pgsql.connections": [
+		{
+			"id": "547EC4AF-059C-442F-A6CF-E35BEC13C367",
+			"groupId": "98E70987-2BC3-42A8-9A52-D5FFDBCCDE40",
+			"authenticationType": "SqlLogin",
+			"connectTimeout": 15,
+			"applicationName": "vscode-pgsql",
+			"clientEncoding": "utf8",
+			"sslmode": "prefer",
+			"server": "db",
+			"user": "postgres",
+			"port": "5432",
+			"database": "litellm",
+			"password": "postgres",
+			"profileName": "litellm",
+			"expiresOn": 0,
+			"profileSource": 0,
+			"displayName": "litellm",
+			"savePassword": true
+		}
+	]
+}


### PR DESCRIPTION
## Title

Add database in devcontainer for easier development

## Relevant issues

N/A

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

_Unchecked items aren't relevant as change is only valid for development of LiteLLM within a VSCode devcontainer and doesn't effect the working codebase/tests etc_

## Type

🧑‍💻 Development Experience

## Changes

- Use [docker compose for VSCode devcontainer](https://code.visualstudio.com/docs/devcontainers/create-dev-container#_use-docker-compose) setup
-PostgreSQL server is running alongside the devcontainer
- Easier development with `DATABASE_URL` environment variable set to point to that server setup in devcontainer.json
- Adding .vscode/settings.json with `psql` connections such that they automatically populate in the PostgreSQL extension, `ms-ossdata.vscode-pgsql`, so developers can easily query and inspect the database if needed
  - _n.b. I realise .vscode/settings.json is gitignored, but I figure this kind of setting is universal to a developer using devcontainers for the litellm repository, so could be added_

## Screenshot

VSCode LiteLLM devcontainer running LiteLLM as well as querying the local database
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/76156585-11e1-4b51-b74e-cdc239c8c86c" />

