### PR TITLE
Fix default parameters for ollama-chat

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -296,6 +296,12 @@ class OllamaChatConfig(BaseConfig):
                 cast(dict, m)["tool_calls"] = new_tools
             new_messages.append(m)
 
+        # Load Config
+        config = self.get_config()
+        for k, v in config.items():
+            if k not in optional_params:
+                optional_params[k] = v
+
         data = {
             "model": model,
             "messages": new_messages,

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -70,3 +70,34 @@ class TestOllamaChatConfigResponseFormat:
         assert (
             optional_params["format"] == "json"
         ), f"Expected 'json' for type 'json_object', got: {optional_params['format']}"
+
+    def test_transform_request_loads_config_parameters(self):
+        """Test that transform_request loads config parameters without overriding existing optional_params"""
+        # Set config parameters on the class
+        import litellm
+
+        litellm.OllamaChatConfig(num_ctx=8000, temperature=0.0)
+
+        try:
+            config = OllamaChatConfig()
+
+            # Initial optional_params with existing temperature (should not be overridden)
+            optional_params = {"temperature": 0.3}
+
+            # Transform request
+            result = config.transform_request(
+                model="llama2",
+                messages=[{"role": "user", "content": "Hello"}],
+                optional_params=optional_params,
+                litellm_params={},
+                headers={},
+            )
+
+            # Verify config values were loaded but existing optional_params were preserved
+            assert result["options"]["temperature"] == 0.3  # Should keep existing value
+            assert result["options"]["num_ctx"] == 8000  # Should load from config
+
+        finally:
+            # Clean up class attributes
+            delattr(litellm.OllamaChatConfig, "num_ctx")
+            delattr(litellm.OllamaChatConfig, "temperature")


### PR DESCRIPTION
## Title

Fixes setting default parameters for Ollama-Chat, which did not work previously

Ollama non-chat still doesn't work, due to other problems there too

## Relevant issues

Fixes #12064 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Local test
![Screenshot 2025-07-01 at 16 02 13](https://github.com/user-attachments/assets/545a0afb-5a90-40b1-97de-16457d231f5e)

## Full test (cropped)

![Screenshot 2025-07-01 at 16 14 15](https://github.com/user-attachments/assets/68f1a0f9-b11e-41c0-89ca-b0a2e5bf7f56)



## Type

🐛 Bug Fix
✅ Test

## Changes

Populates `optional_params` with the values set on the Config object when transforming the request.

Now OllamaChat supports setting optional parameters globally, as described in `Provider-specific Params` https://docs.litellm.ai/docs/completion/provider_specific_params (`## SET MAX TOKENS - via config` )

## Outstanding question

1. Is the proposed test good enough ? Or should we check the params sent to the `httpx post` method, via mocking ? I've seen an example of this in `tests/local_testing/test_provider_specific_config.py` , but the Contributing guidelines say the tests should go in `test_litellm` 

2. I think the non-chat ollama suffers from the same behaviour. Is it due to be deprecated, or should we update that one too ? And in this or separate PR ?



