### PR TITLE
Tune down the logging level from info to debug

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -657,7 +657,7 @@ def completion_cost(  # noqa: PLR0915
             potential_model_names.append(model)
         for idx, model in enumerate(potential_model_names):
             try:
-                verbose_logger.info(
+                verbose_logger.debug(
                     f"selected model name for cost calculation: {model}"
                 )
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3117,7 +3117,7 @@ def get_optional_params(  # noqa: PLR0915
         Args:
             supported_params: List[str] - supported params from the litellm config
         """
-        verbose_logger.info(
+        verbose_logger.debug(
             f"\nLiteLLM completion() model= {model}; provider = {custom_llm_provider}"
         )
         verbose_logger.debug(


### PR DESCRIPTION
When using litellm in an agentic framework like google's adk these are the only 2 logs setup at the info level which can be quite verbose.

## Title

Tune down the logging level from info to debug

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🧹 Refactoring

## Changes

I am proposing to lower the logging level for this 2 logs from info to debug. When using litellm with an agent these logs can be quite verbose using INFO. 


