### PR TITLE
(fix:exception_mapping_utils.py) fix sglang rate limit error issue

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -309,6 +309,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                     or "string too long. Expected a string with maximum length"
                     in error_str
                     or "model's maximum context limit" in error_str
+                    or "is longer than the model's context length" in error_str
                 ):
                     exception_mapping_worked = True
                     raise ContextWindowExceededError(


### PR DESCRIPTION
## Title

Map sglang error to ContextWindowExceededError for proper error handling.

## Relevant issues

"Fixes #10793 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


