### PR TITLE
[Fix] MCP - Ensure internal users can access /mcp and /mcp/ routes 

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -341,7 +341,12 @@ class LiteLLMRoutes(enum.Enum):
 
     anthropic_routes = [
         "/v1/messages",
-        # MCP routes
+    ]
+
+    mcp_routes = [
+        "/mcp",
+        "/mcp/",
+        "/mcp/{subpath}",
         "/mcp/tools",
         "/mcp/tools/list",
         "/mcp/tools/call",
@@ -365,6 +370,7 @@ class LiteLLMRoutes(enum.Enum):
         + anthropic_routes
         + mapped_pass_through_routes
         + apply_guardrail_routes
+        + mcp_routes
     )
     info_routes = [
         "/key/info",

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -195,6 +195,12 @@ class RouteChecks:
         if route in LiteLLMRoutes.anthropic_routes.value:
             return True
 
+        if RouteChecks.check_route_access(
+            route=route, 
+            allowed_routes=LiteLLMRoutes.mcp_routes.value
+        ):
+            return True
+
         # fuzzy match routes like "/v1/threads/thread_49EIN5QF32s4mH20M7GFKdlZ"
         # Check for routes with placeholders
         for openai_route in LiteLLMRoutes.openai_routes.value:

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -8,13 +8,3 @@ mcp_servers:
   deepwiki_mcp:
     url: "https://mcp.deepwiki.com/mcp"
     transport: "http"
-
-general_settings:
-  store_model_in_db: true
-  store_prompts_in_spend_logs: true
-
-litellm_settings:
-  callbacks: ["langfuse", "datadog"]
-  cache: True
-  cache_params:        # set cache params for redis
-    type: redis

--- a/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
+++ b/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
@@ -89,6 +89,8 @@ def test_is_llm_api_route():
     )
 
     # MCP routes
+    assert RouteChecks.is_llm_api_route("/mcp") is True
+    assert RouteChecks.is_llm_api_route("/mcp/") is True
     assert RouteChecks.is_llm_api_route("/mcp/tools") is True
     assert RouteChecks.is_llm_api_route("/mcp/tools/call") is True
     assert RouteChecks.is_llm_api_route("/mcp/tools/list") is True


### PR DESCRIPTION
## [Fix] MCP - Ensure internal users can access /mcp and /mcp/ routes 

This PR ensures internal users can access the /mcp and /mcp/ endpoints by extending route-validation logic, updating route definitions, and adding related unit tests.


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


