### PR TITLE
[MCP Gateway] access group fixes on UI for keys and teams

### DIFF
--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -103,7 +103,7 @@ export function MCPServerPermissions({
                 className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
               >
                 <span className="inline-block w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
-                {getAccessGroupDisplayName(item.value)} <span className="ml-1 text-xs text-blue-500">(access group)</span>
+                {getAccessGroupDisplayName(item.value)} <span className="ml-1 text-xs text-blue-500">(Access Group)</span>
               </div>
             )
           ))}

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -103,7 +103,7 @@ export function MCPServerPermissions({
                 className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
               >
                 <span className="inline-block w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
-                {getAccessGroupDisplayName(item.value)}
+                {getAccessGroupDisplayName(item.value)} <span className="ml-1 text-xs text-blue-500">(access group)</span>
               </div>
             )
           ))}

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -67,9 +67,15 @@ export function MCPServerPermissions({
 
   // Function to get display name for access group
   const getAccessGroupDisplayName = (group: string) => {
-    // If accessGroupNames is a list of names, just return the group string
     return group;
   };
+
+  // Merge servers and access groups into one list
+  const mergedItems = [
+    ...mcpServers.map(server => ({ type: 'server', value: server })),
+    ...mcpAccessGroups.map(group => ({ type: 'accessGroup', value: group })),
+  ];
+  const totalCount = mergedItems.length;
 
   return (
     <div className="space-y-3">
@@ -77,49 +83,35 @@ export function MCPServerPermissions({
         <ServerIcon className="h-4 w-4 text-green-600" />
         <Text className="font-semibold text-gray-900">MCP Servers</Text>
         <Badge color="green" size="xs">
-          {mcpServers.length}
+          {totalCount}
         </Badge>
       </div>
-      {mcpServers.length > 0 ? (
+      {totalCount > 0 ? (
         <div className="flex flex-wrap gap-2">
-          {mcpServers.map((server, index) => (
-            <Tooltip key={index} title={`Full ID: ${server}`} placement="top">
+          {mergedItems.map((item, index) => (
+            item.type === 'server' ? (
+              <Tooltip key={index} title={`Full ID: ${item.value}`} placement="top">
+                <div
+                  className="inline-flex items-center px-3 py-1.5 rounded-lg bg-green-50 border border-green-200 text-green-800 text-sm font-medium cursor-help"
+                >
+                  {getMCPServerDisplayName(item.value)}
+                </div>
+              </Tooltip>
+            ) : (
               <div
-                className="inline-flex items-center px-3 py-1.5 rounded-lg bg-green-50 border border-green-200 text-green-800 text-sm font-medium cursor-help"
+                key={index}
+                className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
               >
-                {getMCPServerDisplayName(server)}
+                <span className="inline-block w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
+                {getAccessGroupDisplayName(item.value)}
               </div>
-            </Tooltip>
+            )
           ))}
         </div>
       ) : (
         <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
           <ServerIcon className="h-4 w-4 text-gray-400" />
-          <Text className="text-gray-500 text-sm">No MCP servers configured</Text>
-        </div>
-      )}
-      <div className="flex items-center gap-2 mt-4">
-        <ServerIcon className="h-4 w-4 text-blue-600" />
-        <Text className="font-semibold text-gray-900">MCP Access Groups</Text>
-        <Badge color="blue" size="xs">
-          {mcpAccessGroups.length}
-        </Badge>
-      </div>
-      {mcpAccessGroups.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {mcpAccessGroups.map((group, index) => (
-            <div
-              key={index}
-              className="inline-flex items-center px-3 py-1.5 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm font-medium"
-            >
-              {getAccessGroupDisplayName(group)}
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 border border-gray-200">
-          <ServerIcon className="h-4 w-4 text-gray-400" />
-          <Text className="text-gray-500 text-sm">No MCP access groups configured</Text>
+          <Text className="text-gray-500 text-sm">No MCP servers or access groups configured</Text>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Title

Merge MCP servers and access groups in the same tab in keys and teams view 

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

<img width="1512" height="378" alt="Screenshot 2025-07-12 at 12 53 37 PM" src="https://github.com/user-attachments/assets/43df99d3-1d90-44e0-ab83-ece7d74a5961" />
<img width="859" height="385" alt="Screenshot 2025-07-12 at 12 53 11 PM" src="https://github.com/user-attachments/assets/6c5fe1bb-90bd-4e76-a8fd-fd9a9a76aa39" />





