### PR TITLE
Fix SambaNova 'created' field validation error - handle float timestamps

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -55,28 +55,17 @@ def _safe_convert_created_field(created_value) -> int:
     """
     if created_value is None:
         return int(time.time())
-    
-    if isinstance(created_value, int):
+    elif isinstance(created_value, int):
         return created_value
-    
-    if isinstance(created_value, float):
-        # Convert float timestamp to int (truncate fractional seconds)
+    elif isinstance(created_value, float):
         return int(created_value)
-    
-    if isinstance(created_value, str):
+    else:
+        # for strings, etc
         try:
-            # Try to parse as float first, then convert to int
             return int(float(created_value))
         except (ValueError, TypeError):
             # Fallback to current time if conversion fails
             return int(time.time())
-    
-    # For any other type, try to convert directly
-    try:
-        return int(created_value)
-    except (ValueError, TypeError):
-        # Fallback to current time if conversion fails
-        return int(time.time())
 
 
 def convert_tool_call_to_json_mode(


### PR DESCRIPTION
## Problem

SambaNova API returns `"created"` field as float but LiteLLM expects integer, causing validation errors.

## Solution

Added `_safe_convert_created_field()` helper function that converts float timestamps to integers while maintaining backward compatibility.

**Updated 3 locations in `convert_dict_to_response.py`:**
- Line 175: `convert_to_streaming_response_async()`
- Line 223: `convert_to_streaming_response()`  
- Line 620: `convert_to_model_response_object()`

**Handles edge cases**: None values, strings, invalid inputs (graceful fallback to current time)

**No breaking changes**: Existing integer timestamps work unchanged.

---

**Fixes**: SambaNova provider validation errors  
**Tested**: Live API calls confirm float→int conversion works

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4c17b5db76b447da8604c5056942831)