### PR TITLE
feat: Add envVars and extraEnvVars support to Helm migrations job

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -49,6 +49,15 @@ spec:
             {{- end }}
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
+            {{- if .Values.envVars }}
+            {{- range $key, $val := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -1,0 +1,113 @@
+suite: test migrations job
+templates:
+  - migrations-job.yaml
+tests:
+  - it: should work with envVars
+    template: migrations-job.yaml
+    set:
+      envVars:
+        TEST_ENV_VAR: "test_value"
+        ANOTHER_VAR: "another_value"
+      migrationJob:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEST_ENV_VAR
+            value: "test_value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ANOTHER_VAR
+            value: "another_value"
+
+  - it: should work with extraEnvVars
+    template: migrations-job.yaml
+    set:
+      extraEnvVars:
+        - name: EXTRA_ENV_VAR
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['env']
+        - name: SIMPLE_EXTRA_VAR
+          value: "simple_value"
+      migrationJob:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ENV_VAR
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['env']
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIMPLE_EXTRA_VAR
+            value: "simple_value"
+
+  - it: should work with both envVars and extraEnvVars
+    template: migrations-job.yaml
+    set:
+      envVars:
+        ENV_VAR: "env_var_value"
+      extraEnvVars:
+        - name: EXTRA_ENV_VAR
+          value: "extra_env_var_value"
+      migrationJob:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENV_VAR
+            value: "env_var_value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ENV_VAR
+            value: "extra_env_var_value"
+
+  - it: should not render when migrations job is disabled
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should still include default env vars
+    template: migrations-job.yaml
+    set:
+      envVars:
+        CUSTOM_VAR: "custom_value"
+      migrationJob:
+        enabled: true
+      db:
+        useExisting: true
+        endpoint: "test-db"
+        database: "testdb"
+        url: "postgresql://user:pass@test-db:5432/testdb"
+        secret:
+          name: "test-secret"
+          usernameKey: "username"
+          passwordKey: "password"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_SCHEMA_UPDATE
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: "test-db"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CUSTOM_VAR
+            value: "custom_value"


### PR DESCRIPTION
This PR adds support for envVars and extraEnvVars configuration to the Helm chart migrations job template. 

Changes:
- Add envVars support (simple key-value pairs)
- Add extraEnvVars support (complex environment variable configurations) 
- Include comprehensive test coverage
- Maintain backward compatibility with existing configurations

Testing includes verification of both simple and complex environment variable configurations, combinations of both, and proper handling when migrations job is disabled.