### PR TITLE
OpenAI Streaming response fixes

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -620,7 +620,6 @@ class CustomStreamWrapper:
 
         args = {
             "model": _model,
-            "stream_options": self.stream_options,
             **chunk_dict,
         }
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1198,6 +1198,15 @@ def completion(  # type: ignore # noqa: PLR0915
 
         if dynamic_api_key is not None:
             api_key = dynamic_api_key
+        # Force include_usage=true for streaming to get accurate token counts from providers
+        if stream:
+            if stream_options is None:
+                stream_options = {"include_usage": True}
+            else:
+                # Create a copy to avoid modifying the original
+                stream_options = dict(stream_options)
+                stream_options["include_usage"] = True
+        
         # check if user passed in any of the OpenAI optional params
         optional_param_args = {
             "functions": functions,


### PR DESCRIPTION
## Title
OpenAI Streaming response fixes

## Type
🐛 Bug Fix

## Changes
* When using streaming mode, force the usage of the `include_usage` parameter in order to get accurate token counts from the provider;
* Removes poluted `stream_options` parameters from chunk responses as this is a server parameter only.

