### PR TITLE
fixed comment in docs for anthropic provider

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -107,7 +107,7 @@ model_list:
   - model_name: claude-4 ### RECEIVED MODEL NAME ###
     litellm_params: # all params accepted by litellm.completion() - https://docs.litellm.ai/docs/completion/input
       model: claude-opus-4-20250514 ### MODEL NAME sent to `litellm.completion()` ###
-      api_key: "os.environ/ANTHROPIC_API_KEY" # does os.getenv("AZURE_API_KEY_EU")
+      api_key: "os.environ/ANTHROPIC_API_KEY" # does os.getenv("ANTHROPIC_API_KEY")
 ```
 
 ```bash


### PR DESCRIPTION
## Title

Fix comment in Anthropic provider documentation


## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code) --- not relevant
- [x] I have added a screenshot of my new test passing locally  ---- not relevant
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) -- not relevant i think
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

  - Fixed incorrect comment in Anthropic provider documentation that referenced AZURE_API_KEY_EU instead of ANTHROPIC_API_KEY
  - Updated the inline comment in the YAML configuration example to correctly indicate it uses os.getenv("ANTHROPIC_API_KEY")

The change corrects a copy-paste error in the documentation where the comment incorrectly mentioned Azure API key instead of the Anthropic API key environment variable.


