### PR TITLE
Bugfix/usage for openrouter

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1216,7 +1216,7 @@ class BaseTokenUsageProcessor:
         Combine multiple Usage objects into a single Usage object, checking model keys for nested values.
         """
         from litellm.types.utils import (
-            CompletionTokensDetails,
+            CompletionTokensDetailsWrapper,
             PromptTokensDetailsWrapper,
             Usage,
         )
@@ -1271,7 +1271,9 @@ class BaseTokenUsageProcessor:
                     not hasattr(combined, "completion_tokens_details")
                     or not combined.completion_tokens_details
                 ):
-                    combined.completion_tokens_details = CompletionTokensDetails()
+                    combined.completion_tokens_details = (
+                        CompletionTokensDetailsWrapper()
+                    )
 
                 # Check what keys exist in the model's completion_tokens_details
                 for attr in dir(usage.completion_tokens_details):

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -119,7 +119,6 @@ async def convert_to_streaming_response_async(response_object: Optional[dict] = 
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
-        # Create Usage object with all fields from the usage dictionary
         usage_object = Usage(**response_object["usage"])
         setattr(model_response_object, "usage", usage_object)
 
@@ -166,7 +165,6 @@ def convert_to_streaming_response(response_object: Optional[dict] = None):
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
-        # Create Usage object with all fields from the usage dictionary
         usage_object = Usage(**response_object["usage"])
         setattr(model_response_object, "usage", usage_object)
 

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -119,15 +119,9 @@ async def convert_to_streaming_response_async(response_object: Optional[dict] = 
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
-        setattr(
-            model_response_object,
-            "usage",
-            Usage(
-                completion_tokens=response_object["usage"].get("completion_tokens", 0),
-                prompt_tokens=response_object["usage"].get("prompt_tokens", 0),
-                total_tokens=response_object["usage"].get("total_tokens", 0),
-            ),
-        )
+        # Create Usage object with all fields from the usage dictionary
+        usage_object = Usage(**response_object["usage"])
+        setattr(model_response_object, "usage", usage_object)
 
     if "id" in response_object:
         model_response_object.id = response_object["id"]
@@ -172,10 +166,9 @@ def convert_to_streaming_response(response_object: Optional[dict] = None):
     model_response_object.choices = choice_list
 
     if "usage" in response_object and response_object["usage"] is not None:
-        setattr(model_response_object, "usage", Usage())
-        model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)  # type: ignore
-        model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)  # type: ignore
-        model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)  # type: ignore
+        # Create Usage object with all fields from the usage dictionary
+        usage_object = Usage(**response_object["usage"])
+        setattr(model_response_object, "usage", usage_object)
 
     if "id" in response_object:
         model_response_object.id = response_object["id"]

--- a/litellm/litellm_core_utils/logging_utils.py
+++ b/litellm/litellm_core_utils/logging_utils.py
@@ -89,6 +89,7 @@ def _assemble_complete_response_from_streaming_chunks(
                 messages=request_kwargs.get("messages", None),
                 start_time=start_time,
                 end_time=end_time,
+                usage=getattr(result, "usage")
             )
         except Exception as e:
             log_message = (

--- a/litellm/litellm_core_utils/logging_utils.py
+++ b/litellm/litellm_core_utils/logging_utils.py
@@ -89,7 +89,7 @@ def _assemble_complete_response_from_streaming_chunks(
                 messages=request_kwargs.get("messages", None),
                 start_time=start_time,
                 end_time=end_time,
-                usage=getattr(result, "usage")
+                usage=getattr(result, "usage"),
             )
         except Exception as e:
             log_message = (

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -314,28 +314,21 @@ class ChunkProcessor:
 
         return reasoning_tokens
 
-    def calculate_usage(
-        self,
-        chunks: List[Union[Dict[str, Any], ModelResponse]],
-        model: str,
-        completion_output: str,
-        messages: Optional[List] = None,
-        reasoning_tokens: Optional[int] = None,
-    ) -> Usage:
+    def _process_usage_chunks(
+        self, chunks: List[Union[Dict[str, Any], ModelResponse]]
+    ) -> Dict[str, Any]:
         """
-        Calculate usage for the given chunks.
+        Process chunks to extract usage information.
         """
-        returned_usage = Usage()
-        # # Update usage information if needed
         prompt_tokens = 0
         completion_tokens = 0
         cost: Optional[float] = None
         is_byok: Optional[bool] = None
-        ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetails] = None
+
         for chunk in chunks:
             usage_chunk: Optional[Usage] = None
             if "usage" in chunk:
@@ -385,43 +378,59 @@ class ChunkProcessor:
                         "completion_tokens_details"
                     ]
                 prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
-        try:
-            returned_usage.prompt_tokens = prompt_tokens or token_counter(
-                model=model, messages=messages
-            )
-        except (
-            Exception
-        ):  # don't allow this failing to block a complete streaming response from being returned
-            print_verbose("token_counter failed, assuming prompt tokens is 0")
-            returned_usage.prompt_tokens = 0
-        returned_usage.completion_tokens = completion_tokens or token_counter(
-            model=model,
-            text=completion_output,
-            count_response_tokens=True,  # count_response_tokens is a Flag to tell token counter this is a response, No need to add extra tokens we do for input messages
-        )
-        returned_usage.total_tokens = (
-            returned_usage.prompt_tokens + returned_usage.completion_tokens
-        )
 
-        if cost is not None:
-            returned_usage.cost = cost
-        if is_byok is not None:
-            returned_usage.is_byok = is_byok
-        if cache_creation_input_tokens is not None:
-            returned_usage._cache_creation_input_tokens = cache_creation_input_tokens
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "cost": cost,
+            "is_byok": is_byok,
+            "cache_creation_input_tokens": cache_creation_input_tokens,
+            "cache_read_input_tokens": cache_read_input_tokens,
+            "completion_tokens_details": completion_tokens_details,
+            "prompt_tokens_details": prompt_tokens_details,
+        }
+
+    def _set_additional_usage_properties(
+        self,
+        returned_usage: Usage,
+        usage_data: Dict[str, Any],
+        reasoning_tokens: Optional[int] = None,
+    ) -> Usage:
+        """
+        Set additional properties on the usage object.
+        """
+        if usage_data["cost"] is not None:
+            returned_usage.cost = usage_data["cost"]
+        if usage_data["is_byok"] is not None:
+            returned_usage.is_byok = usage_data["is_byok"]
+
+        # Set cache tokens
+        if usage_data["cache_creation_input_tokens"] is not None:
+            returned_usage._cache_creation_input_tokens = usage_data[
+                "cache_creation_input_tokens"
+            ]
             setattr(
                 returned_usage,
                 "cache_creation_input_tokens",
-                cache_creation_input_tokens,
+                usage_data["cache_creation_input_tokens"],
             )  # for anthropic
-        if cache_read_input_tokens is not None:
-            returned_usage._cache_read_input_tokens = cache_read_input_tokens
+        if usage_data["cache_read_input_tokens"] is not None:
+            returned_usage._cache_read_input_tokens = usage_data[
+                "cache_read_input_tokens"
+            ]
             setattr(
-                returned_usage, "cache_read_input_tokens", cache_read_input_tokens
+                returned_usage,
+                "cache_read_input_tokens",
+                usage_data["cache_read_input_tokens"],
             )  # for anthropic
-        if completion_tokens_details is not None:
-            returned_usage.completion_tokens_details = completion_tokens_details
 
+        # Set token details
+        if usage_data["completion_tokens_details"] is not None:
+            returned_usage.completion_tokens_details = usage_data[
+                "completion_tokens_details"
+            ]
+
+        # Handle reasoning tokens
         if reasoning_tokens is not None:
             if returned_usage.completion_tokens_details is None:
                 returned_usage.completion_tokens_details = (
@@ -434,8 +443,51 @@ class ChunkProcessor:
                 returned_usage.completion_tokens_details.reasoning_tokens = (
                     reasoning_tokens
                 )
-        if prompt_tokens_details is not None:
-            returned_usage.prompt_tokens_details = prompt_tokens_details
+
+        if usage_data["prompt_tokens_details"] is not None:
+            returned_usage.prompt_tokens_details = usage_data["prompt_tokens_details"]
+
+        return returned_usage
+
+    def calculate_usage(
+        self,
+        chunks: List[Union[Dict[str, Any], ModelResponse]],
+        model: str,
+        completion_output: str,
+        messages: Optional[List] = None,
+        reasoning_tokens: Optional[int] = None,
+    ) -> Usage:
+        """
+        Calculate usage for the given chunks.
+        """
+        returned_usage = Usage()
+        usage_data = self._process_usage_chunks(chunks)
+
+        try:
+            returned_usage.prompt_tokens = usage_data["prompt_tokens"] or token_counter(
+                model=model, messages=messages
+            )
+        except (
+            Exception
+        ):  # don't allow this failing to block a complete streaming response from being returned
+            print_verbose("token_counter failed, assuming prompt tokens is 0")
+            returned_usage.prompt_tokens = 0
+
+        returned_usage.completion_tokens = usage_data[
+            "completion_tokens"
+        ] or token_counter(
+            model=model,
+            text=completion_output,
+            count_response_tokens=True,  # count_response_tokens is a Flag to tell token counter this is a response
+        )
+
+        returned_usage.total_tokens = (
+            returned_usage.prompt_tokens + returned_usage.completion_tokens
+        )
+
+        returned_usage = self._set_additional_usage_properties(
+            returned_usage, usage_data, reasoning_tokens
+        )
 
         return returned_usage
 

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -478,7 +478,7 @@ class ChunkProcessor:
         ] or token_counter(
             model=model,
             text=completion_output,
-            count_response_tokens=True,  # count_response_tokens is a Flag to tell token counter this is a response
+            count_response_tokens=True,
         )
 
         returned_usage.total_tokens = (

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -252,6 +252,8 @@ class ChunkProcessor:
     def _usage_chunk_calculation_helper(self, usage_chunk: Usage) -> dict:
         prompt_tokens = 0
         completion_tokens = 0
+        cost: Optional[float] = None
+        is_byok: Optional[bool] = None
         ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
@@ -262,6 +264,10 @@ class ChunkProcessor:
             prompt_tokens = usage_chunk.get("prompt_tokens", 0) or 0
         if "completion_tokens" in usage_chunk:
             completion_tokens = usage_chunk.get("completion_tokens", 0) or 0
+        if "cost" in usage_chunk:
+            cost = usage_chunk.get("cost")
+        if "is_byok" in usage_chunk:
+            is_byok = usage_chunk.get("is_byok")
         if "cache_creation_input_tokens" in usage_chunk:
             cache_creation_input_tokens = usage_chunk.get("cache_creation_input_tokens")
         if "cache_read_input_tokens" in usage_chunk:
@@ -286,6 +292,8 @@ class ChunkProcessor:
         return {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
+            "cost": cost,
+            "is_byok": is_byok,
             "cache_creation_input_tokens": cache_creation_input_tokens,
             "cache_read_input_tokens": cache_read_input_tokens,
             "completion_tokens_details": completion_tokens_details,
@@ -321,6 +329,8 @@ class ChunkProcessor:
         # # Update usage information if needed
         prompt_tokens = 0
         completion_tokens = 0
+        cost: Optional[float] = None
+        is_byok: Optional[bool] = None
         ## anthropic prompt caching information ##
         cache_creation_input_tokens: Optional[int] = None
         cache_read_input_tokens: Optional[int] = None
@@ -348,6 +358,14 @@ class ChunkProcessor:
                     and usage_chunk_dict["completion_tokens"] > 0
                 ):
                     completion_tokens = usage_chunk_dict["completion_tokens"]
+                if usage_chunk_dict["cost"] is not None and (
+                    usage_chunk_dict["cost"] > 0 or cost is None
+                ):
+                    cost = usage_chunk_dict["cost"]
+                if usage_chunk_dict["is_byok"] is not None and (
+                    usage_chunk_dict["is_byok"] is True or is_byok is None
+                ):
+                    is_byok = usage_chunk_dict["is_byok"]
                 if usage_chunk_dict["cache_creation_input_tokens"] is not None and (
                     usage_chunk_dict["cache_creation_input_tokens"] > 0
                     or cache_creation_input_tokens is None
@@ -385,6 +403,10 @@ class ChunkProcessor:
             returned_usage.prompt_tokens + returned_usage.completion_tokens
         )
 
+        if cost is not None:
+            returned_usage.cost = cost
+        if is_byok is not None:
+            returned_usage.is_byok = is_byok
         if cache_creation_input_tokens is not None:
             returned_usage._cache_creation_input_tokens = cache_creation_input_tokens
             setattr(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1255,15 +1255,15 @@ class CustomStreamWrapper:
                                 prompt_tokens=response_obj["usage"].get(
                                     "prompt_tokens", None
                                 )
-                                              or None,
+                                or None,
                                 completion_tokens=response_obj["usage"].get(
                                     "completion_tokens", None
                                 )
-                                                  or None,
+                                or None,
                                 total_tokens=response_obj["usage"].get(
                                     "total_tokens", None
                                 )
-                                             or None,
+                                or None,
                             ),
                         )
                     elif isinstance(response_obj["usage"], Usage):
@@ -1789,7 +1789,7 @@ class CustomStreamWrapper:
                 if self.sent_stream_usage is False and self.send_stream_usage is True:
                     self.sent_stream_usage = True
                     return response
-                
+
                 asyncio.create_task(
                     self.logging_obj.async_success_handler(
                         complete_streaming_response,

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -98,7 +98,6 @@ class OpenrouterConfig(OpenAIGPTConfig):
 
 class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
     def chunk_parser(self, chunk: dict) -> ModelResponseStream:
-        print(f"OpenRouter Raw Chunk: {chunk}")
         try:
             ## HANDLE ERROR IN CHUNK ##
             if "error" in chunk:

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -14,7 +14,8 @@ from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.llms.openrouter import OpenRouterErrorMessage
-from litellm.types.utils import ModelResponse, ModelResponseStream, Usage
+from litellm.types.utils import Delta, ModelResponse, ModelResponseStream, Usage
+from litellm.utils import StreamingChoices
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 from ..common_utils import OpenRouterException
@@ -117,48 +118,46 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
                     headers=error_message["metadata"].get("headers", {}),
                 )
 
-            new_choices = []
-            for choice in chunk["choices"]:
-                choice["delta"]["reasoning_content"] = choice["delta"].get("reasoning")
-                new_choices.append(choice)
+            finish_reason = None
+            delta = Delta()
+            logprobs = None
+            if "choices" in chunk and len(chunk["choices"]) > 0:
+                choice = chunk["choices"][0]
+                if "delta" in choice and choice["delta"] is not None:
+                    choice["delta"]["reasoning_content"] = choice["delta"].get("reasoning")
+                    delta = Delta(**choice["delta"])
 
-            # Get usage information from the chunk
-            usage_from_chunk = chunk.get("usage")
-            final_usage = None
-            if usage_from_chunk:
-                # Extract all usage fields from OpenRouter response
-                usage_kwargs = {
-                    "prompt_tokens": usage_from_chunk.get("prompt_tokens", 0),
-                    "completion_tokens": usage_from_chunk.get("completion_tokens", 0),
-                    "total_tokens": usage_from_chunk.get("total_tokens", 0),
-                    "cost": usage_from_chunk.get("cost"),
-                    "is_byok": usage_from_chunk.get("is_byok"),
-                }
-                
-                # Handle prompt_tokens_details if present
-                if "prompt_tokens_details" in usage_from_chunk:
-                    usage_kwargs["prompt_tokens_details"] = usage_from_chunk["prompt_tokens_details"]
-                
-                # Handle completion_tokens_details if present
-                if "completion_tokens_details" in usage_from_chunk:
-                    usage_kwargs["completion_tokens_details"] = usage_from_chunk["completion_tokens_details"]
-                
-                # Pass any additional fields that might be present in usage_from_chunk
-                # This handles fields like cost_details that might be present
-                for key, value in usage_from_chunk.items():
-                    if key not in usage_kwargs and value is not None:
-                        usage_kwargs[key] = value
-                
-                final_usage = Usage(**usage_kwargs)
+                if "finish_reason" in choice:
+                    finish_reason = choice["finish_reason"]
 
-            return ModelResponseStream(
+                if "logprobs" in choice:
+                    logprobs = choice["logprobs"]
+
+            new_choices = [
+                StreamingChoices(
+                    finish_reason=finish_reason,
+                    delta=delta,
+                    logprobs=logprobs,
+                    index=0,
+                )
+            ]
+
+            model_response = ModelResponseStream(
                 id=chunk["id"],
                 object="chat.completion.chunk",
                 created=chunk["created"],
-                usage=final_usage,
                 model=chunk["model"],
                 choices=new_choices,
             )
+
+            if "usage" in chunk and chunk["usage"] is not None:
+                usage_from_chunk = chunk["usage"]
+                try:
+                    final_usage = Usage(**usage_from_chunk)
+                except Exception:
+                    final_usage = Usage.parse_obj(usage_from_chunk)
+                model_response.usage = final_usage
+            return model_response
         except KeyError as e:
             raise OpenRouterException(
                 message=f"KeyError: {e}, Got unexpected response from OpenRouter: {chunk}",

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -123,7 +123,9 @@ class OpenRouterChatCompletionStreamingHandler(BaseModelResponseIterator):
             if "choices" in chunk and len(chunk["choices"]) > 0:
                 choice = chunk["choices"][0]
                 if "delta" in choice and choice["delta"] is not None:
-                    choice["delta"]["reasoning_content"] = choice["delta"].get("reasoning")
+                    choice["delta"]["reasoning_content"] = choice["delta"].get(
+                        "reasoning"
+                    )
                     delta = Delta(**choice["delta"])
 
                 if "finish_reason" in choice:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -886,6 +886,16 @@ class ServerToolUse(BaseModel):
 
 
 class Usage(CompletionUsage):
+    # Override with our wrappers
+    prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = Field(None)
+    completion_tokens_details: Optional[CompletionTokensDetailsWrapper] = Field(None)
+
+    # Optional Openroute usage parameters when include_usage = true
+    cost: Optional[float] = None
+    is_byok: Optional[bool] = None
+
+    model_config = ConfigDict(extra="allow", protected_namespaces=())
+
     _cache_creation_input_tokens: int = PrivateAttr(
         0
     )  # hidden param for prompt caching. Might change, once openai introduces their equivalent.

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1025,7 +1025,6 @@ class StreamingChoices(OpenAIObject):
     ):
         # Fix Perplexity return both delta and message cause OpenWebUI repect text
         # https://github.com/BerriAI/litellm/issues/8455
-        params.pop("message", None)
         super(StreamingChoices, self).__init__(**params)
         if finish_reason:
             self.finish_reason = map_finish_reason(finish_reason)
@@ -1037,6 +1036,8 @@ class StreamingChoices(OpenAIObject):
                 self.delta = delta
             elif isinstance(delta, dict):
                 self.delta = Delta(**delta)
+        elif "message" in params and params["message"] is not None:
+            self.delta = Delta(**params["message"])
         else:
             self.delta = Delta()
         if enhancements is not None:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1106,6 +1106,7 @@ class ModelResponseBase(OpenAIObject):
 class ModelResponseStream(ModelResponseBase):
     choices: List[StreamingChoices]
     provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
+    usage: Optional[Usage] = Field(default=None)
 
     def __init__(
         self,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1025,6 +1025,7 @@ class StreamingChoices(OpenAIObject):
     ):
         # Fix Perplexity return both delta and message cause OpenWebUI repect text
         # https://github.com/BerriAI/litellm/issues/8455
+        params.pop("message", None)
         super(StreamingChoices, self).__init__(**params)
         if finish_reason:
             self.finish_reason = map_finish_reason(finish_reason)
@@ -1036,8 +1037,6 @@ class StreamingChoices(OpenAIObject):
                 self.delta = delta
             elif isinstance(delta, dict):
                 self.delta = Delta(**delta)
-        elif "message" in params and params["message"] is not None:
-            self.delta = Delta(**params["message"])
         else:
             self.delta = Delta()
         if enhancements is not None:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -894,8 +894,6 @@ class Usage(CompletionUsage):
     cost: Optional[float] = None
     is_byok: Optional[bool] = None
 
-    model_config = ConfigDict(extra="allow", protected_namespaces=())
-
     _cache_creation_input_tokens: int = PrivateAttr(
         0
     )  # hidden param for prompt caching. Might change, once openai introduces their equivalent.

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -15,7 +15,7 @@ from litellm.types.utils import (
     Delta,
     Function,
     ModelResponseStream,
-    PromptTokensDetails,
+    PromptTokensDetailsWrapper,
     StreamingChoices,
     Usage,
 )
@@ -156,7 +156,6 @@ def test_get_combined_tool_content():
         ),
     ]
 
-
 def test_cache_read_input_tokens_retained():
     chunk1 = ModelResponseStream(
         id="chatcmpl-95aabb85-c39f-443d-ae96-0370c404d70c",
@@ -186,7 +185,7 @@ def test_cache_read_input_tokens_retained():
             prompt_tokens=11779,
             total_tokens=11784,
             completion_tokens_details=None,
-            prompt_tokens_details=PromptTokensDetails(
+            prompt_tokens_details=PromptTokensDetailsWrapper(
                 audio_tokens=None, cached_tokens=11775
             ),
             cache_creation_input_tokens=4,
@@ -222,7 +221,7 @@ def test_cache_read_input_tokens_retained():
             prompt_tokens=0,
             total_tokens=214,
             completion_tokens_details=None,
-            prompt_tokens_details=PromptTokensDetails(
+            prompt_tokens_details=PromptTokensDetailsWrapper(
                 audio_tokens=None, cached_tokens=0
             ),
             cache_creation_input_tokens=0,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -29,6 +29,8 @@ ignored_keys = [
     "endTime",
     "metadata.model_map_information",
     "metadata.usage_object",
+    "metadata.additional_usage_values.is_byok",
+    "metadata.additional_usage_values.cost",
 ]
 
 


### PR DESCRIPTION
## Propogate the openrouter usage information back correctly

Add OpenRouter `include_usage` flag mapping and propagate `cost` & `is_byok` in responses

## Relevant issues

Fixes #11626

## Pre-Submission checklist

- [x] Added or updated tests under [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm)
- [x] Tests pass locally (see attached log snippet)
- [x] All unit tests pass via `make test-unit`
- [x] Changes are scoped to only OpenRouter usage-flag handling and cost propagation

## Type

🐛 Bug Fix

## Changes

- **Parameter mapping**  
  - In `litellm/llms/openrouter/chat/transformation.py`, detect `stream_options.include_usage` and emit:
    ```python
    extra_body["usage"] = {"include": True}
    ```
  - Removes manual default—only when `include_usage: true` is set.

- **OpenRouter chunk parsing**  
  - In `OpenRouterChatCompletionStreamingHandler.chunk_parser`, read `chunk["usage"]["cost"]` and `chunk["usage"]["is_byok"]` and assign them directly to `ModelResponseStream.usage`.

- **Final stream builder**  
  - In `litellm/main.py`’s `stream_chunk_builder`, prefer the OpenRouter-provided `usage` (including `cost`/`is_byok`) over any manual fallback computation.

- **Cost calculator wrappers**  
  - In `litellm/cost_calculator.py`, switched to using `PromptTokensDetailsWrapper` and `CompletionTokensDetailsWrapper` in `combine_usage_objects` to carry nested token details.

- **Response conversion**  
  - In `litellm_core_utils/llm_response_utils/convert_dict_to_response.py`, unified both streaming and non-streaming paths to use:
    ```python
    usage_object = Usage(**response_object["usage"])
    setattr(model_response_object, "usage", usage_object)
    ```

- **Logging utils**  
  - Minor tweak in `litellm_core_utils/logging_utils.py` to preserve exception context when logging errors in `_assemble_complete_response_from_streaming_chunks`.

- **Streaming chunk builder utilities**  
  - In `litellm_core_utils/streaming_chunk_builder_utils.py`:
    - Updated `_usage_chunk_calculation_helper` to include `cost` and `is_byok` in its returned dict.
    - Revised `_process_usage_chunks` to pull `cost`/`is_byok` from each chunk and feed them into the final usage data.

- **Streaming handler iteration**  
  - In `litellm_core_utils/streaming_handler.py`, refactored both `__next__` and `__anext__` to propagate intermediate chunk `usage` objects and combine them into a final `Usage` without re-computing cost.

- **Type extensions**  
  - In `litellm/types/utils.py`, extended the `Usage` model to include:
    ```python
    cost: Optional[float]
    is_byok: Optional[bool]
    ```
    and retained private cache-token attributes for prompt caching.

- **Tests**  
  - `tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py`: new test verifying that, when `stream_options.include_usage` is true, the parsed `ModelResponseStream.usage` includes the OpenRouter cost and `is_byok`.  

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/b84838f3-777a-4eaf-b89c-ef8fd9f37633" />
