### PR TITLE
Fix: Fix custom ca bundle support in aiohttp transport

### DIFF
--- a/docs/my-website/docs/guides/security_settings.md
+++ b/docs/my-website/docs/guides/security_settings.md
@@ -3,12 +3,43 @@ import TabItem from '@theme/TabItem';
 
 # SSL, HTTP Proxy Security Settings
 
-If you're in an environment using an older TTS bundle, with an older encryption, follow this guide. 
+If you're in an environment using an older TTS bundle, with an older encryption, follow this guide. By default
+LiteLLM uses the certifi CA bundle for SSL verification, which is compatible with most modern servers.
+ However, if you need to disable SSL verification or use a custom CA bundle, you can do so by following the steps below.
 
+Be aware that environmental variables take precedence over the settings in the SDK.
 
-LiteLLM uses HTTPX for network requests, unless otherwise specified. 
+LiteLLM uses HTTPX for network requests, unless otherwise specified.
 
-## 1. Disable SSL verification
+## 1. Custom CA Bundle
+
+You can set a custom CA bundle file path using the `SSL_CERT_FILE` environmental variable or passing a string to the the ssl_verify setting.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import litellm
+litellm.ssl_verify = "client.pem"
+```
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+litellm_settings:
+  ssl_verify: "client.pem"
+```
+
+</TabItem>  
+<TabItem value="env_var" label="Environment Variables">
+
+```bash
+export SSL_CERT_FILE="client.pem"
+```
+</TabItem>
+</Tabs>
+
+## 2. Disable SSL verification
 
 
 <Tabs>
@@ -35,14 +66,42 @@ export SSL_VERIFY="False"
 </TabItem>
 </Tabs>
 
-## 2. Lower security settings
+## 3. Lower security settings
+
+The `ssl_certificate` settings allows setting a client side certificate to authenticate the client to the server.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
 ```python
 import litellm
-litellm.ssl_security_level = 1
+litellm.ssl_security_level = "DEFAULT@SECLEVEL=1"
+```
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+```yaml
+litellm_settings:
+  ssl_security_level: DEFAULT@SECLEVEL=1
+```
+</TabItem>
+<TabItem value="env_var" label="Environment Variables">
+
+```bash
+export SSL_SECURITY_LEVEL="DEFAULT@SECLEVEL=1"
+```
+</TabItem>
+</Tabs>
+
+## 4. Certificate authentication
+
+The `SSL_CERTIFICATE` environmental variable or `ssl_certificate` attribute allows setting a client side certificate to authenticate the client to the server.
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+import litellm
 litellm.ssl_certificate = "/path/to/certificate.pem"
 ```
 </TabItem>
@@ -50,20 +109,18 @@ litellm.ssl_certificate = "/path/to/certificate.pem"
 
 ```yaml
 litellm_settings:
-  ssl_security_level: 1
   ssl_certificate: "/path/to/certificate.pem"
 ```
 </TabItem>
 <TabItem value="env_var" label="Environment Variables">
 
 ```bash
-export SSL_SECURITY_LEVEL="1"
 export SSL_CERTIFICATE="/path/to/certificate.pem"
 ```
 </TabItem>
 </Tabs>
 
-## 3. Use HTTP_PROXY environment variable
+## 5. Use HTTP_PROXY environment variable
 
 Both httpx and aiohttp libraries use `urllib.request.getproxies` from environment variables. Before client initialization, you may set proxy (and optional SSL_CERT_FILE) by setting the environment variables:
 

--- a/docs/my-website/docs/guides/security_settings.md
+++ b/docs/my-website/docs/guides/security_settings.md
@@ -68,7 +68,7 @@ export SSL_VERIFY="False"
 
 ## 3. Lower security settings
 
-The `ssl_certificate` settings allows setting a client side certificate to authenticate the client to the server.
+The `ssl_security_level` allows setting a lower security level for SSL connections.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
@@ -82,7 +82,7 @@ litellm.ssl_security_level = "DEFAULT@SECLEVEL=1"
 
 ```yaml
 litellm_settings:
-  ssl_security_level: DEFAULT@SECLEVEL=1
+  ssl_security_level: "DEFAULT@SECLEVEL=1"
 ```
 </TabItem>
 <TabItem value="env_var" label="Environment Variables">

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -214,6 +214,7 @@ use_litellm_proxy: bool = (
 )
 use_client: bool = False
 ssl_verify: Union[str, bool] = True
+ssl_security_level: Optional[str] = None
 ssl_certificate: Optional[str] = None
 disable_streaming_logging: bool = False
 disable_token_counter: bool = False

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -5,6 +5,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
 
 import httpx
+import certifi
 from aiohttp import ClientSession, TCPConnector
 from httpx import USE_CLIENT_DEFAULT, AsyncHTTPTransport, HTTPTransport
 from httpx._types import RequestFiles
@@ -37,6 +38,72 @@ headers = {
 
 # https://www.python-httpx.org/advanced/timeouts
 _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
+
+
+def get_ssl_configuration(ssl_verify: Optional[VerifyTypes] = None) -> Union[bool, str, ssl.SSLContext]:
+    """
+    Unified SSL configuration function that handles ssl_context and ssl_verify logic.
+
+    SSL Configuration Priority:
+    1. If ssl_verify is provided -> is a SSL context use the custom SSL context
+    2. If ssl_verify is False -> disable SSL verification (ssl=False)
+    3. If ssl_verify is a string -> use it as a path to CA bundle file
+    4. If SSL_CERT_FILE environment variable is set and exists -> use it as CA bundle file
+    5. Else will use default SSL context with certifi CA bundle
+
+    If ssl_security_level is set, it will apply the security level to the SSL context.
+
+    Args:
+        ssl_verify: SSL verification setting. Can be:
+            - None: Use default from environment/litellm settings
+            - False: Disable SSL verification
+            - True: Enable SSL verification
+            - str: Path to CA bundle file
+    
+    Returns:
+        Union[bool, str, ssl.SSLContext]: Appropriate SSL configuration
+    """
+    from litellm.secret_managers.main import str_to_bool
+
+    if isinstance(ssl_verify, ssl.SSLContext):
+        # If ssl_verify is already an SSLContext, return it directly
+        return ssl_verify
+
+    # Get ssl_verify from environment or litellm settings if not provided
+    if ssl_verify is None:
+        ssl_verify = os.getenv("SSL_VERIFY", litellm.ssl_verify)
+        ssl_verify_bool = str_to_bool(ssl_verify) if isinstance(ssl_verify, str) else ssl_verify
+        if ssl_verify_bool is not None:
+            ssl_verify = ssl_verify_bool
+
+    ssl_security_level = os.getenv("SSL_SECURITY_LEVEL", litellm.ssl_security_level)
+
+    cafile = None
+    if isinstance(ssl_verify, str) and os.path.exists(ssl_verify):
+        cafile = ssl_verify
+    if not cafile:
+        ssl_cert_file = os.getenv("SSL_CERT_FILE")
+        if ssl_cert_file and os.path.exists(ssl_cert_file):
+            cafile = ssl_cert_file
+        else:
+            cafile = certifi.where()
+
+    if ssl_verify is not False:
+        custom_ssl_context = ssl.create_default_context(
+            cafile=cafile
+        )
+        # If security level is set, apply it to the SSL context
+        if (
+            ssl_security_level
+            and isinstance(ssl_security_level, str)
+        ):
+            # Create a custom SSL context with reduced security level
+            custom_ssl_context.set_ciphers(ssl_security_level)
+
+        # Use our custom SSL context instead of the original ssl_verify value
+        return custom_ssl_context
+
+    return ssl_verify
 
 
 def mask_sensitive_info(error_message):
@@ -119,29 +186,8 @@ class AsyncHTTPHandler:
         event_hooks: Optional[Mapping[str, List[Callable[..., Any]]]],
         ssl_verify: Optional[VerifyTypes] = None,
     ) -> httpx.AsyncClient:
-        # SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts.
-        # /path/to/certificate.pem
-        if ssl_verify is None:
-            ssl_verify = os.getenv("SSL_VERIFY", litellm.ssl_verify)
-
-        ssl_security_level = os.getenv("SSL_SECURITY_LEVEL")
-
-        # If ssl_verify is not False and we need a lower security level
-        if (
-            not ssl_verify
-            and ssl_security_level
-            and isinstance(ssl_security_level, str)
-        ):
-            # Create a custom SSL context with reduced security level
-            custom_ssl_context = ssl.create_default_context()
-            custom_ssl_context.set_ciphers(ssl_security_level)
-
-            # If ssl_verify is a path to a CA bundle, load it into our custom context
-            if isinstance(ssl_verify, str) and os.path.exists(ssl_verify):
-                custom_ssl_context.load_verify_locations(cafile=ssl_verify)
-
-            # Use our custom SSL context instead of the original ssl_verify value
-            ssl_verify = custom_ssl_context
+        # Get unified SSL configuration
+        ssl_config = get_ssl_configuration(ssl_verify)
 
         # An SSL certificate used by the requested host to authenticate the client.
         # /path/to/client.pem
@@ -152,8 +198,8 @@ class AsyncHTTPHandler:
         # Create a client with a connection pool
 
         transport = AsyncHTTPHandler._create_async_transport(
-            ssl_context=ssl_verify if isinstance(ssl_verify, ssl.SSLContext) else None,
-            ssl_verify=ssl_verify if isinstance(ssl_verify, bool) else None,
+            ssl_context=ssl_config if isinstance(ssl_config, ssl.SSLContext) else None,
+            ssl_verify=ssl_config if isinstance(ssl_config, bool) else None,
         )
 
         return httpx.AsyncClient(
@@ -164,7 +210,7 @@ class AsyncHTTPHandler:
                 max_connections=concurrent_limit,
                 max_keepalive_connections=concurrent_limit,
             ),
-            verify=ssl_verify,
+            verify=ssl_config,
             cert=cert,
             headers=headers,
         )
@@ -544,7 +590,6 @@ class AsyncHTTPHandler:
         SSL Configuration Priority:
         1. If ssl_context is provided -> use the custom SSL context
         2. If ssl_verify is False -> disable SSL verification (ssl=False)
-        3. If ssl_verify is True/None -> use default SSL context with certifi CA bundle
 
         Returns:
             Dict with appropriate SSL configuration for TCPConnector
@@ -559,10 +604,6 @@ class AsyncHTTPHandler:
         elif ssl_verify is False:
             # Priority 2: Explicitly disable SSL verification
             connector_kwargs["verify_ssl"] = False
-        else:
-            # Priority 3: Use our default SSL context with certifi CA bundle
-            # This covers ssl_verify=True and ssl_verify=None cases
-            connector_kwargs["ssl"] = AsyncHTTPHandler._get_ssl_context()
         
         return connector_kwargs
 
@@ -577,7 +618,6 @@ class AsyncHTTPHandler:
         Note: aiohttp TCPConnector ssl parameter accepts:
         - SSLContext: custom SSL context
         - False: disable SSL verification
-        - True: use default SSL verification (equivalent to ssl.create_default_context())
         """
         from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
         from litellm.secret_managers.main import str_to_bool
@@ -599,17 +639,6 @@ class AsyncHTTPHandler:
                 connector=TCPConnector(**connector_kwargs),
                 trust_env=trust_env,
             ),
-        )
-    
-
-    @staticmethod
-    def _get_ssl_context() -> ssl.SSLContext:
-        """
-        Get the SSL context for the AiohttpTransport
-        """
-        import certifi
-        return ssl.create_default_context(
-            cafile=certifi.where()
         )
 
     @staticmethod
@@ -637,11 +666,8 @@ class HTTPHandler:
         if timeout is None:
             timeout = _DEFAULT_TIMEOUT
 
-        # SSL certificates (a.k.a CA bundle) used to verify the identity of requested hosts.
-        # /path/to/certificate.pem
-
-        if ssl_verify is None:
-            ssl_verify = os.getenv("SSL_VERIFY", litellm.ssl_verify)
+        # Get unified SSL configuration
+        ssl_config = get_ssl_configuration(ssl_verify)
 
         # An SSL certificate used by the requested host to authenticate the client.
         # /path/to/client.pem
@@ -658,7 +684,7 @@ class HTTPHandler:
                     max_connections=concurrent_limit,
                     max_keepalive_connections=concurrent_limit,
                 ),
-                verify=ssl_verify,
+                verify=ssl_config,
                 cert=cert,
                 headers=headers,
             )


### PR DESCRIPTION
## Unify ssl context creation

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixes #12237
<!-- e.g. "Fixes #000" -->

This PR addresses issues with using aiohttp transport, and using a custom ca bundle. To address these issues I unified the logic for getting the ssl context in different situations across aiohttp transport and httpx transport for both the client and the TCPConnector. I based the logic on what is in `HTTPHandler.create_client` because that logic is what is documented in the docs and it seems a bit more complete. I tried not to significantly change this logic to make this unification, but I do change a bit to include support for  SSL_CERT_FILE and to default to `certifi.where()` when possible to align with what is done in `AsyncHTTPHandler.create_client` in recent PRs, and to maintain the principles that were introduced there. Though I do remove some functions like `_get_ssl_context` because I think they don't seem to align well across aiohttp and httpx transports.

I think this is an improvement, and seems generally in line with what is done in this repository.

I also tried to clarify a bit the language of the documentation, and add some missing information.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

I have modified existing tests that align with this functionality.

<img width="1058" alt="Screenshot 2025-07-03 at 13 13 13" src="https://github.com/user-attachments/assets/1dfabe8c-d833-4fb4-93ac-4adb85cc0ff0" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring

## Changes
- Uses certifi CA bundle by default when using httpx transport.
- Adds support for setting `SSL_CERT_FILE` for aiohttp & httpx transport.

