### PR TITLE
[Feat] introduce new environment variable NO_REDOC to opt-out Redoc

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -555,7 +555,8 @@ router_settings:
 | MICROSOFT_CLIENT_SECRET | Client secret for Microsoft services
 | MICROSOFT_TENANT | Tenant ID for Microsoft Azure
 | MICROSOFT_SERVICE_PRINCIPAL_ID | Service Principal ID for Microsoft Enterprise Application. (This is an advanced feature if you want litellm to auto-assign members to Litellm Teams based on their Microsoft Entra ID Groups)
-| NO_DOCS | Flag to disable documentation generation
+| NO_DOCS | Flag to disable Swagger UI documentation
+| NO_REDOC | Flag to disable Redoc documentation
 | NO_PROXY | List of addresses to bypass proxy
 | NON_LLM_CONNECTION_TIMEOUT | Timeout in seconds for non-LLM service connections. Default is 15
 | OAUTH_TOKEN_INFO_ENDPOINT | Endpoint for OAuth token info retrieval

--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -593,6 +593,16 @@ NO_DOCS="True"
 
 in your environment, and restart the proxy. 
 
+### Disable Redoc
+
+To disable the Redoc docs (defaults to `<your-proxy-url>/redoc`), set 
+
+```env
+NO_REDOC="True"
+```
+
+in your environment, and restart the proxy. 
+
 ### Use CONFIG_FILE_PATH for proxy (Easier Azure container deployment)
 
 1. Setup config.yaml

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2987,32 +2987,37 @@ def get_error_message_str(e: Exception) -> str:
     return error_message
 
 
-def _get_redoc_url() -> str:
+def _get_redoc_url() -> Optional[str]:
     """
-    Get the redoc URL from the environment variables.
+    Get the Redoc URL from the environment variables.
 
     - If REDOC_URL is set, return it.
+    - If NO_REDOC is True, return None.
     - Otherwise, default to "/redoc".
     """
-    return os.getenv("REDOC_URL", "/redoc")
+    if (redoc_url := os.getenv("REDOC_URL")):
+        return redoc_url
+
+    if str_to_bool(os.getenv("NO_REDOC")) is True:
+        return None
+
+    return "/redoc"
 
 
 def _get_docs_url() -> Optional[str]:
     """
-    Get the docs URL from the environment variables.
+    Get the docs (Swagger UI) URL from the environment variables.
 
     - If DOCS_URL is set, return it.
     - If NO_DOCS is True, return None.
     - Otherwise, default to "/".
     """
-    docs_url = os.getenv("DOCS_URL", None)
-    if docs_url:
+    if (docs_url := os.getenv("DOCS_URL")):
         return docs_url
 
-    if os.getenv("NO_DOCS", "False") == "True":
+    if str_to_bool(os.getenv("NO_DOCS")) is True:
         return None
 
-    # default to "/"
     return "/"
 
 

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -674,18 +674,25 @@ async def test_prepare_key_update_data():
 
 
 @pytest.mark.parametrize(
-    "env_value, expected_url",
+    "env_vars, expected_url",
     [
-        (None, "/redoc"),  # default case
-        ("/custom-redoc", "/custom-redoc"),  # custom URL
-        ("https://example.com/redoc", "https://example.com/redoc"),  # full URL
+        ({}, "/redoc"),  # default case
+        ({"REDOC_URL": "/custom-redoc"}, "/custom-redoc"),  # custom URL
+        (
+            {"REDOC_URL": "https://example.com/redoc"},
+            "https://example.com/redoc",
+        ),  # full URL
+        ({"NO_REDOC": "True"}, None), # Redoc disabled
     ],
 )
-def test_get_redoc_url(env_value, expected_url):
-    if env_value is not None:
-        os.environ["REDOC_URL"] = env_value
-    else:
-        os.environ.pop("REDOC_URL", None)  # ensure env var is not set
+def test_get_redoc_url(env_vars, expected_url):
+    # Clear relevant environment variables
+    for key in ["REDOC_URL", "NO_REDOC"]:
+        os.environ.pop(key, None)
+
+    # Set test environment variables
+    for key, value in env_vars.items():
+        os.environ[key] = value
 
     result = _get_redoc_url()
     assert result == expected_url


### PR DESCRIPTION
## Title

introduce new environment variable NO_REDOC to opt-out Redoc

## Relevant issues

Fixes #12071

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Introduce new environment variable `NO_REDOC`, add test and docs.
