### PR TITLE
[Bug Fix] Allow passing litellm_params when using generateContent API endpoint

### DIFF
--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -1,6 +1,7 @@
 from typing import Any, AsyncIterator, Coroutine, Dict, List, Optional, Union, cast
 
 import litellm
+from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ModelResponse
 
 from .transformation import GoogleGenAIAdapter
@@ -18,6 +19,7 @@ class GenerateContentToCompletionHandler:
         contents: Union[List[Dict[str, Any]], Dict[str, Any]],
         config: Optional[Dict[str, Any]] = None,
         stream: bool = False,
+        litellm_params: Optional[GenericLiteLLMParams] = None,
         extra_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Prepare kwargs for litellm.completion/acompletion"""
@@ -27,6 +29,7 @@ class GenerateContentToCompletionHandler:
             model=model,
             contents=contents,
             config=config,
+            litellm_params=litellm_params,
             **(extra_kwargs or {})
         )
         
@@ -43,6 +46,7 @@ class GenerateContentToCompletionHandler:
         contents: Union[List[Dict[str, Any]], Dict[str, Any]],
         config: Optional[Dict[str, Any]] = None,
         stream: bool = False,
+        litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncIterator[bytes]]:
         """Handle generate_content call asynchronously using completion adapter"""
@@ -52,6 +56,7 @@ class GenerateContentToCompletionHandler:
             contents=contents,
             config=config,
             stream=stream,
+            litellm_params=litellm_params,
             extra_kwargs=kwargs,
         )
         
@@ -85,6 +90,7 @@ class GenerateContentToCompletionHandler:
         config: Optional[Dict[str, Any]] = None,
         stream: bool = False,
         _is_async: bool = False,
+        litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncIterator[bytes], Coroutine[Any, Any, Union[Dict[str, Any], AsyncIterator[bytes]]]]:
         """Handle generate_content call using completion adapter"""
@@ -103,6 +109,7 @@ class GenerateContentToCompletionHandler:
             contents=contents,
             config=config,
             stream=stream,
+            litellm_params=litellm_params,
             extra_kwargs=kwargs,
         )
         

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -44,9 +44,9 @@ class GenerateContentToCompletionHandler:
     async def async_generate_content_handler(
         model: str,
         contents: Union[List[Dict[str, Any]], Dict[str, Any]],
+        litellm_params: GenericLiteLLMParams,
         config: Optional[Dict[str, Any]] = None,
         stream: bool = False,
-        litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncIterator[bytes]]:
         """Handle generate_content call asynchronously using completion adapter"""
@@ -87,10 +87,10 @@ class GenerateContentToCompletionHandler:
     def generate_content_handler(
         model: str,
         contents: Union[List[Dict[str, Any]], Dict[str, Any]],
+        litellm_params: GenericLiteLLMParams,
         config: Optional[Dict[str, Any]] = None,
         stream: bool = False,
         _is_async: bool = False,
-        litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
     ) -> Union[Dict[str, Any], AsyncIterator[bytes], Coroutine[Any, Any, Union[Dict[str, Any], AsyncIterator[bytes]]]]:
         """Handle generate_content call using completion adapter"""
@@ -101,6 +101,7 @@ class GenerateContentToCompletionHandler:
                 contents=contents,
                 config=config,
                 stream=stream,
+                litellm_params=litellm_params,
                 **kwargs,
             )
             

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -2,7 +2,6 @@ import json
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Union, cast
 
 from litellm.litellm_core_utils.json_validation_rule import normalize_tool_schema
-from litellm.types.google_genai.adapters import LiteLLMChatCompletionRequest
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantMessage,
@@ -111,7 +110,7 @@ class GoogleGenAIAdapter:
         config: Optional[Dict[str, Any]] = None,
         litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
-    ) -> LiteLLMChatCompletionRequest:
+    ) -> ChatCompletionRequest:
         """
         Transform generate_content request to litellm completion format
 
@@ -135,7 +134,7 @@ class GoogleGenAIAdapter:
         messages = self._transform_contents_to_messages(contents_list)
 
         # Create base request as dict (which is compatible with ChatCompletionRequest)
-        completion_request: LiteLLMChatCompletionRequest = {
+        completion_request: ChatCompletionRequest = {
             "model": model,
             "messages": messages,
         }
@@ -194,16 +193,16 @@ class GoogleGenAIAdapter:
     
     def _add_generic_litellm_params_to_request(
         self, 
-        completion_request: LiteLLMChatCompletionRequest, 
+        completion_request: ChatCompletionRequest, 
         litellm_params: Optional[GenericLiteLLMParams] = None):
         """Add generic litellm params to request. e.g add api_base, api_key, api_version, etc.
 
         Args:
-            completion_request: LiteLLMChatCompletionRequest
+            completion_request: ChatCompletionRequest
             litellm_params: GenericLiteLLMParams
 
         Returns:
-            LiteLLMChatCompletionRequest
+            ChatCompletionRequest
         """
         if litellm_params:
             litellm_dict = litellm_params.model_dump(exclude_none=True)

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -110,7 +110,7 @@ class GoogleGenAIAdapter:
         config: Optional[Dict[str, Any]] = None,
         litellm_params: Optional[GenericLiteLLMParams] = None,
         **kwargs,
-    ) -> ChatCompletionRequest:
+    ) -> Dict[str, Any]:
         """
         Transform generate_content request to litellm completion format
 
@@ -121,7 +121,7 @@ class GoogleGenAIAdapter:
             **kwargs: Additional parameters
 
         Returns:
-            ChatCompletionRequest in OpenAI format
+            Dict in OpenAI format
         """
 
         # Normalize contents to list format
@@ -185,30 +185,37 @@ class GoogleGenAIAdapter:
             if tool_choice:
                 completion_request["tool_choice"] = tool_choice
         
+        #########################################################
         # forward any litellm specific params
+        #########################################################
+        completion_request_dict = dict(completion_request)
         if litellm_params:
-            completion_request = self._add_generic_litellm_params_to_request(completion_request, litellm_params)
+            completion_request_dict = self._add_generic_litellm_params_to_request(
+                completion_request_dict=completion_request_dict,
+                litellm_params=litellm_params
+            )
 
-        return completion_request
+        return completion_request_dict
     
     def _add_generic_litellm_params_to_request(
         self, 
-        completion_request: ChatCompletionRequest, 
-        litellm_params: Optional[GenericLiteLLMParams] = None):
+        completion_request_dict: Dict[str, Any], 
+        litellm_params: Optional[GenericLiteLLMParams] = None
+    ) -> dict:
         """Add generic litellm params to request. e.g add api_base, api_key, api_version, etc.
 
         Args:
-            completion_request: ChatCompletionRequest
+            completion_request_dict: Dict[str, Any]
             litellm_params: GenericLiteLLMParams
 
         Returns:
-            ChatCompletionRequest
+            Dict[str, Any]
         """
         if litellm_params:
             litellm_dict = litellm_params.model_dump(exclude_none=True)
             for key, value in litellm_dict.items():
-                completion_request[key] = value
-        return completion_request
+                completion_request_dict[key] = value
+        return completion_request_dict
 
     def translate_completion_output_params_streaming(
         self, completion_stream: Any

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -300,6 +300,7 @@ def generate_content(
                 config=setup_result.generate_content_config_dict,
                 stream=False,
                 _is_async=_is_async,
+                litellm_params=setup_result.litellm_params,
                 **kwargs
             )
 

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -377,6 +377,7 @@ async def agenerate_content_stream(
                 model=setup_result.model,
                 contents=contents,  # type: ignore
                 config=setup_result.generate_content_config_dict,
+                litellm_params=setup_result.litellm_params,
                 stream=True,
                 **kwargs
             )
@@ -452,6 +453,7 @@ def generate_content_stream(
                 config=setup_result.generate_content_config_dict,
                 stream=True,
                 _is_async=_is_async,
+                litellm_params=setup_result.litellm_params,
                 **kwargs
             )
 


### PR DESCRIPTION
## [Bug Fix] Allow passing litellm_params when using generateContent API endpoint

Allow passing dynamic litellm params when using new generateContent api endoint

Fixes https://github.com/BerriAI/litellm/issues/12174

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


