### PR TITLE
Customizable Email template - Subject and Signature

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -434,9 +434,9 @@ router_settings:
 | DOCS_URL | The path to the Swagger API documentation. **By default this is "/"**
 | EMAIL_LOGO_URL | URL for the logo used in emails
 | EMAIL_SUPPORT_CONTACT | Support contact email address
-| EMAIL_SIGNATURE | Custom signature for emails
-| EMAIL_SUBJECT_INVITATION | Custom subject template for invitation emails
-| EMAIL_SUBJECT_KEY_CREATED | Custom subject template for key creation emails
+| EMAIL_SIGNATURE | Custom HTML footer/signature for all emails. Can include HTML tags for formatting and links.
+| EMAIL_SUBJECT_INVITATION | Custom subject template for invitation emails. 
+| EMAIL_SUBJECT_KEY_CREATED | Custom subject template for key creation emails. 
 | EXPERIMENTAL_MULTI_INSTANCE_RATE_LIMITING | Flag to enable new multi-instance rate limiting. **Default is False**
 | FIREWORKS_AI_4_B | Size parameter for Fireworks AI 4B model. Default is 4
 | FIREWORKS_AI_16_B | Size parameter for Fireworks AI 16B model. Default is 16

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -434,6 +434,9 @@ router_settings:
 | DOCS_URL | The path to the Swagger API documentation. **By default this is "/"**
 | EMAIL_LOGO_URL | URL for the logo used in emails
 | EMAIL_SUPPORT_CONTACT | Support contact email address
+| EMAIL_SIGNATURE | Custom signature for emails
+| EMAIL_SUBJECT_INVITATION | Custom subject template for invitation emails
+| EMAIL_SUBJECT_KEY_CREATED | Custom subject template for key creation emails
 | EXPERIMENTAL_MULTI_INSTANCE_RATE_LIMITING | Flag to enable new multi-instance rate limiting. **Default is False**
 | FIREWORKS_AI_4_B | Size parameter for Fireworks AI 4B model. Default is 4
 | FIREWORKS_AI_16_B | Size parameter for Fireworks AI 16B model. Default is 16

--- a/docs/my-website/docs/proxy/email.md
+++ b/docs/my-website/docs/proxy/email.md
@@ -132,11 +132,40 @@ Customizing Email Branding is an Enterprise Feature [Get in touch with us for a 
 
 :::
 
-LiteLLM allows you to customize:
-- Logo on the Email
-- Email support contact
-- Email signature
-- Email subject lines for different events
+LiteLLM allows you to customize various aspects of your email notifications. Below is a complete reference of all customizable fields:
+
+| Field | Environment Variable | Type | Default Value | Example | Description |
+|-------|-------------------|------|---------------|---------|-------------|
+| Logo URL | `EMAIL_LOGO_URL` | string | LiteLLM logo | `"https://your-company.com/logo.png"` | Public URL to your company logo |
+| Support Contact | `EMAIL_SUPPORT_CONTACT` | string | support@berri.ai | `"support@your-company.com"` | Email address for user support |
+| Email Signature | `EMAIL_SIGNATURE` | string (HTML) | Standard LiteLLM footer | `"<p>Best regards,<br/>Your Team</p><p><a href='https://your-company.com'>Visit us</a></p>"` | HTML-formatted footer for all emails |
+| Invitation Subject | `EMAIL_SUBJECT_INVITATION` | string | "LiteLLM: New User Invitation" | `"Welcome to Your Company!"` | Subject line for invitation emails |
+| Key Creation Subject | `EMAIL_SUBJECT_KEY_CREATED` | string | "LiteLLM: API Key Created" | `"Your New API Key is Ready"` | Subject line for key creation emails |
+
+
+## HTML Support in Email Signature
+
+The `EMAIL_SIGNATURE` field supports HTML formatting for rich, branded email footers. Here's an example of what you can include:
+
+```html
+<p>Best regards,<br/>The LiteLLM Team</p>
+<p>
+  <a href='https://docs.litellm.ai'>Documentation</a> |
+  <a href='https://github.com/BerriAI/litellm'>GitHub</a>
+</p>
+<p style='font-size: 12px; color: #666;'>
+  This is an automated message from LiteLLM Proxy
+</p>
+```
+
+Supported HTML features:
+- Text formatting (bold, italic, etc.)
+- Line breaks (`<br/>`)
+- Links (`<a href='...'>`)
+- Paragraphs (`<p>`)
+- Basic inline styling
+- Company information and social media links
+- Legal disclaimers or terms of service links
 
 ## Environment Variables
 

--- a/docs/my-website/docs/proxy/email.md
+++ b/docs/my-website/docs/proxy/email.md
@@ -124,9 +124,7 @@ On the Create Key Modal, Select Advanced Settings > Set Send Email to True.
 />
 
 
-
-
-## Customizing Email Branding
+## Email Customization
 
 :::info
 
@@ -140,14 +138,61 @@ LiteLLM allows you to customize:
 - Email signature
 - Email subject lines for different events
 
-Set the following in your env to customize your emails:
+## Environment Variables
 
-```shell
-EMAIL_LOGO_URL="https://litellm-listing.s3.amazonaws.com/litellm_logo.png"  # public url to your logo
-EMAIL_SUPPORT_CONTACT="support@berri.ai"                                    # Your company support email
-EMAIL_SIGNATURE="Best regards,\nYour Company Team"                         # Custom email signature
-EMAIL_SUBJECT_INVITATION="Welcome to {company_name}!"                      # Subject for invitation emails
-EMAIL_SUBJECT_KEY_CREATED="Your API Key for {company_name}"               # Subject for key creation emails
+You can customize the following aspects of emails through environment variables:
+
+```bash
+# Email Branding
+EMAIL_LOGO_URL="https://your-company.com/logo.png"  # Custom logo URL
+EMAIL_SUPPORT_CONTACT="support@your-company.com"     # Support contact email
+EMAIL_SIGNATURE="<p>Best regards,<br/>Your Company Team</p><p><a href='https://your-company.com'>Visit our website</a></p>"  # Custom HTML footer/signature
+
+# Email Subject Lines
+EMAIL_SUBJECT_INVITATION="Welcome to Your Company!"  # Subject for invitation emails
+EMAIL_SUBJECT_KEY_CREATED="Your API Key is Ready"    # Subject for key creation emails
 ```
 
-If custom subject templates are not provided, the system will use default templates in the format "LiteLLM: {event_message}".
+## HTML Support in Email Signature
+
+The `EMAIL_SIGNATURE` environment variable supports HTML formatting, allowing you to create rich, branded email footers. You can include:
+
+- Text formatting (bold, italic, etc.)
+- Line breaks using `<br/>`
+- Links using `<a href='...'>`
+- Paragraphs using `<p>`
+- Company information and social media links
+- Legal disclaimers or terms of service links
+
+Example HTML signature:
+```html
+<p>Best regards,<br/>The LiteLLM Team</p>
+<p>
+  <a href='https://docs.litellm.ai'>Documentation</a> |
+  <a href='https://github.com/BerriAI/litellm'>GitHub</a>
+</p>
+<p style='font-size: 12px; color: #666;'>
+  This is an automated message from LiteLLM Proxy
+</p>
+```
+
+## Default Templates
+
+If environment variables are not set, LiteLLM will use default templates:
+
+- Default logo: LiteLLM logo
+- Default support contact: support@berri.ai
+- Default signature: Standard LiteLLM footer
+- Default subjects: "LiteLLM: \{event_message\}" (replaced with actual event message)
+
+## Template Variables
+
+When setting custom email subjects, you can use template variables that will be replaced with actual values:
+
+```bash
+# Examples of template variable usage
+EMAIL_SUBJECT_INVITATION="Welcome to \{company_name\}!"
+EMAIL_SUBJECT_KEY_CREATED="Your \{company_name\} API Key"
+```
+
+The system will automatically replace `\{event_message\}` and other template variables with their actual values when sending emails.

--- a/docs/my-website/docs/proxy/email.md
+++ b/docs/my-website/docs/proxy/email.md
@@ -134,13 +134,20 @@ Customizing Email Branding is an Enterprise Feature [Get in touch with us for a 
 
 :::
 
-LiteLLM allows you to customize the:
+LiteLLM allows you to customize:
 - Logo on the Email
-- Email support contact 
+- Email support contact
+- Email signature
+- Email subject lines for different events
 
-Set the following in your env to customize your emails
+Set the following in your env to customize your emails:
 
 ```shell
 EMAIL_LOGO_URL="https://litellm-listing.s3.amazonaws.com/litellm_logo.png"  # public url to your logo
 EMAIL_SUPPORT_CONTACT="support@berri.ai"                                    # Your company support email
+EMAIL_SIGNATURE="Best regards,\nYour Company Team"                         # Custom email signature
+EMAIL_SUBJECT_INVITATION="Welcome to {company_name}!"                      # Subject for invitation emails
+EMAIL_SUBJECT_KEY_CREATED="Your API Key for {company_name}"               # Subject for key creation emails
 ```
+
+If custom subject templates are not provided, the system will use default templates in the format "LiteLLM: {event_message}".

--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -174,16 +174,15 @@ class BaseEmailLogger(CustomLogger):
 
         # If any custom fields were not applied, log a warning
         if unused_custom_fields:
-            import logging
-            logger = logging.getLogger(__name__)
             fields_str = ", ".join(unused_custom_fields)
             warning_msg = (
                 f"Email sent with default values instead of custom values for: {fields_str}. "
                 "This is an Enterprise feature. To use custom email fields, please upgrade to LiteLLM Enterprise. "
                 "Schedule a meeting here: https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat"
             )
-            logger.warning(warning_msg)
-            print(warning_msg)
+            verbose_proxy_logger.warning(
+                f"Prisma client not found. Unable to lookup user email for user_id: {user_id}"
+            )
 
         return EmailParams(
             logo_url=logo_url,

--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -181,7 +181,7 @@ class BaseEmailLogger(CustomLogger):
                 "Schedule a meeting here: https://calendly.com/d/4mp-gd3-k5k/litellm-1-1-onboarding-chat"
             )
             verbose_proxy_logger.warning(
-                f"Prisma client not found. Unable to lookup user email for user_id: {user_id}"
+                f"{warning_msg}"
             )
 
         return EmailParams(

--- a/enterprise/litellm_enterprise/types/enterprise_callbacks/send_emails.py
+++ b/enterprise/litellm_enterprise/types/enterprise_callbacks/send_emails.py
@@ -1,9 +1,9 @@
-from enum import Enum
-from typing import Dict, List, Optional
-from pydantic import BaseModel
+import enum
+from typing import Dict, List
+
+from pydantic import BaseModel, Field
 
 from litellm.proxy._types import WebhookEvent
-
 
 class EmailParams(BaseModel):
     logo_url: str
@@ -18,43 +18,32 @@ class SendKeyCreatedEmailEvent(WebhookEvent):
     virtual_key: str
     """
     The virtual key that was created
-
     this will be sk-123xxx, since we will be emailing this to the user to start using the key
     """
 
 
-class EmailEvent(str, Enum):
+class EmailEvent(str, enum.Enum):
     virtual_key_created = "Virtual Key Created"
     new_user_invitation = "New User Invitation"
-
 
 class EmailEventSettings(BaseModel):
     event: EmailEvent
     enabled: bool
-
-
 class EmailEventSettingsUpdateRequest(BaseModel):
     settings: List[EmailEventSettings]
-
-
 class EmailEventSettingsResponse(BaseModel):
     settings: List[EmailEventSettings]
-
-
 class DefaultEmailSettings(BaseModel):
     """Default settings for email events"""
-
     settings: Dict[EmailEvent, bool] = Field(
         default_factory=lambda: {
             EmailEvent.virtual_key_created: False,  # Off by default
             EmailEvent.new_user_invitation: True,  # On by default
         }
     )
-
     def to_dict(self) -> Dict[str, bool]:
         """Convert to dictionary with string keys for storage"""
         return {event.value: enabled for event, enabled in self.settings.items()}
-
     @classmethod
     def get_defaults(cls) -> Dict[str, bool]:
         """Get the default settings as a dictionary with string keys"""

--- a/enterprise/litellm_enterprise/types/enterprise_callbacks/send_emails.py
+++ b/enterprise/litellm_enterprise/types/enterprise_callbacks/send_emails.py
@@ -1,7 +1,6 @@
-import enum
-from typing import Dict, List
-
-from pydantic import BaseModel, Field
+from enum import Enum
+from typing import Dict, List, Optional
+from pydantic import BaseModel
 
 from litellm.proxy._types import WebhookEvent
 
@@ -11,6 +10,8 @@ class EmailParams(BaseModel):
     support_contact: str
     base_url: str
     recipient_email: str
+    subject: str
+    signature: str
 
 
 class SendKeyCreatedEmailEvent(WebhookEvent):
@@ -22,7 +23,7 @@ class SendKeyCreatedEmailEvent(WebhookEvent):
     """
 
 
-class EmailEvent(str, enum.Enum):
+class EmailEvent(str, Enum):
     virtual_key_created = "Virtual Key Created"
     new_user_invitation = "New User Invitation"
 

--- a/tests/proxy_admin_ui_tests/test_email_customization.py
+++ b/tests/proxy_admin_ui_tests/test_email_customization.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+sys.path.insert(0, os.path.abspath("../.."))
+
+from enterprise.litellm_enterprise.enterprise_callbacks.send_emails.base_email import BaseEmailLogger
+from enterprise.litellm_enterprise.types.enterprise_callbacks.send_emails import EmailEvent
+from litellm.integrations.email_templates.email_footer import EMAIL_FOOTER
+
+@pytest.fixture
+def mock_env_vars(monkeypatch):
+    """Set up test environment variables"""
+    monkeypatch.setenv("EMAIL_LOGO_URL", "https://test-company.com/logo.png")
+    monkeypatch.setenv("EMAIL_SUPPORT_CONTACT", "support@test-company.com")
+    monkeypatch.setenv("EMAIL_SIGNATURE", "Best regards,\nTest Company Team")
+    monkeypatch.setenv("EMAIL_SUBJECT_INVITATION", "Welcome to Test Company!")
+    monkeypatch.setenv("EMAIL_SUBJECT_KEY_CREATED", "Your Test Company API Key")
+    monkeypatch.setenv("PROXY_BASE_URL", "http://test.com")
+
+@pytest.mark.asyncio
+async def test_get_email_params_custom_templates(mock_env_vars):
+    """Test that _get_email_params returns correct values with custom templates"""
+    email_logger = BaseEmailLogger()
+    
+    # Test invitation email params
+    invitation_params = await email_logger._get_email_params(
+        email_event=EmailEvent.new_user_invitation,
+        user_email="test@example.com",
+        event_message="New User Invitation"
+    )
+    
+    assert invitation_params.subject == "Welcome to Test Company!"
+    assert invitation_params.signature == "Best regards,\nTest Company Team"
+    assert invitation_params.logo_url == "https://test-company.com/logo.png"
+    assert invitation_params.support_contact == "support@test-company.com"
+    assert invitation_params.base_url == "http://test.com"
+    
+    # Test key created email params
+    key_params = await email_logger._get_email_params(
+        email_event=EmailEvent.virtual_key_created,
+        user_email="test@example.com",
+        event_message="API Key Created"
+    )
+    
+    assert key_params.subject == "Your Test Company API Key"
+    assert key_params.signature == "Best regards,\nTest Company Team"
+
+@pytest.mark.asyncio
+async def test_get_email_params_default_templates(monkeypatch):
+    """Test that _get_email_params uses default templates when custom ones aren't provided"""
+    # Clear any existing environment variables
+    monkeypatch.delenv("EMAIL_SUBJECT_INVITATION", raising=False)
+    monkeypatch.delenv("EMAIL_SUBJECT_KEY_CREATED", raising=False)
+    monkeypatch.delenv("EMAIL_SIGNATURE", raising=False)
+    
+    email_logger = BaseEmailLogger()
+    
+    # Test invitation email params with default template
+    invitation_params = await email_logger._get_email_params(
+        email_event=EmailEvent.new_user_invitation,
+        user_email="test@example.com",
+        event_message="New User Invitation"
+    )
+    
+    assert invitation_params.subject == "LiteLLM: New User Invitation"
+    assert invitation_params.signature == EMAIL_FOOTER
+    
+    # Test key created email params with default template
+    key_params = await email_logger._get_email_params(
+        email_event=EmailEvent.virtual_key_created,
+        user_email="test@example.com",
+        event_message="API Key Created"
+    )
+    
+    assert key_params.subject == "LiteLLM: API Key Created"
+    assert key_params.signature == EMAIL_FOOTER 

--- a/tests/proxy_admin_ui_tests/test_email_customization.py
+++ b/tests/proxy_admin_ui_tests/test_email_customization.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 from enterprise.litellm_enterprise.enterprise_callbacks.send_emails.base_email import BaseEmailLogger
 from enterprise.litellm_enterprise.types.enterprise_callbacks.send_emails import EmailEvent
 from litellm.integrations.email_templates.email_footer import EMAIL_FOOTER
+from litellm.proxy._types import CommonProxyErrors
 
 @pytest.fixture
 def mock_env_vars(monkeypatch):
@@ -17,34 +18,68 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("EMAIL_SUBJECT_INVITATION", "Welcome to Test Company!")
     monkeypatch.setenv("EMAIL_SUBJECT_KEY_CREATED", "Your Test Company API Key")
     monkeypatch.setenv("PROXY_BASE_URL", "http://test.com")
+    monkeypatch.setenv("PROXY_API_URL", "https://test.com")
 
 @pytest.mark.asyncio
-async def test_get_email_params_custom_templates(mock_env_vars):
-    """Test that _get_email_params returns correct values with custom templates"""
-    email_logger = BaseEmailLogger()
-    
-    # Test invitation email params
-    invitation_params = await email_logger._get_email_params(
-        email_event=EmailEvent.new_user_invitation,
-        user_email="test@example.com",
-        event_message="New User Invitation"
-    )
-    
-    assert invitation_params.subject == "Welcome to Test Company!"
-    assert invitation_params.signature == "Best regards,\nTest Company Team"
-    assert invitation_params.logo_url == "https://test-company.com/logo.png"
-    assert invitation_params.support_contact == "support@test-company.com"
-    assert invitation_params.base_url == "http://test.com"
-    
-    # Test key created email params
-    key_params = await email_logger._get_email_params(
-        email_event=EmailEvent.virtual_key_created,
-        user_email="test@example.com",
-        event_message="API Key Created"
-    )
-    
-    assert key_params.subject == "Your Test Company API Key"
-    assert key_params.signature == "Best regards,\nTest Company Team"
+async def test_get_email_params_custom_templates_premium_user(mock_env_vars):
+    """Test that _get_email_params returns correct values with custom templates for premium users"""
+    # Mock premium_user as True
+    with patch("litellm.proxy.proxy_server.premium_user", True):
+        email_logger = BaseEmailLogger()
+        
+        # Test invitation email params
+        invitation_params = await email_logger._get_email_params(
+            email_event=EmailEvent.new_user_invitation,
+            user_email="test@example.com",
+            event_message="New User Invitation"
+        )
+        
+        assert invitation_params.subject == "Welcome to Test Company!"
+        assert invitation_params.signature == "Best regards,\nTest Company Team"
+        assert invitation_params.logo_url == "https://test-company.com/logo.png"
+        assert invitation_params.support_contact == "support@test-company.com"
+        assert invitation_params.base_url == "http://test.com"
+        
+        # Test key created email params
+        key_params = await email_logger._get_email_params(
+            email_event=EmailEvent.virtual_key_created,
+            user_email="test@example.com",
+            event_message="API Key Created"
+        )
+        
+        assert key_params.subject == "Your Test Company API Key"
+        assert key_params.signature == "Best regards,\nTest Company Team"
+
+@pytest.mark.asyncio
+async def test_get_email_params_non_premium_user(mock_env_vars):
+    """Test that non-premium users get default templates even when custom ones are provided"""
+    # Mock premium_user as False
+    with patch("litellm.proxy.proxy_server.premium_user", False):
+        email_logger = BaseEmailLogger()
+        
+        # Test invitation email params
+        email_params = await email_logger._get_email_params(
+            email_event=EmailEvent.new_user_invitation,
+            user_email="test@example.com",
+            event_message="New User Invitation"
+        )
+        
+        # Should use default values even though custom values are set in env
+        assert email_params.subject == "LiteLLM: New User Invitation"
+        assert email_params.signature == EMAIL_FOOTER
+        assert email_params.logo_url == "https://litellm-listing.s3.amazonaws.com/litellm_logo.png"
+        assert email_params.support_contact == "support@berri.ai"
+
+        
+        # Test key created email params
+        key_params = await email_logger._get_email_params(
+            email_event=EmailEvent.virtual_key_created,
+            user_email="test@example.com",
+            event_message="API Key Created"
+        )
+        
+        assert key_params.subject == "LiteLLM: API Key Created"
+        assert key_params.signature == EMAIL_FOOTER
 
 @pytest.mark.asyncio
 async def test_get_email_params_default_templates(monkeypatch):
@@ -54,24 +89,26 @@ async def test_get_email_params_default_templates(monkeypatch):
     monkeypatch.delenv("EMAIL_SUBJECT_KEY_CREATED", raising=False)
     monkeypatch.delenv("EMAIL_SIGNATURE", raising=False)
     
-    email_logger = BaseEmailLogger()
-    
-    # Test invitation email params with default template
-    invitation_params = await email_logger._get_email_params(
-        email_event=EmailEvent.new_user_invitation,
-        user_email="test@example.com",
-        event_message="New User Invitation"
-    )
-    
-    assert invitation_params.subject == "LiteLLM: New User Invitation"
-    assert invitation_params.signature == EMAIL_FOOTER
-    
-    # Test key created email params with default template
-    key_params = await email_logger._get_email_params(
-        email_event=EmailEvent.virtual_key_created,
-        user_email="test@example.com",
-        event_message="API Key Created"
-    )
-    
-    assert key_params.subject == "LiteLLM: API Key Created"
-    assert key_params.signature == EMAIL_FOOTER 
+    # Mock premium_user as True (shouldn't matter since no custom values are set)
+    with patch("litellm.proxy.proxy_server.premium_user", True):
+        email_logger = BaseEmailLogger()
+        
+        # Test invitation email params with default template
+        invitation_params = await email_logger._get_email_params(
+            email_event=EmailEvent.new_user_invitation,
+            user_email="test@example.com",
+            event_message="New User Invitation"
+        )
+        
+        assert invitation_params.subject == "LiteLLM: New User Invitation"
+        assert invitation_params.signature == EMAIL_FOOTER
+        
+        # Test key created email params with default template
+        key_params = await email_logger._get_email_params(
+            email_event=EmailEvent.virtual_key_created,
+            user_email="test@example.com",
+            event_message="API Key Created"
+        )
+        
+        assert key_params.subject == "LiteLLM: API Key Created"
+        assert key_params.signature == EMAIL_FOOTER 


### PR DESCRIPTION
## Title

Adds the ability to add custom email subjects and signature HTML

## Relevant issues

Fixes #11361 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Add documentation 
- Add changes to send email and base email for enterprise to use email subject changes
- Add tests
