### PR TITLE
(#11794) use upsert for managed object table rather than create to avoid UniqueViolationError

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -139,15 +139,19 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             litellm_parent_otel_span=litellm_parent_otel_span,
         )
 
-        await self.prisma_client.db.litellm_managedobjecttable.create(
+        await self.prisma_client.db.litellm_managedobjecttable.upsert(
+            where={"unified_object_id": unified_object_id},
             data={
-                "unified_object_id": unified_object_id,
-                "file_object": file_object.model_dump_json(),
-                "model_object_id": model_object_id,
-                "file_purpose": file_purpose,
-                "created_by": user_api_key_dict.user_id,
-                "updated_by": user_api_key_dict.user_id,
-                "status": file_object.status,
+                "create": {
+                    "unified_object_id": unified_object_id,
+                    "file_object": file_object.model_dump_json(),
+                    "model_object_id": model_object_id,
+                    "file_purpose": file_purpose,
+                    "created_by": user_api_key_dict.user_id,
+                    "updated_by": user_api_key_dict.user_id,
+                    "status": file_object.status,
+                },
+                "update": {},  # don't do anything if it already exists
             }
         )
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
UniqueViolationError on Managed Object Table

## Relevant issues

<!-- e.g. "Fixes #000" -->
#11794 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


