### PR TITLE
[Docs] Fix incorrect reference to database_url as master_key

### DIFF
--- a/docs/my-website/docs/proxy/docker_quick_start.md
+++ b/docs/my-website/docs/proxy/docker_quick_start.md
@@ -260,7 +260,7 @@ See All General Settings [here](http://localhost:3000/docs/proxy/configs#all-set
    - **Description**: 
      - Set a `database_url`, this is the connection to your Postgres DB, which is used by litellm for generating keys, users, teams.
    - **Usage**: 
-     - ** Set on config.yaml** set your master key under `general_settings:database_url`, example - 
+     - ** Set on config.yaml** set your `database_url` under `general_settings:database_url`, example - 
         `database_url: "postgresql://..."`
      - Set `DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname>` in your env 
 


### PR DESCRIPTION
## Title

📖 Fix incorrect `database_url` description in `docs/my-website/docs/proxy/docker_quick_start.md`

## Relevant issues

None

## Pre-Submission checklist

- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes
- Corrected the description of `database_url` in `docs/my-website/docs/proxy/docker_quick_start.md`:  
  - Fixed the misleading "set your master key" to "set your database_url".  
  - Added code formatting for clarity.

