### PR TITLE
fix(embeddings): Avoid check for openai if the api base is not the official url

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -138,6 +138,7 @@ from litellm.utils import (
     get_requester_metadata,
     get_secret,
     get_standard_openai_params,
+    is_official_llm_provider_api_base,
     mock_completion_streaming_obj,
     pre_process_non_default_params,
     read_config_args,
@@ -4450,6 +4451,13 @@ def embedding(  # noqa: PLR0915
         api_key=api_key,
     )
 
+    official_base_url = True # Keep official working if api_base is not known
+    if api_base is not None:
+        official_base_url = is_official_llm_provider_api_base(
+            custom_llm_provider=custom_llm_provider,
+            api_base=api_base,
+        )
+
     if dynamic_api_key is not None:
         api_key = dynamic_api_key
 
@@ -4459,6 +4467,7 @@ def embedding(  # noqa: PLR0915
         dimensions=dimensions,
         encoding_format=encoding_format,
         custom_llm_provider=custom_llm_provider,
+        official_base_url=official_base_url,
         **non_default_params,
     )
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2973,6 +2973,7 @@ def get_optional_params_embeddings(  # noqa: PLR0915
     custom_llm_provider="",
     drop_params: Optional[bool] = None,
     additional_drop_params: Optional[List[str]] = None,
+    official_base_url: bool = False,
     **kwargs,
 ):
     # Lazy load get_supported_openai_params
@@ -3045,6 +3046,7 @@ def get_optional_params_embeddings(  # noqa: PLR0915
 
         if (
             model is not None
+            and official_base_url
             and "text-embedding-3" not in model
             and "dimensions" in non_default_params.keys()
         ):
@@ -3299,6 +3301,30 @@ def get_optional_params_embeddings(  # noqa: PLR0915
 
     return final_params
 
+def is_official_llm_provider_api_base(
+    custom_llm_provider: str,
+    api_base: str
+) -> bool:
+    """
+    Check if the api base is the official url for the provider
+
+    Relevant Issues: https://github.com/BerriAI/litellm/issues/11940
+    """
+    default_url = get_official_api_base(custom_llm_provider=custom_llm_provider)
+    return default_url == api_base
+
+def get_official_api_base(
+    custom_llm_provider: str,
+) -> Optional[str]:
+    """
+    Get the official api base for the llm provider
+
+    Relevant Issues: https://github.com/BerriAI/litellm/issues/11940
+    """
+    if custom_llm_provider == "openai":
+        return "https://api.openai.com/v1"
+    else:
+        return None
 
 def _remove_additional_properties(schema):
     """

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -31,9 +31,11 @@ from litellm.utils import (
     function_to_dict,
     get_llm_provider,
     get_max_tokens,
+    get_official_api_base,
     get_supported_openai_params,
     get_token_count,
     get_valid_models,
+    is_official_llm_provider_api_base,
     trim_messages,
     validate_environment,
 )
@@ -2502,4 +2504,18 @@ def test_get_base_model_from_metadata():
     # Test 6: None input
     result = _get_base_model_from_metadata(None)
     assert result is None, f"Expected None for None input, got {result}"
+
+def test_get_official_api_base():
+    """
+    Get the official api base for specific custom_llm_provider
+    """
+    api_base = get_official_api_base(custom_llm_provider="openai")
+    assert api_base == "https://api.openai.com/v1"
+
+def test_is_official_llm_provider_api_base():
+    """
+    Check if given url is a official url
+    """
+    assert is_official_llm_provider_api_base(custom_llm_provider="openai", api_base="https://api.openai.com/v1/")
+    assert not is_official_llm_provider_api_base(custom_llm_provider="openai", api_base="https://api.example.com/v1/")
 


### PR DESCRIPTION
## Add possibility to adapt model compatibility checking with Official / Not official model

When we set custom model from custom API, utils use same compatibility checking as openai.

For now is a draft because i don't know if is a good approach. Free to maintainers to purpose others better solutions.

If it's okay, i can add more LLM provider urls.

## Relevant issues

Fixes: #11940

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


