### PR TITLE
[Fix] Redis - Add better debugging to see what variables are set 

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -19,6 +19,7 @@ import redis.asyncio as async_redis  # type: ignore
 
 from litellm import get_secret, get_secret_str
 from litellm.constants import REDIS_CONNECTION_POOL_TIMEOUT, REDIS_SOCKET_TIMEOUT
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 
 from ._logging import verbose_logger
 
@@ -309,7 +310,7 @@ def get_redis_async_client(
     # Check for Redis Sentinel
     if "sentinel_nodes" in redis_kwargs and "service_name" in redis_kwargs:
         return _init_async_redis_sentinel(redis_kwargs)
-
+    _pretty_print_redis_config(redis_kwargs=redis_kwargs)
     return async_redis.Redis(
         **redis_kwargs,
     )
@@ -331,3 +332,90 @@ def get_redis_connection_pool(**env_overrides):
     return async_redis.BlockingConnectionPool(
         timeout=REDIS_CONNECTION_POOL_TIMEOUT, **redis_kwargs
     )
+
+def _pretty_print_redis_config(redis_kwargs: dict) -> None:
+    """Pretty print the Redis configuration using rich with sensitive data masking"""
+    try:
+        import logging
+
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.table import Table
+        from rich.text import Text
+        if not verbose_logger.isEnabledFor(logging.DEBUG):
+            return
+
+        console = Console()
+
+        # Initialize the sensitive data masker
+        masker = SensitiveDataMasker()
+        
+        # Mask sensitive data in redis_kwargs
+        masked_redis_kwargs = masker.mask_dict(redis_kwargs)
+
+        # Create main panel title
+        title = Text("Redis Configuration", style="bold blue")
+
+        # Create configuration table
+        config_table = Table(
+            title="🔧 Redis Connection Parameters",
+            show_header=True,
+            header_style="bold magenta",
+            title_justify="left",
+        )
+        config_table.add_column("Parameter", style="cyan", no_wrap=True)
+        config_table.add_column("Value", style="yellow")
+
+        # Add rows for each configuration parameter
+        for key, value in masked_redis_kwargs.items():
+            if value is not None:
+                # Special handling for complex objects
+                if isinstance(value, list):
+                    if key == "startup_nodes" and value:
+                        # Special handling for cluster nodes
+                        value_str = f"[{len(value)} cluster nodes]"
+                    elif key == "sentinel_nodes" and value:
+                        # Special handling for sentinel nodes
+                        value_str = f"[{len(value)} sentinel nodes]"
+                    else:
+                        value_str = str(value)
+                else:
+                    value_str = str(value)
+                
+                config_table.add_row(key, value_str)
+
+        # Determine connection type
+        connection_type = "Standard Redis"
+        if masked_redis_kwargs.get("startup_nodes"):
+            connection_type = "Redis Cluster"
+        elif masked_redis_kwargs.get("sentinel_nodes"):
+            connection_type = "Redis Sentinel"
+        elif masked_redis_kwargs.get("url"):
+            connection_type = "Redis (URL-based)"
+
+        # Create connection type info
+        info_table = Table(
+            title="📊 Connection Info",
+            show_header=True,
+            header_style="bold green",
+            title_justify="left",
+        )
+        info_table.add_column("Property", style="cyan", no_wrap=True)
+        info_table.add_column("Value", style="yellow")
+        info_table.add_row("Connection Type", connection_type)
+
+        # Print everything in a nice panel
+        console.print("\n")
+        console.print(Panel(title, border_style="blue"))
+        console.print(info_table)
+        console.print(config_table)
+        console.print("\n")
+
+    except ImportError:
+        # Fallback to simple logging if rich is not available
+        masker = SensitiveDataMasker()
+        masked_redis_kwargs = masker.mask_dict(redis_kwargs)
+        verbose_logger.info(f"Redis configuration: {masked_redis_kwargs}")
+    except Exception as e:
+        verbose_logger.error(f"Error pretty printing Redis configuration: {e}")
+

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,11 +1,8 @@
 model_list:
-  - model_name: vertex_ai/*
+  - model_name: azure_ai/*
     litellm_params:
-      model: vertex_ai/*
-  - model_name: "anthropic/*"
-    litellm_params:
-      model: "anthropic/*"
-      api_key: os.environ/ANTHROPIC_API_KEY
+      model: azure_ai/*
+
 
 mcp_servers:
   deepwiki_mcp:
@@ -18,3 +15,6 @@ general_settings:
 
 litellm_settings:
   callbacks: ["langfuse", "datadog"]
+  cache: True
+  cache_params:        # set cache params for redis
+    type: redis


### PR DESCRIPTION
## [Fix] Redis - Add better debugging to see what variables are set 

- This pretty prints the redis configuration when debug mode is enabled on litellm. Allows users to see what redis settings they have set/are getting used by litellm 

<img width="1280" alt="Screenshot 2025-06-26 at 9 48 42 AM" src="https://github.com/user-attachments/assets/79c554e0-20a1-4063-90bd-8f77d9c591e1" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


