### PR TITLE
fix(acompletion): allow dict for tool_choice argument

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -344,7 +344,7 @@ async def acompletion(
     response_format: Optional[Union[dict, Type[BaseModel]]] = None,
     seed: Optional[int] = None,
     tools: Optional[List] = None,
-    tool_choice: Optional[str] = None,
+    tool_choice: Optional[Union[str, dict]] = None,
     parallel_tool_calls: Optional[bool] = None,
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,


### PR DESCRIPTION
## Relevant issues

<!-- e.g. "Fixes #000" -->
No related issue.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Updated the type annotation for the `tool_choice` argument in the `acompletion` function from `Optional[str]` to `Optional[Union[str, dict]]`, so that both string and dictionary values can be accepted (previously only strings were allowed).
- This improves flexibility and compatibility with cases where a dictionary needs to be passed in as `tool_choice`.