### PR TITLE
Remove from logs the request to health/liveness and readiness

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -665,6 +665,12 @@ app = FastAPI(
     lifespan=proxy_startup_event,
 )
 
+class ExcludePathsFilter(logging.Filter):
+    def filter(self, record):
+        msg = record.getMessage()
+        return not any(path in msg for path in ["/health/liveliness", "/health/readiness"])
+
+logging.getLogger("uvicorn.access").addFilter(ExcludePathsFilter())
 
 ### CUSTOM API DOCS [ENTERPRISE FEATURE] ###
 # Custom OpenAPI schema generator to include only selected routes


### PR DESCRIPTION
## Title
If you use litellm with kubernetes you can get a log full of the various requests to those 2 endpoints, as those happens like every few seconds the logs became useless and very big.
With this solution we are not adding them in the logs.

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes


