### PR TITLE
fix: handle reasoning parameters and response in responses bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -152,11 +152,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 )
             elif key in ResponsesAPIOptionalRequestParams.__annotations__.keys():
                 responses_api_request[key] = value  # type: ignore
-            elif key == "metadata":
-                responses_api_request["metadata"] = value
-            elif key == "previous_response_id":
-                # Support for responses API session management
-                responses_api_request["previous_response_id"] = value
+            elif key in ("metadata", "previous_response_id", "extra_body"):
+                responses_api_request[key] = value
+            elif key == "reasoning_effort":
+                responses_api_request["reasoning"] = self._map_reasoning_effort(value)
 
         # Get stream parameter from litellm_params if not in optional_params
         stream = optional_params.get("stream") or litellm_params.get("stream", False)
@@ -465,6 +464,13 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 )
         return cast(List["ALL_RESPONSES_API_TOOL_PARAMS"], responses_tools)
 
+    def _map_reasoning_effort(self, reasoning_effort: str) -> Optional[Dict[str, str]]:
+        if reasoning_effort == "high":
+            return {"effort": "high", "summary": "detailed"}
+        elif reasoning_effort in ["low", "medium"]:
+            # docs say "summary": "concise" is also an option, but it was rejected in practice, so defaulting "auto"
+            return {"effort": reasoning_effort, "summary": "auto"}
+
     def _map_responses_status_to_finish_reason(self, status: Optional[str]) -> str:
         """Map responses API status to chat completion finish_reason"""
         if not status:
@@ -623,6 +629,22 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
             else:
                 raise ValueError(f"Chat provider: Invalid text delta {parsed_chunk}")
+        elif event_type == "response.reasoning_summary_text.delta":
+            content_part = parsed_chunk.get("delta", None)
+            if content_part:
+                from litellm.types.utils import (
+                    Delta,
+                    ModelResponseStream,
+                    StreamingChoices,
+                )
+
+                return ModelResponseStream(
+                    choices=[
+                        StreamingChoices(
+                            index=parsed_chunk.get("summary_index"), delta=Delta(reasoning_content=content_part)
+                        )
+                    ]
+                )
         else:
             pass
         # For any unhandled event types, create a minimal valid chunk or skip

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -50,3 +50,37 @@ def test_convert_chat_completion_messages_to_responses_api_image_input():
 
     print("response: ", response)
     assert response[0]["content"][1]["image_url"] == user_image
+
+
+def test_openai_responses_chunk_parser_reasoning_summary():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "delta": "**Compar",
+        "item_id": "rs_686d544208748198b6912e27b7c299c00e24bd875d35bade",
+        "output_index": 0,
+        "sequence_number": 4,
+        "summary_index": 0,
+        "type": "response.reasoning_summary_text.delta",
+    }
+
+    result = iterator.chunk_parser(chunk)
+
+    assert isinstance(result, ModelResponseStream)
+    assert len(result.choices) == 1
+    choice = result.choices[0]
+    assert isinstance(choice, StreamingChoices)
+    assert choice.index == 0
+    delta = choice.delta
+    assert isinstance(delta, Delta)
+    assert delta.content is None
+    assert delta.reasoning_content == "**Compar"
+    assert delta.tool_calls is None
+    assert delta.function_call is None


### PR DESCRIPTION
Updates the OpenAI completions/responses bridge to map reasoning_effort to reasoning parameters, and the chunk parser to return reasoning_content.

ref: 12432

fixes #12432 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
![image](https://github.com/user-attachments/assets/32ac35af-63c3-4033-9fe4-96692c0662f3)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
✅ Test
