### PR TITLE
Fix credentials CLI test

### DIFF
--- a/tests/test_litellm/proxy/client/cli/test_credentials_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_credentials_commands.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -16,11 +16,18 @@ from litellm.proxy.client.cli.main import cli
 
 
 @pytest.fixture
-def mock_credentials_client():
-    with patch(
-        "litellm.proxy.client.cli.commands.credentials.CredentialsManagementClient"
-    ) as mock:
-        yield mock
+def mock_credentials_client(monkeypatch):
+    """Patch the CredentialsManagementClient used by the CLI commands."""
+    mock_client = MagicMock()
+    monkeypatch.setattr(
+        "litellm.proxy.client.credentials.CredentialsManagementClient",
+        mock_client,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.client.cli.commands.credentials.CredentialsManagementClient",
+        mock_client,
+    )
+    return mock_client
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- patch CredentialsManagementClient in the CLI tests more robustly

## Testing
- `pytest tests/test_litellm/proxy/client/cli/test_credentials_commands.py::test_list_credentials_json_format -vv`
- `pytest tests/test_litellm/proxy/client/cli -vv`


------
https://chatgpt.com/codex/tasks/task_e_6867177848a083218150672053df7194