### PR TITLE
[Feat] MCP - Allow connecting to MCP with authentication headers + Allow clients to specify MCP headers (#11890)

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -292,7 +292,7 @@ curl --location 'https://api.openai.com/v1/responses' \
             "require_approval": "never",
             "headers": {
                 "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
-                "x-mcp-auth": "Bearer YOUR_MCP_AUTH_TOKEN"
+                "x-mcp-auth": YOUR_MCP_AUTH_TOKEN
             }
         }
     ],
@@ -323,7 +323,7 @@ curl --location '<your-litellm-proxy-base-url>/v1/responses' \
             "require_approval": "never",
             "headers": {
                 "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
-                "x-mcp-auth": "Bearer YOUR_MCP_AUTH_TOKEN"
+                "x-mcp-auth": "YOUR_MCP_AUTH_TOKEN"
             }
         }
     ],
@@ -353,7 +353,7 @@ Use tools directly from Cursor IDE with LiteLLM MCP and include your MCP authent
       "url": "<your-litellm-proxy-base-url>/mcp",
       "headers": {
         "x-litellm-api-key": "Bearer $LITELLM_API_KEY",
-        "x-mcp-auth": "Bearer $MCP_AUTH_TOKEN"
+        "x-mcp-auth": "$MCP_AUTH_TOKEN"
       }
     }
   }

--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -265,6 +265,182 @@ if __name__ == "__main__":
 </Tabs>
 
 
+## Using your MCP with client side credentials
+
+Use this if you want to pass a client side authentication token to LiteLLM to then pass to your MCP to auth to your MCP.
+
+You can specify your MCP auth token using the header `x-mcp-auth`. LiteLLM will forward this token to your MCP server for authentication.
+
+<Tabs>
+<TabItem value="openai" label="OpenAI API">
+
+#### Connect via OpenAI Responses API with MCP Auth
+
+Use the OpenAI Responses API and include the `x-mcp-auth` header for your MCP server authentication:
+
+```bash title="cURL Example with MCP Auth" showLineNumbers
+curl --location 'https://api.openai.com/v1/responses' \
+--header 'Content-Type: application/json' \
+--header "Authorization: Bearer $OPENAI_API_KEY" \
+--data '{
+    "model": "gpt-4o",
+    "tools": [
+        {
+            "type": "mcp",
+            "server_label": "litellm",
+            "server_url": "<your-litellm-proxy-base-url>/mcp",
+            "require_approval": "never",
+            "headers": {
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+                "x-mcp-auth": "Bearer YOUR_MCP_AUTH_TOKEN"
+            }
+        }
+    ],
+    "input": "Run available tools",
+    "tool_choice": "required"
+}'
+```
+
+</TabItem>
+
+<TabItem value="litellm" label="LiteLLM Proxy">
+
+#### Connect via LiteLLM Proxy Responses API with MCP Auth
+
+Use this when calling LiteLLM Proxy for LLM API requests to `/v1/responses` endpoint with MCP authentication:
+
+```bash title="cURL Example with MCP Auth" showLineNumbers
+curl --location '<your-litellm-proxy-base-url>/v1/responses' \
+--header 'Content-Type: application/json' \
+--header "Authorization: Bearer $LITELLM_API_KEY" \
+--data '{
+    "model": "gpt-4o",
+    "tools": [
+        {
+            "type": "mcp",
+            "server_label": "litellm",
+            "server_url": "<your-litellm-proxy-base-url>/mcp",
+            "require_approval": "never",
+            "headers": {
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+                "x-mcp-auth": "Bearer YOUR_MCP_AUTH_TOKEN"
+            }
+        }
+    ],
+    "input": "Run available tools",
+    "tool_choice": "required"
+}'
+```
+
+</TabItem>
+
+<TabItem value="cursor" label="Cursor IDE">
+
+#### Connect via Cursor IDE with MCP Auth
+
+Use tools directly from Cursor IDE with LiteLLM MCP and include your MCP authentication token:
+
+**Setup Instructions:**
+
+1. **Open Cursor Settings**: Use `⇧+⌘+J` (Mac) or `Ctrl+Shift+J` (Windows/Linux)
+2. **Navigate to MCP Tools**: Go to the "MCP Tools" tab and click "New MCP Server"
+3. **Add Configuration**: Copy and paste the JSON configuration below, then save with `Cmd+S` or `Ctrl+S`
+
+```json title="Cursor MCP Configuration with Auth" showLineNumbers
+{
+  "mcpServers": {
+    "LiteLLM": {
+      "url": "<your-litellm-proxy-base-url>/mcp",
+      "headers": {
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY",
+        "x-mcp-auth": "Bearer $MCP_AUTH_TOKEN"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="http" label="Streamable HTTP">
+
+#### Connect via Streamable HTTP Transport with MCP Auth
+
+Connect to LiteLLM MCP using HTTP transport with MCP authentication:
+
+**Server URL:**
+```text showLineNumbers
+<your-litellm-proxy-base-url>/mcp
+```
+
+**Headers:**
+```text showLineNumbers
+x-litellm-api-key: Bearer YOUR_LITELLM_API_KEY
+x-mcp-auth: Bearer YOUR_MCP_AUTH_TOKEN
+```
+
+This URL can be used with any MCP client that supports HTTP transport. The `x-mcp-auth` header will be forwarded to your MCP server for authentication.
+
+</TabItem>
+
+<TabItem value="fastmcp" label="Python FastMCP">
+
+#### Connect via Python FastMCP Client with MCP Auth
+
+Use the Python FastMCP client to connect to your LiteLLM MCP server with MCP authentication:
+
+```python title="Python FastMCP Example with MCP Auth" showLineNumbers
+import asyncio
+import json
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+# Create the transport with your LiteLLM MCP server URL and auth headers
+server_url = "<your-litellm-proxy-base-url>/mcp"
+transport = StreamableHttpTransport(
+    server_url,
+    headers={
+        "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+        "x-mcp-auth": "Bearer YOUR_MCP_AUTH_TOKEN"
+    }
+)
+
+# Initialize the client with the transport
+client = Client(transport=transport)
+
+
+async def main():
+    # Connection is established here
+    print("Connecting to LiteLLM MCP server with authentication...")
+    async with client:
+        print(f"Client connected: {client.is_connected()}")
+
+        # Make MCP calls within the context
+        print("Fetching available tools...")
+        tools = await client.list_tools()
+
+        print(f"Available tools: {json.dumps([t.name for t in tools], indent=2)}")
+        
+        # Example: Call a tool (replace 'tool_name' with an actual tool name)
+        if tools:
+            tool_name = tools[0].name
+            print(f"Calling tool: {tool_name}")
+            
+            # Call the tool with appropriate arguments
+            result = await client.call_tool(tool_name, arguments={})
+            print(f"Tool result: {result}")
+
+
+# Run the example
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+</TabItem>
+</Tabs>
+
+
 ## ✨ MCP Permission Management
 
 LiteLLM supports managing permissions for MCP Servers by Keys, Teams, Organizations (entities) on LiteLLM. When a MCP client attempts to list tools, LiteLLM will only return the tools the entity has permissions to access.

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -1,0 +1,148 @@
+from typing import List, Optional
+import base64
+from datetime import timedelta
+from mcp import ClientSession
+from mcp.types import Tool as MCPTool
+from mcp.types import CallToolResult as MCPCallToolResult
+from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from litellm.types.mcp import MCPAuth, MCPTransport, MCPTransportType, MCPAuthType
+
+def to_basic_auth(auth_value: str) -> str:
+    """Convert auth value to Basic Auth format."""
+    return base64.b64encode(auth_value.encode("utf-8")).decode()
+
+
+class MCPClient:
+    """
+    MCP Client supporting:
+      SSE and HTTP transports
+      Authentication via Bearer token, Basic Auth, or API Key
+      Tool calling with error handling and result parsing
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        transport_type: MCPTransportType = MCPTransport.http,
+        auth_type: MCPAuthType = None,
+        auth_value: Optional[str] = None,
+        timeout: float = 60.0,
+    ):
+        self.server_url: str = server_url
+        self.transport_type: MCPTransport = transport_type
+        self.auth_type: MCPAuthType = auth_type
+        self.timeout: float = timeout
+        self._mcp_auth_value: Optional[str] = None
+        self._session: Optional[ClientSession] = None
+        self._context = None
+        self._transport_ctx = None
+        self._transport = None
+        self._session_ctx = None
+
+        # handle the basic auth value if provided
+        if auth_value:
+            self.update_auth_value(auth_value)
+
+    async def __aenter__(self):
+        """
+        Enable async context manager support.
+          Initializes the transport and session.
+        """
+        headers = self._get_auth_headers()
+
+        if self.transport_type == MCPTransport.sse:
+            self._transport_ctx = sse_client(
+                url=self.server_url,
+                timeout=self.timeout,
+                headers=headers,
+            )
+            self._transport = await self._transport_ctx.__aenter__()
+            self._session_ctx = ClientSession(self._transport[0], self._transport[1])
+            self._session = await self._session_ctx.__aenter__()
+            await self._session.initialize()
+        else:
+            self._transport_ctx = streamablehttp_client(
+                url=self.server_url,
+                timeout=timedelta(seconds=self.timeout),
+                headers=headers,
+            )
+            self._transport = await self._transport_ctx.__aenter__()
+            self._session_ctx = ClientSession(self._transport[0], self._transport[1])
+            self._session = await self._session_ctx.__aenter__()
+            await self._session.initialize()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Cleanup when exiting context manager."""
+        if self._session:
+            await self._session_ctx.__aexit__(exc_type, exc_val, exc_tb) # type: ignore
+        if self._transport_ctx:
+            await self._transport_ctx.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def disconnect(self):
+        """Clean up session and connections."""
+        if self._session:
+            try:
+                # Ensure session is properly closed
+                await self._session.close()  # type: ignore 
+            except Exception:
+                pass
+            self._session = None
+
+        if self._context:
+            try:
+                await self._context.__aexit__(None, None, None) # type: ignore
+            except Exception:
+                pass
+            self._context = None
+
+    def update_auth_value(self, mcp_auth_value: str):
+        """
+        Set the authentication header for the MCP client.
+        """
+        if self.auth_type == MCPAuth.basic:
+            # Assuming mcp_auth_value is in format "username:password", convert it when updating
+            mcp_auth_value = to_basic_auth(mcp_auth_value)
+        self._mcp_auth_value = mcp_auth_value
+
+    def _get_auth_headers(self) -> dict:
+        """Generate authentication headers based on auth type."""
+        if not self._mcp_auth_value:
+            return {}
+
+        if self.auth_type == MCPAuth.bearer_token:
+            return {"Authorization": f"Bearer {self._mcp_auth_value}"}
+        elif self.auth_type == MCPAuth.basic:
+            return {"Authorization": f"Basic {self._mcp_auth_value}"}
+        elif self.auth_type == MCPAuth.api_key:
+            return {"X-API-Key": self._mcp_auth_value}
+        return {}
+
+    async def list_tools(self) -> List[MCPTool]:
+        """List available tools from the server."""
+        if not self._session:
+            await self.connect() # type: ignore
+
+        result = await self._session.list_tools()
+        if hasattr(result, "tools") and result.tools:
+            return result.tools
+        return result
+
+    async def call_tool(
+        self, call_tool_request_params: MCPCallToolRequestParams
+    ) -> MCPCallToolResult:
+        """
+        Call an MCP Tool.
+        """
+        if not self._session:
+            await self.connect() # type: ignore
+
+        tool_result = await self._session.call_tool(
+            name=call_tool_request_params.name,
+            arguments=call_tool_request_params.arguments,
+        )
+        return tool_result
+

--- a/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 
 from litellm.proxy._types import UserAPIKeyAuth
@@ -8,5 +10,6 @@ class LiteLLMAuthenticatedUser(AuthenticatedUser):
     Wrapper class to make UserAPIKeyAuth compatible with MCP's AuthenticatedUser
     """
 
-    def __init__(self, user_api_key_auth: UserAPIKeyAuth):
+    def __init__(self, user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None):
         self.user_api_key_auth = user_api_key_auth
+        self.mcp_auth_header = mcp_auth_header

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -241,7 +241,13 @@ class MCPServerManager:
 
             return tools
     
-    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> CallToolResult:
+    async def call_tool(
+        self, 
+        name: str, 
+        arguments: Dict[str, Any],
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        mcp_auth_header: Optional[str] = None,
+    ) -> CallToolResult:
         """
         Call a tool with the given name and arguments
         """
@@ -249,7 +255,10 @@ class MCPServerManager:
         if mcp_server is None:
             raise ValueError(f"Tool {name} not found")
 
-        client = self._create_mcp_client(mcp_server)
+        client = self._create_mcp_client(
+            server=mcp_server,
+            mcp_auth_header=mcp_auth_header,
+        )
         async with client:
             call_tool_params = MCPCallToolRequestParams(
                 name=name,

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query, Request
 
 from litellm._logging import verbose_logger
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth, mcp_auth_header
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 MCP_AVAILABLE: bool = True
 try:
@@ -37,7 +37,6 @@ if MCP_AVAILABLE:
         server_id: Optional[str] = Query(
             None, description="The server id to list tools for"
         ),
-        mcp_auth: Optional[str] = mcp_auth_header,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ) -> List[ListMCPToolsRestAPIResponseObject]:
         """
@@ -71,7 +70,9 @@ if MCP_AVAILABLE:
             if server_id and server.server_id != server_id:
                 continue
             try:
-                tools = await global_mcp_server_manager._get_tools_from_server(server)
+                tools = await global_mcp_server_manager._get_tools_from_server(
+                    server=server,
+                )
                 for tool in tools:
                     list_tools_result.append(
                         ListMCPToolsRestAPIResponseObject(
@@ -89,7 +90,6 @@ if MCP_AVAILABLE:
     @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
     async def call_tool_rest_api(
         request: Request,
-        mcp_auth: Optional[str] = mcp_auth_header,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ):
         """

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Query, Request
 
 from litellm._logging import verbose_logger
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth, mcp_auth_header
 
 MCP_AVAILABLE: bool = True
 try:
@@ -37,6 +37,7 @@ if MCP_AVAILABLE:
         server_id: Optional[str] = Query(
             None, description="The server id to list tools for"
         ),
+        mcp_auth: Optional[str] = mcp_auth_header,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ) -> List[ListMCPToolsRestAPIResponseObject]:
         """
@@ -88,6 +89,7 @@ if MCP_AVAILABLE:
     @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
     async def call_tool_rest_api(
         request: Request,
+        mcp_auth: Optional[str] = mcp_auth_header,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ):
         """

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -238,7 +238,7 @@ if MCP_AVAILABLE:
 
     @client
     async def call_mcp_tool(
-        name: str, arguments: Optional[Dict[str, Any]] = None, **kwargs: Any
+        name: str, arguments: Optional[Dict[str, Any]] = None, mcp_auth_header: Optional[str] = None, **kwargs: Any
     ) -> List[Union[MCPTextContent, MCPImageContent, MCPEmbeddedResource]]:
         """
         Call a specific tool with the provided arguments

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -4,7 +4,7 @@ LiteLLM MCP Server Routes
 
 import asyncio
 import contextlib
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 from fastapi import FastAPI, HTTPException
 from pydantic import ConfigDict
@@ -166,11 +166,14 @@ if MCP_AVAILABLE:
         List all available tools
         """
         # Get user authentication from context variable
-        user_api_key_auth = get_auth_context()
+        user_api_key_auth, mcp_auth_header = get_auth_context()
         verbose_logger.debug(
             f"MCP list_tools - User API Key Auth from context: {user_api_key_auth}"
         )
-        return await _list_mcp_tools(user_api_key_auth)
+        return await _list_mcp_tools(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=mcp_auth_header,
+        )
 
     @server.call_tool()
     async def mcp_server_tool_call(
@@ -190,9 +193,15 @@ if MCP_AVAILABLE:
             HTTPException: If tool not found or arguments missing
         """
         # Validate arguments
+        user_api_key_auth, mcp_auth_header = get_auth_context()
+        verbose_logger.debug(
+            f"MCP mcp_server_tool_call - User API Key Auth from context: {user_api_key_auth}"
+        )
         response = await call_mcp_tool(
             name=name,
             arguments=arguments,
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=mcp_auth_header,
         )
         return response
 
@@ -206,6 +215,7 @@ if MCP_AVAILABLE:
 
     async def _list_mcp_tools(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        mcp_auth_header: Optional[str] = None,
     ) -> List[MCPTool]:
         """
         List all available tools
@@ -229,6 +239,7 @@ if MCP_AVAILABLE:
         tools_from_mcp_servers: List[MCPTool] = (
             await global_mcp_server_manager.list_tools(
                 user_api_key_auth=user_api_key_auth,
+                mcp_auth_header=mcp_auth_header,
             )
         )
         verbose_logger.debug("TOOLS FROM MCP SERVERS: %s", tools_from_mcp_servers)
@@ -238,7 +249,11 @@ if MCP_AVAILABLE:
 
     @client
     async def call_mcp_tool(
-        name: str, arguments: Optional[Dict[str, Any]] = None, mcp_auth_header: Optional[str] = None, **kwargs: Any
+        name: str, 
+        arguments: Optional[Dict[str, Any]] = None, 
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        mcp_auth_header: Optional[str] = None, 
+        **kwargs: Any
     ) -> List[Union[MCPTextContent, MCPImageContent, MCPEmbeddedResource]]:
         """
         Call a specific tool with the provided arguments
@@ -270,7 +285,12 @@ if MCP_AVAILABLE:
 
         # Try managed server tool first
         if name in global_mcp_server_manager.tool_name_to_mcp_server_name_mapping:
-            return await _handle_managed_mcp_tool(name, arguments)
+            return await _handle_managed_mcp_tool(
+                name=name,
+                arguments=arguments,
+                user_api_key_auth=user_api_key_auth,
+                mcp_auth_header=mcp_auth_header,
+            )
 
         # Fall back to local tool registry
         return await _handle_local_mcp_tool(name, arguments)
@@ -295,12 +315,17 @@ if MCP_AVAILABLE:
             )
 
     async def _handle_managed_mcp_tool(
-        name: str, arguments: Dict[str, Any]
+        name: str, 
+        arguments: Dict[str, Any],
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        mcp_auth_header: Optional[str] = None,
     ) -> List[Union[MCPTextContent, MCPImageContent, MCPEmbeddedResource]]:
         """Handle tool execution for managed server tools"""
         call_tool_result = await global_mcp_server_manager.call_tool(
             name=name,
             arguments=arguments,
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=mcp_auth_header,
         )
         verbose_logger.debug("CALL TOOL RESULT: %s", call_tool_result)
         return call_tool_result.content
@@ -325,11 +350,14 @@ if MCP_AVAILABLE:
         """Handle MCP requests through StreamableHTTP."""
         try:
             # Validate headers and log request info
-            user_api_key_auth: UserAPIKeyAuth = (
+            user_api_key_auth, mcp_auth_header = (
                 await UserAPIKeyAuthMCP.user_api_key_auth_mcp(scope)
             )
             # Set the auth context variable for easy access in MCP functions
-            set_auth_context(user_api_key_auth)
+            set_auth_context(
+                user_api_key_auth=user_api_key_auth,
+                mcp_auth_header=mcp_auth_header,
+            )
 
             # Ensure session managers are initialized
             if not _SESSION_MANAGERS_INITIALIZED:
@@ -346,11 +374,14 @@ if MCP_AVAILABLE:
         """Handle MCP requests through SSE."""
         try:
             # Validate headers and log request info
-            user_api_key_auth: UserAPIKeyAuth = (
+            user_api_key_auth, mcp_auth_header = (
                 await UserAPIKeyAuthMCP.user_api_key_auth_mcp(scope)
             )
             # Set the auth context variable for easy access in MCP functions
-            set_auth_context(user_api_key_auth)
+            set_auth_context(
+                user_api_key_auth=user_api_key_auth,
+                mcp_auth_header=mcp_auth_header,
+            )
 
             # Ensure session managers are initialized
             if not _SESSION_MANAGERS_INITIALIZED:
@@ -390,17 +421,31 @@ if MCP_AVAILABLE:
     ############ Auth Context Functions ####################
     ########################################################
 
-    def set_auth_context(user_api_key_auth: UserAPIKeyAuth) -> None:
-        """Set the UserAPIKeyAuth in the auth context variable."""
-        auth_user = LiteLLMAuthenticatedUser(user_api_key_auth)
+    def set_auth_context(user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None) -> None:
+        """
+        Set the UserAPIKeyAuth in the auth context variable.
+
+        Args:
+            user_api_key_auth: UserAPIKeyAuth object
+            mcp_auth_header: MCP auth header to be passed to the MCP server
+        """
+        auth_user = LiteLLMAuthenticatedUser(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=mcp_auth_header,
+        )
         auth_context_var.set(auth_user)
 
-    def get_auth_context() -> Optional[UserAPIKeyAuth]:
-        """Get the UserAPIKeyAuth from the auth context variable."""
+    def get_auth_context() -> Tuple[Optional[UserAPIKeyAuth], Optional[str]]:
+        """
+        Get the UserAPIKeyAuth from the auth context variable.
+
+        Returns:
+            Tuple[Optional[UserAPIKeyAuth], Optional[str]]: UserAPIKeyAuth object and MCP auth header
+        """
         auth_user = auth_context_var.get()
         if auth_user and isinstance(auth_user, LiteLLMAuthenticatedUser):
-            return auth_user.user_api_key_auth
-        return None
+            return auth_user.user_api_key_auth, auth_user.mcp_auth_header
+        return None, None
 
     ########################################################
     ############ End of Auth Context Functions #############

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2703,6 +2703,7 @@ class SpecialHeaders(enum.Enum):
     google_ai_studio_authorization = "x-goog-api-key"
     azure_apim_authorization = "Ocp-Apim-Subscription-Key"
     custom_litellm_api_key = "x-litellm-api-key"
+    mcp_auth = "x-mcp-auth"
 
 
 class LitellmDataForBackendLLMCall(TypedDict, total=False):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -17,6 +17,13 @@ from typing_extensions import Required, TypedDict
 
 from litellm.types.integrations.slack_alerting import AlertType
 from litellm.types.llms.openai import AllMessageValues, OpenAIFileObject
+from litellm.types.mcp import (
+    MCPAuthType,
+    MCPSpecVersion,
+    MCPSpecVersionType,
+    MCPTransport,
+    MCPTransportType,
+)
 from litellm.types.router import RouterErrors, UpdateRouterConfig
 from litellm.types.utils import (
     CallTypes,
@@ -829,32 +836,6 @@ class LiteLLM_ProxyModelTable(LiteLLMPydanticObjectBase):
 class SpecialMCPServerName(str, enum.Enum):
     all_team_servers = "all-team-mcpservers"
     all_proxy_servers = "all-proxy-mcpservers"
-
-
-class MCPTransport(str, enum.Enum):
-    sse = "sse"
-    http = "http"
-
-
-class MCPSpecVersion(str, enum.Enum):
-    nov_2024 = "2024-11-05"
-    mar_2025 = "2025-03-26"
-
-
-class MCPAuth(str, enum.Enum):
-    none = "none"
-    api_key = "api_key"
-    bearer_token = "bearer_token"
-    basic = "basic"
-
-
-# MCP Literals
-MCPTransportType = Literal[MCPTransport.sse, MCPTransport.http]
-MCPSpecVersionType = Literal[MCPSpecVersion.nov_2024, MCPSpecVersion.mar_2025]
-MCPAuthType = Optional[
-    Literal[MCPAuth.none, MCPAuth.api_key, MCPAuth.bearer_token, MCPAuth.basic]
-]
-
 
 # MCP Proxy Request Types
 class NewMCPServerRequest(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple, cast
 
 import fastapi
-from fastapi import Header, HTTPException, Request, WebSocket, status
+from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security.api_key import APIKeyHeader
 
 import litellm

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -91,11 +91,6 @@ anthropic_api_key_header = APIKeyHeader(
     auto_error=False,
     description="If anthropic client used.",
 )
-mcp_auth_header: Optional[str] = Header(
-    name=SpecialHeaders.mcp_auth.value,
-    default=None,
-    description="MCP Auth header to be passed to the mcp servers",
-)
 google_ai_studio_api_key_header = APIKeyHeader(
     name=SpecialHeaders.google_ai_studio_authorization.value,
     auto_error=False,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple, cast
 
 import fastapi
-from fastapi import HTTPException, Request, WebSocket, status, Header
+from fastapi import Header, HTTPException, Request, WebSocket, status
 from fastapi.security.api_key import APIKeyHeader
 
 import litellm
@@ -91,6 +91,11 @@ anthropic_api_key_header = APIKeyHeader(
     auto_error=False,
     description="If anthropic client used.",
 )
+mcp_auth_header: Optional[str] = Header(
+    name=SpecialHeaders.mcp_auth.value,
+    default=None,
+    description="MCP Auth header to be passed to the mcp servers",
+)
 google_ai_studio_api_key_header = APIKeyHeader(
     name=SpecialHeaders.google_ai_studio_authorization.value,
     auto_error=False,
@@ -100,11 +105,6 @@ azure_apim_header = APIKeyHeader(
     name=SpecialHeaders.azure_apim_authorization.value,
     auto_error=False,
     description="The default name of the subscription key header of Azure",
-)
-mcp_auth_header: Optional[str] = Header(
-    name=SpecialHeaders.mcp_auth.value,
-    default=None,
-    description="MCP Auth header to be passed to the mcp servers",
 )
 
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple, cast
 
 import fastapi
-from fastapi import HTTPException, Request, WebSocket, status
+from fastapi import HTTPException, Request, WebSocket, status, Header
 from fastapi.security.api_key import APIKeyHeader
 
 import litellm
@@ -100,6 +100,11 @@ azure_apim_header = APIKeyHeader(
     name=SpecialHeaders.azure_apim_authorization.value,
     auto_error=False,
     description="The default name of the subscription key header of Azure",
+)
+mcp_auth_header: Optional[str] = Header(
+    name=SpecialHeaders.mcp_auth.value,
+    default=None,
+    description="MCP Auth header to be passed to the mcp servers",
 )
 
 

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -1,0 +1,47 @@
+import enum
+from typing import Literal, Optional, TypedDict
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MCPTransport(str, enum.Enum):
+    sse = "sse"
+    http = "http"
+
+
+class MCPSpecVersion(str, enum.Enum):
+    nov_2024 = "2024-11-05"
+    mar_2025 = "2025-03-26"
+
+
+class MCPAuth(str, enum.Enum):
+    none = "none"
+    api_key = "api_key"
+    bearer_token = "bearer_token"
+    basic = "basic"
+
+
+# MCP Literals
+MCPTransportType = Literal[MCPTransport.sse, MCPTransport.http]
+MCPSpecVersionType = Literal[MCPSpecVersion.nov_2024, MCPSpecVersion.mar_2025]
+MCPAuthType = Optional[
+    Literal[MCPAuth.none, MCPAuth.api_key, MCPAuth.bearer_token, MCPAuth.basic]
+]
+
+
+class MCPInfo(TypedDict, total=False):
+    server_name: str
+    description: Optional[str]
+    logo_url: Optional[str]
+
+
+class MCPServer(BaseModel):
+    server_id: str
+    name: str
+    url: str
+    # TODO: alter the types to be the Literal explicit
+    transport: MCPTransportType
+    spec_version: MCPSpecVersionType
+    auth_type: Optional[MCPAuthType] = None
+    mcp_info: Optional[MCPInfo] = None
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -13,7 +13,6 @@ class MCPSpecVersion(str, enum.Enum):
     nov_2024 = "2024-11-05"
     mar_2025 = "2025-03-26"
 
-
 class MCPAuth(str, enum.Enum):
     none = "none"
     api_key = "api_key"

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -27,21 +27,3 @@ MCPSpecVersionType = Literal[MCPSpecVersion.nov_2024, MCPSpecVersion.mar_2025]
 MCPAuthType = Optional[
     Literal[MCPAuth.none, MCPAuth.api_key, MCPAuth.bearer_token, MCPAuth.basic]
 ]
-
-
-class MCPInfo(TypedDict, total=False):
-    server_name: str
-    description: Optional[str]
-    logo_url: Optional[str]
-
-
-class MCPServer(BaseModel):
-    server_id: str
-    name: str
-    url: str
-    # TODO: alter the types to be the Literal explicit
-    transport: MCPTransportType
-    spec_version: MCPSpecVersionType
-    auth_type: Optional[MCPAuthType] = None
-    mcp_info: Optional[MCPInfo] = None
-    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -1,7 +1,8 @@
 import enum
-from typing import Literal, Optional, TypedDict
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import TypedDict
 
 
 class MCPTransport(str, enum.Enum):

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -16,9 +16,9 @@ class MCPServer(BaseModel):
     server_id: str
     name: str
     url: str
-    # TODO: alter the types to be the Literal explicit
     transport: MCPTransportType
     spec_version: MCPSpecVersionType
     auth_type: Optional[MCPAuthType] = None
+    authentication_token: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for the MCPClient class - critical functionality only.
+"""
+import base64
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add the project root to the path
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.experimental_mcp_client.client import MCPClient
+from litellm.types.mcp import MCPAuth, MCPTransport
+from mcp.types import Tool as MCPTool, CallToolResult as MCPCallToolResult
+
+
+class TestMCPClientUnitTests:
+    """Unit tests for MCPClient functionality."""
+    
+    def test_init_with_auth(self):
+        """Test initialization with authentication."""
+        client = MCPClient(
+            server_url="http://example.com",
+            transport_type=MCPTransport.sse,
+            auth_type=MCPAuth.bearer_token,
+            auth_value="test_token",
+            timeout=30.0
+        )
+        assert client.server_url == "http://example.com"
+        assert client.transport_type == MCPTransport.sse
+        assert client.auth_type == MCPAuth.bearer_token
+        assert client.timeout == 30.0
+        assert client._mcp_auth_value == "test_token"
+    
+    def test_get_auth_headers(self):
+        """Test authentication header generation for different auth types."""
+        # Bearer token
+        client = MCPClient(
+            "http://example.com", 
+            auth_type=MCPAuth.bearer_token,
+            auth_value="test_token"
+        )
+        headers = client._get_auth_headers()
+        assert headers == {"Authorization": "Bearer test_token"}
+        
+        # Basic auth
+        client = MCPClient(
+            "http://example.com",
+            auth_type=MCPAuth.basic,
+            auth_value="user:pass"
+        )
+        expected_encoded = base64.b64encode("user:pass".encode("utf-8")).decode()
+        headers = client._get_auth_headers()
+        assert headers == {"Authorization": f"Basic {expected_encoded}"}
+        
+        # API key
+        client = MCPClient(
+            "http://example.com",
+            auth_type=MCPAuth.api_key,
+            auth_value="api_key_123"
+        )
+        headers = client._get_auth_headers()
+        assert headers == {"X-API-Key": "api_key_123"}
+    
+    @pytest.mark.asyncio
+    @patch('litellm.experimental_mcp_client.client.streamablehttp_client')
+    @patch('litellm.experimental_mcp_client.client.ClientSession')
+    async def test_connect(self, mock_session_class, mock_transport):
+        """Test connecting to MCP server with authentication."""
+        # Setup mocks
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        
+        client = MCPClient(
+            "http://example.com",
+            auth_type=MCPAuth.bearer_token,
+            auth_value="test_token"
+        )
+        await client.connect()
+        
+        # Verify transport was created with auth headers
+        call_args = mock_transport.call_args
+        assert call_args[1]['headers'] == {"Authorization": "Bearer test_token"}
+        
+        # Verify session was initialized
+        mock_session_instance.initialize.assert_called_once()
+        assert client._session == mock_session_instance
+    
+    @pytest.mark.asyncio
+    @patch('litellm.experimental_mcp_client.client.streamablehttp_client')
+    @patch('litellm.experimental_mcp_client.client.ClientSession')
+    async def test_list_tools(self, mock_session_class, mock_transport):
+        """Test listing tools from the server."""
+        # Setup mocks
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        
+        mock_tools = [
+            MCPTool(
+                name="test_tool", 
+                description="Test tool",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"arg1": {"type": "string"}},
+                    "required": ["arg1"]
+                }
+            )
+        ]
+        mock_result = MagicMock()
+        mock_result.tools = mock_tools
+        mock_session_instance.list_tools.return_value = mock_result
+        
+        client = MCPClient("http://example.com")
+        result = await client.list_tools()
+        
+        assert result == mock_tools
+        mock_session_instance.initialize.assert_called_once()
+        mock_session_instance.list_tools.assert_called_once()
+    
+    @pytest.mark.asyncio
+    @patch('litellm.experimental_mcp_client.client.streamablehttp_client')
+    @patch('litellm.experimental_mcp_client.client.ClientSession')
+    async def test_call_tool(self, mock_session_class, mock_transport):
+        """Test calling a tool."""
+        from mcp.types import CallToolRequestParams
+        
+        # Setup mocks
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+        
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        
+        mock_result = MCPCallToolResult(content=[])
+        mock_session_instance.call_tool.return_value = mock_result
+        
+        client = MCPClient("http://example.com")
+        params = CallToolRequestParams(name="test_tool", arguments={"arg1": "value1"})
+        result = await client.call_tool(params)
+        
+        assert result == mock_result
+        mock_session_instance.initialize.assert_called_once()
+        mock_session_instance.call_tool.assert_called_once_with(
+            name="test_tool", 
+            arguments={"arg1": "value1"}
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"]) 

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -101,26 +101,17 @@ async def test_mcp_http_transport_list_tools_mock():
         )
     ]
     
-    # Mock the session and its methods
-    mock_session = AsyncMock()
-    mock_session.initialize = AsyncMock()
-    mock_session.list_tools = AsyncMock(return_value=ListToolsResult(tools=mock_tools))
+    # Create a mock MCPClient that returns our test tools
+    mock_client = AsyncMock()
+    mock_client.list_tools = AsyncMock(return_value=mock_tools)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     
-    # Create an async context manager mock for streamablehttp_client
-    @asynccontextmanager
-    async def mock_streamablehttp_client(url):
-        read_stream = AsyncMock()
-        write_stream = AsyncMock()
-        get_session_id = MagicMock(return_value="test-session-123")
-        yield (read_stream, write_stream, get_session_id)
+    # Mock the MCPClient constructor to return our mock
+    def mock_client_constructor(*args, **kwargs):
+        return mock_client
     
-    # Create an async context manager mock for ClientSession
-    @asynccontextmanager
-    async def mock_client_session(read_stream, write_stream):
-        yield mock_session
-    
-    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.streamablehttp_client', mock_streamablehttp_client), \
-         patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.ClientSession', mock_client_session):
+    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPClient', mock_client_constructor):
         
         # Load server config with HTTP transport
         test_manager.load_servers_from_config({
@@ -139,9 +130,9 @@ async def test_mcp_http_transport_list_tools_mock():
         assert tools[0].name == "gmail_send_email"
         assert tools[1].name == "calendar_create_event"
         
-        # Verify session methods were called
-        mock_session.initialize.assert_called_once()
-        mock_session.list_tools.assert_called_once()
+        # Verify client methods were called
+        mock_client.__aenter__.assert_called()
+        mock_client.list_tools.assert_called_once()
         
         # Verify tool mapping was updated
         assert test_manager.tool_name_to_mcp_server_name_mapping["gmail_send_email"] == "test_http_server"
@@ -166,26 +157,17 @@ async def test_mcp_http_transport_call_tool_mock():
         isError=False
     )
     
-    # Mock the session and its methods
-    mock_session = AsyncMock()
-    mock_session.initialize = AsyncMock()
-    mock_session.call_tool = AsyncMock(return_value=mock_result)
+    # Create a mock MCPClient that returns our test result
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     
-    # Create an async context manager mock for streamablehttp_client
-    @asynccontextmanager
-    async def mock_streamablehttp_client(url):
-        read_stream = AsyncMock()
-        write_stream = AsyncMock()
-        get_session_id = MagicMock(return_value="test-session-456")
-        yield (read_stream, write_stream, get_session_id)
+    # Mock the MCPClient constructor to return our mock
+    def mock_client_constructor(*args, **kwargs):
+        return mock_client
     
-    # Create an async context manager mock for ClientSession
-    @asynccontextmanager
-    async def mock_client_session(read_stream, write_stream):
-        yield mock_session
-    
-    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.streamablehttp_client', mock_streamablehttp_client), \
-         patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.ClientSession', mock_client_session):
+    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPClient', mock_client_constructor):
         
         # Load server config with HTTP transport
         test_manager.load_servers_from_config({
@@ -216,16 +198,9 @@ async def test_mcp_http_transport_call_tool_mock():
         assert isinstance(result.content[0], TextContent)
         assert result.content[0].text == "Email sent successfully to test@example.com"
         
-        # Verify session methods were called
-        mock_session.initialize.assert_called_once()
-        mock_session.call_tool.assert_called_once_with(
-            "gmail_send_email",
-            {
-                "to": "test@example.com", 
-                "subject": "Test Subject",
-                "body": "Test email body"
-            }
-        )
+        # Verify client methods were called
+        mock_client.__aenter__.assert_called()
+        mock_client.call_tool.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -246,26 +221,17 @@ async def test_mcp_http_transport_call_tool_error_mock():
         isError=True
     )
     
-    # Mock the session and its methods
-    mock_session = AsyncMock()
-    mock_session.initialize = AsyncMock()
-    mock_session.call_tool = AsyncMock(return_value=mock_error_result)
+    # Create a mock MCPClient that returns our test error result
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_error_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     
-    # Create an async context manager mock for streamablehttp_client
-    @asynccontextmanager
-    async def mock_streamablehttp_client(url):
-        read_stream = AsyncMock()
-        write_stream = AsyncMock()
-        get_session_id = MagicMock(return_value="test-session-789")
-        yield (read_stream, write_stream, get_session_id)
+    # Mock the MCPClient constructor to return our mock
+    def mock_client_constructor(*args, **kwargs):
+        return mock_client
     
-    # Create an async context manager mock for ClientSession
-    @asynccontextmanager
-    async def mock_client_session(read_stream, write_stream):
-        yield mock_session
-    
-    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.streamablehttp_client', mock_streamablehttp_client), \
-         patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.ClientSession', mock_client_session):
+    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPClient', mock_client_constructor):
         
         # Load server config with HTTP transport
         test_manager.load_servers_from_config({
@@ -292,9 +258,9 @@ async def test_mcp_http_transport_call_tool_error_mock():
         assert isinstance(result.content[0], TextContent)
         assert "Error: Invalid email address" in result.content[0].text
         
-        # Verify session methods were called
-        mock_session.initialize.assert_called_once()
-        mock_session.call_tool.assert_called_once()
+        # Verify client methods were called
+        mock_client.__aenter__.assert_called()
+        mock_client.call_tool.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -18,11 +18,11 @@ from typing import Optional
 from litellm.proxy._types import (
     LiteLLM_MCPServerTable,
     LitellmUserRoles,
-    MCPAuth,
     MCPSpecVersion,
     MCPTransport,
     UserAPIKeyAuth,
 )
+from litellm.types.mcp import MCPAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPInfo, MCPServer
 
 


### PR DESCRIPTION
## MCP - Allow connecting to MCP with authentication headers + Allow clients to specify MCP headers 

Adds the following:

1. Support for clients to specify `x-mcp-auth` as a header to authenticate to the MCP Server 
2. Support for connecting to MCP servers using the specified auth tokens



## Using your MCP with client side credentials

Use this if you want to pass a client side authentication token to LiteLLM to then pass to your MCP to auth to your MCP.

You can specify your MCP auth token using the header `x-mcp-auth`. LiteLLM will forward this token to your MCP server for authentication.

<Tabs>
<TabItem value="openai" label="OpenAI API">

#### Connect via OpenAI Responses API with MCP Auth

Use the OpenAI Responses API and include the `x-mcp-auth` header for your MCP server authentication:

```bash title="cURL Example with MCP Auth" showLineNumbers
curl --location 'https://api.openai.com/v1/responses' \
--header 'Content-Type: application/json' \
--header "Authorization: Bearer $OPENAI_API_KEY" \
--data '{
    "model": "gpt-4o",
    "tools": [
        {
            "type": "mcp",
            "server_label": "litellm",
            "server_url": "<your-litellm-proxy-base-url>/mcp",
            "require_approval": "never",
            "headers": {
                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
                "x-mcp-auth": "YOUR_MCP_AUTH_TOKEN"
            }
        }
    ],
    "input": "Run available tools",
    "tool_choice": "required"
}'
```

</TabItem>

<TabItem value="litellm" label="LiteLLM Proxy">

#### Connect via LiteLLM Proxy Responses API with MCP Auth

Use this when calling LiteLLM Proxy for LLM API requests to `/v1/responses` endpoint with MCP authentication:

```bash title="cURL Example with MCP Auth" showLineNumbers
curl --location '<your-litellm-proxy-base-url>/v1/responses' \
--header 'Content-Type: application/json' \
--header "Authorization: Bearer $LITELLM_API_KEY" \
--data '{
    "model": "gpt-4o",
    "tools": [
        {
            "type": "mcp",
            "server_label": "litellm",
            "server_url": "<your-litellm-proxy-base-url>/mcp",
            "require_approval": "never",
            "headers": {
                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
                "x-mcp-auth": "YOUR_MCP_AUTH_TOKEN"
            }
        }
    ],
    "input": "Run available tools",
    "tool_choice": "required"
}'
```

</TabItem>

<TabItem value="cursor" label="Cursor IDE">

#### Connect via Cursor IDE with MCP Auth

Use tools directly from Cursor IDE with LiteLLM MCP and include your MCP authentication token:

**Setup Instructions:**

1. **Open Cursor Settings**: Use `⇧+⌘+J` (Mac) or `Ctrl+Shift+J` (Windows/Linux)
2. **Navigate to MCP Tools**: Go to the "MCP Tools" tab and click "New MCP Server"
3. **Add Configuration**: Copy and paste the JSON configuration below, then save with `Cmd+S` or `Ctrl+S`

```json title="Cursor MCP Configuration with Auth" showLineNumbers
{
  "mcpServers": {
    "LiteLLM": {
      "url": "<your-litellm-proxy-base-url>/mcp",
      "headers": {
        "x-litellm-api-key": "Bearer $LITELLM_API_KEY",
        "x-mcp-auth": "$MCP_AUTH_TOKEN"
      }
    }
  }
}
```

</TabItem>

<TabItem value="http" label="Streamable HTTP">

#### Connect via Streamable HTTP Transport with MCP Auth

Connect to LiteLLM MCP using HTTP transport with MCP authentication:

**Server URL:**
```text showLineNumbers
<your-litellm-proxy-base-url>/mcp
```

**Headers:**
```text showLineNumbers
x-litellm-api-key: Bearer YOUR_LITELLM_API_KEY
x-mcp-auth: YOUR_MCP_AUTH_TOKEN
```

This URL can be used with any MCP client that supports HTTP transport. The `x-mcp-auth` header will be forwarded to your MCP server for authentication.

</TabItem>

<TabItem value="fastmcp" label="Python FastMCP">

#### Connect via Python FastMCP Client with MCP Auth

Use the Python FastMCP client to connect to your LiteLLM MCP server with MCP authentication:

```python title="Python FastMCP Example with MCP Auth" showLineNumbers
import asyncio
import json

from fastmcp import Client
from fastmcp.client.transports import StreamableHttpTransport

# Create the transport with your LiteLLM MCP server URL and auth headers
server_url = "<your-litellm-proxy-base-url>/mcp"
transport = StreamableHttpTransport(
    server_url,
    headers={
        "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
        "x-mcp-auth": "YOUR_MCP_AUTH_TOKEN"
    }
)

# Initialize the client with the transport
client = Client(transport=transport)


async def main():
    # Connection is established here
    print("Connecting to LiteLLM MCP server with authentication...")
    async with client:
        print(f"Client connected: {client.is_connected()}")

        # Make MCP calls within the context
        print("Fetching available tools...")
        tools = await client.list_tools()

        print(f"Available tools: {json.dumps([t.name for t in tools], indent=2)}")
        
        # Example: Call a tool (replace 'tool_name' with an actual tool name)
        if tools:
            tool_name = tools[0].name
            print(f"Calling tool: {tool_name}")
            
            # Call the tool with appropriate arguments
            result = await client.call_tool(tool_name, arguments={})
            print(f"Tool result: {result}")


# Run the example
if __name__ == "__main__":
    asyncio.run(main())
```

</TabItem>
</Tabs>

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


