### PR TITLE
The parameter timestamp_granularities is broken for openai-like transcription

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2380,6 +2380,7 @@ def get_optional_params_transcription(
         "prompt": None,
         "response_format": None,
         "temperature": None,  # openai defaults this to 0
+        "timestamp_granularities": None
     }
 
     non_default_params = {

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -451,6 +451,8 @@ class TestOpenAIGPT4OAudioTranscription(BaseLLMAudioTranscriptionTest):
     def get_base_audio_transcription_call_args(self) -> dict:
         return {
             "model": "openai/gpt-4o-transcribe",
+            "response_format": "verbose_json",
+            "timestamp_granularities": ["word"],
         }
 
     def get_custom_llm_provider(self) -> litellm.LlmProviders:

--- a/tests/local_testing/test_whisper.py
+++ b/tests/local_testing/test_whisper.py
@@ -66,6 +66,7 @@ async def test_transcription(
         api_key=api_key,
         api_base=api_base,
         response_format=response_format,
+        timestamp_granularities=timestamp_granularities,
         drop_params=True,
     )
     print(f"transcript: {transcript.model_dump()}")


### PR DESCRIPTION
## The parameter timestamp_granularities is broken for openai-like transcription

Well, it's a very simple fix. The "timestamp_granularities" param was missing from the "default_params" bloc.
I think it was just a typo.

After that, the timestamp_granularities is used for the calling of openai trancription.

## Relevant issues

Part of "Fixes #12407 "

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix



