### PR TITLE
Fix vertex ai claude thinking params

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
@@ -46,6 +46,9 @@ class VertexAIAnthropicConfig(AnthropicConfig):
 
     Note: Please make sure to modify the default parameters as required for your use case.
     """
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "vertex_ai"
 
     def transform_request(
         self,

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
@@ -1,0 +1,28 @@
+import sys
+import os
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../../../..")
+)  # Adds the parent directory to the system path
+from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.transformation import (
+    VertexAIAnthropicConfig,
+)
+
+
+@pytest.mark.parametrize(
+    "model, expected_thinking",
+    [
+        ("claude-sonnet-4@20250514", True), 
+    ],
+)
+def test_vertex_ai_anthropic_thinking_param(model, expected_thinking):
+    supported_openai_params = VertexAIAnthropicConfig().get_supported_openai_params(
+            model=model
+        )
+    
+    if expected_thinking:
+        assert "thinking" in supported_openai_params
+    else:
+        assert "thinking" not in supported_openai_params


### PR DESCRIPTION
## Title
Fix vertex ai claude thinking params can not be accepted.
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
![my new test pass](https://github.com/user-attachments/assets/13c1c01d-c2f5-428f-ae6d-8b40ec520b77)
![all tests pass](https://github.com/user-attachments/assets/df3b5ef9-6267-4e7d-92c3-96eee82951cc)



## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Add `custom_llm_provider` to `VertexAIAnthropicConfig`, otherwise using `vertex_ai/claude-sonnet-4@20250514` will encounter  error `vertex_ai does not support parameters: ['thinking']` , just like when I used it in Cline below: 

![image](https://github.com/user-attachments/assets/6972bb82-fc44-482c-be39-bee23f4e1f3a)

Because `custom_llm_provider` is None when we not set `custom_llm_provider` in `VertexAIAnthropicConfig`, it will raise a exception due to provider not found, in finally `supports_reasoning` return False.

![image](https://github.com/user-attachments/assets/09bb8767-c0bf-474d-9c43-06662e1e5fc7)




