### PR TITLE
Add support for configurable CORS origins/security headers via ENV params

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,10 @@ INFINITY_API_KEY = ""
 LITELLM_MASTER_KEY = "sk-1234"
 DATABASE_URL = "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
 STORE_MODEL_IN_DB = "True"
+
+
+# Allowed origins
+ALLOWED_ORIGINS="https://abc.ai,https://abc.com"
+
+# Security headers
+SECURITY_HEADERS='{"Content-Security-Policy": "default-src \'none\'", "Cache-Control": "no-store, no-cache, must-revalidate"}'

--- a/tests/test_litellm/proxy/test_allowed_origins_and_security_headers.py
+++ b/tests/test_litellm/proxy/test_allowed_origins_and_security_headers.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+
+request_test_data = {
+    "model": "gpt-3.5-turbo",
+    "messages": [{"role": "user", "content": "Hello"}]
+}
+
+security_headers = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "X-XSS-Protection": "1; mode=block",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains"
+}
+
+example_chat_completion_result = {
+    "id": "chatcmpl-123",
+    "object": "chat.completion",
+    "created": 1677652288,
+    "model": "gpt-3.5-turbo",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello! How can I help you today?"
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 9,
+        "completion_tokens": 12,
+        "total_tokens": 21
+    }
+}
+
+
+def mock_patch_acompletion():
+    mock_obj = mock.AsyncMock(return_value=example_chat_completion_result)
+    mock_obj.__name__ = "acompletion"
+    return mock.patch(
+        "litellm.acompletion",
+        new_callable=lambda: mock_obj,
+    )
+
+@pytest.fixture(scope="function")
+def client_with_selected_origins_and_security_headers():
+    os.environ["ALLOWED_ORIGINS"] = "https://docs.litellm.ai,https://docs.litellm.com"
+    os.environ["SECURITY_HEADERS"] = json.dumps(security_headers)
+    from litellm.proxy.proxy_server import cleanup_router_config_variables
+    cleanup_router_config_variables()
+    mock_completion = mock.AsyncMock(return_value=example_chat_completion_result)
+    mock_completion.__name__ = "acompletion"
+    with mock.patch(
+            "litellm.acompletion",
+            new_callable=lambda: mock_completion,
+    ) as patched_completion, \
+            mock.patch(
+                "litellm.proxy.route_llm_request.route_request",
+                new_callable=lambda: mock.AsyncMock(return_value=example_chat_completion_result)
+            ):
+        from litellm.proxy.proxy_server import app, initialize
+        filepath = os.path.dirname(os.path.abspath(__file__))
+        config_fp = f"{filepath}/test_configs/test_config_no_auth.yaml"
+        print(f"config_fp: {config_fp}")
+        asyncio.run(initialize(config=config_fp, debug=True))
+        client = TestClient(app)
+        yield client, patched_completion
+
+
+class TestAllowedOrigins:
+    """Test suite for Allowed Origins and Security Headers."""
+
+    def test_cors_specific_origin_allowed(self, client_with_selected_origins_and_security_headers):
+        client, mock_acompletion = client_with_selected_origins_and_security_headers
+        response = client.post(
+            "/v1/chat/completions",
+            json=request_test_data,
+            headers={"origin": "https://docs.litellm.ai"}
+        )
+        assert response.status_code == 200
+        assert response.headers.get("Access-Control-Allow-Origin") == "https://docs.litellm.ai"
+
+    def test_cors_specific_origin_blocked(self, client_with_selected_origins_and_security_headers):
+        client, mock_acompletion = client_with_selected_origins_and_security_headers
+        response = client.post(
+            "/v1/chat/completions",
+            json=request_test_data,
+            headers={"origin": "https://malicious.com"}
+        )
+        assert response.status_code == 403
+        response_data = response.json()
+        assert "CORS policy violation" in response_data["error"]["message"]
+        assert "https://malicious.com" in response_data["error"]["message"]
+
+    def test_cors_no_origin_header(self, client_with_selected_origins_and_security_headers):
+        client, mock_acompletion = client_with_selected_origins_and_security_headers
+        response = client.post("/v1/chat/completions", json=request_test_data)
+        assert response.status_code == 200
+        assert "Access-Control-Allow-Origin" not in response.headers
+
+    def test_security_headers_applied(self, client_with_selected_origins_and_security_headers):
+        client, mock_acompletion = client_with_selected_origins_and_security_headers
+        response = client.post(
+            "/v1/chat/completions",
+            json=request_test_data,
+            headers={"origin": "https://docs.litellm.ai"}
+        )
+        assert response.status_code == 200
+        for header, value in security_headers.items():
+            assert response.headers.get(header) == value

--- a/tests/test_litellm/proxy/test_configs/test_config_no_auth.yaml
+++ b/tests/test_litellm/proxy/test_configs/test_config_no_auth.yaml
@@ -4,3 +4,8 @@ model_list:
   model_info:
     description: this is a test embedding hosted_vllm model
   model_name: vllm_embed_model
+- litellm_params:
+    model: gpt-3.5-turbo
+  model_info:
+    description: this is a test openai model
+  model_name: gpt-3.5-turbo


### PR DESCRIPTION
## Title

Add support for configurable CORS origins via ALLOWED_ORIGINS env variable


## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ✅] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature



## Changes
Make CORS origins configurable through `ALLOWED_ORIGINS` environment variable



