### PR TITLE
fix: handle missing 'env' attribute in MCP server Prisma model

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -160,7 +160,9 @@ class MCPServerManager:
             _mcp_info: MCPInfo = mcp_server.mcp_info or {}
             
             # Use helper to deserialize environment dictionary
-            env_dict = _deserialize_env_dict(mcp_server.env)
+            # Safely access env field which may not exist on Prisma model objects
+            env_data = getattr(mcp_server, 'env', None)
+            env_dict = _deserialize_env_dict(env_data)
             
             new_server = MCPServer(
                 server_id=mcp_server.server_id,


### PR DESCRIPTION
## Title

fix: handle missing 'env' attribute in MCP server Prisma model

## Relevant issues

Fixes AttributeError when starting proxy with MCP servers: `'LiteLLM_MCPServerTable' object has no attribute 'env'`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Modified `mcp_server_manager.py` to use `getattr()` with a default value when accessing `mcp_server.env`
- This prevents `AttributeError` when Prisma doesn't include null/undefined fields in the returned model object
- The issue was reported on Slack where users were getting startup errors with the message: `'LiteLLM_MCPServerTable' object has no attribute 'env'`

### Technical Details

When Prisma fetches records from the database, it may not include fields that are null or undefined in the returned object. The `env` field in the `LiteLLM_MCPServerTable` schema is defined as optional (`Json?` with default `{}`), which can lead to the field being absent from the Prisma model object.

The fix safely accesses the field using:
```python
env_data = getattr(mcp_server, 'env', None)
env_dict = _deserialize_env_dict(env_data)
```

This ensures that if the `env` attribute doesn't exist, we get `None` instead of an `AttributeError`.