### PR TITLE
docs: update instructions for disabling Swagger and ReDoc in LiteLLM

### DIFF
--- a/docs/my-website/docs/proxy/configs.md
+++ b/docs/my-website/docs/proxy/configs.md
@@ -588,7 +588,7 @@ general_settings:
 To disable the Swagger docs from the base url, set 
 
 ```env
-NO_DOCS="True"
+NO_DOCS=True
 ```
 
 in your environment, and restart the proxy. 
@@ -598,7 +598,7 @@ in your environment, and restart the proxy.
 To disable the Redoc docs (defaults to `<your-proxy-url>/redoc`), set 
 
 ```env
-NO_REDOC="True"
+NO_REDOC=True
 ```
 
 in your environment, and restart the proxy. 


### PR DESCRIPTION
## Title

📖 Update documentation for disabling Swagger and ReDoc in LiteLLM

## Relevant issues

<!-- No issue linked -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

* [ ] I have added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
* [ ] I have added a screenshot of my new test passing locally
* [x] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
* [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

* Clarified the correct usage of environment variables `NO_DOCS` and `NO_REDOC` in the documentation
* Explained the proper format (`NO_DOCS=True` instead of `NO_DOCS="True"`)
* Added troubleshooting tips to ensure variables are correctly loaded in Docker environments