### PR TITLE
Use the -d flag in docs instead of -D

### DIFF
--- a/docs/my-website/docs/assistants.md
+++ b/docs/my-website/docs/assistants.md
@@ -279,7 +279,7 @@ with run as run:
 curl -X POST 'http://0.0.0.0:4000/threads/{thread_id}/runs' \
 -H 'Authorization: Bearer sk-1234' \
 -H 'Content-Type: application/json' \
--D '{
+-d '{
       "assistant_id": "asst_6xVZQFFy1Kw87NbnYeNebxTf",
       "stream": true
 }'

--- a/docs/my-website/docs/image_generation.md
+++ b/docs/my-website/docs/image_generation.md
@@ -52,7 +52,7 @@ litellm --config /path/to/config.yaml
 curl -X POST 'http://0.0.0.0:4000/v1/images/generations' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: Bearer sk-1234' \
--D '{
+-d '{
     "model": "gpt-image-1",
     "prompt": "A cute baby sea otter",
     "n": 1,

--- a/docs/my-website/docs/old_guardrails.md
+++ b/docs/my-website/docs/old_guardrails.md
@@ -212,7 +212,7 @@ If you need to switch `pii_masking` off for an API Key set `"permissions": {"pii
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
         "permissions": {"pii_masking": true}
     }'
 ```

--- a/docs/my-website/docs/proxy/customers.md
+++ b/docs/my-website/docs/proxy/customers.md
@@ -136,7 +136,7 @@ Create / Update a customer with budget
 curl -X POST 'http://0.0.0.0:4000/customer/new'         
     -H 'Authorization: Bearer sk-1234'         
     -H 'Content-Type: application/json'         
-    -D '{
+    -d '{
         "user_id" : "my-customer-id",
         "max_budget": "0", # 👈 CAN BE FLOAT
     }'

--- a/docs/my-website/docs/proxy/guardrails.md
+++ b/docs/my-website/docs/proxy/guardrails.md
@@ -216,7 +216,7 @@ If you need to switch `pii_masking` off for an API Key set `"permissions": {"pii
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
         "permissions": {"pii_masking": true}
     }'
 ```

--- a/docs/my-website/docs/proxy/guardrails/aporia_api.md
+++ b/docs/my-website/docs/proxy/guardrails/aporia_api.md
@@ -155,7 +155,7 @@ Use this to control what guardrails run per project. In this tutorial we only wa
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
             "guardrails": ["aporia-pre-guard", "aporia-post-guard"]
         }
     }'

--- a/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
+++ b/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
@@ -74,7 +74,7 @@ Use this to control what guardrails run per project. In this tutorial we only wa
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
             "guardrails": ["guardrails_ai-guard"]
         }
     }'

--- a/docs/my-website/docs/proxy/guardrails/quick_start.md
+++ b/docs/my-website/docs/proxy/guardrails/quick_start.md
@@ -421,7 +421,7 @@ Use this to control what guardrails run per API Key. In this tutorial we only wa
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
             "guardrails": ["aporia-pre-guard", "aporia-post-guard"]
         }
     }'

--- a/docs/my-website/docs/proxy/team_budgets.md
+++ b/docs/my-website/docs/proxy/team_budgets.md
@@ -318,7 +318,7 @@ curl -X POST 'http://0.0.0.0:4000/key/generate' \
 curl -X POST 'http://0.0.0.0:4000/chat/completions' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: sk-...' \ # 👈 key from step 2.
-  -D '{
+  -d '{
   "model": "gpt-3.5-turbo",
   "messages": [
       {

--- a/docs/my-website/docs/tutorials/litellm_proxy_aporia.md
+++ b/docs/my-website/docs/tutorials/litellm_proxy_aporia.md
@@ -150,7 +150,7 @@ Use this to control what guardrails run per project. In this tutorial we only wa
 curl -X POST 'http://0.0.0.0:4000/key/generate' \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
-    -D '{
+    -d '{
             "guardrails": ["aporia-pre-guard", "aporia-post-guard"]
         }
     }'


### PR DESCRIPTION
## Replace the -D flag with the -d in the docs

The `-D` flag in curl is for dumping headers to a file. To pass JSON data to an endpoint, the `-d/--data` flag should be used instead.
This PR updates the documentation examples accordingly.

## Relevant issues


## Pre-Submission checklist

This a docs-only PR, no code affected, thus no tests.

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes


