### PR TITLE
[Liveness/Liveliness probe] add separate health app for liveness probes in files

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -640,6 +640,8 @@ router_settings:
 | REQUEST_TIMEOUT | Timeout in seconds for requests. Default is 6000
 | ROUTER_MAX_FALLBACKS | Maximum number of fallbacks for router. Default is 5
 | SECRET_MANAGER_REFRESH_INTERVAL | Refresh interval in seconds for secret manager. Default is 86400 (24 hours)
+| SEPARATE_HEALTH_APP | If set to '1', runs health endpoints on a separate ASGI app and port. Default: '0'. |
+| SEPARATE_HEALTH_PORT| Port for the separate health endpoints app. Only used if SEPARATE_HEALTH_APP=1. Default: 4001. |
 | SERVER_ROOT_PATH | Root path for the server application
 | SET_VERBOSE | Flag to enable verbose logging
 | SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD | Minimum number of requests to consider "reasonable traffic" for single-deployment cooldown logic. Default is 1000

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -640,8 +640,8 @@ router_settings:
 | REQUEST_TIMEOUT | Timeout in seconds for requests. Default is 6000
 | ROUTER_MAX_FALLBACKS | Maximum number of fallbacks for router. Default is 5
 | SECRET_MANAGER_REFRESH_INTERVAL | Refresh interval in seconds for secret manager. Default is 86400 (24 hours)
-| SEPARATE_HEALTH_APP | If set to '1', runs health endpoints on a separate ASGI app and port. Default: '0'. |
-| SEPARATE_HEALTH_PORT| Port for the separate health endpoints app. Only used if SEPARATE_HEALTH_APP=1. Default: 4001. |
+| SEPARATE_HEALTH_APP | If set to '1', runs health endpoints on a separate ASGI app and port. Default: '0'.
+| SEPARATE_HEALTH_PORT | Port for the separate health endpoints app. Only used if SEPARATE_HEALTH_APP=1. Default: 4001.
 | SERVER_ROOT_PATH | Root path for the server application
 | SET_VERBOSE | Flag to enable verbose logging
 | SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD | Minimum number of requests to consider "reasonable traffic" for single-deployment cooldown logic. Default is 1000

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -232,6 +232,21 @@ To fix this, just set `LITELLM_MIGRATION_DIR="/path/to/writeable/directory"` in 
 
 LiteLLM will use this directory to write migration files.
 
+## 10. Use a Separate Health Check App
+Using a separate health check app ensures that your liveness and readiness probes remain responsive even when the main application is under heavy load. 
+
+**Why is this important?**
+
+- If your health endpoints share the same process as your main app, high traffic or resource exhaustion can cause health checks to hang or fail.
+- When Kubernetes liveness probes hang or time out, it may incorrectly assume your pod is unhealthy and restart it—even if the main app is just busy, not dead.
+- By running health endpoints on a separate lightweight FastAPI app (with its own port), you guarantee that health checks remain fast and reliable, preventing unnecessary pod restarts during traffic spikes or heavy workloads.
+
+**How to enable:**
+
+Set the following environment variable:
+Set the environment variable `SEPARATE_HEALTH_APP=1` to enable the separate health check app:
+You can also specify the port for the separate health check app by setting the `SEPARATE_HEALTH_PORT` environment variable. By default, the health app will run on port 4001
+
 ## Extras
 ### Expected Performance in Production
 

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -244,8 +244,9 @@ Using a separate health check app ensures that your liveness and readiness probe
 **How to enable:**
 
 Set the following environment variable:
-Set the environment variable `SEPARATE_HEALTH_APP=1` to enable the separate health check app:
-You can also specify the port for the separate health check app by setting the `SEPARATE_HEALTH_PORT` environment variable. By default, the health app will run on port 4001
+- Set the environment variable `SEPARATE_HEALTH_APP=1` to enable the separate health check app
+
+- You can also specify the port for the separate health check app by setting the `SEPARATE_HEALTH_PORT` environment variable. By default, the health app will run on port 4001
 
 ## Extras
 ### Expected Performance in Production

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -240,13 +240,15 @@ Using a separate health check app ensures that your liveness and readiness probe
 - If your health endpoints share the same process as your main app, high traffic or resource exhaustion can cause health checks to hang or fail.
 - When Kubernetes liveness probes hang or time out, it may incorrectly assume your pod is unhealthy and restart it—even if the main app is just busy, not dead.
 - By running health endpoints on a separate lightweight FastAPI app (with its own port), you guarantee that health checks remain fast and reliable, preventing unnecessary pod restarts during traffic spikes or heavy workloads.
+- Since the proxy and health app are running in the same pod, if health check app fails, it signifies that the pod is unhealthy and needs to restart/have action taken upon.
 
 **How to enable:**
 
-Set the following environment variable:
-- Set the environment variable `SEPARATE_HEALTH_APP=1` to enable the separate health check app
-
-- You can also specify the port for the separate health check app by setting the `SEPARATE_HEALTH_PORT` environment variable. By default, the health app will run on port 4001
+Set the following environment variable(s):
+```bash
+SEPARATE_HEALTH_APP="1" # Default "0" 
+SEPARATE_HEALTH_PORT="8001" # Default "4001", Works only if `SEPARATE_HEALTH_APP` is "1"
+```
 
 ## Extras
 ### Expected Performance in Production

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -792,13 +792,13 @@ def run_server(  # noqa: PLR0915
         from litellm.proxy.proxy_server import app  # noqa
         
         # --- SEPARATE HEALTH APP LOGIC ---
-        separate_health = os.getenv("SEPARATE_HEALTH", "0")
+        separate_health = os.getenv("SEPARATE_HEALTH_APP", "0")
         if separate_health == "1":
             from fastapi import FastAPI
             from litellm.proxy.health_endpoints._health_endpoints import router as health_router
             health_app = FastAPI(title="LiteLLM Health Endpoints")
             health_app.include_router(health_router)
-            health_port = int(os.getenv("HEALTH_PORT", 4001))
+            health_port = int(os.getenv("SEPARATE_HEALTH_PORT", 4001))
             print(f"\033[1;32mLiteLLM Health Endpoints: Running on http://0.0.0.0:{health_port}\033[0m")
             import threading
             def run_health_app():

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -790,7 +790,23 @@ def run_server(  # noqa: PLR0915
 
         # DO NOT DELETE - enables global variables to work across files
         from litellm.proxy.proxy_server import app  # noqa
-
+        
+        # --- SEPARATE HEALTH APP LOGIC ---
+        separate_health = os.getenv("SEPARATE_HEALTH", "0")
+        if separate_health == "1":
+            from fastapi import FastAPI
+            from litellm.proxy.health_endpoints._health_endpoints import router as health_router
+            health_app = FastAPI(title="LiteLLM Health Endpoints")
+            health_app.include_router(health_router)
+            health_port = int(os.getenv("HEALTH_PORT", 4001))
+            print(f"\033[1;32mLiteLLM Health Endpoints: Running on http://0.0.0.0:{health_port}\033[0m")
+            import threading
+            def run_health_app():
+                uvicorn.run(health_app, host="0.0.0.0", port=health_port, log_level="info")
+            t = threading.Thread(target=run_health_app, daemon=True)
+            t.start()
+        # --- END SEPARATE HEALTH APP LOGIC ---
+        
         # Skip server startup if requested (after all setup is done)
         if skip_server_startup:
             print(  # noqa

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -302,6 +302,22 @@ class ProxyInitializationHelpers:
         return "uvloop"
 
 
+def run_separate_health_app():
+    separate_health = os.getenv("SEPARATE_HEALTH_APP", "0")
+    if separate_health == "1":
+        from fastapi import FastAPI
+        from litellm.proxy.health_endpoints._health_endpoints import router as health_router
+        health_app = FastAPI(title="LiteLLM Health Endpoints")
+        health_app.include_router(health_router)
+        health_port = int(os.getenv("SEPARATE_HEALTH_PORT", 4001))
+        print(f"\033[1;32mLiteLLM Health Endpoints: Running on http://0.0.0.0:{health_port}\033[0m")
+        import threading
+        def run_health_app():
+            uvicorn.run(health_app, host="0.0.0.0", port=health_port, log_level="info")
+        t = threading.Thread(target=run_health_app, daemon=True)
+        t.start()
+
+
 @click.command()
 @click.option(
     "--host", default="0.0.0.0", help="Host for the server to listen on.", envvar="HOST"
@@ -792,19 +808,7 @@ def run_server(  # noqa: PLR0915
         from litellm.proxy.proxy_server import app  # noqa
         
         # --- SEPARATE HEALTH APP LOGIC ---
-        separate_health = os.getenv("SEPARATE_HEALTH_APP", "0")
-        if separate_health == "1":
-            from fastapi import FastAPI
-            from litellm.proxy.health_endpoints._health_endpoints import router as health_router
-            health_app = FastAPI(title="LiteLLM Health Endpoints")
-            health_app.include_router(health_router)
-            health_port = int(os.getenv("SEPARATE_HEALTH_PORT", 4001))
-            print(f"\033[1;32mLiteLLM Health Endpoints: Running on http://0.0.0.0:{health_port}\033[0m")
-            import threading
-            def run_health_app():
-                uvicorn.run(health_app, host="0.0.0.0", port=health_port, log_level="info")
-            t = threading.Thread(target=run_health_app, daemon=True)
-            t.start()
+        run_separate_health_app()
         # --- END SEPARATE HEALTH APP LOGIC ---
         
         # Skip server startup if requested (after all setup is done)

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -313,6 +313,7 @@ def run_separate_health_app():
         print(f"\033[1;32mLiteLLM Health Endpoints: Running on http://0.0.0.0:{health_port}\033[0m")
         import threading
         def run_health_app():
+            import uvicorn
             uvicorn.run(health_app, host="0.0.0.0", port=health_port, log_level="info")
         t = threading.Thread(target=run_health_app, daemon=True)
         t.start()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8715,9 +8715,7 @@ app.include_router(anthropic_router)
 app.include_router(google_router)
 app.include_router(langfuse_router)
 app.include_router(pass_through_router)
-# Only include health_router if SEPARATE_HEALTH_APP is not set to '1'
-if os.getenv("SEPARATE_HEALTH_APP", "0") != "1":
-    app.include_router(health_router)
+app.include_router(health_router)
 app.include_router(key_management_router)
 app.include_router(internal_user_router)
 app.include_router(team_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8715,7 +8715,9 @@ app.include_router(anthropic_router)
 app.include_router(google_router)
 app.include_router(langfuse_router)
 app.include_router(pass_through_router)
-app.include_router(health_router)
+# Only include health_router if SEPARATE_HEALTH_APP is not set to '1'
+if os.getenv("SEPARATE_HEALTH_APP", "0") != "1":
+    app.include_router(health_router)
 app.include_router(key_management_router)
 app.include_router(internal_user_router)
 app.include_router(team_router)


### PR DESCRIPTION
## Title

[Liveness/Liveliness probe] add separate health app for liveness probes in files

## Relevant issues

Fixes issues of liveness probe hanging when server is under stress 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🆕 New Feature

## Changes


