### PR TITLE
fix deprecated pydantic configuration usage

### DIFF
--- a/litellm/integrations/deepeval/types.py
+++ b/litellm/integrations/deepeval/types.py
@@ -1,6 +1,7 @@
 # Duplicate -> https://github.com/confident-ai/deepeval/blob/main/deepeval/tracing/api.py
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
+
 from pydantic import BaseModel, Field
 
 
@@ -40,8 +41,9 @@ class BaseApiSpan(BaseModel):
     cost_per_input_token: Optional[float] = Field(None, alias="costPerInputToken")
     cost_per_output_token: Optional[float] = Field(None, alias="costPerOutputToken")
 
-    class Config:
-        use_enum_values = True
+    model_config = {
+        "use_enum_values": True,
+    }
 
 
 class TraceApi(BaseModel):

--- a/litellm/types/mcp_server/tool_registry.py
+++ b/litellm/types/mcp_server/tool_registry.py
@@ -9,8 +9,9 @@ class MCPTool(BaseModel):
     input_schema: Dict[str, Any]
     handler: Callable
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = {
+        'arbitrary_types_allowed': True,
+    }
 
 
 class ToolSchema(BaseModel):


### PR DESCRIPTION
litellm/types/mcp_server/tool_registry.py   has the deprecated Pydantic configuration style "class Config".