### PR TITLE
[Bug Fix] Exception mapping for context window exceeded - should catch anthropic exceptions

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -51,6 +51,7 @@ class ExceptionCheckers:
         """
         Check if an error string indicates a context window exceeded error.
         """
+        _error_str_lowercase = error_str.lower()
         known_exception_substrings = [
             "exceed context limit",
             "this model's maximum context length is",
@@ -59,7 +60,7 @@ class ExceptionCheckers:
             "is longer than the model's context length",
         ]
         for substring in known_exception_substrings:
-            if substring in error_str.lower():
+            if substring in _error_str_lowercase:
                 return True
         return False
 

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -44,6 +44,24 @@ class ExceptionCheckers:
             return False
             
         return "429" in error_str or "rate limit" in error_str.lower()
+    
+
+    @staticmethod
+    def is_error_str_context_window_exceeded(error_str: str) -> bool:
+        """
+        Check if an error string indicates a context window exceeded error.
+        """
+        known_exception_substrings = [
+            "exceed context limit",
+            "this model's maximum context length is",
+            "string too long. expected a string with maximum length",
+            "model's maximum context limit",
+            "is longer than the model's context length",
+        ]
+        for substring in known_exception_substrings:
+            if substring in error_str.lower():
+                return True
+        return False
 
 
 def get_error_message(error_obj) -> Optional[str]:
@@ -304,13 +322,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         llm_provider=custom_llm_provider,
                         response=getattr(original_exception, "response", None),
                     )
-                elif (
-                    "This model's maximum context length is" in error_str
-                    or "string too long. Expected a string with maximum length"
-                    in error_str
-                    or "model's maximum context limit" in error_str
-                    or "is longer than the model's context length" in error_str
-                ):
+                elif ExceptionCheckers.is_error_str_context_window_exceeded(error_str):
                     exception_mapping_worked = True
                     raise ContextWindowExceededError(
                         message=f"ContextWindowExceededError: {exception_provider} - {message}",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1,0 +1,31 @@
+import pytest
+
+from litellm.litellm_core_utils.exception_mapping_utils import ExceptionCheckers
+
+# Test cases for is_error_str_context_window_exceeded
+# Tuple format: (error_message, expected_result)
+context_window_test_cases = [
+    # Positive cases (should return True)
+    ("An error occurred: The input exceeds the model's maximum context limit of 8192 tokens.", True),
+    ("Some text before, this model's maximum context length is 4096 tokens. Some text after.", True),
+    ("Validation Error: string too long. expected a string with maximum length 1000.", True),
+    ("Your prompt is longer than the model's context length of 2048.", True),
+    ("AWS Bedrock Error: The request payload size has exceed context limit.", True),
+
+    # Test case insensitivity
+    ("ERROR: THIS MODEL'S MAXIMUM CONTEXT LENGTH IS 1024.", True),
+
+    # Negative cases (should return False)
+    ("A generic API error occurred.", False),
+    ("Invalid API Key provided.", False),
+    ("Rate limit reached for requests.", False),
+    ("The context is large, but acceptable.", False),
+    ("", False), # Empty string
+]
+
+@pytest.mark.parametrize("error_str, expected", context_window_test_cases)
+def test_is_error_str_context_window_exceeded(error_str, expected):
+    """
+    Tests the is_error_str_context_window_exceeded function with various error strings.
+    """
+    assert ExceptionCheckers.is_error_str_context_window_exceeded(error_str) == expected


### PR DESCRIPTION
## [Bug Fix] Exception mapping for context window exceeded - should catch anthropic exceptions

This pull request fixes a bug by properly mapping exceptions related to context window limits by catching anthropic exceptions, ensuring that the error message check is centralized.



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


