### PR TITLE
Fix SSO Logout | Create Unified Login Page with SSO and Username/Password Options

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -938,10 +938,10 @@ class TestUISSO_FunctionsExistence:
         from litellm.proxy.management_endpoints.ui_sso import auth_callback
         assert callable(auth_callback)
 
-    def test_google_login_exists(self):
-        """Test that google_login function exists"""
-        from litellm.proxy.management_endpoints.ui_sso import google_login
-        assert callable(google_login)
+    def test_sso_login_redirect_exists(self):
+        """Test that sso_login_redirect function exists"""
+        from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
+        assert callable(sso_login_redirect)
 
     def test_sso_authentication_handler_exists(self):
         """Test that SSOAuthenticationHandler class exists with new methods"""
@@ -1054,7 +1054,7 @@ class TestCustomUISSO:
         """Test that proper error is raised when enterprise module is not available"""
         from unittest.mock import MagicMock, patch
 
-        from litellm.proxy.management_endpoints.ui_sso import google_login
+        from litellm.proxy.management_endpoints.ui_sso import sso_login_redirect
 
         # Mock request
         mock_request = MagicMock()


### PR DESCRIPTION
## Title
Fix SSO Logout | Create Unified Login Page with SSO and Username/Password Options
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have Added testing in the [tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
<img width="855" height="209" alt="Screenshot 2025-07-18 at 3 16 06" src="https://github.com/user-attachments/assets/ffc5efd7-d0fc-4abc-91da-64e00c7a9b3d" />

- My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement
🐛 Bug Fix

## Changes
**_Problem_**
SSO Redirect Loop Issue:
When SSO was configured, the logout flow created a confusing user experience:

1. Client-Side Redirect: page.tsx executes window.location.href = "http://localhost:4000/sso/key/generate"

1. Server-Side Redirect: The LiteLLM proxy receives the /sso/key/generate request but immediately sends back an HTTP 302/307 redirect response to the SSO provider (Google/Microsoft/etc)

1. Browser Obeys: Browser automatically navigates to the SSO provider URL

This meant users were immediately redirected to SSO without any option to use username/password login, and when logoutUrl was null, users got caught in a redirect loop with no clear login page.

_**Solution**_
This PR transforms /sso/key/generate from a redirect-only endpoint into a unified login page that provides both authentication methods.

_**Key Changes**_

1. Unified Login Page (/sso/key/generate GET)

- Before: Immediate server-side redirect to SSO provider
- After: Serves a styled login form with username/password fields (always available)
- Conditionally displays "Login with SSO" button only when SSO is configured and premium license is active

2. Username/Password Authentication (/sso/key/generate POST)

- New endpoint that processes form submissions using existing authentication logic

3. SSO Login Redirect (/sso/login GET)

- New dedicated endpoint for SSO authentication flow
- Contains the original SSO redirect logic (moved from /sso/key/generate)
- Separates SSO logic from the main login page display

https://www.loom.com/share/28c7cc65170645aa9da37f8ad8f59039?sid=77b65a41-233e-48da-a9ec-707db8a90861
