### PR TITLE
fix: fix test_get_azure_ad_token_with_oidc_token testcase issue

### DIFF
--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1237,6 +1237,7 @@ def test_get_azure_ad_token_with_oidc_token(setup_mocks):
         azure_scope="test-azure-scope",
         # Ensure no other auth methods are available
         azure_ad_token_provider=None,
+        client_secret=None
     )
 
     # Call the function


### PR DESCRIPTION
## Fix test_get_azure_ad_token_with_oidc_token testcase issue

because CI/CD pipeline setup AZURE_CLIENT_SECRET within enviroment variable, so we need to setup as None in this case

## Relevant issues

https://app.circleci.com/pipelines/github/BerriAI/litellm/35593/workflows/a4bcd3c9-5b61-44a4-aef2-1284347a68fe/jobs/492282/steps

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test

## Changes


