### PR TITLE
Add proxy support for aiohttp

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -568,8 +568,8 @@ class AsyncHTTPHandler:
 
     @staticmethod
     def _create_aiohttp_transport(
-        ssl_verify: Optional[bool] = None,
-        ssl_context: Optional[ssl.SSLContext] = None,
+            ssl_verify: Optional[bool] = None,
+            ssl_context: Optional[ssl.SSLContext] = None,
     ) -> LiteLLMAiohttpTransport:
         """
         Creates an AiohttpTransport with RequestNotRead error handling
@@ -588,10 +588,10 @@ class AsyncHTTPHandler:
         verbose_logger.debug("Creating AiohttpTransport...")
         return LiteLLMAiohttpTransport(
             client=lambda: ClientSession(
-                connector=TCPConnector(**connector_kwargs)
+                connector=TCPConnector(**connector_kwargs),
+                trust_env=True # Trust environment variables for proxy settings
             ),
         )
-    
 
     @staticmethod
     def _get_ssl_context() -> ssl.SSLContext:

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -568,8 +568,8 @@ class AsyncHTTPHandler:
 
     @staticmethod
     def _create_aiohttp_transport(
-            ssl_verify: Optional[bool] = None,
-            ssl_context: Optional[ssl.SSLContext] = None,
+        ssl_verify: Optional[bool] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ) -> LiteLLMAiohttpTransport:
         """
         Creates an AiohttpTransport with RequestNotRead error handling


### PR DESCRIPTION
## Title 

Add proxy support for aiohttp transport

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #11944 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

The original _create_aiohttp_transport function did not support environment-based proxy configuration because it omitted the trust_env=True flag when creating the aiohttp.ClientSession.

In the modified version:

✅ trust_env=True was added to the ClientSession constructor.

This enables aiohttp to automatically read and respect standard environment variables such as HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.

✅ This allows the application to route traffic through a proxy without needing to hardcode the proxy URL — you can now configure it via environment variables.

This makes the transport layer more flexible and production-friendly, especially in enterprise environments where outbound traffic must go through a proxy.

