### PR TITLE
fix bedrock cost calculation for cached tokens

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -29,6 +29,9 @@ from litellm.llms.anthropic.cost_calculation import (
 from litellm.llms.azure.cost_calculation import (
     cost_per_token as azure_openai_cost_per_token,
 )
+from litellm.llms.bedrock.cost_calculation import (
+    cost_per_token as bedrock_cost_per_token,
+)
 from litellm.llms.bedrock.image.cost_calculator import (
     cost_calculator as bedrock_image_cost_calculator,
 )
@@ -326,6 +329,8 @@ def cost_per_token(  # noqa: PLR0915
             )
     elif custom_llm_provider == "anthropic":
         return anthropic_cost_per_token(model=model, usage=usage_block)
+    elif custom_llm_provider == "bedrock":
+        return bedrock_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "openai":
         return openai_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "databricks":

--- a/litellm/llms/bedrock/cost_calculation.py
+++ b/litellm/llms/bedrock/cost_calculation.py
@@ -1,0 +1,22 @@
+"""
+Helper util for handling bedrock-specific cost calculation
+- e.g.: prompt caching
+"""
+
+from typing import TYPE_CHECKING, Tuple
+
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+
+if TYPE_CHECKING:
+    from litellm.types.utils import Usage
+
+
+def cost_per_token(model: str, usage: "Usage") -> Tuple[float, float]:
+    """
+    Calculates the cost per token for a given model, prompt tokens, and completion tokens.
+
+    Follows the same logic as Anthropic's cost per token calculation.
+    """
+    return generic_cost_per_token(
+        model=model, usage=usage, custom_llm_provider="bedrock"
+    )

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -354,9 +354,9 @@ def test_bedrock_cost_calculator_comparison_with_without_cache():
             )
         ],
         usage=Usage(
-            total_tokens=1020,
-            prompt_tokens=1000,
-            completion_tokens=20,
+            total_tokens=28508,
+            prompt_tokens=28495,
+            completion_tokens=13,
         ),
     )
 
@@ -377,13 +377,20 @@ def test_bedrock_cost_calculator_comparison_with_without_cache():
             )
         ],
         usage=Usage(
-            total_tokens=1020,
-            prompt_tokens=1000,
-            completion_tokens=20,
-            prompt_tokens_details=PromptTokensDetailsWrapper(
-                cached_tokens=900,  # 900 tokens are cached (cheaper)
-                text_tokens=100,    # Only 100 new tokens
-            ),
+            **{
+                "total_tokens": 28508,
+                "prompt_tokens": 28495,
+                "completion_tokens": 13,
+                "prompt_tokens_details": {"audio_tokens": None, "cached_tokens": 0},
+                "cache_read_input_tokens": 28491,  # Most tokens are read from cache (cheaper)
+                "completion_tokens_details": {
+                    "audio_tokens": None,
+                    "reasoning_tokens": 0,
+                    "accepted_prediction_tokens": None,
+                    "rejected_prediction_tokens": None,
+                },
+                "cache_creation_input_tokens": 15,  # Only 15 new tokens added to cache
+            }
         ),
     )
 
@@ -404,6 +411,3 @@ def test_bedrock_cost_calculator_comparison_with_without_cache():
     assert cost_with_cache < cost_no_cache
     print(f"Cost without cache: {cost_no_cache}")
     print(f"Cost with cache: {cost_with_cache}")
-    print(f"Savings: {cost_no_cache - cost_with_cache} ({((cost_no_cache - cost_with_cache) / cost_no_cache * 100):.1f}%)")
-
-


### PR DESCRIPTION
## Title

Fix Cost Calculation for Bedrock 

## Relevant issues

Fixes #12258
Possible Fix #12313

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

I have added a cost_calculation.py function to the bedrock provider, similar to the gemini provider, and added it to the cost calculator. I have added a related test.

As a result, the costs for cached tokens are now calculated correctly. I have tested it myself with Roo Code via the Open AI Compatible provider (converse) and also via the anthropic provider (invoke). 

<img width="1440" height="269" alt="test_local" src="https://github.com/user-attachments/assets/39d8a25c-dd6d-463f-a75c-cd1581d00afe" />