### PR TITLE
[Bug fix] MCP MCP_TOOL_PREFIX_SEPARATOR to work with claude code

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -9,7 +9,7 @@ import importlib
 LITELLM_MCP_SERVER_NAME = "litellm-mcp-server"
 LITELLM_MCP_SERVER_VERSION = "1.0.0"
 LITELLM_MCP_SERVER_DESCRIPTION = "MCP Server for LiteLLM"
-MCP_TOOL_PREFIX_SEPARATOR = "/"
+MCP_TOOL_PREFIX_SEPARATOR = "-"
 MCP_TOOL_PREFIX_FORMAT = "{server_name}{separator}{tool_name}"
 
 def is_mcp_available() -> bool:


### PR DESCRIPTION
## Title

[Bug fix] MCP MCP_TOOL_PREFIX_SEPARATOR to work with claude code


## Relevant issues

Fixes: #12372 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
## Changes


