### PR TITLE
Add project_id to cached credentials for VertexAI

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -405,10 +405,20 @@ class VertexBase:
             verbose_logger.debug(
                 f"Cached credentials found for project_id: {project_id}."
             )
-            _credentials = self._credentials_project_mapping[credential_cache_key]
-            verbose_logger.debug("Using cached credentials")
-            credential_project_id = _credentials.quota_project_id or getattr(
-                _credentials, "project_id", None
+            # Retrieve both credentials and cached project_id
+            cached_entry = self._credentials_project_mapping[credential_cache_key]
+            verbose_logger.debug("cached_entry: %s", cached_entry)
+            if isinstance(cached_entry, tuple):
+                _credentials, credential_project_id = cached_entry
+            else:
+                # Backward compatibility with old cache format
+                _credentials = cached_entry
+                credential_project_id = _credentials.quota_project_id or getattr(
+                    _credentials, "project_id", None
+                )
+            verbose_logger.debug(
+                "Using cached credentials for project_id: %s",
+                credential_project_id,
             )
 
         else:
@@ -432,8 +442,11 @@ class VertexBase:
                         project_id
                     )
                 )
-
-            self._credentials_project_mapping[credential_cache_key] = _credentials
+            # Cache the project_id and credentials from load_auth result (resolved project_id)
+            self._credentials_project_mapping[credential_cache_key] = (
+                _credentials,
+                credential_project_id,
+            )
 
         ## VALIDATE CREDENTIALS
         verbose_logger.debug(f"Validating credentials for project_id: {project_id}")
@@ -443,9 +456,23 @@ class VertexBase:
             and isinstance(credential_project_id, str)
         ):
             project_id = credential_project_id
+            # Update cache with resolved project_id for future lookups
+            resolved_cache_key = (cache_credentials, project_id)
+            if resolved_cache_key not in self._credentials_project_mapping:
+                self._credentials_project_mapping[resolved_cache_key] = (
+                    _credentials,
+                    credential_project_id,
+                )
 
         if _credentials.expired:
+            verbose_logger.debug(
+                f"Credentials expired, refreshing for project_id: {project_id}"
+            )
             self.refresh_auth(_credentials)
+            self._credentials_project_mapping[credential_cache_key] = (
+                _credentials,
+                credential_project_id,
+            )
 
         ## VALIDATION STEP
         if _credentials.token is None or not isinstance(_credentials.token, str):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from unittest.mock import MagicMock, call, patch
@@ -334,6 +335,341 @@ class TestVertexBase:
             assert mock_credentials_from_identity_pool_with_aws.called
             assert token == "refreshed-token"
 
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_new_cache_format_tuple_storage(self, is_async):
+        """Test that new cache format stores (credentials, project_id) tuples"""
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "token-1"
+        mock_creds.expired = False
+        mock_creds.project_id = "project-1"
+        mock_creds.quota_project_id = "project-1"
+
+        credentials = {"type": "service_account", "project_id": "project-1"}
+
+        with patch.object(
+            vertex_base, "load_auth", return_value=(mock_creds, "project-1")
+        ):
+            if is_async:
+                token, project = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id="project-1",
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token, project = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id="project-1",
+                    custom_llm_provider="vertex_ai",
+                )
+
+            assert token == "token-1"
+            assert project == "project-1"
+
+            # Verify cache stores tuple format
+            cache_key = (json.dumps(credentials), "project-1")
+            assert cache_key in vertex_base._credentials_project_mapping
+            cached_entry = vertex_base._credentials_project_mapping[cache_key]
+            assert isinstance(cached_entry, tuple)
+            assert len(cached_entry) == 2
+            cached_creds, cached_project = cached_entry
+            assert cached_creds == mock_creds
+            assert cached_project == "project-1"
+
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_backward_compatibility_old_cache_format(self, is_async):
+        """Test backward compatibility with old cache format (just credentials)"""
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "token-1"
+        mock_creds.expired = False
+        mock_creds.project_id = "project-1"
+        mock_creds.quota_project_id = "project-1"
+
+        credentials = {"type": "service_account", "project_id": "project-1"}
+
+        # Simulate old cache format by manually adding just credentials (not tuple)
+        cache_key = (json.dumps(credentials), "project-1")
+        vertex_base._credentials_project_mapping[cache_key] = mock_creds
+
+        # Should handle old format gracefully
+        if is_async:
+            token, project = await vertex_base._ensure_access_token_async(
+                credentials=credentials,
+                project_id="project-1",
+                custom_llm_provider="vertex_ai",
+            )
+        else:
+            token, project = vertex_base._ensure_access_token(
+                credentials=credentials,
+                project_id="project-1",
+                custom_llm_provider="vertex_ai",
+            )
+
+        assert token == "token-1"
+        assert project == "project-1"
+
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_resolved_project_id_cache_optimization(self, is_async):
+        """Test that resolved project_id creates additional cache entries for optimization"""
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "token-1"
+        mock_creds.expired = False
+        mock_creds.project_id = "resolved-project"
+        mock_creds.quota_project_id = "resolved-project"
+
+        credentials = {"type": "service_account"}
+
+        with patch.object(
+            vertex_base, "load_auth", return_value=(mock_creds, "resolved-project")
+        ):
+            # Call without project_id, should use resolved project from credentials
+            if is_async:
+                token, project = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id=None,
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token, project = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id=None,
+                    custom_llm_provider="vertex_ai",
+                )
+
+            assert token == "token-1"
+            assert project == "resolved-project"
+
+                        # Verify both cache entries exist
+            original_cache_key = (json.dumps(credentials), None)
+            resolved_cache_key = (json.dumps(credentials), "resolved-project")
+
+            assert original_cache_key in vertex_base._credentials_project_mapping
+            assert resolved_cache_key in vertex_base._credentials_project_mapping
+
+            # Both should contain the same tuple
+            original_entry = vertex_base._credentials_project_mapping[original_cache_key]
+            resolved_entry = vertex_base._credentials_project_mapping[resolved_cache_key]
+
+            assert isinstance(original_entry, tuple)
+            assert isinstance(resolved_entry, tuple)
+            assert original_entry[0] == mock_creds
+            assert original_entry[1] == "resolved-project"
+            assert resolved_entry[0] == mock_creds
+            assert resolved_entry[1] == "resolved-project"
+
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_cache_update_on_credential_refresh(self, is_async):
+        """Test that cache is updated when credentials are refreshed"""
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "original-token"
+        mock_creds.expired = True  # Start with expired credentials
+        mock_creds.project_id = "project-1"
+        mock_creds.quota_project_id = "project-1"
+
+        credentials = {"type": "service_account", "project_id": "project-1"}
+
+        with patch.object(
+            vertex_base, "load_auth", return_value=(mock_creds, "project-1")
+        ), patch.object(vertex_base, "refresh_auth") as mock_refresh:
+
+            def mock_refresh_impl(creds):
+                creds.token = "refreshed-token"
+                creds.expired = False
+
+            mock_refresh.side_effect = mock_refresh_impl
+
+            if is_async:
+                token, project = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id="project-1",
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token, project = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id="project-1",
+                    custom_llm_provider="vertex_ai",
+                )
+
+            assert mock_refresh.called
+            assert token == "refreshed-token"
+            assert project == "project-1"
+
+            # Verify cache was updated with refreshed credentials
+            cache_key = (json.dumps(credentials), "project-1")
+            assert cache_key in vertex_base._credentials_project_mapping
+            cached_entry = vertex_base._credentials_project_mapping[cache_key]
+            assert isinstance(cached_entry, tuple)
+            cached_creds, cached_project = cached_entry
+            assert cached_creds.token == "refreshed-token"
+            assert not cached_creds.expired
+            assert cached_project == "project-1"
+
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_cache_with_different_project_id_combinations(self, is_async):
+        """Test caching behavior with different project_id parameter combinations"""
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "token-1"
+        mock_creds.expired = False
+        mock_creds.project_id = "cred-project"
+        mock_creds.quota_project_id = "cred-project"
+
+        credentials = {"type": "service_account", "project_id": "cred-project"}
+
+        with patch.object(
+            vertex_base, "load_auth", return_value=(mock_creds, "cred-project")
+        ):
+            # First call with explicit project_id
+            if is_async:
+                token1, project1 = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id="explicit-project",
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token1, project1 = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id="explicit-project",
+                    custom_llm_provider="vertex_ai",
+                )
+
+            # Second call with None project_id (should use credential project)
+            if is_async:
+                token2, project2 = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id=None,
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token2, project2 = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id=None,
+                    custom_llm_provider="vertex_ai",
+                )
+
+            assert token1 == "token-1"
+            assert project1 == "explicit-project"  # Should use explicit project_id
+            assert token2 == "token-1"
+            assert project2 == "cred-project"  # Should use credential project_id
+
+            # Verify separate cache entries
+            explicit_cache_key = (json.dumps(credentials), "explicit-project")
+            none_cache_key = (json.dumps(credentials), None)
+            resolved_cache_key = (json.dumps(credentials), "cred-project")
+
+            assert explicit_cache_key in vertex_base._credentials_project_mapping
+            assert none_cache_key in vertex_base._credentials_project_mapping
+            assert resolved_cache_key in vertex_base._credentials_project_mapping
+
+    @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
+    @pytest.mark.asyncio
+    async def test_project_id_resolution_and_caching_core_issue(self, is_async):
+        """
+        When user doesn't provide project_id, system should resolve it from credentials
+        and cache the resolved project_id for future calls without calling load_auth again.
+        """
+        vertex_base = VertexBase()
+
+        mock_creds = MagicMock()
+        mock_creds.token = "token-from-creds"
+        mock_creds.expired = False
+        mock_creds.project_id = "resolved-from-credentials"
+        mock_creds.quota_project_id = "resolved-from-credentials"
+
+        # User provides credentials but NO project_id (this is the key scenario)
+        credentials = {"type": "service_account"}
+
+        with patch.object(
+            vertex_base, "load_auth", return_value=(mock_creds, "resolved-from-credentials")
+        ) as mock_load_auth:
+
+            # First call: User provides NO project_id, should resolve from credentials
+            if is_async:
+                token1, project1 = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id=None,  # Key: user doesn't provide project_id
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token1, project1 = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id=None,  # Key: user doesn't provide project_id
+                    custom_llm_provider="vertex_ai",
+                )
+
+            # Should have called load_auth once to resolve project_id
+            assert mock_load_auth.call_count == 1
+            assert token1 == "token-from-creds"
+            assert project1 == "resolved-from-credentials"
+
+            # Verify cache contains both the original key and resolved key
+            original_cache_key = (json.dumps(credentials), None)
+            resolved_cache_key = (json.dumps(credentials), "resolved-from-credentials")
+
+            assert original_cache_key in vertex_base._credentials_project_mapping
+            assert resolved_cache_key in vertex_base._credentials_project_mapping
+
+            # Both should contain the tuple with resolved project_id
+            original_entry = vertex_base._credentials_project_mapping[original_cache_key]
+            resolved_entry = vertex_base._credentials_project_mapping[resolved_cache_key]
+
+            assert isinstance(original_entry, tuple)
+            assert isinstance(resolved_entry, tuple)
+            assert original_entry[1] == "resolved-from-credentials"
+            assert resolved_entry[1] == "resolved-from-credentials"
+
+            # Second call: Same scenario - should use cache and NOT call load_auth again
+            if is_async:
+                token2, project2 = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id=None,  # Still no project_id provided
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token2, project2 = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id=None,  # Still no project_id provided
+                    custom_llm_provider="vertex_ai",
+                )
+
+            # Should NOT have called load_auth again (still 1 call total)
+            assert mock_load_auth.call_count == 1
+            assert token2 == "token-from-creds"
+            assert project2 == "resolved-from-credentials"
+
+            # Third call: Now user provides the resolved project_id explicitly
+            # This should also use cache (the resolved_cache_key)
+            if is_async:
+                token3, project3 = await vertex_base._ensure_access_token_async(
+                    credentials=credentials,
+                    project_id="resolved-from-credentials",  # Explicit resolved project_id
+                    custom_llm_provider="vertex_ai",
+                )
+            else:
+                token3, project3 = vertex_base._ensure_access_token(
+                    credentials=credentials,
+                    project_id="resolved-from-credentials",  # Explicit resolved project_id
+                    custom_llm_provider="vertex_ai",
+                )
+
+            # Should still NOT have called load_auth again (cache hit)
+            assert mock_load_auth.call_count == 1
+            assert token3 == "token-from-creds"
+            assert project3 == "resolved-from-credentials"
 
     @pytest.mark.parametrize(
         "api_base, vertex_location, expected",
@@ -362,7 +698,6 @@ class TestVertexBase:
             ),
         ],
     )
-
     def test_get_api_base(self, api_base, vertex_location, expected):
         vertex_base = VertexBase()
         assert (


### PR DESCRIPTION
## Fix VertexAI Auth when no project_id provided

In the current VertexAI authentication code, if no `project_id` (`vertex_project`) is provided, the initial auth request eventually uses the authentication metadata service and successfully operates as the service account associated. After the initial request, when litellm needs to re-authenticate, the following error is thrown:

```
ValueError: Could not resolve project_id
```

The core issue seems to be that the cached credentials do not contain the project_id that was "resolved" during the the `load_auth` step. When the cached credentials are then reused, code later in the process fails expecting a project_id.  It's reasonable to assume that if a user has not provided a project_id explicitly, litelllm should use the one provided via authenticate process & metadata service (which it already does on the initial authentication).

This fix adds the project_id to the cached credentials in this scenario so that it may be reused on subsequent credential refresh calls.

## Relevant issues

Fixes #9863

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

All VertexAI unit tests passed
<img width="969" height="157" alt="Screenshot 2025-07-16 at 1 57 26 PM" src="https://github.com/user-attachments/assets/fbe40a75-9fe3-46cd-990f-2960e2441c02" />

All unit tests did not pass due to an unrelated import issue with the Google GenAI code / tests.

## Type

🐛 Bug Fix
✅ Test

## Changes

Described above. Additionally 6 (12 in total due to parameterize) new unit tests are added for different conditions. `test_project_id_resolution_and_caching_core_issue` is the most pertinent but the others are useful.

I chose this solution since it seems that cached credentials are preferred and adding the project_id into them makes sense. An alternative would be to return the project_id from `load_auth` each time it's called but this seems to go against the credential caching mechanism.

FYI @krrishdholakia . I can reliably reproduce the issue in a VM on GCP on the 2nd run of a process based on some interval (i.e. call litelllm every 10min). This fix has been been running for 16+ hours without issue.

