### PR TITLE
[Feat] UI - Allow setting Logging Callback Setting per Key

### DIFF
--- a/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
@@ -50,6 +50,15 @@ export const callbackInfo: Record<string, CallbackInfo> = {
         "arize_space_id": "text",
       }
     },
+    [Callbacks.LangSmith]: {
+      logo: `${asset_logos_folder}langsmith.png`,
+      supports_key_team_logging: true,
+      dynamic_params: {
+        "langsmith_api_key": "password",
+        "langsmith_project": "text",
+        "langsmith_base_url": "text"
+      }
+  },
     [Callbacks.Braintrust]: {
         logo: `${asset_logos_folder}braintrust.png`,
         supports_key_team_logging: false,
@@ -62,11 +71,6 @@ export const callbackInfo: Record<string, CallbackInfo> = {
     },
     [Callbacks.Datadog]: {
         logo: `${asset_logos_folder}datadog.png`,
-        supports_key_team_logging: false,
-        dynamic_params: {}
-    },
-    [Callbacks.LangSmith]: {
-        logo: `${asset_logos_folder}langsmith.png`,
         supports_key_team_logging: false,
         dynamic_params: {}
     },

--- a/ui/litellm-dashboard/src/components/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_edit_view.tsx
@@ -7,6 +7,7 @@ import { modelAvailableCall } from "./networking";
 import NumericalInput from "./shared/numerical_input";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
+import EditLoggingSettings from "./team/EditLoggingSettings";
 
 interface KeyEditViewProps {
   keyData: KeyResponse;
@@ -100,7 +101,8 @@ export function KeyEditView({
     metadata: keyData.metadata ? JSON.stringify(keyData.metadata, null, 2) : "",
     guardrails: keyData.metadata?.guardrails || [],
     vector_stores: keyData.object_permission?.vector_stores || [],
-    mcp_servers: keyData.object_permission?.mcp_servers || []
+    mcp_servers: keyData.object_permission?.mcp_servers || [],
+    logging_settings: keyData.metadata?.logging || []
   };
 
   return (
@@ -188,6 +190,13 @@ export function KeyEditView({
           value={form.getFieldValue('mcp_servers')}
           accessToken={accessToken || ""}
           placeholder="Select MCP servers"
+        />
+      </Form.Item>
+
+      <Form.Item label="Logging Settings" name="logging_settings">
+        <EditLoggingSettings
+          value={form.getFieldValue('logging_settings')}
+          onChange={(values) => form.setFieldValue('logging_settings', values)}
         />
       </Form.Item>
 

--- a/ui/litellm-dashboard/src/components/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_edit_view.tsx
@@ -8,6 +8,7 @@ import NumericalInput from "./shared/numerical_input";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
 import EditLoggingSettings from "./team/EditLoggingSettings";
+import { extractLoggingSettings, formatMetadataForDisplay } from "./key_info_utils";
 
 interface KeyEditViewProps {
   keyData: KeyResponse;
@@ -98,11 +99,11 @@ export function KeyEditView({
   const initialValues = {
     ...keyData,
     budget_duration: getBudgetDuration(keyData.budget_duration),
-    metadata: keyData.metadata ? JSON.stringify(keyData.metadata, null, 2) : "",
+    metadata: formatMetadataForDisplay(keyData.metadata),
     guardrails: keyData.metadata?.guardrails || [],
     vector_stores: keyData.object_permission?.vector_stores || [],
     mcp_servers: keyData.object_permission?.mcp_servers || [],
-    logging_settings: keyData.metadata?.logging || []
+    logging_settings: extractLoggingSettings(keyData.metadata)
   };
 
   return (

--- a/ui/litellm-dashboard/src/components/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_edit_view.tsx
@@ -194,16 +194,6 @@ export function KeyEditView({
         />
       </Form.Item>
 
-      <Form.Item label="Logging Settings" name="logging_settings">
-        <EditLoggingSettings
-          value={form.getFieldValue('logging_settings')}
-          onChange={(values) => form.setFieldValue('logging_settings', values)}
-        />
-      </Form.Item>
-
-      <Form.Item label="Metadata" name="metadata">
-        <Input.TextArea rows={10} />
-      </Form.Item>
 
       <Form.Item label="Team ID" name="team_id">
         <Select
@@ -218,6 +208,18 @@ export function KeyEditView({
           ))}
         </Select>
       </Form.Item>
+      <Form.Item label="Logging Settings" name="logging_settings">
+        <EditLoggingSettings
+          value={form.getFieldValue('logging_settings')}
+          onChange={(values) => form.setFieldValue('logging_settings', values)}
+        />
+      </Form.Item>
+
+
+      <Form.Item label="Metadata" name="metadata">
+        <Input.TextArea rows={10} />
+      </Form.Item>
+
 
       {/* Hidden form field for token */}
       <Form.Item name="token" hidden>

--- a/ui/litellm-dashboard/src/components/key_info_utils.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_utils.tsx
@@ -1,0 +1,45 @@
+/**
+ * Utility functions for handling key information and metadata
+ */
+
+// Fields that should be filtered out from metadata display due to security concerns
+const SENSITIVE_METADATA_FIELDS = ['logging'] as const;
+
+/**
+ * Filters out sensitive information from metadata for display purposes
+ * @param metadata - The metadata object to filter
+ * @returns Filtered metadata object without sensitive fields
+ */
+export const filterSensitiveMetadata = (metadata: Record<string, any> | null | undefined): Record<string, any> => {
+  if (!metadata || typeof metadata !== 'object') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => !SENSITIVE_METADATA_FIELDS.includes(key as any))
+  );
+};
+
+/**
+ * Safely extracts logging settings from metadata
+ * @param metadata - The metadata object to extract from
+ * @returns Array of logging configurations or empty array if not found
+ */
+export const extractLoggingSettings = (metadata: Record<string, any> | null | undefined): any[] => {
+  if (!metadata || typeof metadata !== 'object') {
+    return [];
+  }
+
+  return Array.isArray(metadata.logging) ? metadata.logging : [];
+};
+
+/**
+ * Formats metadata for JSON display (with sensitive fields filtered)
+ * @param metadata - The metadata object to format
+ * @param indent - Number of spaces for indentation (default: 2)
+ * @returns Formatted JSON string
+ */
+export const formatMetadataForDisplay = (metadata: Record<string, any> | null | undefined, indent: number = 2): string => {
+  const filtered = filterSensitiveMetadata(metadata);
+  return JSON.stringify(filtered, null, indent);
+}; 

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -25,6 +25,7 @@ import { rolesWithWriteAccess } from '../utils/roles';
 import ObjectPermissionsView from "./object_permissions_view";
 import LoggingSettingsView from "./logging_settings_view";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { extractLoggingSettings, formatMetadataForDisplay } from "./key_info_utils";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -292,7 +293,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
               </Card>
 
               <LoggingSettingsView
-                loggingConfigs={keyData.metadata?.logging || []}
+                loggingConfigs={extractLoggingSettings(keyData.metadata)}
                 variant="card"
               />
             </Grid>
@@ -401,7 +402,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                   <div>
                     <Text className="font-medium">Metadata</Text>
                     <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto mt-1">
-                      {JSON.stringify(keyData.metadata, null, 2)}
+                      {formatMetadataForDisplay(keyData.metadata)}
                     </pre>
                   </div>
 
@@ -413,7 +414,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                   />
 
                   <LoggingSettingsView
-                    loggingConfigs={keyData.metadata?.logging || []}
+                    loggingConfigs={extractLoggingSettings(keyData.metadata)}
                     variant="inline"
                     className="pt-4 border-t border-gray-200"
                   />

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -23,6 +23,7 @@ import { KeyEditView } from "./key_edit_view";
 import { RegenerateKeyModal } from "./regenerate_key_modal";
 import { rolesWithWriteAccess } from '../utils/roles';
 import ObjectPermissionsView from "./object_permissions_view";
+import LoggingSettingsView from "./logging_settings_view";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 interface KeyInfoViewProps {
@@ -93,6 +94,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
           formValues.metadata = {
             ...parsedMetadata,
             ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
+            ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {})
           };
         } catch (error) {
           console.error("Error parsing metadata JSON:", error);
@@ -103,8 +105,11 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
         formValues.metadata = {
           ...(formValues.metadata || {}),
           ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
+          ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {})
         };
       }
+
+      delete formValues.logging_settings;
 
       // Convert budget_duration to API format
       if (formValues.budget_duration) {
@@ -279,12 +284,17 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
               </Card>
 
               <Card>
-                <ObjectPermissionsView 
-                  objectPermission={keyData.object_permission} 
+                <ObjectPermissionsView
+                  objectPermission={keyData.object_permission}
                   variant="inline"
                   accessToken={accessToken}
                 />
               </Card>
+
+              <LoggingSettingsView
+                loggingConfigs={keyData.metadata?.logging || []}
+                variant="card"
+              />
             </Grid>
           </TabPanel>
 
@@ -395,11 +405,17 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                     </pre>
                   </div>
 
-                  <ObjectPermissionsView 
-                    objectPermission={keyData.object_permission} 
+                  <ObjectPermissionsView
+                    objectPermission={keyData.object_permission}
                     variant="inline"
                     className="pt-4 border-t border-gray-200"
                     accessToken={accessToken}
+                  />
+
+                  <LoggingSettingsView
+                    loggingConfigs={keyData.metadata?.logging || []}
+                    variant="inline"
+                    className="pt-4 border-t border-gray-200"
                   />
                 </div>
               )}


### PR DESCRIPTION
## [Feat] UI - Allow setting Logging Callback Setting per Key

- Added support for setting logging settings per key, editing / viewing logging settings 
- Ensure the logging keys are not visible on LiteLLM ui

<img width="708" alt="Screenshot 2025-07-04 at 5 46 24 PM" src="https://github.com/user-attachments/assets/409e6afb-2644-4b8a-8197-f3557827db9d" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


