### PR TITLE
Fix DeepEval logging format for failure events

### DIFF
--- a/litellm/integrations/deepeval/deepeval.py
+++ b/litellm/integrations/deepeval/deepeval.py
@@ -100,7 +100,7 @@ class DeepEvalLogger(CustomLogger):
         except Exception as e:
             raise e
         verbose_logger.debug(
-            "DeepEvalLogger: sync_log_failure_event: Api response", response
+            "DeepEvalLogger: sync_log_failure_event: Api response %s", response
         )
 
     async def _async_event_handler(
@@ -116,7 +116,7 @@ class DeepEvalLogger(CustomLogger):
         )
 
         verbose_logger.debug(
-            "DeepEvalLogger: async_event_handler: Api response", response
+            "DeepEvalLogger: async_event_handler: Api response %s", response
         )
 
     def _create_base_api_span(


### PR DESCRIPTION
## Summary
- fix formatting of debug messages in DeepEvalLogger

## Testing
- `pytest tests/test_litellm/integrations/test_deepeval.py::TestDeepEvalLogger::test_log_failure_event -q`

------
https://chatgpt.com/codex/tasks/task_e_6867149827e48321ba644c23d1143969