### PR TITLE
Add `Build and push litellm-non_root` to `docker-hub-deploy` CICD workflow

### DIFF
--- a/.github/workflows/ghcr_deploy.yml
+++ b/.github/workflows/ghcr_deploy.yml
@@ -73,7 +73,14 @@ jobs:
           push: true
           file: ./litellm-js/spend-logs/Dockerfile
           tags: litellm/litellm-spend_logs:${{ github.event.inputs.tag || 'latest' }}
-      
+      -
+        name: Build and push litellm-non_root image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./docker/Dockerfile.non_root
+          tags: litellm/litellm-non_root:${{ github.event.inputs.tag || 'latest' }}
   build-and-push-image:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.


### PR DESCRIPTION
## Title

Add `Build and push litellm-non_root` image missing on `docker-hub-deploy`

## Relevant issues

Docker.io registry is missing the non root image, which exists on ghcr only

![Screenshot 2025-07-08 at 15 16 44](https://github.com/user-attachments/assets/d4b3b8f4-d357-49c5-abd3-b176122e6645)



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🚄 Infrastructure

## Changes

Add `Build and push litellm-non_root` image missing on `docker-hub-deploy`

It is a simple step to the previous ones, since docker.io registry was lacking the non_root image, existing on GHCR.

```yaml
      -
        name: Build and push litellm-non_root image
        uses: docker/build-push-action@v5
        with:
          context: .
          push: true
          file: ./docker/Dockerfile.non_root
          tags: litellm/litellm-non_root:${{ github.event.inputs.tag || 'latest' }}
```

