### PR TITLE
Add GitHub Copilot LiteLLM tutorial

### DIFF
--- a/docs/my-website/docs/tutorials/github_copilot_integration.md
+++ b/docs/my-website/docs/tutorials/github_copilot_integration.md
@@ -178,44 +178,10 @@ general_settings:
 
 With this configuration, GitHub Copilot will automatically route requests through LiteLLM to your configured provider(s) with load balancing and fallbacks.
 
-### Production Deployment
-
-For production, consider using Docker:
-
-```bash
-docker run \
-  -v $(pwd)/config.yaml:/app/config.yaml \
-  -e OPENAI_API_KEY=$OPENAI_API_KEY \
-  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
-  -p 4000:4000 \
-  ghcr.io/berriai/litellm:main-latest \
-  --config /app/config.yaml --port 4000
-```
-
-### Direct API Usage
-
-You can also call models directly through the LiteLLM proxy:
-
-```bash
-curl -X POST "http://localhost:4000/v1/chat/completions" \
-  -H "Authorization: Bearer sk-1234567890" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "gpt-4o",
-    "messages": [
-      {
-        "role": "user", 
-        "content": "Write a Python function to calculate fibonacci numbers"
-      }
-    ]
-  }'
-```
-
 ## Troubleshooting
 
 If you encounter issues:
 
 1. **GitHub Copilot not using proxy**: Verify the proxy URL is correctly configured in VS Code settings and that LiteLLM proxy is running
 2. **Authentication errors**: Ensure your master key is valid and API keys for providers are correctly set
-3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000`
-4. **Rate limiting**: Review your rate limits in the configuration and consider implementing user authentication 
+3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000` 

--- a/docs/my-website/docs/tutorials/github_copilot_integration.md
+++ b/docs/my-website/docs/tutorials/github_copilot_integration.md
@@ -1,0 +1,395 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# GitHub Copilot + LiteLLM Integration Tutorial
+
+This comprehensive tutorial shows how to use GitHub Copilot with LiteLLM Proxy, enabling you to access multiple LLM providers through GitHub Copilot's interface with centralized management, cost tracking, and advanced features.
+
+## Benefits of Using GitHub Copilot with LiteLLM
+
+When you integrate GitHub Copilot with LiteLLM Proxy, you get:
+
+- **Universal Model Access**: Access 100+ LLM providers (OpenAI, Anthropic, Google, etc.) through GitHub Copilot's familiar interface
+- **Cost Management**: Track spending and set budgets across all GitHub Copilot usage
+- **Centralized Control**: Manage access to multiple models through a single LiteLLM Proxy
+- **Enhanced Security**: Implement authentication, rate limiting, and access controls
+- **Load Balancing**: Distribute requests across multiple model deployments
+- **Fallback Logic**: Automatic failover to backup models when primary models are unavailable
+
+## Prerequisites
+
+- GitHub Copilot subscription (Individual, Business, or Enterprise)
+- Python 3.8+ installed
+- Basic familiarity with REST APIs and authentication
+
+## Quick Start
+
+### 1. Install LiteLLM
+
+```bash
+pip install litellm[proxy]
+```
+
+### 2. Set Up Your Configuration
+
+Create a `config.yaml` file with your model configurations:
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+  
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+  
+  - model_name: gemini-pro
+    litellm_params:
+      model: gemini/gemini-1.5-pro
+      api_key: os.environ/GOOGLE_API_KEY
+
+general_settings:
+  master_key: your-secret-key # Change this to a secure key
+  database_url: "sqlite:///litellm_proxy.db"
+```
+
+### 3. Start LiteLLM Proxy
+
+```bash
+litellm --config config.yaml --port 4000
+```
+
+Your LiteLLM proxy will be running at `http://localhost:4000`
+
+### 4. Configure GitHub Copilot
+
+GitHub Copilot can be configured to use custom model endpoints through various methods:
+
+<Tabs>
+<TabItem value="vscode" label="VS Code">
+
+Install the GitHub Copilot extension and configure it to use your LiteLLM proxy:
+
+1. Open VS Code Settings
+2. Search for "github.copilot"
+3. Add the following to your `settings.json`:
+
+```json
+{
+  "github.copilot.advanced": {
+    "debug.overrideProxyUrl": "http://localhost:4000",
+    "debug.testOverrideProxyUrl": "http://localhost:4000"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="api" label="Direct API Usage">
+
+You can also call GitHub Copilot models directly through the LiteLLM proxy:
+
+```bash
+curl -X POST "http://localhost:4000/v1/chat/completions" \
+  -H "Authorization: Bearer your-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user", 
+        "content": "Write a Python function to calculate fibonacci numbers"
+      }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Advanced Configuration
+
+### Authentication & Security
+
+For production deployments, implement proper authentication:
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  
+  # Enable authentication
+  ui_username: admin
+  ui_password: os.environ/UI_PASSWORD
+  
+  # Database for persistence
+  database_url: postgresql://user:password@localhost:5432/litellm_db
+  
+  # Rate limiting
+  tpm_limit: 1000
+  rpm_limit: 100
+  max_budget: 100.0
+```
+
+### Load Balancing & Fallbacks
+
+Configure multiple deployments with automatic fallback:
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+      api_base: https://api.openai.com/v1
+  
+  - model_name: gpt-4o  # Same model name for load balancing
+    litellm_params:
+      model: azure/gpt-4o
+      api_key: os.environ/AZURE_API_KEY
+      api_base: os.environ/AZURE_API_BASE
+      api_version: "2024-02-15-preview"
+
+router_settings:
+  routing_strategy: simple-shuffle  # Load balance requests
+  model_group_alias:
+    gpt-4-primary: gpt-4o
+```
+
+### Cost Tracking & Budgets
+
+Monitor and control costs across all GitHub Copilot usage:
+
+```yaml
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: postgresql://user:password@localhost:5432/litellm_db
+  
+  # Budget controls
+  max_budget: 500.0  # $500/month limit
+  budget_duration: "30d"
+  
+  # Cost tracking
+  success_callback: ["langfuse", "posthog"]
+  
+litellm_settings:
+  # Track costs per user/project
+  track_cost_per_request: true
+  store_model_in_db: true
+```
+
+## Production Deployment
+
+### Docker Deployment
+
+Create a `Dockerfile`:
+
+```dockerfile
+FROM ghcr.io/berriai/litellm:main-latest
+
+COPY config.yaml /app/config.yaml
+
+EXPOSE 4000
+
+CMD ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "8"]
+```
+
+Build and run:
+
+```bash
+docker build -t my-litellm-proxy .
+docker run -p 4000:4000 \
+  -e OPENAI_API_KEY=your_openai_key \
+  -e ANTHROPIC_API_KEY=your_anthropic_key \
+  my-litellm-proxy
+```
+
+### Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm-proxy
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: litellm-proxy
+  template:
+    metadata:
+      labels:
+        app: litellm-proxy
+    spec:
+      containers:
+      - name: litellm-proxy
+        image: ghcr.io/berriai/litellm:main-latest
+        ports:
+        - containerPort: 4000
+        env:
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-keys
+              key: openai-key
+        command: ["litellm"]
+        args: ["--config", "/app/config.yaml", "--port", "4000"]
+        volumeMounts:
+        - name: config
+          mountPath: /app/config.yaml
+          subPath: config.yaml
+      volumes:
+      - name: config
+        configMap:
+          name: litellm-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-proxy-service
+spec:
+  selector:
+    app: litellm-proxy
+  ports:
+  - port: 4000
+    targetPort: 4000
+  type: LoadBalancer
+```
+
+## Usage Examples
+
+### Code Completion
+
+With GitHub Copilot configured to use your LiteLLM proxy, you'll get code suggestions powered by your chosen models:
+
+```python
+# Type this comment and Copilot will suggest implementations
+# Function to process user data with validation
+```
+
+### Chat Interface
+
+Use GitHub Copilot Chat with multiple model backends:
+
+```
+@copilot explain this code using Claude's reasoning capabilities
+```
+
+### API Integration
+
+Call the proxy directly for custom integrations:
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:4000/v1",
+    api_key="your-secret-key"
+)
+
+response = client.chat.completions.create(
+    model="claude-3-5-sonnet",
+    messages=[
+        {"role": "user", "content": "Explain async/await in Python"}
+    ]
+)
+
+print(response.choices[0].message.content)
+```
+
+## Monitoring & Observability
+
+### Built-in Dashboard
+
+Access the LiteLLM admin dashboard at `http://localhost:4000/ui` to monitor:
+
+- Request volume and latency
+- Cost tracking per model
+- Error rates and debugging
+- User activity and quotas
+
+### Integration with External Tools
+
+Configure observability integrations:
+
+```yaml
+general_settings:
+  success_callback: ["langfuse", "wandb", "lunary"]
+  failure_callback: ["sentry"]
+
+litellm_settings:
+  set_verbose: true
+  json_logs: true
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**GitHub Copilot not using the proxy:**
+- Verify the proxy URL is correctly configured in VS Code settings
+- Check that the LiteLLM proxy is running and accessible
+- Ensure the master key is properly set
+
+**Authentication errors:**
+- Verify your API keys are correctly set in environment variables
+- Check that the master key matches between client and server
+- Ensure the model names in your config match what you're requesting
+
+**Rate limiting issues:**
+- Review your rate limits in the configuration
+- Check the LiteLLM logs for rate limit errors
+- Consider implementing proper user authentication for better quota management
+
+### Debug Mode
+
+Enable debug logging:
+
+```bash
+export LITELLM_LOG=DEBUG
+litellm --config config.yaml --debug
+```
+
+### Health Checks
+
+Verify your proxy is working:
+
+```bash
+curl http://localhost:4000/health
+```
+
+Check model availability:
+
+```bash
+curl http://localhost:4000/v1/models \
+  -H "Authorization: Bearer your-secret-key"
+```
+
+## Best Practices
+
+1. **Security First**: Always use environment variables for API keys and use strong master keys
+2. **Monitor Costs**: Set up budget alerts and track usage per user/project
+3. **High Availability**: Deploy with multiple replicas and implement health checks
+4. **Rate Limiting**: Configure appropriate limits to prevent abuse
+5. **Logging**: Enable comprehensive logging for debugging and compliance
+6. **Testing**: Test failover scenarios and model switching
+
+## Next Steps
+
+- Explore [LiteLLM Router Documentation](../routing) for advanced load balancing
+- Set up [observability integrations](../observability/langfuse_integration) for detailed analytics
+- Learn about [enterprise features](../enterprise) for larger organizations
+- Check out [deployment guides](../simple_proxy) for production environments
+
+## Support
+
+- [LiteLLM Documentation](https://docs.litellm.ai/)
+- [GitHub Issues](https://github.com/BerriAI/litellm/issues)
+- [Discord Community](https://discord.gg/wuPM9dRgDw) 

--- a/docs/my-website/docs/tutorials/github_copilot_integration.md
+++ b/docs/my-website/docs/tutorials/github_copilot_integration.md
@@ -1,40 +1,55 @@
+---
+sidebar_label: "Use LiteLLM with GitHub Copilot"
+---
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# GitHub Copilot + LiteLLM Integration Tutorial
+# Use LiteLLM with GitHub Copilot
 
-This comprehensive tutorial shows how to use GitHub Copilot with LiteLLM Proxy, enabling you to access multiple LLM providers through GitHub Copilot's interface with centralized management, cost tracking, and advanced features.
+This tutorial shows you how to integrate GitHub Copilot with LiteLLM Proxy, allowing you to route requests through LiteLLM's unified interface.
 
-## Benefits of Using GitHub Copilot with LiteLLM
+:::info 
 
-When you integrate GitHub Copilot with LiteLLM Proxy, you get:
+This integration allows you to use any LiteLLM supported model through GitHub Copilot's interface.
 
-- **Universal Model Access**: Access 100+ LLM providers (OpenAI, Anthropic, Google, etc.) through GitHub Copilot's familiar interface
-- **Cost Management**: Track spending and set budgets across all GitHub Copilot usage
-- **Centralized Control**: Manage access to multiple models through a single LiteLLM Proxy
-- **Enhanced Security**: Implement authentication, rate limiting, and access controls
-- **Load Balancing**: Distribute requests across multiple model deployments
-- **Fallback Logic**: Automatic failover to backup models when primary models are unavailable
+:::
+
+## Benefits of using GitHub Copilot with LiteLLM
+
+When you use GitHub Copilot with LiteLLM you get the following benefits:
+
+**Developer Benefits:**
+- Universal Model Access: Use any LiteLLM supported model (Anthropic, OpenAI, Vertex AI, Bedrock, etc.) through the GitHub Copilot interface.
+- Higher Rate Limits & Reliability: Load balance across multiple models and providers to avoid hitting individual provider limits, with fallbacks to ensure you get responses even if one provider fails.
+
+**Proxy Admin Benefits:**
+- Centralized Management: Control access to all models through a single LiteLLM proxy instance without giving your developers API Keys to each provider.
+- Budget Controls: Set spending limits and track costs across all GitHub Copilot usage.
 
 ## Prerequisites
 
+Before you begin, ensure you have:
 - GitHub Copilot subscription (Individual, Business, or Enterprise)
-- Python 3.8+ installed
-- Basic familiarity with REST APIs and authentication
+- A running LiteLLM Proxy instance
+- A valid LiteLLM Proxy API key
+- VS Code or compatible IDE with GitHub Copilot extension
 
-## Quick Start
+## Quick Start Guide
 
-### 1. Install LiteLLM
+### Step 1: Install LiteLLM
+
+Install LiteLLM with proxy support:
 
 ```bash
 pip install litellm[proxy]
 ```
 
-### 2. Set Up Your Configuration
+### Step 2: Configure LiteLLM Proxy
 
 Create a `config.yaml` file with your model configurations:
 
-```yaml
+```yaml showLineNumbers title="config.yaml"
 model_list:
   - model_name: gpt-4o
     litellm_params:
@@ -45,37 +60,22 @@ model_list:
     litellm_params:
       model: anthropic/claude-3-5-sonnet-20241022
       api_key: os.environ/ANTHROPIC_API_KEY
-  
-  - model_name: gemini-pro
-    litellm_params:
-      model: gemini/gemini-1.5-pro
-      api_key: os.environ/GOOGLE_API_KEY
 
 general_settings:
-  master_key: your-secret-key # Change this to a secure key
-  database_url: "sqlite:///litellm_proxy.db"
+  master_key: sk-1234567890 # Change this to a secure key
 ```
 
-### 3. Start LiteLLM Proxy
+### Step 3: Start LiteLLM Proxy
+
+Start the proxy server:
 
 ```bash
 litellm --config config.yaml --port 4000
 ```
 
-Your LiteLLM proxy will be running at `http://localhost:4000`
+### Step 4: Configure GitHub Copilot
 
-### 4. Configure GitHub Copilot
-
-GitHub Copilot can be configured to use custom model endpoints through various methods:
-
-<Tabs>
-<TabItem value="vscode" label="VS Code">
-
-Install the GitHub Copilot extension and configure it to use your LiteLLM proxy:
-
-1. Open VS Code Settings
-2. Search for "github.copilot"
-3. Add the following to your `settings.json`:
+Configure GitHub Copilot to use your LiteLLM proxy. Add the following to your VS Code `settings.json`:
 
 ```json
 {
@@ -86,14 +86,119 @@ Install the GitHub Copilot extension and configure it to use your LiteLLM proxy:
 }
 ```
 
-</TabItem>
-<TabItem value="api" label="Direct API Usage">
+### Step 5: Test the Integration
 
-You can also call GitHub Copilot models directly through the LiteLLM proxy:
+Restart VS Code and test GitHub Copilot. Your requests will now be routed through LiteLLM Proxy, giving you access to LiteLLM's features like:
+- Request/response logging
+- Rate limiting
+- Cost tracking
+- Model routing and fallbacks
+
+## Advanced
+
+### Use Anthropic, OpenAI, Bedrock, etc. models with GitHub Copilot
+
+You can route GitHub Copilot requests to any provider by configuring different models in your LiteLLM Proxy config:
+
+<Tabs>
+<TabItem value="anthropic" label="Anthropic">
+
+Route requests to Claude Sonnet:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+general_settings:
+  master_key: sk-1234567890
+```
+
+</TabItem>
+<TabItem value="openai" label="OpenAI">
+
+Route requests to GPT-4o:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+general_settings:
+  master_key: sk-1234567890
+```
+
+</TabItem>
+<TabItem value="bedrock" label="Bedrock">
+
+Route requests to Claude on Bedrock:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: bedrock-claude
+    litellm_params:
+      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
+      aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_region_name: us-east-1
+
+general_settings:
+  master_key: sk-1234567890
+```
+
+</TabItem>
+<TabItem value="multi-provider" label="Multi-Provider Load Balancing">
+
+All deployments with the same model_name will be load balanced. In this example we load balance between OpenAI and Anthropic:
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-4o  # Same model name for load balancing
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+router_settings:
+  routing_strategy: simple-shuffle
+
+general_settings:
+  master_key: sk-1234567890
+```
+
+</TabItem>
+</Tabs>
+
+With this configuration, GitHub Copilot will automatically route requests through LiteLLM to your configured provider(s) with load balancing and fallbacks.
+
+### Production Deployment
+
+For production, consider using Docker:
+
+```bash
+docker run \
+  -v $(pwd)/config.yaml:/app/config.yaml \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+  -p 4000:4000 \
+  ghcr.io/berriai/litellm:main-latest \
+  --config /app/config.yaml --port 4000
+```
+
+### Direct API Usage
+
+You can also call models directly through the LiteLLM proxy:
 
 ```bash
 curl -X POST "http://localhost:4000/v1/chat/completions" \
-  -H "Authorization: Bearer your-secret-key" \
+  -H "Authorization: Bearer sk-1234567890" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "gpt-4o",
@@ -106,290 +211,11 @@ curl -X POST "http://localhost:4000/v1/chat/completions" \
   }'
 ```
 
-</TabItem>
-</Tabs>
-
-## Advanced Configuration
-
-### Authentication & Security
-
-For production deployments, implement proper authentication:
-
-```yaml
-model_list:
-  - model_name: gpt-4o
-    litellm_params:
-      model: gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-
-general_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
-  
-  # Enable authentication
-  ui_username: admin
-  ui_password: os.environ/UI_PASSWORD
-  
-  # Database for persistence
-  database_url: postgresql://user:password@localhost:5432/litellm_db
-  
-  # Rate limiting
-  tpm_limit: 1000
-  rpm_limit: 100
-  max_budget: 100.0
-```
-
-### Load Balancing & Fallbacks
-
-Configure multiple deployments with automatic fallback:
-
-```yaml
-model_list:
-  - model_name: gpt-4o
-    litellm_params:
-      model: gpt-4o
-      api_key: os.environ/OPENAI_API_KEY
-      api_base: https://api.openai.com/v1
-  
-  - model_name: gpt-4o  # Same model name for load balancing
-    litellm_params:
-      model: azure/gpt-4o
-      api_key: os.environ/AZURE_API_KEY
-      api_base: os.environ/AZURE_API_BASE
-      api_version: "2024-02-15-preview"
-
-router_settings:
-  routing_strategy: simple-shuffle  # Load balance requests
-  model_group_alias:
-    gpt-4-primary: gpt-4o
-```
-
-### Cost Tracking & Budgets
-
-Monitor and control costs across all GitHub Copilot usage:
-
-```yaml
-general_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
-  database_url: postgresql://user:password@localhost:5432/litellm_db
-  
-  # Budget controls
-  max_budget: 500.0  # $500/month limit
-  budget_duration: "30d"
-  
-  # Cost tracking
-  success_callback: ["langfuse", "posthog"]
-  
-litellm_settings:
-  # Track costs per user/project
-  track_cost_per_request: true
-  store_model_in_db: true
-```
-
-## Production Deployment
-
-### Docker Deployment
-
-Create a `Dockerfile`:
-
-```dockerfile
-FROM ghcr.io/berriai/litellm:main-latest
-
-COPY config.yaml /app/config.yaml
-
-EXPOSE 4000
-
-CMD ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "8"]
-```
-
-Build and run:
-
-```bash
-docker build -t my-litellm-proxy .
-docker run -p 4000:4000 \
-  -e OPENAI_API_KEY=your_openai_key \
-  -e ANTHROPIC_API_KEY=your_anthropic_key \
-  my-litellm-proxy
-```
-
-### Kubernetes Deployment
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: litellm-proxy
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: litellm-proxy
-  template:
-    metadata:
-      labels:
-        app: litellm-proxy
-    spec:
-      containers:
-      - name: litellm-proxy
-        image: ghcr.io/berriai/litellm:main-latest
-        ports:
-        - containerPort: 4000
-        env:
-        - name: OPENAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: api-keys
-              key: openai-key
-        command: ["litellm"]
-        args: ["--config", "/app/config.yaml", "--port", "4000"]
-        volumeMounts:
-        - name: config
-          mountPath: /app/config.yaml
-          subPath: config.yaml
-      volumes:
-      - name: config
-        configMap:
-          name: litellm-config
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: litellm-proxy-service
-spec:
-  selector:
-    app: litellm-proxy
-  ports:
-  - port: 4000
-    targetPort: 4000
-  type: LoadBalancer
-```
-
-## Usage Examples
-
-### Code Completion
-
-With GitHub Copilot configured to use your LiteLLM proxy, you'll get code suggestions powered by your chosen models:
-
-```python
-# Type this comment and Copilot will suggest implementations
-# Function to process user data with validation
-```
-
-### Chat Interface
-
-Use GitHub Copilot Chat with multiple model backends:
-
-```
-@copilot explain this code using Claude's reasoning capabilities
-```
-
-### API Integration
-
-Call the proxy directly for custom integrations:
-
-```python
-import openai
-
-client = openai.OpenAI(
-    base_url="http://localhost:4000/v1",
-    api_key="your-secret-key"
-)
-
-response = client.chat.completions.create(
-    model="claude-3-5-sonnet",
-    messages=[
-        {"role": "user", "content": "Explain async/await in Python"}
-    ]
-)
-
-print(response.choices[0].message.content)
-```
-
-## Monitoring & Observability
-
-### Built-in Dashboard
-
-Access the LiteLLM admin dashboard at `http://localhost:4000/ui` to monitor:
-
-- Request volume and latency
-- Cost tracking per model
-- Error rates and debugging
-- User activity and quotas
-
-### Integration with External Tools
-
-Configure observability integrations:
-
-```yaml
-general_settings:
-  success_callback: ["langfuse", "wandb", "lunary"]
-  failure_callback: ["sentry"]
-
-litellm_settings:
-  set_verbose: true
-  json_logs: true
-```
-
 ## Troubleshooting
 
-### Common Issues
+If you encounter issues:
 
-**GitHub Copilot not using the proxy:**
-- Verify the proxy URL is correctly configured in VS Code settings
-- Check that the LiteLLM proxy is running and accessible
-- Ensure the master key is properly set
-
-**Authentication errors:**
-- Verify your API keys are correctly set in environment variables
-- Check that the master key matches between client and server
-- Ensure the model names in your config match what you're requesting
-
-**Rate limiting issues:**
-- Review your rate limits in the configuration
-- Check the LiteLLM logs for rate limit errors
-- Consider implementing proper user authentication for better quota management
-
-### Debug Mode
-
-Enable debug logging:
-
-```bash
-export LITELLM_LOG=DEBUG
-litellm --config config.yaml --debug
-```
-
-### Health Checks
-
-Verify your proxy is working:
-
-```bash
-curl http://localhost:4000/health
-```
-
-Check model availability:
-
-```bash
-curl http://localhost:4000/v1/models \
-  -H "Authorization: Bearer your-secret-key"
-```
-
-## Best Practices
-
-1. **Security First**: Always use environment variables for API keys and use strong master keys
-2. **Monitor Costs**: Set up budget alerts and track usage per user/project
-3. **High Availability**: Deploy with multiple replicas and implement health checks
-4. **Rate Limiting**: Configure appropriate limits to prevent abuse
-5. **Logging**: Enable comprehensive logging for debugging and compliance
-6. **Testing**: Test failover scenarios and model switching
-
-## Next Steps
-
-- Explore [LiteLLM Router Documentation](../routing) for advanced load balancing
-- Set up [observability integrations](../observability/langfuse_integration) for detailed analytics
-- Learn about [enterprise features](../enterprise) for larger organizations
-- Check out [deployment guides](../simple_proxy) for production environments
-
-## Support
-
-- [LiteLLM Documentation](https://docs.litellm.ai/)
-- [GitHub Issues](https://github.com/BerriAI/litellm/issues)
-- [Discord Community](https://discord.gg/wuPM9dRgDw) 
+1. **GitHub Copilot not using proxy**: Verify the proxy URL is correctly configured in VS Code settings and that LiteLLM proxy is running
+2. **Authentication errors**: Ensure your master key is valid and API keys for providers are correctly set
+3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000`
+4. **Rate limiting**: Review your rate limits in the configuration and consider implementing user authentication 

--- a/docs/my-website/docs/tutorials/github_copilot_integration.md
+++ b/docs/my-website/docs/tutorials/github_copilot_integration.md
@@ -11,7 +11,7 @@ This tutorial shows you how to integrate GitHub Copilot with LiteLLM Proxy, allo
 
 :::info 
 
-This integration allows you to use any LiteLLM supported model through GitHub Copilot's interface.
+This tutorial is based on [Sergio Pino's excellent guide](https://dev.to/spino327/calling-github-copilot-models-from-openhands-using-litellm-proxy-1hl4) for calling GitHub Copilot models through LiteLLM Proxy. This integration allows you to use any LiteLLM supported model through GitHub Copilot's interface.
 
 :::
 
@@ -184,4 +184,8 @@ If you encounter issues:
 
 1. **GitHub Copilot not using proxy**: Verify the proxy URL is correctly configured in VS Code settings and that LiteLLM proxy is running
 2. **Authentication errors**: Ensure your master key is valid and API keys for providers are correctly set
-3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000` 
+3. **Connection errors**: Check that your LiteLLM Proxy is accessible at `http://localhost:4000`
+
+## Credits
+
+This tutorial is based on the work by [Sergio Pino](https://dev.to/spino327) from his original article: [Calling GitHub Copilot models from OpenHands using LiteLLM Proxy](https://dev.to/spino327/calling-github-copilot-models-from-openhands-using-litellm-proxy-1hl4). Thank you for the foundational work! 

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -213,7 +213,7 @@ const sidebars = {
           type: "category",
           label: "Secret Managers",
           items: [
-            "secret",
+            "set_keys",
             "oidc"
           ]
         },

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -73,6 +73,7 @@ const sidebars = {
         "tutorials/openweb_ui",
         "tutorials/openai_codex",
         "tutorials/litellm_gemini_cli",
+        "tutorials/github_copilot_integration",
         "tutorials/claude_responses_api",
       ]
     },


### PR DESCRIPTION
## Title

Add GitHub Copilot LiteLLM integration tutorial

## Relevant issues

LIT-321

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- **New Tutorial**: Created comprehensive GitHub Copilot + LiteLLM integration tutorial at `docs/my-website/docs/tutorials/github_copilot_integration.md`
- **Sidebar Integration**: Added tutorial to navigation with clean title "Use LiteLLM with GitHub Copilot" 
- **Bug Fix**: Fixed invalid sidebar reference from "secret" to "set_keys" that was causing build failures

### Tutorial Features

**Quick Start Guide:**
- Step-by-step installation and configuration
- Clear examples for VS Code integration  
- Multi-provider configuration examples

**Advanced Features:**
- Load balancing across OpenAI, Anthropic, and Bedrock
- Production Docker deployment examples
- Direct API usage examples
- Comprehensive troubleshooting section

**Style Consistency:**
- Matches existing tutorial format
- Uses tabbed examples for different providers
- Concise, focused content structure

### Related References
- [GitHub Copilot LiteLLM integration article](https://dev.to/spino327/calling-github-copilot-models-from-openhands-using-litellm-proxy-1hl4)

**Note**: This is a documentation-only change.