### PR TITLE
Fix incorrect environment variable names in Claude code docs

### DIFF
--- a/docs/my-website/docs/tutorials/claude_responses_api.md
+++ b/docs/my-website/docs/tutorials/claude_responses_api.md
@@ -83,7 +83,7 @@ Setup Claude Code to use your LiteLLM proxy:
 
 ```bash
 export ANTHROPIC_BASE_URL="http://0.0.0.0:4000"
-export ANTHROPIC_API_KEY="$LITELLM_MASTER_KEY"
+export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 ```
 
 ### 5. Use Claude Code
@@ -108,7 +108,7 @@ Common issues and solutions:
 **Claude Code not connecting:**
 - Verify your proxy is running: `curl http://0.0.0.0:4000/health`
 - Check that `ANTHROPIC_BASE_URL` is set correctly
-- Ensure your `ANTHROPIC_API_KEY` matches your LiteLLM master key
+- Ensure your `ANTHROPIC_AUTH_TOKEN` matches your LiteLLM master key
 
 **Authentication errors:**
 - Verify your environment variables are set: `echo $LITELLM_MASTER_KEY`


### PR DESCRIPTION
## Title

Fix incorrect environment variable names in Claude code docs

## Relevant issues

N/A - Documentation fix

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- Updated incorrect environment variable name from `ANTHROPIC_API_KEY` to `ANTHROPIC_AUTH_TOKEN` in the tutorial
- This aligns with the official Anthropic documentation for LiteLLM gateway configuration
- Fixed both the configuration section and troubleshooting section to use the correct variable name