### PR TITLE
[Feat] `DataDogLLMObsLogger` push `total_cost` 

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -160,11 +160,12 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             input_tokens=float(standard_logging_payload.get("prompt_tokens", 0)),
             output_tokens=float(standard_logging_payload.get("completion_tokens", 0)),
             total_tokens=float(standard_logging_payload.get("total_tokens", 0)),
+            total_cost=float(standard_logging_payload.get("response_cost", 0)),
         )
 
         return LLMObsPayload(
             parent_id=metadata.get("parent_id", "undefined"),
-            trace_id=metadata.get("trace_id", str(uuid.uuid4())),
+            trace_id=standard_logging_payload.get("trace_id", str(uuid.uuid4())),
             span_id=metadata.get("span_id", str(uuid.uuid4())),
             name=metadata.get("name", "litellm_llm_call"),
             meta=meta,
@@ -202,11 +203,19 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
     def _get_dd_llm_obs_payload_metadata(
         self, standard_logging_payload: StandardLoggingPayload
     ) -> Dict:
+        """
+        Fields to track in DD LLM Observability metadata from litellm standard logging payload
+        """
         _metadata = {
             "model_name": standard_logging_payload.get("model", "unknown"),
             "model_provider": standard_logging_payload.get(
                 "custom_llm_provider", "unknown"
             ),
+            "id": standard_logging_payload.get("id", "unknown"),
+            "trace_id": standard_logging_payload.get("trace_id", "unknown"),
+            "cache_hit": standard_logging_payload.get("cache_hit", "unknown"),
+            "cache_key": standard_logging_payload.get("cache_key", "unknown"),
+            "saved_cache_cost": standard_logging_payload.get("saved_cache_cost", 0),
         }
         _standard_logging_metadata: dict = (
             dict(standard_logging_payload.get("metadata", {})) or {}

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -186,12 +186,16 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
 
         For non streaming calls, CompletionStartTime is time we get the response back
         """
-        start_time = standard_logging_payload.get("startTime")
-        completion_start_time = standard_logging_payload.get("completionStartTime")
-        end_time = standard_logging_payload.get("endTime")
-        if completion_start_time is not None:
+        start_time: Optional[float] = standard_logging_payload.get("startTime")
+        completion_start_time: Optional[float] = standard_logging_payload.get("completionStartTime")
+        end_time: Optional[float] = standard_logging_payload.get("endTime")
+
+        if completion_start_time is not None and start_time is not None:
             return completion_start_time - start_time
-        return end_time - start_time
+        elif end_time is not None and start_time is not None:
+            return end_time - start_time
+        else:
+            return 0.0
 
 
     def _get_response_messages(self, response_obj: Any) -> List[Any]:

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -13,3 +13,6 @@ guardrails:
       mode: "during_call"
       guardrailIdentifier: ff6ujrregl1q
       guardrailVersion: "DRAFT"
+
+litellm_settings:
+  callbacks: ["datadog_llm_observability"]

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -31,6 +31,7 @@ class LLMMetrics(TypedDict, total=False):
     total_tokens: float
     time_to_first_token: float
     time_per_output_token: float
+    total_cost: float
 
 
 class LLMObsPayload(TypedDict):

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -156,4 +156,21 @@ class TestDataDogLLMObsLogger:
             assert metadata["model_name"] == "gpt-4"
             assert metadata["model_provider"] == "openai"
 
+    def test_get_time_to_first_token_seconds(self, mock_env_vars):
+        """Test the _get_time_to_first_token_seconds method for streaming calls"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+            
+            # Test streaming case (completion_start_time available)
+            streaming_payload = create_standard_logging_payload_with_cache()
+            # Modify times for testing: start=1000, completion_start=1002, end=1005
+            streaming_payload["startTime"] = 1000.0
+            streaming_payload["completionStartTime"] = 1002.0
+            streaming_payload["endTime"] = 1005.0
+            
+            # Test streaming case: should use completion_start_time - start_time
+            time_to_first_token = logger._get_time_to_first_token_seconds(streaming_payload)
+            assert time_to_first_token == 2.0  # 1002.0 - 1000.0 = 2.0 seconds
+
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -1,0 +1,159 @@
+import json
+import os
+import sys
+import uuid
+from datetime import datetime
+from typing import Dict, Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+# Adds the grandparent directory to sys.path to allow importing project modules
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+from litellm.types.integrations.datadog_llm_obs import LLMMetrics, LLMObsPayload
+from litellm.types.utils import (
+    StandardLoggingHiddenParams,
+    StandardLoggingMetadata,
+    StandardLoggingModelInformation,
+    StandardLoggingPayload,
+)
+
+
+def create_standard_logging_payload_with_cache() -> StandardLoggingPayload:
+    """Create a real StandardLoggingPayload object for testing"""
+    return StandardLoggingPayload(
+        id="test-request-id-456",
+        call_type="completion",
+        response_cost=0.05,
+        response_cost_failure_debug_info=None,
+        status="success",
+        total_tokens=30,
+        prompt_tokens=10,
+        completion_tokens=20,
+        startTime=1234567890.0,
+        endTime=1234567891.0,
+        completionStartTime=1234567890.5,
+        model_map_information=StandardLoggingModelInformation(
+            model_map_key="gpt-4", model_map_value=None
+        ),
+        model="gpt-4",
+        model_id="model-123",
+        model_group="openai-gpt",
+        api_base="https://api.openai.com",
+        metadata=StandardLoggingMetadata(
+            user_api_key_hash="test_hash",
+            user_api_key_org_id=None,
+            user_api_key_alias="test_alias",
+            user_api_key_team_id="test_team",
+            user_api_key_user_id="test_user",
+            user_api_key_team_alias="test_team_alias",
+            spend_logs_metadata=None,
+            requester_ip_address="127.0.0.1",
+            requester_metadata=None,
+        ),
+        cache_hit=True,
+        cache_key="test-cache-key-789",
+        saved_cache_cost=0.02,
+        request_tags=[],
+        end_user=None,
+        requester_ip_address="127.0.0.1",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        response={"choices": [{"message": {"content": "Hi there!"}}]},
+        error_str=None,
+        model_parameters={"stream": True},
+        hidden_params=StandardLoggingHiddenParams(
+            model_id="model-123",
+            cache_key="test-cache-key-789",
+            api_base="https://api.openai.com",
+            response_cost="0.05",
+            additional_headers=None,
+        ),
+        trace_id="test-trace-id-123",
+        custom_llm_provider="openai",
+    )
+
+
+class TestDataDogLLMObsLogger:
+    """Test suite for DataDog LLM Observability Logger"""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        """Mock environment variables for DataDog"""
+        with patch.dict(os.environ, {
+            "DD_API_KEY": "test_api_key",
+            "DD_SITE": "us5.datadoghq.com"
+        }):
+            yield
+
+    @pytest.fixture
+    def mock_response_obj(self):
+        """Create a mock response object"""
+        mock_response = Mock()
+        mock_response.__getitem__ = Mock(return_value={
+            "choices": [{"message": Mock(json=Mock(return_value={"role": "assistant", "content": "Hello!"}))}]
+        })
+        return mock_response
+
+    def test_cost_and_trace_id_integration(self, mock_env_vars, mock_response_obj):
+        """Test that total_cost is passed and trace_id from standard payload is used"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+            
+            standard_payload = create_standard_logging_payload_with_cache()
+            
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {"trace_id": "old-trace-id-should-be-ignored"}}
+            }
+            
+            start_time = datetime.now()
+            end_time = datetime.now()
+            
+            payload = logger.create_llm_obs_payload(kwargs, mock_response_obj, start_time, end_time)
+            
+            # Test 1: Verify total_cost is correctly extracted from response_cost
+            assert payload["metrics"].get("total_cost") == 0.05
+            
+            # Test 2: Verify trace_id comes from standard_logging_payload, not metadata
+            assert payload["trace_id"] == "test-trace-id-123"
+            
+            # Test 3: Verify saved_cache_cost is in metadata 
+            metadata = payload["meta"]["metadata"]
+            assert metadata["saved_cache_cost"] == 0.02
+            assert metadata["cache_hit"] == True
+            assert metadata["cache_key"] == "test-cache-key-789"
+
+    def test_cache_metadata_fields(self, mock_env_vars, mock_response_obj):
+        """Test that cache-related metadata fields are correctly tracked"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+            
+            standard_payload = create_standard_logging_payload_with_cache()
+            
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}}
+            }
+            
+            start_time = datetime.now()
+            end_time = datetime.now()
+            
+            payload = logger.create_llm_obs_payload(kwargs, mock_response_obj, start_time, end_time)
+            
+            # Test the _get_dd_llm_obs_payload_metadata method directly
+            metadata = logger._get_dd_llm_obs_payload_metadata(standard_payload)
+            
+            # Verify all cache-related fields are present
+            assert metadata["cache_hit"] == True
+            assert metadata["cache_key"] == "test-cache-key-789"
+            assert metadata["saved_cache_cost"] == 0.02
+            assert metadata["id"] == "test-request-id-456"
+            assert metadata["trace_id"] == "test-trace-id-123"
+            assert metadata["model_name"] == "gpt-4"
+            assert metadata["model_provider"] == "openai"
+
+


### PR DESCRIPTION
## [Bug Fix] `DataDogLLMObsLogger` push `total_cost` 

- Added `total_cost` field to track costs in DataDog LLM observability metrics
- Fixed trace_id source - now uses standard logging payload trace_id
- Added 5 new metadata fields from litellm: `id`, `trace_id`, `cache_hit`, `cache_key`,` saved_cache_cost`

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


