### PR TITLE
Add support for extra body option for aiohttp_openai

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -242,6 +242,7 @@ class BaseLLMAIOHTTPHandler:
             stream=stream,
         )
 
+        extra_body = optional_params.pop("extra_body", {})
         data = provider_config.transform_request(
             model=model,
             messages=messages,
@@ -249,6 +250,7 @@ class BaseLLMAIOHTTPHandler:
             litellm_params=litellm_params,
             headers=headers,
         )
+        data = {**data, **extra_body}
 
         ## LOGGING
         logging_obj.pre_call(

--- a/tests/llm_translation/test_aiohttp_openai.py
+++ b/tests/llm_translation/test_aiohttp_openai.py
@@ -31,3 +31,35 @@ async def test_aiohttp_openai_gpt_4o():
         messages=[{"role": "user", "content": "Hello, world!"}],
     )
     print(response)
+
+
+@pytest.mark.asyncio()
+async def test_aiohttp_openai_extra_body():
+    """Test that extra_body parameter is properly supported"""
+    litellm.set_verbose = True
+    response = await litellm.acompletion(
+        model="aiohttp_openai/fake-model",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        api_base="https://exampleopenaiendpoint-production.up.railway.app/v1/chat/completions",
+        api_key="fake-key",
+        extra_body={"enable_thinking": True}
+    )
+    print(response)
+
+
+@pytest.mark.asyncio()
+async def test_aiohttp_openai_extra_body_multiple_params():
+    """Test that extra_body with multiple parameters works correctly"""
+    litellm.set_verbose = True
+    response = await litellm.acompletion(
+        model="aiohttp_openai/fake-model",
+        messages=[{"role": "user", "content": "Test multiple extra_body params"}],
+        api_base="https://exampleopenaiendpoint-production.up.railway.app/v1/chat/completions",
+        api_key="fake-key",
+        extra_body={
+            "enable_thinking": True,
+            "custom_param": "test_value",
+            "another_param": 42
+        }
+    )
+    print(response)


### PR DESCRIPTION
## Add support for extra body option for aiohttp_openai
This PR adds support for passing extra_body to the aiohttp_openai provider. It was modeled after openai implementation.

Motivation: This change enables the use of `enable_thinking` on qwen 3 through the extra body when using a self hosted deployment of this LLM.
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


<img width="1512" alt="Screenshot 2025-07-01 at 08 37 41" src="https://github.com/user-attachments/assets/c6332a39-6696-40be-95fd-918f9e27e420" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
- Adds support for passing extra_body to the aiohttp_openai provider.

