### PR TITLE
Add devstral-small-2507 and devstral-medium-2507 models

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4512,6 +4512,34 @@
         "supports_tool_choice": true,
         "supports_response_schema": true
     },
+    "mistral/devstral-small-2507": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 3e-07,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/devstral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true
+    },
+    "mistral/devstral-medium-2507": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "mistral",
+        "mode": "chat",
+        "source": "https://mistral.ai/news/devstral",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true
+    },
     "mistral/magistral-medium-latest": {
         "max_tokens": 40000,
         "max_input_tokens": 40000,


### PR DESCRIPTION
This PR adds support for the new Devstral 2507 models to the model pricing configuration:

## Models Added

### devstral-small-2507
- **Input cost**: $0.1/M tokens (1e-07 per token)
- **Output cost**: $0.3/M tokens (3e-07 per token)
- Same pricing as Mistral Small 3.1

### devstral-medium-2507
- **Input cost**: $0.4/M tokens (4e-07 per token)  
- **Output cost**: $2/M tokens (2e-06 per token)
- Same pricing as Mistral Medium 3

## Configuration Details
- Both models support function calling, assistant prefill, tool choice, and response schema
- Max tokens: 128,000 for both input and output
- Provider: mistral
- Mode: chat
- Source: https://mistral.ai/news/devstral

The models have been added to the `model_prices_and_context_window.json` file following the existing pattern for Devstral models.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1337c57ad2be4643a35ae27294e350d9)