### PR TITLE
Cost Per Unit Values Can Now Be Strings

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -163,6 +163,17 @@ def calculate_cost_component(
         float: The calculated cost
     """
     cost_per_unit = model_info.get(cost_key)
+
+    # Sometimes the cost per unit is a string (e.g.: If a value like "3e-7" was read from the config.yaml)
+    try:
+        if isinstance(cost_per_unit, str):
+            cost_per_unit = float(cost_per_unit)
+    except ValueError:
+        verbose_logger.exception(
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::calculate_cost_per_component(): Exception occured - {cost_per_unit}\nDefaulting to 0.0"
+        )
+        return 0.0
+    
     if (
         cost_per_unit is not None
         and isinstance(cost_per_unit, float)

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -77,9 +77,8 @@ def _generic_cost_per_character(
         prompt_cost = prompt_characters * custom_prompt_cost
     except Exception as e:
         verbose_logger.exception(
-            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
-                str(e)
-            )
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): "
+            f"Exception occured - {str(e)}\nDefaulting to None"
         )
 
         prompt_cost = None
@@ -97,9 +96,8 @@ def _generic_cost_per_character(
         completion_cost = completion_characters * custom_completion_cost
     except Exception as e:
         verbose_logger.exception(
-            "litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {}\nDefaulting to None".format(
-                str(e)
-            )
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): "
+            f"Exception occured - {str(e)}\nDefaulting to None"
         )
 
         completion_cost = None
@@ -111,8 +109,8 @@ def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, fl
     """
     Return prompt cost for a given model and usage.
 
-    If input_tokens > threshold and `input_cost_per_token_above_[x]k_tokens` or `input_cost_per_token_above_[x]_tokens` is set,
-    then we use the corresponding threshold cost.
+    If input_tokens > threshold and `input_cost_per_token_above_[x]k_tokens` or 
+    `input_cost_per_token_above_[x]_tokens` is set, then we use the corresponding threshold cost.
     """
     prompt_base_cost = model_info["input_cost_per_token"]
     completion_base_cost = model_info["output_cost_per_token"]
@@ -123,7 +121,8 @@ def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, fl
             prompt_base_cost = float(prompt_base_cost)
         except ValueError:
             verbose_logger.exception(
-                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): Exception converting prompt_base_cost string to float - {prompt_base_cost}\nDefaulting to 0.0"
+                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): "
+                f"Exception converting prompt_base_cost string to float - {prompt_base_cost}\nDefaulting to 0.0"
             )
             prompt_base_cost = 0.0
     
@@ -132,7 +131,8 @@ def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, fl
             completion_base_cost = float(completion_base_cost)
         except ValueError:
             verbose_logger.exception(
-                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): Exception converting completion_base_cost string to float - {completion_base_cost}\nDefaulting to 0.0"
+                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): "
+                f"Exception converting completion_base_cost string to float - {completion_base_cost}\nDefaulting to 0.0"
             )
             completion_base_cost = 0.0
 
@@ -159,7 +159,8 @@ def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, fl
                             threshold_prompt_cost = float(threshold_prompt_cost)
                         except ValueError:
                             verbose_logger.exception(
-                                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): Exception converting threshold_prompt_cost string to float - {threshold_prompt_cost}\nDefaulting to base cost"
+                                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): "
+                                f"Exception converting threshold_prompt_cost string to float - {threshold_prompt_cost}\nDefaulting to base cost"
                             )
                             threshold_prompt_cost = prompt_base_cost
                     
@@ -168,7 +169,8 @@ def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, fl
                             threshold_completion_cost = float(threshold_completion_cost)
                         except ValueError:
                             verbose_logger.exception(
-                                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): Exception converting threshold_completion_cost string to float - {threshold_completion_cost}\nDefaulting to base cost"
+                                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_get_token_base_cost(): "
+                                f"Exception converting threshold_completion_cost string to float - {threshold_completion_cost}\nDefaulting to base cost"
                             )
                             threshold_completion_cost = completion_base_cost
                     
@@ -205,7 +207,8 @@ def calculate_cost_component(
             cost_per_unit = float(cost_per_unit)
     except ValueError:
         verbose_logger.exception(
-            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::calculate_cost_per_component(): Exception occured - {cost_per_unit}\nDefaulting to 0.0"
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::calculate_cost_per_component(): "
+            f"Exception occured - {cost_per_unit}\nDefaulting to 0.0"
         )
         return 0.0
     
@@ -357,7 +360,8 @@ def _convert_string_cost_to_float(cost_value: Any, cost_name: str) -> Optional[f
             return float(cost_value)
         except ValueError:
             verbose_logger.exception(
-                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::generic_cost_per_token(): Exception converting {cost_name} string to float - {cost_value}\nDefaulting to None"
+                f"litellm.litellm_core_utils.llm_cost_calc.utils.py::generic_cost_per_token(): "
+                f"Exception converting {cost_name} string to float - {cost_value}\nDefaulting to None"
             )
             return None
     elif isinstance(cost_value, (int, float)):
@@ -367,7 +371,8 @@ def _convert_string_cost_to_float(cost_value: Any, cost_name: str) -> Optional[f
     else:
         # For any other type, log a warning and return None
         verbose_logger.warning(
-            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_convert_string_cost_to_float(): Unexpected type for {cost_name}: {type(cost_value)}. Defaulting to None"
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::_convert_string_cost_to_float(): "
+            f"Unexpected type for {cost_name}: {type(cost_value)}. Defaulting to None"
         )
         return None
 

--- a/mypy_simple.ini
+++ b/mypy_simple.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = True
+show_error_codes = True
+warn_return_any = False
+

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -140,3 +140,193 @@ def test_generic_cost_per_token_above_200k_tokens():
         * usage.completion_tokens,
         10,
     )
+
+
+def test_string_cost_values():
+    """Test that cost values defined as strings are properly converted to floats."""
+    from unittest.mock import patch
+    
+    # Mock model info with string cost values (as might be read from config.yaml)
+    mock_model_info = {
+        "input_cost_per_token": "3e-7",  # String representation of scientific notation
+        "output_cost_per_token": "6e-7",  # String representation of scientific notation
+        "input_cost_per_audio_token": "0.000001",  # String representation of decimal
+        "output_cost_per_audio_token": "0.000002",  # String representation of decimal
+        "cache_read_input_token_cost": "1.5e-8",  # String representation of scientific notation
+        "cache_creation_input_token_cost": "2.5e-8",  # String representation of scientific notation
+    }
+    
+    # Test usage with various token types
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=100,
+            cached_tokens=200,
+            text_tokens=700,
+            image_tokens=None
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            audio_tokens=50,
+            reasoning_tokens=None,
+            text_tokens=450,
+            accepted_prediction_tokens=None,
+            rejected_prediction_tokens=None
+        ),
+        _cache_creation_input_tokens=150
+    )
+    
+    # Mock get_model_info to return our mock model info
+    with patch('litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info', return_value=mock_model_info):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="test-model",
+            usage=usage,
+            custom_llm_provider="test-provider"
+        )
+    
+    # Calculate expected costs manually
+    # Prompt cost = text_tokens * input_cost + audio_tokens * audio_cost + cached_tokens * cache_read_cost + cache_creation_tokens * cache_creation_cost
+    expected_prompt_cost = (
+        700 * 3e-7 +  # text tokens
+        100 * 1e-6 +  # audio tokens  
+        200 * 1.5e-8 +  # cached tokens
+        150 * 2.5e-8   # cache creation tokens
+    )
+    
+    # Completion cost = text_tokens * output_cost + audio_tokens * audio_output_cost
+    expected_completion_cost = (
+        450 * 6e-7 +  # text tokens
+        50 * 2e-6     # audio tokens
+    )
+    
+    # Assert costs are calculated correctly
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+    assert round(completion_cost, 12) == round(expected_completion_cost, 12)
+
+
+def test_calculate_cost_component_with_string_values():
+    """Test the calculate_cost_component function directly with string cost values."""
+    from litellm.litellm_core_utils.llm_cost_calc.utils import calculate_cost_component
+    
+    # Test with valid string scientific notation
+    model_info = {"input_cost_per_token": "3e-7"}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 1000)
+    assert cost == 1000 * 3e-7
+    
+    # Test with valid string decimal notation
+    model_info = {"output_cost_per_token": "0.000001"}
+    cost = calculate_cost_component(model_info, "output_cost_per_token", 500)
+    assert cost == 500 * 0.000001
+    
+    # Test with float value (should work as before)
+    model_info = {"input_cost_per_token": 3e-7}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 1000)
+    assert cost == 1000 * 3e-7
+    
+    # Test with invalid string value (should return 0.0)
+    model_info = {"input_cost_per_token": "invalid_number"}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 1000)
+    assert cost == 0.0
+    
+    # Test with None value (should return 0.0)
+    model_info = {"input_cost_per_token": None}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 1000)
+    assert cost == 0.0
+    
+    # Test with missing key (should return 0.0)
+    model_info = {}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 1000)
+    assert cost == 0.0
+    
+    # Test with zero usage (should return 0.0)
+    model_info = {"input_cost_per_token": "3e-7"}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", 0)
+    assert cost == 0.0
+    
+    # Test with None usage (should return 0.0)
+    model_info = {"input_cost_per_token": "3e-7"}
+    cost = calculate_cost_component(model_info, "input_cost_per_token", None)
+    assert cost == 0.0
+
+
+def test_string_cost_values_edge_cases():
+    """Test edge cases for string cost value handling."""
+    from unittest.mock import patch
+    
+    # Test with mixed string and float cost values
+    mock_model_info = {
+        "input_cost_per_token": "1e-6",  # String
+        "output_cost_per_token": 2e-6,   # Float
+        "input_cost_per_audio_token": "invalid",  # Invalid string
+        "output_cost_per_audio_token": None,  # None value
+    }
+    
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=100,
+            cached_tokens=0,
+            text_tokens=1000,
+            image_tokens=None
+        ),
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            audio_tokens=50,
+            reasoning_tokens=None,
+            text_tokens=500,
+            accepted_prediction_tokens=None,
+            rejected_prediction_tokens=None
+        )
+    )
+    
+    with patch('litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info', return_value=mock_model_info):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="test-model",
+            usage=usage,
+            custom_llm_provider="test-provider"
+        )
+    
+    # Expected costs:
+    # Prompt: 1000 * 1e-6 + 100 * 0 (invalid string becomes 0)
+    # Completion: 500 * 2e-6 (text_tokens == completion_tokens, so is_text_tokens_total=True, no separate audio cost)
+    expected_prompt_cost = 1000 * 1e-6
+    expected_completion_cost = 500 * 2e-6
+    
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+    assert round(completion_cost, 12) == round(expected_completion_cost, 12)
+
+
+def test_string_cost_values_with_threshold():
+    """Test that string cost values work correctly with threshold pricing."""
+    from unittest.mock import patch
+    
+    # Mock model info with string cost values including threshold pricing
+    mock_model_info = {
+        "input_cost_per_token": "1e-6",  # String base cost
+        "output_cost_per_token": "2e-6",  # String base cost
+        "input_cost_per_token_above_200k_tokens": "5e-7",  # String threshold cost (lower)
+        "output_cost_per_token_above_200k_tokens": "1e-6",  # String threshold cost (lower)
+    }
+    
+    # Test usage above threshold
+    usage = Usage(
+        prompt_tokens=250000,  # Above 200k threshold
+        completion_tokens=1000,
+        total_tokens=251000,
+    )
+    
+    with patch('litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info', return_value=mock_model_info):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="test-model",
+            usage=usage,
+            custom_llm_provider="test-provider"
+        )
+    
+    # Expected costs using threshold pricing (string values converted to float)
+    expected_prompt_cost = 250000 * 5e-7  # threshold cost
+    expected_completion_cost = 1000 * 1e-6  # threshold cost
+    
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+    assert round(completion_cost, 12) == round(expected_completion_cost, 12)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1,21 +1,10 @@
-import json
 import os
 import sys
 
-import pytest
-from fastapi.testclient import TestClient
-
 import litellm
-from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
-    StandardBuiltInToolCostTracking,
-)
-from litellm.types.llms.openai import FileSearchTool, WebSearchOptions
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
-    ModelInfo,
-    ModelResponse,
     PromptTokensDetailsWrapper,
-    StandardBuiltInToolsParams,
 )
 
 sys.path.insert(
@@ -28,7 +17,6 @@ from litellm.types.utils import Usage
 
 def test_reasoning_tokens_no_price_set():
     model = "o1-mini"
-    custom_llm_provider = "openai"
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
     model_cost_map = litellm.model_cost[model]
@@ -56,11 +44,9 @@ def test_reasoning_tokens_no_price_set():
         model_cost_map["input_cost_per_token"] * usage.prompt_tokens,
         10,
     )
-    print(f"completion_cost: {completion_cost}")
     expected_completion_cost = (
         model_cost_map["output_cost_per_token"] * usage.completion_tokens
     )
-    print(f"expected_completion_cost: {expected_completion_cost}")
     assert round(completion_cost, 10) == round(
         expected_completion_cost,
         10,


### PR DESCRIPTION
## Title

Cost Per Unit Values Can Now Be Strings

## Relevant issues

I'm not sure.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/e12f61bc-23d4-4ace-a2d9-8bc14c3938ec" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

We have an ongoing issue where specifying custom price values in the Helm Chart causes the `user_spend` to fail to update. For example (From the `deploy.yaml`) Suppose I specify a custom price...

```
releases:
- name: litellm
  repository: litellm
  chart: litellm-helm
  version: main
  values:
    ...
    proxy_config:
      ...
      model_list:
      ...
      - model_name: "prod/claude-3-5-sonnet-20241022"
        litellm_params:
          model: "anthropic/claude-3-5-sonnet-20241022"
          api_key: os.environ/ANTHROPIC_PROD_API_KEY
        model_info:
          input_cost_per_token: 0.000006
          ...
      ...
```

Taking `input_cost_per_token` as an example - the ConfigMap produces an /etc/litellm/config.yaml with a value for this `6e-7`. Given that LiteLLM uses PyYaml and interprets this as YAML 1.1 (Not YAML 1.2!), this is interpreted as the string `6e-7`, and before the change, LiteLLM disregards this string.

After the change, LiteLLM will try to convert any string to a float and log an error if the conversion fails, while still maintaining the default behavior of returning `0.0` when the string cannot be parsed as a float

