### PR TITLE
Add pricing for C4AI Aya models and update command-nightly pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9899,10 +9899,11 @@
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
-        "input_cost_per_token": 0.000015,
-        "output_cost_per_token": 0.000015,
+        "input_cost_per_token": 0.00000015,
+        "output_cost_per_token": 0.0000006,
         "litellm_provider": "cohere",
-        "mode": "completion"
+        "mode": "completion",
+        "source": "https://cohere.com/pricing (based on Command R pricing)"
     },
     "command": {
         "max_tokens": 4096,
@@ -16155,7 +16156,8 @@
         "litellm_provider": "c4ai",
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_system_messages": true
+        "supports_system_messages": true,
+        "source": "https://cohere.com/pricing (FAQ #11: Aya Expanse models pricing)"
     },
     "c4ai-aya-expanse-32b": {
         "max_tokens": 32768,
@@ -16166,7 +16168,8 @@
         "litellm_provider": "c4ai",
         "mode": "chat",
         "supports_function_calling": true,
-        "supports_system_messages": true
+        "supports_system_messages": true,
+        "source": "https://cohere.com/pricing (FAQ #11: Aya Expanse models pricing)"
     },
     "c4ai-aya-vision-8b": {
         "max_tokens": 32768,
@@ -16178,7 +16181,8 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "source": "https://cohere.com/pricing (FAQ #11: Aya Expanse models pricing - applied to Vision models)"
     },
     "c4ai-aya-vision-32b": {
         "max_tokens": 32768,
@@ -16190,6 +16194,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_system_messages": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "source": "https://cohere.com/pricing (FAQ #11: Aya Expanse models pricing - applied to Vision models)"
     }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9899,8 +9899,8 @@
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
-        "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 2e-06,
+        "input_cost_per_token": 0.000015,
+        "output_cost_per_token": 0.000015,
         "litellm_provider": "cohere",
         "mode": "completion"
     },
@@ -16145,5 +16145,51 @@
         "supports_tool_choice": true,
         "mode": "chat",
         "source": "https://platform.moonshot.ai/docs/pricing"
+    },
+    "c4ai-aya-expanse-8b": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000015,
+        "litellm_provider": "c4ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "c4ai-aya-expanse-32b": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000015,
+        "litellm_provider": "c4ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true
+    },
+    "c4ai-aya-vision-8b": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000015,
+        "litellm_provider": "c4ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_vision": true
+    },
+    "c4ai-aya-vision-32b": {
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0000005,
+        "output_cost_per_token": 0.0000015,
+        "litellm_provider": "c4ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_vision": true
     }
 }


### PR DESCRIPTION
This PR adds pricing information for the following models:

1. C4AI Aya models:
   - c4ai-aya-expanse-8b
   - c4ai-aya-expanse-32b
   - c4ai-aya-vision-8b
   - c4ai-aya-vision-32b

   Based on official Cohere pricing (https://cohere.com/pricing - FAQ #11): $0.50/1M tokens for input and $1.50/1M tokens for output.

2. Updates the pricing for command-nightly:
   - Updated to match Command R pricing from the official Cohere pricing page: $0.15/1M tokens for input and $0.60/1M tokens for output.

This fixes the schema validation errors mentioned in the issue:
```
c4ai-aya-vision-32b: schema validation failed, 0.0 is less than or equal to the minimum of 0 in $.response_cost
command-nightly: schema validation failed, 0.0 is less than or equal to the minimum of 0 in $.response_cost
c4ai-aya-expanse-8b: schema validation failed, 0.0 is less than or equal to the minimum of 0 in $.response_cost
c4ai-aya-vision-8b: schema validation failed, 0.0 is less than or equal to the minimum of 0 in $.response_cost
c4ai-aya-expanse-32b: schema validation failed, 0.0 is less than or equal to the minimum of 0 in $.response_cost
```