### PR TITLE
Add MCP servers header to the scope of header

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
@@ -5,9 +5,14 @@ from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from litellm.proxy._types import UserAPIKeyAuth
 
 
-class LiteLLMAuthenticatedUser(AuthenticatedUser):
+class MCPAuthenticatedUser(AuthenticatedUser):
     """
-    Wrapper class to make UserAPIKeyAuth compatible with MCP's AuthenticatedUser
+    Wrapper class to make LiteLLM's authentication and configuration compatible with MCP's AuthenticatedUser.
+    
+    This class handles:
+    1. User API key authentication information
+    2. MCP authentication header
+    3. MCP server configuration
     """
 
     def __init__(self, user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None, mcp_servers: Optional[List[str]] = None):

--- a/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 
@@ -10,6 +10,7 @@ class LiteLLMAuthenticatedUser(AuthenticatedUser):
     Wrapper class to make UserAPIKeyAuth compatible with MCP's AuthenticatedUser
     """
 
-    def __init__(self, user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None):
+    def __init__(self, user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None, mcp_servers: Optional[List[str]] = None):
         self.user_api_key_auth = user_api_key_auth
         self.mcp_auth_header = mcp_auth_header
+        self.mcp_servers = mcp_servers

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -59,7 +59,8 @@ class MCPRequestHandler:
                 mcp_servers = json.loads(mcp_servers_header)
                 if not isinstance(mcp_servers, list):
                     mcp_servers = None
-            except:
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                verbose_logger.debug(f"Error parsing mcp_servers header: {e}")
                 mcp_servers = None
 
         # Create a proper Request object with mock body method to avoid ASGI receive channel issues

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -101,7 +101,7 @@ class UserAPIKeyAuthMCP:
                 for name, value in raw_headers
             }
             return Headers(headers_dict)
-        except Exception as e:
+        except (UnicodeDecodeError, AttributeError, TypeError) as e:
             verbose_logger.exception(f"Error getting headers from scope: {e}")
             # Return empty Headers object with empty dict
             return Headers({})

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -9,7 +9,6 @@ from litellm._logging import verbose_logger
 from litellm.proxy._types import LiteLLM_TeamTable, SpecialHeaders, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
-
 class MCPRequestHandler:
     """
     Class to handle MCP request processing, including:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -18,7 +18,7 @@ from mcp.types import Tool as MCPTool
 from litellm._logging import verbose_logger
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-    UserAPIKeyAuthMCP,
+    MCPRequestHandler,
 )
 from litellm.proxy._types import (
     LiteLLM_MCPServerTable,
@@ -143,7 +143,7 @@ class MCPServerManager:
         """
         Get the allowed MCP Servers for the user
         """
-        allowed_mcp_servers = await UserAPIKeyAuthMCP.get_allowed_mcp_servers(
+        allowed_mcp_servers = await MCPRequestHandler.get_allowed_mcp_servers(
             user_api_key_auth
         )
         verbose_logger.debug(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -14,12 +14,16 @@ from litellm._logging import verbose_logger
 from litellm.constants import MCP_TOOL_NAME_PREFIX
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-    UserAPIKeyAuthMCP,
+    MCPRequestHandler,
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPInfo
 from litellm.types.utils import StandardLoggingMCPToolCall
 from litellm.utils import client
+
+from litellm.proxy._experimental.mcp_server.auth.litellm_auth_handler import (
+    MCPAuthenticatedUser,
+)
 
 LITELLM_MCP_SERVER_NAME = "litellm-mcp-server"
 LITELLM_MCP_SERVER_VERSION = "1.0.0"
@@ -55,9 +59,6 @@ if MCP_AVAILABLE:
     from mcp.types import TextContent as MCPTextContent
     from mcp.types import Tool as MCPTool
 
-    from litellm.proxy._experimental.mcp_server.auth.litellm_auth_handler import (
-        LiteLLMAuthenticatedUser,
-    )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
     )
@@ -350,9 +351,7 @@ if MCP_AVAILABLE:
         """Handle MCP requests through StreamableHTTP."""
         try:
             # Validate headers and log request info
-            user_api_key_auth, mcp_auth_header = (
-                await UserAPIKeyAuthMCP.user_api_key_auth_mcp(scope)
-            )
+            user_api_key_auth, mcp_auth_header = await MCPRequestHandler.process_mcp_request(scope)
             # Set the auth context variable for easy access in MCP functions
             set_auth_context(
                 user_api_key_auth=user_api_key_auth,
@@ -374,9 +373,7 @@ if MCP_AVAILABLE:
         """Handle MCP requests through SSE."""
         try:
             # Validate headers and log request info
-            user_api_key_auth, mcp_auth_header = (
-                await UserAPIKeyAuthMCP.user_api_key_auth_mcp(scope)
-            )
+            user_api_key_auth, mcp_auth_header = await MCPRequestHandler.process_mcp_request(scope)
             # Set the auth context variable for easy access in MCP functions
             set_auth_context(
                 user_api_key_auth=user_api_key_auth,
@@ -429,7 +426,7 @@ if MCP_AVAILABLE:
             user_api_key_auth: UserAPIKeyAuth object
             mcp_auth_header: MCP auth header to be passed to the MCP server
         """
-        auth_user = LiteLLMAuthenticatedUser(
+        auth_user = MCPAuthenticatedUser(
             user_api_key_auth=user_api_key_auth,
             mcp_auth_header=mcp_auth_header,
         )
@@ -443,7 +440,7 @@ if MCP_AVAILABLE:
             Tuple[Optional[UserAPIKeyAuth], Optional[str]]: UserAPIKeyAuth object and MCP auth header
         """
         auth_user = auth_context_var.get()
-        if auth_user and isinstance(auth_user, LiteLLMAuthenticatedUser):
+        if auth_user and isinstance(auth_user, MCPAuthenticatedUser):
             return auth_user.user_api_key_auth, auth_user.mcp_auth_header
         return None, None
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -351,7 +351,9 @@ if MCP_AVAILABLE:
         """Handle MCP requests through StreamableHTTP."""
         try:
             # Validate headers and log request info
-            user_api_key_auth, mcp_auth_header = await MCPRequestHandler.process_mcp_request(scope)
+            user_api_key_auth, mcp_auth_header, mcp_servers = (
+                await MCPRequestHandler.process_mcp_request(scope)
+            )
             # Set the auth context variable for easy access in MCP functions
             set_auth_context(
                 user_api_key_auth=user_api_key_auth,
@@ -373,7 +375,9 @@ if MCP_AVAILABLE:
         """Handle MCP requests through SSE."""
         try:
             # Validate headers and log request info
-            user_api_key_auth, mcp_auth_header = await MCPRequestHandler.process_mcp_request(scope)
+            user_api_key_auth, mcp_auth_header, mcp_servers = (
+                await MCPRequestHandler.process_mcp_request(scope)
+            )
             # Set the auth context variable for easy access in MCP functions
             set_auth_context(
                 user_api_key_auth=user_api_key_auth,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2695,6 +2695,7 @@ class SpecialHeaders(enum.Enum):
     azure_apim_authorization = "Ocp-Apim-Subscription-Key"
     custom_litellm_api_key = "x-litellm-api-key"
     mcp_auth = "x-mcp-auth"
+    mcp_servers = "x-mcp-servers"
 
 
 class LitellmDataForBackendLLMCall(TypedDict, total=False):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -13,13 +13,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-    UserAPIKeyAuthMCP,
+    MCPRequestHandler,
 )
 from litellm.proxy._types import UserAPIKeyAuth
 
 
 @pytest.mark.asyncio
-class TestUserAPIKeyAuthMCP:
+class TestMCPRequestHandler:
 
     @pytest.mark.parametrize(
         "user_api_key_auth,object_permission_id,prisma_client_available,db_result,expected_result",
@@ -91,7 +91,7 @@ class TestUserAPIKeyAuthMCP:
 
         with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
             # Call the method
-            result = await UserAPIKeyAuthMCP._get_allowed_mcp_servers_for_key(
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(
                 user_api_key_auth
             )
 
@@ -170,8 +170,8 @@ class TestUserAPIKeyAuthMCP:
             ),
         ],
     )
-    async def test_user_api_key_auth_mcp(self, headers, expected_api_key, expected_mcp_auth_header):
-        """Test user_api_key_auth_mcp method with various header scenarios"""
+    async def test_process_mcp_request(self, headers, expected_api_key, expected_mcp_auth_header):
+        """Test process_mcp_request method with various header scenarios"""
 
         # Create ASGI scope with headers
         scope = {
@@ -189,12 +189,12 @@ class TestUserAPIKeyAuthMCP:
         )
 
         with patch(
-            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth"
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.process_mcp_request"
         ) as mock_user_api_key_auth:
             mock_user_api_key_auth.return_value = mock_auth_result
 
             # Call the method
-            auth_result, mcp_auth_header = await UserAPIKeyAuthMCP.user_api_key_auth_mcp(scope)
+            auth_result, mcp_auth_header = await MCPRequestHandler.process_mcp_request(scope)
 
             # Assert the results
             assert auth_result == mock_auth_result


### PR DESCRIPTION
## Title

Add new way to get which servers are being fetched over http and sse

## Relevant issues

NA

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
## Changes


