### PR TITLE
Add MCP url masking on frontend

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -111,6 +111,12 @@ class BaseEmailLogger(CustomLogger):
         """
         Get common email parameters used across different email sending methods
 
+        Args:
+            email_event: Type of email event
+            user_id: Optional user ID to look up email
+            user_email: Optional direct email address
+            event_message: Optional message to include in email subject
+
         Returns:
             EmailParams object containing logo_url, support_contact, base_url, recipient_email, subject, and signature
         """

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
@@ -406,6 +406,7 @@ async def test_get_email_params_custom_templates_premium_user(mock_env_vars):
         # Test invitation email params
         invitation_params = await email_logger._get_email_params(
             email_event=EmailEvent.new_user_invitation,
+            user_id="testid",
             user_email="test@example.com",
             event_message="New User Invitation"
         )
@@ -419,6 +420,7 @@ async def test_get_email_params_custom_templates_premium_user(mock_env_vars):
         # Test key created email params
         key_params = await email_logger._get_email_params(
             email_event=EmailEvent.virtual_key_created,
+            user_id="testid",
             user_email="test@example.com",
             event_message="API Key Created"
         )

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { Tooltip } from "antd";
-import { Icon, Button } from "@tremor/react";
+import { Icon } from "@tremor/react";
 import { PencilAltIcon, TrashIcon } from "@heroicons/react/outline";
 import { MCPServer, handleAuth, handleTransport } from "./types";
 import { isAdminRole } from "@/utils/roles";
+import { maskUrl } from "./utils";
 
 const displayFriendlyId = (id: string) => `${id.slice(0, 7)}...`;
 
@@ -20,64 +21,41 @@ export const mcpServerColumns = (
   onDelete: (serverId: string) => void
 ): ColumnDef<MCPServer>[] => [
   {
-    header: "Server ID",
     accessorKey: "server_id",
-    cell: ({ row, getValue }) => (
-      <div className="overflow-hidden">
-        <Tooltip title={getValue() as string}>
-          <Button
-            size="xs"
-            variant="light"
-            className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left overflow-hidden truncate max-w-[200px]"
-            onClick={() => onSelect(row.original.server_id)}
-          >
-            {displayFriendlyId(getValue() as string)}
-          </Button>
-        </Tooltip>
-      </div>
+    header: "ID",
+    cell: ({ getValue, row }) => (
+      <button
+        onClick={() => onSelect(row.original.server_id)}
+        className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left overflow-hidden truncate max-w-[200px]"
+      >
+        {displayFriendlyId(getValue() as string)}
+      </button>
     ),
   },
   {
-    header: "Server Name",
     accessorKey: "alias",
-    cell: ({ getValue }) => <span>{getValue() as string}</span>,
+    header: "Name",
   },
   {
-    header: "Description",
-    accessorKey: "description",
-    cell: ({ getValue }) => <span>{getValue() as string}</span>,
-  },
-  {
-    header: "Transport",
-    accessorKey: "transport",
-    cell: ({ getValue }) => <span>{handleTransport(getValue() as string)}</span>,
-  },
-  {
-    header: "Auth Type",
-    accessorKey: "auth_type",
-    cell: ({ getValue }) => <span>{handleAuth(getValue() as string)}</span>,
-  },
-  {
-    header: "Url",
     accessorKey: "url",
+    header: "URL",
     cell: ({ getValue }) => (
-      <div className="overflow-hidden">
-        <Tooltip title={getValue() as string}>
-          <span className="font-mono text-gray-600 text-xs">
-            {displayFriendlyUrl(getValue() as string)}
-          </span>
-        </Tooltip>
-      </div>
+      <Tooltip title={getValue() as string}>
+        <span className="font-mono text-gray-600 text-xs">
+          {maskUrl(getValue() as string)}
+        </span>
+      </Tooltip>
     ),
   },
   {
-    header: "Created",
-    accessorKey: "created_at",
-    cell: ({ getValue }) => (
-      <span>
-        {getValue() ? new Date(getValue() as string).toLocaleDateString() : "N/A"}
-      </span>
-    ),
+    accessorKey: "transport",
+    header: "Transport",
+    cell: ({ row }) => handleTransport(row.original.transport),
+  },
+  {
+    accessorKey: "auth_type",
+    header: "Auth Type",
+    cell: ({ row }) => handleAuth(row.original.auth_type),
   },
   {
     id: "actions",

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
 import {
   Title,
   Card,
@@ -11,12 +11,14 @@ import {
   TabPanel,
   TabPanels,
   Tab,
+  Icon,
 } from "@tremor/react";
 
 import { MCPServer, handleTransport, handleAuth } from "./types";
 // TODO: Move Tools viewer from index file
 import { MCPToolsViewer } from ".";
 import MCPServerEdit from "./mcp_server_edit";
+import { getMaskedAndFullUrl } from "./utils";
 
 interface MCPServerViewProps {
   mcpServer: MCPServer;
@@ -38,10 +40,18 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
   userID,
 }) => {
   const [editing, setEditing] = useState(isEditing);
+  const [showFullUrl, setShowFullUrl] = useState(false);
 
   const handleSuccess = (updated: MCPServer) => {
     setEditing(false);
     onBack();
+  };
+
+  const { maskedUrl, hasToken } = getMaskedAndFullUrl(mcpServer.url);
+
+  const renderUrlWithToggle = (url: string, showFull: boolean) => {
+    if (!hasToken) return url;
+    return showFull ? url : maskedUrl;
   };
 
   return (
@@ -86,8 +96,22 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
 
               <Card>
                 <Text>Host Url</Text>
-                <div className="mt-2">
-                  <Text className="break-all overflow-wrap-anywhere">{mcpServer.url}</Text>
+                <div className="mt-2 flex items-center gap-2">
+                  <Text className="break-all overflow-wrap-anywhere">
+                    {renderUrlWithToggle(mcpServer.url, showFullUrl)}
+                  </Text>
+                  {hasToken && (
+                    <button
+                      onClick={() => setShowFullUrl(!showFullUrl)}
+                      className="p-1 hover:bg-gray-100 rounded"
+                    >
+                      <Icon
+                        icon={showFullUrl ? EyeOffIcon : EyeIcon}
+                        size="sm"
+                        className="text-gray-500"
+                      />
+                    </button>
+                  )}
                 </div>
               </Card>
             </Grid>
@@ -134,7 +158,21 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">URL</Text>
-                    <div className="font-mono break-all overflow-wrap-anywhere max-w-full">{mcpServer.url}</div>
+                    <div className="font-mono break-all overflow-wrap-anywhere max-w-full flex items-center gap-2">
+                      {renderUrlWithToggle(mcpServer.url, showFullUrl)}
+                      {hasToken && (
+                        <button
+                          onClick={() => setShowFullUrl(!showFullUrl)}
+                          className="p-1 hover:bg-gray-100 rounded"
+                        >
+                          <Icon
+                            icon={showFullUrl ? EyeOffIcon : EyeIcon}
+                            size="sm"
+                            className="text-gray-500"
+                          />
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <div>
                     <Text className="font-medium">Transport</Text>

--- a/ui/litellm-dashboard/src/components/mcp_tools/utils.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/utils.tsx
@@ -1,0 +1,37 @@
+export const extractMCPToken = (url: string): { token: string | null, baseUrl: string } => {
+  try {
+    const mcpIndex = url.indexOf('/mcp/');
+    if (mcpIndex === -1) return { token: null, baseUrl: url };
+
+    const parts = url.split('/mcp/');
+    if (parts.length !== 2) return { token: null, baseUrl: url };
+
+    const baseUrl = parts[0] + '/mcp/';
+    const afterMcp = parts[1];
+
+    // If there's no content after /mcp/, return null token
+    if (!afterMcp) return { token: null, baseUrl: url };
+
+    return {
+      token: afterMcp,
+      baseUrl: baseUrl
+    };
+  } catch (error) {
+    console.error('Error parsing MCP URL:', error);
+    return { token: null, baseUrl: url };
+  }
+};
+
+export const maskUrl = (url: string): string => {
+  const { token, baseUrl } = extractMCPToken(url);
+  if (!token) return url;
+  return baseUrl + '...';
+};
+
+export const getMaskedAndFullUrl = (url: string): { maskedUrl: string, hasToken: boolean } => {
+  const { token } = extractMCPToken(url);
+  return {
+    maskedUrl: maskUrl(url),
+    hasToken: !!token
+  };
+}; 


### PR DESCRIPTION
## Title

This PR helps with masking the URL on the frontend to hide any keys being directly visible, until the user themselves unhide it.

## Relevant issues

The URL with sensitive? params was always visible on the frontend, this PR aims to fix that.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes
<img width="1512" alt="Screenshot 2025-07-02 at 10 42 51 AM" src="https://github.com/user-attachments/assets/9b6a5212-9cd3-44c1-b786-2a9fe6c1824f" />
<img width="1512" alt="Screenshot 2025-07-02 at 10 42 57 AM" src="https://github.com/user-attachments/assets/99180c4b-cbf8-493c-9395-1daeb05b13c6" />



