### PR TITLE
Fix bedrock nova micro and lite info

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11299,7 +11299,7 @@
     },
     "amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.5e-08,
         "output_cost_per_token": 1.4e-07,
@@ -11311,7 +11311,7 @@
     },
     "us.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.5e-08,
         "output_cost_per_token": 1.4e-07,
@@ -11323,7 +11323,7 @@
     },
     "eu.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 4.6e-08,
         "output_cost_per_token": 1.84e-07,
@@ -11335,7 +11335,7 @@
     },
     "amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.4e-07,
@@ -11349,7 +11349,7 @@
     },
     "us.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.4e-07,
@@ -11363,7 +11363,7 @@
     },
     "eu.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 7.8e-08,
         "output_cost_per_token": 3.12e-07,
@@ -11426,7 +11426,7 @@
     },
     "apac.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.7e-08,
         "output_cost_per_token": 1.48e-07,
@@ -11438,7 +11438,7 @@
     },
     "apac.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6.3e-08,
         "output_cost_per_token": 2.52e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11299,7 +11299,7 @@
     },
     "amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.5e-08,
         "output_cost_per_token": 1.4e-07,
@@ -11311,7 +11311,7 @@
     },
     "us.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.5e-08,
         "output_cost_per_token": 1.4e-07,
@@ -11323,7 +11323,7 @@
     },
     "eu.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 4.6e-08,
         "output_cost_per_token": 1.84e-07,
@@ -11335,7 +11335,7 @@
     },
     "amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.4e-07,
@@ -11349,7 +11349,7 @@
     },
     "us.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.4e-07,
@@ -11363,7 +11363,7 @@
     },
     "eu.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 7.8e-08,
         "output_cost_per_token": 3.12e-07,
@@ -11426,7 +11426,7 @@
     },
     "apac.amazon.nova-micro-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 300000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 3.7e-08,
         "output_cost_per_token": 1.48e-07,
@@ -11438,7 +11438,7 @@
     },
     "apac.amazon.nova-lite-v1:0": {
         "max_tokens": 10000,
-        "max_input_tokens": 128000,
+        "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "input_cost_per_token": 6.3e-08,
         "output_cost_per_token": 2.52e-07,


### PR DESCRIPTION
## Fix Bedrock Nova Micro and Lite max input tokens

Model info does not match AWS documentation, causing errors because trimming doesn't appropriately fit the true context window.
https://docs.aws.amazon.com/nova/latest/userguide/what-is-nova.html

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
Just updated the model config. No tests to add.
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
Updates model jsons


