### PR TITLE
[Fix] JWT - Fix error when team member already part of team

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -686,9 +686,9 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
     permissions: Optional[dict] = {}
-    model_max_budget: Optional[
-        dict
-    ] = {}  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    model_max_budget: Optional[dict] = (
+        {}
+    )  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -1027,12 +1027,12 @@ class NewCustomerRequest(BudgetNewRequest):
     blocked: bool = False  # allow/disallow requests for this end-user
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
     spend: Optional[float] = None
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -1054,12 +1054,12 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    allowed_model_region: Optional[
-        AllowedModelRegion
-    ] = None  # require all user requests to use models in this specific region
-    default_model: Optional[
-        str
-    ] = None  # if no equivalent model in allowed region - default all requests to this model
+    allowed_model_region: Optional[AllowedModelRegion] = (
+        None  # require all user requests to use models in this specific region
+    )
+    default_model: Optional[str] = (
+        None  # if no equivalent model in allowed region - default all requests to this model
+    )
 
 
 class DeleteCustomerRequest(LiteLLMPydanticObjectBase):
@@ -1197,9 +1197,9 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
     callback_name: str
-    callback_type: Optional[
-        Literal["success", "failure", "success_and_failure"]
-    ] = "success_and_failure"
+    callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
+        "success_and_failure"
+    )
     callback_vars: Dict[str, str]
 
     @model_validator(mode="before")
@@ -1484,9 +1484,9 @@ class ConfigList(LiteLLMPydanticObjectBase):
     stored_in_db: Optional[bool]
     field_default_value: Any
     premium_field: bool = False
-    nested_fields: Optional[
-        List[FieldDetail]
-    ] = None  # For nested dictionary or Pydantic fields
+    nested_fields: Optional[List[FieldDetail]] = (
+        None  # For nested dictionary or Pydantic fields
+    )
 
 
 class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
@@ -1756,9 +1756,9 @@ class LiteLLM_OrganizationMembershipTable(LiteLLMPydanticObjectBase):
     budget_id: Optional[str] = None
     created_at: datetime
     updated_at: datetime
-    user: Optional[
-        Any
-    ] = None  # You might want to replace 'Any' with a more specific type if available
+    user: Optional[Any] = (
+        None  # You might want to replace 'Any' with a more specific type if available
+    )
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
 
     model_config = ConfigDict(protected_namespaces=())
@@ -2423,6 +2423,11 @@ class ProxyErrorTypes(str, enum.Enum):
     Organization does not have access to the vector store
     """
 
+    team_member_already_in_team = "team_member_already_in_team"
+    """
+    Team member is already in team
+    """
+
     @classmethod
     def get_model_access_error_type_for_object(
         cls, object_type: Literal["key", "user", "team", "org"]
@@ -2599,9 +2604,9 @@ class TeamModelDeleteRequest(BaseModel):
 # Organization Member Requests
 class OrganizationMemberAddRequest(OrgMemberAddRequest):
     organization_id: str
-    max_budget_in_organization: Optional[
-        float
-    ] = None  # Users max budget within the organization
+    max_budget_in_organization: Optional[float] = (
+        None  # Users max budget within the organization
+    )
 
 
 class OrganizationMemberDeleteRequest(MemberDeleteRequest):
@@ -2792,9 +2797,9 @@ class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     Maps provider names to their budget configs.
     """
 
-    providers: Dict[
-        str, ProviderBudgetResponseObject
-    ] = {}  # Dictionary mapping provider names to their budget configurations
+    providers: Dict[str, ProviderBudgetResponseObject] = (
+        {}
+    )  # Dictionary mapping provider names to their budget configurations
 
 
 class ProxyStateVariables(TypedDict):
@@ -2922,9 +2927,9 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None
-    object_id_jwt_field: Optional[
-        str
-    ] = None  # can be either user / team, inferred from the role mapping
+    object_id_jwt_field: Optional[str] = (
+        None  # can be either user / team, inferred from the role mapping
+    )
     scope_mappings: Optional[List[ScopeMapping]] = None
     enforce_scope_based_access: bool = False
     enforce_team_based_model_access: bool = False

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2,7 +2,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from litellm.proxy._types import LiteLLM_TeamTable, LiteLLM_UserTable, Member
+from litellm.proxy._types import (
+    LiteLLM_TeamTable,
+    LiteLLM_UserTable,
+    Member,
+    ProxyErrorTypes,
+    ProxyException,
+)
 from litellm.proxy.auth.handle_jwt import JWTAuthManager
 
 
@@ -44,6 +50,64 @@ async def test_map_user_to_teams_add_new_user():
         assert call_args.member.user_id == "test_user_1"
         assert call_args.member.role == "user"
         assert call_args.team_id == "test_team_1"
+
+
+@pytest.mark.asyncio
+async def test_map_user_to_teams_handles_already_in_team_exception():
+    """Test that team_member_already_in_team exception is handled gracefully"""
+    # Setup test data
+    user = LiteLLM_UserTable(user_id="test_user_1")
+    team = LiteLLM_TeamTable(team_id="test_team_1", members_with_roles=[])
+
+    # Create a ProxyException with team_member_already_in_team error type
+    already_in_team_exception = ProxyException(
+        message="User test_user_1 already in team",
+        type=ProxyErrorTypes.team_member_already_in_team,
+        param="user_id",
+        code="400",
+    )
+
+    # Mock team_member_add to raise the exception
+    with patch(
+        "litellm.proxy.management_endpoints.team_endpoints.team_member_add",
+        new_callable=AsyncMock,
+        side_effect=already_in_team_exception,
+    ) as mock_add:
+        with patch("litellm.proxy.auth.handle_jwt.verbose_proxy_logger") as mock_logger:
+            # This should not raise an exception
+            result = await JWTAuthManager.map_user_to_teams(
+                user_object=user, team_object=team
+            )
+
+            # Verify the method completed successfully
+            assert result is None
+            mock_add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_map_user_to_teams_reraises_other_proxy_exceptions():
+    """Test that other ProxyException types are re-raised"""
+    # Setup test data
+    user = LiteLLM_UserTable(user_id="test_user_1")
+    team = LiteLLM_TeamTable(team_id="test_team_1", members_with_roles=[])
+
+    # Create a ProxyException with a different error type
+    other_exception = ProxyException(
+        message="Some other error",
+        type=ProxyErrorTypes.internal_server_error,
+        param="some_param",
+        code="500",
+    )
+
+    # Mock team_member_add to raise the exception
+    with patch(
+        "litellm.proxy.management_endpoints.team_endpoints.team_member_add",
+        new_callable=AsyncMock,
+        side_effect=other_exception,
+    ) as mock_add:
+        # This should re-raise the exception
+        with pytest.raises(ProxyException) as exc_info:
+            await JWTAuthManager.map_user_to_teams(user_object=user, team_object=team)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## [Fix] JWT - Fix error when team member already part of team

This PR ensures that attempts to add an already-existing team member no longer cause unhandled errors during JWT-based user-team assignment, and adds corresponding unit tests.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


