### PR TITLE
Truncate long labels and improve tooltip in Top API Keys chart

### DIFF
--- a/ui/litellm-dashboard/src/components/top_key_view.tsx
+++ b/ui/litellm-dashboard/src/components/top_key_view.tsx
@@ -101,6 +101,11 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
     },
   ];
 
+  const processedTopKeys = topKeys.map(k => ({
+    ...k,
+    display_key_alias: k.key_alias && k.key_alias.length > 10 ? `${k.key_alias.slice(0, 10)}...` : (k.key_alias || '-'),
+  }));
+
   return (
     <>
       <div className="mb-4 flex justify-end items-center">
@@ -124,11 +129,11 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
         <div className="relative">
           <BarChart
             className="mt-4 h-40 cursor-pointer hover:opacity-90"
-            data={topKeys}
-            index="key_alias"
+            data={processedTopKeys}
+            index="display_key_alias"
             categories={["spend"]}
             colors={["cyan"]}
-            yAxisWidth={80}
+            yAxisWidth={120}
             tickGap={5}
             layout="vertical"
             showXAxis={false}
@@ -139,11 +144,15 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
             customTooltip={(props) => {
               const item = props.payload?.[0]?.payload;
               return (
-                <div className="p-3 bg-black/90 shadow-lg rounded-lg text-white">
+                <div className="relative z-50 p-3 bg-black/90 shadow-lg rounded-lg text-white max-w-xs">
                   <div className="space-y-1.5">
                     <div className="text-sm">
-                      <span className="text-gray-300">Key: </span>
-                      <span className="font-mono text-gray-100">{item?.api_key?.slice(0, 10)}...</span>
+                      <span className="text-gray-300">Key Alias: </span>
+                      <span className="font-mono text-gray-100 break-all">{item?.key_alias}</span>
+                    </div>
+                    <div className="text-sm">
+                      <span className="text-gray-300">Key ID: </span>
+                      <span className="font-mono text-gray-100 break-all">{item?.api_key}</span>
                     </div>
                     <div className="text-sm">
                       <span className="text-gray-300">Spend: </span>


### PR DESCRIPTION
## Title
Truncate long labels and improve tooltip in Top API Keys chart

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Truncated Y-Axis string Labels: Y-axis string labels for the "Top API Keys" chart are now truncated to 10 characters with an ellipsis (...) to prevent them from being clipped.
- Enhanced Tooltip: The on-hover tooltip has been updated to display the full, untruncated `key_alias` as well as the full api_key for complete visibility.
- Responsive Tooltip: The tooltip is now fully responsive. A max-width and word-wrapping (break-all) have been added to ensure it reflows gracefully and doesn't break the layout on smaller screens.
- Z-Index Adjustment: A z-index has been applied to the tooltip to ensure it renders above other page elements.

What was tested?
- Confirm that any long key aliases on the y-axis are truncated correctly.
- Hover over a bar in the chart to trigger the tooltip.
- Verify that the tooltip shows the full Key Alias and Key ID.
- Resize your browser to a smaller width and check that the tooltip remains contained within the view, with text wrapping as needed.

https://www.loom.com/share/a7a5f029a25b49adba680dfda5bdfbf1