### PR TITLE
Enhance Mistral API: Add support for parallel tool calls

### DIFF
--- a/litellm/llms/mistral/mistral_chat_transformation.py
+++ b/litellm/llms/mistral/mistral_chat_transformation.py
@@ -294,8 +294,14 @@ Then provide a clear, concise answer based on your reasoning."""
         Otherwise, we drop `name`
         """
         _name = message.get("name")  # type: ignore
-        if _name is not None and (message["role"] != "tool" or (isinstance(_name, str) and len(_name.strip()) == 0)):
-            message.pop("name", None)  # type: ignore
+        
+        if _name is not None:
+            # Remove name if not a tool message
+            if message["role"] != "tool":
+                message.pop("name", None)  # type: ignore
+            # For tool messages, remove name if it's an empty string
+            elif isinstance(_name, str) and len(_name.strip()) == 0:
+                message.pop("name", None)  # type: ignore
 
         return message
 

--- a/litellm/llms/mistral/mistral_chat_transformation.py
+++ b/litellm/llms/mistral/mistral_chat_transformation.py
@@ -294,7 +294,7 @@ Then provide a clear, concise answer based on your reasoning."""
         Otherwise, we drop `name`
         """
         _name = message.get("name")  # type: ignore
-        if _name is not None and (message["role"] != "tool" or len(_name.strip()) == 0):
+        if _name is not None and (message["role"] != "tool" or (isinstance(_name, str) and len(_name.strip()) == 0)):
             message.pop("name", None)  # type: ignore
 
         return message

--- a/litellm/llms/mistral/mistral_chat_transformation.py
+++ b/litellm/llms/mistral/mistral_chat_transformation.py
@@ -86,8 +86,9 @@ class MistralConfig(OpenAIGPTConfig):
             "seed",
             "stop",
             "response_format",
+            "parallel_tool_calls",
         ]
-        
+
         # Add reasoning support for magistral models
         if "magistral" in model.lower():
             supported_params.extend(["thinking", "reasoning_effort"])
@@ -154,6 +155,8 @@ Then provide a clear, concise answer based on your reasoning."""
             if param == "thinking" and "magistral" in model.lower():
                 # Flag that we need to add reasoning system prompt
                 optional_params["_add_reasoning_prompt"] = True
+            if param == "parallel_tool_calls":
+                optional_params["parallel_tool_calls"] = value
         return optional_params
 
     def _get_openai_compatible_provider_info(
@@ -287,11 +290,11 @@ Then provide a clear, concise answer based on your reasoning."""
         """
         Mistral API only supports `name` in tool messages
 
-        If role == tool, then we keep `name`
+        If role == tool, then we keep `name` if it's not an empty string
         Otherwise, we drop `name`
         """
         _name = message.get("name")  # type: ignore
-        if _name is not None and message["role"] != "tool":
+        if _name is not None and (message["role"] != "tool" or len(_name.strip()) == 0):
             message.pop("name", None)  # type: ignore
 
         return message

--- a/tests/llm_translation/test_mistral_api.py
+++ b/tests/llm_translation/test_mistral_api.py
@@ -36,3 +36,17 @@ class TestMistralCompletion(BaseLLMChatTest):
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""
         pass
+
+@pytest.mark.parametrize("model", ["mistral/devstral-small-latest","mistral/mistral-small-latest"])
+def test_mistral_parallel_tool_calls(model):
+    litellm.completion(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": "foo",
+            }
+        ],
+        parallel_tool_calls=True,
+        drop_params=False,
+    )

--- a/tests/llm_translation/test_mistral_api.py
+++ b/tests/llm_translation/test_mistral_api.py
@@ -36,17 +36,3 @@ class TestMistralCompletion(BaseLLMChatTest):
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""
         pass
-
-@pytest.mark.parametrize("model", ["mistral/devstral-small-latest","mistral/mistral-small-latest"])
-def test_mistral_parallel_tool_calls(model):
-    litellm.completion(
-        model=model,
-        messages=[
-            {
-                "role": "user",
-                "content": "foo",
-            }
-        ],
-        parallel_tool_calls=True,
-        drop_params=False,
-    )

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -349,3 +349,67 @@ class TestMistralReasoningSupport:
         assert result["messages"][1]["content"] == "Solve for x: 2x + 5 = 13"
         assert result.get("temperature") == 0.7
         assert "_add_reasoning_prompt" not in result
+
+
+
+class TestMistralNameHandling:
+    """Test suite for Mistral name handling in messages."""
+
+    def test_handle_name_in_message_tool_role_empty_name_removes_name(self):
+        """Test that empty name is removed for tool messages."""
+        # Test with empty string
+        tool_message = {"role": "tool", "content": "Function result", "name": ""}
+        result = MistralConfig._handle_name_in_message(tool_message)
+        assert "name" not in result
+        assert result["role"] == "tool"
+        assert result["content"] == "Function result"
+
+    def test_handle_name_in_message_tool_role_valid_name_keeps_name(self):
+        """Test that valid name is kept for tool messages."""
+        # Test with normal function name
+        tool_message = {"role": "tool", "content": "Function result", "name": "get_weather"}
+        result = MistralConfig._handle_name_in_message(tool_message)
+        assert "name" in result
+        assert result["name"] == "get_weather"
+        assert result["role"] == "tool"
+        assert result["content"] == "Function result"
+
+    def test_handle_name_in_message_no_name_field(self):
+        """Test that messages without name field are unchanged."""
+        # Test with user role
+        user_message = {"role": "user", "content": "Hello"}
+        result = MistralConfig._handle_name_in_message(user_message)
+        assert "name" not in result
+        assert result["role"] == "user"
+        assert result["content"] == "Hello"
+
+
+class TestMistralParallelToolCalls:
+    """Test suite for Mistral parallel tool calls functionality."""
+
+    def test_get_supported_openai_params_includes_parallel_tool_calls(self):
+        """Test that parallel_tool_calls is in supported parameters."""
+        mistral_config = MistralConfig()
+        supported_params = mistral_config.get_supported_openai_params("mistral/mistral-large-latest")
+        assert "parallel_tool_calls" in supported_params
+
+    def test_transform_request_preserves_parallel_tool_calls(self):
+        """Test that transform_request preserves parallel_tool_calls parameter."""
+        mistral_config = MistralConfig()
+        
+        messages = [
+            {"role": "user", "content": "What's the weather like?"}
+        ]
+        optional_params = {"parallel_tool_calls": True}
+        
+        result = mistral_config.transform_request(
+            model="mistral/mistral-large-latest",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={}
+        )
+        
+        assert result.get("parallel_tool_calls") is True
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["role"] == "user"


### PR DESCRIPTION
## Title
Mistral API now supports parallel tool calls, this PR adds that information to Litellm. 

https://docs.mistral.ai/capabilities/function_calling/#parallel_tool_calls

I also address a scenario where an agent framework may respond with a name parameter that is not None, but is an empty string.

Relates to https://github.com/mozilla-ai/any-agent/issues/519

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes


