### PR TITLE
fix: Handle circular references in spend tracking metadata JSON serialization

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -24,6 +24,81 @@ from litellm.types.utils import (
 from litellm.utils import get_end_user_id_for_cost_tracking
 
 
+def _safe_json_dumps(obj: Any, **kwargs) -> str:
+    """
+    Safely serialize an object to JSON, handling circular references.
+    
+    This function detects circular references and replaces them with a placeholder
+    to prevent the ValueError: Circular reference detected error.
+    """
+    def _handle_circular_refs(obj, seen=None):
+        if seen is None:
+            seen = set()
+        
+        # Get the object id to detect if we've seen this object before
+        obj_id = id(obj)
+        
+        if obj_id in seen:
+            # Circular reference detected, return a placeholder
+            return f"<circular reference to {type(obj).__name__} id={obj_id}>"
+        
+        if isinstance(obj, (str, int, float, bool, type(None))):
+            return obj
+        elif isinstance(obj, dict):
+            seen.add(obj_id)
+            try:
+                result = {k: _handle_circular_refs(v, seen.copy()) for k, v in obj.items()}
+            except:
+                result = f"<error serializing dict id={obj_id}>"
+            seen.discard(obj_id)
+            return result
+        elif isinstance(obj, (list, tuple)):
+            seen.add(obj_id)
+            try:
+                result = [_handle_circular_refs(item, seen.copy()) for item in obj]
+            except:
+                result = f"<error serializing {type(obj).__name__} id={obj_id}>"
+            seen.discard(obj_id)
+            return result
+        elif hasattr(obj, '__dict__'):
+            seen.add(obj_id)
+            try:
+                result = _handle_circular_refs(obj.__dict__, seen.copy())
+            except:
+                result = f"<error serializing {type(obj).__name__} id={obj_id}>"
+            seen.discard(obj_id)
+            return result
+        elif hasattr(obj, 'model_dump'):  # Pydantic models
+            seen.add(obj_id)
+            try:
+                result = _handle_circular_refs(obj.model_dump(), seen.copy())
+            except:
+                result = f"<error serializing pydantic model {type(obj).__name__} id={obj_id}>"
+            seen.discard(obj_id)
+            return result
+        else:
+            # For other types, try to convert to string
+            try:
+                return str(obj)
+            except:
+                return f"<non-serializable {type(obj).__name__} id={obj_id}>"
+    
+    try:
+        # First try regular json.dumps
+        return json.dumps(obj, **kwargs)
+    except ValueError as e:
+        if "circular reference" in str(e).lower():
+            # Handle circular references
+            verbose_proxy_logger.warning(
+                f"Circular reference detected in JSON serialization, using safe serialization: {e}"
+            )
+            safe_obj = _handle_circular_refs(obj)
+            return json.dumps(safe_obj, **kwargs)
+        else:
+            # Re-raise other ValueError exceptions
+            raise
+
+
 def _is_master_key(api_key: str, _master_key: Optional[str]) -> bool:
     if _master_key is None:
         return False
@@ -305,7 +380,7 @@ def get_logging_payload(  # noqa: PLR0915
             model=kwargs.get("model", "") or "",
             user=metadata.get("user_api_key_user_id", "") or "",
             team_id=metadata.get("user_api_key_team_id", "") or "",
-            metadata=json.dumps(clean_metadata),
+            metadata=_safe_json_dumps(clean_metadata),
             cache_key=cache_key,
             spend=kwargs.get("response_cost", 0),
             total_tokens=usage.get("total_tokens", standard_logging_total_tokens),

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -48,7 +48,7 @@ def _safe_json_dumps(obj: Any, **kwargs) -> str:
             seen.add(obj_id)
             try:
                 result = {k: _handle_circular_refs(v, seen.copy()) for k, v in obj.items()}
-            except:
+            except Exception:
                 result = f"<error serializing dict id={obj_id}>"
             seen.discard(obj_id)
             return result
@@ -56,7 +56,7 @@ def _safe_json_dumps(obj: Any, **kwargs) -> str:
             seen.add(obj_id)
             try:
                 result = [_handle_circular_refs(item, seen.copy()) for item in obj]
-            except:
+            except Exception:
                 result = f"<error serializing {type(obj).__name__} id={obj_id}>"
             seen.discard(obj_id)
             return result
@@ -64,7 +64,7 @@ def _safe_json_dumps(obj: Any, **kwargs) -> str:
             seen.add(obj_id)
             try:
                 result = _handle_circular_refs(obj.__dict__, seen.copy())
-            except:
+            except Exception:
                 result = f"<error serializing {type(obj).__name__} id={obj_id}>"
             seen.discard(obj_id)
             return result
@@ -72,7 +72,7 @@ def _safe_json_dumps(obj: Any, **kwargs) -> str:
             seen.add(obj_id)
             try:
                 result = _handle_circular_refs(obj.model_dump(), seen.copy())
-            except:
+            except Exception:
                 result = f"<error serializing pydantic model {type(obj).__name__} id={obj_id}>"
             seen.discard(obj_id)
             return result
@@ -80,7 +80,7 @@ def _safe_json_dumps(obj: Any, **kwargs) -> str:
             # For other types, try to convert to string
             try:
                 return str(obj)
-            except:
+            except Exception:
                 return f"<non-serializable {type(obj).__name__} id={obj_id}>"
     
     try:

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -19,6 +19,7 @@ import litellm
 from litellm.constants import REDACTED_BY_LITELM_STRING
 from litellm.proxy.spend_tracking.spend_tracking_utils import (
     _get_vector_store_request_for_spend_logs_payload,
+    _safe_json_dumps,
     _sanitize_request_body_for_spend_logs_payload,
 )
 
@@ -175,3 +176,75 @@ def test_get_vector_store_request_for_spend_logs_payload_null_input(mock_should_
     mock_should_store.return_value = False
     result = _get_vector_store_request_for_spend_logs_payload(None)
     assert result is None
+
+
+def test_safe_json_dumps_handles_circular_references():
+    """Test that _safe_json_dumps can handle circular references without raising exceptions"""
+    
+    # Create a circular reference
+    obj1 = {"name": "obj1"}
+    obj2 = {"name": "obj2", "ref": obj1}
+    obj1["ref"] = obj2  # This creates a circular reference
+    
+    # This should not raise an exception
+    result = _safe_json_dumps(obj1)
+    
+    # Should be a valid JSON string
+    assert isinstance(result, str)
+    
+    # Should contain placeholder for circular reference
+    assert "circular reference" in result
+    
+    # Should be parseable as JSON
+    parsed = json.loads(result)
+    assert parsed["name"] == "obj1"
+    assert parsed["ref"]["name"] == "obj2"
+
+
+def test_safe_json_dumps_normal_objects():
+    """Test that _safe_json_dumps works correctly with normal objects"""
+    
+    normal_obj = {
+        "string": "test",
+        "number": 42,
+        "boolean": True,
+        "null": None,
+        "list": [1, 2, 3],
+        "nested": {"key": "value"}
+    }
+    
+    result = _safe_json_dumps(normal_obj)
+    
+    # Should be identical to regular json.dumps for normal objects
+    expected = json.dumps(normal_obj)
+    assert result == expected
+
+
+def test_safe_json_dumps_complex_metadata_like_object():
+    """Test with a complex metadata-like object similar to what caused the issue"""
+    
+    # Simulate a complex metadata object
+    metadata = {
+        "user_api_key": "test-key",
+        "model": "gpt-4",
+        "usage": {"total_tokens": 100},
+        "mcp_tool_call_metadata": {
+            "name": "test_tool", 
+            "arguments": {"param": "value"}
+        }
+    }
+    
+    # Add a potential circular reference
+    usage_detail = {"parent_metadata": metadata}
+    metadata["usage"]["detail"] = usage_detail
+    
+    # This should not raise an exception
+    result = _safe_json_dumps(metadata)
+    
+    # Should be a valid JSON string
+    assert isinstance(result, str)
+    
+    # Should be parseable as JSON
+    parsed = json.loads(result)
+    assert parsed["user_api_key"] == "test-key"
+    assert parsed["model"] == "gpt-4"


### PR DESCRIPTION
## Title

fix: Handle circular references in spend tracking metadata JSON serialization

## Relevant issues

Fixes [#12634](https://github.com/BerriAI/litellm/issues/12634)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

- Added `_safe_json_dumps()` function in `spend_tracking_utils.py` to safely serialize metadata, handling circular references by replacing them with placeholders
- Replaced `json.dumps(clean_metadata)` with `_safe_json_dumps(clean_metadata)` in `get_logging_payload()`
- Added unit tests for `_safe_json_dumps()` in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py` covering circular references, normal objects, and complex metadata-like objects

### Problem
Critical circular reference error in spend tracking causing logging failures and spend errors:
- `ValueError: Circular reference detected` when logging spend data
- Requests not being logged properly in the logs menu
- Issue occurs with basic chat completions using test key menu

### Solution
Implemented safe JSON serialization that gracefully handles circular references while preserving normal functionality for all other objects.

### Test Results Screenshot
<img width="965" height="81" alt="Screenshot 2025-07-16 at 7 48 17 AM" src="https://github.com/user-attachments/assets/31dcc1f4-21ad-47b1-957e-15d665e97c17" />
