### PR TITLE
[Feat] Add Support for calling Gemini/Vertex models in their native format

### DIFF
--- a/litellm/google_genai/Readme.md
+++ b/litellm/google_genai/Readme.md
@@ -1,1 +1,123 @@
-# Interface to interact with Google GenAI Functions in the native google interface
+# LiteLLM Google GenAI Interface
+
+Interface to interact with Google GenAI Functions in the native Google interface format.
+
+## Overview
+
+This module provides a native interface to Google's Generative AI API, allowing you to use Google's content generation capabilities with both streaming and non-streaming modes, in both synchronous and asynchronous contexts.
+
+## Available Functions
+
+### Non-Streaming Functions
+
+- `generate_content()` - Synchronous content generation
+- `agenerate_content()` - Asynchronous content generation
+
+### Streaming Functions
+
+- `generate_content_stream()` - Synchronous streaming content generation
+- `agenerate_content_stream()` - Asynchronous streaming content generation
+
+## Usage Examples
+
+### Basic Non-Streaming Usage
+
+```python
+from litellm.google_genai import generate_content, agenerate_content
+from google.genai.types import ContentDict, PartDict
+
+# Synchronous usage
+contents = ContentDict(
+    parts=[
+        PartDict(text="Hello, can you tell me a short joke?")
+    ],
+)
+
+response = generate_content(
+    contents=contents,
+    model="gemini-pro",  # or your preferred model
+    # Add other model-specific parameters as needed
+)
+
+print(response)
+```
+
+### Async Non-Streaming Usage
+
+```python
+import asyncio
+from litellm.google_genai import agenerate_content
+from google.genai.types import ContentDict, PartDict
+
+async def main():
+    contents = ContentDict(
+        parts=[
+            PartDict(text="Hello, can you tell me a short joke?")
+        ],
+    )
+    
+    response = await agenerate_content(
+        contents=contents,
+        model="gemini-pro",
+        # Add other model-specific parameters as needed
+    )
+    
+    print(response)
+
+# Run the async function
+asyncio.run(main())
+```
+
+### Streaming Usage
+
+```python
+from litellm.google_genai import generate_content_stream
+from google.genai.types import ContentDict, PartDict
+
+# Synchronous streaming
+contents = ContentDict(
+    parts=[
+        PartDict(text="Tell me a story about space exploration")
+    ],
+)
+
+for chunk in generate_content_stream(
+    contents=contents,
+    model="gemini-pro",
+):
+    print(f"Chunk: {chunk}")
+```
+
+### Async Streaming Usage
+
+```python
+import asyncio
+from litellm.google_genai import agenerate_content_stream
+from google.genai.types import ContentDict, PartDict
+
+async def main():
+    contents = ContentDict(
+        parts=[
+            PartDict(text="Tell me a story about space exploration")
+        ],
+    )
+    
+    async for chunk in agenerate_content_stream(
+        contents=contents,
+        model="gemini-pro",
+    ):
+        print(f"Async chunk: {chunk}")
+
+asyncio.run(main())
+```
+
+
+## Testing
+
+This module includes comprehensive tests covering:
+- Sync and async non-streaming requests
+- Sync and async streaming requests
+- Response validation
+- Error handling scenarios
+
+See `tests/unified_google_tests/base_google_test.py` for test implementation examples.

--- a/litellm/google_genai/Readme.md
+++ b/litellm/google_genai/Readme.md
@@ -1,0 +1,1 @@
+# Interface to interact with Google GenAI Functions in the native google interface

--- a/litellm/google_genai/__init__.py
+++ b/litellm/google_genai/__init__.py
@@ -1,0 +1,19 @@
+"""
+This allows using Google GenAI model in their native interface.
+
+This module provides generate_content functionality for Google GenAI models.
+"""
+
+from .main import (
+    agenerate_content,
+    agenerate_content_stream,
+    generate_content,
+    generate_content_stream,
+)
+
+__all__ = [
+    "generate_content",
+    "agenerate_content", 
+    "generate_content_stream",
+    "agenerate_content_stream",
+] 

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -1,0 +1,14 @@
+def generate_content():
+    pass
+
+
+async def agenerate_content():
+    pass
+
+
+def generate_content_stream():
+    pass
+
+
+async def agenerate_content_stream():
+    pass

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -9,14 +9,12 @@ from pydantic import BaseModel
 import litellm
 from litellm.constants import request_timeout
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.llms.base_llm.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import ProviderConfigManager, client
-
-from .utils import GoogleGenAIRequestUtils
 
 ####### ENVIRONMENT VARIABLES ###################
 # Initialize any necessary instances or variables here
@@ -131,16 +129,7 @@ class GenerateContentHelper:
             local_vars.update(kwargs)
         
         # Get optional parameters for generate content
-        generate_content_request_params: Dict[str, Any] = (
-            GoogleGenAIRequestUtils.get_optional_params_generate_content(
-                model=model,
-                generate_content_provider_config=generate_content_provider_config,
-                contents=contents,
-                config=config,
-                local_vars=local_vars or kwargs,
-            )
-        )
-
+        generate_content_request_params: Dict[str, Any] = {}
         # Pre Call logging
         if litellm_logging_obj:
             litellm_logging_obj.update_environment_variables(

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -1,14 +1,91 @@
-def generate_content():
-    pass
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union
 
 
-async def agenerate_content():
-    pass
+def generate_content(
+    model: str,
+    contents: Union[str, List[Dict[str, Any]]],
+    config: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> Any:
+    """
+    Generate content using Google GenAI.
+    
+    Args:
+        model: The model name to use for generation
+        contents: The input content (can be string, Content object, or list of Content objects)
+        config: Optional generation configuration
+        **kwargs: Additional parameters
+        
+    Returns:
+        The generated response
+    """
+    # Implementation will be added later
+    raise NotImplementedError("Implementation pending")
 
 
-def generate_content_stream():
-    pass
+async def agenerate_content(
+    model: str,
+    contents: Union[str, List[Dict[str, Any]]],
+    config: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> Any:
+    """
+    Asynchronously generate content using Google GenAI.
+    
+    Args:
+        model: The model name to use for generation
+        contents: The input content (can be string, Content object, or list of Content objects)
+        config: Optional generation configuration
+        **kwargs: Additional parameters
+        
+    Returns:
+        The generated response
+    """
+    # Implementation will be added later
+    raise NotImplementedError("Implementation pending")
 
 
-async def agenerate_content_stream():
-    pass
+def generate_content_stream(
+    model: str,
+    contents: Union[str, List[Dict[str, Any]]],
+    config: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> Iterator[Any]:
+    """
+    Generate content using Google GenAI with streaming response.
+    
+    Args:
+        model: The model name to use for generation
+        contents: The input content (can be string, Content object, or list of Content objects)
+        config: Optional generation configuration
+        **kwargs: Additional parameters
+        
+    Yields:
+        Streamed response chunks
+    """
+    # Implementation will be added later
+    raise NotImplementedError("Implementation pending")
+
+
+async def agenerate_content_stream(
+    model: str,
+    contents: Union[str, List[Dict[str, Any]]],
+    config: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> AsyncIterator[Any]:
+    """
+    Asynchronously generate content using Google GenAI with streaming response.
+    
+    Args:
+        model: The model name to use for generation
+        contents: The input content (can be string, Content object, or list of Content objects)
+        config: Optional generation configuration
+        **kwargs: Additional parameters
+        
+    Yields:
+        Streamed response chunks
+    """
+    # Implementation will be added later
+    if False:  # This will never execute, just to satisfy the type checker
+        yield None  # type: ignore
+    raise NotImplementedError("Implementation pending")

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 from functools import partial
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Iterator, Optional, Union
 
 import httpx
 from pydantic import BaseModel
@@ -13,13 +13,20 @@ from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
-from litellm.types.google_genai.main import (
-    GenerateContentConfigDict,
-    GenerateContentContentListUnionDict,
-)
 from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import ProviderConfigManager, client
 
+if TYPE_CHECKING:
+    from litellm.types.google_genai.main import (
+        GenerateContentConfigDict,
+        GenerateContentContentListUnionDict,
+        GenerateContentResponse,
+    )
+else:
+    GenerateContentConfigDict = Any
+    GenerateContentContentListUnionDict = Any
+    GenerateContentResponse = Any
+    
 ####### ENVIRONMENT VARIABLES ###################
 # Initialize any necessary instances or variables here
 base_llm_http_handler = BaseLLMHTTPHandler()

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 from functools import partial
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, AsyncIterator, Dict, Iterator, Optional, Union
 
 import httpx
 from pydantic import BaseModel
@@ -146,7 +146,7 @@ class GenerateContentHelper:
 
         # Pre Call logging
         if litellm_logging_obj is None:
-            raise ValueError(f"litellm_logging_obj is required, but got None")
+            raise ValueError("litellm_logging_obj is required, but got None")
         
         litellm_logging_obj.update_environment_variables(
             model=model,

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -34,7 +34,7 @@ class GenerateContentSetupResult(BaseModel):
     generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig
     generate_content_config_dict: Dict[str, Any]
     litellm_params: GenericLiteLLMParams
-    litellm_logging_obj: Optional[LiteLLMLoggingObj]
+    litellm_logging_obj: LiteLLMLoggingObj
     litellm_call_id: Optional[str]
 
     class Config:
@@ -145,15 +145,17 @@ class GenerateContentHelper:
         )
 
         # Pre Call logging
-        if litellm_logging_obj:
-            litellm_logging_obj.update_environment_variables(
-                model=model,
-                optional_params=dict(generate_content_config_dict),
-                litellm_params={
-                    "litellm_call_id": litellm_call_id,
-                },
-                custom_llm_provider=custom_llm_provider,
-            )
+        if litellm_logging_obj is None:
+            raise ValueError(f"litellm_logging_obj is required, but got None")
+        
+        litellm_logging_obj.update_environment_variables(
+            model=model,
+            optional_params=dict(generate_content_config_dict),
+            litellm_params={
+                "litellm_call_id": litellm_call_id,
+            },
+            custom_llm_provider=custom_llm_provider,
+        )
 
         return GenerateContentSetupResult(
             model=model,

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -1,91 +1,414 @@
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union
+import asyncio
+import contextvars
+from functools import partial
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Union
+
+import httpx
+from pydantic import BaseModel
+
+import litellm
+from litellm.constants import request_timeout
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.base_llm.google_genai.transformation import (
+    BaseGoogleGenAIGenerateContentConfig,
+)
+from litellm.types.router import GenericLiteLLMParams
+from litellm.utils import ProviderConfigManager, client
+
+from .utils import GoogleGenAIRequestUtils
+
+####### ENVIRONMENT VARIABLES ###################
+# Initialize any necessary instances or variables here
+base_llm_http_handler = BaseLLMHTTPHandler()
+#################################################
 
 
-def generate_content(
-    model: str,
-    contents: Union[str, List[Dict[str, Any]]],
-    config: Optional[Dict[str, Any]] = None,
-    **kwargs
-) -> Any:
-    """
-    Generate content using Google GenAI.
+class GenerateContentSetupResult(BaseModel):
+    """Internal Type - Result of setting up a generate content call"""
+    model: str
+    custom_llm_provider: str
+    generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig
+    generate_content_request_params: Dict[str, Any]
+    litellm_params: GenericLiteLLMParams
+    litellm_logging_obj: Optional[LiteLLMLoggingObj]
+    litellm_call_id: Optional[str]
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class GenerateContentHelper:
+    """Helper class for Google GenAI generate content operations"""
     
-    Args:
-        model: The model name to use for generation
-        contents: The input content (can be string, Content object, or list of Content objects)
-        config: Optional generation configuration
-        **kwargs: Additional parameters
+    @staticmethod
+    def mock_generate_content_response(
+        mock_response: str = "This is a mock response from Google GenAI generate_content.",
+    ) -> Dict[str, Any]:
+        """Mock response for generate_content for testing purposes"""
+        return {
+            "text": mock_response,
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [{"text": mock_response}],
+                        "role": "model"
+                    },
+                    "finishReason": "STOP",
+                    "index": 0,
+                    "safetyRatings": []
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 20,
+                "totalTokenCount": 30
+            }
+        }
+
+    @staticmethod
+    def setup_generate_content_call(
+        model: str,
+        contents: Union[str, List[Dict[str, Any]]],
+        config: Optional[Dict[str, Any]] = None,
+        custom_llm_provider: Optional[str] = None,
+        stream: bool = False,
+        local_vars: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ) -> GenerateContentSetupResult:
+        """
+        Common setup logic for generate_content calls
         
-    Returns:
-        The generated response
-    """
-    # Implementation will be added later
-    raise NotImplementedError("Implementation pending")
+        Args:
+            model: The model name
+            contents: The content to generate from
+            config: Optional configuration
+            custom_llm_provider: Optional custom LLM provider
+            stream: Whether this is a streaming call
+            local_vars: Local variables from the calling function
+            **kwargs: Additional keyword arguments
+            
+        Returns:
+            GenerateContentSetupResult containing all setup information
+        """
+        litellm_logging_obj: Optional[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        
+        # get llm provider logic
+        litellm_params = GenericLiteLLMParams(**kwargs)
+
+        ## MOCK RESPONSE LOGIC (only for non-streaming)
+        if not stream and litellm_params.mock_response and isinstance(litellm_params.mock_response, str):
+            raise ValueError("Mock response should be handled by caller")
+
+        (
+            model,
+            custom_llm_provider,
+            dynamic_api_key,
+            dynamic_api_base,
+        ) = litellm.get_llm_provider(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            api_base=litellm_params.api_base,
+            api_key=litellm_params.api_key,
+        )
+
+        # get provider config
+        generate_content_provider_config: Optional[BaseGoogleGenAIGenerateContentConfig] = (
+            ProviderConfigManager.get_provider_google_genai_generate_content_config(
+                model=model,
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if generate_content_provider_config is None:
+            operation = "streaming" if stream else ""
+            raise ValueError(
+                f"Generate content {operation} is not supported for {custom_llm_provider}".strip()
+            )
+
+        if local_vars:
+            local_vars.update(kwargs)
+        
+        # Get optional parameters for generate content
+        generate_content_request_params: Dict[str, Any] = (
+            GoogleGenAIRequestUtils.get_optional_params_generate_content(
+                model=model,
+                generate_content_provider_config=generate_content_provider_config,
+                contents=contents,
+                config=config,
+                local_vars=local_vars or kwargs,
+            )
+        )
+
+        # Pre Call logging
+        if litellm_logging_obj:
+            litellm_logging_obj.update_environment_variables(
+                model=model,
+                optional_params=dict(generate_content_request_params),
+                litellm_params={
+                    "litellm_call_id": litellm_call_id,
+                    **generate_content_request_params,
+                },
+                custom_llm_provider=custom_llm_provider,
+            )
+
+        return GenerateContentSetupResult(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            generate_content_provider_config=generate_content_provider_config,
+            generate_content_request_params=generate_content_request_params,
+            litellm_params=litellm_params,
+            litellm_logging_obj=litellm_logging_obj,
+            litellm_call_id=litellm_call_id
+        )
 
 
+@client
 async def agenerate_content(
     model: str,
     contents: Union[str, List[Dict[str, Any]]],
     config: Optional[Dict[str, Any]] = None,
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    # LiteLLM specific params,
+    custom_llm_provider: Optional[str] = None,
     **kwargs
 ) -> Any:
     """
-    Asynchronously generate content using Google GenAI.
-    
-    Args:
-        model: The model name to use for generation
-        contents: The input content (can be string, Content object, or list of Content objects)
-        config: Optional generation configuration
-        **kwargs: Additional parameters
-        
-    Returns:
-        The generated response
+    Async: Generate content using Google GenAI
     """
-    # Implementation will be added later
-    raise NotImplementedError("Implementation pending")
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["agenerate_content"] = True
+
+        # get custom llm provider so we can use this for mapping exceptions
+        if custom_llm_provider is None:
+            _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+            )
+
+        func = partial(
+            generate_content,
+            model=model,
+            contents=contents,
+            config=config,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
 
 
-def generate_content_stream(
+@client
+def generate_content(
     model: str,
     contents: Union[str, List[Dict[str, Any]]],
     config: Optional[Dict[str, Any]] = None,
-    **kwargs
-) -> Iterator[Any]:
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    # LiteLLM specific params,
+    custom_llm_provider: Optional[str] = None,
+    **kwargs,
+) -> Any:
     """
-    Generate content using Google GenAI with streaming response.
-    
-    Args:
-        model: The model name to use for generation
-        contents: The input content (can be string, Content object, or list of Content objects)
-        config: Optional generation configuration
-        **kwargs: Additional parameters
+    Generate content using Google GenAI
+    """
+    local_vars = locals()
+    try:
+        _is_async = kwargs.pop("agenerate_content", False) is True
         
-    Yields:
-        Streamed response chunks
-    """
-    # Implementation will be added later
-    raise NotImplementedError("Implementation pending")
+        # Check for mock response first
+        litellm_params = GenericLiteLLMParams(**kwargs)
+        if litellm_params.mock_response and isinstance(litellm_params.mock_response, str):
+            return GenerateContentHelper.mock_generate_content_response(
+                mock_response=litellm_params.mock_response
+            )
+
+        # Setup the call
+        setup_result = GenerateContentHelper.setup_generate_content_call(
+            model=model,
+            contents=contents,
+            config=config,
+            custom_llm_provider=custom_llm_provider,
+            stream=False,
+            local_vars=local_vars,
+            **kwargs
+        )
+
+        # Call the handler
+        response = base_llm_http_handler.generate_content_handler(
+            model=setup_result.model,
+            contents=contents,
+            generate_content_provider_config=setup_result.generate_content_provider_config,
+            generate_content_request_params=setup_result.generate_content_request_params,
+            custom_llm_provider=setup_result.custom_llm_provider,
+            litellm_params=setup_result.litellm_params,
+            logging_obj=setup_result.litellm_logging_obj,
+            extra_headers=extra_headers,
+            extra_body=extra_body,
+            timeout=timeout or request_timeout,
+            _is_async=_is_async,
+            client=kwargs.get("client"),
+            stream=False,
+            litellm_metadata=kwargs.get("litellm_metadata", {}),
+        )
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
 
 
+@client
 async def agenerate_content_stream(
     model: str,
     contents: Union[str, List[Dict[str, Any]]],
     config: Optional[Dict[str, Any]] = None,
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    # LiteLLM specific params,
+    custom_llm_provider: Optional[str] = None,
     **kwargs
 ) -> AsyncIterator[Any]:
     """
-    Asynchronously generate content using Google GenAI with streaming response.
-    
-    Args:
-        model: The model name to use for generation
-        contents: The input content (can be string, Content object, or list of Content objects)
-        config: Optional generation configuration
-        **kwargs: Additional parameters
-        
-    Yields:
-        Streamed response chunks
+    Async: Generate content using Google GenAI with streaming response
     """
-    # Implementation will be added later
-    if False:  # This will never execute, just to satisfy the type checker
-        yield None  # type: ignore
-    raise NotImplementedError("Implementation pending")
+    local_vars = locals()
+    try:
+        # Get the streaming generator from the sync version
+        kwargs["agenerate_content_stream"] = True
+        
+        # get custom llm provider so we can use this for mapping exceptions
+        if custom_llm_provider is None:
+            _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                model=model, api_base=local_vars.get("base_url", None)
+            )
+
+        # Call the sync streaming version to get the generator
+        stream_response = generate_content_stream(
+            model=model,
+            contents=contents,
+            config=config,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            **kwargs,
+        )
+
+        # Convert the sync generator to async
+        for chunk in stream_response:
+            yield chunk
+            
+    except Exception as e:
+        raise litellm.exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+@client
+def generate_content_stream(
+    model: str,
+    contents: Union[str, List[Dict[str, Any]]],
+    config: Optional[Dict[str, Any]] = None,
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+    # LiteLLM specific params,
+    custom_llm_provider: Optional[str] = None,
+    **kwargs,
+) -> Iterator[Any]:
+    """
+    Generate content using Google GenAI with streaming response
+    """
+    local_vars = locals()
+    try:
+        _is_async = kwargs.pop("agenerate_content_stream", False) is True
+
+        # Setup the call
+        setup_result = GenerateContentHelper.setup_generate_content_call(
+            model=model,
+            contents=contents,
+            config=config,
+            custom_llm_provider=custom_llm_provider,
+            stream=True,
+            local_vars=local_vars,
+            **kwargs
+        )
+
+        # Call the handler with streaming enabled
+        return base_llm_http_handler.generate_content_handler(
+            model=setup_result.model,
+            contents=contents,
+            generate_content_provider_config=setup_result.generate_content_provider_config,
+            generate_content_request_params=setup_result.generate_content_request_params,
+            custom_llm_provider=setup_result.custom_llm_provider,
+            litellm_params=setup_result.litellm_params,
+            logging_obj=setup_result.litellm_logging_obj,
+            extra_headers=extra_headers,
+            extra_body=extra_body,
+            timeout=timeout or request_timeout,
+            _is_async=_is_async,
+            client=kwargs.get("client"),
+            stream=True,
+            litellm_metadata=kwargs.get("litellm_metadata", {}),
+        )
+
+    except Exception as e:
+        raise litellm.exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+    

--- a/litellm/google_genai/streaming_iterator.py
+++ b/litellm/google_genai/streaming_iterator.py
@@ -1,0 +1,116 @@
+import asyncio
+import json
+from datetime import datetime
+from typing import Any, AsyncIterator, Iterator, List, Optional, Union
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.google_genai.transformation import (
+    BaseGoogleGenAIGenerateContentConfig,
+)
+from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
+
+
+class BaseGoogleGenAIGenerateContentStreamingIterator:
+    """
+    Base class for Google GenAI Generate Content streaming iterators that provides common logic
+    for streaming response handling and logging.
+    """
+
+    def __init__(
+        self,
+        litellm_logging_obj: LiteLLMLoggingObj,
+        request_body: dict,
+    ):
+        self.litellm_logging_obj = litellm_logging_obj
+        self.request_body = request_body
+        self.start_time = datetime.now()
+
+    async def _handle_streaming_logging(self, collected_chunks: List[bytes]):
+        """Handle the logging after all chunks have been collected."""
+        pass
+
+
+class GoogleGenAIGenerateContentStreamingIterator(BaseGoogleGenAIGenerateContentStreamingIterator):
+    """
+    Streaming iterator specifically for Google GenAI generate content API.
+    """
+
+    def __init__(
+        self,
+        response,
+        model: str,
+        logging_obj: LiteLLMLoggingObj,
+        generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig,
+        litellm_metadata: dict,
+        custom_llm_provider: str,
+        request_body: Optional[dict] = None,
+    ):
+        super().__init__(
+            litellm_logging_obj=logging_obj,
+            request_body=request_body or {},
+        )
+        self.response = response
+        self.model = model
+        self.generate_content_provider_config = generate_content_provider_config
+        self.litellm_metadata = litellm_metadata
+        self.custom_llm_provider = custom_llm_provider
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            chunk = next(self.response.iter_lines())
+            # Just yield raw bytes
+            return chunk
+        except StopIteration:
+            raise StopIteration
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            chunk = await self.response.__anext__()
+            # Just yield raw bytes
+            return chunk
+        except StopAsyncIteration:
+            raise StopAsyncIteration
+
+
+class AsyncGoogleGenAIGenerateContentStreamingIterator(BaseGoogleGenAIGenerateContentStreamingIterator):
+    """
+    Async streaming iterator specifically for Google GenAI generate content API.
+    """
+
+    def __init__(
+        self,
+        response,
+        model: str,
+        logging_obj: LiteLLMLoggingObj,
+        generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig,
+        litellm_metadata: dict,
+        custom_llm_provider: str,
+        request_body: Optional[dict] = None,
+    ):
+        super().__init__(
+            litellm_logging_obj=logging_obj,
+            request_body=request_body or {},
+        )
+        self.response = response
+        self.model = model
+        self.generate_content_provider_config = generate_content_provider_config
+        self.litellm_metadata = litellm_metadata
+        self.custom_llm_provider = custom_llm_provider
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            async for chunk in self.response.aiter_lines():
+                # Just yield raw bytes
+                return chunk
+            raise StopAsyncIteration
+        except StopAsyncIteration:
+            raise StopAsyncIteration 

--- a/litellm/google_genai/streaming_iterator.py
+++ b/litellm/google_genai/streaming_iterator.py
@@ -1,7 +1,5 @@
-import asyncio
-import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -48,14 +48,44 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         Returns:
             List of supported parameter names
         """
-        pass
+        return [
+            "http_options",
+            "system_instruction", 
+            "temperature",
+            "top_p",
+            "top_k",
+            "candidate_count",
+            "max_output_tokens",
+            "stop_sequences",
+            "response_logprobs",
+            "logprobs",
+            "presence_penalty",
+            "frequency_penalty",
+            "seed",
+            "response_mime_type",
+            "response_schema",
+            "routing_config",
+            "model_selection_config",
+            "safety_settings",
+            "tools",
+            "tool_config",
+            "labels",
+            "cached_content",
+            "response_modalities",
+            "media_resolution",
+            "speech_config",
+            "audio_timestamp",
+            "automatic_function_calling",
+            "thinking_config"
+        ]
+
 
     @abstractmethod
     def map_generate_content_optional_params(
         self,
         generate_content_optional_params: Dict[str, Any],
         model: str,
-    ) -> Dict[str, Any]:
+    ) -> GenerateContentConfigDict:
         """
         Map Google GenAI parameters to provider-specific format.
 
@@ -66,7 +96,12 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         Returns:
             Mapped parameters for the provider
         """
-        pass
+        generate_content_config_dict = GenerateContentConfigDict()
+        supported_google_genai_params = self.get_supported_generate_content_optional_params(model)
+        for param, value in generate_content_optional_params.items():
+            if param in supported_google_genai_params:
+                generate_content_config_dict[param] = value
+        return generate_content_config_dict
 
     @abstractmethod
     def validate_environment(

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -1,6 +1,6 @@
 import types
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
@@ -48,36 +48,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         Returns:
             List of supported parameter names
         """
-        return [
-            "http_options",
-            "system_instruction", 
-            "temperature",
-            "top_p",
-            "top_k",
-            "candidate_count",
-            "max_output_tokens",
-            "stop_sequences",
-            "response_logprobs",
-            "logprobs",
-            "presence_penalty",
-            "frequency_penalty",
-            "seed",
-            "response_mime_type",
-            "response_schema",
-            "routing_config",
-            "model_selection_config",
-            "safety_settings",
-            "tools",
-            "tool_config",
-            "labels",
-            "cached_content",
-            "response_modalities",
-            "media_resolution",
-            "speech_config",
-            "audio_timestamp",
-            "automatic_function_calling",
-            "thinking_config"
-        ]
+        raise NotImplementedError("get_supported_generate_content_optional_params is not implemented")
 
 
     @abstractmethod
@@ -96,12 +67,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         Returns:
             Mapped parameters for the provider
         """
-        generate_content_config_dict = GenerateContentConfigDict()
-        supported_google_genai_params = self.get_supported_generate_content_optional_params(model)
-        for param, value in generate_content_optional_params.items():
-            if param in supported_google_genai_params:
-                generate_content_config_dict[param] = value
-        return generate_content_config_dict
+        raise NotImplementedError("map_generate_content_optional_params is not implemented")
 
     @abstractmethod
     def validate_environment(
@@ -124,14 +90,14 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
             Updated headers
         """
         raise NotImplementedError("validate_environment is not implemented")
-
-    @abstractmethod
-    def get_complete_url(
+    
+    async def get_auth_token_and_url(
         self,
         api_base: Optional[str],
         model: str,
         litellm_params: dict,
-    ) -> str:
+        stream: bool,
+    ) -> Tuple[dict, str]:
         """
         Get the complete URL for the request.
 
@@ -141,11 +107,9 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
             litellm_params: LiteLLM parameters
 
         Returns:
-            Complete URL for the API request
+            Tuple of headers and API base
         """
-        if api_base is None:
-            raise ValueError("api_base is required")
-        return api_base
+        raise NotImplementedError("get_auth_token_and_url is not implemented")
 
     @abstractmethod
     def transform_generate_content_request(
@@ -186,24 +150,6 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
 
         Returns:
             Transformed response data
-        """
-        pass
-
-    @abstractmethod
-    def transform_streaming_response(
-        self,
-        model: str,
-        parsed_chunk: dict,
-    ) -> Dict[str, Any]:
-        """
-        Transform a parsed streaming response chunk.
-
-        Args:
-            model: The model name
-            parsed_chunk: Parsed chunk data
-
-        Returns:
-            Transformed chunk data
         """
         pass
 

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -65,12 +65,17 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
 
     @abstractmethod
     def validate_environment(
-        self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]
+        self, 
+        api_key: Optional[str],
+        headers: Optional[dict],
+        model: str,
+        litellm_params: Optional[Union[GenericLiteLLMParams, dict]]
     ) -> dict:
         """
         Validate the environment and return headers for the request.
 
         Args:
+            api_key: API key
             headers: Existing headers
             model: The model name
             litellm_params: LiteLLM parameters
@@ -78,7 +83,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         Returns:
             Updated headers
         """
-        return headers
+        raise NotImplementedError("validate_environment is not implemented")
 
     @abstractmethod
     def get_complete_url(

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -1,0 +1,185 @@
+import types
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from litellm.types.router import GenericLiteLLMParams
+
+
+class BaseGoogleGenAIGenerateContentConfig(ABC):
+    """Base configuration class for Google GenAI generate_content functionality"""
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_config(cls):
+        return {
+            k: v
+            for k, v in cls.__dict__.items()
+            if not k.startswith("__")
+            and not k.startswith("_abc")
+            and not isinstance(
+                v,
+                (
+                    types.FunctionType,
+                    types.BuiltinFunctionType,
+                    classmethod,
+                    staticmethod,
+                ),
+            )
+            and v is not None
+        }
+
+    @abstractmethod
+    def get_supported_generate_content_optional_params(self, model: str) -> List[str]:
+        """
+        Get the list of supported Google GenAI parameters for the model.
+
+        Args:
+            model: The model name
+
+        Returns:
+            List of supported parameter names
+        """
+        pass
+
+    @abstractmethod
+    def map_generate_content_optional_params(
+        self,
+        generate_content_optional_params: Dict[str, Any],
+        model: str,
+    ) -> Dict[str, Any]:
+        """
+        Map Google GenAI parameters to provider-specific format.
+
+        Args:
+            generate_content_optional_params: Optional parameters for generate content
+            model: The model name
+
+        Returns:
+            Mapped parameters for the provider
+        """
+        pass
+
+    @abstractmethod
+    def validate_environment(
+        self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]
+    ) -> dict:
+        """
+        Validate the environment and return headers for the request.
+
+        Args:
+            headers: Existing headers
+            model: The model name
+            litellm_params: LiteLLM parameters
+
+        Returns:
+            Updated headers
+        """
+        return headers
+
+    @abstractmethod
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        model: str,
+        litellm_params: dict,
+    ) -> str:
+        """
+        Get the complete URL for the request.
+
+        Args:
+            api_base: Base API URL
+            model: The model name
+            litellm_params: LiteLLM parameters
+
+        Returns:
+            Complete URL for the API request
+        """
+        if api_base is None:
+            raise ValueError("api_base is required")
+        return api_base
+
+    @abstractmethod
+    def transform_generate_content_request(
+        self,
+        model: str,
+        contents: Union[str, List[Dict[str, Any]]],
+        generate_content_request_params: Dict[str, Any],
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Dict[str, Any]:
+        """
+        Transform the request parameters for the generate content API.
+
+        Args:
+            model: The model name
+            contents: Input contents
+            generate_content_request_params: Request parameters
+            litellm_params: LiteLLM parameters
+            headers: Request headers
+
+        Returns:
+            Transformed request data
+        """
+        pass
+
+    @abstractmethod
+    def transform_generate_content_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+    ) -> Dict[str, Any]:
+        """
+        Transform the raw response from the generate content API.
+
+        Args:
+            model: The model name
+            raw_response: Raw HTTP response
+
+        Returns:
+            Transformed response data
+        """
+        pass
+
+    @abstractmethod
+    def transform_streaming_response(
+        self,
+        model: str,
+        parsed_chunk: dict,
+    ) -> Dict[str, Any]:
+        """
+        Transform a parsed streaming response chunk.
+
+        Args:
+            model: The model name
+            parsed_chunk: Parsed chunk data
+
+        Returns:
+            Transformed chunk data
+        """
+        pass
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> Exception:
+        """
+        Get the appropriate exception class for the error.
+
+        Args:
+            error_message: Error message
+            status_code: HTTP status code
+            headers: Response headers
+
+        Returns:
+            Exception instance
+        """
+        from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+        return BaseLLMException(
+            status_code=status_code,
+            message=error_message,
+            headers=headers,
+        )

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
+from litellm.types.google_genai.main import GenerateContentResponse
 from litellm.types.router import GenericLiteLLMParams
 
 
@@ -136,7 +137,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         self,
         model: str,
         raw_response: httpx.Response,
-    ) -> Dict[str, Any]:
+    ) -> GenerateContentResponse:
         """
         Transform the raw response from the generate content API.
 

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -91,6 +91,27 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         """
         raise NotImplementedError("validate_environment is not implemented")
     
+    def sync_get_auth_token_and_url(
+        self,
+        api_base: Optional[str],
+        model: str,
+        litellm_params: dict,
+        stream: bool,
+    ) -> Tuple[dict, str]:
+        """
+        Sync version of get_auth_token_and_url.
+
+        Args:
+            api_base: Base API URL
+            model: The model name
+            litellm_params: LiteLLM parameters
+            stream: Whether this is a streaming call
+
+        Returns:
+            Tuple of headers and API base
+        """
+        raise NotImplementedError("sync_get_auth_token_and_url is not implemented")
+    
     async def get_auth_token_and_url(
         self,
         api_base: Optional[str],

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -1,14 +1,20 @@
 import types
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
-from litellm.types.google_genai.main import (
-    GenerateContentConfigDict,
-    GenerateContentContentListUnionDict,
-    GenerateContentResponse,
-)
+if TYPE_CHECKING:
+    from litellm.types.google_genai.main import (
+        GenerateContentConfigDict,
+        GenerateContentContentListUnionDict,
+        GenerateContentResponse,
+    )
+else:
+    GenerateContentConfigDict = Any
+    GenerateContentContentListUnionDict = Any
+    GenerateContentResponse = Any
+    
 from litellm.types.router import GenericLiteLLMParams
 
 

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -54,9 +54,9 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
     @abstractmethod
     def map_generate_content_optional_params(
         self,
-        generate_content_optional_params: Dict[str, Any],
+        generate_content_config_dict: GenerateContentConfigDict,
         model: str,
-    ) -> GenerateContentConfigDict:
+    ) -> Dict[str, Any]:
         """
         Map Google GenAI parameters to provider-specific format.
 
@@ -116,9 +116,7 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         self,
         model: str,
         contents: GenerateContentContentListUnionDict,
-        generate_content_config_dict: GenerateContentConfigDict,
-        litellm_params: GenericLiteLLMParams,
-        headers: dict,
+        generate_content_config_dict: Dict,
     ) -> dict:
         """
         Transform the request parameters for the generate content API.

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
-from litellm.types.google_genai.main import GenerateContentResponse
+from litellm.types.google_genai.main import (
+    GenerateContentConfigDict,
+    GenerateContentContentListUnionDict,
+    GenerateContentResponse,
+)
 from litellm.types.router import GenericLiteLLMParams
 
 
@@ -112,11 +116,11 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
     def transform_generate_content_request(
         self,
         model: str,
-        contents: Union[str, List[Dict[str, Any]]],
-        generate_content_request_params: Dict[str, Any],
+        contents: GenerateContentContentListUnionDict,
+        generate_content_config_dict: GenerateContentConfigDict,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
-    ) -> Dict[str, Any]:
+    ) -> dict:
         """
         Transform the request parameters for the generate content API.
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2887,4 +2887,19 @@ class BaseLLMHTTPHandler:
         return vector_store_provider_config.transform_create_vector_store_response(
             response=response,
         )
+    
+    #####################################################################
+    ################ Google GenAI GENERATE CONTENT HANDLER ###########################
+    #####################################################################
+    def generate_content_handler(
+        self,
+        **kwargs,
+    ) -> Any:
+        pass
+    
 
+    async def async_generate_content_handler(
+        self,
+        **kwargs,
+    ) -> Any:
+        pass

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -20,10 +20,6 @@ import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
 from litellm._logging import verbose_logger
-from litellm.google_genai.streaming_iterator import (
-    AsyncGoogleGenAIGenerateContentStreamingIterator,
-    GoogleGenAIGenerateContentStreamingIterator,
-)
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
@@ -2919,6 +2915,10 @@ class BaseLLMHTTPHandler:
         Handles Google GenAI generate content requests.
         When _is_async=True, returns a coroutine instead of making the call directly.
         """
+        from litellm.google_genai.streaming_iterator import (
+            GoogleGenAIGenerateContentStreamingIterator,
+        )
+        
         if _is_async:
             return self.async_generate_content_handler(
                 model=model,
@@ -3032,6 +3032,10 @@ class BaseLLMHTTPHandler:
         Async version of the generate content handler.
         Uses async HTTP client to make requests.
         """
+        from litellm.google_genai.streaming_iterator import (
+            AsyncGoogleGenAIGenerateContentStreamingIterator,
+        )
+
         if client is None or not isinstance(client, AsyncHTTPHandler):
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -20,6 +20,10 @@ import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
 from litellm._logging import verbose_logger
+from litellm.google_genai.streaming_iterator import (
+    AsyncGoogleGenAIGenerateContentStreamingIterator,
+    GoogleGenAIGenerateContentStreamingIterator,
+)
 from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
@@ -2980,12 +2984,16 @@ class BaseLLMHTTPHandler:
                     timeout=timeout,
                     stream=True,
                 )
-                # Return streaming iterator from provider config
-                # return generate_content_provider_config.get_generate_content_stream_iterator(
-                #     response=response,
-                #     model=model,
-                #     logging_obj=logging_obj,
-                # )
+                # Return streaming iterator
+                return GoogleGenAIGenerateContentStreamingIterator(
+                    response=response,
+                    model=model,
+                    logging_obj=logging_obj,
+                    generate_content_provider_config=generate_content_provider_config,
+                    litellm_metadata=litellm_metadata or {},
+                    custom_llm_provider=custom_llm_provider,
+                    request_body=data,
+                )
             else:
                 response = sync_httpx_client.post(
                     url=api_base,
@@ -3073,12 +3081,16 @@ class BaseLLMHTTPHandler:
                     timeout=timeout,
                     stream=True,
                 )
-                # Return async streaming iterator from provider config
-                # return generate_content_provider_config.get_async_generate_content_stream_iterator(
-                #     response=response,
-                #     model=model,
-                #     logging_obj=logging_obj,
-                # )
+                # Return async streaming iterator
+                return AsyncGoogleGenAIGenerateContentStreamingIterator(
+                    response=response,
+                    model=model,
+                    logging_obj=logging_obj,
+                    generate_content_provider_config=generate_content_provider_config,
+                    litellm_metadata=litellm_metadata or {},
+                    custom_llm_provider=custom_llm_provider,
+                    request_body=data,
+                )
             else:
                 response = await async_httpx_client.post(
                     url=api_base,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -31,6 +31,9 @@ from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
 from litellm.llms.base_llm.chat.transformation import BaseConfig
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.llms.base_llm.files.transformation import BaseFilesConfig
+from litellm.llms.base_llm.google_genai.transformation import (
+    BaseGoogleGenAIGenerateContentConfig,
+)
 from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
@@ -2349,7 +2352,7 @@ class BaseLLMHTTPHandler:
         self,
         e: Exception,
         provider_config: Union[
-            BaseConfig, BaseRerankConfig, BaseResponsesAPIConfig, BaseImageEditConfig, BaseVectorStoreConfig
+            BaseConfig, BaseRerankConfig, BaseResponsesAPIConfig, BaseImageEditConfig, BaseVectorStoreConfig, BaseGoogleGenAIGenerateContentConfig
         ],
     ):
         status_code = getattr(e, "status_code", 500)
@@ -2893,13 +2896,203 @@ class BaseLLMHTTPHandler:
     #####################################################################
     def generate_content_handler(
         self,
-        **kwargs,
+        model: str,
+        contents: Any,
+        generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig,
+        generate_content_config_dict: Dict,
+        custom_llm_provider: str,
+        litellm_params: GenericLiteLLMParams,
+        logging_obj: LiteLLMLoggingObj,
+        extra_headers: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+        _is_async: bool = False,
+        client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
+        stream: bool = False,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        pass
-    
+        """
+        Handles Google GenAI generate content requests.
+        When _is_async=True, returns a coroutine instead of making the call directly.
+        """
+        if _is_async:
+            return self.async_generate_content_handler(
+                model=model,
+                contents=contents,
+                generate_content_provider_config=generate_content_provider_config,
+                generate_content_config_dict=generate_content_config_dict,
+                custom_llm_provider=custom_llm_provider,
+                litellm_params=litellm_params,
+                logging_obj=logging_obj,
+                extra_headers=extra_headers,
+                extra_body=extra_body,
+                timeout=timeout,
+                client=client if isinstance(client, AsyncHTTPHandler) else None,
+                stream=stream,
+                litellm_metadata=litellm_metadata,
+            )
+
+        if client is None or not isinstance(client, HTTPHandler):
+            sync_httpx_client = _get_httpx_client(
+                params={"ssl_verify": litellm_params.get("ssl_verify", None)}
+            )
+        else:
+            sync_httpx_client = client
+
+        # Get headers and URL from the provider config
+        headers, api_base = generate_content_provider_config.sync_get_auth_token_and_url(
+            api_base=litellm_params.api_base,
+            model=model,
+            litellm_params=dict(litellm_params),
+            stream=stream,
+        )
+
+        if extra_headers:
+            headers.update(extra_headers)
+
+        # Get the request body from the provider config
+        data = generate_content_provider_config.transform_generate_content_request(
+            model=model,
+            contents=contents,
+            generate_content_config_dict=generate_content_config_dict,
+        )
+
+        if extra_body:
+            data.update(extra_body)
+
+        ## LOGGING
+        logging_obj.pre_call(
+            input=contents,
+            api_key="",
+            additional_args={
+                "complete_input_dict": data,
+                "api_base": api_base,
+                "headers": headers,
+            },
+        )
+
+        try:
+            if stream:
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                    stream=True,
+                )
+                # Return streaming iterator from provider config
+                # return generate_content_provider_config.get_generate_content_stream_iterator(
+                #     response=response,
+                #     model=model,
+                #     logging_obj=logging_obj,
+                # )
+            else:
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                )
+        except Exception as e:
+            raise self._handle_error(
+                e=e,
+                provider_config=generate_content_provider_config,
+            )
+
+        return generate_content_provider_config.transform_generate_content_response(
+            model=model,
+            raw_response=response,
+        )
 
     async def async_generate_content_handler(
         self,
-        **kwargs,
+        model: str,
+        contents: Any,
+        generate_content_provider_config: BaseGoogleGenAIGenerateContentConfig,
+        generate_content_config_dict: Dict,
+        custom_llm_provider: str,
+        litellm_params: GenericLiteLLMParams,
+        logging_obj: LiteLLMLoggingObj,
+        extra_headers: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
+        client: Optional[AsyncHTTPHandler] = None,
+        stream: bool = False,
+        litellm_metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        pass
+        """
+        Async version of the generate content handler.
+        Uses async HTTP client to make requests.
+        """
+        if client is None or not isinstance(client, AsyncHTTPHandler):
+            async_httpx_client = get_async_httpx_client(
+                llm_provider=litellm.LlmProviders(custom_llm_provider),
+                params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+            )
+        else:
+            async_httpx_client = client
+
+        # Get headers and URL from the provider config
+        headers, api_base = await generate_content_provider_config.get_auth_token_and_url(
+            model=model,
+            litellm_params=dict(litellm_params),
+            stream=stream, 
+            api_base=litellm_params.api_base,
+        )
+
+        if extra_headers:
+            headers.update(extra_headers)
+
+        # Get the request body from the provider config
+        data = generate_content_provider_config.transform_generate_content_request(
+            model=model,
+            contents=contents,
+            generate_content_config_dict=generate_content_config_dict,
+        )
+
+        if extra_body:
+            data.update(extra_body)
+
+        ## LOGGING
+        logging_obj.pre_call(
+            input=contents,
+            api_key="",
+            additional_args={
+                "complete_input_dict": data,
+                "api_base": api_base,
+                "headers": headers,
+            },
+        )
+
+        try:
+            if stream:
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                    stream=True,
+                )
+                # Return async streaming iterator from provider config
+                # return generate_content_provider_config.get_async_generate_content_stream_iterator(
+                #     response=response,
+                #     model=model,
+                #     logging_obj=logging_obj,
+                # )
+            else:
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                )
+        except Exception as e:
+            raise self._handle_error(
+                e=e,
+                provider_config=generate_content_provider_config,
+            )
+
+        return generate_content_provider_config.transform_generate_content_response(
+            model=model,
+            raw_response=response,
+        )

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -32,6 +32,70 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         super().__init__()
         VertexLLM.__init__(self)
     
+    def get_supported_generate_content_optional_params(self, model: str) -> List[str]:
+        """
+        Get the list of supported Google GenAI parameters for the model.
+
+        Args:
+            model: The model name
+
+        Returns:
+            List of supported parameter names
+        """
+        return [
+            "http_options",
+            "system_instruction", 
+            "temperature",
+            "top_p",
+            "top_k",
+            "candidate_count",
+            "max_output_tokens",
+            "stop_sequences",
+            "response_logprobs",
+            "logprobs",
+            "presence_penalty",
+            "frequency_penalty",
+            "seed",
+            "response_mime_type",
+            "response_schema",
+            "routing_config",
+            "model_selection_config",
+            "safety_settings",
+            "tools",
+            "tool_config",
+            "labels",
+            "cached_content",
+            "response_modalities",
+            "media_resolution",
+            "speech_config",
+            "audio_timestamp",
+            "automatic_function_calling",
+            "thinking_config"
+        ]
+
+
+    def map_generate_content_optional_params(
+        self,
+        generate_content_optional_params: Dict[str, Any],
+        model: str,
+    ) -> GenerateContentConfigDict:
+        """
+        Map Google GenAI parameters to provider-specific format.
+
+        Args:
+            generate_content_optional_params: Optional parameters for generate content
+            model: The model name
+
+        Returns:
+            Mapped parameters for the provider
+        """
+        generate_content_config_dict = GenerateContentConfigDict()
+        supported_google_genai_params = self.get_supported_generate_content_optional_params(model)
+        for param, value in generate_content_optional_params.items():
+            if param in supported_google_genai_params:
+                generate_content_config_dict[param] = value
+        return generate_content_config_dict
+    
     def validate_environment(
         self, 
         api_key: Optional[str],
@@ -74,7 +138,7 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             litellm_params: LiteLLM parameters
 
         Returns:
-            Complete URL for the API request
+            Tuple of headers and API base
         """
 
         vertex_credentials = self.get_vertex_ai_credentials(litellm_params)

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -76,9 +76,9 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
 
     def map_generate_content_optional_params(
         self,
-        generate_content_optional_params: Dict[str, Any],
+        generate_content_config_dict: GenerateContentConfigDict,
         model: str,
-    ) -> GenerateContentConfigDict:
+    ) -> Dict[str, Any]:
         """
         Map Google GenAI parameters to provider-specific format.
 
@@ -89,12 +89,12 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         Returns:
             Mapped parameters for the provider
         """
-        generate_content_config_dict = GenerateContentConfigDict()
+        _generate_content_config_dict = GenerateContentConfigDict()
         supported_google_genai_params = self.get_supported_generate_content_optional_params(model)
-        for param, value in generate_content_optional_params.items():
+        for param, value in generate_content_config_dict.items():
             if param in supported_google_genai_params:
-                generate_content_config_dict[param] = value
-        return generate_content_config_dict
+                _generate_content_config_dict[param] = value
+        return dict(_generate_content_config_dict)
     
     def validate_environment(
         self, 
@@ -178,15 +178,13 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         self,
         model: str,
         contents: GenerateContentContentListUnionDict,
-        generate_content_config_dict: GenerateContentConfigDict,
-        litellm_params: GenericLiteLLMParams,
-        headers: dict,
+        generate_content_config_dict: Dict,
     ) -> dict:
 
         typed_generate_content_request = GenerateContentRequestDict(
             model=model,
             contents=contents,
-            config=generate_content_config_dict,
+            config=GenerateContentConfigDict(**generate_content_config_dict),
         )
 
         request_dict = cast(dict, typed_generate_content_request)

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -1,7 +1,7 @@
 """
 Transformation for Calling Google models in their native format.
 """
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import httpx
 
@@ -11,13 +11,18 @@ from litellm.llms.base_llm.google_genai.transformation import (
 )
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.google_genai.main import (
-    GenerateContentConfigDict,
-    GenerateContentContentListUnionDict,
-    GenerateContentRequestDict,
-    GenerateContentResponse,
-)
 from litellm.types.router import GenericLiteLLMParams
+
+if TYPE_CHECKING:
+    from litellm.types.google_genai.main import (
+        GenerateContentConfigDict,
+        GenerateContentContentListUnionDict,
+        GenerateContentResponse,
+    )
+else:
+    GenerateContentConfigDict = Any
+    GenerateContentContentListUnionDict = Any
+    GenerateContentResponse = Any
 
 
 class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
@@ -89,6 +94,7 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         Returns:
             Mapped parameters for the provider
         """
+        from litellm.types.google_genai.main import GenerateContentConfigDict
         _generate_content_config_dict = GenerateContentConfigDict()
         supported_google_genai_params = self.get_supported_generate_content_optional_params(model)
         for param, value in generate_content_config_dict.items():
@@ -247,7 +253,10 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         contents: GenerateContentContentListUnionDict,
         generate_content_config_dict: Dict,
     ) -> dict:
-
+        from litellm.types.google_genai.main import (
+            GenerateContentConfigDict,
+            GenerateContentRequestDict,
+        )
         typed_generate_content_request = GenerateContentRequestDict(
             model=model,
             contents=contents,
@@ -273,6 +282,7 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         Returns:
             Transformed response data
         """
+        from litellm.types.google_genai.main import GenerateContentResponse
         try:
             response = raw_response.json()
         except Exception as e:

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -1,0 +1,102 @@
+"""
+Transformation for Calling Google models in their native format.
+"""
+from typing import Literal, Optional, Tuple, Union
+
+import litellm
+from litellm.llms.base_llm.google_genai.transformation import (
+    BaseGoogleGenAIGenerateContentConfig,
+)
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.router import GenericLiteLLMParams
+
+
+class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
+    """
+    Configuration for calling Google models in their native format.
+    """
+    @property
+    def custom_llm_provider(self) -> Literal["gemini"]:
+        return "gemini"
+    
+    def __init__(self):
+        super().__init__()
+        VertexLLM.__init__(self)
+    
+    def validate_environment(
+        self, 
+        api_key: Optional[str],
+        headers: Optional[dict],
+        model: str,
+        litellm_params: Optional[Union[GenericLiteLLMParams, dict]]
+    ) -> dict:
+        default_headers = {
+            "Content-Type": "application/json",
+        }
+        if api_key is not None:
+            default_headers["Authorization"] = f"Bearer {api_key}"
+        if headers is not None:
+            default_headers.update(headers)
+
+        return default_headers
+
+    def _get_google_ai_studio_api_key(self, litellm_params: dict) -> Optional[str]:
+        return (
+            litellm_params.pop("api_key", None)
+            or litellm_params.pop("gemini_api_key", None)
+            or get_secret_str("GEMINI_API_KEY")
+            or litellm.api_key
+        )
+
+
+    async def get_auth_token_and_url(
+        self,
+        api_base: Optional[str],
+        model: str,
+        litellm_params: dict,
+        stream: bool,
+    ) -> Tuple[dict, str]:
+        """
+        Get the complete URL for the request.
+
+        Args:
+            api_base: Base API URL
+            model: The model name
+            litellm_params: LiteLLM parameters
+
+        Returns:
+            Complete URL for the API request
+        """
+
+        vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
+        vertex_project = self.get_vertex_ai_project(litellm_params)
+        vertex_location = self.get_vertex_ai_location(litellm_params)
+
+        _auth_header, vertex_project = await self._ensure_access_token_async(
+            credentials=vertex_credentials,
+            project_id=vertex_project,
+            custom_llm_provider=self.custom_llm_provider,
+        )
+
+        auth_header, api_base = self._get_token_and_url(
+            model=model,
+            gemini_api_key=self._get_google_ai_studio_api_key(litellm_params),
+            auth_header=_auth_header,
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            vertex_credentials=vertex_credentials,
+            stream=stream,
+            custom_llm_provider=self.custom_llm_provider,
+            api_base=api_base,
+            should_use_v1beta1_features=True,
+        )
+
+        headers = self.validate_environment(
+            api_key=auth_header,
+            headers=None,
+            model=model,
+            litellm_params=litellm_params,
+        )
+
+        return headers, api_base

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -1,7 +1,7 @@
 """
 Transformation for Calling Google models in their native format.
 """
-from typing import Any, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
 import httpx
 
@@ -11,7 +11,12 @@ from litellm.llms.base_llm.google_genai.transformation import (
 )
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.google_genai.main import GenerateContentResponse
+from litellm.types.google_genai.main import (
+    GenerateContentConfigDict,
+    GenerateContentContentListUnionDict,
+    GenerateContentRequestDict,
+    GenerateContentResponse,
+)
 from litellm.types.router import GenericLiteLLMParams
 
 
@@ -103,6 +108,26 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         )
 
         return headers, api_base
+    
+
+    def transform_generate_content_request(
+        self,
+        model: str,
+        contents: GenerateContentContentListUnionDict,
+        generate_content_config_dict: GenerateContentConfigDict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> dict:
+
+        typed_generate_content_request = GenerateContentRequestDict(
+            model=model,
+            contents=contents,
+            config=generate_content_config_dict,
+        )
+
+        request_dict = cast(dict, typed_generate_content_request)
+
+        return request_dict
     
     def transform_generate_content_response(
         self,

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -28,25 +28,9 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         Validate the environment for the request
         """
         if "Authorization" not in headers:
-            vertex_ai_project = (
-                litellm_params.pop("vertex_project", None)
-                or litellm_params.pop("vertex_ai_project", None)
-                or litellm.vertex_project
-                or get_secret_str("VERTEXAI_PROJECT")
-            )
-            vertex_credentials = (
-                litellm_params.pop("vertex_credentials", None)
-                or litellm_params.pop("vertex_ai_credentials", None)
-                or get_secret_str("VERTEXAI_CREDENTIALS")
-            )
-
-            vertex_ai_location = (
-                litellm_params.pop("vertex_location", None)
-                or litellm_params.pop("vertex_ai_location", None)
-                or litellm.vertex_location
-                or get_secret_str("VERTEXAI_LOCATION")
-                or get_secret_str("VERTEX_LOCATION")
-            )
+            vertex_ai_project = VertexBase.get_vertex_ai_project(litellm_params)
+            vertex_credentials = VertexBase.get_vertex_ai_credentials(litellm_params)
+            vertex_ai_location = VertexBase.get_vertex_ai_location(litellm_params)
 
             access_token, project_id = self._ensure_access_token(
                 credentials=vertex_credentials,

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -1,10 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-import litellm
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
-from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.vertex_ai import VertexPartnerProvider
 from litellm.types.router import GenericLiteLLMParams
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -12,7 +12,7 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.asyncify import asyncify
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
-from litellm.secrets import get_secret_str
+from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES, VertexPartnerProvider
 
 from .common_utils import (
@@ -492,7 +492,7 @@ class VertexBase:
         return headers
     
     @staticmethod
-    def get_vertex_ai_project(litellm_params: dict) -> str:
+    def get_vertex_ai_project(litellm_params: dict) -> Optional[str]:
         return (
             litellm_params.pop("vertex_project", None)
             or litellm_params.pop("vertex_ai_project", None)
@@ -501,7 +501,7 @@ class VertexBase:
         )
     
     @staticmethod
-    def get_vertex_ai_credentials(litellm_params: dict) -> str:
+    def get_vertex_ai_credentials(litellm_params: dict) -> Optional[str]:
         return (
             litellm_params.pop("vertex_credentials", None)
             or litellm_params.pop("vertex_ai_credentials", None)
@@ -509,7 +509,7 @@ class VertexBase:
         )
     
     @staticmethod
-    def get_vertex_ai_location(litellm_params: dict) -> str:
+    def get_vertex_ai_location(litellm_params: dict) -> Optional[str]:
         return (
             litellm_params.pop("vertex_location", None)
             or litellm_params.pop("vertex_ai_location", None)

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -8,9 +8,11 @@ import json
 import os
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
 
+import litellm
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.asyncify import asyncify
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.secrets import get_secret_str
 from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES, VertexPartnerProvider
 
 from .common_utils import (
@@ -80,11 +82,9 @@ class VertexBase:
             # Check if the JSON object contains Workload Identity Federation configuration
             if "type" in json_obj and json_obj["type"] == "external_account":
                 # If environment_id key contains "aws" value it corresponds to an AWS config file
-                if (
-                    "credential_source" in json_obj
-                    and "environment_id" in json_obj["credential_source"]
-                    and "aws" in json_obj["credential_source"]["environment_id"]
-                ):
+                credential_source = json_obj.get("credential_source", {})
+                environment_id = credential_source.get("environment_id", "") if isinstance(credential_source, dict) else ""
+                if isinstance(environment_id, str) and "aws" in environment_id:
                     creds = self._credentials_from_identity_pool_with_aws(json_obj)
                 else:
                     creds = self._credentials_from_identity_pool(json_obj)
@@ -490,3 +490,30 @@ class VertexBase:
             headers.update(extra_headers)
 
         return headers
+    
+    @staticmethod
+    def get_vertex_ai_project(litellm_params: dict) -> str:
+        return (
+            litellm_params.pop("vertex_project", None)
+            or litellm_params.pop("vertex_ai_project", None)
+            or litellm.vertex_project
+            or get_secret_str("VERTEXAI_PROJECT")
+        )
+    
+    @staticmethod
+    def get_vertex_ai_credentials(litellm_params: dict) -> str:
+        return (
+            litellm_params.pop("vertex_credentials", None)
+            or litellm_params.pop("vertex_ai_credentials", None)
+            or get_secret_str("VERTEXAI_CREDENTIALS")
+        )
+    
+    @staticmethod
+    def get_vertex_ai_location(litellm_params: dict) -> str:
+        return (
+            litellm_params.pop("vertex_location", None)
+            or litellm_params.pop("vertex_ai_location", None)
+            or litellm.vertex_location
+            or get_secret_str("VERTEXAI_LOCATION")
+            or get_secret_str("VERTEX_LOCATION")
+        )

--- a/litellm/types/google_genai/__init__.py
+++ b/litellm/types/google_genai/__init__.py
@@ -1,0 +1,13 @@
+from .main import (
+    ContentListUnion,
+    ContentListUnionDict,
+    GenerateContentConfigOrDict,
+    GenerateContentResponse,
+)
+
+__all__ = [
+    "ContentListUnion",
+    "ContentListUnionDict", 
+    "GenerateContentConfigOrDict",
+    "GenerateContentResponse",
+] 

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,14 +1,7 @@
 # Import types from the Google GenAI SDK
-from typing import Any, Dict, List, Union
+from google.genai import types
 
-try:
-    from google.genai import types
-    ContentListUnion = types.ContentListUnion
-    ContentListUnionDict = types.ContentListUnionDict
-    GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
-    GenerateContentResponse = types.GenerateContentResponse
-except ImportError:
-    ContentListUnion = Union[List[Dict[str, Any]], str]
-    ContentListUnionDict = Union[List[Dict[str, Any]], str, Dict[str, Any]]
-    GenerateContentConfigOrDict = Union[Dict[str, Any], None]
-    GenerateContentResponse = Any
+ContentListUnion = types.ContentListUnion
+ContentListUnionDict = types.ContentListUnionDict
+GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
+GenerateContentResponse = types.GenerateContentResponse

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,4 +1,6 @@
 # Import types from the Google GenAI SDK
+from typing import Optional
+
 from google.genai import types
 
 ContentListUnion = types.ContentListUnion
@@ -9,6 +11,9 @@ GenerateContentResponse = types.GenerateContentResponse
 ########################################################
 # Request Type
 ########################################################
-GenerateContentRequestDict = types._GenerateContentParametersDict
 GenerateContentContentListUnionDict = types.ContentListUnionDict
 GenerateContentConfigDict = types.GenerateContentConfigDict
+
+
+class GenerateContentRequestDict(types._GenerateContentParametersDict, total=False):
+    generationConfig: Optional[GenerateContentConfigDict]

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,19 +1,39 @@
 # Import types from the Google GenAI SDK
-from typing import Optional
+from typing import Any, Optional, TypedDict
 
-from google.genai import types
-
-ContentListUnion = types.ContentListUnion
-ContentListUnionDict = types.ContentListUnionDict
-GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
-GenerateContentResponse = types.GenerateContentResponse
-
-########################################################
-# Request Type
-########################################################
-GenerateContentContentListUnionDict = types.ContentListUnionDict
-GenerateContentConfigDict = types.GenerateContentConfigDict
+from pydantic import BaseModel
 
 
-class GenerateContentRequestDict(types._GenerateContentParametersDict, total=False):
-    generationConfig: Optional[GenerateContentConfigDict]
+# Define fallback base class
+class _FallbackRequestDict(TypedDict):
+    pass
+
+try:
+    from google.genai import types
+
+    ContentListUnion = types.ContentListUnion
+    ContentListUnionDict = types.ContentListUnionDict
+    GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
+    GenerateContentResponse = types.GenerateContentResponse
+
+    ########################################################
+    # Request Type
+    ########################################################
+    GenerateContentContentListUnionDict = types.ContentListUnionDict
+    GenerateContentConfigDict = types.GenerateContentConfigDict
+    GenerateContentRequestParametersDict = types._GenerateContentParametersDict
+
+    # When google-genai is available, inherit from their base clas
+
+except ImportError:
+    # If google-genai is not installed, we need to define the types manually
+    ContentListUnion = Any
+    ContentListUnionDict = Any
+    GenerateContentConfigOrDict = Any
+    GenerateContentResponse = Any
+    GenerateContentContentListUnionDict = Any
+    GenerateContentConfigDict = Any
+    GenerateContentRequestParametersDict = _FallbackRequestDict
+
+class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore
+    generationConfig: Optional[Any]

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -5,3 +5,10 @@ ContentListUnion = types.ContentListUnion
 ContentListUnionDict = types.ContentListUnionDict
 GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
 GenerateContentResponse = types.GenerateContentResponse
+
+########################################################
+# Request Type
+########################################################
+GenerateContentRequestDict = types._GenerateContentParametersDict
+GenerateContentContentListUnionDict = types.ContentListUnionDict
+GenerateContentConfigDict = types.GenerateContentConfigDict

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,39 +1,37 @@
 # Import types from the Google GenAI SDK
-from typing import Any, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, TypeAlias, TypedDict
 
 from pydantic import BaseModel
 
 
 # Define fallback base class
 class _FallbackRequestDict(TypedDict):
-    pass
+    """Fallback when google.genai types are unavailable."""
 
-try:
-    from google.genai import types
 
-    ContentListUnion = types.ContentListUnion
-    ContentListUnionDict = types.ContentListUnionDict
-    GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
-    GenerateContentResponse = types.GenerateContentResponse
+if TYPE_CHECKING:
+    # During static type-checking we can rely on the real google-genai types.
+    from google.genai import types as _genai_types  # type: ignore
 
-    ########################################################
-    # Request Type
-    ########################################################
-    GenerateContentContentListUnionDict = types.ContentListUnionDict
-    GenerateContentConfigDict = types.GenerateContentConfigDict
-    GenerateContentRequestParametersDict = types._GenerateContentParametersDict
+    ContentListUnion = _genai_types.ContentListUnion
+    ContentListUnionDict = _genai_types.ContentListUnionDict
+    GenerateContentConfigOrDict = _genai_types.GenerateContentConfigOrDict
+    GenerateContentResponse = _genai_types.GenerateContentResponse
 
-    # When google-genai is available, inherit from their base clas
+    GenerateContentContentListUnionDict = _genai_types.ContentListUnionDict
+    GenerateContentConfigDict = _genai_types.GenerateContentConfigDict
+    GenerateContentRequestParametersDict = _genai_types._GenerateContentParametersDict
+else:
+    # At runtime we fall back to `Any` to avoid a hard dependency on the SDK.
+    ContentListUnion: TypeAlias = Any
+    ContentListUnionDict: TypeAlias = Any
+    GenerateContentConfigOrDict: TypeAlias = Any
+    GenerateContentResponse: TypeAlias = Any
 
-except ImportError:
-    # If google-genai is not installed, we need to define the types manually
-    ContentListUnion = Any
-    ContentListUnionDict = Any
-    GenerateContentConfigOrDict = Any
-    GenerateContentResponse = Any
-    GenerateContentContentListUnionDict = Any
-    GenerateContentConfigDict = Any
-    GenerateContentRequestParametersDict = _FallbackRequestDict
+    GenerateContentContentListUnionDict: TypeAlias = Any
+    GenerateContentConfigDict: TypeAlias = Any
+    GenerateContentRequestParametersDict: TypeAlias = _FallbackRequestDict
 
-class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore
+
+class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore[misc]
     generationConfig: Optional[Any]

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,0 +1,14 @@
+# Import types from the Google GenAI SDK
+from typing import Any, Dict, List, Union
+
+try:
+    from google.genai import types
+    ContentListUnion = types.ContentListUnion
+    ContentListUnionDict = types.ContentListUnionDict
+    GenerateContentConfigOrDict = types.GenerateContentConfigOrDict
+    GenerateContentResponse = types.GenerateContentResponse
+except ImportError:
+    ContentListUnion = Union[List[Dict[str, Any]], str]
+    ContentListUnionDict = Union[List[Dict[str, Any]], str, Dict[str, Any]]
+    GenerateContentConfigOrDict = Union[Dict[str, Any], None]
+    GenerateContentResponse = Any

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -1,37 +1,18 @@
 # Import types from the Google GenAI SDK
 from typing import TYPE_CHECKING, Any, Optional, TypeAlias, TypedDict
 
+# During static type-checking we can rely on the real google-genai types.
+from google.genai import types as _genai_types  # type: ignore
 from pydantic import BaseModel
 
+ContentListUnion = _genai_types.ContentListUnion
+ContentListUnionDict = _genai_types.ContentListUnionDict
+GenerateContentConfigOrDict = _genai_types.GenerateContentConfigOrDict
+GenerateContentResponse = _genai_types.GenerateContentResponse
 
-# Define fallback base class
-class _FallbackRequestDict(TypedDict):
-    """Fallback when google.genai types are unavailable."""
-
-
-if TYPE_CHECKING:
-    # During static type-checking we can rely on the real google-genai types.
-    from google.genai import types as _genai_types  # type: ignore
-
-    ContentListUnion = _genai_types.ContentListUnion
-    ContentListUnionDict = _genai_types.ContentListUnionDict
-    GenerateContentConfigOrDict = _genai_types.GenerateContentConfigOrDict
-    GenerateContentResponse = _genai_types.GenerateContentResponse
-
-    GenerateContentContentListUnionDict = _genai_types.ContentListUnionDict
-    GenerateContentConfigDict = _genai_types.GenerateContentConfigDict
-    GenerateContentRequestParametersDict = _genai_types._GenerateContentParametersDict
-else:
-    # At runtime we fall back to `Any` to avoid a hard dependency on the SDK.
-    ContentListUnion: TypeAlias = Any
-    ContentListUnionDict: TypeAlias = Any
-    GenerateContentConfigOrDict: TypeAlias = Any
-    GenerateContentResponse: TypeAlias = Any
-
-    GenerateContentContentListUnionDict: TypeAlias = Any
-    GenerateContentConfigDict: TypeAlias = Any
-    GenerateContentRequestParametersDict: TypeAlias = _FallbackRequestDict
-
+GenerateContentContentListUnionDict = _genai_types.ContentListUnionDict
+GenerateContentConfigDict = _genai_types.GenerateContentConfigDict
+GenerateContentRequestParametersDict = _genai_types._GenerateContentParametersDict
 
 class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore[misc]
     generationConfig: Optional[Any]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6991,7 +6991,11 @@ class ProviderConfigManager:
         provider: LlmProviders,
     ) -> Optional[BaseGoogleGenAIGenerateContentConfig]:
         if litellm.LlmProviders.GEMINI == provider:
-            pass
+            from litellm.llms.gemini.google_genai.transformation import (
+                GoogleGenAIConfig,
+            )
+
+            return GoogleGenAIConfig()
         elif litellm.LlmProviders.VERTEX_AI == provider:
             pass
         return None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -129,6 +129,9 @@ from litellm.litellm_core_utils.redact_messages import (
 from litellm.litellm_core_utils.rules import Rules
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.litellm_core_utils.token_counter import get_modified_max_tokens
+from litellm.llms.base_llm.google_genai.transformation import (
+    BaseGoogleGenAIGenerateContentConfig,
+)
 from litellm.llms.bedrock.common_utils import BedrockModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.router_utils.get_retry_from_policy import (
@@ -6980,6 +6983,17 @@ class ProviderConfigManager:
             )
 
             return AzureImageEditConfig()
+        return None
+    
+    @staticmethod
+    def get_provider_google_genai_generate_content_config(
+        model: str,
+        provider: LlmProviders,
+    ) -> Optional[BaseGoogleGenAIGenerateContentConfig]:
+        if litellm.LlmProviders.GEMINI == provider:
+            pass
+        elif litellm.LlmProviders.VERTEX_AI == provider:
+            pass
         return None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ mangum==0.17.0 # for aws lambda functions
 pynacl==1.5.0 # for encrypting keys
 google-cloud-aiplatform==1.47.0 # for vertex ai calls
 anthropic[vertex]==0.54.0
+google-genai==1.21.1
 mcp==1.9.3    # for MCP server
 google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # LITELLM PROXY DEPENDENCIES #
-anyio==4.5.0 # openai + http req.
+anyio==4.8.0 # openai + http req.
 httpx==0.27.0 # Pin Httpx dependency
 openai==1.81.0  # openai req.
 fastapi==0.115.5 # server dep

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ mangum==0.17.0 # for aws lambda functions
 pynacl==1.5.0 # for encrypting keys
 google-cloud-aiplatform==1.47.0 # for vertex ai calls
 anthropic[vertex]==0.54.0
-google-genai==1.21.1
 mcp==1.9.3    # for MCP server
 google-generativeai==0.5.0 # for vertex ai calls
 async_generator==1.10.0 # for async ollama calls

--- a/tests/unified_google_tests/base_google_test.py
+++ b/tests/unified_google_tests/base_google_test.py
@@ -16,6 +16,7 @@ from litellm.google_genai import (
     generate_content_stream,
     agenerate_content_stream,
 )
+from google.genai.types import ContentDict, PartDict
 
 
 class BaseGoogleGenAITest:
@@ -26,10 +27,6 @@ class BaseGoogleGenAITest:
         """Override in subclasses to provide model-specific configuration"""
         raise NotImplementedError("Subclasses must implement model_config")
     
-    @property
-    def test_contents(self) -> Union[str, List[Dict[str, Any]]]:
-        """Override in subclasses to provide test content"""
-        return "Hello, can you tell me a short joke?"
     
     def _validate_non_streaming_response(self, response: Any):
         """Validate non-streaming response structure"""
@@ -55,8 +52,13 @@ class BaseGoogleGenAITest:
     async def test_non_streaming_base(self, is_async: bool):
         """Base test for non-streaming requests (parametrized for sync/async)"""
         request_params = self.model_config
-        contents = self.test_contents
-
+        contents = ContentDict(
+            parts=[
+                PartDict(
+                    text="Hello, can you tell me a short joke?"
+                )
+            ],
+        )
         litellm._turn_on_debug()
 
         print(f"Testing {'async' if is_async else 'sync'} non-streaming with model config: {request_params}")

--- a/tests/unified_google_tests/base_google_test.py
+++ b/tests/unified_google_tests/base_google_test.py
@@ -87,7 +87,13 @@ class BaseGoogleGenAITest:
     async def test_streaming_base(self, is_async: bool):
         """Base test for streaming requests (parametrized for sync/async)"""
         request_params = self.model_config
-        contents = self.test_contents
+        contents = ContentDict(
+            parts=[
+                PartDict(
+                    text="Hello, can you tell me a short joke?"
+                )
+            ],
+        )
 
         print(f"Testing {'async' if is_async else 'sync'} streaming with model config: {request_params}")
         print(f"Contents: {contents}")

--- a/tests/unified_google_tests/base_google_test.py
+++ b/tests/unified_google_tests/base_google_test.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+import sys
+import os
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.google_genai import (
+    generate_content,
+    agenerate_content,
+    generate_content_stream,
+    agenerate_content_stream,
+)
+
+
+class BaseGoogleGenAITest:
+    """Base class for Google GenAI generate content tests to reduce code duplication"""
+    
+    @property
+    def model_config(self) -> Dict[str, Any]:
+        """Override in subclasses to provide model-specific configuration"""
+        raise NotImplementedError("Subclasses must implement model_config")
+    
+    @property
+    def test_contents(self) -> Union[str, List[Dict[str, Any]]]:
+        """Override in subclasses to provide test content"""
+        return "Hello, can you tell me a short joke?"
+    
+    def _validate_non_streaming_response(self, response: Any):
+        """Validate non-streaming response structure"""
+        # Handle type checking - response should be a dict for non-streaming
+        if isinstance(response, AsyncIterator):
+            pytest.fail("Expected non-streaming response but got AsyncIterator")
+        
+        assert isinstance(response, dict), f"Expected dict response, got {type(response)}"
+        print(f"Response keys: {list(response.keys())}")
+        
+        # Basic validation - adjust based on actual Google GenAI response structure
+        # The exact structure may vary, so we'll be flexible here
+        assert response is not None, "Response should not be None"
+    
+    def _validate_streaming_response(self, chunks: List[Any]):
+        """Validate streaming response chunks"""
+        assert isinstance(chunks, list), f"Expected list of chunks, got {type(chunks)}"
+        assert len(chunks) >= 0, "Should have at least 0 chunks"
+        print(f"Total chunks received: {len(chunks)}")
+    
+    @pytest.mark.parametrize("is_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_non_streaming_base(self, is_async: bool):
+        """Base test for non-streaming requests (parametrized for sync/async)"""
+        request_params = self.model_config
+        contents = self.test_contents
+
+        print(f"Testing {'async' if is_async else 'sync'} non-streaming with model config: {request_params}")
+        print(f"Contents: {contents}")
+        
+        if is_async:
+            print("\n--- Testing async agenerate_content ---")
+            response = await agenerate_content(
+                contents=contents,
+                **request_params
+            )
+        else:
+            print("\n--- Testing sync generate_content ---")
+            response = generate_content(
+                contents=contents,
+                **request_params
+            )
+        
+        print(f"{'Async' if is_async else 'Sync'} response: {json.dumps(response, indent=2, default=str)}")
+        self._validate_non_streaming_response(response)
+        
+        return response
+    
+    @pytest.mark.parametrize("is_async", [False, True])
+    @pytest.mark.asyncio
+    async def test_streaming_base(self, is_async: bool):
+        """Base test for streaming requests (parametrized for sync/async)"""
+        request_params = self.model_config
+        contents = self.test_contents
+
+        print(f"Testing {'async' if is_async else 'sync'} streaming with model config: {request_params}")
+        print(f"Contents: {contents}")
+        
+        chunks = []
+        
+        if is_async:
+            print("\n--- Testing async agenerate_content_stream ---")
+            async for chunk in agenerate_content_stream(
+                contents=contents,
+                **request_params
+            ):
+                print(f"Async chunk: {chunk}")
+                chunks.append(chunk)
+        else:
+            print("\n--- Testing sync generate_content_stream ---")
+            for chunk in generate_content_stream(
+                contents=contents,
+                **request_params
+            ):
+                print(f"Sync chunk: {chunk}")
+                chunks.append(chunk)
+        
+        self._validate_streaming_response(chunks)
+        
+        return chunks

--- a/tests/unified_google_tests/base_google_test.py
+++ b/tests/unified_google_tests/base_google_test.py
@@ -9,6 +9,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.google_genai import (
     generate_content,
     agenerate_content,
@@ -55,6 +56,8 @@ class BaseGoogleGenAITest:
         """Base test for non-streaming requests (parametrized for sync/async)"""
         request_params = self.model_config
         contents = self.test_contents
+
+        litellm._turn_on_debug()
 
         print(f"Testing {'async' if is_async else 'sync'} non-streaming with model config: {request_params}")
         print(f"Contents: {contents}")

--- a/tests/unified_google_tests/base_google_test.py
+++ b/tests/unified_google_tests/base_google_test.py
@@ -16,7 +16,7 @@ from litellm.google_genai import (
     generate_content_stream,
     agenerate_content_stream,
 )
-from google.genai.types import ContentDict, PartDict
+from google.genai.types import ContentDict, PartDict, GenerateContentResponse
 
 
 class BaseGoogleGenAITest:
@@ -34,8 +34,8 @@ class BaseGoogleGenAITest:
         if isinstance(response, AsyncIterator):
             pytest.fail("Expected non-streaming response but got AsyncIterator")
         
-        assert isinstance(response, dict), f"Expected dict response, got {type(response)}"
-        print(f"Response keys: {list(response.keys())}")
+        assert isinstance(response, GenerateContentResponse), f"Expected dict response, got {type(response)}"
+        print(f"Response: {response.model_dump_json(indent=4)}")
         
         # Basic validation - adjust based on actual Google GenAI response structure
         # The exact structure may vary, so we'll be flexible here

--- a/tests/unified_google_tests/test_google_ai_studio.py
+++ b/tests/unified_google_tests/test_google_ai_studio.py
@@ -1,0 +1,10 @@
+from base_google_test import BaseGoogleGenAITest
+
+class TestGoogleGenAIStudio(BaseGoogleGenAITest):
+    """Test Google GenAI Studio"""
+
+    @property
+    def model_config(self):
+        return {
+            "model": "gemini/gemini-1.5-flash",
+        }


### PR DESCRIPTION
## [Feat] Add Support for calling Gemini/Vertex models in their native format

Closes https://github.com/BerriAI/litellm/issues/11984

# LiteLLM Google GenAI Interface

Interface to interact with Google GenAI Functions in the native Google interface format.

## Overview

This module provides a native interface to Google's Generative AI API, allowing you to use Google's content generation capabilities with both streaming and non-streaming modes, in both synchronous and asynchronous contexts.

## Available Functions

### Non-Streaming Functions

- `generate_content()` - Synchronous content generation
- `agenerate_content()` - Asynchronous content generation

### Streaming Functions

- `generate_content_stream()` - Synchronous streaming content generation
- `agenerate_content_stream()` - Asynchronous streaming content generation

## Usage Examples

### Basic Non-Streaming Usage

```python
from litellm.google_genai import generate_content, agenerate_content
from google.genai.types import ContentDict, PartDict

# Synchronous usage
contents = ContentDict(
    parts=[
        PartDict(text="Hello, can you tell me a short joke?")
    ],
)

response = generate_content(
    contents=contents,
    model="gemini-pro",  # or your preferred model
    # Add other model-specific parameters as needed
)

print(response)
```

### Async Non-Streaming Usage

```python
import asyncio
from litellm.google_genai import agenerate_content
from google.genai.types import ContentDict, PartDict

async def main():
    contents = ContentDict(
        parts=[
            PartDict(text="Hello, can you tell me a short joke?")
        ],
    )
    
    response = await agenerate_content(
        contents=contents,
        model="gemini-pro",
        # Add other model-specific parameters as needed
    )
    
    print(response)

# Run the async function
asyncio.run(main())
```

### Streaming Usage

```python
from litellm.google_genai import generate_content_stream
from google.genai.types import ContentDict, PartDict

# Synchronous streaming
contents = ContentDict(
    parts=[
        PartDict(text="Tell me a story about space exploration")
    ],
)

for chunk in generate_content_stream(
    contents=contents,
    model="gemini-pro",
):
    print(f"Chunk: {chunk}")
```

### Async Streaming Usage

```python
import asyncio
from litellm.google_genai import agenerate_content_stream
from google.genai.types import ContentDict, PartDict

async def main():
    contents = ContentDict(
        parts=[
            PartDict(text="Tell me a story about space exploration")
        ],
    )
    
    async for chunk in agenerate_content_stream(
        contents=contents,
        model="gemini-pro",
    ):
        print(f"Async chunk: {chunk}")

asyncio.run(main())
```


## Testing

This module includes comprehensive tests covering:
- Sync and async non-streaming requests
- Sync and async streaming requests
- Response validation
- Error handling scenarios

See `tests/unified_google_tests/base_google_test.py` for test implementation examples.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


