### PR TITLE
fix: re-export get_valid_models utils in init file

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -16,6 +16,7 @@ from litellm.types.utils import (
     all_litellm_params,
     all_litellm_params as _litellm_completion_params,
     CredentialItem,
+    get_valid_models,
 )  # maintain backwards compatibility for root param
 from litellm._logging import (
     set_verbose,

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -16,7 +16,6 @@ from litellm.types.utils import (
     all_litellm_params,
     all_litellm_params as _litellm_completion_params,
     CredentialItem,
-    get_valid_models,
 )  # maintain backwards compatibility for root param
 from litellm._logging import (
     set_verbose,
@@ -868,6 +867,7 @@ from .utils import (
     TextCompletionResponse,
     get_provider_fields,
     ModelResponseListIterator,
+    get_valid_models,
 )
 
 ALL_LITELLM_RESPONSE_TYPES = [


### PR DESCRIPTION
## Title

re-export get_valid_models utils in init file

## Relevant issues

Documentation code snippet does not work: https://docs.litellm.ai/docs/set_keys#get_valid_modelscheck_provider_endpoint-true.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


