### PR TITLE
VSCode devcontainer debugging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,9 @@
 	"customizations": {
 		// Configure properties specific to VS Code.
 		"vscode": {
-			"settings": {},
+			"settings": {
+				"python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python"
+			},
 			"extensions": [
 				"ms-python.python",
 				"ms-python.vscode-pylance",
@@ -53,5 +55,5 @@
 	// "remoteUser": "litellm",
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pipx install poetry && poetry install -E extra_proxy -E proxy"
+	"postCreateCommand": "pipx install poetry && poetry config virtualenvs.in-project true && poetry install -E extra_proxy -E proxy"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
 	"name": "Python 3.11",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
+	"dockerComposeFile": "./docker-compose.yaml",
+	"service": "workspace",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
 	// https://github.com/devcontainers/images/tree/main/src/python
 	// https://mcr.microsoft.com/en-us/product/devcontainers/python/tags
 
@@ -23,19 +26,21 @@
 				"ms-python.vscode-pylance",
 				"GitHub.copilot",
 				"GitHub.copilot-chat",
-				"ms-python.autopep8"
+				"ms-python.autopep8",
+				"ms-ossdata.vscode-pgsql"
 			]
 		}
 	},
-	
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [4000],
 
 	"containerEnv": {
-		"LITELLM_LOG": "DEBUG"
+		"LITELLM_LOG": "DEBUG",
+		"DATABASE_URL": "postgresql://postgres:postgres@db:5432/litellm"
 	},
 
-	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// Use 'portsAttributes' to set default properties for specific forwarded ports.
 	// More info: https://containers.dev/implementors/json_reference/#port-attributes
 	"portsAttributes": {
 		"4000": {

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  workspace:
+    image: mcr.microsoft.com/devcontainers/python:3.11-bookworm
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    network_mode: service:db
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: litellm
+
+volumes:
+  postgres-data:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "LiteLLM Proxy",
+			"type": "debugpy",
+			"request": "launch",
+			"python": "${command:python.interpreterPath}",
+			"module": "litellm.proxy.proxy_cli",
+			"justMyCode": false,
+			"args": ["--config", "config.yaml", "--detailed_debug"],
+			"envFile": "${workspaceFolder}/.env",
+			"cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+			"preLaunchTask": "install-proxy-dev"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+	"pgsql.serverGroups": [
+		{
+			"name": "Servers",
+			"id": "98E70987-2BC3-42A8-9A52-D5FFDBCCDE40",
+			"isDefault": true
+		}
+	],
+	"pgsql.connections": [
+		{
+			"id": "547EC4AF-059C-442F-A6CF-E35BEC13C367",
+			"groupId": "98E70987-2BC3-42A8-9A52-D5FFDBCCDE40",
+			"authenticationType": "SqlLogin",
+			"connectTimeout": 15,
+			"applicationName": "vscode-pgsql",
+			"clientEncoding": "utf8",
+			"sslmode": "prefer",
+			"server": "db",
+			"user": "postgres",
+			"port": "5432",
+			"database": "litellm",
+			"password": "postgres",
+			"profileName": "litellm",
+			"expiresOn": 0,
+			"profileSource": 0,
+			"displayName": "litellm",
+			"savePassword": true
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "install-proxy-dev",
+			"type": "shell",
+			"command": "make",
+			"args": [
+				"install-proxy-dev"
+			]
+		},
+	]
+}


### PR DESCRIPTION
## Title

Add debugging launch profile for VSCode and configure with devcontainer setup

## Relevant issues

N/A

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

_Unchecked items aren't relevant as change is only valid for development of LiteLLM within a VSCode devcontainer and doesn't effect the working codebase/tests etc_

## Type

🧑‍💻 Developer Experience

## Changes

- Use in project poetry virtualenv so it's easy to point to within the workspace
- Configure the default python interpreter to be this virtualenv from within devcontainer.json
- Add a launch for LiteLLM Proxy to begin debugging within VSCode
- Add a prelaunch task to ensure the install command has been run
- Follows on from #11532 to scope each PR to a single change

## Screenshot

<img width="1766" alt="image" src="https://github.com/user-attachments/assets/a65534af-96b2-4a20-af94-76cc357cb446" />
