### PR TITLE
De-duplicate models in team settings dropdown

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -441,7 +441,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       <Select.Option key="all-proxy-models" value="all-proxy-models">
                         All Proxy Models
                       </Select.Option>
-                      {userModels.map((model, idx) => (
+                      {Array.from(new Set(userModels)).map((model, idx) => (
                         <Select.Option key={idx} value={model}>
                           {getModelDisplayName(model)}
                         </Select.Option>


### PR DESCRIPTION
## Title
De-duplicate models in team settings dropdown
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- This pull request resolves an issue where the model selection dropdown in the team settings could display duplicate model names.
The list of user-selectable models is now filtered to ensure each model appears only once, providing a cleaner and less confusing user experience. This was achieved by converting the userModels array to a Set and then back to an array using Array.from().
<img width="1512" alt="Screenshot 2025-06-27 at 2 25 10" src="https://github.com/user-attachments/assets/efef1e1f-0628-4621-b54b-f193774415a3" />


