### PR TITLE
Passes through extra_ properties on "custom" llm provider

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3231,6 +3231,7 @@ def completion(  # type: ignore # noqa: PLR0915
                         "top_p": top_p,
                         "top_k": kwargs.get("top_k"),
                     },
+                    **kwargs.get("extra_body", {}),
                 },
             )
             response_json = resp.json()

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3221,6 +3221,7 @@ def completion(  # type: ignore # noqa: PLR0915
             prompt = " ".join([message["content"] for message in messages])  # type: ignore
             resp = litellm.module_level_client.post(
                 url,
+                headers=headers,
                 json={
                     "model": model,
                     "params": {

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -282,6 +282,51 @@ def test_custom_provider_with_extra_headers():
         mock_post.assert_called_once()
         assert mock_post.call_args[1]["headers"]["X-Custom-Header"] == "custom-value"
 
+def test_custom_provider_with_extra_body():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
+        response = litellm.completion(
+            model="custom/custom",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            extra_body={"X-Custom-BodyValue": "custom-value", "X-Custom-BodyValue2": "custom-value2"},
+            api_base="https://example.com/api/v1",
+        )
+        mock_post.assert_called_once()
+
+        assert mock_post.call_args[1]["json"]["X-Custom-BodyValue"] == "custom-value"
+        assert mock_post.call_args[1]["json"] == {
+            'model': 'custom',
+            'params': {
+                'prompt': ['Hello, how are you?'],
+                'max_tokens': None,
+                'temperature': None,
+                'top_p': None,
+                'top_k': None
+            },
+            'X-Custom-BodyValue': 'custom-value',
+            'X-Custom-BodyValue2': 'custom-value2'
+        }
+
+    # test that extra_body is not passed if not provided
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
+        response = litellm.completion(
+            model="custom/custom",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            api_base="https://example.com/api/v1",
+        )
+        mock_post.assert_called_once()
+        assert mock_post.call_args[1]["json"] == {
+            'model': 'custom',
+            'params': {
+                'prompt': ['Hello, how are you?'],
+                'max_tokens': None,
+                'temperature': None,
+                'top_p': None,
+                'top_k': None
+            }
+        }
+
 
 @pytest.fixture(autouse=True)
 def set_openrouter_api_key():

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -268,6 +268,21 @@ def test_bedrock_latency_optimized_inference():
         assert json_data["performanceConfig"]["latency"] == "optimized"
 
 
+def test_custom_provider_with_extra_headers():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    with patch.object(litellm.llms.custom_httpx.http_handler.HTTPHandler, "post") as mock_post:
+        response = litellm.completion(
+            model="custom/custom",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            headers={"X-Custom-Header": "custom-value"},
+            api_base="https://example.com/api/v1",
+        )
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args[1]["headers"]["X-Custom-Header"] == "custom-value"
+
+
 @pytest.fixture(autouse=True)
 def set_openrouter_api_key():
     original_api_key = os.environ.get("OPENROUTER_API_KEY")


### PR DESCRIPTION
## Title

Pass extra headers and body through post request when using a "custom" llm provider.

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature


## Changes

- Pass headers/extra_headers through when using a custom model provider
- Pass extra_body through when using a custom model provider


# Screenshot of new unit tests
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/278285a7-cb59-4090-9bab-e5996344095a" />

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/dff8ffa9-cfb7-42a9-8d1c-3add12ecad8e" />



# screenshot of all unit tests

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/e34b9759-4d10-46d7-8cb4-eee1915423f4" />


