### PR TITLE
[Bug Fix] Invite links email should contain the correct invite id

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -166,48 +166,81 @@ class BaseEmailLogger(CustomLogger):
         """
         Get invitation link for the user
         """
-        import asyncio
+        # Early validation
+        if not user_id:
+            verbose_proxy_logger.debug("No user_id provided for invitation link")
+            return base_url
+            
+        if not await self._is_prisma_client_available():
+            return base_url
+            
+        # Wait for any concurrent invitation creation to complete
+        await self._wait_for_invitation_creation()
+        
+        # Get or create invitation
+        invitation = await self._get_or_create_invitation(user_id)
+        if not invitation:
+            verbose_proxy_logger.warning(f"Failed to get/create invitation for user_id: {user_id}")
+            return base_url
+            
+        return self._construct_invitation_link(invitation.id, base_url)
 
+    async def _is_prisma_client_available(self) -> bool:
+        """Check if Prisma client is available"""
+        from litellm.proxy.proxy_server import prisma_client
+        
+        if prisma_client is None:
+            verbose_proxy_logger.debug("Prisma client not found. Unable to lookup invitation")
+            return False
+        return True
+
+    async def _wait_for_invitation_creation(self) -> None:
+        """
+        Wait for any concurrent invitation creation to complete.
+        
+        The UI calls /invitation/new to generate the invitation link.
+        We wait to ensure any pending invitation creation is completed.
+        """
+        import asyncio
+        await asyncio.sleep(10)
+
+    async def _get_or_create_invitation(self, user_id: str):
+        """
+        Get existing invitation or create a new one for the user
+        
+        Returns:
+            Invitation object with id attribute, or None if failed
+        """
         from litellm.proxy.management_helpers.user_invitation import (
             create_invitation_for_user,
         )
         from litellm.proxy.proxy_server import prisma_client
-
-        ################################################################################
-        ########## Sleep for 10 seconds to wait for the invitation link to be created ###
-        ################################################################################
-        # The UI, calls /invitation/new to generate the invitation link
-        # We wait 10 seconds to ensure the link is created
-        ################################################################################
-        await asyncio.sleep(10)
-
+        
         if prisma_client is None:
-            verbose_proxy_logger.debug(
-                f"Prisma client not found. Unable to lookup user email for user_id: {user_id}"
+            verbose_proxy_logger.error("Prisma client is None in _get_or_create_invitation")
+            return None
+            
+        try:
+            # Try to get existing invitation
+            existing_invitations = await prisma_client.db.litellm_invitationlink.find_many(
+                where={"user_id": user_id},
+                order={"created_at": "desc"},
             )
-            return base_url
-
-        if user_id is None:
-            return base_url
-
-        # get the latest invitation link for the user
-        invitation_rows = await prisma_client.db.litellm_invitationlink.find_many(
-            where={"user_id": user_id},
-            order={"created_at": "desc"},
-        )
-        if invitation_rows is None or len(invitation_rows) == 0:
-            invitation_row = await create_invitation_for_user(
+            
+            if existing_invitations and len(existing_invitations) > 0:
+                verbose_proxy_logger.debug(f"Found existing invitation for user_id: {user_id}")
+                return existing_invitations[0]
+            
+            # Create new invitation if none exists
+            verbose_proxy_logger.debug(f"Creating new invitation for user_id: {user_id}")
+            return await create_invitation_for_user(
                 data=InvitationNew(user_id=user_id),
                 user_api_key_dict=UserAPIKeyAuth(user_id=user_id),
             )
-
-        if len(invitation_rows) > 0:
-            invitation_row = invitation_rows[0]
-            return self._construct_invitation_link(
-                invitation_id=invitation_row.id, base_url=base_url
-            )
-
-        return base_url
+            
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error getting/creating invitation for user_id {user_id}: {e}")
+            return None
 
     def _construct_invitation_link(self, invitation_id: str, base_url: str) -> str:
         """

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -152,7 +152,6 @@ from .initialize_dynamic_callback_params import (
 from .specialty_caches.dynamic_logging_cache import DynamicLoggingCache
 
 if TYPE_CHECKING:
-    from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
     from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
 try:
     from litellm_enterprise.enterprise_callbacks.callback_controls import (

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23,6 +23,12 @@
             "search_context_size_medium": 0.0,
             "search_context_size_high": 0.0
         },
+        "file_search_cost_per_1k_calls": 0.0,
+        "file_search_cost_per_gb_per_day": 0.0,
+        "vector_store_cost_per_gb_per_day": 0.0,
+        "computer_use_input_cost_per_1k_tokens": 0.0,
+        "computer_use_output_cost_per_1k_tokens": 0.0,
+        "code_interpreter_cost_per_session": 0.0,
         "supported_regions": [
             "global",
             "us-west-2",
@@ -4560,6 +4566,37 @@
         "supports_prompt_caching": true
     },
     "deepseek/deepseek-chat": {
+        "max_tokens": 8192,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 2.7e-07,
+        "input_cost_per_token_cache_hit": 7e-08,
+        "cache_read_input_token_cost": 7e-08,
+        "cache_creation_input_token_cost": 0.0,
+        "output_cost_per_token": 1.1e-06,
+        "litellm_provider": "deepseek",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true
+    },
+    "deepseek/deepseek-r1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 5.5e-07,
+        "input_cost_per_token_cache_hit": 1.4e-07,
+        "output_cost_per_token": 2.19e-06,
+        "litellm_provider": "deepseek",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true
+    },
+    "deepseek/deepseek-v3": {
         "max_tokens": 8192,
         "max_input_tokens": 65536,
         "max_output_tokens": 8192,

--- a/litellm/proxy/management_helpers/user_invitation.py
+++ b/litellm/proxy/management_helpers/user_invitation.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+
+from fastapi import HTTPException
+
+import litellm
+from litellm.proxy._types import CommonProxyErrors, InvitationNew, UserAPIKeyAuth
+
+
+async def create_invitation_for_user(
+    data: InvitationNew,
+    user_api_key_dict: UserAPIKeyAuth,
+):
+    """
+    Create an invitation for the user to onboard to LiteLLM Admin UI.
+    """
+    from litellm.proxy.proxy_server import litellm_proxy_admin_name, prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+
+    current_time = litellm.utils.get_utc_datetime()
+    expires_at = current_time + timedelta(days=7)
+
+    try:
+        response = await prisma_client.db.litellm_invitationlink.create(
+            data={
+                "user_id": data.user_id,
+                "created_at": current_time,
+                "expires_at": expires_at,
+                "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                "updated_at": current_time,
+                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+            }  # type: ignore
+        )
+        return response
+    except Exception as e:
+        if "Foreign key constraint failed on the field" in str(e):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "User id does not exist in 'LiteLLM_UserTable'. Fix this by creating user via `/user/new`."
+                },
+            )
+        raise HTTPException(status_code=500, detail={"error": str(e)})

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -323,6 +323,7 @@ from litellm.proxy.utils import (
     get_custom_url,
     get_error_message_str,
     get_server_root_path,
+    handle_exception_on_proxy,
     hash_token,
     update_spend,
 )
@@ -7510,49 +7511,37 @@ async def new_invitation(
         }'
     ```
     """
-    global prisma_client
-
-    if prisma_client is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
-        )
-
-    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "{}, your role={}".format(
-                    CommonProxyErrors.not_allowed_access.value,
-                    user_api_key_dict.user_role,
-                )
-            },
-        )
-
-    current_time = litellm.utils.get_utc_datetime()
-    expires_at = current_time + timedelta(days=7)
-
     try:
-        response = await prisma_client.db.litellm_invitationlink.create(
-            data={
-                "user_id": data.user_id,
-                "created_at": current_time,
-                "expires_at": expires_at,
-                "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                "updated_at": current_time,
-                "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-            }  # type: ignore
+        from litellm.proxy.management_helpers.user_invitation import (
+            create_invitation_for_user,
         )
-        return response
-    except Exception as e:
-        if "Foreign key constraint failed on the field" in str(e):
+        global prisma_client
+
+        if prisma_client is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": CommonProxyErrors.db_not_connected_error.value},
+            )
+
+        if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "error": "User id does not exist in 'LiteLLM_UserTable'. Fix this by creating user via `/user/new`."
+                    "error": "{}, your role={}".format(
+                        CommonProxyErrors.not_allowed_access.value,
+                        user_api_key_dict.user_role,
+                    )
                 },
             )
-        raise HTTPException(status_code=500, detail={"error": str(e)})
+        
+        response = await create_invitation_for_user(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
+        return response
+    except Exception as e:
+        raise handle_exception_on_proxy(e)
+
 
 
 @router.get(


### PR DESCRIPTION
## [Bug Fix] Invite links email should contain the correct invite id

Fixes https://github.com/BerriAI/litellm/issues/11978 

Ensure the correct email / invite link is sent when using tf providers or API for inviting users to LiteLLM. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


