### PR TITLE
Fix gemini tool call indexes

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -784,6 +784,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ]:
         function: Optional[ChatCompletionToolCallFunctionChunk] = None
         _tools: List[ChatCompletionToolCallChunk] = []
+        # in a single chunk, each tool call appears as a separate part
+        # they need to be separate indexes as they are separate tool calls
+        funcCallIndex = 0
         for part in parts:
             if "functionCall" in part:
                 _function_chunk = ChatCompletionToolCallFunctionChunk(
@@ -800,6 +803,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         index=index,
                     )
                     _tools.append(_tool_response_chunk)
+                funcCallIndex += 1
         if len(_tools) == 0:
             tools: Optional[List[ChatCompletionToolCallChunk]] = None
         else:
@@ -1846,6 +1850,7 @@ class ModelResponseIterator:
 
     def chunk_parser(self, chunk: dict) -> Optional["ModelResponseStream"]:
         try:
+            print(f"RAW GEMINI CHUNK: {chunk}")
             verbose_logger.debug(f"RAW GEMINI CHUNK: {chunk}")
             from litellm.types.utils import ModelResponseStream
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -776,7 +776,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     @staticmethod
     def _transform_parts(
         parts: List[HttpxPartType],
-        index: int,
         is_function_call: Optional[bool],
     ) -> Tuple[
         Optional[ChatCompletionToolCallFunctionChunk],
@@ -1117,7 +1116,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
                 functions, tools = VertexGeminiConfig._transform_parts(
                     parts=candidate["content"]["parts"],
-                    index=candidate.get("index", idx),
                     is_function_call=is_function_call(standard_optional_params),
                 )
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -800,7 +800,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         id=f"call_{str(uuid.uuid4())}",
                         type="function",
                         function=_function_chunk,
-                        index=index,
+                        index=funcCallIndex,
                     )
                     _tools.append(_tool_response_chunk)
                 funcCallIndex += 1

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1850,7 +1850,6 @@ class ModelResponseIterator:
 
     def chunk_parser(self, chunk: dict) -> Optional["ModelResponseStream"]:
         try:
-            print(f"RAW GEMINI CHUNK: {chunk}")
             verbose_logger.debug(f"RAW GEMINI CHUNK: {chunk}")
             from litellm.types.utils import ModelResponseStream
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -598,3 +598,130 @@ def test_vertex_ai_streaming_usage_web_search_calculation():
     usage: Usage = completed_response.usage
     assert usage.prompt_tokens_details.web_search_requests is not None
     assert usage.prompt_tokens_details.web_search_requests == 1
+
+
+def test_vertex_ai_transform_parts():
+    """
+    Test the _transform_parts method for converting Vertex AI function calls 
+    to OpenAI-compatible tool calls and function calls.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+    from litellm.types.llms.vertex_ai import HttpxPartType
+
+    # Test case 1: Function call mode (is_function_call=True)
+    parts_with_function = [
+        HttpxPartType(
+            functionCall={
+                "name": "get_current_weather",
+                "args": {"location": "Boston", "unit": "celsius"}
+            }
+        ),
+        HttpxPartType(text="Some text content")
+    ]
+    
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=parts_with_function, 
+        is_function_call=True
+    )
+    
+    # Should return function, no tools
+    assert function is not None
+    assert function["name"] == "get_current_weather"
+    assert function["arguments"] == '{"location": "Boston", "unit": "celsius"}'
+    assert tools is None
+
+    # Test case 2: Tool call mode (is_function_call=False)
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=parts_with_function, 
+        is_function_call=False
+    )
+    
+    # Should return tools, no function
+    assert function is None
+    assert tools is not None
+    assert len(tools) == 1
+    assert tools[0]["type"] == "function"
+    assert tools[0]["function"]["name"] == "get_current_weather"
+    assert tools[0]["function"]["arguments"] == '{"location": "Boston", "unit": "celsius"}'
+    assert tools[0]["id"].startswith("call_")
+    assert tools[0]["index"] == 0
+
+    # Test case 3: Multiple function calls
+    parts_with_multiple_functions = [
+        HttpxPartType(
+            functionCall={
+                "name": "get_current_weather",
+                "args": {"location": "Boston"}
+            }
+        ),
+        HttpxPartType(
+            functionCall={
+                "name": "get_forecast",
+                "args": {"location": "New York", "days": 3}
+            }
+        ),
+        HttpxPartType(text="Some text content")
+    ]
+    
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=parts_with_multiple_functions, 
+        is_function_call=False
+    )
+    
+    # Should return multiple tools
+    assert function is None
+    assert tools is not None
+    assert len(tools) == 2
+    assert tools[0]["function"]["name"] == "get_current_weather"
+    assert tools[0]["index"] == 0
+    assert tools[1]["function"]["name"] == "get_forecast"
+    assert tools[1]["index"] == 1
+    assert tools[1]["function"]["arguments"] == '{"location": "New York", "days": 3}'
+
+    # Test case 4: No function calls
+    parts_without_functions = [
+        HttpxPartType(text="Just some text content"),
+        HttpxPartType(text="More text")
+    ]
+    
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=parts_without_functions, 
+        is_function_call=False
+    )
+    
+    # Should return nothing
+    assert function is None
+    assert tools is None
+
+    # Test case 5: Empty parts list
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=[], 
+        is_function_call=False
+    )
+    
+    # Should return nothing
+    assert function is None
+    assert tools is None
+
+    # Test case 6: Function call with empty args
+    parts_with_empty_args = [
+        HttpxPartType(
+            functionCall={
+                "name": "simple_function",
+                "args": {}
+            }
+        )
+    ]
+    
+    function, tools = VertexGeminiConfig._transform_parts(
+        parts=parts_with_empty_args, 
+        is_function_call=True
+    )
+    
+    # Should handle empty args correctly
+    assert function is not None
+    assert function["name"] == "simple_function"
+    assert function["arguments"] == "{}"
+    assert tools is None


### PR DESCRIPTION
## Title

Fix Gemini model tool call indexes

OpenAI has an index field within each tool call chunk. This is meant for consolidating streaming tool calls for OpenAI models. However for Gemini models, the complete function call definition comes as a chunk. 
Each "part" in a Gemini tool call is a separate function call, and therefore they need to be different OpenAI indexes so that clients won't merge them together. 

![image](https://github.com/user-attachments/assets/aa133f0c-4952-4fac-8cbd-f31d81ded56b)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


