### PR TITLE
[Draft PR] Allow setting disabled callbacks on UI

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import litellm
 from litellm._logging import verbose_logger
 from litellm.constants import X_LITELLM_DISABLE_CALLBACKS
@@ -6,15 +8,18 @@ from litellm.litellm_core_utils.llm_request_utils import (
     get_proxy_server_request_headers,
 )
 from litellm.proxy._types import CommonProxyErrors
+from litellm.types.utils import StandardCallbackDynamicParams
 
 
 class EnterpriseCallbackControls:
     @staticmethod
-    def is_callback_disabled_via_headers(
-            callback: litellm.CALLBACK_TYPES, litellm_params: dict
+    def is_callback_disabled_dynamically(
+            callback: litellm.CALLBACK_TYPES, 
+            litellm_params: dict,
+            standard_callback_dynamic_params: StandardCallbackDynamicParams
         ) -> bool:
             """
-            Check if a callback is disabled via the x-litellm-disable-callbacks header.
+            Check if a callback is disabled via the x-litellm-disable-callbacks header or via `litellm_disabled_callbacks` in standard_callback_dynamic_params.
             
             Args:
                 callback: The callback to check (can be string, CustomLogger instance, or callable)
@@ -28,8 +33,7 @@ class EnterpriseCallbackControls:
             )
 
             try:
-                request_headers = get_proxy_server_request_headers(litellm_params)
-                disabled_callbacks = request_headers.get(X_LITELLM_DISABLE_CALLBACKS, None)
+                disabled_callbacks = EnterpriseCallbackControls.get_disabled_callbacks(litellm_params, standard_callback_dynamic_params)
                 verbose_logger.debug(f"Dynamically disabled callbacks from {X_LITELLM_DISABLE_CALLBACKS}: {disabled_callbacks}")
                 verbose_logger.debug(f"Checking if {callback} is disabled via headers. Disable callbacks from headers: {disabled_callbacks}")
                 if disabled_callbacks is not None:
@@ -39,7 +43,6 @@ class EnterpriseCallbackControls:
                     if not EnterpriseCallbackControls._premium_user_check():
                         return False
                     #########################################################
-                    disabled_callbacks = set([cb.strip().lower() for cb in disabled_callbacks.split(",")])
                     if isinstance(callback, str):
                         if callback.lower() in disabled_callbacks:
                             verbose_logger.debug(f"Not logging to {callback} because it is disabled via {X_LITELLM_DISABLE_CALLBACKS}")
@@ -56,6 +59,29 @@ class EnterpriseCallbackControls:
                     f"Error checking disabled callbacks header: {str(e)}"
                 )
                 return False
+    @staticmethod
+    def get_disabled_callbacks(litellm_params: dict, standard_callback_dynamic_params: StandardCallbackDynamicParams) -> Optional[List[str]]:
+        """
+        Get the disabled callbacks from the standard callback dynamic params.
+        """
+
+        #########################################################
+        # check if disabled via headers
+        #########################################################
+        request_headers = get_proxy_server_request_headers(litellm_params)
+        disabled_callbacks = request_headers.get(X_LITELLM_DISABLE_CALLBACKS, None)
+        if disabled_callbacks is not None:
+            disabled_callbacks = set([cb.strip().lower() for cb in disabled_callbacks.split(",")])
+            return list(disabled_callbacks)
+        
+
+        #########################################################
+        # check if disabled via request body
+        #########################################################
+        if standard_callback_dynamic_params.get("litellm_disabled_callbacks", None) is not None:
+            return standard_callback_dynamic_params.get("litellm_disabled_callbacks", None)
+        
+        return None
     
     @staticmethod
     def _premium_user_check():

--- a/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
@@ -34,7 +34,7 @@ class EnterpriseCallbackControls:
 
             try:
                 disabled_callbacks = EnterpriseCallbackControls.get_disabled_callbacks(litellm_params, standard_callback_dynamic_params)
-                verbose_logger.debug(f"Dynamically disabled callbacks from {X_LITELLM_DISABLE_CALLBACKS}: {disabled_callbacks}")
+                verbose_logger.debug(f"Dynamically disabled callbacks: {disabled_callbacks}")
                 verbose_logger.debug(f"Checking if {callback} is disabled via headers. Disable callbacks from headers: {disabled_callbacks}")
                 if disabled_callbacks is not None:
                     #########################################################

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1317,8 +1317,10 @@ class Logging(LiteLLMLoggingBaseClass):
         # Check for dynamically disabled callbacks via headers
         if (
             EnterpriseCallbackControls is not None
-            and EnterpriseCallbackControls.is_callback_disabled_via_headers(
-                callback, litellm_params
+            and EnterpriseCallbackControls.is_callback_disabled_dynamically(
+                callback=callback, 
+                litellm_params=litellm_params,
+                standard_callback_dynamic_params = self.standard_callback_dynamic_params
             )
         ):
             verbose_logger.debug(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1208,7 +1208,7 @@ class BlockKeyRequest(LiteLLMPydanticObjectBase):
 
 
 class AddTeamCallback(LiteLLMPydanticObjectBase):
-    callback_name: str
+    callback_name: Optional[str] = None
     callback_type: Optional[Literal["success", "failure", "success_and_failure"]] = (
         "success_and_failure"
     )
@@ -1235,6 +1235,11 @@ class TeamCallbackMetadata(LiteLLMPydanticObjectBase):
     callbacks: Optional[List[str]] = []
     # for now - only supported for langfuse
     callback_vars: Optional[Dict[str, str]] = {}
+
+    #########################################################################################
+    # Add disabled callbacks
+    #########################################################################################
+    litellm_disabled_callbacks: Optional[List[str]] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -11,10 +11,6 @@ def _get_salt_key():
     salt_key = os.getenv("LITELLM_SALT_KEY", None)
 
     if salt_key is None:
-        verbose_proxy_logger.debug(
-            "LITELLM_SALT_KEY is None using master_key to encrypt/decrypt secrets stored in DB"
-        )
-
         salt_key = master_key
 
     return salt_key

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -105,13 +105,13 @@ def convert_key_logging_metadata_to_callback(
         if team_callback_settings_obj.success_callback is None:
             team_callback_settings_obj.success_callback = []
 
-        if data.callback_name not in team_callback_settings_obj.success_callback:
+        if data.callback_name and data.callback_name not in team_callback_settings_obj.success_callback:
             team_callback_settings_obj.success_callback.append(data.callback_name)
     elif data.callback_type == "failure":
         if team_callback_settings_obj.failure_callback is None:
             team_callback_settings_obj.failure_callback = []
 
-        if data.callback_name not in team_callback_settings_obj.failure_callback:
+        if data.callback_name and data.callback_name not in team_callback_settings_obj.failure_callback:
             team_callback_settings_obj.failure_callback.append(data.callback_name)
     elif (
         not data.callback_type or data.callback_type == "success_and_failure"
@@ -122,15 +122,15 @@ def convert_key_logging_metadata_to_callback(
             team_callback_settings_obj.failure_callback = []
         if team_callback_settings_obj.callbacks is None:
             team_callback_settings_obj.callbacks = []
+        if data.callback_name:
+            if data.callback_name not in team_callback_settings_obj.success_callback:
+                team_callback_settings_obj.success_callback.append(data.callback_name)
 
-        if data.callback_name not in team_callback_settings_obj.success_callback:
-            team_callback_settings_obj.success_callback.append(data.callback_name)
+            if data.callback_name not in team_callback_settings_obj.failure_callback:
+                team_callback_settings_obj.failure_callback.append(data.callback_name)
 
-        if data.callback_name not in team_callback_settings_obj.failure_callback:
-            team_callback_settings_obj.failure_callback.append(data.callback_name)
-
-        if data.callback_name not in team_callback_settings_obj.callbacks:
-            team_callback_settings_obj.callbacks.append(data.callback_name)
+            if data.callback_name not in team_callback_settings_obj.callbacks:
+                team_callback_settings_obj.callbacks.append(data.callback_name)
 
     for var, value in data.callback_vars.items():
         if team_callback_settings_obj.callback_vars is None:
@@ -774,9 +774,17 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         user_api_key_dict=user_api_key_dict, proxy_config=proxy_config
     )
     if callback_settings_obj is not None:
-        data["success_callback"] = callback_settings_obj.success_callback
-        data["failure_callback"] = callback_settings_obj.failure_callback
+        #########################################################################################
+        # Add success_callback, failure_callback, callback_vars
+        #########################################################################################
+        if callback_settings_obj.success_callback is not None:
+            data["success_callback"] = callback_settings_obj.success_callback
+        if callback_settings_obj.failure_callback is not None:
+            data["failure_callback"] = callback_settings_obj.failure_callback
 
+        #########################################################################################
+        # Add StandardDynamicCallbackParams
+        #########################################################################################
         if callback_settings_obj.callback_vars is not None:
             # unpack callback_vars in data
             for k, v in callback_settings_obj.callback_vars.items():

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -15,4 +15,12 @@ guardrails:
       guardrailVersion: "DRAFT"
 
 litellm_settings:
-  callbacks: ["datadog_llm_observability"]
+  callbacks: ["langfuse"]
+
+
+litellm_settings:
+  default_team_settings: 
+    - team_id: "7f32e788-ff68-48e7-beb1-861e7ae7b042"
+      success_callback: ["langfuse"] # LF - Test-Key-Logging Project
+      langfuse_public_key: pk-lf-625e59a3-5651-496a-863b-7896552ef6fe
+      langfuse_secret: sk-lf-61acbe99-9c00-4b3e-9032-d9973ca90886

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2086,6 +2086,7 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
 
     # Logging settings
     turn_off_message_logging: Optional[bool]  # when true will not log messages
+    litellm_disabled_callbacks: Optional[List[str]]
 
 
 all_litellm_params = [

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py
@@ -1,4 +1,5 @@
 import unittest.mock as mock
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,
 )
 from litellm.integrations.s3_v2 import S3Logger
+from litellm.types.utils import StandardCallbackDynamicParams
 
 
 class TestEnterpriseCallbackControls:
@@ -39,131 +41,145 @@ class TestEnterpriseCallbackControls:
         """Test that 'langfuse' string callback is disabled when specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
         assert result is True
 
     def test_callback_disabled_langfuse_customlogger(self, mock_premium_user, mock_request_headers):
         """Test that LangfusePromptManagement CustomLogger instance is disabled when 'langfuse' specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         langfuse_logger = LangfusePromptManagement()
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers(langfuse_logger, litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically(langfuse_logger, litellm_params, standard_callback_dynamic_params)
         assert result is True
 
     def test_callback_disabled_s3_v2_string(self, mock_premium_user, mock_request_headers):
         """Test that 's3_v2' string callback is disabled when specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "s3_v2"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("s3_v2", litellm_params, standard_callback_dynamic_params)
         assert result is True
 
     def test_callback_disabled_s3_v2_customlogger(self, mock_premium_user, mock_request_headers):
         """Test that S3Logger CustomLogger instance is disabled when 's3_v2' specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "s3_v2"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         # Mock S3Logger to avoid async initialization issues
         with patch('litellm.integrations.s3_v2.S3Logger.__init__', return_value=None):
             s3_logger = S3Logger()
-            result = EnterpriseCallbackControls.is_callback_disabled_via_headers(s3_logger, litellm_params)
+            result = EnterpriseCallbackControls.is_callback_disabled_dynamically(s3_logger, litellm_params, standard_callback_dynamic_params)
             assert result is True
 
     def test_callback_disabled_datadog_string(self, mock_premium_user, mock_request_headers):
         """Test that 'datadog' string callback is disabled when specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "datadog"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params)
         assert result is True
 
     def test_callback_disabled_datadog_customlogger(self, mock_premium_user, mock_request_headers):
         """Test that DataDogLogger CustomLogger instance is disabled when 'datadog' specified in headers"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "datadog"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         # Mock DataDogLogger to avoid async initialization issues
         with patch('litellm.integrations.datadog.datadog.DataDogLogger.__init__', return_value=None):
             datadog_logger = DataDogLogger()
-            result = EnterpriseCallbackControls.is_callback_disabled_via_headers(datadog_logger, litellm_params)
+            result = EnterpriseCallbackControls.is_callback_disabled_dynamically(datadog_logger, litellm_params, standard_callback_dynamic_params)
             assert result is True
 
     def test_multiple_callbacks_disabled(self, mock_premium_user, mock_request_headers):
         """Test that multiple callbacks can be disabled with comma-separated list"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse,datadog,s3_v2"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         # Test each callback is disabled
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("s3_v2", litellm_params, standard_callback_dynamic_params) is True
         
         # Test non-disabled callback is not disabled
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("prometheus", litellm_params) is False
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("prometheus", litellm_params, standard_callback_dynamic_params) is False
 
     def test_callback_not_disabled_when_not_in_list(self, mock_premium_user, mock_request_headers):
         """Test that callbacks not in the disabled list are not disabled"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params)
         assert result is False
 
     def test_callback_not_disabled_when_no_header(self, mock_premium_user, mock_request_headers):
         """Test that callbacks are not disabled when the header is not present"""
         mock_request_headers.return_value = {}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
         assert result is False
 
     def test_callback_not_disabled_when_header_none(self, mock_premium_user, mock_request_headers):
         """Test that callbacks are not disabled when the header value is None"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: None}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
         assert result is False
 
     def test_non_premium_user_cannot_disable_callbacks(self, mock_non_premium_user, mock_request_headers):
         """Test that non-premium users cannot disable callbacks even with the header"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "langfuse"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
         assert result is False
 
     def test_case_insensitive_callback_matching(self, mock_premium_user, mock_request_headers):
         """Test that callback matching is case insensitive"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "LANGFUSE,DataDog"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         # Test lowercase callbacks are disabled
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params) is True
 
     def test_whitespace_handling_in_disabled_callbacks(self, mock_premium_user, mock_request_headers):
         """Test that whitespace around callback names is handled correctly"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: " langfuse , datadog , s3_v2 "}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params) is True
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("datadog", litellm_params) is True
-        assert EnterpriseCallbackControls.is_callback_disabled_via_headers("s3_v2", litellm_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("s3_v2", litellm_params, standard_callback_dynamic_params) is True
 
     def test_custom_logger_not_in_registry(self, mock_premium_user, mock_request_headers):
         """Test that CustomLogger not in registry is not disabled"""
         mock_request_headers.return_value = {X_LITELLM_DISABLE_CALLBACKS: "unknown_logger"}
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
         # Create a mock CustomLogger that's not in the registry
         class UnknownLogger(CustomLogger):
             pass
         
         unknown_logger = UnknownLogger()
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers(unknown_logger, litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically(unknown_logger, litellm_params, standard_callback_dynamic_params)
         assert result is False
 
     def test_exception_handling(self, mock_premium_user, mock_request_headers):
@@ -171,6 +187,30 @@ class TestEnterpriseCallbackControls:
         # Make get_proxy_server_request_headers raise an exception
         mock_request_headers.side_effect = Exception("Test exception")
         litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams()
         
-        result = EnterpriseCallbackControls.is_callback_disabled_via_headers("langfuse", litellm_params)
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
         assert result is False
+
+    def test_callback_disabled_via_request_body_langfuse(self, mock_premium_user, mock_request_headers):
+        """Test that callbacks can be disabled via request body litellm_disabled_callbacks"""
+        mock_request_headers.return_value = {}  # No headers
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams(litellm_disabled_callbacks=["langfuse"])
+        
+        result = EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params)
+        assert result is True
+
+    def test_callback_disabled_via_request_body_multiple(self, mock_premium_user, mock_request_headers):
+        """Test that multiple callbacks can be disabled via request body"""
+        mock_request_headers.return_value = {}  # No headers
+        litellm_params = {"proxy_server_request": {"url": "test"}}
+        standard_callback_dynamic_params = StandardCallbackDynamicParams(litellm_disabled_callbacks=["langfuse", "datadog", "s3_v2"])
+        
+        # Test each callback is disabled
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("langfuse", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("datadog", litellm_params, standard_callback_dynamic_params) is True
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("s3_v2", litellm_params, standard_callback_dynamic_params) is True
+        
+        # Test non-disabled callback is not disabled
+        assert EnterpriseCallbackControls.is_callback_disabled_dynamically("prometheus", litellm_params, standard_callback_dynamic_params) is False

--- a/ui/litellm-dashboard/src/components/common_components/PremiumLoggingSettings.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/PremiumLoggingSettings.tsx
@@ -6,12 +6,18 @@ interface PremiumLoggingSettingsProps {
   value: any[];
   onChange: (settings: any[]) => void;
   premiumUser?: boolean;
+  disabledCallbacks?: string[];
+  onDisabledCallbacksChange?: (disabled: string[]) => void;
+  accessToken?: string;
 }
 
 export function PremiumLoggingSettings({
   value,
   onChange,
-  premiumUser = false
+  premiumUser = false,
+  disabledCallbacks,
+  onDisabledCallbacksChange,
+  accessToken
 }: PremiumLoggingSettingsProps) {
   if (!premiumUser) {
     return (
@@ -37,6 +43,9 @@ export function PremiumLoggingSettings({
     <LoggingSettings
       value={value}
       onChange={onChange}
+      disabledCallbacks={disabledCallbacks}
+      onDisabledCallbacksChange={onDisabledCallbacksChange}
+      accessToken={accessToken}
     />
   );
 }

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -861,23 +861,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                     />
                   </Form.Item>
 
-                  <Accordion className="mt-4 mb-4">
-                    <AccordionHeader>
-                      <b>Logging Settings</b>
-                    </AccordionHeader>
-                    <AccordionBody>
-                      <div className="mt-4">
-                        <PremiumLoggingSettings
-                          value={loggingSettings}
-                          onChange={setLoggingSettings}
-                          premiumUser={premiumUser}
-                          disabledCallbacks={disabledCallbacks}
-                          onDisabledCallbacksChange={setDisabledCallbacks}
-                          accessToken={accessToken}
-                        />
-                      </div>
-                    </AccordionBody>
-                  </Accordion>
+
                   <Accordion className="mt-4 mb-4">
                     <AccordionHeader>
                     <div className="flex items-center gap-2">
@@ -908,6 +892,29 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                       />
                     </AccordionBody>
                   </Accordion>
+                </AccordionBody>
+              </Accordion>
+            </div>
+          )}
+
+          {/* Section 4: Logging Settings */}
+          {!isFormDisabled && (
+            <div className="mb-8">
+              <Accordion className="mt-4 mb-4">
+                <AccordionHeader>
+                  <b>Logging Settings</b>
+                </AccordionHeader>
+                <AccordionBody>
+                  <div className="mt-4">
+                    <PremiumLoggingSettings
+                      value={loggingSettings}
+                      onChange={setLoggingSettings}
+                      premiumUser={premiumUser}
+                      disabledCallbacks={disabledCallbacks}
+                      onDisabledCallbacksChange={setDisabledCallbacks}
+                      accessToken={accessToken}
+                    />
+                  </div>
                 </AccordionBody>
               </Accordion>
             </div>

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -171,6 +171,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
   const [predefinedTags, setPredefinedTags] = useState(getPredefinedTags(data));
   const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
   const [loggingSettings, setLoggingSettings] = useState<any[]>([]);
+  const [disabledCallbacks, setDisabledCallbacks] = useState<string[]>([]);
   const [selectedCreateKeyTeam, setSelectedCreateKeyTeam] = useState<Team | null>(team);
   const [isCreateUserModalVisible, setIsCreateUserModalVisible] = useState(false);
   const [newlyCreatedUserId, setNewlyCreatedUserId] = useState<string | null>(null);
@@ -186,6 +187,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
     setIsModalVisible(false);
     form.resetFields();
     setLoggingSettings([]);
+    setDisabledCallbacks([]);
   };
 
   const handleCancel = () => {
@@ -194,6 +196,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
     setSelectedCreateKeyTeam(null);
     form.resetFields();
     setLoggingSettings([]);
+    setDisabledCallbacks([]);
   };
 
   useEffect(() => {
@@ -303,6 +306,14 @@ const CreateKey: React.FC<CreateKeyProps> = ({
         metadata = {
           ...metadata,
           logging: loggingSettings.filter(config => config.callback_name)
+        };
+      }
+
+      // Add disabled callbacks to the metadata
+      if (disabledCallbacks.length > 0) {
+        metadata = {
+          ...metadata,
+          litellm_disabled_callbacks: disabledCallbacks
         };
       }
       
@@ -860,6 +871,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                           value={loggingSettings}
                           onChange={setLoggingSettings}
                           premiumUser={premiumUser}
+                          disabledCallbacks={disabledCallbacks}
+                          onDisabledCallbacksChange={setDisabledCallbacks}
+                          accessToken={accessToken}
                         />
                       </div>
                     </AccordionBody>

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -900,10 +900,10 @@ const CreateKey: React.FC<CreateKeyProps> = ({
           {/* Section 4: Logging Settings */}
           {!isFormDisabled && (
             <div className="mb-8">
-              <Accordion className="mt-4 mb-4">
-                <AccordionHeader>
-                  <b>Logging Settings</b>
-                </AccordionHeader>
+                             <Accordion className="mt-4 mb-4">
+                 <AccordionHeader>
+                   <Title className="m-0">Logging Settings</Title>
+                 </AccordionHeader>
                 <AccordionBody>
                   <div className="mt-4">
                     <PremiumLoggingSettings

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4104,6 +4104,38 @@ export const getCallbacksCall = async (
   }
 };
 
+export const getCallbacksListCall = async (accessToken: String) => {
+  /**
+   * Get all active callbacks on the proxy
+   */
+  try {
+    let url = proxyBaseUrl
+      ? `${proxyBaseUrl}/callbacks/list`
+      : `/callbacks/list`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    console.log("Active callbacks list:", data);
+    return data;
+  } catch (error) {
+    console.error("Failed to get callbacks list:", error);
+    throw error;
+  }
+};
+
 export const getGeneralSettingsCall = async (accessToken: String) => {
   try {
     let url = proxyBaseUrl

--- a/ui/litellm-dashboard/src/components/team/DisabledCallbacks.tsx
+++ b/ui/litellm-dashboard/src/components/team/DisabledCallbacks.tsx
@@ -124,7 +124,7 @@ const DisabledCallbacks: React.FC<DisabledCallbacksProps> = ({
                           className="w-4 h-4 object-contain" 
                         />
                       )}
-                      <span>{callbackInfo?.displayName || callbackName}</span>
+                      <span>{callbackInfo?.displayName || callbackName} </span>
                     </div>
                     <span className="text-xs text-gray-500">
                       {callbackType}

--- a/ui/litellm-dashboard/src/components/team/DisabledCallbacks.tsx
+++ b/ui/litellm-dashboard/src/components/team/DisabledCallbacks.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from 'react';
+import { Select, Tooltip } from 'antd';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { Card } from '@tremor/react';
+import { getCallbacksListCall } from '../networking';
+import { callbackInfo, callback_map } from '../callback_info_helpers';
+
+const { Option } = Select;
+
+interface DisabledCallbacksProps {
+  value?: string[];
+  onChange?: (disabled: string[]) => void;
+  accessToken?: string;
+}
+
+interface CallbacksList {
+  success: string[];
+  failure: string[];
+  success_and_failure: string[];
+}
+
+const DisabledCallbacks: React.FC<DisabledCallbacksProps> = ({
+  value = [],
+  onChange,
+  accessToken
+}) => {
+  const [availableCallbacks, setAvailableCallbacks] = useState<CallbacksList>({
+    success: [],
+    failure: [],
+    success_and_failure: []
+  });
+
+  // Fetch available callbacks from the API
+  useEffect(() => {
+    const fetchCallbacks = async () => {
+      if (!accessToken) return;
+      
+      try {
+        const callbacksList = await getCallbacksListCall(accessToken);
+        setAvailableCallbacks(callbacksList);
+      } catch (error) {
+        console.error('Failed to fetch callbacks list:', error);
+      }
+    };
+
+    fetchCallbacks();
+  }, [accessToken]);
+
+  // Get all available callbacks for the disabled callbacks selector
+  const getAllAvailableCallbacks = () => {
+    const { success, failure, success_and_failure } = availableCallbacks;
+    return [...success, ...failure, ...success_and_failure];
+  };
+
+  // Find callback info (logo, display name) for a given callback name
+  const getCallbackInfo = (callbackName: string) => {
+    // Try to find a matching callback in callback_map (reverse lookup)
+    const displayName = Object.entries(callback_map).find(
+      ([_, value]) => value === callbackName
+    )?.[0];
+
+    if (displayName && callbackInfo[displayName]) {
+      return {
+        logo: callbackInfo[displayName].logo,
+        displayName
+      };
+    }
+
+    // If no match found, return null
+    return null;
+  };
+
+  const getCallbackType = (callbackName: string) => {
+    const { success, failure, success_and_failure } = availableCallbacks;
+    if (success.includes(callbackName)) return 'Success';
+    if (failure.includes(callbackName)) return 'Failure';
+    if (success_and_failure.includes(callbackName)) return 'Success & Failure';
+    return '';
+  };
+
+  const handleChange = (disabled: string[]) => {
+    onChange?.(disabled);
+  };
+
+  return (
+    <Card className="border border-gray-200 shadow-sm">
+      <div className="space-y-4">
+        <div className="flex items-center space-x-2">
+          <div className="w-3 h-3 bg-red-100 rounded-full flex items-center justify-center">
+            <div className="w-1.5 h-1.5 bg-red-500 rounded-full"></div>
+          </div>
+          <span className="text-sm font-medium text-gray-700">Disabled Callbacks</span>
+          <Tooltip title="Select callbacks to disable for this key. These callbacks will not be executed.">
+            <InfoCircleOutlined className="text-gray-400 cursor-help text-xs" />
+          </Tooltip>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-gray-700">
+            Callbacks to Disable
+          </label>
+          <Select
+            mode="multiple"
+            placeholder="Select callbacks to disable"
+            value={value}
+            onChange={handleChange}
+            className="w-full"
+            showSearch
+            filterOption={(input, option) =>
+              String(option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+            }
+          >
+            {getAllAvailableCallbacks().map((callbackName) => {
+              const callbackInfo = getCallbackInfo(callbackName);
+              const callbackType = getCallbackType(callbackName);
+              
+              return (
+                <Option key={callbackName} value={callbackName} label={callbackName}>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      {callbackInfo?.logo && (
+                        <img 
+                          src={callbackInfo.logo} 
+                          alt={callbackInfo.displayName} 
+                          className="w-4 h-4 object-contain" 
+                        />
+                      )}
+                      <span>{callbackInfo?.displayName || callbackName}</span>
+                    </div>
+                    <span className="text-xs text-gray-500">
+                      {callbackType}
+                    </span>
+                  </div>
+                </Option>
+              );
+            })}
+          </Select>
+          {value.length > 0 && (
+            <div className="text-xs text-gray-500 mt-2">
+              {value.length} callback(s) will be disabled for this key
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default DisabledCallbacks; 

--- a/ui/litellm-dashboard/src/components/team/EditLoggingSettings.tsx
+++ b/ui/litellm-dashboard/src/components/team/EditLoggingSettings.tsx
@@ -4,14 +4,31 @@ import LoggingSettings from './LoggingSettings';
 interface EditLoggingSettingsProps {
   value: any[];
   onChange: (value: any[]) => void;
+  disabledCallbacks?: string[];
+  onDisabledCallbacksChange?: (disabled: string[]) => void;
+  accessToken?: string;
 }
 
 /**
  * Wrapper component around LoggingSettings used for editing
- * a team's logging integrations.
+ * a team's logging integrations and disabled callbacks.
  */
-const EditLoggingSettings: React.FC<EditLoggingSettingsProps> = ({ value, onChange }) => {
-  return <LoggingSettings value={value} onChange={onChange} />;
+const EditLoggingSettings: React.FC<EditLoggingSettingsProps> = ({ 
+  value, 
+  onChange, 
+  disabledCallbacks,
+  onDisabledCallbacksChange,
+  accessToken
+}) => {
+  return (
+    <LoggingSettings 
+      value={value} 
+      onChange={onChange}
+      disabledCallbacks={disabledCallbacks}
+      onDisabledCallbacksChange={onDisabledCallbacksChange}
+      accessToken={accessToken}
+    />
+  );
 };
 
 export default EditLoggingSettings;

--- a/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
+++ b/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
@@ -6,6 +6,7 @@ import { InfoCircleOutlined } from '@ant-design/icons';
 import { Button, Card, TextInput } from '@tremor/react';
 import { PlusIcon, TrashIcon, CogIcon } from '@heroicons/react/outline';
 import { callbackInfo, Callbacks, callback_map } from '../callback_info_helpers';
+import DisabledCallbacks from './DisabledCallbacks';
 
 const { Option } = Select;
 
@@ -18,9 +19,18 @@ interface LoggingConfig {
 interface LoggingSettingsProps {
   value?: LoggingConfig[];
   onChange?: (value: LoggingConfig[]) => void;
+  disabledCallbacks?: string[];
+  onDisabledCallbacksChange?: (disabled: string[]) => void;
+  accessToken?: string;
 }
 
-const LoggingSettings: React.FC<LoggingSettingsProps> = ({ value = [], onChange }) => {
+const LoggingSettings: React.FC<LoggingSettingsProps> = ({ 
+  value = [], 
+  onChange, 
+  disabledCallbacks = [],
+  onDisabledCallbacksChange,
+  accessToken 
+}) => {
   // Get callbacks that support team and key logging
   const supportedCallbacks = Object.entries(callbackInfo)
     .filter(([_, info]) => info.supports_key_team_logging)
@@ -145,6 +155,15 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({ value = [], onChange 
           Add Integration
         </Button>
       </div>
+
+      {/* Disabled Callbacks Section */}
+      {onDisabledCallbacksChange && (
+        <DisabledCallbacks
+          value={disabledCallbacks}
+          onChange={onDisabledCallbacksChange}
+          accessToken={accessToken}
+        />
+      )}
 
       <div className="space-y-4">
         {value.map((config, index) => {


### PR DESCRIPTION
## [Feat] Allow setting disabled callbacks on UI

This PR allows proxy admins to disable specific logging callbacks for a key 

### Key changes 
- Allow passing `litellm_disabled_callbacks` as a standard callback dynamic param
- This change works on the backend, but waiting on frontend QA 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


