### PR TITLE
Add support for new Mistral Magistral models (magistral-medium-2506 and magistral-small-2506)

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4153,6 +4153,32 @@
         "supports_assistant_prefill": true,
         "supports_tool_choice": true
     },
+    "mistral/magistral-medium-2506": {
+        "max_tokens": 40000,
+        "max_input_tokens": 40000,
+        "max_output_tokens": 40000,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/magistral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true
+    },
+    "mistral/magistral-small-2506": {
+        "max_tokens": 40000,
+        "max_input_tokens": 40000,
+        "max_output_tokens": 40000,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/magistral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-embed": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,


### PR DESCRIPTION
## Title

Add support for new Mistral Magistral models (magistral-medium-2506 and magistral-small-2506)

## Relevant issues

<!-- Please link any relevant issues here -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

This PR adds support for two new Mistral Magistral models by updating the `model_prices_and_context_window.json` file:

### Added Models:
- **mistral/magistral-medium-2506**: 
  - Input cost: $2.00 per 1M tokens
  - Output cost: $5.00 per 1M tokens
  - Max tokens: 40,000 (input/output)
  - Supports function calling, assistant prefill, and tool choice

- **mistral/magistral-small-2506**:
  - Free model (no cost)
  - Max tokens: 40,000 (input/output) 
  - Supports function calling, assistant prefill, and tool choice

Both models are configured with:
- LiteLLM provider: `mistral`
- Mode: `chat`
- Source: https://mistral.ai/news/magistral

### Technical Details:
- Updated `model_prices_and_context_window.json` with pricing and capability information
- Follows existing patterns for Mistral model configurations
- Maintains consistency with other model definitions in the file