### PR TITLE
Comma separated spend and budget

### DIFF
--- a/ui/litellm-dashboard/src/components/SSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/SSOSettings.tsx
@@ -5,6 +5,7 @@ import { PlusOutlined, DeleteOutlined } from "@ant-design/icons";
 import { getInternalUserSettings, updateInternalUserSettings, modelAvailableCall } from "./networking";
 import BudgetDurationDropdown, { getBudgetDurationLabel } from "./common_components/budget_duration_dropdown";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface SSOSettingsProps {
   accessToken: string | null;
@@ -333,7 +334,7 @@ const SSOSettings: React.FC<SSOSettingsProps> = ({ accessToken, possibleUIRoles,
                   <span className="font-medium text-gray-600">Max Budget:</span>
                   <p className="text-gray-900">
                     {team.max_budget_in_team !== undefined 
-                      ? `$${team.max_budget_in_team}` 
+                      ? `$${formatNumberWithCommas(team.max_budget_in_team, 4)}` 
                       : "No limit"}
                   </p>
                 </div>

--- a/ui/litellm-dashboard/src/components/activity_metrics.tsx
+++ b/ui/litellm-dashboard/src/components/activity_metrics.tsx
@@ -3,6 +3,7 @@ import { Card, Grid, Text, Title, Accordion, AccordionHeader, AccordionBody } fr
 import { AreaChart, BarChart } from '@tremor/react';
 import { SpendMetrics, DailyData, ModelActivityData, MetricWithMetadata, KeyMetricWithMetadata } from './usage/types';
 import { Collapse } from 'antd';
+import { formatNumberWithCommas } from '@/utils/dataUtils';
 
 interface ActivityMetricsProps {
   modelMetrics: Record<string, ModelActivityData>;
@@ -28,8 +29,8 @@ const ModelSection = ({ modelName, metrics }: { modelName: string; metrics: Mode
         </Card>
         <Card>
           <Text>Total Spend</Text>
-          <Title>${metrics.total_spend.toFixed(2)}</Title>
-          <Text>${(metrics.total_spend / metrics.total_successful_requests).toFixed(3)} per successful request</Text>
+          <Title>${formatNumberWithCommas(metrics.total_spend, 2)}</Title>
+          <Text>${formatNumberWithCommas((metrics.total_spend / metrics.total_successful_requests), 3)} per successful request</Text>
         </Card>
       </Grid>
 
@@ -64,7 +65,7 @@ const ModelSection = ({ modelName, metrics }: { modelName: string; metrics: Mode
             index="date"
             categories={["metrics.spend"]}
             colors={["green"]}
-            valueFormatter={(value: number) => `$${value.toFixed(2)}`}
+            valueFormatter={(value: number) => `$${formatNumberWithCommas(value, 2)}`}
           />
         </Card>
 
@@ -188,7 +189,7 @@ export const ActivityMetrics: React.FC<ActivityMetricsProps> = ({ modelMetrics }
           </Card>
           <Card>
             <Text>Total Spend</Text>
-            <Title>${totalMetrics.total_spend.toFixed(2)}</Title>
+            <Title>${formatNumberWithCommas(totalMetrics.total_spend, 2)}</Title>
           </Card>
         </Grid>
 
@@ -226,7 +227,7 @@ export const ActivityMetrics: React.FC<ActivityMetricsProps> = ({ modelMetrics }
               <div className="flex justify-between items-center w-full">
                 <Title>{modelMetrics[modelName].label || 'Unknown Item'}</Title>
                 <div className="flex space-x-4 text-sm text-gray-500">
-                  <span>${modelMetrics[modelName].total_spend.toFixed(2)}</span>
+                  <span>${formatNumberWithCommas(modelMetrics[modelName].total_spend, 2)}</span>
                   <span>{modelMetrics[modelName].total_requests.toLocaleString()} requests</span>
                 </div>
               </div>

--- a/ui/litellm-dashboard/src/components/all_keys_table.tsx
+++ b/ui/litellm-dashboard/src/components/all_keys_table.tsx
@@ -38,6 +38,7 @@ import {
 import { SwitchVerticalIcon, ChevronUpIcon, ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/outline";
 import { Badge, Text } from "@tremor/react";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface AllKeysTableProps {
   keys: KeyResponse[];
@@ -352,16 +353,19 @@ export function AllKeysTable({
       id: "spend",
       accessorKey: "spend",
       header: "Spend (USD)",
-      cell: (info) => Number(info.getValue()).toFixed(4),
+      cell: (info) => formatNumberWithCommas(info.getValue() as number, 4),
     },
     {
       id: "max_budget",
       accessorKey: "max_budget",
       header: "Budget (USD)",
-      cell: (info) =>
-        info.getValue() !== null && info.getValue() !== undefined
-          ? info.getValue()
-          : "Unlimited",
+      cell: (info) => {
+        const maxBudget = info.getValue() as number | null;
+        if (maxBudget === null) {
+          return "Unlimited";
+        }
+        return `$${formatNumberWithCommas(maxBudget)}`;
+      },
     },
     {
       id: "budget_reset_at",

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -44,6 +44,7 @@ import Createuser from "./create_user_button";
 import debounce from 'lodash/debounce';
 import { rolesWithWriteAccess } from '../utils/roles';
 import BudgetDurationDropdown from "./common_components/budget_duration_dropdown";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 
 
@@ -589,7 +590,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                           value > team.max_budget
                         ) {
                           throw new Error(
-                            `Budget cannot exceed team max budget: $${team.max_budget}`
+                            `Budget cannot exceed team max budget: $${formatNumberWithCommas(team.max_budget, 4)}`
                           );
                         }
                       },

--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -12,6 +12,7 @@ import { ActivityMetrics, processActivityData } from './activity_metrics';
 import { DailyData, KeyMetricWithMetadata, EntityMetricWithMetadata } from './usage/types';
 import { tagDailyActivityCall, teamDailyActivityCall } from './networking';
 import TopKeyView from "./top_key_view";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface EntityMetrics {
   metrics: {
@@ -327,7 +328,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                     <Card>
                       <Title>Total Spend</Title>
                       <Text className="text-2xl font-bold mt-2">
-                        ${spendData.metadata.total_spend.toFixed(2)}
+                        ${formatNumberWithCommas(spendData.metadata.total_spend, 2)}
                       </Text>
                     </Card>
                     <Card>
@@ -369,7 +370,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                           index="date"
                           categories={["metrics.spend"]}
                           colors={["cyan"]}
-                          valueFormatter={(value) => `$${value.toFixed(2)}`}
+                          valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                           yAxisWidth={100}
                           showLegend={false}
                           customTooltip={({ payload, active }) => {
@@ -378,7 +379,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                             return (
                               <div className="bg-white p-4 shadow-lg rounded-lg border">
                                 <p className="font-bold">{data.date}</p>
-                                <p className="text-cyan-500">Total Spend: ${data.metrics.spend.toFixed(2)}</p>
+                                <p className="text-cyan-500">Total Spend: ${formatNumberWithCommas(data.metrics.spend, 2)}</p>
                                 <p className="text-gray-600">Total Requests: {data.metrics.api_requests}</p>
                                 <p className="text-gray-600">Successful: {data.metrics.successful_requests}</p>
                                 <p className="text-gray-600">Failed: {data.metrics.failed_requests}</p>
@@ -389,7 +390,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                                     const metrics = entityData as EntityMetrics;
                                     return (
                                       <p key={entity} className="text-sm text-gray-600">
-                                        {metrics.metadata.team_alias || entity}: ${metrics.metrics.spend.toFixed(2)}
+                                        {metrics.metadata.team_alias || entity}: ${formatNumberWithCommas(metrics.metrics.spend, 2)}
                                       </p>
                                     );
                                   })}
@@ -422,7 +423,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                           index="metadata.alias"
                           categories={["metrics.spend"]}
                           colors={["cyan"]}
-                          valueFormatter={(value) => `$${value.toFixed(4)}`}
+                          valueFormatter={(value) => `$${formatNumberWithCommas(value, 4)}`}
                           layout="vertical"
                           showLegend={false}
                           yAxisWidth={100}
@@ -445,7 +446,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                               .map((entity) => (
                                 <TableRow key={entity.metadata.id}>
                                   <TableCell>{entity.metadata.alias}</TableCell>
-                                  <TableCell>${entity.metrics.spend.toFixed(4)}</TableCell>
+                                  <TableCell>${formatNumberWithCommas(entity.metrics.spend, 4)}</TableCell>
                                   <TableCell className="text-green-600">
                                     {entity.metrics.successful_requests.toLocaleString()}
                                   </TableCell>
@@ -489,7 +490,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                     index="key"
                     categories={["spend"]}
                     colors={["cyan"]}
-                    valueFormatter={(value) => `$${value.toFixed(2)}`}
+                    valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                     layout="vertical"
                     yAxisWidth={200}
                     showLegend={false}
@@ -511,7 +512,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                           data={getProviderSpend()}
                           index="provider"
                           category="spend"
-                          valueFormatter={(value) => `$${value.toFixed(2)}`}
+                          valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                           colors={["cyan", "blue", "indigo", "violet", "purple"]}
                         />
                       </Col>
@@ -530,7 +531,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                             {getProviderSpend().map((provider) => (
                               <TableRow key={provider.provider}>
                                 <TableCell>{provider.provider}</TableCell>
-                                <TableCell>${provider.spend.toFixed(2)}</TableCell>
+                                <TableCell>${formatNumberWithCommas(provider.spend, 2)}</TableCell>
                                 <TableCell className="text-green-600">
                                   {provider.successful_requests.toLocaleString()}
                                 </TableCell>

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -23,6 +23,7 @@ import { KeyEditView } from "./key_edit_view";
 import { RegenerateKeyModal } from "./regenerate_key_modal";
 import { rolesWithWriteAccess } from '../utils/roles';
 import ObjectPermissionsView from "./object_permissions_view";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -249,8 +250,8 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
               <Card>
                 <Text>Spend</Text>
                 <div className="mt-2">
-                  <Title>${Number(keyData.spend).toFixed(4)}</Title>
-                  <Text>of {keyData.max_budget !== null ? `$${keyData.max_budget}` : "Unlimited"}</Text>
+                  <Title>${formatNumberWithCommas(keyData.spend, 4)}</Title>
+                  <Text>of {keyData.max_budget !== null ? `$${formatNumberWithCommas(keyData.max_budget)}` : "Unlimited"}</Text>
                 </div>
               </Card>
 
@@ -348,12 +349,16 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
 
                   <div>
                     <Text className="font-medium">Spend</Text>
-                    <Text>${Number(keyData.spend).toFixed(4)} USD</Text>
+                    <Text>${formatNumberWithCommas(keyData.spend, 4)} USD</Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Budget</Text>
-                    <Text>{keyData.max_budget !== null ? `$${keyData.max_budget} USD` : "Unlimited"}</Text>
+                    <Text>
+                      {keyData.max_budget !== null
+                        ? `$${formatNumberWithCommas(keyData.max_budget, 2)}`
+                        : "Unlimited"}
+                    </Text>
                   </div>
 
                   <div>

--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -28,6 +28,7 @@ import EntityUsage from './entity_usage';
 import { old_admin_roles, v2_admin_role_names, all_admin_roles, rolesAllowedToSeeUsage, rolesWithWriteAccess, internalUserRoles } from '../utils/roles';
 import { Team } from "./key_team_helpers/key_list";
 import { EntityList } from "./entity_usage";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface NewUsagePageProps {
   accessToken: string | null;
@@ -348,7 +349,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                           <Card>
                             <Title>Average Cost per Request</Title>
                             <Text className="text-2xl font-bold mt-2">
-                              ${((totalSpend || 0) / (userSpendData.metadata?.total_api_requests || 1)).toFixed(4)}
+                              ${formatNumberWithCommas(((totalSpend || 0) / (userSpendData.metadata?.total_api_requests || 1)), 4)}
                             </Text>
                           </Card>
                         </Grid>
@@ -366,7 +367,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                           index="date"
                           categories={["metrics.spend"]}
                           colors={["cyan"]}
-                          valueFormatter={(value) => `$${value.toFixed(2)}`}
+                          valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                           yAxisWidth={100}
                           showLegend={false}
                           customTooltip={({ payload, active }) => {
@@ -375,7 +376,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                             return (
                               <div className="bg-white p-4 shadow-lg rounded-lg border">
                                 <p className="font-bold">{data.date}</p>
-                                <p className="text-cyan-500">Spend: ${data.metrics.spend.toFixed(2)}</p>
+                                <p className="text-cyan-500">Spend: ${formatNumberWithCommas(data.metrics.spend, 2)}</p>
                                 <p className="text-gray-600">Requests: {data.metrics.api_requests}</p>
                                 <p className="text-gray-600">Successful: {data.metrics.successful_requests}</p>
                                 <p className="text-gray-600">Failed: {data.metrics.failed_requests}</p>
@@ -413,7 +414,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                           index="key"
                           categories={["spend"]}
                           colors={["cyan"]}
-                          valueFormatter={(value) => `$${value.toFixed(2)}`}
+                          valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                           layout="vertical"
                           yAxisWidth={200}
                           showLegend={false}
@@ -423,7 +424,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                             return (
                               <div className="bg-white p-4 shadow-lg rounded-lg border">
                                 <p className="font-bold">{data.key}</p>
-                                <p className="text-cyan-500">Spend: ${data.spend.toFixed(2)}</p>
+                                <p className="text-cyan-500">Spend: ${formatNumberWithCommas(data.spend, 2)}</p>
                                 <p className="text-gray-600">Total Requests: {data.requests.toLocaleString()}</p>
                                 <p className="text-green-600">Successful: {data.successful_requests.toLocaleString()}</p>
                                 <p className="text-red-600">Failed: {data.failed_requests.toLocaleString()}</p>
@@ -448,7 +449,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                               data={getProviderSpend()}
                               index="provider"
                               category="spend"
-                              valueFormatter={(value) => `$${value.toFixed(2)}`}
+                              valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                               colors={["cyan"]}
                             />
                           </Col>
@@ -470,9 +471,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
                                     <TableRow key={provider.provider}>
                                       <TableCell>{provider.provider}</TableCell>
                                       <TableCell>
-                                        ${provider.spend < 0.00001
-                                            ? "less than 0.00001" 
-                                            : provider.spend.toFixed(2)}
+                                        ${formatNumberWithCommas(provider.spend, 2)}
                                     </TableCell>
                                     <TableCell className="text-green-600">
                                       {provider.successful_requests.toLocaleString()}

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -31,6 +31,7 @@ import MemberModal from "../team/edit_membership";
 import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface OrganizationInfoProps {
   organizationId: string;
@@ -216,7 +217,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
             <Card>
                 <Text>Budget Status</Text>
                 <div className="mt-2">
-                <Title>${orgData.spend.toFixed(6)}</Title>
+                <Title>${formatNumberWithCommas(orgData.spend, 4)}</Title>
                 <Text>of {orgData.litellm_budget_table.max_budget === null ? "Unlimited" : `$${orgData.litellm_budget_table.max_budget}`}</Text>
                 {orgData.litellm_budget_table.budget_duration && (
                     <Text className="text-gray-500">Reset: {orgData.litellm_budget_table.budget_duration}</Text>
@@ -293,7 +294,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                             <Text className="font-mono">{member.user_role}</Text>
                         </TableCell>
                         <TableCell>
-                            <Text>${member.spend.toFixed(6)}</Text>
+                            <Text>${formatNumberWithCommas(member.spend, 4)}</Text>
                         </TableCell>
                         <TableCell>
                             <Text>{new Date(member.created_at).toLocaleString()}</Text>

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -218,7 +218,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                 <Text>Budget Status</Text>
                 <div className="mt-2">
                 <Title>${formatNumberWithCommas(orgData.spend, 4)}</Title>
-                <Text>of {orgData.litellm_budget_table.max_budget === null ? "Unlimited" : `$${orgData.litellm_budget_table.max_budget}`}</Text>
+                <Text>of {orgData.litellm_budget_table.max_budget === null ? "Unlimited" : `$${formatNumberWithCommas(orgData.litellm_budget_table.max_budget, 4)}`}</Text>
                 {orgData.litellm_budget_table.budget_duration && (
                     <Text className="text-gray-500">Reset: {orgData.litellm_budget_table.budget_duration}</Text>
                 )}
@@ -478,7 +478,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Budget</Text>
-                    <div>Max: {orgData.litellm_budget_table.max_budget !== null ? `$${orgData.litellm_budget_table.max_budget}` : 'No Limit'}</div>
+                    <div>Max: {orgData.litellm_budget_table.max_budget !== null ? `$${formatNumberWithCommas(orgData.litellm_budget_table.max_budget, 4)}` : 'No Limit'}</div>
                     <div>Reset: {orgData.litellm_budget_table.budget_duration || 'Never'}</div>
                   </div>
 

--- a/ui/litellm-dashboard/src/components/organizations.tsx
+++ b/ui/litellm-dashboard/src/components/organizations.tsx
@@ -31,6 +31,7 @@ import OrganizationInfoView from './organization/organization_view';
 import { Organization, organizationListCall, organizationCreateCall, organizationDeleteCall } from './networking';
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
+import { formatNumberWithCommas } from "../utils/dataUtils";
 
 interface OrganizationsTableProps {
   organizations: Organization[];
@@ -351,7 +352,7 @@ const OrganizationsTable: React.FC<OrganizationsTableProps> = ({
                               <TableCell>
                                 {org.created_at ? new Date(org.created_at).toLocaleDateString() : "N/A"}
                               </TableCell>
-                              <TableCell>{org.spend}</TableCell>
+                              <TableCell>{formatNumberWithCommas(org.spend, 4)}</TableCell>
                               <TableCell>
                                 {org.litellm_budget_table?.max_budget !== null && org.litellm_budget_table?.max_budget !== undefined ? org.litellm_budget_table?.max_budget : "No limit"}
                               </TableCell>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -37,6 +37,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
 import PremiumVectorStoreSelector from "../common_components/PremiumVectorStoreSelector";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 export interface TeamMembership {
   user_id: string;
@@ -322,7 +323,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
               <Card>
                 <Text>Budget Status</Text>
                 <div className="mt-2">
-                  <Title>${info.spend.toFixed(6)}</Title>
+                  <Title>${formatNumberWithCommas(info.spend, 4)}</Title>
                   <Text>of {info.max_budget === null ? "Unlimited" : `$${info.max_budget}`}</Text>
                   {info.budget_duration && (
                     <Text className="text-gray-500">Reset: {info.budget_duration}</Text>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -324,13 +324,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 <Text>Budget Status</Text>
                 <div className="mt-2">
                   <Title>${formatNumberWithCommas(info.spend, 4)}</Title>
-                  <Text>of {info.max_budget === null ? "Unlimited" : `$${info.max_budget}`}</Text>
+                  <Text>of {info.max_budget === null ? "Unlimited" : `$${formatNumberWithCommas(info.max_budget, 4)}`}</Text>
                   {info.budget_duration && (
                     <Text className="text-gray-500">Reset: {info.budget_duration}</Text>
                   )}
                   <br/>
                   {info.team_member_budget_table && (
-                    <Text className="text-gray-500">Team Member Budget: ${info.team_member_budget_table.max_budget}</Text>
+                    <Text className="text-gray-500">Team Member Budget: ${formatNumberWithCommas(info.team_member_budget_table.max_budget, 4)}</Text>
                   )}
                 </div>
               </Card>
@@ -576,7 +576,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Team Budget</Text>
-                      <div>Max Budget: {info.max_budget !== null ? `$${info.max_budget}` : 'No Limit'}</div>
+                      <div>Max Budget: {info.max_budget !== null ? `$${formatNumberWithCommas(info.max_budget, 4)}` : 'No Limit'}</div>
                     <div>Budget Reset: {info.budget_duration || 'Never'}</div>
                   </div>
                   <div>

--- a/ui/litellm-dashboard/src/components/team/team_member_view.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_member_view.tsx
@@ -111,7 +111,7 @@ const TeamMembersComponent: React.FC<TeamMembersComponentProps> = ({
                   <Text className="font-mono">${formatNumberWithCommas(getUserSpend(member.user_id), 4)}</Text>
                 </TableCell>
                 <TableCell>
-                  <Text className="font-mono">{getUserBudget(member.user_id) ? `$${getUserBudget(member.user_id)}` : 'No Limit'}</Text>
+                  <Text className="font-mono">{getUserBudget(member.user_id) ? `$${formatNumberWithCommas(Number(getUserBudget(member.user_id)), 4)}` : 'No Limit'}</Text>
                 </TableCell>
                 <TableCell>
                   {canEditTeam && (

--- a/ui/litellm-dashboard/src/components/team/team_member_view.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_member_view.tsx
@@ -18,6 +18,7 @@ import {
     TeamData,
 } from './team_info';
 import { PencilAltIcon, PlusIcon, TrashIcon } from "@heroicons/react/outline";
+import { formatNumberWithCommas } from '@/utils/dataUtils';
 
 interface TeamMembersComponentProps {
   teamData: TeamData;
@@ -50,7 +51,7 @@ const TeamMembersComponent: React.FC<TeamMembersComponentProps> = ({
       }
       
       // For decimal numbers, use toFixed and remove trailing zeros
-      return normalNumber.toFixed(8).replace(/\.?0+$/, '');
+      return formatNumberWithCommas(normalNumber, 8).replace(/\.?0+$/, '');
     }
     
     return '0';
@@ -107,7 +108,7 @@ const TeamMembersComponent: React.FC<TeamMembersComponentProps> = ({
                   <Text className="font-mono">{member.role}</Text>
                 </TableCell>
                 <TableCell>
-                  <Text className="font-mono">${formatNumber(getUserSpend(member.user_id))}</Text>
+                  <Text className="font-mono">${formatNumberWithCommas(getUserSpend(member.user_id), 4)}</Text>
                 </TableCell>
                 <TableCell>
                   <Text className="font-mono">{getUserBudget(member.user_id) ? `$${getUserBudget(member.user_id)}` : 'No Limit'}</Text>

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -62,6 +62,7 @@ import PremiumVectorStoreSelector from "./common_components/PremiumVectorStoreSe
 import PremiumMCPSelector from "./common_components/PremiumMCPSelector";
 import LoggingSettings from "./team/LoggingSettings";
 import type { KeyResponse, Team } from "./key_team_helpers/key_list";
+import { formatNumberWithCommas } from "../utils/dataUtils";
 
 interface TeamProps {
   teams: Team[] | null;
@@ -725,7 +726,7 @@ const Teams: React.FC<TeamProps> = ({
                             overflow: "hidden",
                           }}
                         >
-                          {Number(team["spend"]).toFixed(4)}
+                          {formatNumberWithCommas(team["spend"], 4)}
                         </TableCell>
                         <TableCell
                           style={{

--- a/ui/litellm-dashboard/src/components/top_key_view.tsx
+++ b/ui/litellm-dashboard/src/components/top_key_view.tsx
@@ -6,6 +6,7 @@ import { transformKeyInfo } from "../components/key_team_helpers/transform_key_i
 import { DataTable } from "./view_logs/table";
 import { Tooltip } from "antd";
 import { Button } from "@tremor/react";
+import { formatNumberWithCommas } from "../utils/dataUtils";
 
 interface TopKeyViewProps {
   topKeys: any[];
@@ -97,7 +98,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
     {
       header: "Spend (USD)",
       accessorKey: "spend",
-      cell: (info: any) => `$${Number(info.getValue()).toFixed(2)}`,
+      cell: (info: any) => `$${formatNumberWithCommas(info.getValue(), 2)}`,
     },
   ];
 
@@ -147,7 +148,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
                     </div>
                     <div className="text-sm">
                       <span className="text-gray-300">Spend: </span>
-                      <span className="text-white font-medium">${item?.spend.toFixed(2)}</span>
+                      <span className="text-white font-medium">${formatNumberWithCommas(item?.spend, 2)}</span>
                     </div>
                   </div>
                 </div>

--- a/ui/litellm-dashboard/src/components/top_key_view.tsx
+++ b/ui/litellm-dashboard/src/components/top_key_view.tsx
@@ -134,7 +134,7 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
             layout="vertical"
             showXAxis={false}
             showLegend={false}
-            valueFormatter={(value) => value ? `$${value.toFixed(2)}` : "No Key Alias"}
+            valueFormatter={(value) => value ? `$${formatNumberWithCommas(value, 2)}` : "No Key Alias"}
             onValueChange={(item) => handleKeyClick(item)}
             showTooltip={true}
             customTooltip={(props) => {

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -41,6 +41,7 @@ import {
 } from "./networking";
 import { start } from "repl";
 import TopKeyView from "./top_key_view";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 console.log("process.env.NODE_ENV", process.env.NODE_ENV);
 
 interface UsagePageProps {
@@ -91,7 +92,7 @@ const customTooltip = (props: CustomTooltipTypeBar) => {
               {":"}
               <span className="text-xs text-tremor-content-emphasis">
                 {" "}
-                {value ? `$${value.toFixed(2)}` : ""}
+                {value ? `$${formatNumberWithCommas(value, 2)}` : ""}
               </span>
             </p>
           </div>
@@ -402,7 +403,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
         const top_models = await adminTopModelsCall(accessToken);
         return top_models.map((k: any) => ({
           key: k["model"],
-          spend: Number(k["total_spend"].toFixed(2)),
+          spend: formatNumberWithCommas(k["total_spend"], 2),
         }));
       },
       setTopModels,
@@ -434,7 +435,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
         setUniqueTeamIds(teamSpend.teams);
         return teamSpend.total_spend_per_team.map((tspt: any) => ({
           name: tspt["team_id"] || "",
-          value: Number(tspt["total_spend"] || 0).toFixed(2),
+          value: formatNumberWithCommas(tspt["total_spend"] || 0, 2),
         }));
       },
       setTotalSpendPerTeam,
@@ -666,7 +667,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                     layout="vertical"
                     showXAxis={false}
                     showLegend={false}
-                    valueFormatter={(value) => `$${value.toFixed(2)}`}
+                    valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                   />
                 </Card>
               </Col>
@@ -686,7 +687,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                       index="provider"
                       category="spend"
                       colors={["cyan"]}
-                      valueFormatter={(value) => `$${value.toFixed(2)}`}
+                      valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
                     />
                   </Col>
                   <Col numColSpan={1}>
@@ -704,7 +705,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                             <TableCell>
                               {parseFloat(provider.spend.toFixed(2)) < 0.00001
                                 ? "less than 0.00"
-                                : provider.spend.toFixed(2)}
+                                : formatNumberWithCommas(provider.spend, 2)}
                             </TableCell>
                           </TableRow>
                         ))}
@@ -889,7 +890,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
                     {topUsers?.map((user: any, index: number) => (
                       <TableRow key={index}>
                         <TableCell>{user.end_user}</TableCell>
-                        <TableCell>{user.total_spend?.toFixed(4)}</TableCell>
+                        <TableCell>{formatNumberWithCommas(user.total_spend, 2)}</TableCell>
                         <TableCell>{user.total_count}</TableCell>
                       </TableRow>
                     ))}

--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -268,7 +268,7 @@ const UsagePage: React.FC<UsagePageProps> = ({
   console.log(`End date is ${endTime}`);
 
   const valueFormatter = (number: number) =>
-    `$ ${number.toFixed(2)}`;
+    `$ ${formatNumberWithCommas(number, 2)}`;
 
   const fetchAndSetData = async (
     fetchFunction: () => Promise<any>,

--- a/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
@@ -4,6 +4,7 @@ import { DataTable } from './table';
 import { columns } from './columns';
 import { Card, Title, Text, Metric, AreaChart } from '@tremor/react';
 import { RequestViewer } from './index';
+import { formatNumberWithCommas } from '@/utils/dataUtils';
 
 interface SessionViewProps {
   sessionId: string;
@@ -71,7 +72,7 @@ export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBac
         </Card>
         <Card>
           <Text>Total Cost</Text>
-          <Metric>${totalCost.toFixed(4)}</Metric>
+          <Metric>${formatNumberWithCommas(totalCost, 4)}</Metric>
         </Card>
         <Card>
           <Text>Total Tokens</Text>

--- a/ui/litellm-dashboard/src/components/view_logs/audit_logs.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/audit_logs.tsx
@@ -6,6 +6,7 @@ import { uiAuditLogsCall, keyListCall } from "../networking";
 import { AuditLogEntry, auditLogColumns } from "./columns";
 import { Text } from "@tremor/react";
 import { Team } from "../key_team_helpers/key_list";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface AuditLogsProps {
   accessToken: string | null;
@@ -308,8 +309,8 @@ export default function AuditLogs({
             return (
               <div>
                 {changedKeys.includes('token') && <p><strong>Token:</strong> {value.token || 'N/A'}</p>}
-                {changedKeys.includes('spend') && <p><strong>Spend:</strong> {value.spend !== undefined ? `$${Number(value.spend).toFixed(6)}` : 'N/A'}</p>}
-                {changedKeys.includes('max_budget') && <p><strong>Max Budget:</strong> {value.max_budget !== undefined ? `$${Number(value.max_budget).toFixed(6)}` : 'N/A'}</p>}
+                {changedKeys.includes('spend') && <p><strong>Spend:</strong> {value.spend !== undefined ? `$${formatNumberWithCommas(value.spend, 6)}` : 'N/A'}</p>}
+                {changedKeys.includes('max_budget') && <p><strong>Max Budget:</strong> {value.max_budget !== undefined ? `$${formatNumberWithCommas(value.max_budget, 6)}` : 'N/A'}</p>}
               </div>
             );
           } else {

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from "antd";
 import { TimeCell } from "./time_cell";
 import { Button, Badge } from "@tremor/react";
 import { Eye, EyeOff} from "lucide-react"
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 // Helper to get the appropriate logo URL
 const getLogoUrl = (
@@ -158,7 +159,7 @@ export const columns: ColumnDef<LogEntry>[] = [
     header: "Cost",
     accessorKey: "spend",
     cell: (info: any) => (
-      <span>${Number(info.getValue() || 0).toFixed(6)}</span>
+      <span>${formatNumberWithCommas(info.getValue() || 0, 4)}</span>
     ),
   },
   {

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -33,6 +33,7 @@ import {
 } from "@tremor/react";
 import AuditLogs from "./audit_logs";
 import { getTimeRangeDisplay } from "./logs_utils";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface SpendLogsTableProps {
   accessToken: string | null;
@@ -906,7 +907,7 @@ export function RequestViewer({ row }: { row: Row<LogEntry> }) {
             </div>
             <div className="flex">
               <span className="font-medium w-1/3">Cost:</span>
-              <span>${Number(row.original.spend || 0).toFixed(6)}</span>
+              <span>${formatNumberWithCommas(row.original.spend || 0, 4)}</span>
             </div>
             <div className="flex">
               <span className="font-medium w-1/3">Cache Hit:</span>

--- a/ui/litellm-dashboard/src/components/view_user_spend.tsx
+++ b/ui/litellm-dashboard/src/components/view_user_spend.tsx
@@ -42,7 +42,7 @@ interface ViewUserSpendProps {
 const ViewUserSpend: React.FC<ViewUserSpendProps> = ({ userID, userRole, accessToken, userSpend, userMaxBudget, selectedTeam }) => {
     console.log(`userSpend: ${userSpend}`)
     let [spend, setSpend] = useState(userSpend !== null ? userSpend : 0.0);
-    const [maxBudget, setMaxBudget] = useState(selectedTeam ? selectedTeam.max_budget : null);
+    const [maxBudget, setMaxBudget] = useState(selectedTeam ? Number(formatNumberWithCommas(selectedTeam.max_budget, 4)) : null);
     useEffect(() => {
       if (selectedTeam) {
           if (selectedTeam.team_alias === "Default Team") {
@@ -133,7 +133,7 @@ const ViewUserSpend: React.FC<ViewUserSpendProps> = ({ userID, userRole, accessT
     }
 
 
-    const displayMaxBudget = maxBudget !== null ? `$${maxBudget} limit` : "No limit";
+    const displayMaxBudget = maxBudget !== null ? `$${formatNumberWithCommas(Number(maxBudget), 4)} limit` : "No limit";
 
     const roundedSpend = spend !== undefined ? formatNumberWithCommas(spend, 4) : null;
 

--- a/ui/litellm-dashboard/src/components/view_user_spend.tsx
+++ b/ui/litellm-dashboard/src/components/view_user_spend.tsx
@@ -23,6 +23,7 @@ import {
 } from "@tremor/react";
 import { Statistic } from "antd"
 import { spendUsersCall, modelAvailableCall }  from "./networking";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 // Define the props type
 interface UserSpendData {
@@ -134,7 +135,7 @@ const ViewUserSpend: React.FC<ViewUserSpendProps> = ({ userID, userRole, accessT
 
     const displayMaxBudget = maxBudget !== null ? `$${maxBudget} limit` : "No limit";
 
-    const roundedSpend = spend !== undefined ? spend.toFixed(4) : null;
+    const roundedSpend = spend !== undefined ? formatNumberWithCommas(spend, 4) : null;
 
     console.log(`spend in view user spend: ${spend}`)
     return (

--- a/ui/litellm-dashboard/src/components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/columns.tsx
@@ -3,6 +3,7 @@ import { Badge, Grid, Icon } from "@tremor/react";
 import { Tooltip } from "antd";
 import { UserInfo } from "./types";
 import { PencilAltIcon, TrashIcon, InformationCircleIcon, RefreshIcon } from "@heroicons/react/outline";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 export const columns = (
   possibleUIRoles: Record<string, Record<string, string>>,
@@ -41,7 +42,7 @@ export const columns = (
     accessorKey: "spend",
     cell: ({ row }) => (
       <span className="text-xs">
-        {row.original.spend ? row.original.spend.toFixed(4) : "-"}
+        {row.original.spend ? formatNumberWithCommas(row.original.spend, 4) : "-"}
       </span>
     ),
   },

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -19,6 +19,7 @@ import { message } from "antd";
 import { rolesWithWriteAccess } from '../../utils/roles';
 import { UserEditView } from "../user_edit_view";
 import OnboardingModal, { InvitationLink } from "../onboarding_link";
+import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface UserInfoViewProps {
   userId: string;
@@ -275,7 +276,7 @@ export default function UserInfoView({
               <Card>
                 <Text>Spend</Text>
                 <div className="mt-2">
-                  <Title>${Number(userData.user_info?.spend || 0).toFixed(4)}</Title>
+                  <Title>${formatNumberWithCommas(userData.user_info?.spend || 0, 4)}</Title>
                   <Text>of {userData.user_info?.max_budget !== null ? `$${userData.user_info.max_budget}` : "Unlimited"}</Text>
                 </div>
               </Card>

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -277,7 +277,7 @@ export default function UserInfoView({
                 <Text>Spend</Text>
                 <div className="mt-2">
                   <Title>${formatNumberWithCommas(userData.user_info?.spend || 0, 4)}</Title>
-                  <Text>of {userData.user_info?.max_budget !== null ? `$${userData.user_info.max_budget}` : "Unlimited"}</Text>
+                  <Text>of {userData.user_info?.max_budget !== null ? `$${formatNumberWithCommas(userData.user_info.max_budget, 4)}` : "Unlimited"}</Text>
                 </div>
               </Card>
 

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -12,3 +12,13 @@ export function updateExistingKeys<Source extends Object>(
 
   return clonedTarget;
 }
+
+export const formatNumberWithCommas = (value: number | null | undefined, decimals: number = 0): string => {
+  if (value === null || value === undefined) {
+    return '-';
+  }
+  return value.toLocaleString('en-US', {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+};


### PR DESCRIPTION
## Title
Make all spend / budget values use commas
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
This PR enhances the ui by formatting all monetary values and other large numbers with commas, significantly improving readability for users. For example, $1000000 is now displayed as $1,000,000.

Key Changes:
- Added `formatNumberWithCommas()` Utility: A new helper function has been introduced in `utils/dataUtils.ts` to ensure consistent number formatting across the dashboard.
- Applied Comma Separation: The new function has been applied to all spend, budget, token counts, and request metrics throughout the UI.



<img width="1496" alt="Screenshot 2025-07-04 at 2 37 38" src="https://github.com/user-attachments/assets/7a05b89f-e69f-4e80-b676-b4d8725e62ad" />
<img width="629" alt="Screenshot 2025-07-04 at 2 53 46" src="https://github.com/user-attachments/assets/ab56b3ad-3256-40b7-8193-21bd7513a0f5" />
<img width="1511" alt="Screenshot 2025-07-04 at 2 54 08" src="https://github.com/user-attachments/assets/010e1242-b7d2-4a7c-b715-4bee7bb4e7b7" />
<img width="1511" alt="Screenshot 2025-07-04 at 2 58 09" src="https://github.com/user-attachments/assets/82aeca6e-7faa-4590-9b04-39c281d55f32" />
<img width="1511" alt="Screenshot 2025-07-04 at 3 01 11" src="https://github.com/user-attachments/assets/38500fc1-83c2-462d-9689-59d292aa5e88" />
<img width="1512" alt="Screenshot 2025-07-04 at 13 39 20" src="https://github.com/user-attachments/assets/5c488a84-09a1-457d-99fd-5c48e79052fa" />
<img width="1512" alt="Screenshot 2025-07-04 at 13 39 27" src="https://github.com/user-attachments/assets/2006e480-d51a-4b70-beec-03b246e8fc36" />
<img width="1512" alt="Screenshot 2025-07-04 at 13 39 47" src="https://github.com/user-attachments/assets/e649d8a6-82b3-4075-8f69-5321311b1d86" />
<img width="1512" alt="Screenshot 2025-07-04 at 13 41 09" src="https://github.com/user-attachments/assets/f650a268-9d4b-4540-8eea-0268e64960e6" />
<img width="1512" alt="Screenshot 2025-07-04 at 21 05 35" src="https://github.com/user-attachments/assets/ba1a5cc4-9249-40c4-ace1-7e4e99b1f269" />
<img width="1512" alt="Screenshot 2025-07-04 at 21 07 41" src="https://github.com/user-attachments/assets/39c87f6f-7cbd-41fd-8800-4ec736c39d11" />
<img width="1512" alt="Screenshot 2025-07-04 at 22 08 01" src="https://github.com/user-attachments/assets/0bfdf476-01a4-4efd-9110-ec8d6a4023db" />
<img width="836" alt="Screenshot 2025-07-04 at 22 12 29" src="https://github.com/user-attachments/assets/af87605e-4d31-4f3c-abdb-c200597b9128" />
<img width="956" alt="Screenshot 2025-07-04 at 21 44 38" src="https://github.com/user-attachments/assets/9c05a837-22d0-4f33-83f1-f2decb88c93b" />
<img width="1512" alt="Screenshot 2025-07-04 at 21 53 37" src="https://github.com/user-attachments/assets/c885f8c5-6462-443f-923d-6a01a1977b3e" />