### PR TITLE
Patch 1

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -331,6 +331,24 @@
         "supports_response_schema": true,
         "supports_system_messages": true
     },
+    "watsonx/mistralai/mistral-large"": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.00001,
+        "litellm_provider": "watsonx",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": false,
+        "supports_vision": false,
+        "supports_audio_input": false,
+        "supports_audio_output": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true
+    },
     "gpt-4o-search-preview-2025-03-11": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -331,7 +331,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true
     },
-    "watsonx/mistralai/mistral-large"": {
+    "watsonx/mistralai/mistral-large": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 16384,


### PR DESCRIPTION
## add watsonx/mistralai/mistral-large to model prices and context window json

- Set max_tokens and max_input_tokens to 131072 and max_output_tokens to 16384 to match IBM's official context window limit for Mistral Large models hosted on watsonx.
- Correct input_cost_per_token and output_cost_per_token to reflect IBM's pricing of $0.003 and $0.01 per 1000 tokens, respectively, converted to per-token rates (0.000003 and 0.00001).
- Confirmed function-calling support based on IBM documentation and Mistral's own API schema.
- Aligns with Mistral's own model entries that specify token windows of ~128K and matches LiteLLM's expected cost format.

**Sources:**
- IBM watsonx Foundation Models docs: https://www.ibm.com/docs/en/watsonx/w-and-w/2.1.x?topic=models-foundation-model-details#mistral-large
- IBM Pricing information for watsonx.ai models: https://www.ibm.com/products/watsonx-ai/pricing
- LiteLLM repo docs on token cost formatting and limits https://docs.litellm.ai/docs/proxy/custom_pricing.
- Imitating entries from litellm/model_prices_and_context_window.json for watsonx/ibm/granite-3-8b-instruct as well as Mistral's own mistral/mistral-large-latest and similar.
## Title

## Relevant issues

Found no open issue related to this. The pricing for this model and provider was simply missing.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

I have not tested it but I have validated the json and it follows the exact same format as the previous entry. And the model id `watsonx/mistralai/mistral-large` matches the exact model ID that I successfully call from my app.


- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


