### PR TITLE
fix(model_management_endpoints.clear_cache): only clear database models from cache on model update

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1145,7 +1145,9 @@ async def clear_cache():
         return
 
     try:
-        llm_router.model_list.clear()
+        for model in llm_router.model_list:
+            if model.get("model_info", {}).get("db_model"):
+                llm_router.model_list.remove(model)
 
         await proxy_config.add_deployment(
             prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj


### PR DESCRIPTION
## Only Clear Database Models On Model Update

Updated `model_management_endpoints.clear_cache` function so that it only clears database models from the cache since model from the config are not reloaded by this function.

## Relevant issues

Fixes #12711

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

In `litellm.proxy.management_endpoints.model_management_endpoints.clear_cache`, instead of calling `llm_router.model_list.clear()`, iterate over the models and check for `model_info.db_model` to be truthy.  If it is, remove it from the list.

<img width="2062" height="445" alt="Screenshot From 2025-07-17 16-15-55" src="https://github.com/user-attachments/assets/3e111825-cc70-4cad-9438-5839f74853a2" />
