### PR TITLE
Feature/required headers validation

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -224,6 +224,7 @@ class Router:
         ] = {},
         enable_pre_call_checks: bool = False,
         enable_tag_filtering: bool = False,
+        required_tags: Optional[Union[str, List[str]]] = None,
         retry_after: int = 0,  # min time to wait before retrying a failed request
         retry_policy: Optional[
             Union[RetryPolicy, dict]
@@ -334,6 +335,7 @@ class Router:
         self.debug_level = debug_level
         self.enable_pre_call_checks = enable_pre_call_checks
         self.enable_tag_filtering = enable_tag_filtering
+        self.required_tags = required_tags
         litellm.suppress_debug_info = True  # prevents 'Give Feedback/Get help' message from being emitted on Router - Relevant Issue: https://github.com/BerriAI/litellm/issues/5942
         if self.set_verbose is True:
             if debug_level == "INFO":

--- a/tests/test_litellm/proxy/test_required_headers.py
+++ b/tests/test_litellm/proxy/test_required_headers.py
@@ -1,0 +1,265 @@
+"""
+Test required headers functionality in LiteLLM Proxy.
+
+This tests the header-based request blocking feature that allows blocking requests
+unless they have specific required headers.
+"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock
+from fastapi import Request
+from starlette.datastructures import Headers
+
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+
+class TestRequiredHeaders:
+    """Test the required headers functionality."""
+
+    def create_mock_request(self, headers_dict=None):
+        """Create a mock FastAPI Request object."""
+        if headers_dict is None:
+            headers_dict = {}
+        
+        # Convert to lowercase keys as FastAPI does
+        headers_dict = {k.lower(): v for k, v in headers_dict.items()}
+        
+        mock_request = Mock(spec=Request)
+        mock_request.headers = Headers(headers_dict)
+        
+        # Mock the URL object properly
+        mock_url = Mock()
+        mock_url.path = "/v1/chat/completions"
+        mock_url.__str__ = Mock(return_value="http://localhost:4000/v1/chat/completions")
+        mock_request.url = mock_url
+        
+        mock_request.method = "POST"
+        mock_request.query_params = {}
+        mock_request.client = None
+        
+        return mock_request
+
+    def create_user_api_key_dict(self, key_metadata=None, team_metadata=None):
+        """Create a UserAPIKeyAuth object for testing."""
+        return UserAPIKeyAuth(
+            api_key="test-key-hash",
+            user_id="test-user",
+            team_id="test-team",
+            metadata=key_metadata or {},
+            team_metadata=team_metadata or {},
+            parent_otel_span=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_required_headers_allows_request(self):
+        """Test that requests pass when no required headers are configured."""
+        request = self.create_mock_request({"user-agent": "TestBot/1.0"})
+        user_api_key_dict = self.create_user_api_key_dict()
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_key_level_required_header_exact_match(self):
+        """Test key-level required header with exact string match."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/1.0"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp/1.0"
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_key_level_required_header_wrong_value_blocks(self):
+        """Test that wrong header value blocks the request."""
+        request = self.create_mock_request({
+            "user-agent": "BadBot/1.0"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp/1.0"
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        with pytest.raises(ProxyException) as exc_info:
+            await add_litellm_data_to_request(
+                data=data,
+                request=request,
+                user_api_key_dict=user_api_key_dict,
+                proxy_config=Mock(),
+            )
+        
+        assert "Request blocked" in str(exc_info.value)
+        assert "User-Agent" in str(exc_info.value)
+        assert exc_info.value.code == 403
+
+    @pytest.mark.asyncio
+    async def test_key_level_required_header_wildcard_match(self):
+        """Test wildcard pattern matching for required headers."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/2.0 (+https://example.com)"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp*"
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_key_level_required_header_list_of_values(self):
+        """Test required header with list of allowed values."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/1.0"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": [
+                        "MyApp/1.0",
+                        "MyApp/2.0"
+                    ]
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_team_level_required_header(self):
+        """Test team-level required header validation."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/1.0"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            team_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp/1.0"
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_multiple_required_headers(self):
+        """Test multiple required headers."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/1.0",
+            "origin": "https://example.com"
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp*",
+                    "Origin": "https://example.com"
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_header_matching(self):
+        """Test that header matching is case insensitive."""
+        request = self.create_mock_request({
+            "user-agent": "MyApp/1.0"  # lowercase in request
+        })
+        
+        user_api_key_dict = self.create_user_api_key_dict(
+            key_metadata={
+                "required_headers": {
+                    "User-Agent": "MyApp/1.0"  # mixed case in config
+                }
+            }
+        )
+        
+        data = {"model": "gpt-3.5-turbo", "messages": []}
+        
+        # Should not raise any exception
+        result = await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+            proxy_config=Mock(),
+        )
+        
+        assert result is not None


### PR DESCRIPTION
This pull request introduces key enhancements to the `litellm` proxy system, focusing on request validation and tag-based filtering. The most significant changes include the addition of required header validation at multiple levels (key, team, and user), tag-based request blocking, and corresponding updates to the `litellm/router.py` and test coverage. 

### Request Validation Enhancements:
* **Header Validation:** Added required header validation at key, team, and user levels in `add_litellm_data_to_request`. This includes support for exact matches, wildcard patterns, and lists of allowed values, with appropriate error handling using `ProxyException`. [[1]](diffhunk://#diff-87790e464b9e0244fcfa733b54b2e0c3afd218e541d06d0ff93cce9dd8fe37e8R661-R743) [[2]](diffhunk://#diff-87790e464b9e0244fcfa733b54b2e0c3afd218e541d06d0ff93cce9dd8fe37e8R803-R844)
* **Tag-Based Blocking:** Introduced tag-based request blocking in `add_litellm_data_to_request`, ensuring requests include at least one required tag specified by the router configuration.

### Router Updates:
* **Required Tags:** Added a `required_tags` parameter to the `Router` class, enabling tag-based filtering for requests. [[1]](diffhunk://#diff-b0c899fae4bf607df1d0d1a3b170246a0f9d2b5dfe230c48e4539c78222ecc57R227) [[2]](diffhunk://#diff-b0c899fae4bf607df1d0d1a3b170246a0f9d2b5dfe230c48e4539c78222ecc57R338)

### Test Coverage:
* **Required Headers Tests:** Created comprehensive tests in `tests/test_litellm/proxy/test_required_headers.py` to validate the behavior of required headers, including exact matches, wildcard patterns, lists, and case-insensitive matching.

These changes improve the security and configurability of the proxy system, ensuring stricter adherence to user and team-level policies.


For clarification, I used Claude to create the Code, since I'm realy not a python developer and this is more or less just a concept of something I would realy like to have in litellm.

I also did not manage to get the tests running properly.. So if this whole thing is crap, crap it ;)