### PR TITLE
fix: Add size parameter support for Vertex AI image generation

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -539,9 +539,9 @@ def function_setup(  # noqa: PLR0915
         function_id: Optional[str] = kwargs["id"] if "id" in kwargs else None
 
         ## DYNAMIC CALLBACKS ##
-        dynamic_callbacks: Optional[List[Union[str, Callable, CustomLogger]]] = (
-            kwargs.pop("callbacks", None)
-        )
+        dynamic_callbacks: Optional[
+            List[Union[str, Callable, CustomLogger]]
+        ] = kwargs.pop("callbacks", None)
         all_callbacks = get_dynamic_callbacks(dynamic_callbacks=dynamic_callbacks)
 
         if len(all_callbacks) > 0:
@@ -1261,9 +1261,9 @@ def client(original_function):  # noqa: PLR0915
                         exception=e,
                         retry_policy=kwargs.get("retry_policy"),
                     )
-                    kwargs["retry_policy"] = (
-                        reset_retry_policy()
-                    )  # prevent infinite loops
+                    kwargs[
+                        "retry_policy"
+                    ] = reset_retry_policy()  # prevent infinite loops
                 litellm.num_retries = (
                     None  # set retries to None to prevent infinite loops
                 )
@@ -1405,7 +1405,7 @@ def client(original_function):  # noqa: PLR0915
                     kwargs["max_tokens"] = modified_max_tokens
                 except Exception as e:
                     print_verbose(f"Error while checking max token limit: {str(e)}")
-            
+
             # MODEL CALL
             result = await original_function(*args, **kwargs)
             end_time = datetime.datetime.now()
@@ -2546,13 +2546,29 @@ def get_optional_params_image_gen(
             non_default_params=non_default_params, optional_params={}
         )
     elif custom_llm_provider == "vertex_ai":
-        supported_params = ["n"]
+        supported_params = ["n", "size"]
         """
         All params here: https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/imagegeneration?project=adroit-crow-413218
         """
         _check_valid_arg(supported_params=supported_params)
         if n is not None:
             optional_params["sampleCount"] = int(n)
+
+        # Map OpenAI size parameter to Vertex AI aspectRatio
+        if size is not None:
+            # Map OpenAI size strings to Vertex AI aspect ratio strings
+            # Vertex AI accepts: "1:1", "9:16", "16:9", "4:3", "3:4"
+            size_to_aspect_ratio = {
+                "256x256": "1:1",  # Square
+                "512x512": "1:1",  # Square
+                "1024x1024": "1:1",  # Square (default)
+                "1792x1024": "16:9",  # Landscape
+                "1024x1792": "9:16",  # Portrait
+            }
+            aspect_ratio = size_to_aspect_ratio.get(
+                size, "1:1"
+            )  # Default to square if size not recognized
+            optional_params["aspectRatio"] = aspect_ratio
 
     for k in passed_params.keys():
         if k not in default_params.keys():
@@ -2981,10 +2997,10 @@ def pre_process_non_default_params(
 
     if "response_format" in non_default_params:
         if provider_config is not None:
-            non_default_params["response_format"] = (
-                provider_config.get_json_schema_from_pydantic_object(
-                    response_format=non_default_params["response_format"]
-                )
+            non_default_params[
+                "response_format"
+            ] = provider_config.get_json_schema_from_pydantic_object(
+                response_format=non_default_params["response_format"]
             )
         else:
             non_default_params["response_format"] = type_to_response_format_param(
@@ -3111,16 +3127,16 @@ def pre_process_optional_params(
                     True  # so that main.py adds the function call to the prompt
                 )
                 if "tools" in non_default_params:
-                    optional_params["functions_unsupported_model"] = (
-                        non_default_params.pop("tools")
-                    )
+                    optional_params[
+                        "functions_unsupported_model"
+                    ] = non_default_params.pop("tools")
                     non_default_params.pop(
                         "tool_choice", None
                     )  # causes ollama requests to hang
                 elif "functions" in non_default_params:
-                    optional_params["functions_unsupported_model"] = (
-                        non_default_params.pop("functions")
-                    )
+                    optional_params[
+                        "functions_unsupported_model"
+                    ] = non_default_params.pop("functions")
             elif (
                 litellm.add_function_to_prompt
             ):  # if user opts to add it to prompt instead
@@ -4203,9 +4219,9 @@ def _count_characters(text: str) -> int:
 
 
 def get_response_string(response_obj: Union[ModelResponse, ModelResponseStream]) -> str:
-    _choices: Union[List[Union[Choices, StreamingChoices]], List[StreamingChoices]] = (
-        response_obj.choices
-    )
+    _choices: Union[
+        List[Union[Choices, StreamingChoices]], List[StreamingChoices]
+    ] = response_obj.choices
 
     response_str = ""
     for choice in _choices:
@@ -7131,7 +7147,7 @@ class ProviderConfigManager:
             #########################################################
             if VertexAIPartnerModels.is_vertex_partner_model(model):
                 return None
-            
+
             #########################################################
             # If the model is not a Vertex Partner model, return the Vertex AI Google Gen AI Config
             # This is for Vertex `gemini` models

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -38,6 +38,45 @@ def test_get_optional_params_image_gen():
     assert optional_params["n"] == 3
 
 
+def test_get_optional_params_image_gen_vertex_ai_size():
+    """Test that Vertex AI image generation properly handles size parameter and maps it to aspectRatio"""
+    # Test with various size parameters
+    test_cases = [
+        ("1024x1024", "1:1"),  # Square aspect ratio
+        ("256x256", "1:1"),  # Square aspect ratio
+        ("512x512", "1:1"),  # Square aspect ratio
+        ("1792x1024", "16:9"),  # Landscape aspect ratio
+        ("1024x1792", "9:16"),  # Portrait aspect ratio
+        ("unsupported", "1:1"),  # Default to square for unsupported sizes
+    ]
+
+    for size_input, expected_aspect_ratio in test_cases:
+        optional_params = get_optional_params_image_gen(
+            model="vertex_ai/imagegeneration@006",
+            size=size_input,
+            n=2,
+            custom_llm_provider="vertex_ai",
+            drop_params=True,
+        )
+        assert optional_params is not None
+        assert optional_params["aspectRatio"] == expected_aspect_ratio
+        assert optional_params["sampleCount"] == 2
+        assert "size" not in optional_params  # size should be converted to aspectRatio
+
+    # Test without size parameter
+    optional_params = get_optional_params_image_gen(
+        model="vertex_ai/imagegeneration@006",
+        n=1,
+        custom_llm_provider="vertex_ai",
+        drop_params=True,
+    )
+    assert optional_params is not None
+    assert (
+        "aspectRatio" not in optional_params
+    )  # aspectRatio should not be set if size is not provided
+    assert optional_params["sampleCount"] == 1
+
+
 def test_all_model_configs():
     from litellm.llms.vertex_ai.vertex_ai_partner_models.ai21.transformation import (
         VertexAIAi21Config,
@@ -2009,8 +2048,6 @@ class TestProxyFunctionCalling:
                 ), f"Claude 3 model should support function calling: {model}"
             except Exception as e:
                 print(f"Could not test {model}: {e}")
-
-
 
 
 def test_register_model_with_scientific_notation():


### PR DESCRIPTION
## Title

Add size parameter support for Vertex AI image generation

## Relevant issues

Fixes LIT-279: Vertex AI Image Generation Aspect Ratio Support - Size parameter ignored

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

### Problem
When using Vertex AI image generation through LiteLLM, the size parameter was being ignored and images were always returned as 1:1 (1024x1024) regardless of the specified size.

### Solution
- Added "size" to the list of supported parameters for vertex_ai in `get_optional_params_image_gen()`
- Implemented mapping from OpenAI-style size strings (e.g., "1024x1024") to Vertex AI aspectRatio format (e.g., "1:1")
- Supports common aspect ratios:
  - Square (1:1): "256x256", "512x512", "1024x1024"
  - Landscape (16:9): "1792x1024"
  - Portrait (9:16): "1024x1792"
- Defaults to "1:1" for unrecognized size values

### Testing
Added comprehensive test `test_get_optional_params_image_gen_vertex_ai_size` that verifies:
- Correct mapping of various size inputs to aspect ratios
- Proper handling of unsupported sizes (defaults to "1:1")
- Behavior when size parameter is not provided

### Test Results
```
============================= test session starts ==============================
platform darwin -- Python 3.11.13, pytest-7.4.4, pluggy-1.5.0
tests/test_litellm/test_utils.py::test_get_optional_params_image_gen_vertex_ai_size PASSED [100%]
=============================== 1 passed, 1 warning in 0.18s =========================
```