### PR TITLE
fix: set logger levels based on LITELLM_LOG environment variable

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -103,6 +103,11 @@ verbose_proxy_logger = logging.getLogger("LiteLLM Proxy")
 verbose_router_logger = logging.getLogger("LiteLLM Router")
 verbose_logger = logging.getLogger("LiteLLM")
 
+# Set the logger level based on LITELLM_LOG environment variable
+verbose_proxy_logger.setLevel(numeric_level)
+verbose_router_logger.setLevel(numeric_level)
+verbose_logger.setLevel(numeric_level)
+
 # Add the handler to the logger
 verbose_router_logger.addHandler(handler)
 verbose_proxy_logger.addHandler(handler)

--- a/tests/test_litellm/test_logger_level_initialization.py
+++ b/tests/test_litellm/test_logger_level_initialization.py
@@ -1,0 +1,63 @@
+"""Test that loggers respect LITELLM_LOG environment variable"""
+import logging
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+
+def test_logger_level_respects_env_var(monkeypatch):
+    """
+    Test that loggers are initialized with the correct level based on LITELLM_LOG env var.
+    This verifies the fix for issue #9815 where loggers ignored the LITELLM_LOG setting.
+    """
+    # Test different log levels
+    test_cases = [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+    ]
+    
+    for env_level, expected_numeric_level in test_cases:
+        # Set the environment variable
+        monkeypatch.setenv("LITELLM_LOG", env_level)
+        
+        # Re-import the logging module to pick up the new env var
+        import importlib
+        import litellm._logging
+        importlib.reload(litellm._logging)
+        
+        # Check that all loggers have the correct level
+        assert litellm._logging.verbose_logger.level == expected_numeric_level, \
+            f"verbose_logger level should be {expected_numeric_level} for LITELLM_LOG={env_level}"
+        
+        assert litellm._logging.verbose_proxy_logger.level == expected_numeric_level, \
+            f"verbose_proxy_logger level should be {expected_numeric_level} for LITELLM_LOG={env_level}"
+        
+        assert litellm._logging.verbose_router_logger.level == expected_numeric_level, \
+            f"verbose_router_logger level should be {expected_numeric_level} for LITELLM_LOG={env_level}"
+
+
+def test_handler_and_logger_levels_match(monkeypatch):
+    """
+    Test that both handler and logger levels are set to the same value.
+    This ensures consistent behavior across the logging system.
+    """
+    monkeypatch.setenv("LITELLM_LOG", "WARNING")
+    
+    # Re-import to apply settings
+    import importlib
+    import litellm._logging
+    importlib.reload(litellm._logging)
+    
+    # Get the handler level (first handler should be our configured one)
+    handler_level = litellm._logging.handler.level
+    
+    # All loggers should have the same level as the handler
+    assert litellm._logging.verbose_logger.level == handler_level
+    assert litellm._logging.verbose_proxy_logger.level == handler_level
+    assert litellm._logging.verbose_router_logger.level == handler_level


### PR DESCRIPTION
## Title

fix: set logger levels based on LITELLM_LOG environment variable

## Relevant issues

Part 1/2 of fix for #9815

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

This PR addresses the root cause of issue #9815 where loggers were not respecting the `LITELLM_LOG` environment variable.

### Problem
When users set `LITELLM_LOG=WARNING`, the logging handler was configured correctly, but the loggers themselves (verbose_logger, verbose_proxy_logger, verbose_router_logger) were not having their levels set. This caused them to emit all log messages regardless of the environment setting.

### Solution
Set the logger levels explicitly based on the `LITELLM_LOG` environment variable during initialization in `_logging.py`:
```python
# Set the logger level based on LITELLM_LOG environment variable
verbose_proxy_logger.setLevel(numeric_level)
verbose_router_logger.setLevel(numeric_level)
verbose_logger.setLevel(numeric_level)
```

### Testing
Added comprehensive tests in `test_logger_level_initialization.py` that verify:
- All loggers respect different LITELLM_LOG settings (DEBUG, INFO, WARNING, ERROR, CRITICAL)
- Handler and logger levels are synchronized

### Test Output
```
tests/test_litellm/test_logger_level_initialization.py::test_handler_and_logger_levels_match PASSED [ 50%]
tests/test_litellm/test_logger_level_initialization.py::test_logger_level_respects_env_var PASSED [100%]
========================= 2 passed, 1 warning in 0.12s =========================
```

This is part 1 of a 2-part fix. The second PR will address the log level categorization for cost calculation messages.