### PR TITLE
Cleanup temp files for S3 config loading

### DIFF
--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -1,4 +1,5 @@
 import yaml
+import os
 
 from litellm._logging import verbose_proxy_logger
 
@@ -36,9 +37,16 @@ def get_file_contents_from_s3(bucket_name, object_key):
             temp_file_path = temp_file.name
             verbose_proxy_logger.debug(f"File stored temporarily at: {temp_file_path}")
 
-        # Load the YAML file content
-        with open(temp_file_path, "r") as yaml_file:
-            config = yaml.safe_load(yaml_file)
+        try:
+            # Load the YAML file content
+            with open(temp_file_path, "r") as yaml_file:
+                config = yaml.safe_load(yaml_file)
+        finally:
+            try:
+                os.remove(temp_file_path)
+                verbose_proxy_logger.debug(f"Cleaned up temporary file: {temp_file_path}")
+            except OSError as cleanup_error:
+                verbose_proxy_logger.warning(f"Failed to clean up temporary file {temp_file_path}: {cleanup_error}")
 
         return config
     except ImportError as e:


### PR DESCRIPTION
## Title

Cleanup temp files for S3 config loading


## Relevant issues

Not raised as a separate issue, went straight to a PR.

LiteLLM Config loading from S3 was leaving behind a temp file which polluted /tmp directory, eventually running out of disk space. For some reason, the config yaml is re-pulled from S3 on each completion request, so there were hundreds of thousands of temp files accumulated over time. This PR adds temp file cleanup.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Added temp file cleanup after config is downloaded from S3 and ingested

![CleanShot 2025-06-26 at 12 45 47@2x](https://github.com/user-attachments/assets/65112af6-4617-424e-86f7-af612b7f0e46)


