### PR TITLE
Fix: Preserve Live Tail State on Log Pages

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -102,7 +102,15 @@ export default function SpendLogsTable({
 
   const queryClient = useQueryClient();
 
-  const [isLiveTail, setIsLiveTail] = useState(true); // Default to true
+  const [isLiveTail, setIsLiveTail] = useState<boolean>(() => {
+    const storedValue = sessionStorage.getItem("isLiveTail");
+    // default to true if nothing is stored
+    return storedValue !== null ? JSON.parse(storedValue) : true;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem("isLiveTail", JSON.stringify(isLiveTail));
+  }, [isLiveTail]);
 
   const [selectedTimeInterval, setSelectedTimeInterval] = useState<{ value: number; unit: string }>({ 
     value: 24, 
@@ -244,7 +252,7 @@ export default function SpendLogsTable({
       return response;
     },
     enabled: !!accessToken && !!token && !!userRole && !!userID && activeTab === "request logs",
-    refetchInterval: isLiveTail ? 15000 : false,
+    refetchInterval: isLiveTail && currentPage === 1 ? 15000 : false,
     refetchIntervalInBackground: true,
   });
 
@@ -735,7 +743,7 @@ export default function SpendLogsTable({
                     </div>
                   </div>
                 </div>
-                {isLiveTail && (
+                {isLiveTail && currentPage === 1 && (
                   <div className="mb-4 px-4 py-2 bg-green-50 border border-greem-200 rounded-md flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-green-700">


### PR DESCRIPTION
## Title
Fix: Preserve Live Tail State on Log Pages
<!-- e.g. "Implement user authentication feature" -->


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
This PR fixes an issue where the "Live Tail" setting would incorrectly reset when changing pages in the logs view.
Changes:
- Preserves State: The Live Tail setting (on/off) is now saved in sessionStorage, so it is remembered when you navigate to other pages.
- Smarter Refreshing: Auto-refresh now only runs when you are on Page 1, since new logs always appear there.
This makes the Live Tail feature more reliable and intuitive to use.

https://www.loom.com/share/6a9095802c974a71951e7c5719b37d19?sid=60855c8d-c34d-4256-9b0f-e0a8e5e9622e
