### PR TITLE
Remove retired version of gpt-3.5 from prometheus.md

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -23,9 +23,9 @@ If you're using the LiteLLM CLI with `litellm --config proxy_config.yaml` then y
 Add this to your proxy config.yaml 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+ - model_name: gpt-4o
     litellm_params:
-      model: gpt-3.5-turbo
+      model: gpt-4o
 litellm_settings:
   callbacks: ["prometheus"]
 ```
@@ -40,7 +40,7 @@ Test Request
 curl --location 'http://0.0.0.0:4000/chat/completions' \
     --header 'Content-Type: application/json' \
     --data '{
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o",
     "messages": [
         {
         "role": "user",
@@ -201,9 +201,9 @@ Track custom metrics on prometheus on all events mentioned above.
 
 ```yaml
 model_list:
-  - model_name: openai/gpt-3.5-turbo
+  - model_name: openai/gpt-4o
     litellm_params:
-      model: openai/gpt-3.5-turbo
+      model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
 
 litellm_settings:
@@ -218,7 +218,7 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Bearer <LITELLM_API_KEY>' \
 -d '{
-    "model": "openai/gpt-3.5-turbo",
+    "model": "openai/gpt-4o",
     "messages": [
       {
         "role": "user",
@@ -254,9 +254,9 @@ Configure which metrics to emit by specifying them in `prometheus_metrics_config
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+ - model_name: gpt-4o
     litellm_params:
-      model: gpt-3.5-turbo
+      model: gpt-4o
 
 litellm_settings:
   callbacks: ["prometheus"]
@@ -358,9 +358,9 @@ To monitor the health of litellm adjacent services (redis / postgres), do:
 
 ```yaml
 model_list:
- - model_name: gpt-3.5-turbo
+ - model_name: gpt-4o
     litellm_params:
-      model: gpt-3.5-turbo
+      model: gpt-4o
 litellm_settings:
   service_callback: ["prometheus_system"]
 ```


### PR DESCRIPTION
## Title

Update prometheus.md: Remove the gpt-3.5 model which was retired by Azure.

## Relevant issues

Fixes #11857

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] Testing: N/A. Only changed the documentation
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Updated docs/my-website/docs/proxy/configs.md.](https://docs.litellm.ai/docs/proxy/prometheus.
Removed references to the retired gpt-3.5 version.
This helps prevent the confusion when user tries to use the gpt-3.5 with Azure and prometheus which will cause errors.
