### PR TITLE
Fix/ssl verify async for OpenAI LLM Client

### DIFF
--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -199,7 +199,7 @@ class BaseOpenAILLM:
         return httpx.AsyncClient(
             limits=httpx.Limits(max_connections=1000, max_keepalive_connections=100),
             verify=litellm.ssl_verify,
-            transport=AsyncHTTPHandler._create_async_transport(),
+            transport=AsyncHTTPHandler._create_async_transport(verify=litellm.ssl_verify),
         )
 
     @staticmethod

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -199,7 +199,7 @@ class BaseOpenAILLM:
         return httpx.AsyncClient(
             limits=httpx.Limits(max_connections=1000, max_keepalive_connections=100),
             verify=litellm.ssl_verify,
-            transport=AsyncHTTPHandler._create_async_transport(verify=litellm.ssl_verify),
+            transport=AsyncHTTPHandler._create_async_transport(ssl_verify=litellm.ssl_verify),
         )
 
     @staticmethod

--- a/tests/test_litellm/llms/openai/test_openai_common_utils.py
+++ b/tests/test_litellm/llms/openai/test_openai_common_utils.py
@@ -129,3 +129,18 @@ async def test_openai_client_reuse(function_name, is_async, args):
 
         # Verify we tried to get from cache 10 times (once per request)
         assert mock_get_cache.call_count == 10, "Should check cache for each request"
+
+
+@pytest.mark.asyncio
+async def test_openai_llm_async_client_has_unverified_ssl_context(monkeypatch):
+    """
+    Test that BaseOpenAILLM's async client has SSL verification disabled when ssl_verify=False
+    """
+    from litellm.llms.openai.openai import BaseOpenAILLM
+    
+    # Safely patch litellm.ssl_verify - will be automatically restored after test
+    monkeypatch.setattr(litellm, 'ssl_verify', False)
+
+    # Directly check the SSL context of the async client's transport
+    assert BaseOpenAILLM._get_async_http_client()._transport.client()._connector._ssl == False
+    


### PR DESCRIPTION
## Title
Fix: Ensure SSL verification is correctly disabled for OpenAI async client

## Relevant issues
#9340 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
✅ Test

## Changes

This PR addresses an issue with SSL verification in the OpenAI async client:

1. **Bug Fix**: Ensures `ssl_verify=False` is correctly propagated to the transport layer in OpenAI's async client
2. **Test Addition**: Added a new test `test_openai_llm_async_client_has_unverified_ssl_context` that:
   - Directly verifies the SSL context configuration in the transport layer
   - Uses `monkeypatch` to safely handle global state changes
   - Tests the functionality without making actual API calls

The changes are focused on ensuring consistent SSL verification behavior when users explicitly disable it, particularly in async contexts.

![Screenshot of the individual test passing](https://github.com/user-attachments/assets/0a9ca3c7-d192-4ad7-93aa-70f2e211c308)

## Failed unit tests

It fails an __unrelated__ test 

FAILED tests/test_litellm/proxy/test_proxy_server.py::test_initialize_scheduled_jobs_credentials - TypeError: 'Mock' object is not subscriptable


____________________________ test_initialize_scheduled_jobs_credentials ____________________________
[gw3] darwin -- Python 3.11.2 /Users/ansht/Projects/litellm/venv/bin/python

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x12ec39c90>

    @pytest.mark.asyncio
    async def test_initialize_scheduled_jobs_credentials(monkeypatch):
        """
        Test that get_credentials is only called when store_model_in_db is True
        """
        monkeypatch.delenv("DISABLE_PRISMA_SCHEMA_UPDATE", raising=False)
        monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
        from litellm.proxy.proxy_server import ProxyStartupEvent
        from litellm.proxy.utils import ProxyLogging
    
        # Mock dependencies
        mock_prisma_client = MagicMock()
        mock_proxy_logging = MagicMock(spec=ProxyLogging)
        mock_proxy_logging.slack_alerting_instance = MagicMock()
        mock_proxy_config = AsyncMock()
    
        with patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config), patch(
            "litellm.proxy.proxy_server.store_model_in_db", False
        ):  # set store_model_in_db to False
            # Test when store_model_in_db is False
            await ProxyStartupEvent.initialize_scheduled_background_jobs(
                general_settings={},
                prisma_client=mock_prisma_client,
                proxy_budget_rescheduler_min_time=1,
                proxy_budget_rescheduler_max_time=2,
                proxy_batch_write_at=5,
                proxy_logging_obj=mock_proxy_logging,
            )
    
            # Verify get_credentials was not called
            mock_proxy_config.get_credentials.assert_not_called()
    
        # Now test with store_model_in_db = True
        with patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config), patch(
            "litellm.proxy.proxy_server.store_model_in_db", True
        ), patch("litellm.proxy.proxy_server.get_secret_bool", return_value=True):
>           await ProxyStartupEvent.initialize_scheduled_background_jobs(
                general_settings={},
                prisma_client=mock_prisma_client,
                proxy_budget_rescheduler_min_time=1,
                proxy_budget_rescheduler_max_time=2,
                proxy_batch_write_at=5,
                proxy_logging_obj=mock_proxy_logging,
            )

tests/test_litellm/proxy/test_proxy_server.py:108: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
litellm/proxy/proxy_server.py:3340: in initialize_scheduled_background_jobs
    scheduler.add_job(
venv/lib/python3.11/site-packages/apscheduler/schedulers/base.py:501: in add_job
    job = Job(self, **job_kwargs)
venv/lib/python3.11/site-packages/apscheduler/job.py:62: in __init__
    self._modify(id=id or uuid4().hex, **kwargs)
venv/lib/python3.11/site-packages/apscheduler/job.py:195: in _modify
    check_callable_args(func, args, kwargs)
venv/lib/python3.11/site-packages/apscheduler/util.py:363: in check_callable_args
    sig = signature(func, follow_wrapped=False)
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/inspect.py:3279: in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/inspect.py:3027: in from_callable
    return _signature_from_callable(obj, sigcls=cls,
/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/inspect.py:2514: in _signature_from_callable
    return _signature_from_function(sigcls, obj,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'inspect.Signature'>, func = <AsyncMock name='mock.add_deployment' id='5031847824'>
skip_bound_arg = True, globals = None, locals = None, eval_str = False

    def _signature_from_function(cls, func, skip_bound_arg=True,
                                 globals=None, locals=None, eval_str=False):
        """Private helper: constructs Signature for the given python function."""
    
        is_duck_function = False
        if not isfunction(func):
            if _signature_is_functionlike(func):
                is_duck_function = True
            else:
                # If it's not a pure Python function, and not a duck type
                # of pure function:
                raise TypeError('{!r} is not a Python function'.format(func))
    
        s = getattr(func, "__text_signature__", None)
        if s:
            return _signature_fromstr(cls, func, s, skip_bound_arg)
    
        Parameter = cls._parameter_cls
    
        # Parameter information.
        func_code = func.__code__
        pos_count = func_code.co_argcount
        arg_names = func_code.co_varnames
        posonly_count = func_code.co_posonlyargcount
>       positional = arg_names[:pos_count]
E       TypeError: 'Mock' object is not subscriptable

/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/inspect.py:2355: TypeError

