### PR TITLE
[Bug Fix] - Ensure "Request" is tracked for pass through requests on LiteLLM Proxy 

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import copy
 import json
 import traceback
 import uuid
@@ -468,6 +469,11 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         kwargs = {
             "litellm_params": {
                 "metadata": _metadata,
+                "proxy_server_request": {
+                        "url": str(request.url),
+                        "method": request.method,
+                        "body": copy.copy(_parsed_body),  # use copy instead of deepcopy
+                    }
             },
             "call_type": "pass_through_endpoint",
             "litellm_call_id": litellm_call_id,

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -12,3 +12,7 @@ mcp_servers:
   deepwiki_mcp:
     url: "https://mcp.deepwiki.com/mcp"
     transport: "http"
+
+general_settings:
+  store_model_in_db: true
+  store_prompts_in_spend_logs: true


### PR DESCRIPTION
## [Bug Fix] - Ensure "Request" is tracked for pass through requests on LiteLLM Proxy 

<img width="1081" alt="Screenshot 2025-06-18 at 5 09 02 PM" src="https://github.com/user-attachments/assets/fbecf88a-d78f-4ce1-b89d-7faaad63bbcc" />



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


