### PR TITLE
[Feat] Use dedicated Rest endpoints for list, calling MCP tools 

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -416,6 +416,7 @@ router_settings:
 | DIRECT_URL | Direct URL for service endpoint
 | DISABLE_ADMIN_UI | Toggle to disable the admin UI
 | DISABLE_AIOHTTP_TRANSPORT | Flag to disable aiohttp transport. When this is set to True, litellm will use httpx instead of aiohttp. **Default is False**
+| DISABLE_AIOHTTP_TRUST_ENV | Flag to disable aiohttp trust environment. When this is set to True, litellm will not trust the environment for aiohttp eg. `HTTP_PROXY` and `HTTPS_PROXY` environment variables will not be used when this is set to True. **Default is False**
 | DISABLE_SCHEMA_UPDATE | Toggle to disable schema updates
 | DOCS_DESCRIPTION | Description text for documentation pages
 | DOCS_FILTERED | Flag indicating filtered documentation

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4274,7 +4274,8 @@
         "source": "https://mistral.ai/news/magistral",
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "mistral/magistral-small-2506": {
         "max_tokens": 40000,
@@ -4287,7 +4288,8 @@
         "source": "https://mistral.ai/news/magistral",
         "supports_function_calling": true,
         "supports_assistant_prefill": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "mistral/mistral-embed": {
         "max_tokens": 8192,

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -4,10 +4,6 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query, Request
 
 from litellm._logging import verbose_logger
-from litellm.proxy._experimental.mcp_server.server import (
-    ListMCPToolsRestAPIResponseObject,
-    call_mcp_tool,
-)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
@@ -27,6 +23,10 @@ router = APIRouter(
 if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
+    )
+    from litellm.proxy._experimental.mcp_server.server import (
+        ListMCPToolsRestAPIResponseObject,
+        call_mcp_tool,
     )
 
     ########################################################

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1,0 +1,105 @@
+import importlib
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from litellm._logging import verbose_logger
+from litellm.proxy._experimental.mcp_server.server import (
+    ListMCPToolsRestAPIResponseObject,
+    call_mcp_tool,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+MCP_AVAILABLE: bool = True
+try:
+    importlib.import_module("mcp")
+except ImportError as e:
+    verbose_logger.debug(f"MCP module not found: {e}")
+    MCP_AVAILABLE = False
+
+
+router = APIRouter(
+    prefix="/mcp-rest",
+    tags=["mcp"],
+)
+
+if MCP_AVAILABLE:
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    ########################################################
+    ############ MCP Server REST API Routes #################
+    ########################################################
+    @router.get("/tools/list", dependencies=[Depends(user_api_key_auth)])
+    async def list_tool_rest_api(
+        server_id: Optional[str] = Query(
+            None, description="The server id to list tools for"
+        ),
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ) -> List[ListMCPToolsRestAPIResponseObject]:
+        """
+        List all available tools with information about the server they belong to.
+
+        Example response:
+        Tools:
+        [
+            {
+                "name": "create_zap",
+                "description": "Create a new zap",
+                "inputSchema": "tool_input_schema",
+                "mcp_info": {
+                    "server_name": "zapier",
+                    "logo_url": "https://www.zapier.com/logo.png",
+                }
+            },
+            {
+                "name": "fetch_data",
+                "description": "Fetch data from a URL",
+                "inputSchema": "tool_input_schema",
+                "mcp_info": {
+                    "server_name": "fetch",
+                    "logo_url": "https://www.fetch.com/logo.png",
+                }
+            }
+        ]
+        """
+        list_tools_result: List[ListMCPToolsRestAPIResponseObject] = []
+        for server in global_mcp_server_manager.get_registry().values():
+            if server_id and server.server_id != server_id:
+                continue
+            try:
+                tools = await global_mcp_server_manager._get_tools_from_server(server)
+                for tool in tools:
+                    list_tools_result.append(
+                        ListMCPToolsRestAPIResponseObject(
+                            name=tool.name,
+                            description=tool.description,
+                            inputSchema=tool.inputSchema,
+                            mcp_info=server.mcp_info,
+                        )
+                    )
+            except Exception as e:
+                verbose_logger.exception(f"Error getting tools from {server.name}: {e}")
+                continue
+        return list_tools_result
+
+    @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
+    async def call_tool_rest_api(
+        request: Request,
+        user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    ):
+        """
+        REST API to call a specific MCP tool with the provided arguments
+        """
+        from litellm.proxy.proxy_server import add_litellm_data_to_request, proxy_config
+
+        data = await request.json()
+        data = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=proxy_config,
+        )
+        return await call_mcp_tool(**data)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -144,6 +144,9 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.proxy._experimental.mcp_server.rest_endpoints import (
+    router as mcp_rest_endpoints_router,
+)
 from litellm.proxy._experimental.mcp_server.server import app as mcp_app
 from litellm.proxy._experimental.mcp_server.tool_registry import (
     global_mcp_tool_registry,
@@ -8301,3 +8304,4 @@ app.include_router(ui_discovery_endpoints_router)
 # MCP Server
 ########################################################
 app.mount(path=BASE_MCP_ROUTE, app=mcp_app)
+app.include_router(mcp_rest_endpoints_router)

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4609,8 +4609,8 @@ export const listMCPTools = async (accessToken: string, serverId: string) => {
   try {
     // Construct base URL
     let url = proxyBaseUrl 
-      ? `${proxyBaseUrl}/mcp/tools/list?server_id=${serverId}`
-      : `/mcp/tools/list?server_id=${serverId}`;
+      ? `${proxyBaseUrl}/mcp-rest/tools/list?server_id=${serverId}`
+      : `/mcp-rest/tools/list?server_id=${serverId}`;
 
     console.log("Fetching MCP tools from:", url);
     
@@ -4642,8 +4642,8 @@ export const callMCPTool = async (accessToken: string, toolName: string, toolArg
   try {
     // Construct base URL
     let url = proxyBaseUrl 
-      ? `${proxyBaseUrl}/mcp/tools/call`
-      : `/mcp/tools/call`;
+      ? `${proxyBaseUrl}/mcp-rest/tools/call`
+      : `/mcp-rest/tools/call`;
 
     console.log("Calling MCP tool:", toolName, "with arguments:", toolArguments);
     


### PR DESCRIPTION
## [Feat] Use dedicated Rest endpoints for list, calling MCP tools 

This PR introduces dedicated REST endpoints for listing and calling MCP tools, updating the frontend to use the new /mcp-rest paths and wiring the routers into the proxy server.

Frontend URLs updated to /mcp-rest/tools/list and /mcp-rest/tools/call
New rest_endpoints.py module defines the REST API routers under /mcp-rest
Proxy server mounts and includes the new router; refactors existing server code to remove inline route definitions

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


