### PR TITLE
[Bug Fix] Add audio/ogg mapping for Audio MIME types

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -116,7 +116,7 @@ def strip_none_values_from_message(message: AllMessageValues) -> AllMessageValue
 
 
 def convert_content_list_to_str(
-    message: Union[AllMessageValues, ChatCompletionResponseMessage]
+    message: Union[AllMessageValues, ChatCompletionResponseMessage],
 ) -> str:
     """
     - handles scenario where content is list and not string
@@ -532,6 +532,7 @@ def _get_image_mime_type_from_url(url: str) -> Optional[str]:
     audio/mpeg
     audio/mp3
     audio/wav
+    audio/ogg
     image/png
     image/jpeg
     image/webp
@@ -565,6 +566,7 @@ def _get_image_mime_type_from_url(url: str) -> Optional[str]:
         (".mp3",): "audio/mp3",
         (".wav",): "audio/wav",
         (".mpeg",): "audio/mpeg",
+        (".ogg",): "audio/ogg",
         # Documents
         (".pdf",): "application/pdf",
         (".txt",): "text/plain",
@@ -621,7 +623,6 @@ def get_file_ids_from_messages(messages: List[AllMessageValues]) -> List[str]:
     return file_ids
 
 
-
 def check_is_function_call(logging_obj: "LoggingClass") -> bool:
     from litellm.litellm_core_utils.prompt_templates.common_utils import (
         is_function_call,
@@ -634,6 +635,7 @@ def check_is_function_call(logging_obj: "LoggingClass") -> bool:
             return True
 
     return False
+
 
 def filter_value_from_dict(dictionary: dict, key: str, depth: int = 0) -> Any:
     """
@@ -686,5 +688,3 @@ def migrate_file_to_image_url(
     if format and isinstance(image_url_object["image_url"], dict):
         image_url_object["image_url"]["format"] = format
     return image_url_object
-
-

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -3959,3 +3959,39 @@ def test_vertex_ai_gemini_2_5_pro_streaming():
         if chunk.choices[0].delta.content is not None and len(chunk.choices[0].delta.content) > 0:
             has_real_content = True
     assert has_real_content
+
+
+def test_vertex_ai_gemini_audio_ogg():
+    #load_vertex_ai_credentials()
+    litellm._turn_on_debug()
+    response = completion(
+        model="vertex_ai/gemini-2.0-flash",
+        messages=[
+            {
+                "content": [
+                    {
+                        "text": "generate a transcript of the speech.",
+                        "type": "text"
+                    }
+                ],
+                "role": "user"
+            },
+            {
+                "content": [
+                    {
+                        "file": {
+                            "file_id": "https://upload.wikimedia.org/wikipedia/commons/5/5f/En-us-public.ogg"
+                        },
+                        "type": "file"
+                    }
+                ],
+                "role": "user"
+            }
+        ],
+    )
+    print(response)
+
+
+
+
+

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -3962,7 +3962,7 @@ def test_vertex_ai_gemini_2_5_pro_streaming():
 
 
 def test_vertex_ai_gemini_audio_ogg():
-    #load_vertex_ai_credentials()
+    load_vertex_ai_credentials()
     litellm._turn_on_debug()
     response = completion(
         model="vertex_ai/gemini-2.0-flash",

--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -1218,6 +1218,10 @@ def test_get_image_mime_type_from_url():
         _get_image_mime_type_from_url("https://example.com/IMAGE.WEBP") == "image/webp"
     )
 
+    # Test audio formats
+    assert _get_image_mime_type_from_url("https://example.com/audio.ogg") == "audio/ogg"
+    assert _get_image_mime_type_from_url("https://example.com/track.OGG") == "audio/ogg"
+
     # Test unsupported formats
     assert _get_image_mime_type_from_url("https://example.com/image.gif") is None
     assert _get_image_mime_type_from_url("https://example.com/image.bmp") is None


### PR DESCRIPTION
## [Bug Fix] Add audio/ogg mapping for Audio 

This PR adds support for the audio/ogg MIME type in the URL-based MIME mapping function and ensures it’s covered by unit tests.



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes


