### PR TITLE
Fix SSO Logout | Create Unified Login Page with SSO and Username/Password Options

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -72,11 +72,13 @@ router = APIRouter()
 
 
 @router.get("/sso/key/generate", tags=["experimental"], include_in_schema=False)
-async def google_login(request: Request, source: Optional[str] = None, key: Optional[str] = None):  # noqa: PLR0915
+async def serve_login_page(request: Request, source: Optional[str] = None, key: Optional[str] = None, error: Optional[str] = None):
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
     Example:
+    Serves a unified login page with options for both normal
+    username/password login and SSO.
     """
     from litellm.proxy.proxy_server import (
         premium_user,
@@ -94,6 +96,316 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
         if is_disabled:
             return admin_ui_disabled()
 
+    ####### Check if user is a Enterprise / Premium User for SSO #######
+    sso_available = False
+    if (
+        microsoft_client_id is not None
+        or google_client_id is not None
+        or generic_client_id is not None
+    ):
+        if premium_user is True:
+            sso_available = True
+
+    ####### Detect DB + MASTER KEY in .env #######
+    missing_env_vars = show_missing_vars_in_env()
+    if missing_env_vars is not None:
+        return missing_env_vars
+
+    # Build the unified login page HTML
+    error_message = ""
+    if error == "1":
+        error_message = """
+        <div style="
+            background-color: #fef2f2;
+            border-left: 4px solid #dc2626;
+            border-radius: 6px;
+            padding: 16px;
+            margin-bottom: 20px;
+            color: #dc2626;
+            font-size: 14px;
+            font-weight: 500;
+        ">
+            ⚠️ Invalid username or password. Please try again.
+        </div>
+        """
+
+    sso_button = ""
+    if sso_available:
+        sso_button = """
+        <div style="
+            margin-top: 20px;
+            padding-top: 20px;
+            border-top: 1px solid #e2e8f0;
+            text-align: center;
+        ">
+            <p style="
+                color: #64748b;
+                font-size: 14px;
+                margin-bottom: 16px;
+            ">or</p>
+            <a href="/sso/login" style="
+                display: inline-block;
+                background-color: #f8fafc;
+                border: 1px solid #e2e8f0;
+                color: #374151;
+                padding: 10px 20px;
+                border-radius: 6px;
+                text-decoration: none;
+                font-weight: 500;
+                transition: all 0.2s;
+                font-size: 14px;
+            " onmouseover="this.style.backgroundColor='#f1f5f9'; this.style.borderColor='#cbd5e1';" 
+               onmouseout="this.style.backgroundColor='#f8fafc'; this.style.borderColor='#e2e8f0';">
+                🔐 Login with SSO
+            </a>
+        </div>
+        """
+
+    # Get the base URL for form action - CHANGE THIS TO POINT TO /login
+    proxy_base_url = os.getenv("PROXY_BASE_URL", "")
+    server_root_path = os.getenv("SERVER_ROOT_PATH", "")
+    if server_root_path != "":
+        proxy_base_url += server_root_path
+    form_action = proxy_base_url + "/sso/key/generate"  # CHANGE BACK to /sso/key/generate
+
+    unified_login_html = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>LiteLLM Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background-color: #f8fafc;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            color: #333;
+        }}
+
+        form {{
+            background-color: #fff;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            width: 450px;
+            max-width: 100%;
+        }}
+        
+        .logo-container {{
+            text-align: center;
+            margin-bottom: 30px;
+        }}
+        
+        .logo {{
+            font-size: 24px;
+            font-weight: 600;
+            color: #1e293b;
+        }}
+        
+        h2 {{
+            margin: 0 0 10px;
+            color: #1e293b;
+            font-size: 28px;
+            font-weight: 600;
+            text-align: center;
+        }}
+        
+        .subtitle {{
+            color: #64748b;
+            margin: 0 0 20px;
+            font-size: 16px;
+            text-align: center;
+        }}
+
+        .info-box {{
+            background-color: #f1f5f9;
+            border-radius: 6px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border-left: 4px solid #2563eb;
+        }}
+        
+        .info-header {{
+            display: flex;
+            align-items: center;
+            margin-bottom: 12px;
+            color: #1e40af;
+            font-weight: 600;
+            font-size: 16px;
+        }}
+        
+        .info-header svg {{
+            margin-right: 8px;
+        }}
+        
+        .info-box p {{
+            color: #475569;
+            margin: 8px 0;
+            line-height: 1.5;
+            font-size: 14px;
+        }}
+
+        label {{
+            display: block;
+            margin-bottom: 8px;
+            font-weight: 500;
+            color: #334155;
+            font-size: 14px;
+        }}
+        
+        .required {{
+            color: #dc2626;
+            margin-left: 2px;
+        }}
+
+        input[type="text"],
+        input[type="password"] {{
+            width: 100%;
+            padding: 10px 14px;
+            margin-bottom: 20px;
+            box-sizing: border-box;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            font-size: 15px;
+            color: #1e293b;
+            background-color: #fff;
+            transition: border-color 0.2s, box-shadow 0.2s;
+        }}
+        
+        input[type="text"]:focus,
+        input[type="password"]:focus {{
+            outline: none;
+            border-color: #3b82f6;
+            box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+        }}
+
+        .toggle-password {{
+            display: flex;
+            align-items: center;
+            margin-top: -15px;
+            margin-bottom: 20px;
+        }}
+        
+        .toggle-password input[type="checkbox"] {{
+            margin-right: 8px;
+            vertical-align: middle;
+            width: 16px;
+            height: 16px;
+        }}
+        
+        .toggle-password label {{
+            margin-bottom: 0;
+            font-size: 14px;
+            cursor: pointer;
+            line-height: 1;
+        }}
+
+        input[type="submit"] {{
+            background-color: #6466E9;
+            color: #fff;
+            cursor: pointer;
+            font-weight: 500;
+            border: none;
+            padding: 10px 16px;
+            transition: background-color 0.2s;
+            border-radius: 6px;
+            margin-top: 10px;
+            font-size: 14px;
+            width: 100%;
+        }}
+
+        input[type="submit"]:hover {{
+            background-color: #4138C2;
+        }}
+        
+        a {{
+            color: #3b82f6;
+            text-decoration: none;
+        }}
+
+        a:hover {{
+            text-decoration: underline;
+        }}
+        
+        code {{
+            background-color: #f1f5f9;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 13px;
+            color: #334155;
+        }}
+    </style>
+</head>
+<body>
+    <form action="{form_action}" method="post">
+        <div class="logo-container">
+            <div class="logo">
+                🚅 LiteLLM
+            </div>
+        </div>
+        <h2>Login</h2>
+        <p class="subtitle">Access your LiteLLM Admin UI.</p>
+        
+        {error_message}
+        
+        <div class="info-box">
+            <div class="info-header">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10"></circle>
+                    <line x1="12" y1="16" x2="12" y2="12"></line>
+                    <line x1="12" y1="8" x2="12.01" y2="8"></line>
+                </svg>
+                Default Credentials
+            </div>
+            <p>By default, Username is <code>admin</code> and Password is your set LiteLLM Proxy <code>MASTER_KEY</code>.</p>
+            <p>Need to set UI credentials or SSO? <a href="https://docs.litellm.ai/docs/proxy/ui" target="_blank">Check the documentation</a>.</p>
+        </div>
+        
+        <label for="username">Username<span class="required">*</span></label>
+        <input type="text" id="username" name="username" required placeholder="Enter your username" autocomplete="username">
+        
+        <label for="password">Password<span class="required">*</span></label>
+        <input type="password" id="password" name="password" required placeholder="Enter your password" autocomplete="current-password">
+        <div class="toggle-password">
+            <input type="checkbox" id="show-password" onclick="togglePasswordVisibility()">
+            <label for="show-password">Show password</label>
+        </div>
+        <input type="submit" value="Login">
+        
+        {sso_button}
+    </form>
+    <script>
+        function togglePasswordVisibility() {{
+            var passwordField = document.getElementById("password");
+            passwordField.type = passwordField.type === "password" ? "text" : "password";
+        }}
+    </script>
+</body>
+</html>
+    """
+
+    from fastapi.responses import HTMLResponse
+    return HTMLResponse(content=unified_login_html, status_code=200)
+
+
+@router.get("/sso/login", tags=["experimental"], include_in_schema=False)
+async def sso_login_redirect(request: Request, source: Optional[str] = None, key: Optional[str] = None):
+    """
+    Handles SSO login redirect - this is what the "Login with SSO" button points to
+    """
+    from litellm.proxy.proxy_server import premium_user, user_custom_ui_sso_sign_in_handler
+
+    microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
+    google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
+    generic_client_id = os.getenv("GENERIC_CLIENT_ID", None)
+
     ####### Check if user is a Enterprise / Premium User #######
     if (
         microsoft_client_id is not None
@@ -107,12 +419,6 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
                 param="premium_user",
                 code=status.HTTP_403_FORBIDDEN,
             )
-
-    ####### Detect DB + MASTER KEY in .env #######
-    missing_env_vars = show_missing_vars_in_env()
-    if missing_env_vars is not None:
-        return missing_env_vars
-    ui_username = os.getenv("UI_USERNAME")
 
     # get url from request - always use regular callback, but set state for CLI
     redirect_url = SSOAuthenticationHandler.get_redirect_url_for_sso(
@@ -155,16 +461,9 @@ async def google_login(request: Request, source: Optional[str] = None, key: Opti
             generic_client_id=generic_client_id,
             state=cli_state,
         )
-    elif ui_username is not None:
-        # No Google, Microsoft SSO
-        # Use UI Credentials set in .env
-        from fastapi.responses import HTMLResponse
-
-        return HTMLResponse(content=html_form, status_code=200)
     else:
-        from fastapi.responses import HTMLResponse
-
-        return HTMLResponse(content=html_form, status_code=200)
+        # No SSO configured, redirect back to login page
+        return RedirectResponse(url="/sso/key/generate", status_code=303)
 
 
 def generic_response_convertor(
@@ -1889,3 +2188,28 @@ async def debug_sso_callback(request: Request):
     )
 
     return HTMLResponse(content=html_content)
+
+
+@router.post("/sso/key/generate", tags=["experimental"], include_in_schema=False)
+async def process_login(request: Request):
+    """
+    Process username/password login from the unified login page
+    """
+    try:
+        # Get form data
+        form_data = await request.form()
+        username = form_data.get("username")
+        password = form_data.get("password")
+        
+        if not username or not password:
+            return RedirectResponse(url="/sso/key/generate?error=1", status_code=303)
+        
+        # Import the actual login function from proxy_server
+        from litellm.proxy.proxy_server import login
+        
+        # Call the real login function that handles all the authentication properly
+        return await login(request)
+            
+    except Exception as e:
+        verbose_proxy_logger.error(f"Error processing login: {e}")
+        return RedirectResponse(url="/sso/key/generate?error=1", status_code=303)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -84,10 +84,7 @@ async def serve_login_page(
     Serves a unified login page with options for both normal
     username/password login and SSO.
     """
-    from litellm.proxy.proxy_server import (
-        premium_user,
-        user_custom_ui_sso_sign_in_handler,
-    )
+    from litellm.proxy.proxy_server import premium_user
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)
@@ -409,7 +406,10 @@ async def sso_login_redirect(
     """
     Handles SSO login redirect - this is what the "Login with SSO" button points to
     """
-    from litellm.proxy.proxy_server import premium_user
+    from litellm.proxy.proxy_server import (
+        premium_user,
+        user_custom_ui_sso_sign_in_handler,
+    )
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -51,7 +51,6 @@ from litellm.proxy.common_utils.admin_ui_utils import (
 from litellm.proxy.common_utils.html_forms.jwt_display_template import (
     jwt_display_template,
 )
-from litellm.proxy.common_utils.html_forms.ui_login import html_form
 from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
 from litellm.proxy.management_endpoints.sso_helper_utils import (
     check_is_admin_only_access,
@@ -400,7 +399,7 @@ async def sso_login_redirect(request: Request, source: Optional[str] = None, key
     """
     Handles SSO login redirect - this is what the "Login with SSO" button points to
     """
-    from litellm.proxy.proxy_server import premium_user, user_custom_ui_sso_sign_in_handler
+    from litellm.proxy.proxy_server import premium_user
 
     microsoft_client_id = os.getenv("MICROSOFT_CLIENT_ID", None)
     google_client_id = os.getenv("GOOGLE_CLIENT_ID", None)

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -71,7 +71,12 @@ router = APIRouter()
 
 
 @router.get("/sso/key/generate", tags=["experimental"], include_in_schema=False)
-async def serve_login_page(request: Request, source: Optional[str] = None, key: Optional[str] = None, error: Optional[str] = None):
+async def serve_login_page(
+    request: Request,
+    source: Optional[str] = None,
+    key: Optional[str] = None,
+    error: Optional[str] = None,
+):
     """
     Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
@@ -165,7 +170,9 @@ async def serve_login_page(request: Request, source: Optional[str] = None, key: 
     server_root_path = os.getenv("SERVER_ROOT_PATH", "")
     if server_root_path != "":
         proxy_base_url += server_root_path
-    form_action = proxy_base_url + "/sso/key/generate"  # CHANGE BACK to /sso/key/generate
+    form_action = (
+        proxy_base_url + "/sso/key/generate"
+    )  # CHANGE BACK to /sso/key/generate
 
     unified_login_html = f"""
 <!DOCTYPE html>
@@ -391,11 +398,14 @@ async def serve_login_page(request: Request, source: Optional[str] = None, key: 
     """
 
     from fastapi.responses import HTMLResponse
+
     return HTMLResponse(content=unified_login_html, status_code=200)
 
 
 @router.get("/sso/login", tags=["experimental"], include_in_schema=False)
-async def sso_login_redirect(request: Request, source: Optional[str] = None, key: Optional[str] = None):
+async def sso_login_redirect(
+    request: Request, source: Optional[str] = None, key: Optional[str] = None
+):
     """
     Handles SSO login redirect - this is what the "Login with SSO" button points to
     """
@@ -424,7 +434,7 @@ async def sso_login_redirect(request: Request, source: Optional[str] = None, key
         request=request,
         sso_callback_route="sso/callback",
     )
-    
+
     # Store CLI key in state for OAuth flow
     cli_state: Optional[str] = SSOAuthenticationHandler._get_cli_state(
         source=source,
@@ -437,11 +447,14 @@ async def sso_login_redirect(request: Request, source: Optional[str] = None, key
             from litellm_enterprise.proxy.auth.custom_sso_handler import (
                 EnterpriseCustomSSOHandler,
             )
+
             return await EnterpriseCustomSSOHandler.handle_custom_ui_sso_sign_in(
                 request=request,
             )
         except ImportError:
-            raise ValueError("Enterprise features are not available. Custom UI SSO sign-in requires LiteLLM Enterprise.")
+            raise ValueError(
+                "Enterprise features are not available. Custom UI SSO sign-in requires LiteLLM Enterprise."
+            )
 
     # Check if we should use SSO handler
     if (
@@ -818,15 +831,16 @@ async def check_and_update_if_proxy_admin_id(
 async def auth_callback(request: Request, state: Optional[str] = None):  # noqa: PLR0915
     """Verify login"""
     verbose_proxy_logger.info(f"Starting SSO callback with state: {state}")
-    
+
     # Check if this is a CLI login (state starts with our CLI prefix)
     from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
+
     if state and state.startswith(f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:"):
         # Extract the key ID from the state
         key_id = state.split(":", 1)[1]
         verbose_proxy_logger.info(f"CLI SSO callback detected for key: {key_id}")
         return await cli_sso_callback(request, key=key_id)
-    
+
     from litellm.proxy._types import LiteLLM_JWTAuth
     from litellm.proxy.auth.handle_jwt import JWTHandler
     from litellm.proxy.proxy_server import (
@@ -901,7 +915,7 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
             status_code=401,
             detail="Result not returned by SSO provider.",
         )
-    
+
     return await SSOAuthenticationHandler.get_redirect_response_from_openid(
         result=result,
         request=request,
@@ -911,28 +925,26 @@ async def auth_callback(request: Request, state: Optional[str] = None):  # noqa:
     )
 
 
-    
-
 async def cli_sso_callback(request: Request, key: Optional[str] = None):
     """CLI SSO callback - generates the key with pre-specified ID"""
     verbose_proxy_logger.info(f"CLI SSO callback for key: {key}")
-    
+
     from litellm.proxy.management_endpoints.key_management_endpoints import (
         generate_key_helper_fn,
     )
     from litellm.proxy.proxy_server import prisma_client
-    
-    if not key or not key.startswith('sk-'):
+
+    if not key or not key.startswith("sk-"):
         raise HTTPException(
             status_code=400,
-            detail="Invalid key parameter. Must be a valid key ID starting with 'sk-'"
+            detail="Invalid key parameter. Must be a valid key ID starting with 'sk-'",
         )
-    
+
     if prisma_client is None:
         raise HTTPException(
             status_code=500, detail=CommonProxyErrors.db_not_connected_error.value
         )
-    
+
     # Generate a simple key for CLI usage with the pre-specified key ID
     try:
         await generate_key_helper_fn(
@@ -946,63 +958,57 @@ async def cli_sso_callback(request: Request, key: Optional[str] = None):
             table_name="key",
             token=key,  # Use the pre-specified key ID
         )
-        
+
         verbose_proxy_logger.info(f"Generated CLI key: {key}")
-        
+
         # Return success page
         from fastapi.responses import HTMLResponse
 
         from litellm.proxy.common_utils.html_forms.cli_sso_success import (
             render_cli_sso_success_page,
         )
-        
+
         html_content = render_cli_sso_success_page()
         return HTMLResponse(content=html_content, status_code=200)
-        
+
     except Exception as e:
         verbose_proxy_logger.error(f"Error generating CLI key: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to generate key: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to generate key: {str(e)}")
 
 
 @router.get("/sso/cli/poll/{key_id}", tags=["experimental"], include_in_schema=False)
 async def cli_poll_key(key_id: str):
     """CLI polling endpoint - checks if key exists in DB"""
     from litellm.proxy.proxy_server import prisma_client
-    
-    if not key_id.startswith('sk-'):
-        raise HTTPException(
-            status_code=400,
-            detail="Invalid key ID format"
-        )
-    
+
+    if not key_id.startswith("sk-"):
+        raise HTTPException(status_code=400, detail="Invalid key ID format")
+
     if prisma_client is None:
         raise HTTPException(
             status_code=500, detail=CommonProxyErrors.db_not_connected_error.value
         )
-    
+
     try:
         # Check if key exists in database
         from litellm.proxy.utils import hash_token
+
         hashed_token = hash_token(key_id)
-        
+
         key_obj = await prisma_client.db.litellm_verificationtoken.find_unique(
             where={"token": hashed_token}
         )
-        
+
         if key_obj:
             verbose_proxy_logger.info(f"CLI key found: {key_id}")
             return {"status": "ready", "key": key_id}
         else:
             return {"status": "pending"}
-            
+
     except Exception as e:
         verbose_proxy_logger.error(f"Error polling for CLI key: {e}")
         raise HTTPException(
-            status_code=500,
-            detail=f"Error checking key status: {str(e)}"
+            status_code=500, detail=f"Error checking key status: {str(e)}"
         )
 
 
@@ -1039,9 +1045,9 @@ async def insert_sso_user(
         if user_defined_values.get("max_budget") is None:
             user_defined_values["max_budget"] = litellm.max_internal_user_budget
         if user_defined_values.get("budget_duration") is None:
-            user_defined_values["budget_duration"] = (
-                litellm.internal_user_budget_duration
-            )
+            user_defined_values[
+                "budget_duration"
+            ] = litellm.internal_user_budget_duration
 
     if user_defined_values["user_role"] is None:
         user_defined_values["user_role"] = LitellmUserRoles.INTERNAL_USER_VIEW_ONLY
@@ -1104,6 +1110,7 @@ class SSOAuthenticationHandler:
     """
     Handler for SSO Authentication across all SSO providers
     """
+
     @staticmethod
     async def get_sso_login_redirect(
         redirect_url: str,
@@ -1239,9 +1246,9 @@ class SSOAuthenticationHandler:
                 if state:
                     redirect_params["state"] = state
                 elif "okta" in generic_authorization_endpoint:
-                    redirect_params["state"] = (
-                        uuid.uuid4().hex
-                    )  # set state param for okta - required
+                    redirect_params[
+                        "state"
+                    ] = uuid.uuid4().hex  # set state param for okta - required
                 return await generic_sso.get_login_redirect(**redirect_params)  # type: ignore
         raise ValueError(
             "Unknown SSO provider. Please setup SSO with client IDs https://docs.litellm.ai/docs/proxy/admin_ui_sso"
@@ -1456,7 +1463,6 @@ class SSOAuthenticationHandler:
             _new_team_request.update(_default_team_params)
             team_request = NewTeamRequest(**_new_team_request)
         return team_request
-    
 
     @staticmethod
     def _get_cli_state(source: Optional[str], key: Optional[str]) -> Optional[str]:
@@ -1469,13 +1475,15 @@ class SSOAuthenticationHandler:
             LITELLM_CLI_SESSION_TOKEN_PREFIX,
             LITELLM_CLI_SOURCE_IDENTIFIER,
         )
-        return f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}" if source == LITELLM_CLI_SOURCE_IDENTIFIER and key else None
-    
 
-
+        return (
+            f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:{key}"
+            if source == LITELLM_CLI_SOURCE_IDENTIFIER and key
+            else None
+        )
 
     @staticmethod
-    async def get_redirect_response_from_openid( # noqa: PLR0915
+    async def get_redirect_response_from_openid(  # noqa: PLR0915
         result: Union[OpenID, dict, CustomOpenID],
         request: Request,
         received_response: Optional[dict] = None,
@@ -1495,14 +1503,18 @@ class SSOAuthenticationHandler:
         )
         from litellm.proxy.utils import get_custom_url, get_prisma_client_or_throw
         from litellm.types.proxy.ui_sso import ReturnedUITokenObject
-        prisma_client = get_prisma_client_or_throw("Prisma client is None, connect a database to your proxy")
 
+        prisma_client = get_prisma_client_or_throw(
+            "Prisma client is None, connect a database to your proxy"
+        )
 
         # User is Authe'd in - generate key for the UI to access Proxy
         verbose_proxy_logger.info(f"SSO callback result: {result}")
 
         user_email: Optional[str] = getattr(result, "email", None)
-        user_id: Optional[str] = getattr(result, "id", None) if result is not None else None
+        user_id: Optional[str] = (
+            getattr(result, "id", None) if result is not None else None
+        )
 
         if user_email is not None and os.getenv("ALLOWED_EMAIL_DOMAINS") is not None:
             email_domain = user_email.split("@")[1]
@@ -1687,7 +1699,8 @@ class SSOAuthenticationHandler:
         redirect_response = RedirectResponse(url=litellm_dashboard_ui, status_code=303)
         redirect_response.set_cookie(key="token", value=jwt_token)
         return redirect_response
-        
+
+
 class MicrosoftSSOHandler:
     """
     Handles Microsoft SSO callback response and returns a CustomOpenID object
@@ -1756,9 +1769,9 @@ class MicrosoftSSOHandler:
 
         # if user is trying to get the raw sso response for debugging, return the raw sso response
         if return_raw_sso_response:
-            original_msft_result[MicrosoftSSOHandler.GRAPH_API_RESPONSE_KEY] = (
-                user_team_ids
-            )
+            original_msft_result[
+                MicrosoftSSOHandler.GRAPH_API_RESPONSE_KEY
+            ] = user_team_ids
             return original_msft_result or {}
 
         result = MicrosoftSSOHandler.openid_from_response(
@@ -1826,9 +1839,9 @@ class MicrosoftSSOHandler:
 
             # Fetch user membership from Microsoft Graph API
             all_group_ids = []
-            next_link: Optional[str] = (
-                MicrosoftSSOHandler.graph_api_user_groups_endpoint
-            )
+            next_link: Optional[
+                str
+            ] = MicrosoftSSOHandler.graph_api_user_groups_endpoint
             auth_headers = {"Authorization": f"Bearer {access_token}"}
             page_count = 0
 
@@ -2199,16 +2212,16 @@ async def process_login(request: Request):
         form_data = await request.form()
         username = form_data.get("username")
         password = form_data.get("password")
-        
+
         if not username or not password:
             return RedirectResponse(url="/sso/key/generate?error=1", status_code=303)
-        
+
         # Import the actual login function from proxy_server
         from litellm.proxy.proxy_server import login
-        
+
         # Call the real login function that handles all the authentication properly
         return await login(request)
-            
+
     except Exception as e:
         verbose_proxy_logger.error(f"Error processing login: {e}")
         return RedirectResponse(url="/sso/key/generate?error=1", status_code=303)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1060,79 +1060,140 @@ class TestUISSO_FunctionsExistence:
         assert callable(SSOAuthenticationHandler._get_cli_state)
 
 
-class TestCustomSSOHandling:
-    """Test the custom SSO handling functionality without enterprise dependencies"""
+class TestCustomUISSO:
+    """Test the custom UI SSO sign-in handler functionality"""
 
     @pytest.mark.asyncio
-    async def test_enterprise_import_error_handling(self):
-        """Test that proper error is raised when enterprise module is not available"""
-        from unittest.mock import MagicMock, patch
-        import sys
-
-        # Mock request
-        mock_request = MagicMock()
-        mock_request.base_url = "https://test.example.com/"
+    async def test_handle_custom_ui_sso_sign_in_success(self):
+        """Test successful custom UI SSO sign-in with valid headers"""
+        from unittest.mock import MagicMock, patch, AsyncMock
         
-        # Mock a custom handler to trigger the enterprise import path
+        # Mock the enterprise classes we need
+        mock_enterprise_handler = MagicMock()
+        mock_enterprise_handler.handle_custom_ui_sso_sign_in = AsyncMock()
+        
+        # Mock the OpenID response
+        mock_openid = MagicMock()
+        mock_openid.id = "test_user_123"
+        mock_openid.email = "test@example.com"
+        mock_openid.first_name = "Test"
+        mock_openid.last_name = "User"
+        mock_openid.display_name = "Test User"
+        mock_openid.picture = None
+        mock_openid.provider = "custom"
+        
+        mock_enterprise_handler.handle_custom_ui_sso_sign_in.return_value = mock_openid
+
+        # Mock request with custom headers
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {
+            "x-litellm-user-id": "test_user_123",
+            "x-litellm-user-email": "test@example.com",
+            "x-forwarded-for": "192.168.1.1",
+        }
+        mock_request.base_url = "https://test.litellm.ai/"
+
+        # Mock the custom handler
         mock_custom_handler = MagicMock()
-        
-        # Block the enterprise import by removing it from sys.modules and making import fail
-        enterprise_modules_to_block = [
-            'litellm_enterprise',
-            'litellm_enterprise.proxy',
-            'litellm_enterprise.proxy.auth',
-            'litellm_enterprise.proxy.auth.custom_sso_handler'
-        ]
-        
-        # Store original modules if they exist
-        original_modules = {}
-        for module in enterprise_modules_to_block:
-            if module in sys.modules:
-                original_modules[module] = sys.modules[module]
-            sys.modules[module] = None
-        
-        try:
-            # Mock the environment to trigger the enterprise path
-            with patch("litellm.proxy.proxy_server.premium_user", True):
-                with patch("litellm.proxy.proxy_server.user_custom_ui_sso_sign_in_handler", mock_custom_handler):
-                    with patch.dict(os.environ, {"GOOGLE_CLIENT_ID": "test_client_id"}):
-                        # Import the actual function
-                        from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
-                        
-                        # This should trigger the enterprise import and raise ValueError
-                        with pytest.raises(ValueError, match="Enterprise features are not available"):
-                            await sso_login_redirect(request=mock_request)
-        finally:
-            # Restore original modules
-            for module in enterprise_modules_to_block:
-                if module in original_modules:
-                    sys.modules[module] = original_modules[module]
-                else:
-                    sys.modules.pop(module, None)
+        mock_custom_handler.handle_custom_ui_sso_sign_in = AsyncMock(return_value=mock_openid)
+
+        # Mock the redirect response method
+        mock_redirect_response = MagicMock()
+        mock_redirect_response.status_code = 303
+
+        # Mock the enterprise import
+        with patch.dict('sys.modules', {
+            'litellm_enterprise': MagicMock(),
+            'litellm_enterprise.proxy': MagicMock(),
+            'litellm_enterprise.proxy.auth': MagicMock(),
+            'litellm_enterprise.proxy.auth.custom_sso_handler': MagicMock()
+        }):
+            # Mock the enterprise class
+            with patch('litellm_enterprise.proxy.auth.custom_sso_handler.EnterpriseCustomSSOHandler', mock_enterprise_handler):
+                with patch("litellm.proxy.proxy_server.premium_user", True):
+                    with patch("litellm.proxy.proxy_server.user_custom_ui_sso_sign_in_handler", mock_custom_handler):
+                        with patch.object(SSOAuthenticationHandler, "get_redirect_response_from_openid", return_value=mock_redirect_response) as mock_get_redirect:
+                            # Import and test
+                            from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
+                            
+                            # Act
+                            result = await sso_login_redirect(request=mock_request)
+
+                            # Assert - The custom handler path should be triggered
+                            # and the redirect response should be returned
+                            assert result == mock_redirect_response
+                            assert result.status_code == 303
 
     @pytest.mark.asyncio
-    async def test_custom_sso_handler_none_check(self):
-        """Test behavior when user_custom_ui_sso_sign_in_handler is None"""
-        from unittest.mock import patch, MagicMock
-        
-        mock_request = MagicMock()
-        mock_request.base_url = "https://test.example.com/"
-        
-        # Mock all the necessary environment variables and imports
-        with patch("litellm.proxy.proxy_server.premium_user", True):
-            with patch("litellm.proxy.proxy_server.user_custom_ui_sso_sign_in_handler", None):
-                with patch.dict(os.environ, {
-                    "GOOGLE_CLIENT_ID": "test_client_id",
-                    "GOOGLE_CLIENT_SECRET": "test_secret"
-                }):
-                    with patch("litellm.proxy.management_endpoints.ui_sso.SSOAuthenticationHandler.get_sso_login_redirect") as mock_redirect:
-                        from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
-                        
-                        # This should not trigger the custom handler path since it's None
-                        await sso_login_redirect(request=mock_request)
-                        
-                        # Verify that the standard SSO redirect was called
-                        mock_redirect.assert_called_once()
+    async def test_custom_ui_sso_handler_execution_with_real_class(self):
+        """Test that when a user provides a custom class instance, it gets properly executed"""
+        from unittest.mock import MagicMock, patch, AsyncMock
+
+        # Create a mock custom handler class
+        class MockCustomSSOHandler:
+            def __init__(self):
+                self.method_called = False
+                self.received_request = None
+
+            async def handle_custom_ui_sso_sign_in(self, request: Request):
+                self.method_called = True
+                self.received_request = request
+                
+                # Mock OpenID response
+                mock_openid = MagicMock()
+                mock_openid.id = "custom_test_user_456"
+                mock_openid.email = "custom@example.com"
+                mock_openid.first_name = "Custom"
+                mock_openid.last_name = "Handler"
+                mock_openid.display_name = "Custom Handler Test"
+                mock_openid.picture = None
+                mock_openid.provider = "custom"
+                return mock_openid
+
+        # Create instance of our test handler
+        test_handler_instance = MockCustomSSOHandler()
+
+        # Mock request with custom headers
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {
+            "x-litellm-user-id": "custom_test_user_456", 
+            "x-litellm-user-email": "custom@example.com",
+            "x-forwarded-for": "10.0.0.1",
+        }
+        mock_request.base_url = "https://custom.litellm.ai/"
+
+        # Mock the redirect response method
+        mock_redirect_response = MagicMock()
+        mock_redirect_response.status_code = 303
+
+        # Mock enterprise handler
+        mock_enterprise_handler = MagicMock()
+        mock_enterprise_handler.handle_custom_ui_sso_sign_in = AsyncMock()
+
+        # Mock the enterprise import and class
+        with patch.dict('sys.modules', {
+            'litellm_enterprise': MagicMock(),
+            'litellm_enterprise.proxy': MagicMock(),
+            'litellm_enterprise.proxy.auth': MagicMock(),
+            'litellm_enterprise.proxy.auth.custom_sso_handler': MagicMock()
+        }):
+            with patch('litellm_enterprise.proxy.auth.custom_sso_handler.EnterpriseCustomSSOHandler', mock_enterprise_handler):
+                with patch("litellm.proxy.proxy_server.premium_user", True):
+                    with patch("litellm.proxy.proxy_server.user_custom_ui_sso_sign_in_handler", test_handler_instance):
+                        with patch.object(SSOAuthenticationHandler, "get_redirect_response_from_openid", return_value=mock_redirect_response) as mock_get_redirect:
+                            # Import and test
+                            from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
+                            
+                            # Act
+                            result = await sso_login_redirect(request=mock_request)
+
+                            # Assert that our custom handler was executed
+                            assert test_handler_instance.method_called is True
+                            assert test_handler_instance.received_request == mock_request
+
+                            # Verify the result is the redirect response
+                            assert result == mock_redirect_response
+                            assert result.status_code == 303
 
     def test_custom_sso_handler_import_path_check(self):
         """Test that the custom handler import path exists in the code"""


### PR DESCRIPTION
## Title
Fix SSO Logout | Create Unified Login Page with SSO and Username/Password Options
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- I have Added testing in the [tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- I have added a screenshot of my new test passing locally
- My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement
🐛 Bug Fix

## Changes
**_Problem_**
SSO Redirect Loop Issue:
When SSO was configured, the logout flow created a confusing user experience:

1. Client-Side Redirect: page.tsx executes window.location.href = "http://localhost:4000/sso/key/generate"

1. Server-Side Redirect: The LiteLLM proxy receives the /sso/key/generate request but immediately sends back an HTTP 302/307 redirect response to the SSO provider (Google/Microsoft/etc)

1. Browser Obeys: Browser automatically navigates to the SSO provider URL

This meant users were immediately redirected to SSO without any option to use username/password login, and when logoutUrl was null, users got caught in a redirect loop with no clear login page.

_**Solution**_
This PR transforms /sso/key/generate from a redirect-only endpoint into a unified login page that provides both authentication methods.

_**Key Changes**_

1. Unified Login Page (/sso/key/generate GET)

- Before: Immediate server-side redirect to SSO provider
- After: Serves a styled login form with username/password fields (always available)
- Conditionally displays "Login with SSO" button only when SSO is configured and premium license is active

2. Username/Password Authentication (/sso/key/generate POST)

- New endpoint that processes form submissions using existing authentication logic

3. SSO Login Redirect (/sso/login GET)

- New dedicated endpoint for SSO authentication flow
- Contains the original SSO redirect logic (moved from /sso/key/generate)
- Separates SSO logic from the main login page display

https://www.loom.com/share/28c7cc65170645aa9da37f8ad8f59039?sid=77b65a41-233e-48da-a9ec-707db8a90861
