### PR TITLE
Fix unused imports in completion_extras transformation

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -230,10 +230,6 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         from litellm.responses.utils import ResponseAPILoggingUtils
         from litellm.types.llms.openai import ResponsesAPIResponse
-        from litellm.types.responses.main import (
-            GenericResponseOutputItem,
-            OutputFunctionToolCall,
-        )
         from litellm.types.utils import Choices, Message
 
         if not isinstance(raw_response, ResponsesAPIResponse):


### PR DESCRIPTION
## Title

Fix unused imports in completion_extras transformation

## Relevant issues

Fixes F401 linting errors for unused imports

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🧹 Refactoring

## Changes

- Removed unused `GenericResponseOutputItem` import from `litellm/completion_extras/litellm_responses_transformation/transformation.py`
- Removed unused `OutputFunctionToolCall` import from the same file
- Fixes F401 linting errors: 
  - `completion_extras/litellm_responses_transformation/transformation.py:234:13: F401 [*] `litellm.types.responses.main.GenericResponseOutputItem` imported but unused`
  - `completion_extras/litellm_responses_transformation/transformation.py:235:13: F401 [*] `litellm.types.responses.main.OutputFunctionToolCall` imported but unused`

This is a simple cleanup change that removes imports that are not actually used in the file, fixing linting errors without affecting functionality.