### PR TITLE
feat(gemini): Add custom TTL support for context caching (#9810)

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/transformation.py
+++ b/litellm/llms/vertex_ai/context_caching/transformation.py
@@ -4,7 +4,8 @@ Transformation logic for context caching.
 Why separate file? Make it easy to see how transformation works
 """
 
-from typing import List, Tuple
+import re
+from typing import List, Optional, Tuple
 
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.llms.vertex_ai import CachedContentRequestBody
@@ -45,6 +46,72 @@ def get_first_continuous_block_idx(
 
     # If we made it through the whole list, return the last index
     return len(filtered_messages) - 1
+
+
+def extract_ttl_from_cached_messages(messages: List[AllMessageValues]) -> Optional[str]:
+    """
+    Extract TTL from cached messages. Returns the first valid TTL found.
+    
+    Args:
+        messages: List of messages to extract TTL from
+        
+    Returns:
+        Optional[str]: TTL string in format "3600s" or None if not found/invalid
+    """
+    for message in messages:
+        if not is_cached_message(message):
+            continue
+            
+        content = message.get("content")
+        if not content or isinstance(content, str):
+            continue
+            
+        for content_item in content:
+            # Type check to ensure content_item is a dictionary before calling .get()
+            if not isinstance(content_item, dict):
+                continue
+                
+            cache_control = content_item.get("cache_control")
+            if not cache_control or not isinstance(cache_control, dict):
+                continue
+                
+            if cache_control.get("type") != "ephemeral":
+                continue
+                
+            ttl = cache_control.get("ttl")
+            if ttl and _is_valid_ttl_format(ttl):
+                return str(ttl)
+    
+    return None
+
+
+def _is_valid_ttl_format(ttl: str) -> bool:
+    """
+    Validate TTL format. Should be a string ending with 's' for seconds.
+    Examples: "3600s", "7200s", "1.5s"
+    
+    Args:
+        ttl: TTL string to validate
+        
+    Returns:
+        bool: True if valid format, False otherwise
+    """
+    if not isinstance(ttl, str):
+        return False
+    
+    # TTL should end with 's' and contain a valid number before it
+    pattern = r'^([0-9]*\.?[0-9]+)s$'
+    match = re.match(pattern, ttl)
+    
+    if not match:
+        return False
+    
+    try:
+        # Ensure the numeric part is valid and positive
+        numeric_part = float(match.group(1))
+        return numeric_part > 0
+    except ValueError:
+        return False
 
 
 def separate_cached_messages(
@@ -90,6 +157,9 @@ def separate_cached_messages(
 def transform_openai_messages_to_gemini_context_caching(
     model: str, messages: List[AllMessageValues], cache_key: str
 ) -> CachedContentRequestBody:
+    # Extract TTL from cached messages BEFORE system message transformation
+    ttl = extract_ttl_from_cached_messages(messages)
+    
     supports_system_message = get_supports_system_message(
         model=model, custom_llm_provider="gemini"
     )
@@ -99,11 +169,17 @@ def transform_openai_messages_to_gemini_context_caching(
     )
 
     transformed_messages = _gemini_convert_messages_with_history(messages=new_messages)
+    
     data = CachedContentRequestBody(
         contents=transformed_messages,
         model="models/{}".format(model),
         displayName=cache_key,
     )
+    
+    # Add TTL if present and valid
+    if ttl:
+        data["ttl"] = ttl
+    
     if transformed_system_messages is not None:
         data["system_instruction"] = transformed_system_messages
 

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_context_caching_ttl.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_context_caching_ttl.py
@@ -1,0 +1,360 @@
+import pytest
+from litellm.llms.vertex_ai.context_caching.transformation import (
+    extract_ttl_from_cached_messages,
+    _is_valid_ttl_format,
+    transform_openai_messages_to_gemini_context_caching,
+)
+
+
+class TestTTLValidation:
+    """Test TTL format validation"""
+    
+    def test_valid_ttl_formats(self):
+        """Test various valid TTL formats"""
+        valid_ttls = [
+            "3600s",
+            "1s", 
+            "7200s",
+            "1.5s",
+            "0.1s",
+            "86400s",
+            "123.456s"
+        ]
+        
+        for ttl in valid_ttls:
+            assert _is_valid_ttl_format(ttl), f"TTL {ttl} should be valid"
+    
+    def test_invalid_ttl_formats(self):
+        """Test various invalid TTL formats"""
+        invalid_ttls = [
+            "3600",  # missing 's'
+            "s",     # missing number
+            "-1s",   # negative number
+            "0s",    # zero
+            "3600m", # wrong unit
+            "abc.s", # invalid number
+            "",      # empty string
+            "3600.s", # invalid decimal
+            "3600 s", # space
+            "3600ss", # extra 's'
+            None,    # None
+            123,     # not a string
+        ]
+        
+        for ttl in invalid_ttls:
+            assert not _is_valid_ttl_format(ttl), f"TTL {ttl} should be invalid"
+
+
+class TestTTLExtraction:
+    """Test TTL extraction from cached messages"""
+    
+    def test_extract_ttl_from_single_message(self):
+        """Test extracting TTL from a single cached message"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "This is cached content",
+                        "cache_control": {"type": "ephemeral", "ttl": "3600s"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl == "3600s"
+    
+    def test_extract_ttl_from_multiple_messages(self):
+        """Test extracting TTL from multiple cached messages (should return first valid one)"""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text", 
+                        "text": "System message",
+                        "cache_control": {"type": "ephemeral", "ttl": "7200s"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "User message", 
+                        "cache_control": {"type": "ephemeral", "ttl": "3600s"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl == "7200s"  # Should return the first valid TTL found
+    
+    def test_extract_ttl_no_cache_control(self):
+        """Test extracting TTL from messages without cache_control"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Regular message without cache control"
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_extract_ttl_invalid_format(self):
+        """Test extracting TTL with invalid format"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content with invalid TTL",
+                        "cache_control": {"type": "ephemeral", "ttl": "invalid"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_extract_ttl_missing_ttl_field(self):
+        """Test extracting TTL when ttl field is missing"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content without TTL field",
+                        "cache_control": {"type": "ephemeral"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_extract_ttl_mixed_valid_invalid(self):
+        """Test extracting TTL when some messages have valid TTL and others don't"""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "System message with invalid TTL", 
+                        "cache_control": {"type": "ephemeral", "ttl": "invalid"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "User message with valid TTL",
+                        "cache_control": {"type": "ephemeral", "ttl": "3600s"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl == "3600s"  # Should return the first valid TTL found
+    
+    def test_extract_ttl_string_content(self):
+        """Test extracting TTL when message content is a string (not a list)"""
+        messages = [
+            {
+                "role": "user",
+                "content": "String content"
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+
+
+class TestTransformationWithTTL:
+    """Test the complete transformation with TTL support"""
+    
+    def test_transform_with_valid_ttl(self):
+        """Test transformation includes TTL when provided"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content",
+                        "cache_control": {"type": "ephemeral", "ttl": "3600s"}
+                    }
+                ]
+            }
+        ]
+        
+        result = transform_openai_messages_to_gemini_context_caching(
+            model="gemini-1.5-pro",
+            messages=messages,
+            cache_key="test-cache-key"
+        )
+        
+        assert "ttl" in result
+        assert result["ttl"] == "3600s"
+        assert result["model"] == "models/gemini-1.5-pro"
+        assert result["displayName"] == "test-cache-key"
+    
+    def test_transform_without_ttl(self):
+        """Test transformation without TTL"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content",
+                        "cache_control": {"type": "ephemeral"}
+                    }
+                ]
+            }
+        ]
+        
+        result = transform_openai_messages_to_gemini_context_caching(
+            model="gemini-1.5-pro", 
+            messages=messages,
+            cache_key="test-cache-key"
+        )
+        
+        assert "ttl" not in result
+        assert result["model"] == "models/gemini-1.5-pro"
+        assert result["displayName"] == "test-cache-key"
+    
+    def test_transform_with_invalid_ttl(self):
+        """Test transformation with invalid TTL (should be ignored)"""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content",
+                        "cache_control": {"type": "ephemeral", "ttl": "invalid"}
+                    }
+                ]
+            }
+        ]
+        
+        result = transform_openai_messages_to_gemini_context_caching(
+            model="gemini-1.5-pro",
+            messages=messages, 
+            cache_key="test-cache-key"
+        )
+        
+        assert "ttl" not in result
+        assert result["model"] == "models/gemini-1.5-pro"
+        assert result["displayName"] == "test-cache-key"
+    
+    def test_transform_with_system_message_and_ttl(self):
+        """Test transformation with system message and TTL"""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "System instruction",
+                        "cache_control": {"type": "ephemeral", "ttl": "7200s"}
+                    }
+                ]
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "User message"
+                    }
+                ]
+            }
+        ]
+        
+        result = transform_openai_messages_to_gemini_context_caching(
+            model="gemini-1.5-pro",
+            messages=messages,
+            cache_key="test-cache-key"
+        )
+        
+        assert "ttl" in result
+        assert result["ttl"] == "7200s"
+        assert "system_instruction" in result
+        assert result["model"] == "models/gemini-1.5-pro"
+        assert result["displayName"] == "test-cache-key"
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions"""
+    
+    def test_ttl_extraction_empty_messages(self):
+        """Test TTL extraction with empty message list"""
+        messages = []
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_ttl_extraction_none_content(self):
+        """Test TTL extraction when content is None"""
+        messages = [
+            {
+                "role": "user",
+                "content": None
+            }
+        ]
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_ttl_extraction_empty_content_list(self):
+        """Test TTL extraction when content list is empty"""
+        messages = [
+            {
+                "role": "user", 
+                "content": []
+            }
+        ]
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert ttl is None
+    
+    def test_ttl_validation_type_conversion(self):
+        """Test TTL validation handles type conversion properly"""
+        # Test that numeric TTL gets converted to string
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Cached content",
+                        "cache_control": {"type": "ephemeral", "ttl": "3600s"}
+                    }
+                ]
+            }
+        ]
+        
+        ttl = extract_ttl_from_cached_messages(messages)
+        assert isinstance(ttl, str)
+        assert ttl == "3600s"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"]) 


### PR DESCRIPTION
## Summary
This PR adds custom Time-To-Live (TTL) support for Gemini context caching, allowing users to specify cache expiration times using the `ttl` parameter in `cache_control`.

## Title

feat(gemini): Add custom TTL support for context caching (#9810)

## Relevant issues

Fixes #9810

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- **✅ Core Feature**: Added `ttl` parameter support to `cache_control` for Gemini models
- **✅ TTL Format**: Supports Google's TTL format (e.g., `"3600s"`, `"7200s"`, `"1.5s"`)
- **✅ Robust Validation**: Implements comprehensive TTL format validation with error handling
- **✅ Smart Extraction**: Extracts TTL before system message transformation to handle all edge cases
- **✅ Backward Compatibility**: Existing `cache_control` usage continues to work unchanged
- **✅ Documentation**: Updated Gemini provider docs with TTL usage examples

### Usage Example
```python
from litellm import completion

resp = completion(
    model="gemini/gemini-1.5-pro",
    messages=[{
        "role": "system",
        "content": [{
            "type": "text",
            "text": "Long system prompt...",
            "cache_control": {
                "type": "ephemeral",
                "ttl": "7200s"  # Cache for 2 hours
            }
        }]
    }]
)
```


### Testing
- **✅ Comprehensive Test Suite**: Added 17 new test cases covering all scenarios
- **✅ Edge Cases**: Tests validation, error handling, system messages, and mixed scenarios  
- **✅ Integration**: All 31 tests in context caching directory pass

## 📸 **Test Results Screenshot:**

<img width="1919" height="924" alt="Screenshot from 2025-07-12 08-14-14" src="https://github.com/user-attachments/assets/1fcc872a-4345-4bda-8245-1476ab3cb034" />

NOTE: The following test currently fails, but doesn't seem related to this PR: `tests/test_litellm/google_genai/test_google_genai_main.py::test_agenerate_content_stream`, it was included last week in #12224 