### PR TITLE
Fix token counter to ignore unsupported keys like prefix (#11791)

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -462,9 +462,8 @@ def _count_messages(
                     default_token_count,
                 )
             else:
-                raise ValueError(
-                    f"Unsupported type {type(value)} for key {key} in message {message}"
-                )
+                # Skip unsupported keys instead of raising an error
+                continue
     return num_tokens
 
 

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -54,6 +54,15 @@ def test_token_counter_basic():
     )
 
 
+def test_token_counter_with_prefix():
+    messages = [
+        {"role": "user", "content": "Who won the world cup in 2022?"},
+        {"role": "assistant", "content": "Argentina", "prefix": True}
+    ]
+    tokens = token_counter(model="gpt-3.5-turbo", messages=messages)
+    assert tokens == 22 , f"Expected 22 tokens, got {tokens}"
+
+
 def test_token_counter_normal_plus_function_calling():
     messages = [
         {"role": "system", "content": "System prompt"},


### PR DESCRIPTION
## Title

Fix token counter to ignore unsupported keys like prefix (#11791)

## Relevant issues

Closes #11791

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

⚠️ Note: Some unit tests are currently failing, but these failures are not caused by my code changes.

## Type
🐛 Bug Fix
✅ Test

## Changes
- Updated `_count_messages` in `litellm.litellm_core_utils.token_counter.py` to use `continue` instead of raising `ValueError` for unsupported keys like `prefix`.
- Added a new test in `tests/test_litellm/test_token_counter.py` to verify that the token counter handles messages with a `prefix` key without errors.


## Screenshot of Test Passing Locally
![Screenshot_22-Jun_04-00-51_26863](https://github.com/user-attachments/assets/223b0951-e243-4c92-bf67-6e87a8bd2f30)



