### PR TITLE
AWS credentials no longer mandatory

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -225,21 +225,21 @@ const PROVIDER_CREDENTIAL_FIELDS: Record<Providers, ProviderCredentialField[]> =
       key: "aws_access_key_id",
       label: "AWS Access Key ID",
       type: "password",
-      required: true,
+      required: false,
       tooltip: "You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`)."
     },
     {
       key: "aws_secret_access_key",
       label: "AWS Secret Access Key",
       type: "password",
-      required: true,
+      required: false,
       tooltip: "You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`)."
     },
     {
       key: "aws_region_name",
       label: "AWS Region Name",
       placeholder: "us-east-1",
-      required: true,
+      required: false,
       tooltip: "You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`)."
     }
   ],


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Make AWS settings optional when creating Bedrock secrets in the UI

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #8811
Fixes #11669

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Made the "AWS Access Key ID", "AWS Secret Access Key" and "AWS Region Name" fields, when creating a new AWS secret for Bedrock, optional in the UI so as to align with the API functionality.

All tests passes locally, except for a Prometheus related one, as I don't have LiteLLM Premium.