### PR TITLE
[Feat] Passthrough - Add support for setting custom cost per pass through request

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1456,7 +1456,7 @@ class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
         default=False,
         description="If True, requests to subpaths of the path will be forwarded to the target endpoint. For example, if the path is /bria and include_subpath is True, requests to /bria/v1/text-to-image/base/2.3 will be forwarded to the target endpoint.",
     )
-    input_cost_per_request: float = Field(
+    cost_per_request: float = Field(
         default=0.0,
         description="The USD cost per request to the target endpoint. This is used to calculate the cost of the request to the target endpoint.",
     )

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -520,9 +520,22 @@ async def pass_through_request(  # noqa: PLR0915
     merge_query_params: Optional[bool] = False,
     query_params: Optional[dict] = None,
     stream: Optional[bool] = None,
+    cost_per_request: Optional[float] = None,
 ):
     """
     Pass through endpoint handler, makes the httpx request for pass-through endpoints and ensures logging hooks are called
+
+    Args:
+        request: The incoming request
+        target: The target URL
+        custom_headers: The custom headers
+        user_api_key_dict: The user API key dictionary
+        custom_body: The custom body
+        forward_headers: Whether to forward headers
+        merge_query_params: Whether to merge query params
+        query_params: The query params
+        stream: Whether to stream the response
+        cost_per_request: Optional field - cost per request to the target endpoint
     """
     from litellm.litellm_core_utils.litellm_logging import Logging
     from litellm.proxy.proxy_server import proxy_logging_obj
@@ -600,6 +613,7 @@ async def pass_through_request(  # noqa: PLR0915
             url=str(url),
             request_body=_parsed_body,
             request_method=getattr(request, "method", None),
+            cost_per_request=cost_per_request,
         )
         kwargs = HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint(
             user_api_key_dict=user_api_key_dict,
@@ -908,6 +922,7 @@ def create_pass_through_route(
                 query_params=query_params,
                 stream=stream,
                 custom_body=custom_body,
+                cost_per_request=cost_per_request,
             )
 
     return endpoint_func

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -88,6 +88,8 @@ class PassThroughEndpointLogging:
             cache_hit=False,
             **kwargs,
         )
+    
+
 
     async def pass_through_async_success_handler(
         self,
@@ -192,6 +194,13 @@ class PassThroughEndpointLogging:
             standard_logging_response_object = StandardPassThroughResponseObject(
                 response=httpx_response.text
             )
+        
+        kwargs = self._set_cost_per_request(
+            logging_obj=logging_obj,
+            passthrough_logging_payload=passthrough_logging_payload,
+            kwargs=kwargs,
+        )
+        
 
         await self._handle_logging(
             logging_obj=logging_obj,
@@ -200,6 +209,7 @@ class PassThroughEndpointLogging:
             start_time=start_time,
             end_time=end_time,
             cache_hit=cache_hit,
+            standard_pass_through_logging_payload=passthrough_logging_payload,
             **kwargs,
         )
 
@@ -234,3 +244,29 @@ class PassThroughEndpointLogging:
             if route in parsed_url.path:
                 return True
         return False
+    
+
+    def _set_cost_per_request(
+        self, 
+        logging_obj: LiteLLMLoggingObj, 
+        passthrough_logging_payload: PassthroughStandardLoggingPayload,
+        kwargs: dict,
+    ):
+        """
+        Helper function to set the cost per request in the logging object
+
+        Only set the cost per request if it's set in the passthrough logging payload.
+        If it's not set, don't set it in the logging object.
+        """
+        #########################################################
+        # Check if cost per request is set
+        #########################################################
+        if passthrough_logging_payload.get("cost_per_request") is not None:
+            kwargs["response_cost"] = passthrough_logging_payload.get(
+                "cost_per_request"
+            )
+            logging_obj.model_call_details["response_cost"] = passthrough_logging_payload.get(
+                "cost_per_request"
+            )
+        
+        return kwargs

--- a/litellm/types/passthrough_endpoints/pass_through_endpoints.py
+++ b/litellm/types/passthrough_endpoints/pass_through_endpoints.py
@@ -32,3 +32,10 @@ class PassthroughStandardLoggingPayload(TypedDict, total=False):
     """
     The body of the response
     """
+
+    cost_per_request: Optional[float]
+    """
+    The cost per request to the target endpoint
+
+    Optional field, we use this for cost tracking only if it's set.
+    """

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -691,7 +691,7 @@ async def test_pass_through_request_with_cost_per_request():
                 pre_call_kwargs = mock_proxy_logging.pre_call_hook.call_args[1]
                 
                 # Check that the passthrough_logging_payload contains cost_per_request
-                passthrough_payload = pre_call_kwargs["call_type"]
+                passthrough_payload = pre_call_kwargs["data"]
                 assert passthrough_payload["cost_per_request"] == 2.50
 
                 # Verify that async_success_handler was called

--- a/ui/litellm-dashboard/src/components/add_pass_through.tsx
+++ b/ui/litellm-dashboard/src/components/add_pass_through.tsx
@@ -55,7 +55,7 @@ const AddPassThroughEndpoint: React.FC<AddFallbacksProps> = ({
         "path": formValues["path"],
         "target": formValues["target"],
         "include_subpath": formValues["include_subpath"] || false,
-        "input_cost_per_request": formValues["input_cost_per_request"] || 0
+        "cost_per_request": formValues["cost_per_request"] || 0
       }
       
       await createPassThroughEndpoint(accessToken, formValues);
@@ -185,7 +185,7 @@ const AddPassThroughEndpoint: React.FC<AddFallbacksProps> = ({
                     </Tooltip>
                   </span>
                 }
-                name="input_cost_per_request"
+                name="cost_per_request"
               >
                 <InputNumber 
                   min={0} 

--- a/ui/litellm-dashboard/src/components/pass_through_settings.tsx
+++ b/ui/litellm-dashboard/src/components/pass_through_settings.tsx
@@ -79,7 +79,7 @@ export interface passThroughItem {
   target: string
   headers: object
   include_subpath?: boolean
-  input_cost_per_request?: number
+  cost_per_request?: number
 }
 
 // Password field component for headers


### PR DESCRIPTION
## [Feat] Passthrough - Add support for setting custom cost per pass through request

Adds support for passing a custom cost_per_request for Pass Through API endpoints through UI components, backend request handlers, logging, and route initialization.



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


