### PR TITLE
Correct success message when user creates new budget

### DIFF
--- a/ui/litellm-dashboard/src/components/budgets/budget_modal.tsx
+++ b/ui/litellm-dashboard/src/components/budgets/budget_modal.tsx
@@ -54,7 +54,7 @@ const BudgetModal: React.FC<BudgetModalProps> = ({
       setBudgetList((prevData) =>
         prevData ? [...prevData, response] : [response]
       ); // Check if prevData is null
-      message.success("API Key Created");
+      message.success("Budget Created");
       form.resetFields();
     } catch (error) {
       console.error("Error creating the key:", error);


### PR DESCRIPTION
## Title

Correct the message when user creates new budget

## Relevant issues

Fixes #9347

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Update message in src/components/budgets/budget_modal.tsx
