### PR TITLE
Fix gemini tool call sequence

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -834,16 +834,15 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     @staticmethod
     def _transform_parts(
         parts: List[HttpxPartType],
+        cumulative_tool_call_idx: int,
         is_function_call: Optional[bool],
     ) -> Tuple[
         Optional[ChatCompletionToolCallFunctionChunk],
         Optional[List[ChatCompletionToolCallChunk]],
+        int,
     ]:
         function: Optional[ChatCompletionToolCallFunctionChunk] = None
         _tools: List[ChatCompletionToolCallChunk] = []
-        # in a single chunk, each tool call appears as a separate part
-        # they need to be separate indexes as they are separate tool calls
-        funcCallIndex = 0
         for part in parts:
             if "functionCall" in part:
                 _function_chunk = ChatCompletionToolCallFunctionChunk(
@@ -857,15 +856,15 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         id=f"call_{str(uuid.uuid4())}",
                         type="function",
                         function=_function_chunk,
-                        index=funcCallIndex,
+                        index=cumulative_tool_call_idx,
                     )
                     _tools.append(_tool_response_chunk)
-                funcCallIndex += 1
+                cumulative_tool_call_idx += 1
         if len(_tools) == 0:
             tools: Optional[List[ChatCompletionToolCallChunk]] = None
         else:
             tools = _tools
-        return function, tools
+        return function, tools, cumulative_tool_call_idx
 
     @staticmethod
     def _transform_logprobs(
@@ -1126,6 +1125,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         chat_completion_logprobs: Optional[ChoiceLogprobs] = None
         tools: Optional[List[ChatCompletionToolCallChunk]] = []
         functions: Optional[ChatCompletionToolCallFunctionChunk] = None
+        cumulative_tool_call_index: int = 0
 
         for idx, candidate in enumerate(_candidates):
             if "content" not in candidate:
@@ -1172,8 +1172,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 if reasoning_content is not None:
                     chat_completion_message["reasoning_content"] = reasoning_content
 
-                functions, tools = VertexGeminiConfig._transform_parts(
+                functions, tools, cumulative_tool_call_index = VertexGeminiConfig._transform_parts(
                     parts=candidate["content"]["parts"],
+                    cumulative_tool_call_idx=cumulative_tool_call_index,
                     is_function_call=is_function_call(standard_optional_params),
                 )
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Follow up from the previous PR, it seems that in Google AI Studio's Gemini 2.5 Pro, it's possible for tool calls to span multiple assistant messages especially during streaming. 
In Vertex AI, it seems that parallel tool calls are mostly just in 1 tool call message.
To make sure the indexes are accurate, we should be accumulating the index across different messages.

## Testing

- When multiple tools in a single message
```
{
    "id": "6WdaaOX4MJ2tk-4Ppeii6QU",
    "created": 1750755309,
    "model": "gemini-2.5-pro",
    "object": "chat.completion.chunk",
    "choices": [
        {
            "index": 0,
            "delta": {
                "role": "assistant",
                "tool_calls": [
                    {
                        "id": "call_5e3a4c25-c1b7-42b9-9d30-1df43e0b8eb8",
                        "function": {
                            "arguments": "{\"query\": \"a summary of the state of bitcoin, recent news, and research\"}",
                            "name": "search_agent"
                        },
                        "type": "function",
                        "index": 0
                    },
                    {
                        "id": "call_aa08b9c9-9a11-45c7-bcc7-3f42182412a2",
                        "function": {
                            "arguments": "{\"query\": \"key metrics of bitcoin such as price, market cap, volume, and all time high\"}",
                            "name": "compute_agent"
                        },
                        "type": "function",
                        "index": 1
                    },
                    {
                        "id": "call_800db997-2068-410c-8d90-67afc8e0775c",
                        "function": {
                            "arguments": "{\"query\": \"current mindshare and trending topics for bitcoin\"}",
                            "name": "signal_agent"
                        },
                        "type": "function",
                        "index": 2
                    }
                ]
            }
        }
    ]
}
```




## Relevant issues

https://github.com/BerriAI/litellm/pull/11558

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


