### PR TITLE
Add Copy-on-Click for IDs

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -20,6 +20,8 @@ import { getGuardrailLogoAndName, guardrail_provider_map } from "./guardrail_inf
 import PiiConfiguration from "./pii_configuration";
 import GuardrailProviderFields from "./guardrail_provider_fields";
 import GuardrailOptionalParams from "./guardrail_optional_params";
+import { handleCopy } from "@/utils/dataUtils";
+import { ClipboardCopyIcon } from "@heroicons/react/outline";
 
 export interface GuardrailInfoProps {
   guardrailId: string;
@@ -325,7 +327,10 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({
         <div>
           <Button onClick={onClose} className="mb-4">← Back</Button>
           <Title>{guardrailData.guardrail_name || "Unnamed Guardrail"}</Title>
-          <Text className="text-gray-500 font-mono">{guardrailData.guardrail_id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(guardrailData.guardrail_id, 'Guardrail ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{guardrailData.guardrail_id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
       </div>
 
@@ -531,7 +536,10 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({
                   <div className="space-y-4">
                     <div>
                       <Text className="font-medium">Guardrail ID</Text>
-                      <div className="font-mono">{guardrailData.guardrail_id}</div>
+                      <div className="flex items-center cursor-pointer" onClick={() => handleCopy(guardrailData.guardrail_id, 'Guardrail ID copied to clipboard')}>
+                        <div className="font-mono">{guardrailData.guardrail_id}</div>
+                        <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+                      </div>
                     </div>
                     <div>
                       <Text className="font-medium">Guardrail Name</Text>

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -15,7 +15,7 @@ import {
   TextInput,
   Select as TremorSelect
 } from "@tremor/react";
-import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
+import { ArrowLeftIcon, TrashIcon, RefreshIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import { keyDeleteCall, keyUpdateCall } from "./networking";
 import { KeyResponse } from "./key_team_helpers/key_list";
 import { Form, Input, InputNumber, message, Select, Tooltip } from "antd";
@@ -61,6 +61,11 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
       </div>
     );
   }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(keyData.token);
+    message.success('Key copied to clipboard');
+  };
 
   const handleKeyUpdate = async (formValues: Record<string, any>) => {
     try {
@@ -165,7 +170,10 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
             Back to Keys
           </Button>
           <Title>{keyData.key_alias || "API Key"}</Title>
-          <Text className="text-gray-500 font-mono">{keyData.token}</Text>
+          <div className="flex items-center cursor-pointer" onClick={handleCopy}>
+            <Text className="text-gray-500 font-mono">{keyData.token}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
           <div className="flex gap-2">

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -24,7 +24,7 @@ import { RegenerateKeyModal } from "./regenerate_key_modal";
 import { rolesWithWriteAccess } from '../utils/roles';
 import ObjectPermissionsView from "./object_permissions_view";
 import LoggingSettingsView from "./logging_settings_view";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
 import { extractLoggingSettings, formatMetadataForDisplay } from "./key_info_utils";
 
 interface KeyInfoViewProps {
@@ -61,11 +61,6 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
       </div>
     );
   }
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(keyData.token);
-    message.success('Key copied to clipboard');
-  };
 
   const handleKeyUpdate = async (formValues: Record<string, any>) => {
     try {
@@ -170,7 +165,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
             Back to Keys
           </Button>
           <Title>{keyData.key_alias || "API Key"}</Title>
-          <div className="flex items-center cursor-pointer" onClick={handleCopy}>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(keyData.token, 'Key copied to clipboard')}>
             <Text className="text-gray-500 font-mono">{keyData.token}</Text>
             <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
           </div>

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -15,7 +15,7 @@ import {
   TextInput,
   Select as TremorSelect
 } from "@tremor/react";
-import { ArrowLeftIcon, TrashIcon, RefreshIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
+import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
 import { keyDeleteCall, keyUpdateCall } from "./networking";
 import { KeyResponse } from "./key_team_helpers/key_list";
 import { Form, Input, InputNumber, message, Select, Tooltip, Button as AntdButton } from "antd";

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -18,14 +18,15 @@ import {
 import { ArrowLeftIcon, TrashIcon, RefreshIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import { keyDeleteCall, keyUpdateCall } from "./networking";
 import { KeyResponse } from "./key_team_helpers/key_list";
-import { Form, Input, InputNumber, message, Select, Tooltip } from "antd";
+import { Form, Input, InputNumber, message, Select, Tooltip, Button as AntdButton } from "antd";
 import { KeyEditView } from "./key_edit_view";
 import { RegenerateKeyModal } from "./regenerate_key_modal";
 import { rolesWithWriteAccess } from '../utils/roles';
 import ObjectPermissionsView from "./object_permissions_view";
 import LoggingSettingsView from "./logging_settings_view";
-import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
+import { copyToClipboard as utilCopyToClipboard, formatNumberWithCommas } from "@/utils/dataUtils";
 import { extractLoggingSettings, formatMetadataForDisplay } from "./key_info_utils";
+import { CopyIcon, CheckIcon } from "lucide-react";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -45,6 +46,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
   const [form] = Form.useForm();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isRegenerateModalOpen, setIsRegenerateModalOpen] = useState(false);
+  const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
 
   if (!keyData) {
     return (
@@ -152,6 +154,16 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
     }
   };
 
+  const copyToClipboard = async (text: string, key: string) => {
+    const success = await utilCopyToClipboard(text);
+    if (success) {
+      setCopiedStates((prev) => ({ ...prev, [key]: true }));
+      setTimeout(() => {
+        setCopiedStates((prev) => ({ ...prev, [key]: false }));
+      }, 2000);
+    }
+  };
+
   return (
     <div className="w-full h-screen p-4">
       <div className="flex justify-between items-center mb-6">
@@ -165,9 +177,20 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
             Back to Keys
           </Button>
           <Title>{keyData.key_alias || "API Key"}</Title>
-          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(keyData.token, 'Key copied to clipboard')}>
+          <div className="flex items-center cursor-pointer"
+           >
             <Text className="text-gray-500 font-mono">{keyData.token}</Text>
-            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+            <AntdButton
+              type="text"
+              size="small"
+              icon={copiedStates["key-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              onClick={() => copyToClipboard(keyData.token, "key-id")}
+              className={`left-2 z-10 transition-all duration-200 ${
+                copiedStates["key-id"] 
+                  ? 'text-green-600 bg-green-50 border-green-200' 
+                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+              }`}
+            />
           </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connect.tsx
@@ -35,6 +35,7 @@ import {
   Zap
 } from "lucide-react";
 import { getProxyBaseUrl } from "../networking";
+import { copyToClipboard as utilCopyToClipboard } from "../../utils/dataUtils";
 
 const { Title, Text } = Typography;
 const { Panel } = Collapse;
@@ -154,15 +155,12 @@ const MCPConnect: React.FC = () => {
   const [currentServer] = useState("Zapier_MCP"); // This should match the current server being viewed
 
   const copyToClipboard = async (text: string, key: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedStates(prev => ({ ...prev, [key]: true }));
-      message.success('Copied to clipboard');
+    const success = await utilCopyToClipboard(text);
+    if (success) {
+      setCopiedStates((prev) => ({ ...prev, [key]: true }));
       setTimeout(() => {
-        setCopiedStates(prev => ({ ...prev, [key]: false }));
+        setCopiedStates((prev) => ({ ...prev, [key]: false }));
       }, 2000);
-    } catch (err) {
-      message.error('Failed to copy to clipboard');
     }
   };
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_view.tsx
@@ -20,6 +20,10 @@ import { MCPToolsViewer } from ".";
 import MCPServerEdit from "./mcp_server_edit";
 import MCPServerCostDisplay from "./mcp_server_cost_display";
 import { getMaskedAndFullUrl } from "./utils";
+import { Form, Input, Select, message, Tooltip, Divider } from "antd";
+import { InfoCircleOutlined } from '@ant-design/icons';
+import { handleCopy } from "@/utils/dataUtils";
+import { ClipboardCopyIcon } from "@heroicons/react/outline";
 
 interface MCPServerViewProps {
   mcpServer: MCPServer;
@@ -63,7 +67,10 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
             ← Back
           </Button>
           <Title>{mcpServer.alias}</Title>
-          <Text className="text-gray-500 font-mono">{mcpServer.server_id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(mcpServer.server_id, 'Server ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{mcpServer.server_id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
       </div>
 

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -14,7 +14,7 @@ import {
   TextInput,
 } from "@tremor/react";
 import NumericalInput from "./shared/numerical_input";
-import { ArrowLeftIcon, TrashIcon, KeyIcon } from "@heroicons/react/outline";
+import { ArrowLeftIcon, TrashIcon, KeyIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import { modelDeleteCall, modelUpdateCall, CredentialItem, credentialGetCall, credentialCreateCall, modelInfoCall, modelInfoV1Call, modelPatchUpdateCall } from "./networking";
 import { Button, Form, Input, InputNumber, message, Select, Modal } from "antd";
 import EditModelModal from "./edit_model/edit_model_modal";
@@ -24,6 +24,7 @@ import { getDisplayModelName } from "./view_model/model_name_display";
 import AddCredentialsModal from "./model_add/add_credentials_tab";
 import ReuseCredentialsModal from "./model_add/reuse_credentials";
 import CacheControlSettings from "./add_model/cache_control_settings";
+import { handleCopy } from "@/utils/dataUtils";
 
 interface ModelInfoViewProps {
   modelId: string;
@@ -242,7 +243,10 @@ export default function ModelInfoView({
             Back to Models
           </Button>
           <Title>Public Model Name: {getDisplayModelName(modelData)}</Title>
-          <Text className="text-gray-500 font-mono">{modelData.model_info.id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(modelData.model_info.id, 'Model ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{modelData.model_info.id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
         <div className="flex gap-2">
           {isAdmin && (

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -23,7 +23,7 @@ import {
 import NumericalInput from "../shared/numerical_input";
 import { Button, Form, Input, Select, message, Tooltip } from "antd";
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { PencilAltIcon, TrashIcon } from "@heroicons/react/outline";
+import { PencilAltIcon, TrashIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
 import { Member, Organization, organizationInfoCall, organizationMemberAddCall, organizationMemberUpdateCall, organizationMemberDeleteCall, organizationUpdateCall } from "../networking";
 import UserSearchModal from "../common_components/user_search_modal";
@@ -31,7 +31,7 @@ import MemberModal from "../team/edit_membership";
 import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
 
 interface OrganizationInfoProps {
   organizationId: string;
@@ -199,7 +199,10 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
         <div>
           <Button onClick={onClose} className="mb-4">← Back</Button>
           <Title>{orgData.organization_alias}</Title>
-          <Text className="text-gray-500 font-mono">{orgData.organization_id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(orgData.organization_id, 'Organization ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{orgData.organization_id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
       </div>
 
@@ -467,7 +470,10 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Organization ID</Text>
-                    <div className="font-mono">{orgData.organization_id}</div>
+                    <div className="flex items-center cursor-pointer" onClick={() => handleCopy(orgData.organization_id, 'Organization ID copied to clipboard')}>
+                      <div className="font-mono">{orgData.organization_id}</div>
+                      <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+                    </div>
                   </div>
                   <div>
                     <Text className="font-medium">Created At</Text>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -28,7 +28,7 @@ import { InfoCircleOutlined } from '@ant-design/icons';
 import {
   Select as Select2,
 } from "antd";
-import { PencilAltIcon, PlusIcon, TrashIcon } from "@heroicons/react/outline";
+import { PencilAltIcon, PlusIcon, TrashIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import MemberModal from "./edit_membership";
 import UserSearchModal from "@/components/common_components/user_search_modal";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
@@ -37,7 +37,7 @@ import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
 import PremiumVectorStoreSelector from "../common_components/PremiumVectorStoreSelector";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
 import EditLoggingSettings from "./EditLoggingSettings";
 import LoggingSettingsView from "../logging_settings_view";
 import { fetchMCPAccessGroups } from "../networking";
@@ -342,7 +342,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         <div>
           <Button onClick={onClose} className="mb-4">← Back</Button>
           <Title>{info.team_alias}</Title>
-          <Text className="text-gray-500 font-mono">{info.team_id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(info.team_id, 'Team ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{info.team_id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
       </div>
 
@@ -612,7 +615,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Team ID</Text>
-                    <div className="font-mono">{info.team_id}</div>
+                    <div className="flex items-center cursor-pointer" onClick={() => handleCopy(info.team_id, 'Team ID copied to clipboard')}>
+                      <div className="font-mono">{info.team_id}</div>
+                      <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+                    </div>
                   </div>
                   <div>
                     <Text className="font-medium">Created At</Text>

--- a/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/SessionView.tsx
@@ -4,7 +4,8 @@ import { DataTable } from './table';
 import { columns } from './columns';
 import { Card, Title, Text, Metric, AreaChart } from '@tremor/react';
 import { RequestViewer } from './index';
-import { formatNumberWithCommas } from '@/utils/dataUtils';
+import { formatNumberWithCommas, handleCopy } from '@/utils/dataUtils';
+import { ClipboardCopyIcon } from '@heroicons/react/outline';
 
 interface SessionViewProps {
   sessionId: string;
@@ -48,7 +49,10 @@ export const SessionView: React.FC<SessionViewProps> = ({ sessionId, logs, onBac
         <div className="mt-4">
           <h1 className="text-2xl font-semibold text-gray-900">Session Details</h1>
           <div className="space-y-2">
-            <p className="text-sm text-gray-500 font-mono">{sessionId}</p>
+            <div className="flex items-center cursor-pointer" onClick={() => handleCopy(sessionId, 'Session ID copied to clipboard')}>
+              <p className="text-sm text-gray-500 font-mono">{sessionId}</p>
+              <ClipboardCopyIcon className="h-4 w-4 ml-2 text-gray-500" />
+            </div>
             <a 
               href="https://docs.litellm.ai/docs/proxy/ui_logs_sessions" 
               target="_blank" 

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -13,13 +13,13 @@ import {
   Title,
   Badge,
 } from "@tremor/react";
-import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
+import { ArrowLeftIcon, TrashIcon, RefreshIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
 import { userInfoCall, userDeleteCall, userUpdateUserCall, modelAvailableCall, invitationCreateCall, getProxyBaseUrl } from "../networking";
 import { message } from "antd";
 import { rolesWithWriteAccess } from '../../utils/roles';
 import { UserEditView } from "../user_edit_view";
 import OnboardingModal, { InvitationLink } from "../onboarding_link";
-import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
 
 interface UserInfoViewProps {
   userId: string;
@@ -197,7 +197,10 @@ export default function UserInfoView({
             Back to Users
           </Button>
           <Title>{userData.user_info?.user_email || "User"}</Title>
-          <Text className="text-gray-500 font-mono">{userData.user_id}</Text>
+          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(userData.user_id, 'User ID copied to clipboard')}>
+            <Text className="text-gray-500 font-mono">{userData.user_id}</Text>
+            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+          </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
           <div className="flex items-center space-x-2">
@@ -338,7 +341,10 @@ export default function UserInfoView({
                 <div className="space-y-4">
                   <div>
                     <Text className="font-medium">User ID</Text>
-                    <Text className="font-mono">{userData.user_id}</Text>
+                    <div className="flex items-center cursor-pointer" onClick={() => handleCopy(userData.user_id, 'User ID copied to clipboard')}>
+                      <Text className="font-mono">{userData.user_id}</Text>
+                      <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+                    </div>
                   </div>
                   
                   <div>

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -13,13 +13,14 @@ import {
   Title,
   Badge,
 } from "@tremor/react";
-import { ArrowLeftIcon, TrashIcon, RefreshIcon, ClipboardCopyIcon } from "@heroicons/react/outline";
+import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
 import { userInfoCall, userDeleteCall, userUpdateUserCall, modelAvailableCall, invitationCreateCall, getProxyBaseUrl } from "../networking";
-import { message } from "antd";
+import { message, Button as AntdButton } from "antd";
 import { rolesWithWriteAccess } from '../../utils/roles';
 import { UserEditView } from "../user_edit_view";
 import OnboardingModal, { InvitationLink } from "../onboarding_link";
-import { formatNumberWithCommas, handleCopy } from "@/utils/dataUtils";
+import { formatNumberWithCommas, copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
+import { CopyIcon, CheckIcon } from "lucide-react";
 
 interface UserInfoViewProps {
   userId: string;
@@ -68,6 +69,7 @@ export default function UserInfoView({
   const [invitationLinkData, setInvitationLinkData] = useState<InvitationLink | null>(null);
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState(initialTab);
+  const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
 
   React.useEffect(() => {
     setBaseUrl(getProxyBaseUrl());
@@ -184,6 +186,16 @@ export default function UserInfoView({
     );
   }
 
+  const copyToClipboard = async (text: string, key: string) => {
+    const success = await utilCopyToClipboard(text);
+    if (success) {
+      setCopiedStates((prev) => ({ ...prev, [key]: true }));
+      setTimeout(() => {
+        setCopiedStates((prev) => ({ ...prev, [key]: false }));
+      }, 2000);
+    }
+  };
+
   return (
     <div className="p-4">
       <div className="flex justify-between items-center mb-6">
@@ -197,9 +209,19 @@ export default function UserInfoView({
             Back to Users
           </Button>
           <Title>{userData.user_info?.user_email || "User"}</Title>
-          <div className="flex items-center cursor-pointer" onClick={() => handleCopy(userData.user_id, 'User ID copied to clipboard')}>
+          <div className="flex items-center cursor-pointer">
             <Text className="text-gray-500 font-mono">{userData.user_id}</Text>
-            <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+            <AntdButton
+              type="text"
+              size="small"
+              icon={copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              onClick={() => copyToClipboard(userData.user_id, "user-id")}
+              className={`left-2 z-10 transition-all duration-200 ${
+                copiedStates["user-id"] 
+                  ? 'text-green-600 bg-green-50 border-green-200' 
+                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+              }`}
+            />
           </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
@@ -341,9 +363,19 @@ export default function UserInfoView({
                 <div className="space-y-4">
                   <div>
                     <Text className="font-medium">User ID</Text>
-                    <div className="flex items-center cursor-pointer" onClick={() => handleCopy(userData.user_id, 'User ID copied to clipboard')}>
+                    <div className="flex items-center cursor-pointer">
                       <Text className="font-mono">{userData.user_id}</Text>
-                      <ClipboardCopyIcon className="h-5 w-5 ml-2 text-gray-500" />
+                      <AntdButton
+                        type="text"
+                        size="small"
+                        icon={copiedStates["user-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+                        onClick={() => copyToClipboard(userData.user_id, "user-id")}
+                        className={`left-2 z-10 transition-all duration-200 ${
+                          copiedStates["user-id"] 
+                            ? 'text-green-600 bg-green-50 border-green-200' 
+                            : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                        }`}
+                      />
                     </div>
                   </div>
                   

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -25,7 +25,7 @@ export const formatNumberWithCommas = (value: number | null | undefined, decimal
   });
 };
 
-export const handleCopy = (text: string, messageText: string = 'Copied to clipboard') => {
+export const handleCopy = (text: string | null | undefined, messageText: string = 'Copied to clipboard') => {
   if (!text) return;
   navigator.clipboard.writeText(text);
   message.success(messageText);

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -1,3 +1,5 @@
+import { message } from "antd";
+
 export function updateExistingKeys<Source extends Object>(
   target: Source,
   source: Object
@@ -21,4 +23,10 @@ export const formatNumberWithCommas = (value: number | null | undefined, decimal
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   });
+};
+
+export const handleCopy = (text: string, messageText: string = 'Copied to clipboard') => {
+  if (!text) return;
+  navigator.clipboard.writeText(text);
+  message.success(messageText);
 };

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -25,8 +25,18 @@ export const formatNumberWithCommas = (value: number | null | undefined, decimal
   });
 };
 
-export const handleCopy = (text: string | null | undefined, messageText: string = 'Copied to clipboard') => {
-  if (!text) return;
-  navigator.clipboard.writeText(text);
-  message.success(messageText);
+export const copyToClipboard = async (
+  text: string | null | undefined,
+  messageText: string = "Copied to clipboard"
+): Promise<boolean> => {
+  if (!text) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    message.success(messageText);
+    return true;
+  } catch (err) {
+    message.error("Failed to copy to clipboard");
+    console.error("Failed to copy: ", err);
+    return false;
+  }
 };


### PR DESCRIPTION
## Title
Add Copy-on-Click for IDs
<!-- e.g. "Implement user authentication feature" -->


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
A clipboard icon is displayed next to each ID to provide a clear visual cue, and the cursor changes to a pointer on hover.
- Centralized Copy Utility:
A generic handleCopy function has been created in `ui/litellm-dashboard/src/utils/dataUtils.ts`. This function encapsulates the logic for writing text to the clipboard and displaying a confirmation message, ensuring consistency.
- Widespread UI Implementation:
The copy-on-click feature has been added to the following IDs across their respective views:
API Key ID (key_info_view.tsx)
Model ID (model_info_view.tsx)
Team ID (key_info_view.tsx, model_info_view.tsx, team_info.tsx)
User ID (team_member_view.tsx, organization_view.tsx, user_info_view.tsx)
Organization ID (organization_view.tsx)
Session ID (SessionView.tsx)
Guardrail ID (guardrail_info.tsx)
MCP Server ID (mcp_server_view.tsx)

A few screenshots:

<img width="524" height="109" alt="Screenshot 2025-07-12 at 18 04 19" src="https://github.com/user-attachments/assets/4595d78d-bc59-4bde-82b2-f7901f58b0e5" />
<img width="524" height="109" alt="Screenshot 2025-07-12 at 18 04 45" src="https://github.com/user-attachments/assets/d0109844-c5d6-4353-8bf9-ea1993841198" />
<img width="538" height="177" alt="Screenshot 2025-07-12 at 18 04 56" src="https://github.com/user-attachments/assets/07d03416-9973-438e-8e0b-8df416138c10" />

