### PR TITLE
rm claude instant 1 and 1.2 from model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4227,15 +4227,6 @@
         "litellm_provider": "text-completion-openai",
         "mode": "completion"
     },
-    "claude-instant-1": {
-        "max_tokens": 8191,
-        "max_input_tokens": 100000,
-        "max_output_tokens": 8191,
-        "input_cost_per_token": 1.63e-06,
-        "output_cost_per_token": 5.51e-06,
-        "litellm_provider": "anthropic",
-        "mode": "chat"
-    },
     "mistral/mistral-tiny": {
         "max_tokens": 8191,
         "max_input_tokens": 32000,
@@ -5468,16 +5459,6 @@
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true
-    },
-    "claude-instant-1.2": {
-        "max_tokens": 8191,
-        "max_input_tokens": 100000,
-        "max_output_tokens": 8191,
-        "input_cost_per_token": 1.63e-07,
-        "output_cost_per_token": 5.51e-07,
-        "litellm_provider": "anthropic",
-        "mode": "chat",
         "supports_tool_choice": true
     },
     "claude-2": {


### PR DESCRIPTION
## Title

rm claude instant 1 and 1.2 from model_prices_and_context_window.json

## Relevant issues

These models are retired per https://docs.anthropic.com/en/docs/about-claude/model-deprecations and my testing of Anthropic's endpoints, which return 404 not found for these models. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [Not Applicable] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [Not Applicable] I have added a screenshot of my new test passing locally 
- [Y] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [Y] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Removed claude 1 and 1.2 config from json.