### PR TITLE
[Bug Fix] Anthropic - Token Usage Null Handling in calculate_usage

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -708,7 +708,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _litellm_metadata
             and isinstance(_litellm_metadata, dict)
             and "user_id" in _litellm_metadata
-            and not _valid_user_id(cast(str, _litellm_metadata.get("user_id", None)))
+            and _litellm_metadata["user_id"] is not None
+            and not _valid_user_id(_litellm_metadata["user_id"])
         ):
             optional_params["metadata"] = {"user_id": _litellm_metadata["user_id"]}
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -708,7 +708,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _litellm_metadata
             and isinstance(_litellm_metadata, dict)
             and "user_id" in _litellm_metadata
-            and not _valid_user_id(_litellm_metadata.get("user_id", None))
+            and not _valid_user_id(cast(str, _litellm_metadata.get("user_id", None)))
         ):
             optional_params["metadata"] = {"user_id": _litellm_metadata["user_id"]}
 
@@ -805,19 +805,29 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     def calculate_usage(
         self, usage_object: dict, reasoning_content: Optional[str]
     ) -> Usage:
-        prompt_tokens = usage_object.get("input_tokens", 0)
-        completion_tokens = usage_object.get("output_tokens", 0)
+        # NOTE: Sometimes the usage object has None set explicitly for token counts, meaning .get() & key access returns None, and we need to account for this
+        prompt_tokens = usage_object.get("input_tokens", 0) or 0
+        completion_tokens = usage_object.get("output_tokens", 0) or 0
         _usage = usage_object
         cache_creation_input_tokens: int = 0
         cache_read_input_tokens: int = 0
         web_search_requests: Optional[int] = None
-        if "cache_creation_input_tokens" in _usage:
+        if (
+            "cache_creation_input_tokens" in _usage
+            and _usage["cache_creation_input_tokens"] is not None
+        ):
             cache_creation_input_tokens = _usage["cache_creation_input_tokens"]
-        if "cache_read_input_tokens" in _usage:
+        if (
+            "cache_read_input_tokens" in _usage
+            and _usage["cache_read_input_tokens"] is not None
+        ):
             cache_read_input_tokens = _usage["cache_read_input_tokens"]
             prompt_tokens += cache_read_input_tokens
-        if "server_tool_use" in _usage:
-            if "web_search_requests" in _usage["server_tool_use"]:
+        if "server_tool_use" in _usage and _usage["server_tool_use"] is not None:
+            if (
+                "web_search_requests" in _usage["server_tool_use"]
+                and _usage["server_tool_use"]["web_search_requests"] is not None
+            ):
                 web_search_requests = cast(
                     int, _usage["server_tool_use"]["web_search_requests"]
                 )


### PR DESCRIPTION
## Title

Bug fix for #11920 - improper handling of null values in anthropic 

## Relevant issues

Fixes #11920. This issue was actually breaking Aider because LiteLLM would crash with an error, so I have also tested Aider with the changes to validate the fix.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (NOTE: ` tests/test_litellm/test_main.py::test_url_with_format_param[False-bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0]` fails, but was failing when I branched off originally anyway)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

### Test Results
Running all tests:
![image](https://github.com/user-attachments/assets/189a3d8f-587f-4965-8878-069f729245e1)
Running just the test file I edited:
![image](https://github.com/user-attachments/assets/2d08bd8e-1312-4795-8215-4ca46dc71f68)


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Add `None` checks to `calculate_usage` in `litellm/llms/anthropic/chat/transformation.py`
- Add tests for these `None` checks


