### PR TITLE
Enable System Proxy Support for aiohttp Transport

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -318,9 +318,8 @@ use_aiohttp_transport: bool = (
     True  # Older variable, aiohttp is now the default. use disable_aiohttp_transport instead.
 )
 disable_aiohttp_transport: bool = False  # Set this to true to use httpx instead
-force_ipv4: bool = (
-    False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
-)
+disable_aiohttp_trust_env: bool = False  # when True, aiohttp will not trust environment variables for proxy settings
+force_ipv4: bool = False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
 module_level_aclient = AsyncHTTPHandler(
     timeout=request_timeout, client_alias="module level aclient"
 )

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -318,8 +318,12 @@ use_aiohttp_transport: bool = (
     True  # Older variable, aiohttp is now the default. use disable_aiohttp_transport instead.
 )
 disable_aiohttp_transport: bool = False  # Set this to true to use httpx instead
-disable_aiohttp_trust_env: bool = False  # when True, aiohttp will not trust environment variables for proxy settings
-force_ipv4: bool = False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
+disable_aiohttp_trust_env: bool = (
+    False  # when True, aiohttp will not trust environment variables for proxy settings
+)
+force_ipv4: bool = (
+    False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
+)
 module_level_aclient = AsyncHTTPHandler(
     timeout=request_timeout, client_alias="module level aclient"
 )

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -545,6 +545,8 @@ class AsyncHTTPHandler:
         - [Default] If force_ipv4 is False, it will create an AiohttpTransport with default settings
         """
         from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
+        
+        from litellm.secret_managers.main import str_to_bool
 
         #########################################################
         # If ssl_verify is None, set it to True
@@ -553,10 +555,20 @@ class AsyncHTTPHandler:
         #########################################################
         if ssl_verify is None:
             ssl_verify = True
+            
+        #########################################################
+        # Check if user disabled aiohttp trust env
+        # When True, aiohttp will not trust environment variables for proxy settings
+        ########################################################
+        disable_trust_env = (
+            litellm.disable_aiohttp_trust_env is True
+            or str_to_bool(os.getenv("DISABLE_AIOHTTP_TRUST_ENV", "False")) is True
+        )
 
         verbose_logger.debug("Creating AiohttpTransport...")
         return LiteLLMAiohttpTransport(
             client=lambda: ClientSession(
+                trust_env=not disable_trust_env,
                 connector=TCPConnector(
                     verify_ssl=ssl_verify,
                     ssl_context=ssl_context,

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -120,3 +120,70 @@ async def test_ssl_verification_with_aiohttp_transport():
 
     # assert both litellm transport and aiohttp session have ssl_verify=False
     assert transport_connector._ssl == aiohttp_session.connector._ssl
+
+
+@pytest.mark.asyncio
+async def test_disable_aiohttp_trust_env_with_env_variable(monkeypatch):
+    """Test aiohttp transport respects DISABLE_AIOHTTP_TRUST_ENV environment variable"""
+    # Set environment variable to disable trust env
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRUST_ENV", "True")
+    
+    # Ensure aiohttp transport is enabled
+    litellm.disable_aiohttp_transport = False
+    
+    # Create async client
+    client = AsyncHTTPHandler()
+    
+    # Get the transport (should be LiteLLMAiohttpTransport)
+    transport = client.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport)
+    
+    # Get the aiohttp ClientSession
+    client_session = transport._get_valid_client_session()
+    
+    # Verify that trust_env is False when DISABLE_AIOHTTP_TRUST_ENV is True
+    assert client_session._trust_env is False
+
+
+@pytest.mark.asyncio
+async def test_disable_aiohttp_trust_env_with_litellm_setting():
+    """Test aiohttp transport respects litellm.disable_aiohttp_trust_env setting"""
+    # Set litellm setting to disable trust env
+    litellm.disable_aiohttp_trust_env = True
+    
+    # Ensure aiohttp transport is enabled
+    litellm.disable_aiohttp_transport = False
+    
+    # Create async client
+    client = AsyncHTTPHandler()
+    
+    # Get the transport (should be LiteLLMAiohttpTransport)
+    transport = client.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport)
+    
+    # Get the aiohttp ClientSession
+    client_session = transport._get_valid_client_session()
+    
+    # Verify that trust_env is False when litellm.disable_aiohttp_trust_env is True
+    assert client_session._trust_env is False
+
+
+@pytest.mark.asyncio
+async def test_enable_aiohttp_trust_env_default():
+    """Test aiohttp transport enables trust_env by default"""
+    # Ensure both settings are disabled/default
+    litellm.disable_aiohttp_trust_env = False
+    litellm.disable_aiohttp_transport = False
+    
+    # Create async client
+    client = AsyncHTTPHandler()
+    
+    # Get the transport (should be LiteLLMAiohttpTransport)
+    transport = client.client._transport
+    assert isinstance(transport, LiteLLMAiohttpTransport)
+    
+    # Get the aiohttp ClientSession
+    client_session = transport._get_valid_client_session()
+    
+    # Verify that trust_env is True by default
+    assert client_session._trust_env is True


### PR DESCRIPTION
# Enable System Proxy Support for aiohttp Transport

After switching to `aiohttp` as the default HTTP transport, system proxy configurations (HTTP_PROXY) are no longer automatically detected, which differs from the previous `httpx` behavior.

This PR enables [trust_env](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support) by default in `aiohttp` transport to maintain consistent proxy behavior when reading from environment variables.

![图片](https://github.com/user-attachments/assets/21cfb4e8-0401-48ff-98da-95a98713a3dd)

## Relevant issues

Fixes #11389

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

- Set `trust_env=True` by default for `aiohttp` client
- Add configuration options to control this behavior:
  - Environment variable: `DISABLE_AIOHTTP_TRUST_ENV`
  - Code parameter: `litellm.disable_aiohttp_trust_env`

This change ensures backward compatibility with previous proxy behavior while maintaining flexibility for users who need to disable this feature.
