### PR TITLE
Update Azure o3 pricing to match OpenAI pricing ($2/$8 per 1M tokens)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2160,9 +2160,9 @@
         "max_tokens": 100000,
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
-        "input_cost_per_token": 1e-05,
-        "output_cost_per_token": 4e-05,
-        "cache_read_input_token_cost": 2.5e-06,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 8e-06,
+        "cache_read_input_token_cost": 5e-07,
         "litellm_provider": "azure",
         "mode": "chat",
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2160,9 +2160,9 @@
         "max_tokens": 100000,
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
-        "input_cost_per_token": 1e-05,
-        "output_cost_per_token": 4e-05,
-        "cache_read_input_token_cost": 2.5e-06,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 8e-06,
+        "cache_read_input_token_cost": 5e-07,
         "litellm_provider": "azure",
         "mode": "chat",
         "supported_endpoints": [


### PR DESCRIPTION
## Title

Update Azure o3 pricing to match OpenAI pricing ($2/$8 per 1M tokens)

## Relevant issues

Fixes #11932

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Updated the `azure/o3` model entry in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` to match the latest Azure pricing, which now mirrors OpenAI's pricing:
  - `input_cost_per_token`: `1e-05` → `2e-06` ($10 → $2 per 1M tokens)
  - `output_cost_per_token`: `4e-05` → `8e-06` ($40 → $8 per 1M tokens)
  - `cache_read_input_token_cost`: `2.5e-06` → `5e-07` (proportional adjustment)
- Confirmed pricing now matches OpenAI o3 in both JSON files.
- Validated JSON structure and cost calculations.
- Reference: [Azure Pricing Page](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/?cdn=disable)