### PR TITLE
fix watsonx datetime conversion issue py3.10

### DIFF
--- a/litellm/llms/watsonx/completion/transformation.py
+++ b/litellm/llms/watsonx/completion/transformation.py
@@ -300,9 +300,14 @@ class IBMWatsonXAIConfig(IBMWatsonXMixin, BaseConfig):
             json_resp["results"][0]["stop_reason"]
         )
         if json_resp.get("created_at"):
-            model_response.created = int(
-                datetime.fromisoformat(json_resp["created_at"]).timestamp()
-            )
+            try:
+                created_datetime = datetime.fromisoformat(json_resp["created_at"])
+            except ValueError:
+                # datetime.fromisoformat cannot handle 'Z' in Python 3.10
+                created_datetime = datetime.fromisoformat(
+                    f'{json_resp["created_at"].rstrip("Z")}+00:00'
+                )
+            model_response.created = int(created_datetime.timestamp())
         else:
             model_response.created = int(time.time())
         usage = Usage(


### PR DESCRIPTION
Got ValueError on Python3.10 because datetime.fromisoformat could not handle 'Z' -> '+00:00' at the end of a timestamp. Instead, try with the previous behavior, except ValueError, then attempt removing Z, and adding +00:00 to support Python3.10

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


