### PR TITLE
Selecting 'test connect' resets the public model name when selecting an azure model

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
@@ -40,11 +40,14 @@ const ConditionalPublicModelName: React.FC = () => {
       const currentMappings = form.getFieldValue('model_mappings') || [];
       
       // Only update if the mappings don't exist or don't match the selected models
-      const shouldUpdateMappings = currentMappings.length !== selectedModels.length || 
-        !selectedModels.every(model => 
-          currentMappings.some((mapping: { public_name: string; litellm_model: string }) => 
-            mapping.public_name === model || 
-            (model === 'custom' && mapping.public_name === customModelName)));
+      const shouldUpdateMappings = currentMappings.length !== selectedModels.length ||
+        !selectedModels.every(model =>
+          currentMappings.some((mapping: { public_name: string; litellm_model: string }) => {
+            if (model === 'custom') {
+              return mapping.litellm_model === 'custom' || mapping.litellm_model === customModelName;
+            }
+            return mapping.litellm_model === model;
+          }));
       
       if (shouldUpdateMappings) {
         const mappings = selectedModels.map((model: string) => {


### PR DESCRIPTION
## Title
Selecting 'test connect' resets the public model name when selecting an azure model
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Modified the condition to check against the underlying "LiteLLM Model Name" (litellm_model) instead of the "Public Name" (public_name). This ensures that your custom public name is preserved even when other parts of the form are updated.

https://www.loom.com/share/17043dd64b7d4d07a0818d36b42357d6?sid=f071223d-5a09-4ccf-adf0-890d7cb96d77





