### PR TITLE
[Chore] Check team counts on license when creating new team

### DIFF
--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -140,6 +140,18 @@ class LicenseCheck:
         ):
             return False
         return total_users > self.airgapped_license_data["max_users"]
+    
+    def is_team_count_over_limit(self, team_count: int) -> bool:
+        """
+        Check if the license is over the limit
+        """
+        if self.airgapped_license_data is None:
+            return False
+        if "max_teams" not in self.airgapped_license_data or not isinstance(
+            self.airgapped_license_data["max_teams"], int
+        ):
+            return False
+        return team_count > self.airgapped_license_data["max_teams"]
 
     def verify_license_without_api_request(self, public_key, license_key):
         try:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -207,6 +207,7 @@ async def new_team(  # noqa: PLR0915
     """
     try:
         from litellm.proxy.proxy_server import (
+            _license_check,
             create_audit_log_for_update,
             litellm_proxy_admin_name,
             prisma_client,
@@ -214,6 +215,15 @@ async def new_team(  # noqa: PLR0915
 
         if prisma_client is None:
             raise HTTPException(status_code=500, detail={"error": "No db connected"})
+        
+
+        # Check if license is over limit
+        total_teams = await prisma_client.db.litellm_teamtable.count()
+        if total_teams and _license_check.is_team_count_over_limit(team_count=total_teams):
+            raise HTTPException(
+                status_code=403,
+                detail="License is over limit. Please contact support@berri.ai to upgrade your license.",
+            )
 
         if data.team_id is None:
             data.team_id = str(uuid.uuid4())


### PR DESCRIPTION
## [Chore] Check team counts on license when creating new team

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


