### PR TITLE
fix unrecognised parameter reasoning_effort

### DIFF
--- a/litellm/llms/azure/chat/o_series_transformation.py
+++ b/litellm/llms/azure/chat/o_series_transformation.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 import litellm
 from litellm import verbose_logger
 from litellm.types.llms.openai import AllMessageValues
-from litellm.utils import get_model_info
+from litellm.utils import get_model_info, supports_reasoning
 
 from ...openai.chat.o_series_transformation import OpenAIOSeriesConfig
 
@@ -39,7 +39,7 @@ class AzureOpenAIO1Config(OpenAIOSeriesConfig):
         ]
 
         o_series_only_param = []
-        if model and model != "o1-mini":
+        if supports_reasoning(model):
             o_series_only_param.append("reasoning_effort")
         all_openai_params.extend(o_series_only_param)
         return [

--- a/litellm/llms/azure/chat/o_series_transformation.py
+++ b/litellm/llms/azure/chat/o_series_transformation.py
@@ -38,7 +38,9 @@ class AzureOpenAIO1Config(OpenAIOSeriesConfig):
             "top_logprobs",
         ]
 
-        o_series_only_param = ["reasoning_effort"]
+        o_series_only_param = []
+        if model and model != "o1-mini":
+            o_series_only_param.append("reasoning_effort")
         all_openai_params.extend(o_series_only_param)
         return [
             param for param in all_openai_params if param not in non_supported_params


### PR DESCRIPTION
## Title

fix unrecognised parameter reasoning_effort for o1-mini model

## Relevant issues

Fixes #11819

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
Added a check for model type being o1-mini before adding reasoning_effort parameter

