### PR TITLE
[Bug Fix] - QA for MCP Gateway - show the cost config on the root of MCP Settings

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_display.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_cost_display.tsx
@@ -15,9 +15,6 @@ const MCPServerCostDisplay: React.FC<MCPServerCostDisplayProps> = ({ costConfig 
     return (
       <div className="mt-6 pt-6 border-t border-gray-200">
         <div className="space-y-4">
-          <div>
-            <Text className="font-medium text-lg">Cost Configuration</Text>
-          </div>
           <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
             <Text className="text-gray-600">
               No cost configuration set for this server. Tool calls will be charged at $0.00 per tool call.
@@ -31,9 +28,6 @@ const MCPServerCostDisplay: React.FC<MCPServerCostDisplayProps> = ({ costConfig 
   return (
     <div className="mt-6 pt-6 border-t border-gray-200">
       <div className="space-y-4">
-        <div>
-          <Text className="font-medium text-lg">Cost Configuration</Text>
-        </div>
         
         {hasDefaultCost && costConfig?.default_cost_per_query !== undefined && costConfig?.default_cost_per_query !== null && (
           <div>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -211,6 +211,10 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
                       )}
                     </div>
                   </div>
+                  <div>
+                    <Text className="font-medium">Cost Configuration</Text>
+                    <MCPServerCostDisplay costConfig={mcpServer.mcp_info?.mcp_server_cost_info} />
+                  </div>
                 </div>
               )}
             </Card>


### PR DESCRIPTION
## [Bug Fix] - QA for MCP Gateway - show the cost config on the root of MCP Settings

>  On Settings tab, I don't see Server and Cost config tabs before clicking on the "Edit Settings" button but I see them after

<img width="1147" height="616" alt="Screenshot 2025-07-11 at 4 04 27 PM" src="https://github.com/user-attachments/assets/afc712d6-65a9-4c32-9f59-f1776e7d13a2" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


