### PR TITLE
#11748: Added Mistral Small to BEDROCK_CONVERSE_MODELS for Converse A…

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -407,6 +407,7 @@ BEDROCK_CONVERSE_MODELS = [
     "meta.llama3-70b-instruct-v1:0",
     "mistral.mistral-large-2407-v1:0",
     "mistral.mistral-large-2402-v1:0",
+    "mistral.mistral-small-2402-v1:0",
     "meta.llama3-2-1b-instruct-v1:0",
     "meta.llama3-2-3b-instruct-v1:0",
     "meta.llama3-2-11b-instruct-v1:0",


### PR DESCRIPTION
Fixed Issue #11748: Added "mistral.mistral-small-2402-v1:0" to BEDROCK_CONVERSE_MODELS for Converse API support as it supports natively.