### PR TITLE
UI changes for segregating the MCP servers

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -83,7 +83,6 @@ mcp_servers:
 </Tabs>
 
 
-
 ## Using your MCP
 
 <Tabs>
@@ -159,7 +158,7 @@ Use tools directly from Cursor IDE with LiteLLM MCP:
 2. **Navigate to MCP Tools**: Go to the "MCP Tools" tab and click "New MCP Server"
 3. **Add Configuration**: Copy and paste the JSON configuration below, then save with `Cmd+S` or `Ctrl+S`
 
-```json title="Cursor MCP Configuration" showLineNumbers
+```json title="Basic Cursor MCP Configuration" showLineNumbers
 {
   "mcpServers": {
     "LiteLLM": {
@@ -173,97 +172,98 @@ Use tools directly from Cursor IDE with LiteLLM MCP:
 ```
 
 </TabItem>
+</Tabs>
 
-<TabItem value="http" label="Streamable HTTP">
+## Segregating MCP Server Access
 
-#### Connect via Streamable HTTP Transport
+You can choose to access specific MCP servers and only list their tools using the `x-mcp-servers` header. This header allows you to:
+- Limit tool access to one or more specific MCP servers
+- Control which tools are available in different environments or use cases
 
-Connect to LiteLLM MCP using HTTP transport. Compatible with any MCP client that supports HTTP streaming:
+The header accepts a JSON array of server names, where:
+- Server names with spaces should be replaced with underscores
+- Multiple servers can be specified: `["Server1", "Server2", "Server3"]`
+- If the header is not provided, tools from all available MCP servers will be accessible
 
-**Server URL:**
-```text showLineNumbers
-<your-litellm-proxy-base-url>/mcp
+<Tabs>
+<TabItem value="openai" label="OpenAI API">
+
+```bash title="cURL Example with Server Segregation" showLineNumbers
+curl --location 'https://api.openai.com/v1/responses' \
+--header 'Content-Type: application/json' \
+--header "Authorization: Bearer $OPENAI_API_KEY" \
+--data '{
+    "model": "gpt-4o",
+    "tools": [
+        {
+            "type": "mcp",
+            "server_label": "litellm",
+            "server_url": "<your-litellm-proxy-base-url>/mcp",
+            "require_approval": "never",
+            "headers": {
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+                "x-mcp-servers": "[\"Zapier_Gmail\"]"
+            }
+        }
+    ],
+    "input": "Run available tools",
+    "tool_choice": "required"
+}'
 ```
 
-**Headers:**
-```text showLineNumbers
-x-litellm-api-key: Bearer YOUR_LITELLM_API_KEY
-```
-
-This URL can be used with any MCP client that supports HTTP transport. Refer to your client documentation to determine the appropriate transport method.
+In this example, the request will only have access to tools from the "Zapier_Gmail" MCP server.
 
 </TabItem>
 
-<TabItem value="fastmcp" label="Python FastMCP">
+<TabItem value="litellm" label="LiteLLM Proxy">
 
-#### Connect via Python FastMCP Client
-
-Use the Python FastMCP client to connect to your LiteLLM MCP server:
-
-**Installation:**
-
-```bash title="Install FastMCP" showLineNumbers
-pip install fastmcp
+```bash title="cURL Example with Server Segregation" showLineNumbers
+curl --location '<your-litellm-proxy-base-url>/v1/responses' \
+--header 'Content-Type: application/json' \
+--header "Authorization: Bearer $LITELLM_API_KEY" \
+--data '{
+    "model": "gpt-4o",
+    "tools": [
+        {
+            "type": "mcp",
+            "server_label": "litellm",
+            "server_url": "<your-litellm-proxy-base-url>/mcp",
+            "require_approval": "never",
+            "headers": {
+                "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
+                "x-mcp-servers": "[\"Zapier_Gmail\"]"
+            }
+        }
+    ],
+    "input": "Run available tools",
+    "tool_choice": "required"
+}'
 ```
 
-or with uv:
+This configuration restricts the request to only use tools from the specified MCP server.
 
-```bash title="Install with uv" showLineNumbers
-uv pip install fastmcp
-```
+</TabItem>
 
-**Usage:**
+<TabItem value="cursor" label="Cursor IDE">
 
-```python title="Python FastMCP Example" showLineNumbers
-import asyncio
-import json
-
-from fastmcp import Client
-from fastmcp.client.transports import StreamableHttpTransport
-
-# Create the transport with your LiteLLM MCP server URL
-server_url = "<your-litellm-proxy-base-url>/mcp"
-transport = StreamableHttpTransport(
-    server_url,
-    headers={
-        "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY"
+```json title="Cursor MCP Configuration with Server Segregation" showLineNumbers
+{
+  "mcpServers": {
+    "LiteLLM": {
+      "url": "<your-litellm-proxy-base-url>/mcp",
+      "headers": {
+        "x-litellm-api-key": "Bearer $LITELLM_API_KEY",
+        "x-mcp-servers": "[\"Zapier_Gmail\"]"
+      }
     }
-)
-
-# Initialize the client with the transport
-client = Client(transport=transport)
-
-
-async def main():
-    # Connection is established here
-    print("Connecting to LiteLLM MCP server...")
-    async with client:
-        print(f"Client connected: {client.is_connected()}")
-
-        # Make MCP calls within the context
-        print("Fetching available tools...")
-        tools = await client.list_tools()
-
-        print(f"Available tools: {json.dumps([t.name for t in tools], indent=2)}")
-        
-        # Example: Call a tool (replace 'tool_name' with an actual tool name)
-        if tools:
-            tool_name = tools[0].name
-            print(f"Calling tool: {tool_name}")
-            
-            # Call the tool with appropriate arguments
-            result = await client.call_tool(tool_name, arguments={})
-            print(f"Tool result: {result}")
-
-
-# Run the example
-if __name__ == "__main__":
-    asyncio.run(main())
+  }
+}
 ```
+
+This configuration in Cursor IDE settings will limit tool access to only the specified MCP server.
 
 </TabItem>
 </Tabs>
-
 
 ## Using your MCP with client side credentials
 


### PR DESCRIPTION
## Title

Add UI relevant  UI changes to show support for which server to select 

## Relevant issues

Fixes issue where the ui didn't have a way of toggling headers directly to show the correct connection string

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🆕 New Feature

## Changes


