### PR TITLE
Enable Tool Calling for `meta_llama`

### DIFF
--- a/docs/my-website/docs/providers/meta_llama.md
+++ b/docs/my-website/docs/providers/meta_llama.md
@@ -45,7 +45,7 @@ os.environ["LLAMA_API_KEY"] = ""  # your Meta Llama API key
 messages = [{"content": "Hello, how are you?", "role": "user"}]
 
 # Meta Llama call
-response = completion(model="meta_llama/Llama-3.3-70B-Instruct", messages=messages)
+response = completion(model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8", messages=messages)
 ```
 
 ### Streaming
@@ -61,7 +61,7 @@ messages = [{"content": "Hello, how are you?", "role": "user"}]
 
 # Meta Llama call with streaming
 response = completion(
-    model="meta_llama/Llama-3.3-70B-Instruct",
+    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     messages=messages,
     stream=True
 )
@@ -209,7 +209,7 @@ client = OpenAI(
 
 # Non-streaming response
 response = client.chat.completions.create(
-    model="meta_llama/Llama-3.3-70B-Instruct",
+    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     messages=[{"role": "user", "content": "Write a short poem about AI."}]
 )
 
@@ -227,7 +227,7 @@ client = OpenAI(
 
 # Streaming response
 response = client.chat.completions.create(
-    model="meta_llama/Llama-3.3-70B-Instruct",
+    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     messages=[{"role": "user", "content": "Write a short poem about AI."}],
     stream=True
 )

--- a/docs/my-website/docs/providers/meta_llama.md
+++ b/docs/my-website/docs/providers/meta_llama.md
@@ -70,6 +70,104 @@ for chunk in response:
     print(chunk)
 ```
 
+### Function Calling
+
+```python showLineNumbers title="Meta Llama Function Calling"
+import os
+import litellm
+from litellm import completion
+
+os.environ["LLAMA_API_KEY"] = ""  # your Meta Llama API key
+
+messages = [{"content": "What's the weather like in San Francisco?", "role": "user"}]
+
+# Define the function
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA"
+                    },
+                    "unit": {
+                        "type": "string",
+                        "enum": ["celsius", "fahrenheit"]
+                    }
+                },
+                "required": ["location"]
+            }
+        }
+    }
+]
+
+# Meta Llama call with function calling
+response = completion(
+    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto"
+)
+
+print(response.choices[0].message.tool_calls)
+```
+
+### Tool Use
+
+```python showLineNumbers title="Meta Llama Tool Use"
+import os
+import litellm
+from litellm import completion
+
+os.environ["LLAMA_API_KEY"] = ""  # your Meta Llama API key
+
+messages = [{"content": "Create a chart showing the population growth of New York City from 2010 to 2020", "role": "user"}]
+
+# Define the tools
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "create_chart",
+            "description": "Create a chart with the provided data",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "chart_type": {
+                        "type": "string",
+                        "enum": ["bar", "line", "pie", "scatter"],
+                        "description": "The type of chart to create"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "The title of the chart"
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "The data to plot in the chart"
+                    }
+                },
+                "required": ["chart_type", "title", "data"]
+            }
+        }
+    }
+]
+
+# Meta Llama call with tool use
+response = completion(
+    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+    messages=messages,
+    tools=tools,
+    tool_choice="auto"
+)
+
+print(response.choices[0].message.tool_calls)
+```
 
 ## Usage - LiteLLM Proxy
 

--- a/docs/my-website/docs/providers/meta_llama.md
+++ b/docs/my-website/docs/providers/meta_llama.md
@@ -166,7 +166,7 @@ response = completion(
     tool_choice="auto"
 )
 
-print(response.choices[0].message.tool_calls)
+print(response.choices[0].message.content)
 ```
 
 ## Usage - LiteLLM Proxy

--- a/litellm/llms/meta_llama/chat/transformation.py
+++ b/litellm/llms/meta_llama/chat/transformation.py
@@ -6,7 +6,10 @@ Calls done in OpenAI/openai.py as Llama API is openai-compatible.
 Docs: https://llama.developer.meta.com/docs/features/compatibility/
 """
 
-from typing import Optional
+import warnings
+
+# Suppress Pydantic serialization warnings for Meta Llama responses
+warnings.filterwarnings("ignore", message="Pydantic serializer warnings")
 
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 

--- a/litellm/llms/meta_llama/chat/transformation.py
+++ b/litellm/llms/meta_llama/chat/transformation.py
@@ -8,7 +8,6 @@ Docs: https://llama.developer.meta.com/docs/features/compatibility/
 
 from typing import Optional
 
-from litellm import get_model_info, verbose_logger
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
@@ -17,27 +16,11 @@ class LlamaAPIConfig(OpenAIGPTConfig):
         """
         Llama API has limited support for OpenAI parameters
 
-        Tool calling, Functional Calling, tool choice are not working right now
+        function_call, tools, and tool_choice are working
         response_format: only json_schema is working
         """
-        supports_function_calling: Optional[bool] = None
-        supports_tool_choice: Optional[bool] = None
-        try:
-            model_info = get_model_info(model, custom_llm_provider="meta_llama")
-            supports_function_calling = model_info.get(
-                "supports_function_calling", False
-            )
-            supports_tool_choice = model_info.get("supports_tool_choice", False)
-        except Exception as e:
-            verbose_logger.debug(f"Error getting supported openai params: {e}")
-            pass
-
+        # Function calling and tool choice are now supported on Llama API
         optional_params = super().get_supported_openai_params(model)
-        if not supports_function_calling:
-            optional_params.remove("function_call")
-        if not supports_tool_choice:
-            optional_params.remove("tools")
-            optional_params.remove("tool_choice")
         return optional_params
 
     def map_openai_params(


### PR DESCRIPTION
Now, you can utilize tool-calling features from [Llama API](https://llama.developer.meta.com?utm_source=partner-litellm&utm_medium=readme).
Users can test on the tool_calling with our example codes under [meta_llama.md](docs/my-website/docs/providers/meta_llama.md)

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

```python
import os
import litellm
from litellm import completion

os.environ["LLAMA_API_KEY"] = ""  # your Meta Llama API key

messages = [{"content": "What's the weather like in San Francisco?", "role": "user"}]

# Define the function
tools = [
    {
        "type": "function",
        "function": {
            "name": "get_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "The city and state, e.g. San Francisco, CA"
                    },
                    "unit": {
                        "type": "string",
                        "enum": ["celsius", "fahrenheit"]
                    }
                },
                "required": ["location"]
            }
        }
    }
]

# Meta Llama call with function calling
response = completion(
    model="meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
    messages=messages,
    tools=tools,
    tool_choice="auto"
)

print(response.choices[0].message.tool_calls)
```

