### PR TITLE
support optional args in BedrockToolUseBlock 2

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2631,7 +2631,7 @@ def _convert_to_bedrock_tool_call_invoke(
                 id = tool["id"]
                 name = tool["function"].get("name", "")
                 arguments = tool["function"].get("arguments", "")
-                arguments_dict = json.loads(arguments)
+                arguments_dict = json.loads(arguments) if arguments else {}
                 bedrock_tool = BedrockToolUseBlock(
                     input=arguments_dict, name=name, toolUseId=id
                 )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -82,9 +82,45 @@ async def test_anthropic_bedrock_thinking_blocks_with_none_content():
         == "This is a test thinking block"
     )
 
+@pytest.mark.asyncio
+async def test_convert_to_bedrock_tool_call_invoke_with_no_args():
+    """Test formatting bedrock tool call invocation response"""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "I will call a tool without args",
+            "tool_calls": [{
+                "id": "123",
+                "type": "function",
+                "function": {
+                    "name": "test_tool",
+                    "arguments": ""
+                }
+            }]
+        }, {
+            "role": "tool",
+            "content": "The tool worked",
+            "tool_call_id": "123",
+            "tool_name": "test_tool",
+            "tool_args": None,
+        },
+    ]
+
+    result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        llm_provider="bedrock",
+    )
+
+    print(f"result: {result}")
+    assert len(result) == 2
+    assert (
+            result[1]["content"][0]["toolResult"]["content"][0]["text"]
+            == "The tool worked"
+    )
 
 def test_convert_to_azure_openai_messages():
-    """Test coverting image_url to azure_openai spec"""
+    """Test converting image_url to azure_openai spec"""
 
     from typing import List
     from litellm.types.llms.openai import AllMessageValues


### PR DESCRIPTION
## Title

support optional args in BedrockToolUseBlock

same changes as per https://github.com/BerriAI/litellm/pull/12276

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![Screenshot 2025-07-03 at 6 30 52 pm](https://github.com/user-attachments/assets/c1af59a5-d1d4-4607-940c-bf85a4943dd0)

## Type

🐛 Bug Fix

## Changes

After making a tool call which takes no args, litellm threw an exception when formatting the response to Bedrock.
Apparently `input` is required, but this makes the system more robust when the tool doesn't take any args.

https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolUseBlock.html

- There were a lot of unit tests that were failing for unrelated reasons, Cursor has had a go at fixing them.
- `pyproject.toml` specified Python 3.9, but 3.12 is used in the GitHub workflows and 3.9 is EOL in October - https://devguide.python.org/versions/