### PR TITLE
[Fix] v1/messages endpoint always uses us-central1 with vertex_ai-anthropic models

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -40,6 +40,14 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
                 or get_secret_str("VERTEXAI_CREDENTIALS")
             )
 
+            vertex_ai_location = (
+                litellm_params.pop("vertex_location", None)
+                or litellm_params.pop("vertex_ai_location", None)
+                or litellm.vertex_location
+                or get_secret_str("VERTEXAI_LOCATION")
+                or get_secret_str("VERTEX_LOCATION")
+            )
+
             access_token, project_id = self._ensure_access_token(
                 credentials=vertex_credentials,
                 project_id=vertex_ai_project,
@@ -50,7 +58,7 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
 
             api_base = self.get_complete_vertex_url(
                 custom_api_base=api_base,
-                vertex_location=litellm_params.pop("vertex_location", None),
+                vertex_location=vertex_ai_location,
                 vertex_project=vertex_ai_project,
                 project_id=project_id,
                 partner=VertexPartnerProvider.claude,

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+import pytest
+
+from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (
+    VertexAIPartnerModelsAnthropicMessagesConfig,
+)
+
+
+def test_validate_environment_uses_vertex_ai_location():
+    config = VertexAIPartnerModelsAnthropicMessagesConfig()
+    headers = {}
+    litellm_params = {
+        "vertex_ai_project": "test-project",
+        "vertex_ai_location": "europe-west1",
+        "vertex_credentials": "{}",
+    }
+    optional_params = {}
+
+    with patch.object(
+        config, "_ensure_access_token", return_value=("token", "test-project")
+    ), patch.object(
+        config, "get_complete_vertex_url", return_value="https://mock-url"
+    ) as mock_get_url:
+        config.validate_anthropic_messages_environment(
+            headers=headers,
+            model="claude-3-sonnet",
+            messages=[],
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            api_base=None,
+        )
+        assert mock_get_url.call_args.kwargs["vertex_location"] == "europe-west1"


### PR DESCRIPTION
## [Fix] v1/messages endpoint always uses us-central1 with vertex_ai-anthropic models

Fixes https://github.com/BerriAI/litellm/issues/11798

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


