### PR TITLE
[Bug Fix]: Fix gemini - web search error with responses API 

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,7 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
@@ -32,6 +32,7 @@ from litellm.types.llms.openai import (
     ChatCompletionUserMessage,
     GenericChatCompletionMessage,
     OpenAIMcpServerTool,
+    OpenAIWebSearchOptions,
     Reasoning,
     ResponseAPIUsage,
     ResponseInputParam,
@@ -109,6 +110,9 @@ class LiteLLMCompletionResponsesConfig:
         """
         Transform a Responses API request into a Chat Completion request
         """
+        tools, web_search_options = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            responses_api_request.get("tools") or []  # type: ignore
+        )
         litellm_completion_request: dict = {
             "messages": LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
                 input=input,
@@ -116,9 +120,7 @@ class LiteLLMCompletionResponsesConfig:
             ),
             "model": model,
             "tool_choice": responses_api_request.get("tool_choice"),
-            "tools": LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
-                responses_api_request.get("tools") or []  # type: ignore
-            ),
+            "tools": tools,
             "top_p": responses_api_request.get("top_p"),
             "user": responses_api_request.get("user"),
             "temperature": responses_api_request.get("temperature"),
@@ -127,6 +129,7 @@ class LiteLLMCompletionResponsesConfig:
             "stream": stream,
             "metadata": kwargs.get("metadata"),
             "service_tier": kwargs.get("service_tier"),
+            "web_search_options": web_search_options,
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,
         }
@@ -468,32 +471,38 @@ class LiteLLMCompletionResponsesConfig:
     @staticmethod
     def transform_responses_api_tools_to_chat_completion_tools(
         tools: Optional[List[Union[FunctionToolParam, OpenAIMcpServerTool]]],
-    ) -> List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]]:
+    ) -> Tuple[List[Union[ChatCompletionToolParam, OpenAIMcpServerTool]], Optional[OpenAIWebSearchOptions]]:
         """
         Transform a Responses API tools into a Chat Completion tools
         """
         if tools is None:
-            return []
+            return [], None
         chat_completion_tools: List[
             Union[ChatCompletionToolParam, OpenAIMcpServerTool]
         ] = []
+        web_search_options: Optional[OpenAIWebSearchOptions] = None
         for tool in tools:
             if tool.get("type") == "mcp":
                 chat_completion_tools.append(cast(OpenAIMcpServerTool, tool))
+            elif tool.get("type") == "web_search_preview" or tool.get("type") == "web_search":
+                web_search_options = OpenAIWebSearchOptions(
+                    search_context_size=tool.get("search_context_size"),
+                    user_location=tool.get("user_location") or None,
+                )
             else:
                 typed_tool = cast(FunctionToolParam, tool)
                 chat_completion_tools.append(
                     ChatCompletionToolParam(
                         type="function",
                         function=ChatCompletionToolParamFunctionChunk(
-                            name=typed_tool["name"],
+                            name=typed_tool.get("name") or "",
                             description=typed_tool.get("description") or "",
                             parameters=dict(typed_tool.get("parameters", {}) or {}),
                             strict=typed_tool.get("strict", False) or False,
                         ),
                     )
                 )
-        return chat_completion_tools
+        return chat_completion_tools, web_search_options
 
     @staticmethod
     def transform_chat_completion_tools_to_responses_tools(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2,7 +2,7 @@
 Handles transforming from Responses API -> LiteLLM completion  (Chat Completion API)
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
@@ -33,6 +33,7 @@ from litellm.types.llms.openai import (
     GenericChatCompletionMessage,
     OpenAIMcpServerTool,
     OpenAIWebSearchOptions,
+    OpenAIWebSearchUserLocation,
     Reasoning,
     ResponseAPIUsage,
     ResponseInputParam,
@@ -485,9 +486,11 @@ class LiteLLMCompletionResponsesConfig:
             if tool.get("type") == "mcp":
                 chat_completion_tools.append(cast(OpenAIMcpServerTool, tool))
             elif tool.get("type") == "web_search_preview" or tool.get("type") == "web_search":
+                _search_context_size: Literal["low", "medium", "high"] = cast(Literal["low", "medium", "high"], tool.get("search_context_size"))
+                _user_location: Optional[OpenAIWebSearchUserLocation] = cast(Optional[OpenAIWebSearchUserLocation], tool.get("user_location") or None)
                 web_search_options = OpenAIWebSearchOptions(
-                    search_context_size=tool.get("search_context_size"),
-                    user_location=tool.get("user_location") or None,
+                    search_context_size=_search_context_size,
+                    user_location=_user_location,
                 )
             else:
                 typed_tool = cast(FunctionToolParam, tool)

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -1,0 +1,24 @@
+
+import os
+import sys
+import pytest
+sys.path.insert(0, os.path.abspath("../.."))
+import litellm
+import json
+
+@pytest.mark.asyncio
+async def test_basic_google_ai_studio_responses_api_with_tools():
+    litellm._turn_on_debug()
+    litellm.set_verbose = True
+    request_model = "gemini/gemini-2.5-flash"
+    response = await litellm.aresponses(
+        model=request_model,
+        input="what is the latest version of supabase python package and when was it released?",
+        tools=[
+            {
+                "type": "web_search_preview",
+                "search_context_size": "low"
+            }
+        ]
+    )
+    print("litellm response=", json.dumps(response, indent=4, default=str))

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -1,7 +1,7 @@
-
 import os
 import sys
 import pytest
+from unittest.mock import patch, AsyncMock
 sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 import json
@@ -22,3 +22,73 @@ async def test_basic_google_ai_studio_responses_api_with_tools():
         ]
     )
     print("litellm response=", json.dumps(response, indent=4, default=str))
+
+
+@pytest.mark.asyncio
+async def test_mock_basic_google_ai_studio_responses_api_with_tools():
+    """
+    - Ensure that this is the request that litellm.completion gets when we pass web search options 
+
+    litellm.acompletion(messages=[{'role': 'user', 'content': 'what is the latest version of supabase python package and when was it released?'}], model='gemini-2.5-flash', tools=[], web_search_options={'search_context_size': 'low', 'user_location': None})
+    """
+    # Mock the acompletion function
+    litellm._turn_on_debug()
+    mock_response = litellm.ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="gemini/gemini-2.5-flash",
+        object="chat.completion",
+        choices=[
+            litellm.utils.Choices(
+                index=0,
+                message=litellm.utils.Message(
+                    role="assistant",
+                    content="Test response"
+                ),
+                finish_reason="stop"
+            )
+        ]
+    )
+    
+    with patch('litellm.acompletion', new_callable=AsyncMock) as mock_acompletion:
+        mock_acompletion.return_value = mock_response
+        
+        request_model = "gemini/gemini-2.5-flash"
+        await litellm.aresponses(
+            model=request_model,
+            input="what is the latest version of supabase python package and when was it released?",
+            tools=[
+                {
+                    "type": "web_search_preview",
+                    "search_context_size": "low"
+                }
+            ]
+        )
+        
+        # Verify that acompletion was called
+        assert mock_acompletion.called
+        
+        # Get the call arguments
+        call_args, call_kwargs = mock_acompletion.call_args
+        
+        # Verify the expected parameters were passed
+        print("call kwargs to litellm.completion=", json.dumps(call_kwargs, indent=4, default=str))
+        assert "web_search_options" in call_kwargs
+        assert call_kwargs["web_search_options"] is not None
+        assert call_kwargs["web_search_options"]["search_context_size"] == "low"
+        assert call_kwargs["web_search_options"]["user_location"] is None
+        
+        # Verify other expected parameters
+        assert call_kwargs["model"] == "gemini-2.5-flash"
+        assert len(call_kwargs["messages"]) == 1
+        assert call_kwargs["messages"][0]["role"] == "user"
+        assert call_kwargs["messages"][0]["content"] == "what is the latest version of supabase python package and when was it released?"
+        assert call_kwargs["tools"] == []  # web search tools are converted to web_search_options, not kept as tools
+
+
+    
+
+
+    
+
+


### PR DESCRIPTION
## [Bug Fix]: Fix gemini - web search error with responses API 

This PR fixes an error in the Gemini web search functionality by transforming web search tool parameters into web search options for the responses API.

Fixes https://github.com/BerriAI/litellm/issues/11878 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


