### PR TITLE
[Bug Fix] Ensure supported `bedrock/converse/`  params = `bedrock/` params 

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -145,8 +145,14 @@ class AmazonConverseConfig(BaseConfig):
         ):
             supported_params.append("tools")
 
-        if litellm.utils.supports_tool_choice(
-            model=model, custom_llm_provider=self.custom_llm_provider
+        if (
+            litellm.utils.supports_tool_choice(
+                model=model, custom_llm_provider=self.custom_llm_provider
+            )
+            or litellm.utils.supports_tool_choice(
+                model=base_model,
+                custom_llm_provider=self.custom_llm_provider
+            )
         ):
             # only anthropic and mistral support tool choice config. otherwise (E.g. cohere) will fail the call - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             supported_params.append("tool_choice")

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -138,6 +138,7 @@ class AmazonConverseConfig(BaseConfig):
             or base_model.startswith("meta.llama3-1")
             or base_model.startswith("meta.llama3-2")
             or base_model.startswith("meta.llama3-3")
+            or base_model.startswith("meta.llama4")
             or base_model.startswith("amazon.nova")
             or supports_function_calling(
                 model=model, custom_llm_provider=self.custom_llm_provider
@@ -161,9 +162,14 @@ class AmazonConverseConfig(BaseConfig):
             "claude-3-7" in model
             or "claude-sonnet-4" in model
             or "claude-opus-4" in model
+            or "deepseek.r1" in model
             or supports_reasoning(
                 model=model,
                 custom_llm_provider=self.custom_llm_provider,
+            )
+            or supports_reasoning(
+                model=base_model,
+                custom_llm_provider=self.custom_llm_provider
             )
         ):
             supported_params.append("thinking")

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -249,7 +249,7 @@ def test_get_supported_openai_params():
 
 def test_get_supported_openai_params_bedrock_converse():
     """
-    Test that al documented bedrock converse models have the same set of supported openai params when using 
+    Test that all documented bedrock converse models have the same set of supported openai params when using 
     `bedrock/converse/` or `bedrock/` prefix.
 
     Note: This test is critical for routing, if we ever remove `litellm.BEDROCK_CONVERSE_MODELS`, 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -234,3 +234,13 @@ def test_transform_tool_call_with_cache_control():
     transformed_cache_msg = result["toolConfig"]["tools"][1]
     assert "cachePoint" in transformed_cache_msg
     assert transformed_cache_msg["cachePoint"]["type"] == "default"
+
+def test_get_supported_openai_params():
+    config = AmazonConverseConfig()
+    supported_params = config.get_supported_openai_params(
+        model="bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0"
+    )
+    assert "tools" in supported_params
+    assert "tool_choice" in supported_params
+    assert "thinking" in supported_params
+    assert "reasoning_effort" in supported_params

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -251,6 +251,9 @@ def test_get_supported_openai_params_bedrock_converse():
     """
     Test that al documented bedrock converse models have the same set of supported openai params when using 
     `bedrock/converse/` or `bedrock/` prefix.
+
+    Note: This test is critical for routing, if we ever remove `litellm.BEDROCK_CONVERSE_MODELS`, 
+    please update this test to read `bedrock_converse` models from the model cost map.
     """
     for model in litellm.BEDROCK_CONVERSE_MODELS:
         print(f"Testing model: {model}")

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -10,6 +10,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
+import litellm
 from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 from litellm.types.llms.bedrock import ConverseTokenUsageBlock
 
@@ -244,3 +245,23 @@ def test_get_supported_openai_params():
     assert "tool_choice" in supported_params
     assert "thinking" in supported_params
     assert "reasoning_effort" in supported_params
+
+
+def test_get_supported_openai_params_bedrock_converse():
+    """
+    Test that al documented bedrock converse models have the same set of supported openai params when using 
+    `bedrock/converse/` or `bedrock/` prefix.
+    """
+    for model in litellm.BEDROCK_CONVERSE_MODELS:
+        print(f"Testing model: {model}")
+        config = AmazonConverseConfig()
+        supported_params_without_prefix = config.get_supported_openai_params(
+            model=model
+        )
+
+        supported_params_with_prefix = config.get_supported_openai_params(
+            model=f"bedrock/converse/{model}"
+        )
+
+        assert set(supported_params_without_prefix) == set(supported_params_with_prefix), f"Supported params mismatch for model: {model}. Without prefix: {supported_params_without_prefix}, With prefix: {supported_params_with_prefix}"
+        print(f"✅ Passed for model: {model}")


### PR DESCRIPTION
## [Bug Fix] Ensure supported `bedrock/converse/`  params = `bedrock/` params 

- This PR fixes a bug where the supported open_ai params for `bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0` and  `bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0` were not equal. 
- This PR fixes it and added the same validation test for all bedrock converse models, which led to finding other issues 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


