### PR TITLE
[Bug Fixes] MCP - using MCPs defined on config.yaml + fix for MCP error Team doesn't exist in cache

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -166,12 +166,7 @@ class UserAPIKeyAuthMCP:
         first we check if the team has a object_permission_id attached
             - if it does then we look up the object_permission for the team
         """
-        from litellm.proxy.auth.auth_checks import get_team_object
-        from litellm.proxy.proxy_server import (
-            prisma_client,
-            proxy_logging_obj,
-            user_api_key_cache,
-        )
+        from litellm.proxy.proxy_server import prisma_client
 
         if user_api_key_auth is None:
             return []

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -88,7 +88,7 @@ class MCPServerManager:
                 name=server_name,
                 url=server_config["url"],
                 # TODO: utility fn the default values
-                transport=server_config.get("transport", MCPTransport.sse),
+                transport=server_config.get("transport", MCPTransport.http),
                 spec_version=server_config.get("spec_version", MCPSpecVersion.mar_2025),
                 auth_type=server_config.get("auth_type", None),
                 mcp_info=mcp_info,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -364,6 +364,11 @@ class MCPServerManager:
         """
         Generate a stable server ID based on server parameters using a hash function.
 
+        This is critical to ensure the server_id is stable across server restarts.
+        Some users store MCPs on the config.yaml and permission management is based on server_ids.
+
+        Eg a key might have mcp_servers = ["1234"], if the server_id changes across restarts, the key will no longer have access to the MCP.
+
         Args:
             server_name: Name of the server
             url: Server URL

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -9,7 +9,6 @@ This is a Proxy
 import asyncio
 import hashlib
 import json
-import uuid
 from typing import Any, Dict, List, Optional, cast
 
 from mcp import ClientSession

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -52,6 +52,7 @@ if MCP_AVAILABLE:
     from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
     from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
     from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
     def get_prisma_client_or_throw(message: str):
         from litellm.proxy.proxy_server import prisma_client
@@ -91,16 +92,48 @@ if MCP_AVAILABLE:
         --header 'Authorization: Bearer your_api_key_here'
         ```
         """
+        from datetime import datetime
+
         prisma_client = get_prisma_client_or_throw(
             "Database not connected. Connect a database to your proxy"
         )
 
+        LIST_MCP_SERVERS: List[LiteLLM_MCPServerTable] = []
+
         # perform authz check to filter the mcp servers user has access to
         if _user_has_admin_view(user_api_key_dict):
-            return await get_all_mcp_servers(prisma_client)
+            LIST_MCP_SERVERS = await get_all_mcp_servers(prisma_client)
+        else:
+            # Find all mcp servers the user has access to
+            LIST_MCP_SERVERS = await get_all_mcp_servers_for_user(
+                prisma_client, user_api_key_dict
+            )
 
-        # Find all mcp servers the user has access to
-        return await get_all_mcp_servers_for_user(prisma_client, user_api_key_dict)
+        #########################################################
+        # Allowed MCP Servers from config.yaml
+        #########################################################
+        ALLOWED_MCP_SERVER_IDS = (
+            await global_mcp_server_manager.get_allowed_mcp_servers(
+                user_api_key_auth=user_api_key_dict
+            )
+        )
+        ALL_CONFIG_MCP_SERVERS = global_mcp_server_manager.config_mcp_servers
+        for _server_id, _server_config in ALL_CONFIG_MCP_SERVERS.items():
+            if _server_id in ALLOWED_MCP_SERVER_IDS:
+                LIST_MCP_SERVERS.append(
+                    LiteLLM_MCPServerTable(
+                        server_id=_server_id,
+                        alias=_server_config.name,
+                        url=_server_config.url,
+                        transport=_server_config.transport,
+                        spec_version=_server_config.spec_version,
+                        auth_type=_server_config.auth_type,
+                        created_at=datetime.now(),
+                        updated_at=datetime.now(),
+                    )
+                )
+        #########################################################
+        return LIST_MCP_SERVERS
 
     @router.get(
         "/server/{server_id}",

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -52,7 +52,6 @@ if MCP_AVAILABLE:
     from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
     from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
     from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
-    from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
     def get_prisma_client_or_throw(message: str):
         from litellm.proxy.proxy_server import prisma_client

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -8,15 +8,7 @@ model_list:
       model: "anthropic/*"
       api_key: os.environ/ANTHROPIC_API_KEY
 
-litellm_settings:
-  callbacks: ["prometheus"]
-  prometheus_metrics_config:
-    # High-cardinality metrics with minimal labels
-    - group: "proxy_metrics"
-      metrics:
-        - "litellm_proxy_total_requests_metric"
-        - "litellm_proxy_failed_requests_metric"
-      include_labels:
-        - "hashed_api_key"
-        - "requested_model"
-        - "model_group"
+mcp_servers:
+  deepwiki_mcp:
+    url: "https://mcp.deepwiki.com/mcp"
+    transport: "http"

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1,0 +1,371 @@
+import json
+import os
+import sys
+import uuid
+from datetime import datetime
+from typing import List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from typing import Optional
+
+from litellm.proxy._types import (
+    LiteLLM_MCPServerTable,
+    LitellmUserRoles,
+    MCPAuth,
+    MCPSpecVersion,
+    MCPTransport,
+    UserAPIKeyAuth,
+)
+from litellm.types.mcp_server.mcp_server_manager import MCPInfo, MCPServer
+
+
+def generate_mock_mcp_server_db_record(
+    server_id: Optional[str] = None,
+    alias: str = "Test DB Server",
+    url: str = "https://db-server.example.com/mcp",
+    transport: str = "sse",
+    spec_version: str = "2025-03-26",
+    auth_type: Optional[str] = None,
+) -> LiteLLM_MCPServerTable:
+    """Generate a mock MCP server record from database"""
+    now = datetime.now()
+    return LiteLLM_MCPServerTable(
+        server_id=server_id or str(uuid.uuid4()),
+        alias=alias,
+        url=url,
+        transport=MCPTransport.sse if transport == "sse" else MCPTransport.http,
+        spec_version=(
+            MCPSpecVersion.mar_2025
+            if spec_version == "2025-03-26"
+            else MCPSpecVersion.nov_2024
+        ),
+        auth_type=MCPAuth.api_key if auth_type == "api_key" else None,
+        created_at=now,
+        updated_at=now,
+        created_by="test_user",
+        updated_by="test_user",
+    )
+
+
+def generate_mock_mcp_server_config_record(
+    server_id: Optional[str] = None,
+    name: str = "Test Config Server",
+    url: str = "https://config-server.example.com/mcp",
+    transport: str = "http",
+    spec_version: str = "2025-03-26",
+    auth_type: Optional[str] = None,
+) -> MCPServer:
+    """Generate a mock MCP server record from config.yaml"""
+    return MCPServer(
+        server_id=server_id or str(uuid.uuid4()),
+        name=name,
+        url=url,
+        transport=MCPTransport.http if transport == "http" else MCPTransport.sse,
+        spec_version=(
+            MCPSpecVersion.mar_2025
+            if spec_version == "2025-03-26"
+            else MCPSpecVersion.nov_2024
+        ),
+        auth_type=MCPAuth.api_key if auth_type == "api_key" else None,
+        mcp_info=MCPInfo(
+            server_name=name,
+            description="Config server description",
+        ),
+    )
+
+
+def generate_mock_user_api_key_auth(
+    user_role: LitellmUserRoles = LitellmUserRoles.PROXY_ADMIN,
+    user_id: str = "test_user_id",
+    api_key: str = "test_api_key",
+    team_id: Optional[str] = None,
+) -> UserAPIKeyAuth:
+    """Generate a mock UserAPIKeyAuth object"""
+    return UserAPIKeyAuth(
+        user_role=user_role,
+        user_id=user_id,
+        api_key=api_key,
+        team_id=team_id,
+    )
+
+
+class TestListMCPServers:
+    """Test suite for list MCP servers functionality"""
+
+    @pytest.mark.asyncio
+    async def test_list_mcp_servers_config_yaml_only(self):
+        """
+        Test 1: Returns MCPs defined on the config.yaml only
+
+        Scenario: No DB MCPs, only config.yaml MCPs
+        Expected: Should return only config.yaml MCPs
+        """
+        # Mock dependencies
+        mock_prisma_client = MagicMock()
+        mock_user_auth = generate_mock_user_api_key_auth()
+
+        # Mock config MCPs
+        config_server_1 = generate_mock_mcp_server_config_record(
+            server_id="config_server_1",
+            name="Zapier MCP",
+            url="https://actions.zapier.com/mcp/sse",
+            transport="sse",
+        )
+        config_server_2 = generate_mock_mcp_server_config_record(
+            server_id="config_server_2",
+            name="DeepWiki MCP",
+            url="https://mcp.deepwiki.com/mcp",
+            transport="http",
+        )
+
+        # Mock global MCP server manager
+        mock_manager = MagicMock()
+        mock_manager.config_mcp_servers = {
+            "config_server_1": config_server_1,
+            "config_server_2": config_server_2,
+        }
+        mock_manager.get_allowed_mcp_servers = AsyncMock(
+            return_value=["config_server_1", "config_server_2"]
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_all_mcp_servers"
+        ) as mock_get_db_servers, patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+            mock_manager,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints._user_has_admin_view",
+            return_value=True,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=mock_prisma_client,
+        ):
+
+            # Mock empty DB response
+            mock_get_db_servers.return_value = []
+
+            # Import and call the function
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=mock_user_auth)
+
+            # Assertions
+            assert len(result) == 2
+
+            # Check that config servers are included
+            server_ids = [server.server_id for server in result]
+            assert "config_server_1" in server_ids
+            assert "config_server_2" in server_ids
+
+            # Verify properties of returned servers
+            zapier_server = next(s for s in result if s.server_id == "config_server_1")
+            assert zapier_server.alias == "Zapier MCP"
+            assert zapier_server.url == "https://actions.zapier.com/mcp/sse"
+            assert zapier_server.transport == "sse"
+
+            deepwiki_server = next(
+                s for s in result if s.server_id == "config_server_2"
+            )
+            assert deepwiki_server.alias == "DeepWiki MCP"
+            assert deepwiki_server.url == "https://mcp.deepwiki.com/mcp"
+            assert deepwiki_server.transport == "http"
+
+    @pytest.mark.asyncio
+    async def test_list_mcp_servers_combined_config_and_db(self):
+        """
+        Test 2: If both config.yaml and DB then combines both and returns the result
+
+        Scenario: Both DB and config.yaml have MCPs
+        Expected: Should return combined list from both sources without duplicates
+        """
+        # Mock dependencies
+        mock_prisma_client = MagicMock()
+        mock_user_auth = generate_mock_user_api_key_auth()
+
+        # Mock DB MCPs
+        db_server_1 = generate_mock_mcp_server_db_record(
+            server_id="db_server_1",
+            alias="DB Gmail MCP",
+            url="https://gmail-mcp.example.com/mcp",
+            transport="sse",
+        )
+        db_server_2 = generate_mock_mcp_server_db_record(
+            server_id="db_server_2",
+            alias="DB Slack MCP",
+            url="https://slack-mcp.example.com/mcp",
+            transport="http",
+        )
+
+        # Mock config MCPs
+        config_server_1 = generate_mock_mcp_server_config_record(
+            server_id="config_server_1",
+            name="Zapier MCP",
+            url="https://actions.zapier.com/mcp/sse",
+            transport="sse",
+        )
+        config_server_2 = generate_mock_mcp_server_config_record(
+            server_id="config_server_2",
+            name="DeepWiki MCP",
+            url="https://mcp.deepwiki.com/mcp",
+            transport="http",
+        )
+
+        # Mock global MCP server manager
+        mock_manager = MagicMock()
+        mock_manager.config_mcp_servers = {
+            "config_server_1": config_server_1,
+            "config_server_2": config_server_2,
+        }
+        mock_manager.get_allowed_mcp_servers = AsyncMock(
+            return_value=[
+                "db_server_1",
+                "db_server_2",
+                "config_server_1",
+                "config_server_2",
+            ]
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_all_mcp_servers"
+        ) as mock_get_db_servers, patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+            mock_manager,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints._user_has_admin_view",
+            return_value=True,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=mock_prisma_client,
+        ):
+
+            # Mock DB response with servers
+            mock_get_db_servers.return_value = [db_server_1, db_server_2]
+
+            # Import and call the function
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=mock_user_auth)
+
+            # Assertions
+            assert len(result) == 4  # 2 from DB + 2 from config
+
+            # Check that all servers are included
+            server_ids = [server.server_id for server in result]
+            assert "db_server_1" in server_ids
+            assert "db_server_2" in server_ids
+            assert "config_server_1" in server_ids
+            assert "config_server_2" in server_ids
+
+            # Verify DB servers properties
+            gmail_server = next(s for s in result if s.server_id == "db_server_1")
+            assert gmail_server.alias == "DB Gmail MCP"
+            assert gmail_server.url == "https://gmail-mcp.example.com/mcp"
+
+            slack_server = next(s for s in result if s.server_id == "db_server_2")
+            assert slack_server.alias == "DB Slack MCP"
+            assert slack_server.url == "https://slack-mcp.example.com/mcp"
+
+            # Verify config servers properties
+            zapier_server = next(s for s in result if s.server_id == "config_server_1")
+            assert zapier_server.alias == "Zapier MCP"
+            assert zapier_server.url == "https://actions.zapier.com/mcp/sse"
+
+            deepwiki_server = next(
+                s for s in result if s.server_id == "config_server_2"
+            )
+            assert deepwiki_server.alias == "DeepWiki MCP"
+            assert deepwiki_server.url == "https://mcp.deepwiki.com/mcp"
+
+    @pytest.mark.asyncio
+    async def test_list_mcp_servers_non_admin_user_filtered(self):
+        """
+        Test 3: Non-admin users only see MCPs they have access to
+
+        Scenario: Non-admin user with limited access
+        Expected: Should return only MCPs the user has access to
+        """
+        # Mock dependencies
+        mock_prisma_client = MagicMock()
+        mock_user_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.INTERNAL_USER,  # Non-admin user
+            team_id="team_123",
+        )
+
+        # Mock DB MCPs - user only has access to one
+        db_server_allowed = generate_mock_mcp_server_db_record(
+            server_id="db_server_allowed",
+            alias="Allowed Gmail MCP",
+            url="https://gmail-mcp.example.com/mcp",
+        )
+
+        # Mock config MCPs - user has access to one
+        config_server_allowed = generate_mock_mcp_server_config_record(
+            server_id="config_server_allowed",
+            name="Allowed Zapier MCP",
+            url="https://actions.zapier.com/mcp/sse",
+        )
+
+        # Mock global MCP server manager
+        mock_manager = MagicMock()
+        mock_manager.config_mcp_servers = {
+            "config_server_allowed": config_server_allowed,
+            "config_server_not_allowed": generate_mock_mcp_server_config_record(
+                server_id="config_server_not_allowed"
+            ),
+        }
+        # User only has access to specific servers
+        mock_manager.get_allowed_mcp_servers = AsyncMock(
+            return_value=["db_server_allowed", "config_server_allowed"]
+        )
+
+        with patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_all_mcp_servers_for_user"
+        ) as mock_get_user_servers, patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+            mock_manager,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints._user_has_admin_view",
+            return_value=False,
+        ), patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=mock_prisma_client,
+        ):
+
+            # Mock user-specific DB response
+            mock_get_user_servers.return_value = [db_server_allowed]
+
+            # Import and call the function
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=mock_user_auth)
+
+            # Assertions
+            assert len(result) == 2  # Only servers user has access to
+
+            # Check that only allowed servers are included
+            server_ids = [server.server_id for server in result]
+            assert "db_server_allowed" in server_ids
+            assert "config_server_allowed" in server_ids
+            assert "config_server_not_allowed" not in server_ids
+
+            # Verify server properties
+            db_server = next(s for s in result if s.server_id == "db_server_allowed")
+            assert db_server.alias == "Allowed Gmail MCP"
+
+            config_server = next(
+                s for s in result if s.server_id == "config_server_allowed"
+            )
+            assert config_server.alias == "Allowed Zapier MCP"

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
@@ -181,7 +181,7 @@ const MCPConnect: React.FC = () => {
             "server_url": "${proxyBaseUrl}/mcp",
             "require_approval": "never",
             "headers": {
-                "Authorization": "Bearer YOUR_LITELLM_API_KEY"
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY"
             }
         }
     ],
@@ -266,7 +266,7 @@ const MCPConnect: React.FC = () => {
             "server_url": "${proxyBaseUrl}/mcp",
             "require_approval": "never",
             "headers": {
-                "Authorization": "Bearer YOUR_LITELLM_API_KEY"
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY"
             }
         }
     ],
@@ -321,7 +321,7 @@ const MCPConnect: React.FC = () => {
     "LiteLLM": {
       "url": "${proxyBaseUrl}/mcp",
       "headers": {
-        "Authorization": "Bearer $LITELLM_API_KEY"
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY"
       }
     }
   }


### PR DESCRIPTION
## [Bug Fixes] MCP - using MCPs defined on config.yaml + fix for MCP error Team doesn't exist in cache

Closes https://github.com/BerriAI/litellm/issues/11797 & Adds support for using / listing MCPs on config.yaml file 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


