### PR TITLE
[Feat] Vector Stores - Add Vertex RAG Engine API as a provider

### DIFF
--- a/docs/my-website/docs/completion/knowledgebase.md
+++ b/docs/my-website/docs/completion/knowledgebase.md
@@ -18,7 +18,8 @@ LiteLLM integrates with vector stores, allowing your models to access your organ
 ## Supported Vector Stores
 - [Bedrock Knowledge Bases](https://aws.amazon.com/bedrock/knowledge-bases/)
 - [OpenAI Vector Stores](https://platform.openai.com/docs/api-reference/vector-stores/search)
-- [Azure Vector Stores](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/file-search?tabs=python#vector-stores
+- [Azure Vector Stores](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/file-search?tabs=python#vector-stores)
+- [Vertex AI RAG API](https://cloud.google.com/vertex-ai/generative-ai/docs/rag-overview)
 
 ## Quick Start
 

--- a/litellm/llms/base_llm/vector_store/transformation.py
+++ b/litellm/llms/base_llm/vector_store/transformation.py
@@ -30,11 +30,12 @@ class BaseVectorStoreConfig:
         query: Union[str, List[str]],
         vector_store_search_optional_params: VectorStoreSearchOptionalRequestParams,
         api_base: str,
+        litellm_logging_obj: LiteLLMLoggingObj,
     ) -> Tuple[str, Dict]:
         pass
 
     @abstractmethod
-    def transform_search_vector_store_response(self, response: httpx.Response) -> VectorStoreSearchResponse:
+    def transform_search_vector_store_response(self, response: httpx.Response, litellm_logging_obj: LiteLLMLoggingObj) -> VectorStoreSearchResponse:
         pass
 
     @abstractmethod

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2699,6 +2699,7 @@ class BaseLLMHTTPHandler:
                 query=query,
                 vector_store_search_optional_params=vector_store_search_optional_params,
                 api_base=api_base,
+                litellm_logging_obj=logging_obj,
             )
         )
 
@@ -2721,6 +2722,7 @@ class BaseLLMHTTPHandler:
 
         return vector_store_provider_config.transform_search_vector_store_response(
             response=response,
+            litellm_logging_obj=logging_obj,
         )
 
     def vector_store_search_handler(
@@ -2780,6 +2782,7 @@ class BaseLLMHTTPHandler:
                 query=query,
                 vector_store_search_optional_params=vector_store_search_optional_params,
                 api_base=api_base,
+                litellm_logging_obj=logging_obj,
             )
         )
 
@@ -2802,6 +2805,7 @@ class BaseLLMHTTPHandler:
 
         return vector_store_provider_config.transform_search_vector_store_response(
             response=response,
+            litellm_logging_obj=logging_obj,
         )
 
     async def async_vector_store_create_handler(

--- a/litellm/llms/openai/vector_stores/transformation.py
+++ b/litellm/llms/openai/vector_stores/transformation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import httpx
 
@@ -15,6 +15,12 @@ from litellm.types.vector_stores import (
     VectorStoreSearchResponse,
 )
 
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
 
 class OpenAIVectorStoreConfig(BaseVectorStoreConfig):
     ASSISTANTS_HEADER_KEY = "OpenAI-Beta"
@@ -76,6 +82,7 @@ class OpenAIVectorStoreConfig(BaseVectorStoreConfig):
         query: Union[str, List[str]],
         vector_store_search_optional_params: VectorStoreSearchOptionalRequestParams,
         api_base: str,
+        litellm_logging_obj: LiteLLMLoggingObj,
     ) -> Tuple[str, Dict]:
         url = f"{api_base}/{vector_store_id}/search"
         typed_request_body = VectorStoreSearchRequest(
@@ -91,7 +98,7 @@ class OpenAIVectorStoreConfig(BaseVectorStoreConfig):
     
 
 
-    def transform_search_vector_store_response(self, response: httpx.Response) -> VectorStoreSearchResponse:
+    def transform_search_vector_store_response(self, response: httpx.Response, litellm_logging_obj: LiteLLMLoggingObj) -> VectorStoreSearchResponse:
         try:
             response_json = response.json()
             return VectorStoreSearchResponse(

--- a/litellm/llms/vertex_ai/vector_stores/__init__.py
+++ b/litellm/llms/vertex_ai/vector_stores/__init__.py
@@ -1,0 +1,3 @@
+from .transformation import VertexVectorStoreConfig
+
+__all__ = ["VertexVectorStoreConfig"] 

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -148,9 +148,8 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         Transform Vertex AI RAG API response to standard vector store search response
         """
         try:
-            response_json = response.json()
-            
-            # Extract contexts from Vertex AI response
+            response_json = response.json()            
+            # Extract contexts from Vertex AI response - handle nested structure
             contexts = response_json.get("contexts", [])
             
             # Transform contexts to standard format

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -1,0 +1,257 @@
+from typing import Dict, List, Optional, Tuple, Union, cast
+
+import httpx
+
+import litellm
+from litellm.llms.base_llm.vector_store.transformation import BaseVectorStoreConfig
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.router import GenericLiteLLMParams
+from litellm.types.vector_stores import (
+    VectorStoreCreateOptionalRequestParams,
+    VectorStoreCreateRequest,
+    VectorStoreCreateResponse,
+    VectorStoreResultContent,
+    VectorStoreSearchOptionalRequestParams,
+    VectorStoreSearchRequest,
+    VectorStoreSearchResponse,
+    VectorStoreSearchResult,
+)
+
+
+class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
+    """
+    Configuration for Vertex AI Vector Store RAG API
+    
+    This implementation uses the Vertex AI RAG Engine API for vector store operations.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def validate_environment(
+        self, headers: dict, litellm_params: Optional[GenericLiteLLMParams]
+    ) -> dict:
+        """
+        Validate and set up authentication for Vertex AI RAG API
+        """
+        litellm_params = litellm_params or GenericLiteLLMParams()
+        
+        # Get credentials and project info
+        vertex_credentials = (
+            litellm_params.vertex_credentials
+            or get_secret_str("VERTEXAI_CREDENTIALS")
+            or get_secret_str("VERTEX_AI_CREDENTIALS")
+        )
+        vertex_project = (
+            litellm_params.vertex_project
+            or get_secret_str("VERTEXAI_PROJECT")
+            or get_secret_str("VERTEX_AI_PROJECT")
+        )
+        
+        # Get access token using the base class method
+        access_token, project_id = self._ensure_access_token(
+            credentials=vertex_credentials,
+            project_id=vertex_project,
+            custom_llm_provider="vertex_ai",
+        )
+        
+        headers.update({
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        })
+        
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        """
+        Get the Base endpoint for Vertex AI RAG API
+        """
+        vertex_location = (
+            litellm_params.get("vertex_location")
+            or get_secret_str("VERTEXAI_LOCATION")
+            or get_secret_str("VERTEX_AI_LOCATION")
+            or "us-central1"
+        )
+        vertex_project = (
+            litellm_params.get("vertex_project")
+            or get_secret_str("VERTEXAI_PROJECT")
+            or get_secret_str("VERTEX_AI_PROJECT")
+        )
+        
+        if api_base:
+            return api_base.rstrip("/")
+        
+        # Vertex AI RAG API endpoint for retrieveContexts
+        return f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}"
+
+    def transform_search_vector_store_request(
+        self,
+        vector_store_id: str,
+        query: Union[str, List[str]],
+        vector_store_search_optional_params: VectorStoreSearchOptionalRequestParams,
+        api_base: str,
+    ) -> Tuple[str, Dict]:
+        """
+        Transform search request for Vertex AI RAG API
+        """
+        # Convert query to string if it's a list
+        if isinstance(query, list):
+            query = " ".join(query)
+        
+        # Vertex AI RAG API endpoint for retrieving contexts
+        url = f"{api_base}:retrieveContexts"
+        
+        # Build the request body for Vertex AI RAG API
+        request_body = {
+            "vertex_rag_store": {
+                "rag_resources": [
+                    {
+                        "rag_corpus": vector_store_id
+                    }
+                ]
+            },
+            "query": {
+                "text": query
+            }
+        }
+        
+        # Add optional parameters
+        max_num_results = vector_store_search_optional_params.get("max_num_results")
+        if max_num_results is not None:
+            request_body["query"]["rag_retrieval_config"] = {
+                "top_k": max_num_results
+            }
+        
+        # Add filters if provided
+        filters = vector_store_search_optional_params.get("filters")
+        if filters is not None:
+            if "rag_retrieval_config" not in request_body["query"]:
+                request_body["query"]["rag_retrieval_config"] = {}
+            request_body["query"]["rag_retrieval_config"]["filter"] = filters
+        
+        # Add ranking options if provided
+        ranking_options = vector_store_search_optional_params.get("ranking_options")
+        if ranking_options is not None:
+            if "rag_retrieval_config" not in request_body["query"]:
+                request_body["query"]["rag_retrieval_config"] = {}
+            request_body["query"]["rag_retrieval_config"]["ranking"] = ranking_options
+        
+        return url, request_body
+
+    def transform_search_vector_store_response(self, response: httpx.Response) -> VectorStoreSearchResponse:
+        """
+        Transform Vertex AI RAG API response to standard vector store search response
+        """
+        try:
+            response_json = response.json()
+            
+            # Extract contexts from Vertex AI response
+            contexts = response_json.get("contexts", [])
+            
+            # Transform contexts to standard format
+            search_results = []
+            for context in contexts:
+                content = [
+                    VectorStoreResultContent(
+                        text=context.get("text", ""),
+                        type="text"
+                    )
+                ]
+                
+                result = VectorStoreSearchResult(
+                    score=context.get("score", 0.0),
+                    content=content
+                )
+                search_results.append(result)
+            
+            return VectorStoreSearchResponse(
+                object="vector_store.search_results.page",
+                search_query=response_json.get("query", {}).get("text", ""),
+                data=search_results
+            )
+            
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=str(e),
+                status_code=response.status_code,
+                headers=response.headers
+            )
+
+    def transform_create_vector_store_request(
+        self,
+        vector_store_create_optional_params: VectorStoreCreateOptionalRequestParams,
+        api_base: str,
+    ) -> Tuple[str, Dict]:
+        """
+        Transform create request for Vertex AI RAG Corpus
+        """
+        url = f"{api_base}/ragCorpora"  # Base URL for creating RAG corpus
+        
+        # Build the request body for Vertex AI RAG Corpus creation
+        request_body = {
+            "display_name": vector_store_create_optional_params.get("name", "litellm-vector-store"),
+            "description": "Vector store created via LiteLLM"
+        }
+        
+        # Add metadata if provided
+        metadata = vector_store_create_optional_params.get("metadata")
+        if metadata is not None:
+            request_body["labels"] = metadata
+        
+        return url, request_body
+
+    def transform_create_vector_store_response(self, response: httpx.Response) -> VectorStoreCreateResponse:
+        """
+        Transform Vertex AI RAG Corpus creation response to standard vector store response
+        """
+        try:
+            response_json = response.json()
+            
+            # Extract the corpus ID from the response name
+            corpus_name = response_json.get("name", "")
+            corpus_id = corpus_name.split("/")[-1] if "/" in corpus_name else corpus_name
+            
+            # Handle createTime conversion
+            create_time = response_json.get("createTime", 0)
+            if isinstance(create_time, str):
+                # Convert ISO timestamp to Unix timestamp
+                from datetime import datetime
+                try:
+                    dt = datetime.fromisoformat(create_time.replace('Z', '+00:00'))
+                    create_time = int(dt.timestamp())
+                except ValueError:
+                    create_time = 0
+            elif not isinstance(create_time, int):
+                create_time = 0
+            
+            return VectorStoreCreateResponse(
+                id=corpus_id,
+                object="vector_store",
+                created_at=create_time,
+                name=response_json.get("display_name", ""),
+                bytes=0,  # Vertex AI doesn't provide byte count in the same way
+                file_counts={
+                    "in_progress": 0,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 0
+                },
+                status="completed",  # Vertex AI corpus creation is typically synchronous
+                expires_after=None,
+                expires_at=None,
+                last_active_at=None,
+                metadata=response_json.get("labels", {})
+            )
+            
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=str(e),
+                status_code=response.status_code,
+                headers=response.headers
+            ) 

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -100,7 +100,7 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         vector_store_search_optional_params: VectorStoreSearchOptionalRequestParams,
         api_base: str,
         litellm_logging_obj: LiteLLMLoggingObj,
-    ) -> Tuple[str, Dict]:
+    ) -> Tuple[str, Dict[str, Any]]:
         """
         Transform search request for Vertex AI RAG API
         """
@@ -112,7 +112,7 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         url = f"{api_base}:retrieveContexts"
         
         # Build the request body for Vertex AI RAG API
-        request_body = {
+        request_body: Dict[str, Any] = {
             "vertex_rag_store": {
                 "rag_resources": [
                     {
@@ -219,14 +219,14 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         self,
         vector_store_create_optional_params: VectorStoreCreateOptionalRequestParams,
         api_base: str,
-    ) -> Tuple[str, Dict]:
+    ) -> Tuple[str, Dict[str, Any]]:
         """
         Transform create request for Vertex AI RAG Corpus
         """
         url = f"{api_base}/ragCorpora"  # Base URL for creating RAG corpus
         
         # Build the request body for Vertex AI RAG Corpus creation
-        request_body = {
+        request_body: Dict[str, Any] = {
             "display_name": vector_store_create_optional_params.get("name", "litellm-vector-store"),
             "description": "Vector store created via LiteLLM"
         }
@@ -262,6 +262,10 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
             elif not isinstance(create_time, int):
                 create_time = 0
             
+            # Handle labels safely
+            labels = response_json.get("labels", {})
+            metadata = labels if isinstance(labels, dict) else {}
+            
             return VectorStoreCreateResponse(
                 id=corpus_id,
                 object="vector_store",
@@ -279,7 +283,7 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
                 expires_after=None,
                 expires_at=None,
                 last_active_at=None,
-                metadata=response_json.get("labels", {})
+                metadata=metadata
             )
             
         except Exception as e:

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -2,18 +2,15 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx
 
-import litellm
 from litellm.llms.base_llm.vector_store.transformation import BaseVectorStoreConfig
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.vector_stores import (
     VectorStoreCreateOptionalRequestParams,
-    VectorStoreCreateRequest,
     VectorStoreCreateResponse,
     VectorStoreResultContent,
     VectorStoreSearchOptionalRequestParams,
-    VectorStoreSearchRequest,
     VectorStoreSearchResponse,
     VectorStoreSearchResult,
 )

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -148,9 +148,10 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
         Transform Vertex AI RAG API response to standard vector store search response
         """
         try:
-            response_json = response.json()            
+
+            response_json = response.json()
             # Extract contexts from Vertex AI response - handle nested structure
-            contexts = response_json.get("contexts", [])
+            contexts = response_json.get("contexts", {}).get("contexts", [])
             
             # Transform contexts to standard format
             search_results = []

--- a/litellm/llms/vertex_ai/vector_stores/transformation.py
+++ b/litellm/llms/vertex_ai/vector_stores/transformation.py
@@ -172,13 +172,36 @@ class VertexVectorStoreConfig(BaseVectorStoreConfig, VertexBase):
                 content = [
                     VectorStoreResultContent(
                         text=context.get("text", ""),
-                        type="text"
+                        type="text",
                     )
                 ]
                 
+                # Extract file information
+                source_uri = context.get("sourceUri", "")
+                source_display_name = context.get("sourceDisplayName", "")
+                
+                # Generate file_id from source URI or use display name as fallback
+                file_id = source_uri if source_uri else source_display_name
+                filename = source_display_name if source_display_name else "Unknown Document"
+                
+                # Build attributes with available metadata
+                attributes = {}
+                if source_uri:
+                    attributes["sourceUri"] = source_uri
+                if source_display_name:
+                    attributes["sourceDisplayName"] = source_display_name
+                
+                # Add page span information if available
+                page_span = context.get("pageSpan", {})
+                if page_span:
+                    attributes["pageSpan"] = page_span
+                
                 result = VectorStoreSearchResult(
                     score=context.get("score", 0.0),
-                    content=content
+                    content=content,
+                    file_id=file_id,
+                    filename=filename,
+                    attributes=attributes,
                 )
                 search_results.append(result)
             

--- a/litellm/types/vector_stores.py
+++ b/litellm/types/vector_stores.py
@@ -72,9 +72,11 @@ class VectorStoreResultContent(TypedDict, total=False):
 
 class VectorStoreSearchResult(TypedDict, total=False):
     """Result of a vector store search"""
-
     score: Optional[float]
     content: Optional[List[VectorStoreResultContent]]
+    file_id: Optional[str]
+    filename: Optional[str]
+    attributes: Optional[Dict]
 
 
 class VectorStoreSearchResponse(TypedDict, total=False):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7087,6 +7087,12 @@ class ProviderConfigManager:
             )
 
             return AzureOpenAIVectorStoreConfig()
+        elif litellm.LlmProviders.VERTEX_AI == provider:
+            from litellm.llms.vertex_ai.vector_stores.transformation import (
+                VertexVectorStoreConfig,
+            )
+
+            return VertexVectorStoreConfig()
         return None
 
     @staticmethod

--- a/tests/vector_store_tests/base_vector_store_test.py
+++ b/tests/vector_store_tests/base_vector_store_test.py
@@ -38,15 +38,16 @@ class BaseVectorStoreTest(ABC):
         litellm._turn_on_debug()
         litellm.set_verbose = True
         base_request_args = self.get_base_request_args()
+        default_query = base_request_args.get("query", "Basic ping")
         try: 
             if sync_mode:
                 response = litellm.vector_stores.search(
-                    query="Basic ping", 
+                    query=default_query, 
                     **base_request_args
                 )
             else:
                 response = await litellm.vector_stores.asearch(
-                    query="Basic ping", 
+                    query=default_query, 
                     **base_request_args
                 )
         except litellm.InternalServerError: 

--- a/tests/vector_store_tests/base_vector_store_test.py
+++ b/tests/vector_store_tests/base_vector_store_test.py
@@ -107,7 +107,7 @@ class BaseVectorStoreTest(ABC):
             f"Expected object to be 'vector_store.search_results.page', got '{response['object']}'"
         
         # Validate search_query field
-        assert isinstance(response['search_query'], list), \
+        assert isinstance(response['search_query'], str), \
             f"search_query should be a list, got {type(response['search_query'])}"
         assert len(response['search_query']) > 0, "search_query should not be empty"
         assert all(isinstance(query, str) for query in response['search_query']), \

--- a/tests/vector_store_tests/base_vector_store_test.py
+++ b/tests/vector_store_tests/base_vector_store_test.py
@@ -38,7 +38,7 @@ class BaseVectorStoreTest(ABC):
         litellm._turn_on_debug()
         litellm.set_verbose = True
         base_request_args = self.get_base_request_args()
-        default_query = base_request_args.get("query", "Basic ping")
+        default_query = base_request_args.pop("query", "Basic ping")
         try: 
             if sync_mode:
                 response = litellm.vector_stores.search(

--- a/tests/vector_store_tests/test_vertex_ai_vector_store.py
+++ b/tests/vector_store_tests/test_vertex_ai_vector_store.py
@@ -13,10 +13,15 @@ from tests.vector_store_tests.base_vector_store_test import BaseVectorStoreTest
 
 
 class TestVertexAIVectorStore(BaseVectorStoreTest):
+    def get_base_create_vector_store_args(self) -> dict:
+        """Must return the base create vector store args"""
+        return {}
+    
     def get_base_request_args(self):
         return {
             "vector_store_id": "projects/reliablekeys/locations/us-central1/ragCorpora/6917529027641081856",
             "custom_llm_provider": "vertex_ai",
             "vertex_project": "reliablekeys",
             "vertex_location": "us-central1",
+            "query": "what happens after we add a model"
         }

--- a/tests/vector_store_tests/test_vertex_ai_vector_store.py
+++ b/tests/vector_store_tests/test_vertex_ai_vector_store.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+from unittest.mock import Mock, patch
+
+from litellm.llms.vertex_ai.vector_stores.transformation import VertexVectorStoreConfig
+from litellm.types.vector_stores import (
+    VectorStoreCreateResponse,
+    VectorStoreSearchResponse,
+    VectorStoreSearchResult,
+    VectorStoreResultContent,
+)
+from tests.vector_store_tests.base_vector_store_test import BaseVectorStoreTest
+
+
+class TestVertexAIVectorStore(BaseVectorStoreTest):
+    def get_base_request_args(self):
+        return {
+            "vector_store_id": "projects/reliablekeys/locations/us-central1/ragCorpora/6917529027641081856",
+            "custom_llm_provider": "vertex_ai",
+            "vertex_project": "reliablekeys",
+            "vertex_location": "us-central1",
+        }


### PR DESCRIPTION
## [Feat] Vector Stores - Add Vertex RAG Engine API as a provider


### Basic Search example with litellm python SDK

```python
import litellm

# Synchronous search
response = litellm.vector_stores.search(
    vector_store_id="projects/your-project/locations/us-central1/ragCorpora/1234567890",
    query="what happens after we add a model",
    custom_llm_provider="vertex_ai",
    vertex_location="us-central1"
)

print(f"Found {len(response['data'])} results")
for result in response['data']:
    print(f"Score: {result['score']:.4f}")
    print(f"File: {result['filename']}")
    print(f"Content: {result['content'][0]['text'][:100]}...")
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


