### PR TITLE
[Feat] New LLM API Endpoint - Add List input items for Responses API

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -170,3 +170,35 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         data: Dict = {}
         verbose_logger.debug(f"get response url={get_url}")
         return get_url, data
+
+    def transform_list_input_items_request(
+        self,
+        response_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+        include: Optional[List[str]] = None,
+        limit: int = 20,
+        order: Literal["asc", "desc"] = "desc",
+    ) -> Tuple[str, Dict]:
+        url = (
+            self._construct_url_for_response_id_in_path(
+                api_base=api_base, response_id=response_id
+            )
+            + "/input_items"
+        )
+        params: Dict[str, Any] = {}
+        if after is not None:
+            params["after"] = after
+        if before is not None:
+            params["before"] = before
+        if include:
+            params["include"] = ",".join(include)
+        if limit is not None:
+            params["limit"] = limit
+        if order is not None:
+            params["order"] = order
+        verbose_logger.debug(f"list input items url={url}")
+        return url, params

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -156,7 +156,7 @@ class BaseResponsesAPIConfig(ABC):
         headers: dict,
     ) -> Tuple[str, Dict]:
         pass
-    
+
     @abstractmethod
     def transform_get_response_api_response(
         self,
@@ -166,9 +166,35 @@ class BaseResponsesAPIConfig(ABC):
         pass
 
     #########################################################
+    ########## LIST INPUT ITEMS API TRANSFORMATION ##########
+    #########################################################
+    @abstractmethod
+    def transform_list_input_items_request(
+        self,
+        response_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+        include: Optional[List[str]] = None,
+        limit: int = 20,
+        order: Literal["asc", "desc"] = "desc",
+    ) -> Tuple[str, Dict]:
+        pass
+
+    @abstractmethod
+    def transform_list_input_items_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> Dict:
+        pass
+
+    #########################################################
     ########## END GET RESPONSE API TRANSFORMATION ##########
     #########################################################
-    
+
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
     ) -> BaseLLMException:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -251,7 +251,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                 message=raw_response.text, status_code=raw_response.status_code
             )
         return DeleteResponseResult(**raw_response_json)
-    
+
     #########################################################
     ########## GET RESPONSE API TRANSFORMATION ###############
     #########################################################
@@ -271,7 +271,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         url = f"{api_base}/{response_id}"
         data: Dict = {}
         return url, data
-    
+
     def transform_get_response_api_response(
         self,
         raw_response: httpx.Response,
@@ -287,3 +287,44 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                 message=raw_response.text, status_code=raw_response.status_code
             )
         return ResponsesAPIResponse(**raw_response_json)
+
+    #########################################################
+    ########## LIST INPUT ITEMS TRANSFORMATION #############
+    #########################################################
+    def transform_list_input_items_request(
+        self,
+        response_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+        include: Optional[List[str]] = None,
+        limit: int = 20,
+        order: Literal["asc", "desc"] = "desc",
+    ) -> Tuple[str, Dict]:
+        url = f"{api_base}/{response_id}/input_items"
+        params: Dict[str, Any] = {}
+        if after is not None:
+            params["after"] = after
+        if before is not None:
+            params["before"] = before
+        if include:
+            params["include"] = ",".join(include)
+        if limit is not None:
+            params["limit"] = limit
+        if order is not None:
+            params["order"] = order
+        return url, params
+
+    def transform_list_input_items_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> Dict:
+        try:
+            return raw_response.json()
+        except Exception:
+            raise OpenAIError(
+                message=raw_response.text, status_code=raw_response.status_code
+            )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4153,6 +4153,32 @@
         "supports_assistant_prefill": true,
         "supports_tool_choice": true
     },
+    "mistral/magistral-medium-2506": {
+        "max_tokens": 40000,
+        "max_input_tokens": 40000,
+        "max_output_tokens": 40000,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/magistral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true
+    },
+    "mistral/magistral-small-2506": {
+        "max_tokens": 40000,
+        "max_input_tokens": 40000,
+        "max_output_tokens": 40000,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/magistral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-embed": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -330,6 +330,7 @@ class ProxyBaseLLMRequestProcessing:
             "adelete_responses",
             "atext_completion",
             "aimage_edit",
+            "alist_input_items",
         ],
         proxy_logging_obj: ProxyLogging,
         general_settings: dict,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -250,6 +250,7 @@ class ProxyBaseLLMRequestProcessing:
             "acancel_fine_tuning_job",
             "alist_fine_tuning_jobs",
             "aretrieve_fine_tuning_job",
+            "alist_input_items",
             "aimage_edit",
         ],
         version: Optional[str] = None,

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -240,15 +240,48 @@ async def get_response_input_items(
     fastapi_response: Response,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
-    """
-    Get input items for a response.
-    
-    Follows the OpenAI Responses API spec: https://platform.openai.com/docs/api-reference/responses/input-items
-    
-    ```bash
-    curl -X GET http://localhost:4000/v1/responses/resp_abc123/input_items \
-    -H "Authorization: Bearer sk-1234"
-    ```
-    """
-    # TODO: Implement input items retrieval logic
-    pass
+    """List input items for a response."""
+    from litellm.proxy.proxy_server import (
+        _read_request_body,
+        general_settings,
+        llm_router,
+        proxy_config,
+        proxy_logging_obj,
+        select_data_generator,
+        user_api_base,
+        user_max_tokens,
+        user_model,
+        user_request_timeout,
+        user_temperature,
+        version,
+    )
+
+    data = await _read_request_body(request=request)
+    data["response_id"] = response_id
+    processor = ProxyBaseLLMRequestProcessing(data=data)
+    try:
+        return await processor.base_process_llm_request(
+            request=request,
+            fastapi_response=fastapi_response,
+            user_api_key_dict=user_api_key_dict,
+            route_type="alist_input_items",
+            proxy_logging_obj=proxy_logging_obj,
+            llm_router=llm_router,
+            general_settings=general_settings,
+            proxy_config=proxy_config,
+            select_data_generator=select_data_generator,
+            model=None,
+            user_model=user_model,
+            user_temperature=user_temperature,
+            user_request_timeout=user_request_timeout,
+            user_max_tokens=user_max_tokens,
+            user_api_base=user_api_base,
+            version=version,
+        )
+    except Exception as e:
+        raise await processor._handle_llm_api_exception(
+            e=e,
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
+            version=version,
+        )

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -22,6 +22,7 @@ ROUTE_ENDPOINT_MAPPING = {
     "amoderation": "/moderations",
     "arerank": "/rerank",
     "aresponses": "/responses",
+    "alist_input_items": "/responses/{response_id}/input_items",
     "aimage_edit": "/images/edits",
 }
 
@@ -69,6 +70,7 @@ async def route_request(
         "aresponses",
         "aget_responses",
         "adelete_responses",
+        "alist_input_items",
         "_arealtime",  # private function for realtime API
         "aimage_edit",
     ],
@@ -134,7 +136,12 @@ async def route_request(
                 or len(llm_router.pattern_router.patterns) > 0
             ):
                 return getattr(llm_router, f"{route_type}")(**data)
-            elif route_type in ["amoderation", "aget_responses", "adelete_responses"]:
+            elif route_type in [
+                "amoderation",
+                "aget_responses",
+                "adelete_responses",
+                "alist_input_items",
+            ]:
                 # moderation endpoint does not require `model` parameter
                 return getattr(llm_router, f"{route_type}")(**data)
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -435,6 +435,7 @@ def delete_responses(
             extra_kwargs=kwargs,
         )
 
+
 @client
 async def aget_responses(
     response_id: str,
@@ -450,13 +451,13 @@ async def aget_responses(
 ) -> ResponsesAPIResponse:
     """
     Async: Fetch a response by its ID.
-    
+
     GET /v1/responses/{response_id} endpoint in the responses API
-    
+
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
-        
+
     Returns:
         The response object with complete information about the stored response.
     """
@@ -496,7 +497,7 @@ async def aget_responses(
         else:
             response = init_response
 
-         # Update the responses_api_response_id with the model_id
+        # Update the responses_api_response_id with the model_id
         if isinstance(response, ResponsesAPIResponse):
             response = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
                 responses_api_response=response,
@@ -513,6 +514,7 @@ async def aget_responses(
             extra_kwargs=kwargs,
         )
 
+
 @client
 def get_responses(
     response_id: str,
@@ -528,13 +530,13 @@ def get_responses(
 ) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
     """
     Fetch a response by its ID.
-    
+
     GET /v1/responses/{response_id} endpoint in the responses API
-    
+
     Args:
         response_id: The ID of the response to fetch.
         custom_llm_provider: Optional provider name. If not specified, will be decoded from response_id.
-        
+
     Returns:
         The response object with complete information about the stored response.
     """
@@ -609,6 +611,152 @@ def get_responses(
                 litellm_metadata=kwargs.get("litellm_metadata", {}),
                 custom_llm_provider=custom_llm_provider,
             )
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model=None,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+@client
+async def alist_input_items(
+    response_id: str,
+    after: Optional[str] = None,
+    before: Optional[str] = None,
+    include: Optional[List[str]] = None,
+    limit: int = 20,
+    order: Literal["asc", "desc"] = "desc",
+    extra_headers: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    custom_llm_provider: Optional[str] = None,
+    **kwargs,
+) -> Dict:
+    """Async: List input items for a response"""
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["alist_input_items"] = True
+
+        decoded_response_id = (
+            ResponsesAPIRequestUtils._decode_responses_api_response_id(
+                response_id=response_id
+            )
+        )
+        response_id = decoded_response_id.get("response_id") or response_id
+        custom_llm_provider = (
+            decoded_response_id.get("custom_llm_provider") or custom_llm_provider
+        )
+
+        func = partial(
+            list_input_items,
+            response_id=response_id,
+            after=after,
+            before=before,
+            include=include,
+            limit=limit,
+            order=order,
+            extra_headers=extra_headers,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model=None,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+@client
+def list_input_items(
+    response_id: str,
+    after: Optional[str] = None,
+    before: Optional[str] = None,
+    include: Optional[List[str]] = None,
+    limit: int = 20,
+    order: Literal["asc", "desc"] = "desc",
+    extra_headers: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    custom_llm_provider: Optional[str] = None,
+    **kwargs,
+) -> Union[Dict, Coroutine[Any, Any, Dict]]:
+    """List input items for a response"""
+    local_vars = locals()
+    try:
+        litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        _is_async = kwargs.pop("alist_input_items", False) is True
+
+        litellm_params = GenericLiteLLMParams(**kwargs)
+
+        decoded_response_id = (
+            ResponsesAPIRequestUtils._decode_responses_api_response_id(
+                response_id=response_id
+            )
+        )
+        response_id = decoded_response_id.get("response_id") or response_id
+        custom_llm_provider = (
+            decoded_response_id.get("custom_llm_provider") or custom_llm_provider
+        )
+
+        if custom_llm_provider is None:
+            raise ValueError("custom_llm_provider is required but passed as None")
+
+        responses_api_provider_config: Optional[BaseResponsesAPIConfig] = (
+            ProviderConfigManager.get_provider_responses_api_config(
+                model=None,
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if responses_api_provider_config is None:
+            raise ValueError(
+                f"list_input_items is not supported for {custom_llm_provider}"
+            )
+
+        local_vars.update(kwargs)
+
+        litellm_logging_obj.update_environment_variables(
+            model=None,
+            optional_params={"response_id": response_id},
+            litellm_params={"litellm_call_id": litellm_call_id},
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        response = base_llm_http_handler.list_responses_input_items(
+            response_id=response_id,
+            custom_llm_provider=custom_llm_provider,
+            responses_api_provider_config=responses_api_provider_config,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            after=after,
+            before=before,
+            include=include,
+            limit=limit,
+            order=order,
+            extra_headers=extra_headers,
+            timeout=timeout or request_timeout,
+            _is_async=_is_async,
+            client=kwargs.get("client"),
+        )
 
         return response
     except Exception as e:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -349,9 +349,9 @@ class Router:
         )  # names of models under litellm_params. ex. azure/chatgpt-v-2
         self.deployment_latency_map = {}
         ### CACHING ###
-        cache_type: Literal[
-            "local", "redis", "redis-semantic", "s3", "disk"
-        ] = "local"  # default to an in-memory cache
+        cache_type: Literal["local", "redis", "redis-semantic", "s3", "disk"] = (
+            "local"  # default to an in-memory cache
+        )
         redis_cache = None
         cache_config: Dict[str, Any] = {}
 
@@ -573,9 +573,9 @@ class Router:
                 )
             )
 
-        self.model_group_retry_policy: Optional[
-            Dict[str, RetryPolicy]
-        ] = model_group_retry_policy
+        self.model_group_retry_policy: Optional[Dict[str, RetryPolicy]] = (
+            model_group_retry_policy
+        )
 
         self.allowed_fails_policy: Optional[AllowedFailsPolicy] = None
         if allowed_fails_policy is not None:
@@ -752,6 +752,9 @@ class Router:
         )
         self.adelete_responses = self.factory_function(
             litellm.adelete_responses, call_type="adelete_responses"
+        )
+        self.alist_input_items = self.factory_function(
+            litellm.alist_input_items, call_type="alist_input_items"
         )
         self._arealtime = self.factory_function(
             litellm._arealtime, call_type="_arealtime"
@@ -3202,6 +3205,7 @@ class Router:
             "alist_files",
             "aimage_edit",
             "allm_passthrough_route",
+            "alist_input_items",
         ] = "assistants",
     ):
         """
@@ -3262,7 +3266,11 @@ class Router:
                     original_function=original_function,
                     **kwargs,
                 )
-            elif call_type in ("aget_responses", "adelete_responses"):
+            elif call_type in (
+                "aget_responses",
+                "adelete_responses",
+                "alist_input_items",
+            ):
                 return await self._init_responses_api_endpoints(
                     original_function=original_function,
                     **kwargs,
@@ -3406,11 +3414,11 @@ class Router:
 
                 if isinstance(e, litellm.ContextWindowExceededError):
                     if context_window_fallbacks is not None:
-                        fallback_model_group: Optional[
-                            List[str]
-                        ] = self._get_fallback_model_group_from_fallbacks(
-                            fallbacks=context_window_fallbacks,
-                            model_group=model_group,
+                        fallback_model_group: Optional[List[str]] = (
+                            self._get_fallback_model_group_from_fallbacks(
+                                fallbacks=context_window_fallbacks,
+                                model_group=model_group,
+                            )
                         )
                         if fallback_model_group is None:
                             raise original_exception
@@ -3442,11 +3450,11 @@ class Router:
                         e.message += "\n{}".format(error_message)
                 elif isinstance(e, litellm.ContentPolicyViolationError):
                     if content_policy_fallbacks is not None:
-                        fallback_model_group: Optional[
-                            List[str]
-                        ] = self._get_fallback_model_group_from_fallbacks(
-                            fallbacks=content_policy_fallbacks,
-                            model_group=model_group,
+                        fallback_model_group: Optional[List[str]] = (
+                            self._get_fallback_model_group_from_fallbacks(
+                                fallbacks=content_policy_fallbacks,
+                                model_group=model_group,
+                            )
                         )
                         if fallback_model_group is None:
                             raise original_exception

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -275,6 +275,7 @@ class CallTypes(Enum):
     retrieve_fine_tuning_job = "retrieve_fine_tuning_job"
     responses = "responses"
     aresponses = "aresponses"
+    alist_input_items = "alist_input_items"
 
 
 CallTypesLiteral = Literal[

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -315,6 +315,32 @@ class BaseResponsesAPITest(ABC):
                 assert result.output == response.output
             else:
                 raise ValueError("response is not a ResponsesAPIResponse")
+
+    @pytest.mark.asyncio
+    async def test_basic_openai_list_input_items_endpoint(self):
+        """Test that calls the OpenAI List Input Items endpoint"""
+        litellm._turn_on_debug()
+
+        response = await litellm.aresponses(
+            model="gpt-4o",
+            input="Tell me a three sentence bedtime story about a unicorn.",
+        )
+        print("Initial response=", json.dumps(response, indent=4, default=str))
+
+        response_id = response.get("id")
+        assert response_id is not None, "Response should have an ID"
+        print(f"Got response_id: {response_id}")
+
+        list_items_response = await litellm.alist_input_items(
+            response_id=response_id,
+            limit=20,
+            order="desc",
+        )
+        print(
+            "List items response=",
+            json.dumps(list_items_response, indent=4, default=str),
+        )
+
     
     @pytest.mark.asyncio
     async def test_multiturn_responses_api(self):

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -391,6 +391,7 @@ def test_select_azure_base_url_called(setup_mocks):
             "add_message",
             "arun_thread_stream",
             "aresponses",
+            "alist_input_items",
             "acreate_fine_tuning_job",
             "acancel_fine_tuning_job",
             "alist_fine_tuning_jobs",


### PR DESCRIPTION
## [Feat] New LLM API Endpoint - Add List input items for Responses API

This PR adds a new “List Input Items” endpoint to the Responses API, wiring it through the client, router, proxy, and HTTP handler layers, and includes a basic async test.

- Introduces litellm.alist_input_items client methods (sync and async)
- Updates router, proxy routes, and HTTP handler to support the new endpoint
- Adds a smoke test for the new endpoint and necessary type/enum updates

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


