### PR TITLE
[Bug Fix] grok-4 does not support the `stop` param

### DIFF
--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -50,7 +50,7 @@ class XAIChatConfig(OpenAIGPTConfig):
             "web_search_options",
         ]
         # for some reason, grok-3-mini does not support stop tokens
-        if "grok-3-mini" not in model:
+        if self._supports_stop_reason(model):
             base_openai_params.append("stop")
         try:
             if litellm.supports_reasoning(

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -61,6 +61,13 @@ class XAIChatConfig(OpenAIGPTConfig):
             verbose_logger.debug(f"Error checking if model supports reasoning: {e}")
 
         return base_openai_params
+    
+    def _supports_stop_reason(self, model: str) -> bool:
+        if "grok-3-mini" in model:
+            return False
+        elif "grok-4" in model:
+            return False
+        return True
 
     def map_openai_params(
         self,

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -118,14 +118,15 @@ def test_xai_check_for_stop_in_supported_params():
     assert "stop" not in supported_params
 
 
-def test_xai_grok_4_stop_not_supported():
+@pytest.mark.parametrize("model", ["xai/grok-4", "xai/grok-4-0709"])
+def test_xai_grok_4_stop_not_supported(model):
     """
     Test that grok-4 models do not support the stop parameter
 
     Issue: https://github.com/BerriAI/litellm/issues/12635
     """
     supported_params = XAIChatConfig().get_supported_openai_params(
-        model="xai/grok-4"
+        model=model
     )
     assert "stop" not in supported_params
 

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -118,6 +118,20 @@ def test_xai_check_for_stop_in_supported_params():
     assert "stop" not in supported_params
 
 
+def test_xai_grok_4_stop_not_supported():
+    """
+    Test that grok-4 models do not support the stop parameter
+
+    Issue: https://github.com/BerriAI/litellm/issues/12635
+    """
+    supported_params = XAIChatConfig().get_supported_openai_params(
+        model="xai/grok-4"
+    )
+    assert "stop" not in supported_params
+
+
+
+
 @pytest.mark.parametrize("stream", [False, True])
 def test_completion_xai(stream):
     try:
@@ -132,8 +146,7 @@ def test_completion_xai(stream):
         response = completion(
             model="xai/grok-4",
             messages=messages,
-            stream=stream,
-            stop=["END"],
+            stream=stream
         )
         print(response)
 

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -130,9 +130,10 @@ def test_completion_xai(stream):
             },
         ]
         response = completion(
-            model="xai/grok-3-mini-beta",
+            model="xai/grok-4",
             messages=messages,
             stream=stream,
+            stop=["END"],
         )
         print(response)
 


### PR DESCRIPTION
## [Bug Fix] grok-4 does not support the `stop` param

Fixes https://github.com/BerriAI/litellm/issues/12635

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


