### PR TITLE
[SCIM] Add Error handling for existing user on SCIM

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_errors.py
+++ b/litellm/proxy/management_endpoints/scim/scim_errors.py
@@ -6,8 +6,8 @@ class ScimUserAlreadyExists(HTTPException):
     Exception raised when a user already exists in the database.
     """
     def __init__(self, message: str, scim_type: str = "uniqueness"):
+        super().__init__(status_code=409, detail=message)
         self.message = message
         self.scim_type = scim_type
-        self.status_code = 409
         self.schemas = ["urn:ietf:params:scim:api:messages:2.0:Error"]
     

--- a/litellm/proxy/management_endpoints/scim/scim_errors.py
+++ b/litellm/proxy/management_endpoints/scim/scim_errors.py
@@ -1,0 +1,13 @@
+from fastapi import HTTPException
+
+
+class ScimUserAlreadyExists(HTTPException):
+    """
+    Exception raised when a user already exists in the database.
+    """
+    def __init__(self, message: str, scim_type: str = "uniqueness"):
+        self.message = message
+        self.scim_type = scim_type
+        self.status_code = 409
+        self.schemas = ["urn:ietf:params:scim:api:messages:2.0:Error"]
+    

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -214,6 +214,8 @@ async def create_user(
         # Transform and return SCIM user
         return await ScimTransformations.transform_litellm_user_to_scim_user(created_user)
         
+    except HTTPException:
+        raise  # Let HTTPExceptions (including ScimUserAlreadyExists) propagate directly
     except Exception as e:
         raise handle_exception_on_proxy(e)
 

--- a/litellm/proxy/management_endpoints/scim/utils.py
+++ b/litellm/proxy/management_endpoints/scim/utils.py
@@ -1,0 +1,20 @@
+from fastapi import HTTPException
+
+
+async def _check_user_exists(prisma_client, user_name: str) -> bool:
+    """Check if user already exists by username"""
+    if not user_name:
+        return False
+    
+    existing_user = await prisma_client.db.litellm_usertable.find_unique(
+        where={"user_id": user_name}
+    )
+    return existing_user is not None
+
+
+def _extract_error_message(http_exception: HTTPException) -> str:
+    """Extract error message from HTTPException detail"""
+    if isinstance(http_exception.detail, dict):
+        return http_exception.detail.get("error", "User already exists")
+    return str(http_exception.detail)
+

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from litellm.proxy.management_endpoints.scim.scim_errors import ScimUserAlreadyExists
+from litellm.proxy.management_endpoints.scim.scim_v2 import create_user
+from litellm.types.proxy.management_endpoints.scim_v2 import (
+    SCIMUser,
+    SCIMUserEmail,
+    SCIMUserName,
+)
+
+
+@pytest.mark.asyncio
+async def test_create_user_existing_user_conflict(mocker):
+    """If a user already exists, create_user should raise ScimUserAlreadyExists"""
+
+    scim_user = SCIMUser(
+        schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+        userName="existing-user",
+        name=SCIMUserName(familyName="User", givenName="Existing"),
+        emails=[SCIMUserEmail(value="existing@example.com")],
+    )
+
+    mock_prisma = mocker.MagicMock()
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
+        AsyncMock(return_value=True),
+    )
+    mocked_new_user = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.new_user",
+        AsyncMock(),
+    )
+
+    with pytest.raises(ScimUserAlreadyExists) as exc_info:
+        await create_user(user=scim_user)
+
+    assert exc_info.value.status_code == 409
+    assert "existing-user" in exc_info.value.message
+    mocked_new_user.assert_not_called()


### PR DESCRIPTION
## [SCIM] Add Error handling for existing user on SCIM

This PR ensures LiteLLM SCIM Raises a 409 when an existing user is added to the system. This is in accordance with https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.1 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
✅ Test

## Changes


