### PR TITLE
[Bug Fix] Add swagger docs for LiteLLM /chat/completions, /embeddings, /responses 

### DIFF
--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -16,7 +16,11 @@ from pydantic import (
 from typing_extensions import Required, TypedDict
 
 from litellm.types.integrations.slack_alerting import AlertType
-from litellm.types.llms.openai import AllMessageValues, OpenAIFileObject
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionRequest,
+    OpenAIFileObject,
+)
 from litellm.types.mcp import (
     MCPAuthType,
     MCPSpecVersion,
@@ -558,44 +562,14 @@ class LiteLLMPromptInjectionParams(LiteLLMPydanticObjectBase):
                 )
         return values
 
-
 ######### Request Class Definition ######
-class ProxyChatCompletionRequest(LiteLLMPydanticObjectBase):
-    model: str
-    messages: List[Dict[str, str]]
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    n: Optional[int] = None
-    stream: Optional[bool] = None
-    stop: Optional[List[str]] = None
-    max_tokens: Optional[int] = None
-    presence_penalty: Optional[float] = None
-    frequency_penalty: Optional[float] = None
-    logit_bias: Optional[Dict[str, float]] = None
-    user: Optional[str] = None
-    response_format: Optional[Dict[str, str]] = None
-    seed: Optional[int] = None
-    tools: Optional[List[str]] = None
-    tool_choice: Optional[str] = None
-    functions: Optional[List[str]] = None  # soon to be deprecated
-    function_call: Optional[str] = None  # soon to be deprecated
-
+class ProxyChatCompletionRequest(ChatCompletionRequest):
     # Optional LiteLLM params
-    caching: Optional[bool] = None
-    api_base: Optional[str] = None
-    api_version: Optional[str] = None
-    api_key: Optional[str] = None
-    num_retries: Optional[int] = None
-    context_window_fallback_dict: Optional[Dict[str, str]] = None
-    fallbacks: Optional[List[str]] = None
-    metadata: Optional[Dict[str, str]] = {}
-    deployment_id: Optional[str] = None
-    request_timeout: Optional[int] = None
-
-    model_config = ConfigDict(
-        extra="allow"
-    )  # allow params not defined here, these fall in litellm.completion(**kwargs)
-
+    guardrails: Optional[List[str]] 
+    caching: Optional[bool] 
+    num_retries: Optional[int] 
+    context_window_fallback_dict: Optional[Dict[str, str]] 
+    fallbacks: Optional[List[str]] 
 
 class ModelInfoDelete(LiteLLMPydanticObjectBase):
     id: str

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -122,20 +122,20 @@ class CustomOpenAPISpec:
         return openapi_schema
     
     @staticmethod
-    def customize_openapi_schema(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+    def add_llm_api_request_schema_body(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Apply all custom OpenAPI schema modifications.
+        Add LLM API request schema bodies to OpenAPI specification for documentation.
         
         Args:
             openapi_schema: The base OpenAPI schema
             
         Returns:
-            Customized OpenAPI schema
+            OpenAPI schema with added request body schemas
         """
         # Add chat completion request schema
         openapi_schema = CustomOpenAPISpec.add_chat_completion_request_schema(openapi_schema)
         
-        # Future customizations can be added here
+        # Future LLM API request schemas can be added here
         # e.g., CustomOpenAPISpec.add_embedding_request_schema(openapi_schema)
         
         return openapi_schema 

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -1,0 +1,137 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+verbose_proxy_logger = logging.getLogger("litellm.proxy.proxy_server")
+
+
+class CustomOpenAPISpec:
+    """
+    Handler for customizing OpenAPI specifications with Pydantic models
+    for documentation purposes without runtime validation.
+    """
+    
+    def __init__(self):
+        self.chat_completion_paths = [
+            "/v1/chat/completions",
+            "/chat/completions", 
+            "/engines/{model}/chat/completions",
+            "/openai/deployments/{model}/chat/completions"
+        ]
+    
+    def get_pydantic_schema(self, model_class) -> Optional[Dict[str, Any]]:
+        """
+        Get JSON schema from a Pydantic model, handling both v1 and v2 APIs.
+        
+        Args:
+            model_class: Pydantic model class
+            
+        Returns:
+            JSON schema dict or None if failed
+        """
+        try:
+            # Try Pydantic v2 method first
+            return model_class.model_json_schema()  # type: ignore
+        except AttributeError:
+            try:
+                # Fallback to Pydantic v1 method
+                return model_class.schema()  # type: ignore
+            except AttributeError:
+                # If both methods fail, return None
+                return None
+    
+    def add_schema_to_components(self, openapi_schema: Dict[str, Any], schema_name: str, schema_def: Dict[str, Any]) -> None:
+        """
+        Add a schema definition to the OpenAPI components/schemas section.
+        
+        Args:
+            openapi_schema: The OpenAPI schema dict to modify
+            schema_name: Name for the schema component
+            schema_def: The schema definition
+        """
+        # Ensure components/schemas structure exists
+        if "components" not in openapi_schema:
+            openapi_schema["components"] = {}
+        if "schemas" not in openapi_schema["components"]:
+            openapi_schema["components"]["schemas"] = {}
+        
+        # Add the schema
+        openapi_schema["components"]["schemas"][schema_name] = schema_def
+    
+    def add_request_body_to_paths(self, openapi_schema: Dict[str, Any], paths: List[str], schema_ref: str) -> None:
+        """
+        Add request body schema reference to specified paths.
+        
+        Args:
+            openapi_schema: The OpenAPI schema dict to modify
+            paths: List of paths to update
+            schema_ref: Reference to the schema component (e.g., "#/components/schemas/ModelName")
+        """
+        for path in paths:
+            if path in openapi_schema.get("paths", {}) and "post" in openapi_schema["paths"][path]:
+                openapi_schema["paths"][path]["post"]["requestBody"] = {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": schema_ref
+                            }
+                        }
+                    }
+                }
+    
+    def add_chat_completion_request_schema(self, openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Add ProxyChatCompletionRequest schema to chat completion endpoints for documentation.
+        This shows the request body in Swagger without runtime validation.
+        
+        Args:
+            openapi_schema: The OpenAPI schema dict to modify
+            
+        Returns:
+            Modified OpenAPI schema
+        """
+        try:
+            from litellm.proxy._types import ProxyChatCompletionRequest
+
+            # Get the schema for ProxyChatCompletionRequest
+            request_schema = self.get_pydantic_schema(ProxyChatCompletionRequest)
+            
+            # Only proceed if we successfully got the schema
+            if request_schema is not None:
+                # Add schema to components
+                self.add_schema_to_components(openapi_schema, "ProxyChatCompletionRequest", request_schema)
+                
+                # Add request body to chat completion endpoints
+                self.add_request_body_to_paths(
+                    openapi_schema, 
+                    self.chat_completion_paths, 
+                    "#/components/schemas/ProxyChatCompletionRequest"
+                )
+                
+                verbose_proxy_logger.debug("Successfully added ProxyChatCompletionRequest schema to OpenAPI spec")
+            else:
+                verbose_proxy_logger.debug("Could not get schema for ProxyChatCompletionRequest")
+                
+        except Exception as e:
+            # If schema addition fails, continue without it
+            verbose_proxy_logger.debug(f"Failed to add chat completion request schema: {str(e)}")
+        
+        return openapi_schema
+    
+    def customize_openapi_schema(self, openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Apply all custom OpenAPI schema modifications.
+        
+        Args:
+            openapi_schema: The base OpenAPI schema
+            
+        Returns:
+            Customized OpenAPI schema
+        """
+        # Add chat completion request schema
+        openapi_schema = self.add_chat_completion_request_schema(openapi_schema)
+        
+        # Future customizations can be added here
+        # e.g., self.add_embedding_request_schema(openapi_schema)
+        
+        return openapi_schema 

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -10,15 +10,15 @@ class CustomOpenAPISpec:
     for documentation purposes without runtime validation.
     """
     
-    def __init__(self):
-        self.chat_completion_paths = [
-            "/v1/chat/completions",
-            "/chat/completions", 
-            "/engines/{model}/chat/completions",
-            "/openai/deployments/{model}/chat/completions"
-        ]
+    CHAT_COMPLETION_PATHS = [
+        "/v1/chat/completions",
+        "/chat/completions", 
+        "/engines/{model}/chat/completions",
+        "/openai/deployments/{model}/chat/completions"
+    ]
     
-    def get_pydantic_schema(self, model_class) -> Optional[Dict[str, Any]]:
+    @staticmethod
+    def get_pydantic_schema(model_class) -> Optional[Dict[str, Any]]:
         """
         Get JSON schema from a Pydantic model, handling both v1 and v2 APIs.
         
@@ -39,7 +39,8 @@ class CustomOpenAPISpec:
                 # If both methods fail, return None
                 return None
     
-    def add_schema_to_components(self, openapi_schema: Dict[str, Any], schema_name: str, schema_def: Dict[str, Any]) -> None:
+    @staticmethod
+    def add_schema_to_components(openapi_schema: Dict[str, Any], schema_name: str, schema_def: Dict[str, Any]) -> None:
         """
         Add a schema definition to the OpenAPI components/schemas section.
         
@@ -57,7 +58,8 @@ class CustomOpenAPISpec:
         # Add the schema
         openapi_schema["components"]["schemas"][schema_name] = schema_def
     
-    def add_request_body_to_paths(self, openapi_schema: Dict[str, Any], paths: List[str], schema_ref: str) -> None:
+    @staticmethod
+    def add_request_body_to_paths(openapi_schema: Dict[str, Any], paths: List[str], schema_ref: str) -> None:
         """
         Add request body schema reference to specified paths.
         
@@ -79,7 +81,8 @@ class CustomOpenAPISpec:
                     }
                 }
     
-    def add_chat_completion_request_schema(self, openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+    @staticmethod
+    def add_chat_completion_request_schema(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
         """
         Add ProxyChatCompletionRequest schema to chat completion endpoints for documentation.
         This shows the request body in Swagger without runtime validation.
@@ -94,17 +97,17 @@ class CustomOpenAPISpec:
             from litellm.proxy._types import ProxyChatCompletionRequest
 
             # Get the schema for ProxyChatCompletionRequest
-            request_schema = self.get_pydantic_schema(ProxyChatCompletionRequest)
+            request_schema = CustomOpenAPISpec.get_pydantic_schema(ProxyChatCompletionRequest)
             
             # Only proceed if we successfully got the schema
             if request_schema is not None:
                 # Add schema to components
-                self.add_schema_to_components(openapi_schema, "ProxyChatCompletionRequest", request_schema)
+                CustomOpenAPISpec.add_schema_to_components(openapi_schema, "ProxyChatCompletionRequest", request_schema)
                 
                 # Add request body to chat completion endpoints
-                self.add_request_body_to_paths(
+                CustomOpenAPISpec.add_request_body_to_paths(
                     openapi_schema, 
-                    self.chat_completion_paths, 
+                    CustomOpenAPISpec.CHAT_COMPLETION_PATHS, 
                     "#/components/schemas/ProxyChatCompletionRequest"
                 )
                 
@@ -118,7 +121,8 @@ class CustomOpenAPISpec:
         
         return openapi_schema
     
-    def customize_openapi_schema(self, openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+    @staticmethod
+    def customize_openapi_schema(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
         """
         Apply all custom OpenAPI schema modifications.
         
@@ -129,9 +133,9 @@ class CustomOpenAPISpec:
             Customized OpenAPI schema
         """
         # Add chat completion request schema
-        openapi_schema = self.add_chat_completion_request_schema(openapi_schema)
+        openapi_schema = CustomOpenAPISpec.add_chat_completion_request_schema(openapi_schema)
         
         # Future customizations can be added here
-        # e.g., self.add_embedding_request_schema(openapi_schema)
+        # e.g., CustomOpenAPISpec.add_embedding_request_schema(openapi_schema)
         
         return openapi_schema 

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 
-verbose_proxy_logger = logging.getLogger("litellm.proxy.proxy_server")
+from litellm._logging import verbose_proxy_logger
 
 
 class CustomOpenAPISpec:

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, List, Optional, Type
 
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -735,9 +735,9 @@ def custom_openapi():
             paths_to_include[route] = openapi_schema["paths"][route]
     openapi_schema["paths"] = paths_to_include
     
-    # Apply custom OpenAPI schema modifications
+    # Add LLM API request schema bodies for documentation
     from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
-    openapi_schema = CustomOpenAPISpec.customize_openapi_schema(openapi_schema)
+    openapi_schema = CustomOpenAPISpec.add_llm_api_request_schema_body(openapi_schema)
     
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -734,6 +734,12 @@ def custom_openapi():
         if route in openapi_schema["paths"]:
             paths_to_include[route] = openapi_schema["paths"][route]
     openapi_schema["paths"] = paths_to_include
+    
+    # Apply custom OpenAPI schema modifications
+    from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
+    custom_spec = CustomOpenAPISpec()
+    openapi_schema = custom_spec.customize_openapi_schema(openapi_schema)
+    
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -737,8 +737,7 @@ def custom_openapi():
     
     # Apply custom OpenAPI schema modifications
     from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
-    custom_spec = CustomOpenAPISpec()
-    openapi_schema = custom_spec.customize_openapi_schema(openapi_schema)
+    openapi_schema = CustomOpenAPISpec.customize_openapi_schema(openapi_schema)
     
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/tests/test_litellm/proxy/common_utils/test_custom_openapi_spec.py
+++ b/tests/test_litellm/proxy/common_utils/test_custom_openapi_spec.py
@@ -1,0 +1,91 @@
+"""
+Simple unit tests for CustomOpenAPISpec class.
+
+Tests basic functionality of OpenAPI schema generation.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from litellm.proxy.common_utils.custom_openapi_spec import CustomOpenAPISpec
+
+
+class TestCustomOpenAPISpec:
+    """Test suite for CustomOpenAPISpec class."""
+
+    @pytest.fixture
+    def base_openapi_schema(self):
+        """Base OpenAPI schema for testing."""
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {
+                "/v1/chat/completions": {
+                    "post": {
+                        "summary": "Chat completions"
+                    }
+                },
+                "/v1/embeddings": {
+                    "post": {
+                        "summary": "Embeddings"
+                    }
+                },
+                "/v1/responses": {
+                    "post": {
+                        "summary": "Responses API"
+                    }
+                }
+            }
+        }
+
+    @patch('litellm.proxy.common_utils.custom_openapi_spec.CustomOpenAPISpec.add_request_schema')
+    def test_add_chat_completion_request_schema(self, mock_add_schema, base_openapi_schema):
+        """Test that chat completion schema is added correctly."""
+        mock_add_schema.return_value = base_openapi_schema
+        
+        with patch('litellm.proxy._types.ProxyChatCompletionRequest') as mock_model:
+            result = CustomOpenAPISpec.add_chat_completion_request_schema(base_openapi_schema)
+            
+            mock_add_schema.assert_called_once_with(
+                openapi_schema=base_openapi_schema,
+                model_class=mock_model,
+                schema_name="ProxyChatCompletionRequest",
+                paths=CustomOpenAPISpec.CHAT_COMPLETION_PATHS,
+                operation_name="chat completion"
+            )
+            assert result == base_openapi_schema
+
+    @patch('litellm.proxy.common_utils.custom_openapi_spec.CustomOpenAPISpec.add_request_schema')
+    def test_add_embedding_request_schema(self, mock_add_schema, base_openapi_schema):
+        """Test that embedding schema is added correctly."""
+        mock_add_schema.return_value = base_openapi_schema
+        
+        with patch('litellm.types.embedding.EmbeddingRequest') as mock_model:
+            result = CustomOpenAPISpec.add_embedding_request_schema(base_openapi_schema)
+            
+            mock_add_schema.assert_called_once_with(
+                openapi_schema=base_openapi_schema,
+                model_class=mock_model,
+                schema_name="EmbeddingRequest",
+                paths=CustomOpenAPISpec.EMBEDDING_PATHS,
+                operation_name="embedding"
+            )
+            assert result == base_openapi_schema
+
+    @patch('litellm.proxy.common_utils.custom_openapi_spec.CustomOpenAPISpec.add_request_schema')
+    def test_add_responses_api_request_schema(self, mock_add_schema, base_openapi_schema):
+        """Test that responses API schema is added correctly."""
+        mock_add_schema.return_value = base_openapi_schema
+        
+        with patch('litellm.types.llms.openai.ResponsesAPIRequestParams') as mock_model:
+            result = CustomOpenAPISpec.add_responses_api_request_schema(base_openapi_schema)
+            
+            mock_add_schema.assert_called_once_with(
+                openapi_schema=base_openapi_schema,
+                model_class=mock_model,
+                schema_name="ResponsesAPIRequestParams",
+                paths=CustomOpenAPISpec.RESPONSES_API_PATHS,
+                operation_name="responses API"
+            )
+            assert result == base_openapi_schema 


### PR DESCRIPTION
## [Bug Fix] Add swagger docs for LiteLLM /chat/completions

Ensure the swagger docs for /chat/completions, /embeddings and /responses works 

<img width="1280" height="494" alt="Screenshot 2025-07-15 at 12 55 15 PM" src="https://github.com/user-attachments/assets/9aaa32ad-fc5d-4055-bd6a-0eac4bda5ba2" />

<img width="1258" height="446" alt="Screenshot 2025-07-15 at 12 53 48 PM" src="https://github.com/user-attachments/assets/cc705d47-f255-4f52-8088-f88ff8b17877" />




<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test

## Changes


