### PR TITLE
fix(ollama): ensure tool calls without parameters are not skipped during streaming

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -452,7 +452,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             if tool_calls is not None:
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
-                    if function_args is not None and len(function_args) > 0:
+                    if function_args is not None:
                         is_function_call_complete = self._is_function_call_complete(
                             function_args
                         )

--- a/tests/local_testing/test_ollama.py
+++ b/tests/local_testing/test_ollama.py
@@ -331,3 +331,38 @@ def test_ollama_streaming_with_chunk_builder():
     response = stream_chunk_builder(list(response))
 
     assert response.choices[0].message.tool_calls, "No tool call detected"
+
+@pytest.mark.skip(reason="local only test")
+def test_ollama_streaming_parameterless_tool_call():
+    from litellm.main import stream_chunk_builder
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_time",
+                "description": "Get the current date and time",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        }
+    ]
+    completion_kwargs = {
+        "model": "ollama_chat/qwen2.5:0.5b",  # Must be an ollama_chat model
+        "messages": [
+            {"role": "user", "content": "Tell me the current time"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<think>\nThe user is asking for the current time. "
+                    "I will use the get_time tool function to provide this information. "
+                    "Since it doesn't require any parameters, I just need to call it directly.\n</think>\n\n"
+                ),
+            },
+        ],
+        "tools": tools,
+        "stream": True,
+    }
+    response = litellm.completion(**completion_kwargs)
+    response = stream_chunk_builder(list(response))
+
+    assert response.choices[0].message.tool_calls, "No tool call detected for parameterless function"
+


### PR DESCRIPTION
Relevant issues
Fixes [#11262](https://github.com/BerriAI/litellm/issues/11262)

Pre-Submission checklist
Please complete all items before asking a LiteLLM maintainer to review your PR

 I have added testing in the [tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

 I have added a screenshot of my new test passing locally

 My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)

 My PR's scope is as isolated as possible, it only solves 1 specific problem

Type
🐛 Bug Fix
✅ Test

Changes
Assign tool_call.id even when the function has no parameters

This prevents streaming_chunk_builder from skipping such tool calls

Added a test case where a tool with no parameters (e.g., get_time) is correctly processed in streaming responses