### PR TITLE
Fix inconsistent $ref handling for bedrock tool use

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -555,7 +555,7 @@ def resolve_refs(
                     _cache[ref_uri] = resolved
                     return resolved
 
-                except (KeyError, TypeError, ValueError) as e:
+                except (KeyError, TypeError, ValueError):
                     # Clean up cache on error
                     _cache.pop(ref_uri, None)
                     # If reference can't be resolved, return original object

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -625,7 +625,7 @@ def unpack_defs(schema):
     if properties is None:
         return schema
 
-    # Use jsonref to resolve all references
+    # Resolve all references
     resolved_schema = resolve_refs(schema)
 
     # Clean up by removing $defs and definitions sections since they're no longer needed

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -604,14 +604,18 @@ def _resolve_pointer(document: Any, pointer: str) -> Any:
         if isinstance(current, list):
             # Try to convert to array index
             try:
-                part = int(part)
+                index = int(part)
+                current = current[index]
             except ValueError:
                 raise KeyError(f"Invalid array index: {part}")
-
-        try:
-            current = current[part]
-        except (KeyError, IndexError, TypeError) as e:
-            raise KeyError(f"Cannot resolve pointer {pointer}: {e}")
+            except IndexError as e:
+                raise KeyError(f"Cannot resolve pointer {pointer}: {e}")
+        else:
+            # Handle dictionary/object access
+            try:
+                current = current[part]
+            except (KeyError, TypeError) as e:
+                raise KeyError(f"Cannot resolve pointer {pointer}: {e}")
 
     return current
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -825,14 +825,7 @@ def convert_to_anthropic_tool_invoke_xml(tool_calls: list) -> str:
             f"<{param}>{val}</{param}>\n"
             for param, val in json.loads(tool_arguments).items()
         )
-        invokes += (
-            "<invoke>\n"
-            f"<tool_name>{tool_name}</tool_name>\n"
-            "<parameters>\n"
-            f"{parameters}"
-            "</parameters>\n"
-            "</invoke>\n"
-        )
+        invokes += f"<invoke>\n<tool_name>{tool_name}</tool_name>\n<parameters>\n{parameters}</parameters>\n</invoke>\n"
 
     anthropic_tool_invoke = f"<function_calls>\n{invokes}</function_calls>"
 
@@ -1053,10 +1046,10 @@ def convert_to_gemini_tool_call_invoke(
         if tool_calls is not None:
             for tool in tool_calls:
                 if "function" in tool:
-                    gemini_function_call: Optional[VertexFunctionCall] = (
-                        _gemini_tool_call_invoke_helper(
-                            function_call_params=tool["function"]
-                        )
+                    gemini_function_call: Optional[
+                        VertexFunctionCall
+                    ] = _gemini_tool_call_invoke_helper(
+                        function_call_params=tool["function"]
                     )
                     if gemini_function_call is not None:
                         _parts_list.append(
@@ -1142,7 +1135,8 @@ def convert_to_gemini_tool_call_result(
     # We can't determine from openai message format whether it's a successful or
     # error call result so default to the successful result template
     _function_response = VertexFunctionResponse(
-        name=name, response={"content": content_str}  # type: ignore
+        name=name,
+        response={"content": content_str},  # type: ignore
     )
 
     _part = VertexPartType(function_response=_function_response)
@@ -1573,9 +1567,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                             )
 
                             if "cache_control" in _content_element:
-                                _anthropic_content_element["cache_control"] = (
-                                    _content_element["cache_control"]
-                                )
+                                _anthropic_content_element[
+                                    "cache_control"
+                                ] = _content_element["cache_control"]
                             user_content.append(_anthropic_content_element)
                         elif m.get("type", "") == "text":
                             m = cast(ChatCompletionTextObject, m)
@@ -1613,9 +1607,9 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     )
 
                     if "cache_control" in _content_element:
-                        _anthropic_content_text_element["cache_control"] = (
-                            _content_element["cache_control"]
-                        )
+                        _anthropic_content_text_element[
+                            "cache_control"
+                        ] = _content_element["cache_control"]
 
                     user_content.append(_anthropic_content_text_element)
 
@@ -3662,12 +3656,7 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
             "description", name
         )  # converse api requires a description
 
-        defs = parameters.pop("$defs", {})
-        defs_copy = copy.deepcopy(defs)
-        # flatten the defs
-        for _, value in defs_copy.items():
-            unpack_defs(value, defs_copy)
-        unpack_defs(parameters, defs_copy)
+        parameters = unpack_defs(parameters)
         tool_input_schema = BedrockToolInputSchemaBlock(
             json=BedrockToolJsonSchemaBlock(
                 type=parameters.get("type", ""),

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -28,7 +28,9 @@ def get_supports_system_message(
         _custom_llm_provider = custom_llm_provider
         if custom_llm_provider == "vertex_ai_beta":
             _custom_llm_provider = "vertex_ai"
-        supports_system_message = supports_system_messages(model=model, custom_llm_provider=_custom_llm_provider)
+        supports_system_message = supports_system_messages(
+            model=model, custom_llm_provider=_custom_llm_provider
+        )
 
         # Vertex Models called in the `/gemini` request/response format also support system messages
         if litellm.VertexGeminiConfig._is_model_gemini_spec_model(model):
@@ -51,14 +53,18 @@ def get_supports_response_schema(
     if custom_llm_provider == "vertex_ai_beta":
         _custom_llm_provider = "vertex_ai"
 
-    _supports_response_schema = supports_response_schema(model=model, custom_llm_provider=_custom_llm_provider)
+    _supports_response_schema = supports_response_schema(
+        model=model, custom_llm_provider=_custom_llm_provider
+    )
 
     return _supports_response_schema
 
 
 from typing import Literal, Optional
 
-all_gemini_url_modes = Literal["chat", "embedding", "batch_embedding", "image_generation"]
+all_gemini_url_modes = Literal[
+    "chat", "embedding", "batch_embedding", "image_generation"
+]
 
 
 def _get_vertex_url(
@@ -127,8 +133,10 @@ def _get_gemini_url(
                 _gemini_model_name, endpoint, gemini_api_key
             )
         else:
-            url = "https://generativelanguage.googleapis.com/v1beta/{}:{}?key={}".format(
-                _gemini_model_name, endpoint, gemini_api_key
+            url = (
+                "https://generativelanguage.googleapis.com/v1beta/{}:{}?key={}".format(
+                    _gemini_model_name, endpoint, gemini_api_key
+                )
             )
     elif mode == "embedding":
         endpoint = "embedContent"
@@ -215,7 +223,11 @@ def _filter_anyof_fields(schema_dict: Dict[str, Any]) -> Dict[str, Any]:
 
     if isinstance(schema_dict, dict) and schema_dict.get("anyOf"):
         any_of = schema_dict["anyOf"]
-        if (title or description) and isinstance(any_of, list) and all(isinstance(item, dict) for item in any_of):
+        if (
+            (title or description)
+            and isinstance(any_of, list)
+            and all(isinstance(item, dict) for item in any_of)
+        ):
             for item in any_of:
                 if title:
                     item["title"] = title
@@ -244,7 +256,9 @@ def process_items(schema, depth=0):
                         process_items(item, depth + 1)
 
 
-def set_schema_property_ordering(schema: Dict[str, Any], depth: int = 0) -> Dict[str, Any]:
+def set_schema_property_ordering(
+    schema: Dict[str, Any], depth: int = 0
+) -> Dict[str, Any]:
     """
     vertex ai and generativeai apis order output of fields alphabetically, unless you specify the order.
     python dicts retain order, so we just use that. Note that this field only applies to structured outputs, and not tools.
@@ -271,7 +285,9 @@ def set_schema_property_ordering(schema: Dict[str, Any], depth: int = 0) -> Dict
     return schema
 
 
-def filter_schema_fields(schema_dict: Dict[str, Any], valid_fields: Set[str], processed=None) -> Dict[str, Any]:
+def filter_schema_fields(
+    schema_dict: Dict[str, Any], valid_fields: Set[str], processed=None
+) -> Dict[str, Any]:
     """
     Recursively filter a schema dictionary to keep only valid fields.
     """
@@ -294,7 +310,10 @@ def filter_schema_fields(schema_dict: Dict[str, Any], valid_fields: Set[str], pr
             continue
 
         if key == "properties" and isinstance(value, dict):
-            result[key] = {k: filter_schema_fields(v, valid_fields, processed) for k, v in value.items()}
+            result[key] = {
+                k: filter_schema_fields(v, valid_fields, processed)
+                for k, v in value.items()
+            }
         elif key == "items" and isinstance(value, dict):
             result[key] = filter_schema_fields(value, valid_fields, processed)
         elif key == "anyOf" and isinstance(value, list):
@@ -336,7 +355,11 @@ def convert_anyof_null_to_nullable(schema, depth=0):
             # set all types to nullable following guidance found here: https://cloud.google.com/vertex-ai/generative-ai/docs/samples/generativeaionvertexai-gemini-controlled-generation-response-schema-3#generativeaionvertexai_gemini_controlled_generation_response_schema_3-python
             for atype in anyof:
                 # Remove items field if type is array and items is empty
-                if atype.get("type") == "array" and "items" in atype and not atype["items"]:
+                if (
+                    atype.get("type") == "array"
+                    and "items" in atype
+                    and not atype["items"]
+                ):
                     atype.pop("items")
                 atype["nullable"] = True
 
@@ -412,7 +435,9 @@ def get_vertex_location_from_url(url: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
-def replace_project_and_location_in_route(requested_route: str, vertex_project: str, vertex_location: str) -> str:
+def replace_project_and_location_in_route(
+    requested_route: str, vertex_project: str, vertex_location: str
+) -> str:
     """
     Replace project and location values in the route with the provided values
     """
@@ -445,7 +470,9 @@ def construct_target_url(
     new_base_url = httpx.URL(base_url)
     if "locations" in requested_route:  # contains the target project id + location
         if vertex_project and vertex_location:
-            requested_route = replace_project_and_location_in_route(requested_route, vertex_project, vertex_location)
+            requested_route = replace_project_and_location_in_route(
+                requested_route, vertex_project, vertex_location
+            )
         return new_base_url.copy_with(path=requested_route)
 
     """
@@ -457,7 +484,9 @@ def construct_target_url(
     if "cachedContent" in requested_route:
         vertex_version = "v1beta1"
 
-    base_requested_route = "{}/projects/{}/locations/{}".format(vertex_version, vertex_project, vertex_location)
+    base_requested_route = "{}/projects/{}/locations/{}".format(
+        vertex_version, vertex_project, vertex_location
+    )
 
     updated_requested_route = "/" + base_requested_route + requested_route
 
@@ -477,7 +506,9 @@ def is_global_only_vertex_model(model: str) -> bool:
     """
     from litellm.utils import get_supported_regions
 
-    supported_regions = get_supported_regions(model=model, custom_llm_provider="vertex_ai")
+    supported_regions = get_supported_regions(
+        model=model, custom_llm_provider="vertex_ai"
+    )
     if supported_regions is None:
         return False
     return "global" in supported_regions

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -400,7 +400,7 @@ def test_unpack_defs_circular_refs_handling():
         }
     }
     
-    # This should not raise an error (jsonref handles circular refs)
+    # This should not raise an error (handles circular refs)
     result = unpack_defs(schema)
     
     # The structure should be resolved

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_format_from_file_id,
     handle_any_messages_to_chat_completion_str_messages_conversion,
     update_messages_with_model_file_ids,
+    unpack_defs
 )
 
 
@@ -125,3 +126,308 @@ def test_handle_any_messages_to_chat_completion_str_messages_conversion_complex(
     result = handle_any_messages_to_chat_completion_str_messages_conversion(message)
     assert len(result) == 1
     assert result[0]["input"] == json.dumps(message)
+
+
+def test_unpack_defs_basic_reference_resolution():
+    # Test basic $ref resolution to $defs
+    schema = {
+        "type": "object",
+        "properties": {
+            "user": {"$ref": "#/$defs/User"}
+        },
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                },
+                "required": ["id", "name"]
+            }
+        }
+    }
+
+    result = unpack_defs(schema)
+    
+    # Should resolve the reference
+    assert "user" in result["properties"]
+    assert result["properties"]["user"]["type"] == "object"
+    assert "id" in result["properties"]["user"]["properties"]
+    assert "name" in result["properties"]["user"]["properties"]
+    
+    # $defs should be removed
+    assert "$defs" not in result
+
+
+def test_unpack_defs_nested_reference_resolution():
+    # Test nested $refs within resolved content
+    schema = {
+        "type": "object",
+        "properties": {
+            "user": {"$ref": "#/$defs/User"}
+        },
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"},
+                    "profile": {"$ref": "#/$defs/Profile"}
+                }
+            },
+            "Profile": {
+                "type": "object",
+                "properties": {
+                    "bio": {"type": "string"},
+                    "avatar_url": {"type": "string"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    
+    # Should resolve nested reference
+    user_props = result["properties"]["user"]["properties"]
+    assert "profile" in user_props
+    assert user_props["profile"]["type"] == "object"
+    assert "bio" in user_props["profile"]["properties"]
+    assert "avatar_url" in user_props["profile"]["properties"]
+
+
+def test_unpack_defs_anyof_resolution():
+    # Test $ref within an anyOf structure
+    schema = {
+        "type": "object",
+        "properties": {
+            "contact": {
+                "anyOf": [
+                    {"$ref": "#/$defs/User"},
+                    {"$ref": "#/$defs/Company"}
+                ]
+            }
+        },
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "email": {"type": "string"}
+                }
+            },
+            "Company": {
+                "type": "object",
+                "properties": {
+                    "company_name": {"type": "string"},
+                    "website": {"type": "string"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    
+    # Should resolve refs within anyOf
+    contact_anyof = result["properties"]["contact"]["anyOf"]
+    assert len(contact_anyof) == 2
+    assert contact_anyof[0]["type"] == "object"
+    assert "name" in contact_anyof[0]["properties"]
+    assert contact_anyof[1]["type"] == "object"
+    assert "company_name" in contact_anyof[1]["properties"]
+
+
+def test_unpack_defs_allof_resolution():
+    # Test $ref within an allOf structure
+    schema = {
+        "type": "object",
+        "properties": {
+            "enhanced_user": {
+                "allOf": [
+                    {"$ref": "#/$defs/User"},
+                    {"$ref": "#/$defs/Timestamps"}
+                ]
+            }
+        },
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                }
+            },
+            "Timestamps": {
+                "type": "object",
+                "properties": {
+                    "created_at": {"type": "string", "format": "date-time"},
+                    "updated_at": {"type": "string", "format": "date-time"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    
+    # Should resolve refs within allOf
+    enhanced_user_allof = result["properties"]["enhanced_user"]["allOf"]
+    assert len(enhanced_user_allof) == 2
+    assert "id" in enhanced_user_allof[0]["properties"]
+    assert "created_at" in enhanced_user_allof[1]["properties"]
+
+
+def test_unpack_defs_array_items_with_refs():
+    # Test array items containing $refs
+    schema = {
+        "type": "object",
+        "properties": {
+            "users": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/User"}
+            },
+            "posts": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/Post"}
+            }
+        },
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                }
+            },
+            "Post": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "title": {"type": "string"},
+                    "author": {"$ref": "#/$defs/User"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    
+    # Should resolve refs in array items
+    users_items = result["properties"]["users"]["items"]
+    assert users_items["type"] == "object"
+    assert "id" in users_items["properties"]
+    
+    posts_items = result["properties"]["posts"]["items"]
+    assert posts_items["type"] == "object"
+    assert "title" in posts_items["properties"]
+    # Should also resolve nested ref in author
+    assert posts_items["properties"]["author"]["type"] == "object"
+    assert "name" in posts_items["properties"]["author"]["properties"]
+
+
+def test_unpack_defs_no_properties():
+    # Test schema without properties (should return as-is)
+    schema = {
+        "type": "string",
+        "enum": ["value1", "value2"]
+    }
+    
+    result = unpack_defs(schema)
+    assert result == schema
+
+
+def test_unpack_defs_empty_properties():
+    # Test schema with empty properties
+    schema = {
+        "type": "object",
+        "properties": {},
+        "$defs": {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    assert result["properties"] == {}
+    assert "$defs" not in result
+
+def test_unpack_defs_no_refs_in_properties():
+    # Test schema with properties but no $refs
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        },
+        "$defs": {
+            "UnusedDef": {
+                "type": "object",
+                "properties": {
+                    "unused": {"type": "string"}
+                }
+            }
+        }
+    }
+    
+    result = unpack_defs(schema)
+    
+    # Properties should remain unchanged
+    assert result["properties"]["name"]["type"] == "string"
+    assert result["properties"]["age"]["type"] == "integer"
+    # $defs should still be removed
+    assert "$defs" not in result
+
+def test_unpack_defs_circular_refs_handling():
+    # Test that circular references are handled properly.
+    schema = {
+        "type": "object",
+        "properties": {
+            "node": {"$ref": "#/$defs/TreeNode"}
+        },
+        "$defs": {
+            "TreeNode": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string"},
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/TreeNode"}
+                    }
+                }
+            }
+        }
+    }
+    
+    # This should not raise an error (jsonref handles circular refs)
+    result = unpack_defs(schema)
+    
+    # The structure should be resolved
+    assert "node" in result["properties"]
+    node_props = result["properties"]["node"]["properties"]
+    assert "value" in node_props
+    assert "children" in node_props
+
+def test_unpack_defs_from_pydantic_schema():
+    # Test unpacking from a Pydantic schema
+    from pydantic import BaseModel
+    from typing import List, Optional
+
+    class VatAmount(BaseModel):
+        vatRate: float
+        vatAmount: float
+
+    class ExpenseReceipt(BaseModel):
+        vatAmounts: Optional[List[VatAmount]] = None
+
+    schema = ExpenseReceipt.model_json_schema()
+
+    result = unpack_defs(schema)
+
+    # Should resolve the VatAmount reference
+    assert "vatAmounts" in result["properties"]
+    assert "anyOf" in result["properties"]["vatAmounts"]
+    assert len(result["properties"]["vatAmounts"]["anyOf"]) == 2
+    assert any(item["type"] == "null" for item in result["properties"]["vatAmounts"]["anyOf"])
+    assert any(item["type"] == "array" for item in result["properties"]["vatAmounts"]["anyOf"])


### PR DESCRIPTION
## Title

Fixes unhandled edge cases for Bedrock tool use (e.g., nested `$ref`s, schemas containing `allOf`) by reimplementing the `$def` to recursively resolve all references in the JSON schema.

## Relevant issues

- Addresses #11372 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

- ~~Adds `jsonref` as a dependency~~
- Reimplements the `litellm.litellm_core_utils.prompt_templates.common_utils.unpack_defs` function to handle `$ref` flattening more consistently for various uncovered edge cases, such as `$ref` nested in `items` as identified in #11372 and `allOf` schema keys (in addition to existing `anyOf` handling).
- Because this now resolves all `$refs` in the schema, adds support for clients that don't use the `$defs` key in their schema (namely `definitions`), despite having been changed in JSON Schema `draft-handrews-json-schema-02`
- Adds test coverage for `unpack_defs` to validate handling of various cases

## Screenshot of Test Passing Locally
<img width="1195" alt="litellm_test_passing" src="https://github.com/user-attachments/assets/e03b5660-8698-491c-bd21-a70c8184a91f" />


