### PR TITLE
Rewrite get_formatted_prompt.py to support acompletion parsing

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
@@ -1,4 +1,4 @@
-from litellm._logging import verbose_proxy_logge
+from litellm._logging import verbose_proxy_logger
 from typing import List, Literal
 
 def get_formatted_prompt(
@@ -41,3 +41,16 @@ def _extract_messages(messages: List[dict]) -> str:
         content = message.get('content', None)
         if content == None:
             continue
+
+        if isinstance(content, str):
+            result += content
+        elif isinstance(content, list):
+            _tmp = "".join(c.get('text', '') for c in content if c.get('type') == 'text')
+            if _tmp != "":
+                result += _tmp
+
+        for tool_call in message.get("tool_calls", []):
+            function_arguments = tool_call.get("function", {}).get("arguments", None)
+            if isinstance(function_arguments, str):
+                result += function_arguments
+    return result

--- a/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
@@ -1,49 +1,43 @@
+from litellm._logging import verbose_proxy_logge
 from typing import List, Literal
-
 
 def get_formatted_prompt(
     data: dict,
     call_type: Literal[
         "completion",
+        "acompletion",
         "embedding",
         "image_generation",
         "audio_transcription",
         "moderation",
         "text_completion",
-    ],
-) -> str:
+    ]) -> str:
+
     """
     Extracts the prompt from the input data based on the call type.
-
     Returns a string.
     """
-    prompt = ""
-    if call_type == "completion":
-        for message in data["messages"]:
-            if message.get("content", None) is not None:
-                content = message.get("content")
-                if isinstance(content, str):
-                    prompt += message["content"]
-                elif isinstance(content, List):
-                    for c in content:
-                        if c["type"] == "text":
-                            prompt += c["text"]
-            if "tool_calls" in message:
-                for tool_call in message["tool_calls"]:
-                    if "function" in tool_call:
-                        function_arguments = tool_call["function"]["arguments"]
-                        prompt += function_arguments
-    elif call_type == "text_completion":
-        prompt = data["prompt"]
-    elif call_type == "embedding" or call_type == "moderation":
-        if isinstance(data["input"], str):
-            prompt = data["input"]
-        elif isinstance(data["input"], list):
-            for m in data["input"]:
-                prompt += m
-    elif call_type == "image_generation":
-        prompt = data["prompt"]
-    elif call_type == "audio_transcription":
-        if "prompt" in data:
-            prompt = data["prompt"]
-    return prompt
+    if call_type in {"completion", "acompletion"}:
+        return _extract_messages(data.get("messages", []))
+    elif call_type in {"text_completion"}:
+        return "".join(data.get('prompt', []))
+    elif call_type in {"image_generation", "audio_transcription"}:
+        if (prompt:=data.get('prompt', None)):
+            return prompt
+    elif call_type in {"embedding", "moderation"}:
+        input_data = data.get("input", "")
+        if isinstance(input_data, str):
+            return input_data
+        elif isinstance(input_data, list):
+            return "".join(map(str, input_data))
+        return ""
+    else:
+        verbose_proxy_logger.warning(f"Undefined call_type: {call_type}")
+        return ""
+
+def _extract_messages(messages: List[dict]) -> str:
+    result = ""
+    for message in messages:
+        content = message.get('content', None)
+        if content == None:
+            continue

--- a/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_formatted_prompt.py
@@ -24,6 +24,8 @@ def get_formatted_prompt(
     elif call_type in {"image_generation", "audio_transcription"}:
         if (prompt:=data.get('prompt', None)):
             return prompt
+        else: 
+            return ""
     elif call_type in {"embedding", "moderation"}:
         input_data = data.get("input", "")
         if isinstance(input_data, str):
@@ -39,7 +41,7 @@ def _extract_messages(messages: List[dict]) -> str:
     result = ""
     for message in messages:
         content = message.get('content', None)
-        if content == None:
+        if content is None:
             continue
 
         if isinstance(content, str):


### PR DESCRIPTION
## Title

Rewrite `get_formatted_prompt.py` to support `acompletion` parsing

---

## Relevant issues

N/A – this is an internal refactor to improve input handling logic.

---

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)  
- [ ] I have added a screenshot of my new test passing locally  
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)  
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem  

---

## Type

🧹 Refactoring  
🆕 New Feature (if treating `acompletion` support as a feature)

---

## Changes

- Refactored `get_formatted_prompt()` logic in `litellm_core_utils/llm_response_utils/`
- Unified `completion` and `acompletion` prompt extraction via shared logic
- Added `extract_messages()` helper to simplify repeated logic
- Preserved existing support for other call types: `text_completion`, `embedding`, `moderation`, etc.
- Logging fallback for unrecognized `call_type`
