### PR TITLE
Add gpt-4o-audio-preview-2025-06-03 pricing configuration

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -439,6 +439,23 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "gpt-4o-audio-preview-2025-06-03": {
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_audio_token": 4.0e-5,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_audio_token": 8.0e-5,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "gpt-4o-mini-audio-preview": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Title

Add gpt-4o-audio-preview-2025-06-03 pricing configuration

## Relevant issues

<!-- No specific issue referenced -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Verified pricing configuration for `gpt-4o-audio-preview-2025-06-03` model
- Confirmed token costs align with OpenAI's official pricing:
  - Text input: $2.50 per 1M tokens (2.5e-06)
  - Text output: $10.00 per 1M tokens (1e-05)  
  - Audio input: $40.00 per 1M audio tokens (4.0e-5)
  - Audio output: $80.00 per 1M audio tokens (8.0e-5)
- Updated model configuration with correct audio capabilities flags
- Ensured proper support for audio input/output, function calling, and tool choice

> Source: https://platform.openai.com/docs/models/gpt-4o-audio-preview