### PR TITLE
Sort models in get_complete_model_list/_get_model_group_info

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -205,7 +205,7 @@ def get_complete_model_list(
         llm_router=llm_router,
     )
 
-    complete_model_list = list(unique_models) + all_wildcard_models
+    complete_model_list = sorted(list(unique_models) + all_wildcard_models, key=str.casefold)
 
     return complete_model_list
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -205,7 +205,7 @@ def get_complete_model_list(
         llm_router=llm_router,
     )
 
-    complete_model_list = sorted(list(unique_models) + all_wildcard_models, key=str.casefold)
+    complete_model_list = sorted(list(unique_models) + all_wildcard_models, key=lambda x: x.lower())
 
     return complete_model_list
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6594,7 +6594,7 @@ def _get_model_group_info(
             if mg.model_group in litellm.public_model_groups:
                 mg.is_public_model_group = True
 
-    return model_groups
+    return sorted(model_groups, key=lambda x: x.model_group)
 
 
 @router.get(


### PR DESCRIPTION
## Title
In this way the Model Hub doesn't change the order at every litellm restart.

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


