### PR TITLE
[Bug Fix] Perplexity - LiteLLM doesn't support 'web_search_options' for Perplexity' Sonar Pro model

### DIFF
--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -55,4 +55,13 @@ class PerplexityChatConfig(OpenAIGPTConfig):
                 base_openai_params.append("reasoning_effort")
         except Exception as e:
             verbose_logger.debug(f"Error checking if model supports reasoning: {e}")
+        
+        try:
+            if litellm.supports_web_search(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            ):
+                base_openai_params.append("web_search_options")
+        except Exception as e:
+            verbose_logger.debug(f"Error checking if model supports web search: {e}")
+        
         return base_openai_params

--- a/tests/test_litellm/llms/perplexity/test_perplexity.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+from pydantic import BaseModel
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import pytest
+
+
+class TestPerplexityWebSearch:
+    """Test suite for Perplexity web search functionality."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["perplexity/sonar", "perplexity/sonar-pro"]
+    )
+    def test_web_search_options_in_supported_params(self, model):
+        """
+        Test that web_search_options is in the list of supported parameters for Perplexity sonar models
+        """
+        from litellm.llms.perplexity.chat.transformation import PerplexityChatConfig
+        
+        config = PerplexityChatConfig()
+        supported_params = config.get_supported_openai_params(model=model)
+        
+        assert "web_search_options" in supported_params, f"web_search_options should be supported for {model}"

--- a/tests/test_litellm/llms/perplexity/test_perplexity.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-from pydantic import BaseModel
-
 sys.path.insert(0, os.path.abspath("../../.."))
 
 import pytest


### PR DESCRIPTION
## [Bug Fix] Perplexity - LiteLLM doesn't support 'web_search_options' for Perplexity' Sonar Pro model

Fixes https://github.com/BerriAI/litellm/issues/11976 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


