### PR TITLE
[MCP Gateway] List tools from access list for keys

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -335,17 +335,6 @@ if MCP_AVAILABLE:
             mcp_servers: Optional list of server names and access groups to filter by
         """
         tools = []
-        for tool in global_mcp_tool_registry.list_tools():
-            tools.append(
-                MCPTool(
-                    name=tool.name,
-                    description=tool.description,
-                    inputSchema=tool.input_schema,
-                )
-            )
-        verbose_logger.debug(
-            "GLOBAL MCP TOOLS: %s", global_mcp_tool_registry.list_tools()
-        )
 
         # Get tools from MCP servers
         tools_from_mcp_servers = await _get_tools_from_mcp_servers(

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -719,3 +719,66 @@ async def test_get_tools_from_mcp_servers():
         pytest.fail(f"Unexpected error in tests: {str(e)}")
 
 
+@pytest.mark.asyncio
+async def test_list_tools_only_returns_allowed_servers(monkeypatch):
+    """
+    Test that list_tools only returns tools from servers allowed for the user.
+    """
+    test_manager = MCPServerManager()
+
+    # Setup two servers in the config
+    test_manager.load_servers_from_config({
+        "server_a": {
+            "url": "https://server-a.com/mcp",
+            "transport": MCPTransport.http,
+            "description": "Server A"
+        },
+        "server_b": {
+            "url": "https://server-b.com/mcp",
+            "transport": MCPTransport.http,
+            "description": "Server B"
+        }
+    })
+
+    # Patch get_allowed_mcp_servers to only allow server_a
+    async def mock_get_allowed_mcp_servers(self, user_api_key_auth=None):
+        return [list(test_manager.get_registry().keys())[0]]  # Only first server (server_a)
+    monkeypatch.setattr(MCPServerManager, "get_allowed_mcp_servers", mock_get_allowed_mcp_servers)
+
+    # Mock tools for each server
+    mock_tools_a = [
+        MCPTool(
+            name="send_email",
+            description="Send an email via Server A",
+            inputSchema={"type": "object"}
+        )
+    ]
+    mock_tools_b = [
+        MCPTool(
+            name="create_event",
+            description="Create an event via Server B",
+            inputSchema={"type": "object"}
+        )
+    ]
+
+    # Patch MCPClient to return different tools for each server
+    def mock_client_constructor(*args, **kwargs):
+        mock_client = AsyncMock()
+        # Return tools based on server URL
+        if kwargs.get("server_url") == "https://server-a.com/mcp":
+            mock_client.list_tools = AsyncMock(return_value=mock_tools_a)
+        else:
+            mock_client.list_tools = AsyncMock(return_value=mock_tools_b)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        return mock_client
+
+    with patch('litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPClient', mock_client_constructor):
+        # Call list_tools
+        tools = await test_manager.list_tools(user_api_key_auth=MagicMock())
+        # Should only return tools from server_a
+        assert len(tools) == 1
+        assert tools[0].name.startswith("server_a-")
+        assert "Server A" in tools[0].description
+
+


### PR DESCRIPTION
## Title

[MCP Gateway] List tools from access list for keys

## Relevant issues

Currently MCP Gateway lists all tools no matter what access the key or the team has

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


