### PR TITLE
[Feat] UI - Add controls for MCP Permission Management

### DIFF
--- a/ui/litellm-dashboard/src/components/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_edit_view.tsx
@@ -6,6 +6,7 @@ import { fetchTeamModels } from "../components/create_key_button";
 import { modelAvailableCall } from "./networking";
 import NumericalInput from "./shared/numerical_input";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
+import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
 
 interface KeyEditViewProps {
   keyData: KeyResponse;
@@ -98,7 +99,8 @@ export function KeyEditView({
     budget_duration: getBudgetDuration(keyData.budget_duration),
     metadata: keyData.metadata ? JSON.stringify(keyData.metadata, null, 2) : "",
     guardrails: keyData.metadata?.guardrails || [],
-    vector_stores: keyData.object_permission?.vector_stores || []
+    vector_stores: keyData.object_permission?.vector_stores || [],
+    mcp_servers: keyData.object_permission?.mcp_servers || []
   };
 
   return (
@@ -177,6 +179,15 @@ export function KeyEditView({
           value={form.getFieldValue('vector_stores')}
           accessToken={accessToken || ""}
           placeholder="Select vector stores"
+        />
+      </Form.Item>
+
+      <Form.Item label="MCP Servers" name="mcp_servers">
+        <MCPServerSelector
+          onChange={(values) => form.setFieldValue('mcp_servers', values)}
+          value={form.getFieldValue('mcp_servers')}
+          accessToken={accessToken || ""}
+          placeholder="Select MCP servers"
         />
       </Form.Item>
 

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -76,6 +76,15 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
         delete formValues.vector_stores;
       }
 
+      if (formValues.mcp_servers !== undefined) {
+        formValues.object_permission = {
+          ...keyData.object_permission,
+          mcp_servers: formValues.mcp_servers || []
+        };
+        // Remove mcp_servers from the top level as it should be in object_permission
+        delete formValues.mcp_servers;
+      }
+
       // Convert metadata back to an object if it exists and is a string
       if (formValues.metadata && typeof formValues.metadata === "string") {
         try {

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -1,14 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Select } from 'antd';
 import { fetchMCPServers } from '../networking';
+import { MCPServer } from '../mcp_tools/types';
 
-interface MCPServer {
-  server_id: string;
-  alias: string;
-  description?: string;
-  url?: string;
-  transport?: string;
-}
 
 interface MCPServerSelectorProps {
   onChange: (selectedMCPServers: string[]) => void;

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { Select } from 'antd';
+import { fetchMCPServers } from '../networking';
+
+interface MCPServer {
+  server_id: string;
+  alias: string;
+  description?: string;
+  url?: string;
+  transport?: string;
+}
+
+interface MCPServerSelectorProps {
+  onChange: (selectedMCPServers: string[]) => void;
+  value?: string[];
+  className?: string;
+  accessToken: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({ 
+  onChange, 
+  value, 
+  className, 
+  accessToken,
+  placeholder = "Select MCP servers",
+  disabled = false
+}) => {
+  const [mcpServers, setMCPServers] = useState<MCPServer[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchMCPServerList = async () => {
+      if (!accessToken) return;
+      
+      setLoading(true);
+      try {
+        const response = await fetchMCPServers(accessToken);
+        if (response && Array.isArray(response)) {
+          // Direct array response
+          setMCPServers(response);
+        } else if (response.data && Array.isArray(response.data)) {
+          // Response with data wrapper
+          setMCPServers(response.data);
+        }
+      } catch (error) {
+        console.error("Error fetching MCP servers:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMCPServerList();
+  }, [accessToken]);
+
+  return (
+    <div>
+      <Select
+        mode="multiple"
+        placeholder={placeholder}
+        onChange={onChange}
+        value={value}
+        loading={loading}
+        className={className}
+        options={mcpServers.map(server => ({
+          label: `${server.alias} (${server.server_id})`,
+          value: server.server_id,
+          title: server.description || server.alias,
+        }))}
+        optionFilterProp="label"
+        showSearch
+        style={{ width: '100%' }}
+        disabled={disabled}
+      />
+    </div>
+  );
+};
+
+export default MCPServerSelector; 

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -1,12 +1,7 @@
-import React, { useState, useEffect } from "react";
-import { Card, Text, Badge } from "@tremor/react";
-import { ServerIcon, DatabaseIcon } from "@heroicons/react/outline";
-import { vectorStoreListCall } from "./networking";
-
-interface VectorStoreDetails {
-  vector_store_id: string;
-  vector_store_name?: string;
-}
+import React from "react";
+import { Text } from "@tremor/react";
+import VectorStorePermissions from "./permissions/VectorStorePermissions";
+import MCPServerPermissions from "./permissions/MCPServerPermissions";
 
 interface ObjectPermission {
   object_permission_id: string;
@@ -29,97 +24,17 @@ export function ObjectPermissionsView({
 }: ObjectPermissionsViewProps) {
   const vectorStores = objectPermission?.vector_stores || [];
   const mcpServers = objectPermission?.mcp_servers || [];
-  const [vectorStoreDetails, setVectorStoreDetails] = useState<VectorStoreDetails[]>([]);
-
-  // Fetch vector store details when component mounts
-  useEffect(() => {
-    const fetchVectorStores = async () => {
-      if (!accessToken || vectorStores.length === 0) return;
-      
-      try {
-        const response = await vectorStoreListCall(accessToken);
-        if (response.data) {
-          setVectorStoreDetails(response.data.map((store: any) => ({
-            vector_store_id: store.vector_store_id,
-            vector_store_name: store.vector_store_name
-          })));
-        }
-      } catch (error) {
-        console.error("Error fetching vector stores:", error);
-      }
-    };
-
-    fetchVectorStores();
-  }, [accessToken, vectorStores.length]);
-
-  // Function to get display name for vector store
-  const getVectorStoreDisplayName = (storeId: string) => {
-    const storeDetail = vectorStoreDetails.find(store => store.vector_store_id === storeId);
-    if (storeDetail) {
-      return `${storeDetail.vector_store_name || storeDetail.vector_store_id} (${storeDetail.vector_store_id})`;
-    }
-    return storeId;
-  };
 
   const content = (
     <div className={variant === "card" ? "grid grid-cols-1 md:grid-cols-2 gap-6" : "space-y-4"}>
-      {/* Vector Stores Section */}
-      <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <DatabaseIcon className="h-4 w-4 text-blue-600" />
-          <Text className="font-semibold text-gray-900">Vector Stores</Text>
-          <Badge color="blue" size="xs">
-            {vectorStores.length}
-          </Badge>
-        </div>
-        
-        {vectorStores.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {vectorStores.map((store, index) => (
-              <div
-                key={index}
-                className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
-              >
-                {getVectorStoreDisplayName(store)}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
-            <DatabaseIcon className="h-4 w-4 text-gray-400" />
-            <Text className="text-gray-500 text-sm">No vector stores configured</Text>
-          </div>
-        )}
-      </div>
-
-      {/* MCP Servers Section */}
-      {/* <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <ServerIcon className="h-4 w-4 text-blue-600" />
-          <Text className="font-semibold text-gray-900">MCP Servers</Text>
-          <Badge color="blue" size="xs">
-            {mcpServers.length}
-          </Badge>
-        </div>
-        
-        {mcpServers.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {mcpServers.map((server, index) => (
-              <div
-                key={index}
-                className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
-              >
-                {server}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
-            <ServerIcon className="h-4 w-4 text-gray-400" />
-            <Text className="text-gray-500 text-sm">No MCP servers configured</Text>
-          </div>
-        )}
-      </div> */}
+      <VectorStorePermissions 
+        vectorStores={vectorStores} 
+        accessToken={accessToken} 
+      />
+      <MCPServerPermissions 
+        mcpServers={mcpServers} 
+        accessToken={accessToken} 
+      />
     </div>
   );
 
@@ -130,7 +45,7 @@ export function ObjectPermissionsView({
           <div>
             <Text className="font-semibold text-gray-900">Object Permissions</Text>
             <Text className="text-xs text-gray-500">
-              Access control for Vector Stores
+              Access control for Vector Stores and MCP Servers
             </Text>
           </div>
         </div>

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -3,14 +3,7 @@ import { Text, Badge } from "@tremor/react";
 import { ServerIcon } from "@heroicons/react/outline";
 import { Tooltip } from "antd";
 import { fetchMCPServers } from "../networking";
-
-interface MCPServerDetails {
-  server_id: string;
-  alias: string;
-  description?: string;
-  url?: string;
-  transport?: string;
-}
+import { MCPServer } from '../mcp_tools/types';
 
 interface MCPServerPermissionsProps {
   mcpServers: string[];
@@ -21,7 +14,7 @@ export function MCPServerPermissions({
   mcpServers, 
   accessToken 
 }: MCPServerPermissionsProps) {
-  const [mcpServerDetails, setMCPServerDetails] = useState<MCPServerDetails[]>([]);
+  const [mcpServerDetails, setMCPServerDetails] = useState<MCPServer[]>([]);
 
   // Fetch MCP server details when component mounts
   useEffect(() => {

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from "react";
+import { Text, Badge } from "@tremor/react";
+import { ServerIcon } from "@heroicons/react/outline";
+import { fetchMCPServers } from "../networking";
+
+interface MCPServerDetails {
+  mcp_server_id: string;
+  mcp_server_name?: string;
+  server_name?: string;
+}
+
+interface MCPServerPermissionsProps {
+  mcpServers: string[];
+  accessToken?: string | null;
+}
+
+export function MCPServerPermissions({ 
+  mcpServers, 
+  accessToken 
+}: MCPServerPermissionsProps) {
+  const [mcpServerDetails, setMCPServerDetails] = useState<MCPServerDetails[]>([]);
+
+  // Fetch MCP server details when component mounts
+  useEffect(() => {
+    const fetchMCPServerDetails = async () => {
+      if (!accessToken || mcpServers.length === 0) return;
+      
+      try {
+        const response = await fetchMCPServers(accessToken);
+        if (response.data) {
+          setMCPServerDetails(response.data.map((server: any) => ({
+            mcp_server_id: server.mcp_server_id || server.id,
+            mcp_server_name: server.mcp_server_name || server.server_name,
+            server_name: server.server_name
+          })));
+        }
+      } catch (error) {
+        console.error("Error fetching MCP servers:", error);
+      }
+    };
+
+    fetchMCPServerDetails();
+  }, [accessToken, mcpServers.length]);
+
+  // Function to get display name for MCP server
+  const getMCPServerDisplayName = (serverId: string) => {
+    const serverDetail = mcpServerDetails.find(server => server.mcp_server_id === serverId);
+    if (serverDetail) {
+      return `${serverDetail.mcp_server_name || serverDetail.server_name || serverDetail.mcp_server_id} (${serverDetail.mcp_server_id})`;
+    }
+    return serverId;
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <ServerIcon className="h-4 w-4 text-green-600" />
+        <Text className="font-semibold text-gray-900">MCP Servers</Text>
+        <Badge color="green" size="xs">
+          {mcpServers.length}
+        </Badge>
+      </div>
+      
+      {mcpServers.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {mcpServers.map((server, index) => (
+            <div
+              key={index}
+              className="inline-flex items-center px-3 py-1.5 rounded-lg bg-green-50 border border-green-200 text-green-800 text-sm font-medium"
+            >
+              {getMCPServerDisplayName(server)}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
+          <ServerIcon className="h-4 w-4 text-gray-400" />
+          <Text className="text-gray-500 text-sm">No MCP servers configured</Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MCPServerPermissions; 

--- a/ui/litellm-dashboard/src/components/permissions/VectorStorePermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/VectorStorePermissions.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from "react";
+import { Text, Badge } from "@tremor/react";
+import { DatabaseIcon } from "@heroicons/react/outline";
+import { vectorStoreListCall } from "../networking";
+
+interface VectorStoreDetails {
+  vector_store_id: string;
+  vector_store_name?: string;
+}
+
+interface VectorStorePermissionsProps {
+  vectorStores: string[];
+  accessToken?: string | null;
+}
+
+export function VectorStorePermissions({ 
+  vectorStores, 
+  accessToken 
+}: VectorStorePermissionsProps) {
+  const [vectorStoreDetails, setVectorStoreDetails] = useState<VectorStoreDetails[]>([]);
+
+  // Fetch vector store details when component mounts
+  useEffect(() => {
+    const fetchVectorStores = async () => {
+      if (!accessToken || vectorStores.length === 0) return;
+      
+      try {
+        const response = await vectorStoreListCall(accessToken);
+        if (response.data) {
+          setVectorStoreDetails(response.data.map((store: any) => ({
+            vector_store_id: store.vector_store_id,
+            vector_store_name: store.vector_store_name
+          })));
+        }
+      } catch (error) {
+        console.error("Error fetching vector stores:", error);
+      }
+    };
+
+    fetchVectorStores();
+  }, [accessToken, vectorStores.length]);
+
+  // Function to get display name for vector store
+  const getVectorStoreDisplayName = (storeId: string) => {
+    const storeDetail = vectorStoreDetails.find(store => store.vector_store_id === storeId);
+    if (storeDetail) {
+      return `${storeDetail.vector_store_name || storeDetail.vector_store_id} (${storeDetail.vector_store_id})`;
+    }
+    return storeId;
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <DatabaseIcon className="h-4 w-4 text-blue-600" />
+        <Text className="font-semibold text-gray-900">Vector Stores</Text>
+        <Badge color="blue" size="xs">
+          {vectorStores.length}
+        </Badge>
+      </div>
+      
+      {vectorStores.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {vectorStores.map((store, index) => (
+            <div
+              key={index}
+              className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
+            >
+              {getVectorStoreDisplayName(store)}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
+          <DatabaseIcon className="h-4 w-4 text-gray-400" />
+          <Text className="text-gray-500 text-sm">No vector stores configured</Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default VectorStorePermissions; 

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -35,6 +35,7 @@ import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_
 import { isAdminRole } from "@/utils/roles";
 import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
+import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
 import PremiumVectorStoreSelector from "../common_components/PremiumVectorStoreSelector";
 
 export interface TeamData {
@@ -235,10 +236,11 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       };
 
       // Handle object_permission updates
-      if (values.vector_stores !== undefined) {
+      if (values.vector_stores !== undefined || values.mcp_servers !== undefined) {
         updateData.object_permission = {
           ...teamData?.team_info.object_permission,
-          vector_stores: values.vector_stores || []
+          vector_stores: values.vector_stores || [],
+          mcp_servers: values.mcp_servers || []
         };
       }
       
@@ -385,7 +387,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     guardrails: info.metadata?.guardrails || [],
                     metadata: info.metadata ? JSON.stringify(info.metadata, null, 2) : "",
                     organization_id: info.organization_id,
-                    vector_stores: info.object_permission?.vector_stores || []
+                    vector_stores: info.object_permission?.vector_stores || [],
+                    mcp_servers: info.object_permission?.mcp_servers || []
                   }}
                   layout="vertical"
                 >
@@ -464,6 +467,15 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       value={form.getFieldValue('vector_stores')}
                       accessToken={accessToken || ""}
                       placeholder="Select vector stores"
+                    />
+                  </Form.Item>
+
+                  <Form.Item label="MCP Servers" name="mcp_servers">
+                    <MCPServerSelector
+                      onChange={(values) => form.setFieldValue('mcp_servers', values)}
+                      value={form.getFieldValue('mcp_servers')}
+                      accessToken={accessToken || ""}
+                      placeholder="Select MCP servers"
                     />
                   </Form.Item>
                   


### PR DESCRIPTION
## [Feat] UI - Add controls for MCP Permission Management

UI Allow setting MCP permissions per Key, Team

<img width="491" alt="Screenshot 2025-06-10 at 2 27 25 PM" src="https://github.com/user-attachments/assets/baabecd8-ec25-433c-b86c-a734951240d1" />

<img width="1086" alt="Screenshot 2025-06-10 at 2 28 26 PM" src="https://github.com/user-attachments/assets/4ff8a340-9874-45cc-b593-34c246cf7d42" />



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


