### PR TITLE
Added the ability to specify a custom httpx.AsyncClient for AsyncHTTPHandler

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1707,7 +1707,7 @@ If you are using Anthropic models together with models from other providers, we 
 
 :::
 
-### Using HTTP/HTTPS Proxy with LiteLLM
+## Using HTTP/HTTPS Proxy with LiteLLM
 
 This is done by setting your own `httpx.Client` 
 
@@ -1733,6 +1733,6 @@ response = litellm.acompletion(
 
 :::tip
 
-If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#set-ssl_verifyfalse)
+If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#using-httphttps-proxy-with-litellm)
 
 :::

--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1684,7 +1684,7 @@ This is done by setting your own `httpx.Client`
 - For `litellm.completion` set `litellm.client_session` and `litellm.module_level_client`
 - For `litellm.acompletion` set `litellm.aclient_session` and `litellm.module_level_aclient`
 
-as follows
+as follows:
 ```python
 import litellm, httpx
 

--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1676,3 +1676,63 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </TabItem>
 </Tabs>
 
+
+## Usage - Set `ssl_verify=False`
+
+This is done by setting your own `httpx.Client` 
+
+- For `litellm.completion` set `litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(verify=False))`
+- For `litellm.acompletion` set `litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(verify=False))`
+```python
+import litellm, httpx
+
+# for completion
+litellm.module_level_client = litellm.HTTPHandler(client=httpx.Client(verify=False))
+response = litellm.completion(
+    model="claude-3-5-sonnet-20240620",
+    messages=messages,
+)
+
+# for acompletion
+litellm.module_level_aclient = litellm.HTTPHandler(client=httpx.AsyncClient(verify=False))
+response = litellm.acompletion(
+    model="claude-3-5-sonnet-20240620",
+    messages=messages,
+)
+```
+
+:::tip
+
+If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#set-ssl_verifyfalse)
+
+:::
+
+### Using HTTP/HTTPS Proxy with LiteLLM
+
+This is done by setting your own `httpx.Client` 
+
+- For `litellm.completion` set `litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(proxy="http://proxy.com"))`
+- For `litellm.acompletion` set `litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(proxy="http://proxy.com"))`
+```python
+import litellm, httpx
+
+# for completion
+litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(proxy="http://proxy.com"))
+response = litellm.completion(
+    model="claude-3-5-sonnet-20240620",
+    messages=messages,
+)
+
+# for acompletion
+litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(proxy="http://proxy.com"))
+response = litellm.acompletion(
+    model="claude-3-5-sonnet-20240620",
+    messages=messages,
+)
+```
+
+:::tip
+
+If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#set-ssl_verifyfalse)
+
+:::

--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -1681,58 +1681,54 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 
 This is done by setting your own `httpx.Client` 
 
-- For `litellm.completion` set `litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(verify=False))`
-- For `litellm.acompletion` set `litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(verify=False))`
+- For `litellm.completion` set `litellm.client_session` and `litellm.module_level_client`
+- For `litellm.acompletion` set `litellm.aclient_session` and `litellm.module_level_aclient`
+
+as follows
 ```python
 import litellm, httpx
 
 # for completion
-litellm.module_level_client = litellm.HTTPHandler(client=httpx.Client(verify=False))
+litellm.client_session = httpx.Client(verify=False)
+litellm.module_level_client = litellm.HTTPHandler(client=litellm.client_session)
 response = litellm.completion(
     model="claude-3-5-sonnet-20240620",
     messages=messages,
 )
 
 # for acompletion
-litellm.module_level_aclient = litellm.HTTPHandler(client=httpx.AsyncClient(verify=False))
+litellm.aclient_session = httpx.AsyncClient(verify=False)
+litellm.module_level_aclient = litellm.HTTPHandler(client=litellm.aclient_session)
 response = litellm.acompletion(
     model="claude-3-5-sonnet-20240620",
     messages=messages,
 )
 ```
-
-:::tip
-
-If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#set-ssl_verifyfalse)
-
-:::
 
 ## Using HTTP/HTTPS Proxy with LiteLLM
 
 This is done by setting your own `httpx.Client` 
 
-- For `litellm.completion` set `litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(proxy="http://proxy.com"))`
-- For `litellm.acompletion` set `litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(proxy="http://proxy.com"))`
+- For `litellm.completion` set `litellm.client_session` and `litellm.module_level_client`
+- For `litellm.acompletion` set `litellm.aclient_session` and `litellm.module_level_aclient`
+
+as follows:
 ```python
 import litellm, httpx
 
 # for completion
-litellm.module_level_client=litellm.HTTPHandler(client=httpx.Client(proxy="http://proxy.com"))
+litellm.client_session = httpx.Client(proxy="http://proxy.com")
+litellm.module_level_client=litellm.HTTPHandler(client=litellm.client_session)
 response = litellm.completion(
     model="claude-3-5-sonnet-20240620",
     messages=messages,
 )
 
 # for acompletion
-litellm.module_level_aclient=litellm.HTTPHandler(client=httpx.AsyncClient(proxy="http://proxy.com"))
+litellm.aclient_session = httpx.Client(proxy="http://proxy.com")
+litellm.module_level_aclient=litellm.HTTPHandler(client=litellm.aclient_session)
 response = litellm.acompletion(
     model="claude-3-5-sonnet-20240620",
     messages=messages,
 )
 ```
-
-:::tip
-
-If you are using Anthropic models together with models from other providers, we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/openai#using-httphttps-proxy-with-litellm)
-
-:::

--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -609,6 +609,30 @@ response = litellm.acompletion(
 )
 ```
 
+### Using HTTP/HTTPS Proxy with LiteLLM
+
+This is done by setting your own `httpx.Client` 
+
+- For `litellm.completion` set `litellm.client_session=httpx.Client(proxy="http://proxy.com")`
+- For `litellm.acompletion` set `litellm.aclient_session=AsyncClient.Client(proxy="http://proxy.com")`
+```python
+import litellm, httpx
+
+# for completion
+litellm.client_session = httpx.Client(proxy="http://proxy.com")
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=messages,
+)
+
+# for acompletion
+litellm.aclient_session = httpx.AsyncClient(proxy="http://proxy.com")
+response = litellm.acompletion(
+    model="gpt-3.5-turbo",
+    messages=messages,
+)
+```
+
 
 ### Using OpenAI Proxy with LiteLLM
 ```python

--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -609,6 +609,12 @@ response = litellm.acompletion(
 )
 ```
 
+:::tip
+
+If you are using OpenAI models together with models from other providers (e.g. Anthropic), we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/anthropic#usage---set-ssl_verifyfalse)
+
+:::
+
 ### Using HTTP/HTTPS Proxy with LiteLLM
 
 This is done by setting your own `httpx.Client` 
@@ -632,6 +638,12 @@ response = litellm.acompletion(
     messages=messages,
 )
 ```
+
+:::tip
+
+If you are using OpenAI models together with models from other providers (e.g. Anthropic), we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/anthropic#usage---set-ssl_verifyfalse)
+
+:::
 
 
 ### Using OpenAI Proxy with LiteLLM

--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -641,7 +641,7 @@ response = litellm.acompletion(
 
 :::tip
 
-If you are using OpenAI models together with models from other providers (e.g. Anthropic), we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/anthropic#usage---set-ssl_verifyfalse)
+If you are using OpenAI models together with models from other providers (e.g. Anthropic), we recommend setting this parameter along with the other parameter mentioned on [this page.](/docs/providers/anthropic#using-httphttps-proxy-with-litellm)
 
 :::
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -919,12 +919,10 @@ def get_async_httpx_client(
         return _cached_client
 
     if params is not None:
-        _new_client = AsyncHTTPHandler(**params)
-    elif litellm.module_level_aclient is not None:
-        _new_client = litellm.module_level_aclient
+        _new_client = AsyncHTTPHandler(**params, client=litellm.aclient_session)
     else:
         _new_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=600.0, connect=5.0)
+            timeout=httpx.Timeout(timeout=600.0, connect=5.0),client=litellm.aclient_session
         )
 
     litellm.in_memory_llm_clients_cache.set_cache(
@@ -957,11 +955,9 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
         return _cached_client
 
     if params is not None:
-        _new_client = HTTPHandler(**params)
-    elif litellm.module_level_client is not None:
-        _new_client = litellm.module_level_client
+        _new_client = HTTPHandler(**params, client=litellm.client_session)
     else:
-        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
+        _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0), client=litellm.client_session)
 
     litellm.in_memory_llm_clients_cache.set_cache(
         key=_cache_key_name,

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -101,16 +101,21 @@ class AsyncHTTPHandler:
         concurrent_limit=1000,
         client_alias: Optional[str] = None,  # name for client in logs
         ssl_verify: Optional[VerifyTypes] = None,
+        client: Optional[httpx.AsyncClient] = None
     ):
         self.timeout = timeout
         self.event_hooks = event_hooks
-        self.client = self.create_client(
-            timeout=timeout,
-            concurrent_limit=concurrent_limit,
-            event_hooks=event_hooks,
-            ssl_verify=ssl_verify,
-        )
         self.client_alias = client_alias
+
+        if client is None:
+            self.client = self.create_client(
+                timeout=timeout,
+                concurrent_limit=concurrent_limit,
+                event_hooks=event_hooks,
+                ssl_verify=ssl_verify,
+            )
+        else:
+            self.client = client
 
     def create_client(
         self,

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -922,7 +922,7 @@ def get_async_httpx_client(
         _new_client = AsyncHTTPHandler(**params, client=litellm.aclient_session)
     else:
         _new_client = AsyncHTTPHandler(
-            timeout=httpx.Timeout(timeout=600.0, connect=5.0),client=litellm.aclient_session
+            timeout=httpx.Timeout(timeout=600.0, connect=5.0), client=litellm.aclient_session
         )
 
     litellm.in_memory_llm_clients_cache.set_cache(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -920,6 +920,8 @@ def get_async_httpx_client(
 
     if params is not None:
         _new_client = AsyncHTTPHandler(**params)
+    elif litellm.module_level_aclient is not None:
+        _new_client = litellm.module_level_aclient
     else:
         _new_client = AsyncHTTPHandler(
             timeout=httpx.Timeout(timeout=600.0, connect=5.0)
@@ -956,6 +958,8 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
 
     if params is not None:
         _new_client = HTTPHandler(**params)
+    elif litellm.module_level_client is not None:
+        _new_client = litellm.module_level_client
     else:
         _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0))
 

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -907,6 +907,9 @@ def get_async_httpx_client(
     """
     _params_key_name = ""
     if params is not None:
+        if params.get("client") is None and litellm.aclient_session is not None:
+            params["client"] = litellm.aclient_session
+
         for key, value in params.items():
             try:
                 _params_key_name += f"{key}_{value}"
@@ -919,7 +922,7 @@ def get_async_httpx_client(
         return _cached_client
 
     if params is not None:
-        _new_client = AsyncHTTPHandler(**params, client=litellm.aclient_session)
+        _new_client = AsyncHTTPHandler(**params)
     else:
         _new_client = AsyncHTTPHandler(
             timeout=httpx.Timeout(timeout=600.0, connect=5.0), client=litellm.aclient_session
@@ -942,6 +945,9 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
     """
     _params_key_name = ""
     if params is not None:
+        if params.get("client") is None and litellm.client_session is not None:
+            params["client"] = litellm.client_session
+
         for key, value in params.items():
             try:
                 _params_key_name += f"{key}_{value}"
@@ -955,7 +961,7 @@ def _get_httpx_client(params: Optional[dict] = None) -> HTTPHandler:
         return _cached_client
 
     if params is not None:
-        _new_client = HTTPHandler(**params, client=litellm.client_session)
+        _new_client = HTTPHandler(**params)
     else:
         _new_client = HTTPHandler(timeout=httpx.Timeout(timeout=600.0, connect=5.0), client=litellm.client_session)
 

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -180,3 +180,15 @@ def test_get_ssl_context_integration():
     # Verify it has basic SSL context properties
     assert ssl_context.protocol is not None
     assert ssl_context.verify_mode is not None
+
+
+def test_async_http_handler_custom_client():
+    """Test that verifies that setting client=httpx.AsyncClient(...) actually assigns the custom client"""
+    # Create custom httpx.AsyncClient
+    custom_client = httpx.AsyncClient(proxy="http://proxy.com")
+
+    # Create custom AsyncHTTPHandler and pass custom client into it
+    handler = AsyncHTTPHandler(client=custom_client)
+
+    # Verify new client was set
+    assert handler.client == custom_client


### PR DESCRIPTION
## Title

Added the ability to specify a custom httpx.AsyncClient for AsyncHTTPHandler (asynchronous Anthropic model calls)

## Relevant issues

None

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
📖 Documentation
✅ Test