### PR TITLE
Add performance indexes to LiteLLM_SpendLogs for analytics queries

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -266,6 +266,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([end_user])
   @@index([session_id])
+  @@index([model_group, cache_hit, startTime, api_base])
+  @@index([model_group, cache_hit, api_key, startTime])
+  @@index([model_group, cache_hit, end_user, startTime])
 }
 
 // View spend, model, api_key per request

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -265,6 +265,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([end_user])
   @@index([session_id])
+  @@index([model_group, cache_hit, startTime, api_base])
+  @@index([model_group, cache_hit, api_key, startTime])
+  @@index([model_group, cache_hit, end_user, startTime])
 }
 
 // View spend, model, api_key per request

--- a/schema.prisma
+++ b/schema.prisma
@@ -265,6 +265,9 @@ model LiteLLM_SpendLogs {
   @@index([startTime])
   @@index([end_user])
   @@index([session_id])
+  @@index([model_group, cache_hit, startTime, api_base])
+  @@index([model_group, cache_hit, api_key, startTime])
+  @@index([model_group, cache_hit, end_user, startTime])
 }
 
 // View spend, model, api_key per request


### PR DESCRIPTION
## Title

Add performance indexes to LiteLLM_SpendLogs for analytics queries

## Relevant issues

Fixes database performance spikes caused by slow analytics queries on LiteLLM_SpendLogs table

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🚄 Infrastructure

## Changes

Added three composite indexes to the `LiteLLM_SpendLogs` model in all schema.prisma files to optimize analytics query performance:

1. `@@index([model_group, cache_hit, startTime, api_base])` - Primary composite index for main analytics queries
2. `@@index([model_group, cache_hit, api_key, startTime])` - For queries filtering by api_key
3. `@@index([model_group, cache_hit, end_user, startTime])` - For queries filtering by end_user

**Problem Solved:**
Analytics queries that filter by `model_group`, `cache_hit`, and time ranges were causing database table scans across millions of rows, leading to performance spikes. These indexes will allow PostgreSQL to efficiently find exactly the rows needed instead of scanning the entire table.

**Files Modified:**
- `schema.prisma`
- `litellm/proxy/schema.prisma`  
- `litellm-proxy-extras/litellm_proxy_extras/schema.prisma`
- `litellm/proxy/example_config_yaml/bad_schema.prisma`

**Migration Required:**
Database migrations will need to be created to add these indexes to existing databases.