### PR TITLE
fix: always replace input list with string, even if empty

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -86,9 +86,7 @@ def handle_messages_with_content_list_to_str_conversion(
     Handles messages with content list conversion
     """
     for message in messages:
-        texts = convert_content_list_to_str(message=message)
-        if texts:
-            message["content"] = texts
+        message["content"] = convert_content_list_to_str(message=message)
     return messages
 
 


### PR DESCRIPTION
## Title

See bug report: When running with mistral sometimes the LLM returns a message with empty content. This causes the function in question to skip converting the list to the string, which then causes an issue when making another request to the LLM.

Found while working on https://github.com/mozilla-ai/any-agent/issues/519

## Relevant issues

#12197 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


