### PR TITLE
[Feat] Enterprise - Allow dynamically disabling callbacks in request headers

### DIFF
--- a/docs/my-website/docs/proxy/dynamic_logging.md
+++ b/docs/my-website/docs/proxy/dynamic_logging.md
@@ -1,0 +1,161 @@
+import Image from '@theme/IdealImage';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+
+# Dynamic Callback Management
+
+:::info
+
+This is an enterprise feature.
+
+[Get started with LiteLLM Enterprise](https://www.litellm.ai/enterprise)
+
+:::
+
+LiteLLM's dynamic callback management enables teams to control logging behavior on a per-request basis without requiring central infrastructure changes. This is essential for organizations managing large-scale service ecosystems where:
+
+- **Teams manage their own compliance** - Services can handle sensitive data appropriately without central oversight
+- **Decentralized responsibility** - Each team controls their data handling while using shared infrastructure
+
+You can disable callbacks by passing the `x-litellm-disable-callbacks` header with your requests, giving teams granular control over where their data is logged.
+
+## Quick Start
+
+```bash
+# Disable a single callback
+curl -H "x-litellm-disable-callbacks: langfuse" ...
+
+# Disable multiple callbacks
+curl -H "x-litellm-disable-callbacks: langfuse,datadog" ...
+```
+
+## 1. View Active Logging Callbacks
+
+Before disabling callbacks, you can view all currently enabled callbacks on your proxy.
+
+### Request
+
+```bash
+curl --location 'http://0.0.0.0:4000/callbacks/list' \
+    --header 'Authorization: Bearer sk-1234'
+```
+
+### Response
+
+```json
+{
+    "callbacks": [
+        "langfuse",
+        "datadog", 
+        "prometheus",
+        "slack_alerting"
+    ]
+}
+```
+
+## 2. Disable a Single Callback
+
+Use the `x-litellm-disable-callbacks` header to disable specific callbacks for individual requests.
+
+<Tabs>
+<TabItem value="Curl" label="Curl Request">
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-disable-callbacks: langfuse' \
+    --data '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+</TabItem>
+<TabItem value="OpenAI" label="OpenAI Python SDK">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="sk-1234",
+    base_url="http://0.0.0.0:4000"
+)
+
+response = client.chat.completions.create(
+    model="claude-sonnet-4-20250514",
+    messages=[
+        {
+            "role": "user",
+            "content": "what llm are you"
+        }
+    ],
+    extra_headers={
+        "x-litellm-disable-callbacks": "langfuse"
+    }
+)
+
+print(response)
+```
+
+</TabItem>
+</Tabs>
+
+## 3. Disable Multiple Callbacks
+
+You can disable multiple callbacks by providing a comma-separated list in the header.
+
+<Tabs>
+<TabItem value="Curl" label="Curl Request">
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-disable-callbacks: langfuse,datadog,prometheus' \
+    --data '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+</TabItem>
+<TabItem value="OpenAI" label="OpenAI Python SDK">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="sk-1234",
+    base_url="http://0.0.0.0:4000"
+)
+
+response = client.chat.completions.create(
+    model="claude-sonnet-4-20250514",
+    messages=[
+        {
+            "role": "user",
+            "content": "what llm are you"
+        }
+    ],
+    extra_headers={
+        "x-litellm-disable-callbacks": "langfuse,datadog,prometheus"
+    }
+)
+
+print(response)
+```
+
+</TabItem>
+</Tabs>

--- a/docs/my-website/docs/proxy/dynamic_logging.md
+++ b/docs/my-website/docs/proxy/dynamic_logging.md
@@ -22,13 +22,46 @@ You can disable callbacks by passing the `x-litellm-disable-callbacks` header wi
 
 ## Quick Start
 
-```bash
-# Disable a single callback
-curl -H "x-litellm-disable-callbacks: langfuse" ...
+<Tabs>
+<TabItem value="disable-single" label="Disable a single callback">
 
-# Disable multiple callbacks
-curl -H "x-litellm-disable-callbacks: langfuse,datadog" ...
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-disable-callbacks: langfuse' \
+    --data '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
 ```
+
+</TabItem>
+<TabItem value="disable-multiple" label="Disable multiple callbacks">
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-disable-callbacks: langfuse,datadog' \
+    --data '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+</TabItem>
+</Tabs>
 
 ## 1. View Active Logging Callbacks
 

--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -56,27 +56,6 @@ components in your system, including in logging tools.
 
 ## Logging Features
 
-### Conditional Logging by Virtual Keys, Teams
-
-Use this to:
-1. Conditionally enable logging for some virtual keys/teams
-2. Set different logging providers for different virtual keys/teams
-
-[👉 **Get Started** - Team/Key Based Logging](team_logging)
-
-
-### Redacting UserAPIKeyInfo 
-
-Redact information about the user api key (hashed token, user_id, team id, etc.), from logs. 
-
-Currently supported for Langfuse, OpenTelemetry, Logfire, ArizeAI logging.
-
-```yaml
-litellm_settings: 
-  callbacks: ["langfuse"]
-  redact_user_api_key_info: true
-```
-
 
 ### Redact Messages, Response Content
 
@@ -171,6 +150,18 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 
 <Image img={require('../../img/message_redaction_spend_logs.png')} />
 
+
+### Redacting UserAPIKeyInfo 
+
+Redact information about the user api key (hashed token, user_id, team id, etc.), from logs. 
+
+Currently supported for Langfuse, OpenTelemetry, Logfire, ArizeAI logging.
+
+```yaml
+litellm_settings: 
+  callbacks: ["langfuse"]
+  redact_user_api_key_info: true
+```
 
 ### Disable Message Redaction
 
@@ -268,6 +259,81 @@ print(response)
 ```
 LiteLLM.Info: "no-log request, skipping logging"
 ```
+
+### ✨ Dynamically Disable specific callbacks
+
+:::info
+
+This is an enterprise feature.
+
+[Proceed with LiteLLM Enterprise](https://www.litellm.ai/enterprise)
+
+:::
+
+For some use cases, you may want to disable specific callbacks for a request. You can do this by passing `x-litellm-disable-callbacks: <callback_name>` in the request headers.
+
+Send the list of callbacks to disable in the request header `x-litellm-disable-callbacks`.
+
+<Tabs>
+<TabItem value="Curl" label="Curl Request">
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-disable-callbacks: langfuse' \
+    --data '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
+</TabItem>
+<TabItem value="OpenAI" label="OpenAI Python SDK">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="sk-1234",
+    base_url="http://0.0.0.0:4000"
+)
+
+response = client.chat.completions.create(
+    model="claude-sonnet-4-20250514",
+    messages=[
+        {
+            "role": "user",
+            "content": "what llm are you"
+        }
+    ],
+    extra_headers={
+        "x-litellm-disable-callbacks": "langfuse"
+    }
+)
+
+print(response)
+```
+
+</TabItem>
+</Tabs>
+
+
+### ✨ Conditional Logging by Virtual Keys, Teams
+
+Use this to:
+1. Conditionally enable logging for some virtual keys/teams
+2. Set different logging providers for different virtual keys/teams
+
+[👉 **Get Started** - Team/Key Based Logging](team_logging)
+
+
+
 
 
 ## What gets logged?

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -198,7 +198,8 @@ const sidebars = {
           items: [
             "proxy/logging",
             "proxy/logging_spec",
-            "proxy/team_logging"
+            "proxy/team_logging",
+            "proxy/dynamic_logging"
           ],
         },
         

--- a/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
@@ -1,0 +1,56 @@
+import litellm
+from litellm._logging import verbose_logger
+from litellm.constants import X_LITELLM_DISABLE_CALLBACKS
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.llm_request_utils import (
+    get_proxy_server_request_headers,
+)
+from litellm.proxy._types import CommonProxyErrors
+
+
+class EnterpriseCallbackControls:
+    @staticmethod
+    def is_callback_disabled_via_headers(
+            callback: litellm.CALLBACK_TYPES, litellm_params: dict
+        ) -> bool:
+            """
+            Check if a callback is disabled via the x-litellm-disable-callbacks header.
+            
+            Args:
+                callback: The callback to check (can be string, CustomLogger instance, or callable)
+                litellm_params: Parameters containing proxy server request info
+                
+            Returns:
+                bool: True if the callback should be disabled, False otherwise
+            """
+            try:
+                request_headers = get_proxy_server_request_headers(litellm_params)
+                disabled_callbacks = request_headers.get(X_LITELLM_DISABLE_CALLBACKS, None)
+                if disabled_callbacks is not None:
+                    #########################################################
+                    # premium user check
+                    #########################################################
+                    if not EnterpriseCallbackControls._premium_user_check():
+                        return False
+                    #########################################################
+                    disabled_callbacks = set([cb.strip().lower() for cb in disabled_callbacks.split(",")])
+                    if isinstance(callback, str):
+                        if callback.lower() in disabled_callbacks:
+                            return True
+                    elif isinstance(callback, CustomLogger):
+                        if callback.__class__.__name__.lower() in disabled_callbacks:
+                            return True
+                return False
+            except Exception as e:
+                verbose_logger.debug(
+                    f"Error checking disabled callbacks header: {str(e)}"
+                )
+                return False
+    
+    @staticmethod
+    def _premium_user_check():
+        from litellm.proxy.proxy_server import premium_user
+        if premium_user:
+            return True
+        verbose_logger.warning(f"Disabling callbacks using request headers is an enterprise feature. {CommonProxyErrors.not_premium_user.value}")
+        return False

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -693,6 +693,9 @@ PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES = int(
 MCP_TOOL_NAME_PREFIX = "mcp_tool"
 MAXIMUM_TRACEBACK_LINES_TO_LOG = int(os.getenv("MAXIMUM_TRACEBACK_LINES_TO_LOG", 100))
 
+# Headers to control callbacks
+X_LITELLM_DISABLE_CALLBACKS = "x-litellm-disable-callbacks"
+
 ########################### LiteLLM Proxy Specific Constants ###########################
 ########################################################################################
 MAX_SPENDLOG_ROWS_TO_QUERY = int(

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -92,3 +92,37 @@ class CustomLoggerRegistry:
         "s3_v2": S3Logger,
         "langfuse_otel": OpenTelemetry,
     }
+
+    @classmethod
+    def get_callback_str_from_class_type(cls, class_type: type) -> str | None:
+        """
+        Get the callback string from the class type.
+        
+        Args:
+            class_type: The class type to find the string for
+            
+        Returns:
+            str: The callback string, or None if not found
+        """
+        for callback_str, callback_class in cls.CALLBACK_CLASS_STR_TO_CLASS_TYPE.items():
+            if callback_class == class_type:
+                return callback_str
+        return None
+
+    @classmethod
+    def get_all_callback_strs_from_class_type(cls, class_type: type) -> list[str]:
+        """
+        Get all callback strings that map to the same class type.
+        Some class types (like OpenTelemetry) have multiple string mappings.
+        
+        Args:
+            class_type: The class type to find all strings for
+            
+        Returns:
+            list: List of callback strings that map to the class type
+        """
+        callback_strs: list[str] = []
+        for callback_str, callback_class in cls.CALLBACK_CLASS_STR_TO_CLASS_TYPE.items():
+            if callback_class == class_type:
+                callback_strs.append(callback_str)
+        return callback_strs

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -1,0 +1,94 @@
+"""
+Registry mapping the callback class string to the class type.
+
+This is used to get the class type from the callback class string.
+
+Example:
+    "datadog" -> DataDogLogger
+    "prometheus" -> PrometheusLogger
+"""
+
+from litellm_enterprise.enterprise_callbacks.generic_api_callback import (
+    GenericAPILogger,
+)
+from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
+    PagerDutyAlerting,
+)
+from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
+    ResendEmailLogger,
+)
+from litellm_enterprise.enterprise_callbacks.send_emails.smtp_email import (
+    SMTPEmailLogger,
+)
+
+from litellm.integrations.agentops import AgentOps
+from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
+from litellm.integrations.argilla import ArgillaLogger
+from litellm.integrations.azure_storage.azure_storage import AzureBlobStorageLogger
+from litellm.integrations.braintrust_logging import BraintrustLogger
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+from litellm.integrations.deepeval import DeepEvalLogger
+from litellm.integrations.deepeval.deepeval import DeepEvalLogger
+from litellm.integrations.galileo import GalileoObserve
+from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+from litellm.integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
+from litellm.integrations.humanloop import HumanloopLogger
+from litellm.integrations.lago import LagoLogger
+from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
+from litellm.integrations.langfuse.langfuse_prompt_management import (
+    LangfusePromptManagement,
+)
+from litellm.integrations.langsmith import LangsmithLogger
+from litellm.integrations.literal_ai import LiteralAILogger
+from litellm.integrations.mlflow import MlflowLogger
+from litellm.integrations.openmeter import OpenMeterLogger
+from litellm.integrations.opentelemetry import OpenTelemetry
+from litellm.integrations.opik.opik import OpikLogger
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.integrations.s3_v2 import S3Logger
+from litellm.integrations.vector_stores.bedrock_vector_store import BedrockVectorStore
+from litellm.proxy.hooks.dynamic_rate_limiter import _PROXY_DynamicRateLimitHandler
+
+
+class CustomLoggerRegistry:
+    """
+    Registry mapping the callback class string to the class type.
+    """
+    CALLBACK_CLASS_STR_TO_CLASS_TYPE = {
+        "lago": LagoLogger,
+        "openmeter": OpenMeterLogger,
+        "braintrust": BraintrustLogger,
+        "galileo": GalileoObserve,
+        "langsmith": LangsmithLogger,
+        "literalai": LiteralAILogger,
+        "prometheus": PrometheusLogger,
+        "datadog": DataDogLogger,
+        "datadog_llm_observability": DataDogLLMObsLogger,
+        "gcs_bucket": GCSBucketLogger,
+        "opik": OpikLogger,
+        "argilla": ArgillaLogger,
+        "opentelemetry": OpenTelemetry,
+        "azure_storage": AzureBlobStorageLogger,
+        "humanloop": HumanloopLogger,
+        # OTEL compatible loggers
+        "logfire": OpenTelemetry,
+        "arize": OpenTelemetry,
+        "langfuse_otel": OpenTelemetry,
+        "arize_phoenix": OpenTelemetry,
+        "langtrace": OpenTelemetry,
+        "mlflow": MlflowLogger,
+        "langfuse": LangfusePromptManagement,
+        "otel": OpenTelemetry,
+        "pagerduty": PagerDutyAlerting,
+        "gcs_pubsub": GcsPubSubLogger,
+        "anthropic_cache_control_hook": AnthropicCacheControlHook,
+        "agentops": AgentOps,
+        "bedrock_vector_store": BedrockVectorStore,
+        "generic_api": GenericAPILogger,
+        "resend_email": ResendEmailLogger,
+        "smtp_email": SMTPEmailLogger,
+        "deepeval": DeepEvalLogger,
+        "s3_v2": S3Logger,
+        "langfuse_otel": OpenTelemetry,
+    }

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -29,13 +29,11 @@ from litellm.integrations.braintrust_logging import BraintrustLogger
 from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 from litellm.integrations.deepeval import DeepEvalLogger
-from litellm.integrations.deepeval.deepeval import DeepEvalLogger
 from litellm.integrations.galileo import GalileoObserve
 from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
 from litellm.integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
 from litellm.integrations.humanloop import HumanloopLogger
 from litellm.integrations.lago import LagoLogger
-from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
 from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,
 )
@@ -90,7 +88,7 @@ class CustomLoggerRegistry:
         "smtp_email": SMTPEmailLogger,
         "deepeval": DeepEvalLogger,
         "s3_v2": S3Logger,
-        "langfuse_otel": OpenTelemetry,
+        "dynamic_rate_limiter": _PROXY_DynamicRateLimitHandler,
     }
 
     @classmethod

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -8,19 +8,6 @@ Example:
     "prometheus" -> PrometheusLogger
 """
 
-from litellm_enterprise.enterprise_callbacks.generic_api_callback import (
-    GenericAPILogger,
-)
-from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
-    PagerDutyAlerting,
-)
-from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
-    ResendEmailLogger,
-)
-from litellm_enterprise.enterprise_callbacks.send_emails.smtp_email import (
-    SMTPEmailLogger,
-)
-
 from litellm.integrations.agentops import AgentOps
 from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
 from litellm.integrations.argilla import ArgillaLogger
@@ -78,18 +65,38 @@ class CustomLoggerRegistry:
         "mlflow": MlflowLogger,
         "langfuse": LangfusePromptManagement,
         "otel": OpenTelemetry,
-        "pagerduty": PagerDutyAlerting,
         "gcs_pubsub": GcsPubSubLogger,
         "anthropic_cache_control_hook": AnthropicCacheControlHook,
         "agentops": AgentOps,
         "bedrock_vector_store": BedrockVectorStore,
-        "generic_api": GenericAPILogger,
-        "resend_email": ResendEmailLogger,
-        "smtp_email": SMTPEmailLogger,
         "deepeval": DeepEvalLogger,
         "s3_v2": S3Logger,
         "dynamic_rate_limiter": _PROXY_DynamicRateLimitHandler,
     }
+
+    try:
+        from litellm_enterprise.enterprise_callbacks.generic_api_callback import (
+            GenericAPILogger,
+        )
+        from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
+            PagerDutyAlerting,
+        )
+        from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
+            ResendEmailLogger,
+        )
+        from litellm_enterprise.enterprise_callbacks.send_emails.smtp_email import (
+            SMTPEmailLogger,
+        )
+
+        enterprise_loggers = {
+            "pagerduty": PagerDutyAlerting,
+            "generic_api": GenericAPILogger,
+            "resend_email": ResendEmailLogger,
+            "smtp_email": SMTPEmailLogger,
+        }
+        CALLBACK_CLASS_STR_TO_CLASS_TYPE.update(enterprise_loggers)
+    except ImportError:
+        pass  # enterprise not installed
 
     @classmethod
     def get_callback_str_from_class_type(cls, class_type: type) -> str | None:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1242,27 +1242,7 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         try:
             # Extract headers from proxy server request
-            proxy_server_request = litellm_params.get("proxy_server_request", {})
-            headers = proxy_server_request.get("headers", {})
-            
-            # Check for the disable callbacks header (case-insensitive)
-            disable_header = None
-            for header_name, header_value in headers.items():
-                if header_name.lower() == "x-litellm-disable-callbacks":
-                    disable_header = header_value
-                    break
-            
-            if not disable_header:
-                return False
-            
-            # Parse comma-separated list of disabled callbacks
-            disabled_callbacks = [cb.strip().lower() for cb in disable_header.split(",")]
-            
-            # Get callback name for comparison
-            callback_name = self._get_callback_name_for_disable_check(callback)
-            
-            # Check if this callback is in the disabled list
-            return callback_name.lower() in disabled_callbacks
+            return True
             
         except Exception as e:
             verbose_logger.debug(
@@ -1270,68 +1250,6 @@ class Logging(LiteLLMLoggingBaseClass):
             )
             return False
 
-    def _get_callback_name_for_disable_check(
-        self, callback: litellm.CALLBACK_TYPES
-    ) -> str:
-        """
-        Get the name of a callback for comparison with disabled callbacks list.
-        
-        Args:
-            callback: The callback to get the name for
-            
-        Returns:
-            str: The callback name
-        """
-        if isinstance(callback, str):
-            return callback
-        
-        if isinstance(callback, CustomLogger):
-            # For CustomLogger instances, try to get a meaningful name
-            class_name = callback.__class__.__name__
-            
-            # Map common CustomLogger class names to their callback names
-            class_name_mapping = {
-                "LangFuseLogger": "langfuse",
-                "DataDogLogger": "datadog",
-                "DataDogLLMObsLogger": "datadog_llm_observability", 
-                "PrometheusLogger": "prometheus",
-                "OpenMeterLogger": "openmeter",
-                "ArizeLogger": "arize",
-                "OpikLogger": "opik",
-                "BraintrustLogger": "braintrust",
-                "LangsmithLogger": "langsmith",
-                "ArgillaLogger": "argilla",
-                "LiteralAILogger": "literalai",
-                "GCSBucketLogger": "gcs_bucket",
-                "S3V2Logger": "s3_v2",
-                "AzureBlobStorageLogger": "azure_storage",
-                "GalileoObserve": "galileo",
-                "DeepEvalLogger": "deepeval",
-                "MlflowLogger": "mlflow",
-                "HumanloopLogger": "humanloop",
-                "GcsPubSubLogger": "gcs_pubsub",
-                "GenericAPILogger": "generic_api",
-                "ResendEmailLogger": "resend_email",
-                "SMTPEmailLogger": "smtp_email",
-                "PagerDutyAlerting": "pagerduty",
-                "AnthropicCacheControlHook": "anthropic_cache_control_hook",
-                "BedrockVectorStore": "bedrock_vector_store",
-                "OpenTelemetry": "otel",
-                "AgentOps": "agentops",
-                "LagoLogger": "lago",
-            }
-            
-            return class_name_mapping.get(class_name, class_name.lower())
-        
-        if callable(callback):
-            # For callable functions, try to get the function name
-            if hasattr(callback, "__name__"):
-                return callback.__name__
-            if hasattr(callback, "__func__") and hasattr(callback.__func__, "__name__"):
-                return callback.__func__.__name__
-            return "custom_function"
-        
-        return str(callback)
 
     def _update_completion_start_time(self, completion_start_time: datetime.datetime):
         self.completion_start_time = completion_start_time

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -59,9 +59,6 @@ from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
 )
-from litellm.litellm_core_utils.llm_request_utils import (
-    get_proxy_server_request_headers,
-)
 from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
 from litellm.litellm_core_utils.redact_messages import (
     redact_message_input_output_from_custom_logger,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1217,7 +1217,121 @@ class Logging(LiteLLMLoggingBaseClass):
                     f"no-log request, skipping logging for {event_hook} event"
                 )
                 return False
+
+        # Check for dynamically disabled callbacks via headers
+        if self._is_callback_disabled_via_headers(callback, litellm_params):
+            verbose_logger.debug(
+                f"Callback {callback} disabled via x-litellm-disable-callbacks header for {event_hook} event"
+            )
+            return False
+
         return True
+
+    def _is_callback_disabled_via_headers(
+        self, callback: litellm.CALLBACK_TYPES, litellm_params: dict
+    ) -> bool:
+        """
+        Check if a callback is disabled via the x-litellm-disable-callbacks header.
+        
+        Args:
+            callback: The callback to check (can be string, CustomLogger instance, or callable)
+            litellm_params: Parameters containing proxy server request info
+            
+        Returns:
+            bool: True if the callback should be disabled, False otherwise
+        """
+        try:
+            # Extract headers from proxy server request
+            proxy_server_request = litellm_params.get("proxy_server_request", {})
+            headers = proxy_server_request.get("headers", {})
+            
+            # Check for the disable callbacks header (case-insensitive)
+            disable_header = None
+            for header_name, header_value in headers.items():
+                if header_name.lower() == "x-litellm-disable-callbacks":
+                    disable_header = header_value
+                    break
+            
+            if not disable_header:
+                return False
+            
+            # Parse comma-separated list of disabled callbacks
+            disabled_callbacks = [cb.strip().lower() for cb in disable_header.split(",")]
+            
+            # Get callback name for comparison
+            callback_name = self._get_callback_name_for_disable_check(callback)
+            
+            # Check if this callback is in the disabled list
+            return callback_name.lower() in disabled_callbacks
+            
+        except Exception as e:
+            verbose_logger.debug(
+                f"Error checking disabled callbacks header: {str(e)}"
+            )
+            return False
+
+    def _get_callback_name_for_disable_check(
+        self, callback: litellm.CALLBACK_TYPES
+    ) -> str:
+        """
+        Get the name of a callback for comparison with disabled callbacks list.
+        
+        Args:
+            callback: The callback to get the name for
+            
+        Returns:
+            str: The callback name
+        """
+        if isinstance(callback, str):
+            return callback
+        
+        if isinstance(callback, CustomLogger):
+            # For CustomLogger instances, try to get a meaningful name
+            class_name = callback.__class__.__name__
+            
+            # Map common CustomLogger class names to their callback names
+            class_name_mapping = {
+                "LangFuseLogger": "langfuse",
+                "DataDogLogger": "datadog",
+                "DataDogLLMObsLogger": "datadog_llm_observability", 
+                "PrometheusLogger": "prometheus",
+                "OpenMeterLogger": "openmeter",
+                "ArizeLogger": "arize",
+                "OpikLogger": "opik",
+                "BraintrustLogger": "braintrust",
+                "LangsmithLogger": "langsmith",
+                "ArgillaLogger": "argilla",
+                "LiteralAILogger": "literalai",
+                "GCSBucketLogger": "gcs_bucket",
+                "S3V2Logger": "s3_v2",
+                "AzureBlobStorageLogger": "azure_storage",
+                "GalileoObserve": "galileo",
+                "DeepEvalLogger": "deepeval",
+                "MlflowLogger": "mlflow",
+                "HumanloopLogger": "humanloop",
+                "GcsPubSubLogger": "gcs_pubsub",
+                "GenericAPILogger": "generic_api",
+                "ResendEmailLogger": "resend_email",
+                "SMTPEmailLogger": "smtp_email",
+                "PagerDutyAlerting": "pagerduty",
+                "AnthropicCacheControlHook": "anthropic_cache_control_hook",
+                "BedrockVectorStore": "bedrock_vector_store",
+                "OpenTelemetry": "otel",
+                "AgentOps": "agentops",
+                "LagoLogger": "lago",
+            }
+            
+            return class_name_mapping.get(class_name, class_name.lower())
+        
+        if callable(callback):
+            # For callable functions, try to get the function name
+            if hasattr(callback, "__name__"):
+                return callback.__name__
+            if hasattr(callback, "__func__") and hasattr(callback.__func__, "__name__"):
+                return callback.__func__.__name__
+            return "custom_function"
+        
+        return str(callback)
 
     def _update_completion_start_time(self, completion_start_time: datetime.datetime):
         self.completion_start_time = completion_start_time
@@ -2246,6 +2360,14 @@ class Logging(LiteLLMLoggingBaseClass):
             self.has_run_logging(event_type="sync_failure")
             for callback in callbacks:
                 try:
+                    litellm_params = self.model_call_details.get("litellm_params", {})
+                    should_run = self.should_run_callback(
+                        callback=callback,
+                        litellm_params=litellm_params,
+                        event_hook="failure_handler",
+                    )
+                    if not should_run:
+                        continue
                     if callback == "lunary" and lunaryLogger is not None:
                         print_verbose("reaches lunary for logging error!")
 
@@ -2427,6 +2549,14 @@ class Logging(LiteLLMLoggingBaseClass):
         self.has_run_logging(event_type="async_failure")
         for callback in callbacks:
             try:
+                litellm_params = self.model_call_details.get("litellm_params", {})
+                should_run = self.should_run_callback(
+                    callback=callback,
+                    litellm_params=litellm_params,
+                    event_hook="async_failure_handler",
+                )
+                if not should_run:
+                    continue
                 if isinstance(callback, CustomLogger):  # custom logger class
                     await callback.async_log_failure_event(
                         kwargs=self.model_call_details,

--- a/litellm/litellm_core_utils/llm_request_utils.py
+++ b/litellm/litellm_core_utils/llm_request_utils.py
@@ -66,3 +66,18 @@ def pick_cheapest_chat_models_from_llm_provider(custom_llm_provider: str, n=1):
 
     # Return the top n cheapest models
     return [model for model, _ in model_costs[:n]]
+
+def get_proxy_server_request_headers(litellm_params: Optional[dict]) -> dict:
+    """
+    Get the `proxy_server_request` headers from the litellm_params.\
+
+    Use this if you want to access the request headers made to LiteLLM proxy server.
+    """
+    if litellm_params is None:
+        return {}
+
+    proxy_request_headers = (
+        litellm_params.get("proxy_server_request", {}).get("headers", {}) or {}
+    )
+
+    return proxy_request_headers

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -16,48 +16,10 @@ import asyncio
 import logging
 from litellm._logging import verbose_logger
 from prometheus_client import REGISTRY, CollectorRegistry
-
-from litellm.integrations.lago import LagoLogger
-from litellm.integrations.deepeval import DeepEvalLogger
-from litellm.integrations.openmeter import OpenMeterLogger
-from litellm.integrations.braintrust_logging import BraintrustLogger
-from litellm.integrations.galileo import GalileoObserve
-from litellm.integrations.langsmith import LangsmithLogger
-from litellm.integrations.literal_ai import LiteralAILogger
-from litellm.integrations.prometheus import PrometheusLogger
-from litellm.integrations.datadog.datadog import DataDogLogger
-from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
-from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
-from litellm.integrations.gcs_pubsub.pub_sub import GcsPubSubLogger
-from litellm.integrations.opik.opik import OpikLogger
-from litellm.integrations.opentelemetry import OpenTelemetry
-from litellm.integrations.mlflow import MlflowLogger
-from litellm.integrations.argilla import ArgillaLogger
-from litellm.integrations.deepeval.deepeval import DeepEvalLogger
-from litellm.integrations.s3_v2 import S3Logger
-from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
-from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
-from litellm.integrations.vector_stores.bedrock_vector_store import BedrockVectorStore
-from litellm.integrations.langfuse.langfuse_prompt_management import (
-    LangfusePromptManagement,
-)
-from litellm.integrations.azure_storage.azure_storage import AzureBlobStorageLogger
-from litellm.integrations.agentops import AgentOps
-from litellm.integrations.humanloop import HumanloopLogger
-from litellm.proxy.hooks.dynamic_rate_limiter import _PROXY_DynamicRateLimitHandler
-from litellm_enterprise.enterprise_callbacks.generic_api_callback import (
-    GenericAPILogger,
-)
-from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
-    ResendEmailLogger,
-)
-from litellm_enterprise.enterprise_callbacks.send_emails.smtp_email import (
-    SMTPEmailLogger,
-)
-from litellm_enterprise.enterprise_callbacks.pagerduty.pagerduty import (
-    PagerDutyAlerting,
-)
 from unittest.mock import patch
+from litellm.litellm_core_utils.custom_logger_registry import (
+    CustomLoggerRegistry,
+)
 
 # clear prometheus collectors / registry
 collectors = list(REGISTRY._collector_to_names.keys())
@@ -65,43 +27,7 @@ for collector in collectors:
     REGISTRY.unregister(collector)
 ######################################
 
-callback_class_str_to_classType = {
-    "lago": LagoLogger,
-    "openmeter": OpenMeterLogger,
-    "braintrust": BraintrustLogger,
-    "galileo": GalileoObserve,
-    "langsmith": LangsmithLogger,
-    "literalai": LiteralAILogger,
-    "prometheus": PrometheusLogger,
-    "datadog": DataDogLogger,
-    "datadog_llm_observability": DataDogLLMObsLogger,
-    "gcs_bucket": GCSBucketLogger,
-    "opik": OpikLogger,
-    "argilla": ArgillaLogger,
-    "opentelemetry": OpenTelemetry,
-    "azure_storage": AzureBlobStorageLogger,
-    "humanloop": HumanloopLogger,
-    # OTEL compatible loggers
-    "logfire": OpenTelemetry,
-    "arize": OpenTelemetry,
-    "langfuse_otel": OpenTelemetry,
-    "arize_phoenix": OpenTelemetry,
-    "langtrace": OpenTelemetry,
-    "mlflow": MlflowLogger,
-    "langfuse": LangfusePromptManagement,
-    "otel": OpenTelemetry,
-    "pagerduty": PagerDutyAlerting,
-    "gcs_pubsub": GcsPubSubLogger,
-    "anthropic_cache_control_hook": AnthropicCacheControlHook,
-    "agentops": AgentOps,
-    "bedrock_vector_store": BedrockVectorStore,
-    "generic_api": GenericAPILogger,
-    "resend_email": ResendEmailLogger,
-    "smtp_email": SMTPEmailLogger,
-    "deepeval": DeepEvalLogger,
-    "s3_v2": S3Logger,
-    "langfuse_otel": OpenTelemetry,
-}
+
 
 expected_env_vars = {
     "LAGO_API_KEY": "api_key",
@@ -215,7 +141,7 @@ async def use_callback_in_llm_call(
 
         await asyncio.sleep(0.5)
 
-        expected_class = callback_class_str_to_classType[callback]
+        expected_class = CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE[callback]
 
         if used_in == "callbacks":
             assert isinstance(litellm._async_success_callback[0], expected_class)

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py
@@ -1,0 +1,176 @@
+import unittest.mock as mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from enterprise.litellm_enterprise.enterprise_callbacks.callback_controls import (
+    EnterpriseCallbackControls,
+)
+from litellm.constants import X_LITELLM_DISABLE_CALLBACKS
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.integrations.langfuse.langfuse_prompt_management import (
+    LangfusePromptManagement,
+)
+from litellm.integrations.s3_v2 import S3Logger
+
+
+class TestEnterpriseCallbackControls:
+    
+    @pytest.fixture
+    def mock_premium_user(self):
+        """Fixture to mock premium user check as True"""
+        with patch.object(EnterpriseCallbackControls, '_premium_user_check', return_value=True):
+            yield
+    
+    @pytest.fixture 
+    def mock_non_premium_user(self):
+        """Fixture to mock premium user check as False"""
+        with patch.object(EnterpriseCallbackControls, '_premium_user_check', return_value=False):
+            yield
+
+    @pytest.fixture
+    def mock_request_headers(self):
+        """Fixture to mock get_proxy_server_request_headers"""
+        with patch('enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers') as mock_headers:
+            yield mock_headers
+
+    def test_callback_disabled_langfuse_string(self, mock_premium_user, mock_request_headers):
+        """Test that 'langfuse' string callback is disabled when specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        assert result is True
+
+    def test_callback_disabled_langfuse_customlogger(self, mock_premium_user, mock_request_headers):
+        """Test that LangfusePromptManagement CustomLogger instance is disabled when 'langfuse' specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        langfuse_logger = LangfusePromptManagement()
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers(langfuse_logger, litellm_params)
+        assert result is True
+
+    def test_callback_disabled_s3_v2_string(self, mock_premium_user, mock_request_headers):
+        """Test that 's3_v2' string callback is disabled when specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "s3_v2"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params)
+        assert result is True
+
+    def test_callback_disabled_s3_v2_customlogger(self, mock_premium_user, mock_request_headers):
+        """Test that S3Logger CustomLogger instance is disabled when 's3_v2' specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "s3_v2"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        # Mock S3Logger to avoid async initialization issues
+        with patch('litellm.integrations.s3_v2.S3Logger.__init__', return_value=None):
+            s3_logger = S3Logger()
+            result = EnterpriseCallbackControls.is_callback_disabled_via_headers(s3_logger, litellm_params)
+            assert result is True
+
+    def test_callback_disabled_datadog_string(self, mock_premium_user, mock_request_headers):
+        """Test that 'datadog' string callback is disabled when specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "datadog"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params)
+        assert result is True
+
+    def test_callback_disabled_datadog_customlogger(self, mock_premium_user, mock_request_headers):
+        """Test that DataDogLogger CustomLogger instance is disabled when 'datadog' specified in headers"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "datadog"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        # Mock DataDogLogger to avoid async initialization issues
+        with patch('litellm.integrations.datadog.datadog.DataDogLogger.__init__', return_value=None):
+            datadog_logger = DataDogLogger()
+            result = EnterpriseCallbackControls.is_callback_disabled_via_headers(datadog_logger, litellm_params)
+            assert result is True
+
+    def test_multiple_callbacks_disabled(self, mock_premium_user, mock_request_headers):
+        """Test that multiple callbacks can be disabled with comma-separated list"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse,datadog,s3_v2"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        # Test each callback is disabled
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params) is True
+        
+        # Test non-disabled callback is not disabled
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("prometheus", litellm_params) is False
+
+    def test_callback_not_disabled_when_not_in_list(self, mock_premium_user, mock_request_headers):
+        """Test that callbacks not in the disabled list are not disabled"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params)
+        assert result is False
+
+    def test_callback_not_disabled_when_no_header(self, mock_premium_user, mock_request_headers):
+        """Test that callbacks are not disabled when the header is not present"""
+        mock_request_headers.return_value = {}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        assert result is False
+
+    def test_callback_not_disabled_when_header_none(self, mock_premium_user, mock_request_headers):
+        """Test that callbacks are not disabled when the header value is None"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: None}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        assert result is False
+
+    def test_non_premium_user_cannot_disable_callbacks(self, mock_non_premium_user, mock_request_headers):
+        """Test that non-premium users cannot disable callbacks even with the header"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        assert result is False
+
+    def test_case_insensitive_callback_matching(self, mock_premium_user, mock_request_headers):
+        """Test that callback matching is case insensitive"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "LANGFUSE,DataDog"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        # Test lowercase callbacks are disabled
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
+
+    def test_whitespace_handling_in_disabled_callbacks(self, mock_premium_user, mock_request_headers):
+        """Test that whitespace around callback names is handled correctly"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: " langfuse , datadog , s3_v2 "}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params) is True
+
+    def test_custom_logger_not_in_registry(self, mock_premium_user, mock_request_headers):
+        """Test that CustomLogger not in registry is not disabled"""
+        mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "unknown_logger"}
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        # Create a mock CustomLogger that's not in the registry
+        class UnknownLogger(CustomLogger):
+            pass
+        
+        unknown_logger = UnknownLogger()
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers(unknown_logger, litellm_params)
+        assert result is False
+
+    def test_exception_handling(self, mock_premium_user, mock_request_headers):
+        """Test that exceptions are handled gracefully and return False"""
+        # Make get_proxy_server_request_headers raise an exception
+        mock_request_headers.side_effect = Exception("Test exception")
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        assert result is False


### PR DESCRIPTION
## [Feat] Enterprise - Allow dynamically disabling callbacks in request headers


LiteLLM's dynamic callback management enables teams to control logging behavior on a per-request basis without requiring central infrastructure changes. This is essential for organizations managing large-scale service ecosystems where:

- **Teams manage their own compliance** - Services can handle sensitive data appropriately without central oversight
- **Decentralized responsibility** - Each team controls their data handling while using shared infrastructure

You can disable callbacks by passing the `x-litellm-disable-callbacks` header with your requests, giving teams granular control over where their data is logged.

## Quick Start

<Tabs>
<TabItem value="disable-single" label="Disable a single callback">

```bash
curl --location 'http://0.0.0.0:4000/chat/completions' \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer sk-1234' \
    --header 'x-litellm-disable-callbacks: langfuse' \
    --data '{
    "model": "claude-sonnet-4-20250514",
    "messages": [
        {
        "role": "user",
        "content": "what llm are you"
        }
    ]
}'
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


