### PR TITLE
[Feat] SSO - Allow users to run a custom sso login handler

### DIFF
--- a/docs/my-website/docs/proxy/custom_sso.md
+++ b/docs/my-website/docs/proxy/custom_sso.md
@@ -6,7 +6,7 @@ LiteLLM provides two different SSO hooks depending on your authentication setup:
 
 | Hook Type | When to Use | What It Does |
 |-----------|-------------|--------------|
-| **Custom UI SSO Sign-in Handler** | You have an OAuth proxy (oauth2-proxy, Vouch, etc.) in front of LiteLLM | Parses user info from request headers and signs user into UI |
+| **Custom UI SSO Sign-in Handler** | You have an OAuth proxy (oauth2-proxy, Gatekeeper, Vouch, etc.) in front of LiteLLM | Parses user info from request headers and signs user into UI |
 | **Custom SSO Handler** | You use direct SSO providers (Google, Microsoft, SAML) and want custom post-auth logic | Runs custom code after standard OAuth flow to set user permissions/teams |
 
 **Quick Decision Guide:**
@@ -91,6 +91,10 @@ litellm_settings:
 ```shell
 $ litellm --config /path/to/config.yaml 
 ```
+
+#### 4. Navigate to the Admin UI
+
+When a user attempts navigating to the LiteLLM Admin UI, the request will be routed to your custom UI SSO sign-in handler. 
 
 ---
 

--- a/docs/my-website/docs/proxy/custom_sso.md
+++ b/docs/my-website/docs/proxy/custom_sso.md
@@ -1,4 +1,10 @@
-# Event Hooks for SSO Login
+# ✨ Event Hooks for SSO Login
+
+:::info
+
+✨ This is an Enterprise only feature [Get Started with Enterprise here](https://www.litellm.ai/enterprise)
+
+:::
 
 ## Overview
 

--- a/docs/my-website/docs/proxy/custom_sso.md
+++ b/docs/my-website/docs/proxy/custom_sso.md
@@ -27,7 +27,7 @@ Use this when you have an **OAuth proxy in front of LiteLLM** that has already a
 
 ### How it works
 - User lands on Admin UI  
-- **Your custom SSO sign-in handler is called to parse request headers and return user info**
+- 👉 **Your custom SSO sign-in handler is called to parse request headers and return user info**
 - LiteLLM has retrieved user information from your custom handler
 - User signed in to UI
 
@@ -113,7 +113,7 @@ Use this if you want to run your own code **after** a user signs on to the LiteL
 - LiteLLM redirects user to your SSO provider (Google, Microsoft, etc.)
 - Your SSO provider redirects user back to LiteLLM  
 - LiteLLM has retrieved user information from your IDP
-- **Your custom SSO handler is called and returns an object of type SSOUserDefinedValues**
+- 👉 **Your custom SSO handler is called and returns an object of type SSOUserDefinedValues**
 - User signed in to UI
 
 ### Usage

--- a/docs/my-website/docs/proxy/custom_sso.md
+++ b/docs/my-website/docs/proxy/custom_sso.md
@@ -1,20 +1,116 @@
-# Event Hook for SSO Login (Custom Handler)
+# Event Hooks for SSO Login
 
-Use this if you want to run your own code after a user signs on to the LiteLLM UI using SSO
+## Overview
 
-## How it works
+LiteLLM provides two different SSO hooks depending on your authentication setup:
+
+| Hook Type | When to Use | What It Does |
+|-----------|-------------|--------------|
+| **Custom UI SSO Sign-in Handler** | You have an OAuth proxy (oauth2-proxy, Vouch, etc.) in front of LiteLLM | Parses user info from request headers and signs user into UI |
+| **Custom SSO Handler** | You use direct SSO providers (Google, Microsoft, SAML) and want custom post-auth logic | Runs custom code after standard OAuth flow to set user permissions/teams |
+
+**Quick Decision Guide:**
+- ✅ **Use Custom UI SSO Sign-in Handler** if user authentication happens outside LiteLLM (via headers)
+- ✅ **Use Custom SSO Handler** if you want LiteLLM to handle OAuth flow + run custom logic afterward
+
+---
+
+## Option 1: Custom UI SSO Sign-in Handler
+
+Use this when you have an **OAuth proxy in front of LiteLLM** that has already authenticated the user and passes user information via request headers.
+
+### How it works
+- User lands on Admin UI  
+- **Your custom SSO sign-in handler is called to parse request headers and return user info**
+- LiteLLM has retrieved user information from your custom handler
+- User signed in to UI
+
+### Usage
+
+#### 1. Create a custom UI SSO handler file
+
+This handler parses request headers and returns user information as an OpenID object:
+
+```python
+from fastapi import Request
+from fastapi_sso.sso.base import OpenID
+from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler
+
+
+class MyCustomSSOLoginHandler(CustomSSOLoginHandler):
+    """
+    Custom handler for parsing OAuth proxy headers
+    
+    Use this when you have an OAuth proxy (like oauth2-proxy, Vouch, etc.) 
+    in front of LiteLLM that adds user info to request headers
+    """
+    async def handle_custom_ui_sso_sign_in(
+        self,
+        request: Request,
+    ) -> OpenID:
+        # Parse headers from your OAuth proxy
+        request_headers = dict(request.headers)
+        
+        # Extract user info from headers (adjust header names for your proxy)
+        user_id = request_headers.get("x-forwarded-user") or request_headers.get("x-user")
+        user_email = request_headers.get("x-forwarded-email") or request_headers.get("x-email")
+        user_name = request_headers.get("x-forwarded-preferred-username") or request_headers.get("x-preferred-username")
+        
+        # Return OpenID object with user information
+        return OpenID(
+            id=user_id or "unknown",
+            email=user_email or "unknown@example.com", 
+            first_name=user_name or "Unknown",
+            last_name="User",
+            display_name=user_name or "Unknown User",
+            picture=None,
+            provider="oauth-proxy",
+        )
+
+# Create an instance to be used by LiteLLM
+custom_ui_sso_sign_in_handler = MyCustomSSOLoginHandler()
+```
+
+#### 2. Configure in config.yaml
+
+```yaml
+model_list: 
+  - model_name: "openai-model"
+    litellm_params: 
+      model: "gpt-3.5-turbo"
+
+general_settings:
+  custom_ui_sso_sign_in_handler: custom_sso_handler.custom_ui_sso_sign_in_handler
+
+litellm_settings:
+  drop_params: True
+  set_verbose: True
+```
+
+#### 3. Start the proxy
+```shell
+$ litellm --config /path/to/config.yaml 
+```
+
+---
+
+## Option 2: Custom SSO Handler (Post-Authentication)
+
+Use this if you want to run your own code **after** a user signs on to the LiteLLM UI using standard SSO providers (Google, Microsoft, etc.)
+
+### How it works
 - User lands on Admin UI
-- LiteLLM redirects user to your SSO provider
-- Your SSO provider redirects user back to LiteLLM
+- LiteLLM redirects user to your SSO provider (Google, Microsoft, etc.)
+- Your SSO provider redirects user back to LiteLLM  
 - LiteLLM has retrieved user information from your IDP
 - **Your custom SSO handler is called and returns an object of type SSOUserDefinedValues**
 - User signed in to UI
 
-## Usage
+### Usage
 
-#### 1. Create a custom sso handler file. 
+#### 1. Create a custom SSO handler file
 
-Make sure the response type follows the `SSOUserDefinedValues` pydantic object. This is used for logging the user into the Admin UI
+Make sure the response type follows the `SSOUserDefinedValues` pydantic object. This is used for logging the user into the Admin UI:
 
 ```python
 from fastapi import Request
@@ -40,7 +136,7 @@ async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
         
 
         #################################################
-        # Run you custom code / logic here
+        # Run your custom code / logic here
         # check if user exists in litellm proxy DB
         _user_info = await user_info(user_id=userIDPInfo.id)
         print("_user_info from litellm DB ", _user_info)  # noqa
@@ -58,23 +154,24 @@ async def custom_sso_handler(userIDPInfo: OpenID) -> SSOUserDefinedValues:
         raise Exception("Failed custom auth")
 ```
 
-#### 2. Pass the filepath (relative to the config.yaml)
+#### 2. Configure in config.yaml
 
-Pass the filepath to the config.yaml 
+Pass the filepath to the config.yaml. 
 
 e.g. if they're both in the same dir - `./config.yaml` and `./custom_sso.py`, this is what it looks like:
+
 ```yaml 
 model_list: 
   - model_name: "openai-model"
     litellm_params: 
       model: "gpt-3.5-turbo"
 
+general_settings:
+  custom_sso: custom_sso.custom_sso_handler
+
 litellm_settings:
   drop_params: True
   set_verbose: True
-
-general_settings:
-  custom_sso: custom_sso.custom_sso_handler
 ```
 
 #### 3. Start the proxy

--- a/enterprise/litellm_enterprise/proxy/auth/__init__.py
+++ b/enterprise/litellm_enterprise/proxy/auth/__init__.py
@@ -1,0 +1,10 @@
+"""
+Enterprise Authentication Module for LiteLLM Proxy
+
+This module contains enterprise-specific authentication functionality,
+including custom SSO handlers and advanced authentication features.
+"""
+
+from .custom_sso_handler import EnterpriseCustomSSOHandler
+
+__all__ = ["EnterpriseCustomSSOHandler"] 

--- a/enterprise/litellm_enterprise/proxy/auth/custom_sso_handler.py
+++ b/enterprise/litellm_enterprise/proxy/auth/custom_sso_handler.py
@@ -1,0 +1,80 @@
+"""
+Enterprise Custom SSO Handler for LiteLLM Proxy
+
+This module contains enterprise-specific custom SSO authentication functionality
+that allows users to implement their own SSO handling logic by providing custom
+handlers that process incoming request headers and return OpenID objects.
+
+Use this when you have an OAuth proxy in front of LiteLLM (where the OAuth proxy
+has already authenticated the user) and you need to extract user information from
+custom headers or other request attributes.
+"""
+
+from typing import TYPE_CHECKING, Dict, Optional, Union, cast
+
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+
+if TYPE_CHECKING:
+    from fastapi_sso.sso.base import OpenID
+else:
+    from typing import Any as OpenID
+
+from litellm.proxy.management_endpoints.types import CustomOpenID
+
+
+class EnterpriseCustomSSOHandler:
+    """
+    Enterprise Custom SSO Handler for LiteLLM Proxy
+    
+    This class provides methods for handling custom SSO authentication flows
+    where users can implement their own authentication logic by processing
+    request headers and returning user information in OpenID format.
+    """
+    
+    @staticmethod
+    async def handle_custom_ui_sso_sign_in(
+        request: Request,
+    ) -> RedirectResponse:
+        """
+        Allow a user to execute their custom code to parse incoming request headers and return a OpenID object
+
+        Use this when you have an OAuth proxy in front of LiteLLM (where the OAuth proxy has already authenticated the user)
+        
+        Args:
+            request: The FastAPI request object containing headers and other request data
+            
+        Returns:
+            RedirectResponse: Redirect response that sends the user to the LiteLLM UI with authentication token
+            
+        Raises:
+            ValueError: If custom_ui_sso_sign_in_handler is not configured
+            
+        Example:
+            This method is typically called when a user has already been authenticated by an
+            external OAuth proxy and the proxy has added custom headers containing user information.
+            The custom handler extracts this information and converts it to an OpenID object.
+        """
+        from fastapi_sso.sso.base import OpenID
+
+        from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler
+        from litellm.proxy.proxy_server import user_custom_ui_sso_sign_in_handler
+
+        if user_custom_ui_sso_sign_in_handler is None:
+            raise ValueError("custom_ui_sso_sign_in_handler is not configured. Please set it in general_settings.")
+        
+        custom_sso_login_handler = cast(CustomSSOLoginHandler, user_custom_ui_sso_sign_in_handler)
+        openid_response: OpenID = await custom_sso_login_handler.handle_custom_ui_sso_sign_in(
+            request=request,
+        )
+        
+        # Import here to avoid circular imports
+        from litellm.proxy.management_endpoints.ui_sso import SSOAuthenticationHandler
+        
+        return await SSOAuthenticationHandler.get_redirect_response_from_openid(
+            result=openid_response,
+            request=request,
+            received_response=None,
+            generic_client_id=None,
+            ui_access_mode=None,
+        ) 

--- a/enterprise/litellm_enterprise/proxy/auth/custom_sso_handler.py
+++ b/enterprise/litellm_enterprise/proxy/auth/custom_sso_handler.py
@@ -58,8 +58,14 @@ class EnterpriseCustomSSOHandler:
         from fastapi_sso.sso.base import OpenID
 
         from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler
-        from litellm.proxy.proxy_server import user_custom_ui_sso_sign_in_handler
-
+        from litellm.proxy.proxy_server import (
+            CommonProxyErrors,
+            premium_user,
+            user_custom_ui_sso_sign_in_handler,
+        )
+        if premium_user is not True:
+            raise ValueError(CommonProxyErrors.not_premium_user.value)
+        
         if user_custom_ui_sso_sign_in_handler is None:
             raise ValueError("custom_ui_sso_sign_in_handler is not configured. Please set it in general_settings.")
         

--- a/litellm/integrations/custom_sso_handler.py
+++ b/litellm/integrations/custom_sso_handler.py
@@ -1,0 +1,29 @@
+from fastapi import Request
+from fastapi_sso.sso.base import OpenID
+
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class CustomSSOLoginHandler(CustomLogger):
+    """
+    Custom logger for the UI SSO sign in
+
+    Use this to parse the request headers and return a OpenID object
+
+    Useful when you have an OAuth proxy in front of LiteLLM
+    and you want to use the headers from the proxy to sign in the user
+    """
+    async def handle_custom_ui_sso_sign_in(
+        self,
+        request: Request,
+    ) -> OpenID:
+        request_headers_dict = dict(request.headers)
+        return OpenID(
+            id=request_headers_dict.get("x-litellm-user-id"),
+            email=request_headers_dict.get("x-litellm-user-email"),
+            first_name="Test",
+            last_name="Test",
+            display_name="Test",
+            picture="https://test.com/test.png",
+            provider="test",
+        )

--- a/litellm/proxy/custom_hooks/custom_ui_sso_hook.py
+++ b/litellm/proxy/custom_hooks/custom_ui_sso_hook.py
@@ -1,0 +1,32 @@
+from fastapi import Request
+from fastapi_sso.sso.base import OpenID
+
+from litellm._logging import verbose_logger
+from litellm.integrations.custom_logger import CustomLogger
+
+
+class CustomSSOLoginHandler(CustomLogger):
+    """
+    Custom logger for the UI SSO sign in
+
+    Use this to parse the request headers and return a OpenID object
+
+    Useful when you have an OAuth proxy in front of LiteLLM
+    and you want to use the headers from the proxy to sign in the user
+    """
+    async def handle_custom_ui_sso_sign_in(
+        self,
+        request: Request,
+    ) -> OpenID:
+        request_headers_dict = dict(request.headers)
+        verbose_logger.debug("inside custom ui sso sign in hook...")
+        return OpenID(
+            id=request_headers_dict.get("x-litellm-user-id") or "123",
+            email=request_headers_dict.get("x-litellm-user-email") or "test@test.com",
+            first_name="Test",
+            last_name="Test",
+            display_name="Test",
+            picture="https://test.com/test.png",
+            provider="test",
+        )
+custom_ui_sso_sign_in_handler = CustomSSOLoginHandler()

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -531,9 +531,6 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     
     from litellm.proxy._types import LiteLLM_JWTAuth
     from litellm.proxy.auth.handle_jwt import JWTHandler
-    from litellm.proxy.management_endpoints.key_management_endpoints import (
-        generate_key_helper_fn,
-    )
     from litellm.proxy.proxy_server import (
         general_settings,
         jwt_handler,
@@ -1180,7 +1177,7 @@ class SSOAuthenticationHandler:
 
 
     @staticmethod
-    async def get_redirect_response_from_openid(
+    async def get_redirect_response_from_openid( # noqa: PLR0915
         result: Union[OpenID, dict, CustomOpenID],
         request: Request,
         received_response: Optional[dict] = None,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -78,7 +78,10 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
     Example:
     """
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.proxy_server import (
+        premium_user,
+        user_custom_ui_sso_sign_in_handler,
+    )
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
@@ -124,7 +127,7 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
     )
 
     # check if user defined a custom auth sso sign in handler, if yes, use it
-    if general_settings.get("custom_ui_sso_sign_in_handler") is not None:
+    if user_custom_ui_sso_sign_in_handler is not None:
         return await SSOAuthenticationHandler.handle_custom_ui_sso_sign_in(
             request=request,
         )
@@ -800,31 +803,6 @@ class SSOAuthenticationHandler:
     """
     Handler for SSO Authentication across all SSO providers
     """
-
-    @staticmethod
-    async def handle_custom_ui_sso_sign_in(
-        request: Request,
-    ) -> RedirectResponse:
-        """
-        Allow a user to execute their custom code to parse incoming request headers and return a OpenID object
-
-        Use this when you have an OAuth proxy in front of LiteLLM (where the OAuth proxy has already authenticated the user)
-        """
-        from fastapi_sso.sso.base import OpenID
-
-        from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler
-        custom_sso_login_handler = CustomSSOLoginHandler()
-        openid_response: OpenID = await custom_sso_login_handler.handle_custom_ui_sso_sign_in(
-            request=request,
-        )
-        return await SSOAuthenticationHandler.get_redirect_response_from_openid(
-            result=openid_response,
-            request=request,
-            received_response=None,
-            generic_client_id=None,
-            ui_access_mode=None,
-        )
-
     @staticmethod
     async def get_sso_login_redirect(
         redirect_url: str,
@@ -1192,6 +1170,35 @@ class SSOAuthenticationHandler:
         )
         return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}" if source == LITELLM_CLI_SOURCE_IDENTIFIER and key else None
     
+    @staticmethod
+    async def handle_custom_ui_sso_sign_in(
+        request: Request,
+    ) -> RedirectResponse:
+        """
+        Allow a user to execute their custom code to parse incoming request headers and return a OpenID object
+
+        Use this when you have an OAuth proxy in front of LiteLLM (where the OAuth proxy has already authenticated the user)
+        """
+        from fastapi_sso.sso.base import OpenID
+
+        from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler
+        from litellm.proxy.proxy_server import user_custom_ui_sso_sign_in_handler
+
+        if user_custom_ui_sso_sign_in_handler is None:
+            raise ValueError("custom_ui_sso_sign_in_handler is not configured. Please set it in general_settings.")
+        
+        custom_sso_login_handler = cast(CustomSSOLoginHandler, user_custom_ui_sso_sign_in_handler)
+        openid_response: OpenID = await custom_sso_login_handler.handle_custom_ui_sso_sign_in(
+            request=request,
+        )
+        return await SSOAuthenticationHandler.get_redirect_response_from_openid(
+            result=openid_response,
+            request=request,
+            received_response=None,
+            generic_client_id=None,
+            ui_access_mode=None,
+        )
+
 
     @staticmethod
     async def get_redirect_response_from_openid(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -805,7 +805,11 @@ class SSOAuthenticationHandler:
     async def handle_custom_ui_sso_sign_in(
         request: Request,
     ) -> RedirectResponse:
-        # 1. call the user defined custom sso sign in handler
+        """
+        Allow a user to execute their custom code to parse incoming request headers and return a OpenID object
+
+        Use this when you have an OAuth proxy in front of LiteLLM (where the OAuth proxy has already authenticated the user)
+        """
         from fastapi_sso.sso.base import OpenID
 
         from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -6,6 +6,9 @@ model_list:
     litellm_params:
       model: openai/*
 
+general_settings:
+  custom_ui_sso_sign_in_handler: "custom_hooks.custom_ui_sso_hook.custom_ui_sso_sign_in_handler"
+
 guardrails:
   - guardrail_name: "bedrock-pre-guard"
     litellm_params:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1645,7 +1645,7 @@ class ProxyConfig:
         """
         Load config values into proxy global state
         """
-        global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_sso, use_background_health_checks, health_check_interval, use_queue, proxy_budget_rescheduler_max_time, proxy_budget_rescheduler_min_time, ui_access_mode, litellm_master_key_hash, proxy_batch_write_at, disable_spend_logs, prompt_injection_detection_obj, redis_usage_cache, store_model_in_db, premium_user, open_telemetry_logger, health_check_details, callback_settings
+        global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, health_check_interval, use_queue, proxy_budget_rescheduler_max_time, proxy_budget_rescheduler_min_time, ui_access_mode, litellm_master_key_hash, proxy_batch_write_at, disable_spend_logs, prompt_injection_detection_obj, redis_usage_cache, store_model_in_db, premium_user, open_telemetry_logger, health_check_details, callback_settings
 
         config: dict = await self.get_config(config_file_path=config_file_path)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -480,7 +480,7 @@ _description = (
 
 
 def cleanup_router_config_variables():
-    global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_sso, use_background_health_checks, health_check_interval, prisma_client
+    global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, health_check_interval, prisma_client
 
     # Set all variables to None
     master_key = None
@@ -490,6 +490,7 @@ def cleanup_router_config_variables():
     user_custom_auth_path = None
     user_custom_key_generate = None
     user_custom_sso = None
+    user_custom_ui_sso_sign_in_handler = None
     use_background_health_checks = None
     health_check_interval = None
     prisma_client = None
@@ -910,6 +911,7 @@ redis_usage_cache: Optional[RedisCache] = (
 user_custom_auth = None
 user_custom_key_generate = None
 user_custom_sso = None
+user_custom_ui_sso_sign_in_handler = None
 use_background_health_checks = None
 use_queue = False
 health_check_interval = None
@@ -1944,6 +1946,12 @@ class ProxyConfig:
             if custom_sso is not None:
                 user_custom_sso = get_instance_fn(
                     value=custom_sso, config_file_path=config_file_path
+                )
+
+            custom_ui_sso_sign_in_handler = general_settings.get("custom_ui_sso_sign_in_handler", None)
+            if custom_ui_sso_sign_in_handler is not None:
+                user_custom_ui_sso_sign_in_handler = get_instance_fn(
+                    value=custom_ui_sso_sign_in_handler, config_file_path=config_file_path
                 )
 
             if enterprise_proxy_config is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3170,3 +3170,14 @@ def get_server_root_path() -> str:
     - Otherwise, default to "/".
     """
     return os.getenv("SERVER_ROOT_PATH", "/")
+
+
+def get_prisma_client_or_throw(message: str):
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": message},
+        )
+    return prisma_client


### PR DESCRIPTION
## [Feat] SSO - Allow users to run a custom sso login handler

Custom UI SSO Sign-in Handler

Use this when you have an **OAuth proxy in front of LiteLLM** that has already authenticated the user and passes user information via request headers.

### How it works
- User lands on Admin UI  
- 👉 **Your custom SSO sign-in handler is called to parse request headers and return user info**
- LiteLLM has retrieved user information from your custom handler
- User signed in to UI

### Usage

#### 1. Create a custom UI SSO handler file

This handler parses request headers and returns user information as an OpenID object:

```python
from fastapi import Request
from fastapi_sso.sso.base import OpenID
from litellm.integrations.custom_sso_handler import CustomSSOLoginHandler


class MyCustomSSOLoginHandler(CustomSSOLoginHandler):
    """
    Custom handler for parsing OAuth proxy headers
    
    Use this when you have an OAuth proxy (like oauth2-proxy, Vouch, etc.) 
    in front of LiteLLM that adds user info to request headers
    """
    async def handle_custom_ui_sso_sign_in(
        self,
        request: Request,
    ) -> OpenID:
        # Parse headers from your OAuth proxy
        request_headers = dict(request.headers)
        
        # Extract user info from headers (adjust header names for your proxy)
        user_id = request_headers.get("x-forwarded-user") or request_headers.get("x-user")
        user_email = request_headers.get("x-forwarded-email") or request_headers.get("x-email")
        user_name = request_headers.get("x-forwarded-preferred-username") or request_headers.get("x-preferred-username")
        
        # Return OpenID object with user information
        return OpenID(
            id=user_id or "unknown",
            email=user_email or "unknown@example.com", 
            first_name=user_name or "Unknown",
            last_name="User",
            display_name=user_name or "Unknown User",
            picture=None,
            provider="oauth-proxy",
        )

# Create an instance to be used by LiteLLM
custom_ui_sso_sign_in_handler = MyCustomSSOLoginHandler()
```

#### 2. Configure in config.yaml

```yaml
model_list: 
  - model_name: "openai-model"
    litellm_params: 
      model: "gpt-3.5-turbo"

general_settings:
  custom_ui_sso_sign_in_handler: custom_sso_handler.custom_ui_sso_sign_in_handler

litellm_settings:
  drop_params: True
  set_verbose: True
```

#### 3. Start the proxy
```shell
$ litellm --config /path/to/config.yaml 
```

#### 4. Navigate to the Admin UI

When a user attempts navigating to the LiteLLM Admin UI, the request will be routed to your custom UI SSO sign-in handler. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


