### PR TITLE
[BugFix] Ollama response_format not working

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -179,6 +179,8 @@ class OllamaConfig(BaseConfig):
             if param == "response_format" and isinstance(value, dict):
                 if value["type"] == "json_object":
                     optional_params["format"] = "json"
+                elif value["type"] == "json_schema":
+                    optional_params["format"] = value["json_schema"]["schema"]
 
         return optional_params
 


### PR DESCRIPTION
## Fix for Ollama Structured output `response_format` param

### Ref: https://ollama.com/blog/structured-outputs

```py
from litellm import completion
from pydantic import BaseModel

class Pet(BaseModel):
  name: str
  type: str

response = completion(
  model="ollama/llama3.2:1b",
  messages=[
    {"role": "user", "content": "I have a cat named Kate"},
  ],
  api_base="http://localhost:11434",
  response_format=Pet,
)

# This isn't a json output, as the `json_schema` wasn't passed to the model and the `format` parameter
# is missing from the http call.
print(response.choices[0].message.content)

```

### Without the fix output is:
```
Nice to meet you, Kate the cat. What's been going on in your household lately?
Any new toys or treats that have caught your attention?
```

### With the fix output is:
```
{ "name": "Kate", "type": "cat" }
```



## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes


