### PR TITLE
[MCP Gateway] add fix to update object permission on update/delete key/team

### DIFF
--- a/ui/litellm-dashboard/src/components/all_keys_table.tsx
+++ b/ui/litellm-dashboard/src/components/all_keys_table.tsx
@@ -614,9 +614,11 @@ export function AllKeysTable({
               }
               return key
             }))
+            if (refresh) refresh(); // Minimal fix: refresh the full key list after an update
           }}
           onDelete={() => {
             setKeys(keys => keys.filter(key => key.token !== selectedKeyId))
+            if (refresh) refresh(); // Minimal fix: refresh the full key list after a delete
           }}
           accessToken={accessToken}
           userID={userID}

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -550,10 +550,11 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     organization_id: info.organization_id,
                     vector_stores: info.object_permission?.vector_stores || [],
                     mcp_servers: info.object_permission?.mcp_servers || [],
-                    mcp_access_groups:
-                      info.object_permission?.mcp_servers || [],
-                    mcp_servers_and_groups:
-                      info.object_permission?.mcp_servers || [],
+                    mcp_access_groups: info.object_permission?.mcp_access_groups || [],
+                    mcp_servers_and_groups: {
+                      servers: info.object_permission?.mcp_servers || [],
+                      accessGroups: info.object_permission?.mcp_access_groups || [],
+                    },
                   }}
                   layout="vertical"
                 >

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -567,14 +567,17 @@ const Teams: React.FC<TeamProps> = ({
                   if (teams == null) {
                     return teams;
                   }
-
-                  return teams.map((team) => {
+                  const updated = teams.map((team) => {
                     if (data.team_id === team.team_id) {
                       return updateExistingKeys(team, data);
                     }
-
                     return team;
                   });
+                  // Minimal fix: refresh the full team list after an update
+                  if (accessToken) {
+                    fetchTeams(accessToken, userID, userRole, currentOrg, setTeams);
+                  }
+                  return updated;
                 });
               }}
               onClose={() => {


### PR DESCRIPTION
## Title

[MCP Gateway] add fix to update object permission on update/delete

## Relevant issues

Fixes issues when team or key is updated but the object permissions dont show up instantly

Fixes LIT-322

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


https://github.com/user-attachments/assets/b51b0373-c91d-4eb7-902b-a1cd43e11c2c


