### PR TITLE
Updated factory.py

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -229,7 +229,6 @@ def ollama_pt(
         ## MERGE CONSECUTIVE ASSISTANT CONTENT ##
         while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
             assistant_content_str += convert_content_list_to_str(messages[msg_i])
-            msg_i += 1
 
             tool_calls = messages[msg_i].get("tool_calls")
             ollama_tool_calls = []
@@ -255,7 +254,7 @@ def ollama_pt(
                     f"Tool Calls: {json.dumps(ollama_tool_calls, indent=2)}"
                 )
 
-                msg_i += 1
+            msg_i += 1
 
         if assistant_content_str:
             prompt += f"### Assistant:\n{assistant_content_str}\n\n"


### PR DESCRIPTION
I used crewai 0.134.0 and litellm 1.72.0 package for running the ollama model (qwen3:1.7b). I am currently getting the below error while running the model.

  File "project_name/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/prompt_templates/factory.py", line 229, in ollama_pt
    tool_calls = messages[msg_i].get("tool_calls")
                 ~~~~~~~~^^^^^^^
IndexError: list index out of range

After some references in blogs, I updated the ollama_pt function inside the factory.py file as in this PR request and the model is working in local but I am unable to use it in production.

May I know if there is an alternative approach to run the above llm model using litellm and crewai?

