### PR TITLE
Fix Azure-OpenAI Vision API Compliance

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -943,6 +943,12 @@ def _azure_tool_call_invoke_helper(
     return function_call_params
 
 
+def _azure_image_url_helper(content: ChatCompletionImageObject):
+    if isinstance(content["image_url"], str):
+        content["image_url"] = {"url": content["image_url"]}
+    return
+
+
 def convert_to_azure_openai_messages(
     messages: List[AllMessageValues],
 ) -> List[AllMessageValues]:
@@ -951,6 +957,11 @@ def convert_to_azure_openai_messages(
             function_call = m.get("function_call", None)
             if function_call is not None:
                 m["function_call"] = _azure_tool_call_invoke_helper(function_call)
+
+        if m["role"] == "user" and isinstance(m.get("content"), list):
+            for content in m.get("content"):
+                if (isinstance(content, dict) and content.get("type") == "image_url"):
+                    _azure_image_url_helper(content)
     return messages
 
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -959,9 +959,9 @@ def convert_to_azure_openai_messages(
                 m["function_call"] = _azure_tool_call_invoke_helper(function_call)
 
         if m["role"] == "user" and isinstance(m.get("content"), list):
-            for content in m.get("content"):
-                if (isinstance(content, dict) and content.get("type") == "image_url"):
-                    _azure_image_url_helper(content)
+            for content in m.get("content", []):
+                if isinstance(content, dict) and content.get("type") == "image_url":
+                    _azure_image_url_helper(content)  # type: ignore
     return messages
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -83,6 +83,48 @@ async def test_anthropic_bedrock_thinking_blocks_with_none_content():
     )
 
 
+def test_convert_to_azure_openai_messages():
+    """Test coverting image_url to azure_openai spec"""
+
+    from typing import List
+    from litellm.types.llms.openai import AllMessageValues
+    from litellm.litellm_core_utils.prompt_templates.factory  import  convert_to_azure_openai_messages
+
+    input: List[AllMessageValues] = [
+        {
+            "role": "user",
+            "content": [
+                            {
+                                "type": "text",
+                                "text": "What is in this image?"
+                            },
+                            {
+                                "type": "image_url",
+                                "image_url": "www.mock.com"
+                            }
+                        ]
+        }
+    ]
+
+    expected_content = [
+        {
+            "type": "text",
+            "text": "What is in this image?"  
+        },
+        {
+            "type": "image_url",
+            "image_url": {"url": "www.mock.com"}  
+        }
+    ]
+
+    output = convert_to_azure_openai_messages(input)
+
+    content = output[0].get('content')
+    assert content == expected_content
+
+
+
+
 def test_bedrock_validate_format_image_or_video():
     """Test the _validate_format method for images, videos, and documents"""
 


### PR DESCRIPTION
## Title

Fix Azure-OpenAI  Vision API Compatibility

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![Screenshot 2025-06-26 at 10 36 48 AM](https://github.com/user-attachments/assets/ae5dd7e5-db22-4054-8e45-8b6cad90b565)

## Type


🐛 Bug Fix


## Changes

Wraps image_url strings in an object to comply with Azure-Openai spec. Fixes compatibility with Google ADK Web UI.
