### PR TITLE
[fix]: Error handling MCP request: Task group is not initialized

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2,7 +2,6 @@
 LiteLLM MCP Server Routes
 """
 
-import asyncio
 import contextlib
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 


### PR DESCRIPTION
## Fixes: Error handling MCP request: Task group is not initialized

```bash
LiteLLM:ERROR: server.py:370 - Error handling MCP request: Task group is not initialized. Make sure to use run().
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/litellm/proxy/_experimental/mcp_server/server.py", line 368, in handle_streamable_http_mcp
    await session_manager.handle_request(scope, receive, send)
  File "/usr/lib/python3.13/site-packages/mcp/server/streamable_http_manager.py", line 137, in handle_request
    raise RuntimeError("Task group is not initialized. Make sure to use run().")
RuntimeError: Task group is not initialized. Make sure to use run().
```
The `StreamableHTTPSessionManager` requires its task group to be properly initialized before it can handle requests. The current implementation tries to initialize the session managers in the lifespan context, but there's a timing issue where requests can come in before the managers are fully ready.

Minor code changes.



