### PR TITLE
[Bug Fix] Empty bedrock tool arguments

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2610,7 +2610,10 @@ def _convert_to_bedrock_tool_call_invoke(
                 id = tool["id"]
                 name = tool["function"].get("name", "")
                 arguments = tool["function"].get("arguments", "")
-                arguments_dict = json.loads(arguments)
+                if len(arguments) == 0:
+                    arguments_dict = {}
+                else:
+                    arguments_dict = json.loads(arguments)
                 bedrock_tool = BedrockToolUseBlock(
                     input=arguments_dict, name=name, toolUseId=id
                 )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -82,6 +82,38 @@ async def test_anthropic_bedrock_thinking_blocks_with_none_content():
         == "This is a test thinking block"
     )
 
+@pytest.mark.asyncio
+async def test_bedrock_empty_tool_arguments():
+    """Test handling empty tool arguments in Bedrock messages"""
+
+    messages = [
+        {
+            "role": "user",
+            "content": "What is the weather like?",
+        },
+        {
+            "role": "assistant", "content": "", "tool_calls": [{
+                "id": "call_123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '',
+                },
+            }]
+        },
+    ]
+
+    result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        llm_provider="bedrock",
+    )
+
+    # Verify the result
+    assert len(result) == 2
+    assert result[1]["role"] == "assistant"
+    assert result[1]["content"][0]["toolUse"]["input"] == {}
+
 
 def test_bedrock_validate_format_image_or_video():
     """Test the _validate_format method for images, videos, and documents"""


### PR DESCRIPTION
## Fix bedrock empty arguments

When bedrock tool argument is empty, avoid parsing it as a JSON.

## Type

🐛 Bug Fix
✅ Test

