### PR TITLE
[Fix] - Check HTTP_PROXY vars in networking requests

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -324,6 +324,7 @@ use_aiohttp_transport: bool = (
     True  # Older variable, aiohttp is now the default. use disable_aiohttp_transport instead.
 )
 disable_aiohttp_transport: bool = False  # Set this to true to use httpx instead
+disable_aiohttp_trust_env: bool = False  # When False, aiohttp will respect HTTP(S)_PROXY env vars
 force_ipv4: bool = (
     False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
 )


### PR DESCRIPTION
## [Fix] - Check HTTP_PROXY vars in networking requests

Fixes https://github.com/BerriAI/litellm/issues/11944, https://github.com/BerriAI/litellm/issues/11726, https://github.com/BerriAI/litellm/issues/10014

This PR ensures the aiohttp-based transport honors standard HTTP(S)_PROXY environment variables when making requests.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


