### PR TITLE
Fix API base url for Github Copilot provider

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -8,7 +8,7 @@ from ..common_utils import GetAPIKeyError
 
 
 class GithubCopilotConfig(OpenAIConfig):
-    GITHUB_COPILOT_API_BASE = "https://api.github.com/copilot/v1"
+    GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com/"
     def __init__(
         self,
         api_key: Optional[str] = None,

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -54,7 +54,7 @@ def test_github_copilot_config_get_openai_compatible_provider_info():
         custom_llm_provider="github_copilot",
     )
 
-    assert api_base == "https://api.github.com/copilot/v1"
+    assert api_base == "https://api.githubcopilot.com/"
     assert dynamic_api_key == mock_api_key
     assert custom_llm_provider == "github_copilot"
 


### PR DESCRIPTION
## Title

The Github Copilot base URL was inadvertently changed from the original PR when it was merged to main. This restores the base URL to it's original working form.

## Relevant issues

Fixes this already merge PR: https://github.com/BerriAI/litellm/pull/12325

Here is original value of the base url in the original branch (litellm_dev_03_05_2025_contributor_prs): https://github.com/BerriAI/litellm/blob/e4b70ca3ad63d9e23fac09c56f1bc9c48e88e112/litellm/llms/github_copilot/chat/transformation.py#L28

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) 
No new test needed, adjusted existing test.

- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/acfa7ff1-7a72-4705-ac5a-823b9851f0a2" />

## Type

🐛 Bug Fix

## Changes

Just changes single class variable and adjust 1 test that checks that variable.

Here is a simple test script that I am using:
```python
from litellm import completion

response = completion(
    model="github_copilot/gpt-4.1",
    extra_headers={"editor-version": "vscode/1.85.1"},
    messages=[{"content": "Calculate 3*27:", "role":"user"}],
)

print(response.choices[0].message.content)
```

With the base url fix, it works. Without the fix I get this error:
```
Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new
LiteLLM.Info: If you need to debug this error, use `litellm._turn_on_debug()'.

Traceback (most recent call last):
  File "/home/PATH/litellm/litellm/llms/openai/openai.py", line 725, in completion
    raise e
  ...
  File "/home/PATH/.venv-main/lib/python3.12/site-packages/openai/_base_client.py", line 1249, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/PATH/.venv-main/lib/python3.12/site-packages/openai/_base_client.py", line 1037, in request
    raise self._make_status_error_from_response(err.response) from None
openai.AuthenticationError: Error code: 401 - {'message': 'Bad credentials', 'documentation_url': 'https://docs.github.com/rest', 'status': '401'}
```