### PR TITLE
fix: ensure Gemini calls include a user message (fixes #9733)

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -298,6 +298,19 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 )
         if len(tool_call_responses) > 0:
             contents.append(ContentType(parts=tool_call_responses))
+
+        if len(contents) == 0:
+            verbose_logger.warning(
+                """
+                No contents in messages. Contents are required. See
+                https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.publishers.models/generateContent#request-body.
+                If the original request did not comply to OpenAI API requirements it should have failed by now,
+                but LiteLLM does not check for missing messages.
+                Setting an empty content to prevent an 400 error.
+                Relevant Issue - https://github.com/BerriAI/litellm/issues/9733
+                """
+            )
+            contents.append(ContentType(role="user", parts=[PartType(text=" ")]))
         return contents
     except Exception as e:
         raise e
@@ -403,19 +416,21 @@ def sync_transform_request_body(
     context_caching_endpoints = ContextCachingEndpoints()
 
     if gemini_api_key is not None:
-        messages, optional_params, cached_content = (
-            context_caching_endpoints.check_and_create_cache(
-                messages=messages,
-                optional_params=optional_params,
-                api_key=gemini_api_key,
-                api_base=api_base,
-                model=model,
-                client=client,
-                timeout=timeout,
-                extra_headers=extra_headers,
-                cached_content=optional_params.pop("cached_content", None),
-                logging_obj=logging_obj,
-            )
+        (
+            messages,
+            optional_params,
+            cached_content,
+        ) = context_caching_endpoints.check_and_create_cache(
+            messages=messages,
+            optional_params=optional_params,
+            api_key=gemini_api_key,
+            api_base=api_base,
+            model=model,
+            client=client,
+            timeout=timeout,
+            extra_headers=extra_headers,
+            cached_content=optional_params.pop("cached_content", None),
+            logging_obj=logging_obj,
         )
     else:  # [TODO] implement context caching for gemini as well
         cached_content = optional_params.pop("cached_content", None)


### PR DESCRIPTION
## Title

Ensure Gemini calls include a user message

## Relevant issues

Fixes #9733 

## Pre-Submission checklist

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1422" height="303" alt="Screenshot From 2025-07-16 19-37-08" src="https://github.com/user-attachments/assets/0a179911-3c30-42a6-bf42-4e3b8e1fcc6e" />

NOTE: Applied `make format` (`poetry run black [file changed]`) only to files changed by me. The `make lint` command identified a bunch of files requiring formatting that I am not modifying as I did not touch them.

## Type

🐛 Bug Fix

## Changes

When a Gemini model supports system messages, messages with the system role get filtered out from the list of messages, so never appended to the content (and passed as system_instructions instead).

This causes a 400 error, as both generateContent and streamGenerateContent require contents (the systemInstruction object is optional).

This is a quick fix that does not check whether there was a system msg or if the model supports it. It simply makes sure that if the list of messages passed to  _gemini_convert_messages_with_history() yields no contents, that there is at least a single (empty space) user message set to prevent the call from failing.

The potential side effect of this is that we will not fail a call lacking any message at all, but if that needs to be checked (and AFAIU the OpenAI spec messages are required) it should be done elsewhere (e.g. validate_and_fix_openai_messages() @ litellm/utils.py).
