### PR TITLE
[Bug Fix] /generateContent API - Only pass supported params when using OpenAI models

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -211,10 +211,12 @@ class GoogleGenAIAdapter:
         Returns:
             Dict[str, Any]
         """
+        allowed_fields = GenericLiteLLMParams.model_fields.keys()
         if litellm_params:
             litellm_dict = litellm_params.model_dump(exclude_none=True)
             for key, value in litellm_dict.items():
-                completion_request_dict[key] = value
+                if key in allowed_fields:
+                    completion_request_dict[key] = value
         return completion_request_dict
 
     def translate_completion_output_params_streaming(


### PR DESCRIPTION
## [Bug Fix] /generateContent API - Only pass supported params when using OpenAI models

Fixes https://github.com/BerriAI/litellm/issues/12191 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


