### PR TITLE
Fix JSX syntax error in documentation causing Vercel deployment failure

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -447,7 +447,7 @@ router_settings:
 | GENERIC_CLIENT_ID | Client ID for generic OAuth providers
 | GENERIC_CLIENT_SECRET | Client secret for generic OAuth providers
 | GENERIC_CLIENT_STATE | State parameter for generic client authentication
-| GENERIC_SSO_HEADERS | Comma-separated list of additional headers to add to the request - e.g. Authorization=Bearer <token>, Content-Type=application/json, etc.
+| GENERIC_SSO_HEADERS | Comma-separated list of additional headers to add to the request - e.g. Authorization=Bearer `<token>`, Content-Type=application/json, etc.
 | GENERIC_INCLUDE_CLIENT_ID | Include client ID in requests for OAuth
 | GENERIC_SCOPE | Scope settings for generic OAuth providers
 | GENERIC_TOKEN_ENDPOINT | Token endpoint for generic OAuth providers


### PR DESCRIPTION
## Title

Fix JSX syntax error in documentation causing Vercel deployment failure

## Relevant issues

Fixes Vercel deployment error caused by unclosed JSX tag in documentation

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- Fixed unclosed `<token>` tag in `docs/my-website/docs/proxy/config_settings.md` that was causing JSX parsing error during Vercel build
- Changed `<token>` to `` `<token>` `` to properly render as inline code instead of attempting JSX parsing
- This resolves the SyntaxError: "Expected corresponding JSX closing tag for <token>" that was preventing successful Vercel deployments

**Screenshot of passing tests:**
<!-- Add screenshot here after running tests -->