### PR TITLE
fix(vertex_ai): support global location in vertex ai passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1,5 +1,5 @@
 """
-What is this? 
+What is this?
 
 Provider-specific Pass-Through Endpoints
 
@@ -697,12 +697,16 @@ class VertexAIDiscoveryPassThroughHandler(BaseVertexAIPassThroughHandler):
 class VertexAIPassThroughHandler(BaseVertexAIPassThroughHandler):
     @staticmethod
     def get_default_base_target_url(vertex_location: Optional[str]) -> str:
+        if vertex_location == "global":
+            return "https://aiplatform.googleapis.com/"
         return f"https://{vertex_location}-aiplatform.googleapis.com/"
 
     @staticmethod
     def update_base_target_url_with_credential_location(
         base_target_url: str, vertex_location: Optional[str]
     ) -> str:
+        if vertex_location == "global":
+            return "https://aiplatform.googleapis.com/"
         return f"https://{vertex_location}-aiplatform.googleapis.com/"
 
 
@@ -805,7 +809,10 @@ async def _base_vertex_proxy_route(
         )
 
     if base_target_url is None:
-        base_target_url = f"https://{vertex_location}-aiplatform.googleapis.com/"
+        if vertex_location == "global":
+            base_target_url = "https://aiplatform.googleapis.com/"
+        else:
+            base_target_url = f"https://{vertex_location}-aiplatform.googleapis.com/"
 
     request_route = encoded_endpoint
     verbose_proxy_logger.debug("request_route %s", request_route)

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -697,18 +697,21 @@ class VertexAIDiscoveryPassThroughHandler(BaseVertexAIPassThroughHandler):
 class VertexAIPassThroughHandler(BaseVertexAIPassThroughHandler):
     @staticmethod
     def get_default_base_target_url(vertex_location: Optional[str]) -> str:
-        if vertex_location == "global":
-            return "https://aiplatform.googleapis.com/"
-        return f"https://{vertex_location}-aiplatform.googleapis.com/"
+        return get_vertex_base_url(vertex_location)
 
     @staticmethod
     def update_base_target_url_with_credential_location(
         base_target_url: str, vertex_location: Optional[str]
     ) -> str:
-        if vertex_location == "global":
-            return "https://aiplatform.googleapis.com/"
-        return f"https://{vertex_location}-aiplatform.googleapis.com/"
+        return get_vertex_base_url(vertex_location)
 
+def get_vertex_base_url(vertex_location: Optional[str]) -> str:
+    """
+    Returns the base URL for Vertex AI based on the provided location.
+    """
+    if vertex_location == "global":
+        return "https://aiplatform.googleapis.com/"
+    return f"https://{vertex_location}-aiplatform.googleapis.com/"
 
 def get_vertex_pass_through_handler(
     call_type: Literal["discovery", "aiplatform"]
@@ -809,10 +812,7 @@ async def _base_vertex_proxy_route(
         )
 
     if base_target_url is None:
-        if vertex_location == "global":
-            base_target_url = "https://aiplatform.googleapis.com/"
-        else:
-            base_target_url = f"https://{vertex_location}-aiplatform.googleapis.com/"
+        base_target_url = get_vertex_base_url(vertex_location)
 
     request_route = encoded_endpoint
     verbose_proxy_logger.debug("request_route %s", request_route)


### PR DESCRIPTION
## Title

Support global location in vertex ai passthrough

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/11585

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Use correct base url when vertex location is `global`

