### PR TITLE
[Fix] Pass through - Langfuse don't log request to Langfuse passthrough on Langfuse

### DIFF
--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -48,6 +48,9 @@ class PassThroughEndpointLogging:
             AssemblyAIPassthroughLoggingHandler()
         )
 
+        # Langfuse
+        self.TRACKED_LANGFUSE_ROUTES = ["/langfuse/"]
+
     async def _handle_logging(
         self,
         logging_obj: LiteLLMLoggingObj,
@@ -103,9 +106,9 @@ class PassThroughEndpointLogging:
         standard_logging_response_object: Optional[
             PassThroughEndpointLoggingResultValues
         ] = None
-        logging_obj.model_call_details[
-            "passthrough_logging_payload"
-        ] = passthrough_logging_payload
+        logging_obj.model_call_details["passthrough_logging_payload"] = (
+            passthrough_logging_payload
+        )
         if self.is_vertex_route(url_route):
             vertex_passthrough_logging_handler_result = (
                 VertexPassthroughLoggingHandler.vertex_passthrough_handler(
@@ -181,6 +184,9 @@ class PassThroughEndpointLogging:
                 **kwargs,
             )
             return
+        elif self.is_langfuse_route(url_route):
+            # Don't log langfuse pass-through requests
+            return
 
         if standard_logging_response_object is None:
             standard_logging_response_object = StandardPassThroughResponseObject(
@@ -220,4 +226,10 @@ class PassThroughEndpointLogging:
             return True
         elif "/transcript" in parsed_url.path:
             return True
+        return False
+
+    def is_langfuse_route(self, url_route: str):
+        for route in self.TRACKED_LANGFUSE_ROUTES:
+            if route in url_route:
+                return True
         return False

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -229,7 +229,8 @@ class PassThroughEndpointLogging:
         return False
 
     def is_langfuse_route(self, url_route: str):
+        parsed_url = urlparse(url_route)
         for route in self.TRACKED_LANGFUSE_ROUTES:
-            if route in url_route:
+            if route in parsed_url.path:
                 return True
         return False


### PR DESCRIPTION
## [Fix] Pass through - Langfuse don't log request to Langfuse passthrough on Langfuse

This PR adds support to skip logging for Langfuse pass-through requests. Users would see the actual pass through request logged on langfuse itself

This is a bit confusing and not needed 

Closes LIT-113

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


