### PR TITLE
[Bug Fix] Fix handling str, bool types for`mock_testing_fallbacks` on router using /audio endpoints

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -128,6 +128,7 @@ from litellm.types.router import (
     Deployment,
     DeploymentTypedDict,
     LiteLLM_Params,
+    MockRouterTestingParams,
     ModelGroupInfo,
     OptionalPreCallChecks,
     RetryPolicy,
@@ -3629,23 +3630,16 @@ class Router:
             litellm.ContextWindowExceededError: when `mock_testing_context_fallbacks=True` passed in request params
             litellm.ContentPolicyViolationError: when `mock_testing_content_policy_fallbacks=True` passed in request params
         """
-        mock_testing_fallbacks = kwargs.pop("mock_testing_fallbacks", None)
-        mock_testing_context_fallbacks = kwargs.pop(
-            "mock_testing_context_fallbacks", None
-        )
-        mock_testing_content_policy_fallbacks = kwargs.pop(
-            "mock_testing_content_policy_fallbacks", None
-        )
-
-        if mock_testing_fallbacks is not None and mock_testing_fallbacks is True:
+        mock_testing_params = MockRouterTestingParams.from_kwargs(kwargs)
+        if mock_testing_params.mock_testing_fallbacks is not None and mock_testing_params.mock_testing_fallbacks is True:
             raise litellm.InternalServerError(
                 model=model_group,
                 llm_provider="",
                 message=f"This is a mock exception for model={model_group}, to trigger a fallback. Fallbacks={fallbacks}",
             )
         elif (
-            mock_testing_context_fallbacks is not None
-            and mock_testing_context_fallbacks is True
+            mock_testing_params.mock_testing_context_fallbacks is not None
+            and mock_testing_params.mock_testing_context_fallbacks is True
         ):
             raise litellm.ContextWindowExceededError(
                 model=model_group,
@@ -3654,8 +3648,8 @@ class Router:
                     Context_Window_Fallbacks={context_window_fallbacks}",
             )
         elif (
-            mock_testing_content_policy_fallbacks is not None
-            and mock_testing_content_policy_fallbacks is True
+            mock_testing_params.mock_testing_content_policy_fallbacks is not None
+            and mock_testing_params.mock_testing_content_policy_fallbacks is True
         ):
             raise litellm.ContentPolicyViolationError(
                 model=model_group,

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -5,6 +5,7 @@ litellm.Router Types - includes RouterConfig, UpdateRouterConfig, ModelInfo etc
 import datetime
 import enum
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, get_type_hints
 
 import httpx
@@ -730,3 +731,22 @@ class LiteLLM_RouterFileObject(TypedDict, total=False):
 
     litellm_params_sensitive_credential_hash: str
     file_object: OpenAIFileObject
+
+@dataclass
+class MockRouterTestingParams:
+    mock_testing_fallbacks: Optional[bool] = None
+    mock_testing_context_fallbacks: Optional[bool] = None
+    mock_testing_content_policy_fallbacks: Optional[bool] = None
+    
+    @classmethod
+    def from_kwargs(cls, kwargs: dict) -> 'MockRouterTestingParams':
+        from litellm.secret_managers.main import str_to_bool
+        def extract_bool_param(name: str) -> Optional[bool]:
+            value = kwargs.pop(name, None)
+            return str_to_bool(value) if isinstance(value, str) else value
+        
+        return cls(
+            mock_testing_fallbacks=extract_bool_param("mock_testing_fallbacks"),
+            mock_testing_context_fallbacks=extract_bool_param("mock_testing_context_fallbacks"),
+            mock_testing_content_policy_fallbacks=extract_bool_param("mock_testing_content_policy_fallbacks")
+        )

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1186,3 +1186,93 @@ def test_init_responses_api_endpoints(model_list):
     assert isinstance(router.aget_responses, Callable)
     assert router.adelete_responses is not None
     assert isinstance(router.adelete_responses, Callable)
+
+
+@pytest.mark.parametrize(
+    "mock_testing_fallbacks, mock_testing_context_fallbacks, mock_testing_content_policy_fallbacks, expected_fallbacks, expected_context, expected_content_policy",
+    [
+        # Test string to bool conversion
+        ("true", "false", "True", True, False, True),
+        ("TRUE", "FALSE", "False", True, False, False),
+        ("1", "0", "yes", True, False, True),
+        ("false", "true", "no", False, True, False),
+        # Test actual boolean values (should pass through unchanged)
+        (True, False, True, True, False, True),
+        (False, True, False, False, True, False),
+        # Test None values
+        (None, None, None, None, None, None),
+        # Test mixed types
+        ("true", False, None, True, False, None),
+        (True, "false", "1", True, False, True),
+    ],
+)
+def test_mock_router_testing_params_str_to_bool_conversion(
+    mock_testing_fallbacks,
+    mock_testing_context_fallbacks,
+    mock_testing_content_policy_fallbacks,
+    expected_fallbacks,
+    expected_context,
+    expected_content_policy,
+):
+    """Test if MockRouterTestingParams.from_kwargs correctly converts string values to booleans using str_to_bool"""
+    from litellm.types.router import MockRouterTestingParams
+    
+    kwargs = {
+        "mock_testing_fallbacks": mock_testing_fallbacks,
+        "mock_testing_context_fallbacks": mock_testing_context_fallbacks,
+        "mock_testing_content_policy_fallbacks": mock_testing_content_policy_fallbacks,
+        "other_param": "should_remain",  # This should not be affected
+    }
+    
+    # Make a copy to verify kwargs are properly popped
+    original_kwargs = kwargs.copy()
+    
+    mock_params = MockRouterTestingParams.from_kwargs(kwargs)
+    
+    # Verify the converted values
+    assert mock_params.mock_testing_fallbacks == expected_fallbacks
+    assert mock_params.mock_testing_context_fallbacks == expected_context
+    assert mock_params.mock_testing_content_policy_fallbacks == expected_content_policy
+    
+    # Verify that the mock testing params were popped from kwargs
+    assert "mock_testing_fallbacks" not in kwargs
+    assert "mock_testing_context_fallbacks" not in kwargs
+    assert "mock_testing_content_policy_fallbacks" not in kwargs
+    
+    # Verify other params remain unchanged
+    assert kwargs["other_param"] == "should_remain"
+
+
+@pytest.mark.parametrize(
+    "fallback_kwarg_value, expected_error",
+    [
+        # Test string values that should convert to True and trigger exceptions
+        ("true", litellm.InternalServerError),
+        ("TRUE", litellm.InternalServerError),
+        ("1", litellm.InternalServerError),
+        ("yes", litellm.InternalServerError),
+        # Test string values that should convert to False and not trigger exceptions
+        ("false", None),
+        ("FALSE", None),
+        ("0", None),
+        ("no", None),
+        # Test actual boolean values
+        (True, litellm.InternalServerError),
+        (False, None),
+    ],
+)
+def test_handle_mock_testing_fallbacks_with_str_to_bool_integration(model_list, fallback_kwarg_value, expected_error):
+    """Test if the router's _handle_mock_testing_fallbacks correctly handles str_to_bool conversion from MockRouterTestingParams"""
+    router = Router(model_list=model_list)
+    
+    kwargs = {
+        "mock_testing_fallbacks": fallback_kwarg_value,
+    }
+    
+    if expected_error:
+        with pytest.raises(expected_error):
+            router._handle_mock_testing_fallbacks(kwargs=kwargs)
+    else:
+        # Should not raise any exception
+        router._handle_mock_testing_fallbacks(kwargs=kwargs)
+        # If we get here, no exception was raised, which is expected


### PR DESCRIPTION
## Bug Fix] Fix handling str, bool types formock_testing_fallbacks on router using /audio endpoints

This PR fixes a bug where mock_testing_fallbacks did not handle `str` values. Moved this to use internal `str_to_bool` helper with tests. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


