### PR TITLE
Bug Fix - responses api fix got multiple values for keyword argument 'litellm_trace_id' 

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,8 +1,7 @@
 model_list:
-  - model_name: groq/*
+  - model_name: anthropic/*
     litellm_params:
-      model: groq/*
-      api_key: bad
+      model: anthropic/*
   - model_name: openai/*
     litellm_params:
       model: openai/*

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -56,6 +56,10 @@ class LiteLLMCompletionTransformationHandler:
                 responses_api_request=responses_api_request,
                 **kwargs,
             )
+        
+        completion_args = {}
+        completion_args.update(kwargs)
+        completion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
@@ -98,12 +102,15 @@ class LiteLLMCompletionTransformationHandler:
                 previous_response_id=previous_response_id,
                 litellm_completion_request=litellm_completion_request,
             )
+        
+        acompletion_args = {}
+        acompletion_args.update(kwargs)
+        acompletion_args.update(litellm_completion_request)
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
         ] = await litellm.acompletion(
-            **litellm_completion_request,
-            **kwargs,
+            **acompletion_args,
         )
 
         if isinstance(litellm_completion_response, ModelResponse):

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -119,3 +119,12 @@ def test_bad_request_bad_param_error():
         client.responses.create(
             model="gpt-4o", input="This should fail", temperature=2000
         )
+
+def test_anthropic_with_responses_api():
+    client = get_test_client()
+    response = client.responses.create(
+        model="anthropic/claude-3-5-sonnet-20240620", 
+        input="just respond with the word 'ping'",
+        previous_response_id="hi",
+    )
+    print("anthropic response=", response)


### PR DESCRIPTION
## Bug Fix - responses api fix got multiple values for keyword argument 'litellm_trace_id'

Fixes: https://github.com/BerriAI/litellm/issues/12194 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


