### PR TITLE
Add groq/moonshotai-kimi-k2-instruct model configuration

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5362,6 +5362,18 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "groq/moonshotai-kimi-k2-instruct": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3e-06,
+        "litellm_provider": "groq",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "groq/playai-tts": {
         "max_tokens": 10000,
         "max_input_tokens": 10000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5362,6 +5362,18 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "groq/moonshotai-kimi-k2-instruct": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 3e-06,
+        "litellm_provider": "groq",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "groq/playai-tts": {
         "max_tokens": 10000,
         "max_input_tokens": 10000,


### PR DESCRIPTION
## Title

Add groq/moonshotai-kimi-k2-instruct model configuration

## Relevant issues

<!-- No specific issue -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- Added model configuration for `groq/moonshotai-kimi-k2-instruct` to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`
- Configured the following specifications:
  - **Max tokens**: 131,072
  - **Max input tokens**: 131,072  
  - **Max output tokens**: 16,384
  - **Input cost**: 1e-06 per token
  - **Output cost**: 3e-06 per token
  - **Provider**: groq
  - **Mode**: chat
  - **Capabilities**: Function calling, response schema, and tool choice support

Source: https://console.groq.com/docs/model/moonshotai/kimi-k2-instruct