### PR TITLE
[Fix] Allow using HTTP_ Proxy settings with trust_env

### DIFF
--- a/docs/my-website/docs/guides/security_settings.md
+++ b/docs/my-website/docs/guides/security_settings.md
@@ -87,4 +87,5 @@ export HTTPS_PROXY='http://username:password@proxy_uri:port'
 export AIOHTTP_TRUST_ENV='True'
 ```
 </TabItem>
+</Tabs>
 

--- a/docs/my-website/docs/guides/security_settings.md
+++ b/docs/my-website/docs/guides/security_settings.md
@@ -1,14 +1,14 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# SSL Security Settings
+# SSL, HTTP Proxy Security Settings
 
 If you're in an environment using an older TTS bundle, with an older encryption, follow this guide. 
 
 
 LiteLLM uses HTTPX for network requests, unless otherwise specified. 
 
-1. Disable SSL verification
+## 1. Disable SSL verification
 
 
 <Tabs>
@@ -35,7 +35,7 @@ export SSL_VERIFY="False"
 </TabItem>
 </Tabs>
 
-2. Lower security settings
+## 2. Lower security settings
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
@@ -63,4 +63,28 @@ export SSL_CERTIFICATE="/path/to/certificate.pem"
 </TabItem>
 </Tabs>
 
+## 3. Use HTTP_PROXY environment variable
+
+Both httpx and aiohttp libraries use `urllib.request.getproxies` from environment variables. Before client initialization, you may set proxy (and optional SSL_CERT_FILE) by setting the environment variables:
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import litellm
+litellm.aiohttp_trust_env = True
+```
+
+```bash
+export HTTPS_PROXY='http://username:password@proxy_uri:port'
+```
+</TabItem>
+
+<TabItem value="proxy" label="PROXY">
+
+```bash
+export HTTPS_PROXY='http://username:password@proxy_uri:port'
+export AIOHTTP_TRUST_ENV='True'
+```
+</TabItem>
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -307,6 +307,7 @@ router_settings:
 | AGENTOPS_SERVICE_NAME | Service Name for AgentOps logging integration
 | AISPEND_ACCOUNT_ID | Account ID for AI Spend
 | AISPEND_API_KEY | API Key for AI Spend
+| AIOHTTP_TRUST_ENV | Flag to enable aiohttp trust environment. When this is set to True, aiohttp will respect HTTP(S)_PROXY env vars. **Default is False**
 | ALLOWED_EMAIL_DOMAINS | List of email domains allowed for access
 | ARIZE_API_KEY | API key for Arize platform integration
 | ARIZE_SPACE_KEY | Space key for Arize platform

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -323,6 +323,7 @@ priority_reservation: Optional[Dict[str, float]] = None
 use_aiohttp_transport: bool = (
     True  # Older variable, aiohttp is now the default. use disable_aiohttp_transport instead.
 )
+aiohttp_trust_env: bool = False # set to true to use HTTP_ Proxy settings
 disable_aiohttp_transport: bool = False  # Set this to true to use httpx instead
 disable_aiohttp_trust_env: bool = False  # When False, aiohttp will respect HTTP(S)_PROXY env vars
 force_ipv4: bool = (

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -588,7 +588,8 @@ class AsyncHTTPHandler:
         verbose_logger.debug("Creating AiohttpTransport...")
         return LiteLLMAiohttpTransport(
             client=lambda: ClientSession(
-                connector=TCPConnector(**connector_kwargs)
+                connector=TCPConnector(**connector_kwargs),
+                trust_env=litellm.aiohttp_trust_env,
             ),
         )
     

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -580,16 +580,24 @@ class AsyncHTTPHandler:
         - True: use default SSL verification (equivalent to ssl.create_default_context())
         """
         from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
+        from litellm.secret_managers.main import str_to_bool
 
         connector_kwargs = AsyncHTTPHandler._get_ssl_connector_kwargs(
             ssl_verify=ssl_verify, ssl_context=ssl_context
         )
+        #########################################################
+        # Check if user enabled aiohttp trust env
+        # use for HTTP_PROXY, HTTPS_PROXY, etc.
+        ########################################################
+        trust_env: bool = litellm.aiohttp_trust_env
+        if str_to_bool(os.getenv("AIOHTTP_TRUST_ENV", "False")) is True:
+            trust_env = True
 
         verbose_logger.debug("Creating AiohttpTransport...")
         return LiteLLMAiohttpTransport(
             client=lambda: ClientSession(
                 connector=TCPConnector(**connector_kwargs),
-                trust_env=litellm.aiohttp_trust_env,
+                trust_env=trust_env,
             ),
         )
     


### PR DESCRIPTION
## [Fix] Allow using HTTP_ Proxy settings with trust_env


## Use HTTP_PROXY environment variable

Both httpx and aiohttp libraries use `urllib.request.getproxies` from environment variables. Before client initialization, you may set proxy (and optional SSL_CERT_FILE) by setting the environment variables:

<Tabs>
<TabItem value="sdk" label="SDK">

```python
import litellm
litellm.aiohttp_trust_env = True
```

```bash
export HTTPS_PROXY='http://username:password@proxy_uri:port'
```
</TabItem>

<TabItem value="proxy" label="PROXY">

```bash
export HTTPS_PROXY='http://username:password@proxy_uri:port'
export AIOHTTP_TRUST_ENV='True'
```
</TabItem>




<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


