### PR TITLE
Make a prompt_id optional for  custom_prompt:get_chat_completion_prompt

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -360,6 +360,7 @@ router_settings:
 | CIRCLE_OIDC_TOKEN_V2 | Version 2 of the OpenID Connect token for CircleCI
 | CONFIG_FILE_PATH | File path for configuration file
 | CONFIDENT_API_KEY | API key for DeepEval integration
+| CUSTOM_PROMPT_PROMPT_ID_CHECK | Set to false if you don't want your custom prompt to skip checking for a prompt_id, see issue [#11366](https://github.com/BerriAI/litellm/issues/11366)
 | CUSTOM_TIKTOKEN_CACHE_DIR | Custom directory for Tiktoken cache
 | CONFIDENT_API_KEY | API key for Confident AI (Deepeval) Logging service
 | DATABASE_HOST | Hostname for the database server

--- a/docs/my-website/docs/proxy/custom_prompt_management.md
+++ b/docs/my-website/docs/proxy/custom_prompt_management.md
@@ -191,4 +191,7 @@ To:
 }
 ```
 
+### 5. (Optional) you can override a `prompt_id` being required
+Just set Environment Variable `CUSTOM_PROMPT_PROMPT_ID_CHECK` to `false` in your Dockerfile or .env file.
+
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1,7 +1,6 @@
 import os
 from typing import List, Literal
 
-CUSTOM_PROMPT_PROMPT_ID_CHECK = os.getenv("CUSTOM_PROMPT_PROMPT_ID_CHECK", "true").lower() == "true"
 ROUTER_MAX_FALLBACKS = int(os.getenv("ROUTER_MAX_FALLBACKS", 5))
 DEFAULT_BATCH_SIZE = int(os.getenv("DEFAULT_BATCH_SIZE", 512))
 DEFAULT_FLUSH_INTERVAL_SECONDS = int(os.getenv("DEFAULT_FLUSH_INTERVAL_SECONDS", 5))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Literal
 
+CUSTOM_PROMPT_PROMPT_ID_CHECK = os.getenv("CUSTOM_PROMPT_PROMPT_ID_CHECK", "true").lower() == "true"
 ROUTER_MAX_FALLBACKS = int(os.getenv("ROUTER_MAX_FALLBACKS", 5))
 DEFAULT_BATCH_SIZE = int(os.getenv("DEFAULT_BATCH_SIZE", 512))
 DEFAULT_FLUSH_INTERVAL_SECONDS = int(os.getenv("DEFAULT_FLUSH_INTERVAL_SECONDS", 5))

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -42,6 +42,7 @@ from litellm.batches.batch_utils import _handle_completed_batch
 from litellm.caching.caching import DualCache, InMemoryCache
 from litellm.caching.caching_handler import LLMCachingHandler
 from litellm.constants import (
+    CUSTOM_PROMPT_PROMPT_ID_CHECK,
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
     SENTRY_DENYLIST,
@@ -523,7 +524,7 @@ class Logging(LiteLLMLoggingBaseClass):
         ):
             return True
 
-        return False
+        return CUSTOM_PROMPT_PROMPT_ID_CHECK
 
     def _should_run_prompt_management_hooks_without_prompt_id(
         self,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -42,7 +42,6 @@ from litellm.batches.batch_utils import _handle_completed_batch
 from litellm.caching.caching import DualCache, InMemoryCache
 from litellm.caching.caching_handler import LLMCachingHandler
 from litellm.constants import (
-    CUSTOM_PROMPT_PROMPT_ID_CHECK,
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
     SENTRY_DENYLIST,
@@ -222,6 +221,7 @@ additional_details: Optional[Dict[str, str]] = {}
 local_cache: Optional[Dict[str, str]] = {}
 last_fetched_at = None
 last_fetched_at_keys = None
+CUSTOM_PROMPT_PROMPT_ID_CHECK = os.getenv("CUSTOM_PROMPT_PROMPT_ID_CHECK", "true").lower() == "true"
 
 
 ####

--- a/tests/test_litellm/integrations/test_custom_prompt_management.py
+++ b/tests/test_litellm/integrations/test_custom_prompt_management.py
@@ -15,7 +15,7 @@ sys.path.insert(
 import litellm
 from litellm.integrations.custom_prompt_management import CustomPromptManagement
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
-from litellm.types.llms.openai import AllMessageValues
+from litellm.types.llms.openai import AllMessageValues, ChatCompletionUserMessage
 from litellm.types.utils import StandardCallbackDynamicParams
 
 
@@ -23,8 +23,13 @@ from litellm.types.utils import StandardCallbackDynamicParams
 def setup_anthropic_api_key(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-some-key")
 
+@pytest.fixture(autouse=False)
+def setup_custom_prompt_id_skip(monkeypatch):
+    monkeypatch.setenv("CUSTOM_PROMPT_PROMPT_ID_CHECK", "false")
 
-class TestCustomPromptManagement(CustomPromptManagement):
+
+
+class CustomPromptManagementForTest(CustomPromptManagement):
     def get_chat_completion_prompt(
         self,
         model: str,
@@ -37,28 +42,52 @@ class TestCustomPromptManagement(CustomPromptManagement):
         prompt_version: Optional[int] = None,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         print(
-            "TestCustomPromptManagement: running get_chat_completion_prompt for prompt_id: ",
+            "CustomPromptManagementForTest: running get_chat_completion_prompt for prompt_id: ",
             prompt_id,
         )
         if prompt_id == "test_prompt_id":
             messages = [
-                {"role": "user", "content": "This is the prompt for test_prompt_id"},
+                ChatCompletionUserMessage(role="user", content="This is the prompt for test_prompt_id"),
             ]
             return model, messages, non_default_params
         elif prompt_id == "prompt_with_variables":
             content = "Hello, {name}! You are {age} years old and live in {city}."
             content_with_variables = content.format(**(prompt_variables or {}))
             messages = [
-                {"role": "user", "content": content_with_variables},
+                ChatCompletionUserMessage(role="user", content=content_with_variables),
             ]
             return model, messages, non_default_params
         else:
             return model, messages, non_default_params
 
+class CustomPromptManagementForSkippingPromptIdCheck(CustomPromptManagement):
+    def get_chat_completion_prompt(
+            self,
+            model: str,
+            messages: List[AllMessageValues],
+            non_default_params: dict,
+            prompt_id: Optional[str],
+            prompt_variables: Optional[dict],
+            dynamic_callback_params: StandardCallbackDynamicParams,
+            prompt_label: Optional[str] = None,
+            prompt_version: Optional[int] = None,
+    ) -> Tuple[str, List[AllMessageValues], dict]:
+        print(
+            "CustomPromptManagementForSkippingPromptIdCheck: running get_chat_completion_prompt for prompt_id: ",
+            prompt_id,
+        )
+        custom_prompt_prompt_id_check = os.getenv("CUSTOM_PROMPT_PROMPT_ID_CHECK", "true")
+        if custom_prompt_prompt_id_check == "false":
+            messages = [
+                ChatCompletionUserMessage(role="user", content="This is the prompt when prompt_id is None"),
+            ]
+
+        return model, messages, non_default_params
+
 
 @pytest.mark.asyncio
 async def test_custom_prompt_management_with_prompt_id(monkeypatch):
-    custom_prompt_management = TestCustomPromptManagement()
+    custom_prompt_management = CustomPromptManagementForTest()
     litellm.callbacks = [custom_prompt_management]
 
     # Mock AsyncHTTPHandler.post method
@@ -86,7 +115,7 @@ async def test_custom_prompt_management_with_prompt_id(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_custom_prompt_management_with_prompt_id_and_prompt_variables():
-    custom_prompt_management = TestCustomPromptManagement()
+    custom_prompt_management = CustomPromptManagementForTest()
     litellm.callbacks = [custom_prompt_management]
 
     # Mock AsyncHTTPHandler.post method
@@ -115,7 +144,7 @@ async def test_custom_prompt_management_with_prompt_id_and_prompt_variables():
 
 @pytest.mark.asyncio
 async def test_custom_prompt_management_without_prompt_id():
-    custom_prompt_management = TestCustomPromptManagement()
+    custom_prompt_management = CustomPromptManagementForTest()
     litellm.callbacks = [custom_prompt_management]
 
     # Mock AsyncHTTPHandler.post method
@@ -136,4 +165,58 @@ async def test_custom_prompt_management_without_prompt_id():
         # the message does not get applied to the prompt from the custom prompt management callback since we did not pass a prompt_id
         assert (
             request_body["messages"][0]["content"][0]["text"] == "Hello, how are you?"
+        )
+
+
+@pytest.mark.asyncio
+async def test_custom_prompt_management_with_prompt_id_check_off(setup_custom_prompt_id_skip):
+    custom_prompt_management = CustomPromptManagementForSkippingPromptIdCheck()
+    litellm.callbacks = [custom_prompt_management]
+
+    # Mock AsyncHTTPHandler.post method
+    client = AsyncHTTPHandler()
+    with patch.object(client, "post", return_value=MagicMock()) as mock_post:
+        await litellm.acompletion(
+            model="anthropic/claude-3-5-sonnet",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            client=client
+        )
+
+        mock_post.assert_called_once()
+        print(mock_post.call_args.kwargs)
+        request_body = mock_post.call_args.kwargs["json"]
+        print("request_body: ", json.dumps(request_body, indent=4))
+
+        assert request_body["model"] == "claude-3-5-sonnet"
+        # the message gets applied to the prompt from the custom prompt management callback
+        assert (
+                request_body["messages"][0]["content"][0]["text"]
+                == "This is the prompt when prompt_id is None"
+        )
+
+
+@pytest.mark.asyncio
+async def test_custom_prompt_management_with_prompt_id_check_on():
+    custom_prompt_management = CustomPromptManagementForSkippingPromptIdCheck()
+    litellm.callbacks = [custom_prompt_management]
+
+    # Mock AsyncHTTPHandler.post method
+    client = AsyncHTTPHandler()
+    with patch.object(client, "post", return_value=MagicMock()) as mock_post:
+        await litellm.acompletion(
+            model="anthropic/claude-3-5-sonnet",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+            client=client
+        )
+
+        mock_post.assert_called_once()
+        print(mock_post.call_args.kwargs)
+        request_body = mock_post.call_args.kwargs["json"]
+        print("request_body: ", json.dumps(request_body, indent=4))
+
+        assert request_body["model"] == "claude-3-5-sonnet"
+        # the message gets applied to the prompt from the custom prompt management callback
+        assert (
+                request_body["messages"][0]["content"][0]["text"]
+                == "Hello, how are you?"
         )


### PR DESCRIPTION
## Make a prompt_id optional for  custom_prompt:get_chat_completion_prompt

## Relevant issues

Fixes #11366

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
If no prompt_id is defined in a call to `get_chat_completion_prompt` it now doesn't just return False, it now returns a env feature flag that defaults to False.
Added unit tests
Update documentation where I could find it


<img width="2386" height="1132" alt="image" src="https://github.com/user-attachments/assets/d2184471-2d19-49dc-8678-48c6001f9e6a" />
