### PR TITLE
[Bug Fix] s3 config.yaml file - ensure yaml safe load is used 

### DIFF
--- a/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+import yaml
+
+from litellm.proxy.common_utils.load_config_utils import get_file_contents_from_s3
+
+
+class TestGetFileContentsFromS3:
+    """Test suite for S3 config loading functionality."""
+
+    @patch('boto3.client')
+    @patch('litellm.main.bedrock_converse_chat_completion')
+    @patch('yaml.safe_load')
+    def test_get_file_contents_from_s3_no_temp_file_creation(
+        self, mock_yaml_load, mock_bedrock, mock_boto3_client
+    ):
+        """
+        Test that get_file_contents_from_s3 doesn't create temporary files
+        and uses yaml.safe_load directly on the S3 response content.
+
+        Note: It's critical that yaml.safe_load is used
+
+        Relevant issue/PR: https://github.com/BerriAI/litellm/pull/12078
+        """
+        # Mock credentials
+        mock_credentials = MagicMock()
+        mock_credentials.access_key = "test_access_key"
+        mock_credentials.secret_key = "test_secret_key"
+        mock_credentials.token = "test_token"
+        mock_bedrock.get_credentials.return_value = mock_credentials
+
+        # Mock S3 client and response
+        mock_s3_client = MagicMock()
+        mock_boto3_client.return_value = mock_s3_client
+        
+        # Mock S3 response with YAML content
+        yaml_content = """
+        model_list:
+          - model_name: gpt-3.5-turbo
+            litellm_params:
+              model: gpt-3.5-turbo
+        """
+        mock_response_body = MagicMock()
+        mock_response_body.read.return_value = yaml_content.encode('utf-8')
+        mock_s3_response = {
+            'Body': mock_response_body
+        }
+        mock_s3_client.get_object.return_value = mock_s3_response
+
+        # Mock yaml.safe_load to return parsed config
+        expected_config = {
+            'model_list': [{
+                'model_name': 'gpt-3.5-turbo',
+                'litellm_params': {
+                    'model': 'gpt-3.5-turbo'
+                }
+            }]
+        }
+        mock_yaml_load.return_value = expected_config
+
+        # Call the function
+        bucket_name = "test-bucket"
+        object_key = "config.yaml"
+        result = get_file_contents_from_s3(bucket_name, object_key)
+
+        # Assertions
+        assert result == expected_config
+        
+        # Verify S3 client was created with correct credentials
+        mock_boto3_client.assert_called_once_with(
+            "s3",
+            aws_access_key_id="test_access_key",
+            aws_secret_access_key="test_secret_key",
+            aws_session_token="test_token"
+        )
+        
+        # Verify S3 get_object was called with correct parameters
+        mock_s3_client.get_object.assert_called_once_with(
+            Bucket=bucket_name,
+            Key=object_key
+        )
+        
+        # Verify the response body was read and decoded
+        mock_response_body.read.assert_called_once()
+        
+        # Verify yaml.safe_load was called with the decoded content
+        mock_yaml_load.assert_called_once_with(yaml_content)
+
+


### PR DESCRIPTION
## [Bug Fix] s3 config.yaml file - ensure yaml safe load is used 

LiteLLM Config loading from S3 was leaving behind a temp file which polluted /tmp directory, eventually running out of disk space. For some reason, the config yaml is re-pulled from S3 on each completion request, so there were hundreds of thousands of temp files accumulated over time. This PR adds temp file cleanup.

(h/t @DmitriyAlergant) 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


