### PR TITLE
Prevent navigation reset after team member operations

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -116,7 +116,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   is_proxy_admin,
   userModels,
   editTeam,
-  premiumUser = false
+  premiumUser = false,
+  onUpdate
 }) => {
   const [teamData, setTeamData] = useState<TeamData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -163,7 +164,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       message.success("Team member added successfully");
       setIsAddMemberModalVisible(false);
       form.resetFields();
-      fetchTeamInfo();
+      
+      // Fetch updated team info
+      const updatedTeamData = await teamInfoCall(accessToken, teamId);
+      setTeamData(updatedTeamData);
+      
+      // Notify parent component of the update
+      onUpdate(updatedTeamData);
     } catch (error: any) {
       let errMsg = "Failed to add team member";
   
@@ -222,10 +229,16 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         return;
       }
 
-      const response = await teamMemberDeleteCall(accessToken, teamId, member);
+      await teamMemberDeleteCall(accessToken, teamId, member);
 
       message.success("Team member removed successfully");
-      fetchTeamInfo();
+      
+      // Fetch updated team info
+      const updatedTeamData = await teamInfoCall(accessToken, teamId);
+      setTeamData(updatedTeamData);
+      
+      // Notify parent component of the update
+      onUpdate(updatedTeamData);
     } catch (error) {
       message.error("Failed to remove team member");
       console.error("Error removing team member:", error);

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -205,7 +205,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
       message.success("Team member updated successfully");
       setIsEditMemberModalVisible(false);
-      fetchTeamInfo();
+      
+      // Fetch updated team info
+      const updatedTeamData = await teamInfoCall(accessToken, teamId);
+      setTeamData(updatedTeamData);
+      
+      // Notify parent component of the update
+      onUpdate(updatedTeamData);
     } catch (error: any) {
       let errMsg = "Failed to update team member";
       if (error?.raw?.detail?.includes("Assigning team admins is a premium feature")) {


### PR DESCRIPTION
## Title
Prevent navigation reset after team member operations
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
When adding, updating, or deleting team members from the team member page, users were unexpectedly redirected to the overview tab instead of remaining on the team members page. This created a poor user experience as users had to manually navigate back to see their changes.

Solution
Replaced the indirect fetchTeamInfo() calls with direct API calls and proper parent component state updates:
Direct API calls: Use await teamInfoCall() directly instead of the fetchTeamInfo() wrapper
Parent state sync: Call onUpdate(updatedTeamData) to properly notify the parent component of changes
Consistent pattern: Applied the same fix across all three member operation functions

Changes Made
Modified handleMemberCreate: Replace fetchTeamInfo() with direct API call + onUpdate()
Modified handleMemberUpdate: Replace fetchTeamInfo() with direct API call + onUpdate()
Modified handleMemberDelete: Replace fetchTeamInfo() with direct API call + onUpdate()

Testing
✅ Adding team members now keeps user on Members tab
✅ Deleting team members now keeps user on Members tab

https://www.loom.com/share/50802969a2974f008dbfb959932da1da?sid=ca71ddab-28e1-4461-bf2d-8091db7a22a0