### PR TITLE
Fix TypeError for None delta.content in _optional_combine_thinking_block_in_choices (#11699)

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -900,6 +900,10 @@ class CustomStreamWrapper:
             reasoning_content = getattr(
                 model_response.choices[0].delta, "reasoning_content", None
             )
+            # Initialize delta.content if None
+            if model_response.choices[0].delta.content is None:
+                model_response.choices[0].delta.content = ""
+                
             if reasoning_content:
                 if self.sent_first_thinking_block is False:
                     model_response.choices[0].delta.content += (


### PR DESCRIPTION
## Title
Fix TypeError for None delta.content in _optional_combine_thinking_block_in_choices (#11699)

## Relevant issues
Fixes #11699

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

⚠️ Note: Some unit tests and lint are currently failing, but these failures are not caused by my code changes.
## Type
<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
- Modified `litellm/litellm_core_utils/streaming_handler.py` in the `_optional_combine_thinking_block_in_choices` method to initialize `model_response.choices[0].delta.content` as an empty string (`""`) when `None`, preventing a `TypeError` during string concatenation with `gemini-2.5-flash` when `merge_reasoning_content_in_choices=True`.
- Added a new unit test `test_optional_combine_thinking_block_with_none_content` in `tests/test_litellm/test_streaming_handler.py` to verify that the method correctly handles `delta.content=None` by initializing it and merging `reasoning_content` with `<think>` tags.

## Additional Notes
- The fix ensures streaming responses from `gemini-2.5-flash` no longer crash when `delta.content` is `None`, improving compatibility with UIs like OpenWebUI that expect `<think>` tags.
- Please let me know if additional test cases or modifications are needed!

## Screenshot of Test Passing Locally
![Screenshot_22-Jun_02-53-22_16565](https://github.com/user-attachments/assets/5a1749b8-72ee-4629-b749-501af2168971)
