### PR TITLE
Regenerate Key State Management and Authentication Issues

### DIFF
--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -13,19 +13,37 @@ import {
   Title,
   Badge,
   TextInput,
-  Select as TremorSelect
+  Select as TremorSelect,
 } from "@tremor/react";
-import { ArrowLeftIcon, TrashIcon, RefreshIcon } from "@heroicons/react/outline";
+import {
+  ArrowLeftIcon,
+  TrashIcon,
+  RefreshIcon,
+} from "@heroicons/react/outline";
 import { keyDeleteCall, keyUpdateCall } from "./networking";
 import { KeyResponse } from "./key_team_helpers/key_list";
-import { Form, Input, InputNumber, message, Select, Tooltip, Button as AntdButton } from "antd";
+import {
+  Form,
+  Input,
+  InputNumber,
+  message,
+  Select,
+  Tooltip,
+  Button as AntdButton,
+} from "antd";
 import { KeyEditView } from "./key_edit_view";
 import { RegenerateKeyModal } from "./regenerate_key_modal";
-import { rolesWithWriteAccess } from '../utils/roles';
+import { rolesWithWriteAccess } from "../utils/roles";
 import ObjectPermissionsView from "./object_permissions_view";
 import LoggingSettingsView from "./logging_settings_view";
-import { copyToClipboard as utilCopyToClipboard, formatNumberWithCommas } from "@/utils/dataUtils";
-import { extractLoggingSettings, formatMetadataForDisplay } from "./key_info_utils";
+import {
+  copyToClipboard as utilCopyToClipboard,
+  formatNumberWithCommas,
+} from "@/utils/dataUtils";
+import {
+  extractLoggingSettings,
+  formatMetadataForDisplay,
+} from "./key_info_utils";
 import { CopyIcon, CheckIcon } from "lucide-react";
 
 interface KeyInfoViewProps {
@@ -41,18 +59,34 @@ interface KeyInfoViewProps {
   premiumUser: boolean;
 }
 
-export default function KeyInfoView({ keyId, onClose, keyData, accessToken, userID, userRole, teams, onKeyDataUpdate, onDelete, premiumUser }: KeyInfoViewProps) {
+export default function KeyInfoView({
+  keyId,
+  onClose,
+  keyData,
+  accessToken,
+  userID,
+  userRole,
+  teams,
+  onKeyDataUpdate,
+  onDelete,
+  premiumUser,
+}: KeyInfoViewProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [form] = Form.useForm();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isRegenerateModalOpen, setIsRegenerateModalOpen] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
+  const [currentKeyData, setCurrentKeyData] = useState(keyData);
 
-  if (!keyData) {
+  React.useEffect(() => {
+    setCurrentKeyData(keyData);
+  }, [keyData]);
+
+  if (!currentKeyData) {
     return (
       <div className="p-4">
-        <Button 
-          icon={ArrowLeftIcon} 
+        <Button
+          icon={ArrowLeftIcon}
           variant="light"
           onClick={onClose}
           className="mb-4"
@@ -74,19 +108,22 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
       // Handle object_permission updates
       if (formValues.vector_stores !== undefined) {
         formValues.object_permission = {
-          ...keyData.object_permission,
-          vector_stores: formValues.vector_stores || []
+          ...currentKeyData.object_permission,
+          vector_stores: formValues.vector_stores || [],
         };
         // Remove vector_stores from the top level as it should be in object_permission
         delete formValues.vector_stores;
       }
 
       if (formValues.mcp_servers_and_groups !== undefined) {
-        const { servers, accessGroups } = formValues.mcp_servers_and_groups || { servers: [], accessGroups: [] };
+        const { servers, accessGroups } = formValues.mcp_servers_and_groups || {
+          servers: [],
+          accessGroups: [],
+        };
         formValues.object_permission = {
-          ...keyData.object_permission,
+          ...currentKeyData.object_permission,
           mcp_servers: servers || [],
-          mcp_access_groups: accessGroups || []
+          mcp_access_groups: accessGroups || [],
         };
         // Remove mcp_servers_and_groups from the top level as it should be in object_permission
         delete formValues.mcp_servers_and_groups;
@@ -98,8 +135,12 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
           const parsedMetadata = JSON.parse(formValues.metadata);
           formValues.metadata = {
             ...parsedMetadata,
-            ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
-            ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {})
+            ...(formValues.guardrails?.length > 0
+              ? { guardrails: formValues.guardrails }
+              : {}),
+            ...(formValues.logging_settings
+              ? { logging: formValues.logging_settings }
+              : {}),
           };
         } catch (error) {
           console.error("Error parsing metadata JSON:", error);
@@ -109,8 +150,12 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
       } else {
         formValues.metadata = {
           ...(formValues.metadata || {}),
-          ...(formValues.guardrails?.length > 0 ? { guardrails: formValues.guardrails } : {}),
-          ...(formValues.logging_settings ? { logging: formValues.logging_settings } : {})
+          ...(formValues.guardrails?.length > 0
+            ? { guardrails: formValues.guardrails }
+            : {}),
+          ...(formValues.logging_settings
+            ? { logging: formValues.logging_settings }
+            : {}),
         };
       }
 
@@ -121,31 +166,46 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
         const durationMap: Record<string, string> = {
           daily: "24h",
           weekly: "7d",
-          monthly: "30d"
+          monthly: "30d",
         };
         formValues.budget_duration = durationMap[formValues.budget_duration];
       }
 
       const newKeyValues = await keyUpdateCall(accessToken, formValues);
+
+      setCurrentKeyData((prev) =>
+        prev ? { ...prev, ...newKeyValues } : newKeyValues,
+      );
+
       if (onKeyDataUpdate) {
-        onKeyDataUpdate(newKeyValues)
+        onKeyDataUpdate(newKeyValues);
       }
+
       message.success("Key updated successfully");
       setIsEditing(false);
-      // Refresh key data here if needed
     } catch (error) {
       message.error("Failed to update key");
       console.error("Error updating key:", error);
     }
   };
 
+  const handleRegenerateKeyUpdate = (updatedKeyData: Partial<KeyResponse>) => {
+    setCurrentKeyData((prev) =>
+      prev ? { ...prev, ...updatedKeyData } : (updatedKeyData as KeyResponse),
+    );
+
+    if (onKeyDataUpdate) {
+      onKeyDataUpdate(updatedKeyData);
+    }
+  };
+
   const handleDelete = async () => {
     try {
       if (!accessToken) return;
-      await keyDeleteCall(accessToken as string, keyData.token);
+      await keyDeleteCall(accessToken as string, currentKeyData.token);
       message.success("Key deleted successfully");
       if (onDelete) {
-        onDelete()
+        onDelete();
       }
       onClose();
     } catch (error) {
@@ -168,34 +228,47 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
     <div className="w-full h-screen p-4">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <Button 
-            icon={ArrowLeftIcon} 
+          <Button
+            icon={ArrowLeftIcon}
             variant="light"
             onClick={onClose}
             className="mb-4"
           >
             Back to Keys
           </Button>
-          <Title>{keyData.key_alias || "API Key"}</Title>
-          <div className="flex items-center cursor-pointer"
-           >
-            <Text className="text-gray-500 font-mono">{keyData.token}</Text>
+          <Title>{currentKeyData.key_alias || "API Key"}</Title>
+          <div className="flex items-center cursor-pointer">
+            <Text className="text-gray-500 font-mono">
+              {currentKeyData.token}
+            </Text>
             <AntdButton
               type="text"
               size="small"
-              icon={copiedStates["key-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
-              onClick={() => copyToClipboard(keyData.token, "key-id")}
+              icon={
+                copiedStates["key-id"] ? (
+                  <CheckIcon size={12} />
+                ) : (
+                  <CopyIcon size={12} />
+                )
+              }
+              onClick={() => copyToClipboard(currentKeyData.token, "key-id")}
               className={`left-2 z-10 transition-all duration-200 ${
-                copiedStates["key-id"] 
-                  ? 'text-green-600 bg-green-50 border-green-200' 
-                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                copiedStates["key-id"]
+                  ? "text-green-600 bg-green-50 border-green-200"
+                  : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
               }`}
             />
           </div>
         </div>
         {userRole && rolesWithWriteAccess.includes(userRole) && (
           <div className="flex gap-2">
-            <Tooltip title={!premiumUser ? "This is a LiteLLM Enterprise feature, and requires a valid key to use." : ""}>
+            <Tooltip
+              title={
+                !premiumUser
+                  ? "This is a LiteLLM Enterprise feature, and requires a valid key to use."
+                  : ""
+              }
+            >
               <span className="inline-block">
                 <Button
                   icon={RefreshIcon}
@@ -222,22 +295,31 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
 
       {/* Add RegenerateKeyModal */}
       <RegenerateKeyModal
-        selectedToken={keyData}
+        selectedToken={currentKeyData}
         visible={isRegenerateModalOpen}
         onClose={() => setIsRegenerateModalOpen(false)}
         accessToken={accessToken}
         premiumUser={premiumUser}
+        onKeyUpdate={handleRegenerateKeyUpdate}
       />
 
       {/* Delete Confirmation Modal */}
       {isDeleteModalOpen && (
         <div className="fixed z-10 inset-0 overflow-y-auto">
           <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-            <div className="fixed inset-0 transition-opacity" aria-hidden="true">
+            <div
+              className="fixed inset-0 transition-opacity"
+              aria-hidden="true"
+            >
               <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
             </div>
 
-            <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            <span
+              className="hidden sm:inline-block sm:align-middle sm:h-screen"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
 
             <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
               <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
@@ -255,11 +337,7 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                 </div>
               </div>
               <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                <Button
-                  onClick={handleDelete}
-                  color="red"
-                  className="ml-2"
-                >
+                <Button onClick={handleDelete} color="red" className="ml-2">
                   Delete
                 </Button>
                 <Button onClick={() => setIsDeleteModalOpen(false)}>
@@ -284,24 +362,41 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
               <Card>
                 <Text>Spend</Text>
                 <div className="mt-2">
-                  <Title>${formatNumberWithCommas(keyData.spend, 4)}</Title>
-                  <Text>of {keyData.max_budget !== null ? `$${formatNumberWithCommas(keyData.max_budget)}` : "Unlimited"}</Text>
+                  <Title>
+                    ${formatNumberWithCommas(currentKeyData.spend, 4)}
+                  </Title>
+                  <Text>
+                    of{" "}
+                    {currentKeyData.max_budget !== null
+                      ? `$${formatNumberWithCommas(currentKeyData.max_budget)}`
+                      : "Unlimited"}
+                  </Text>
                 </div>
               </Card>
 
               <Card>
                 <Text>Rate Limits</Text>
                 <div className="mt-2">
-                  <Text>TPM: {keyData.tpm_limit !== null ? keyData.tpm_limit : "Unlimited"}</Text>
-                  <Text>RPM: {keyData.rpm_limit !== null ? keyData.rpm_limit : "Unlimited"}</Text>
+                  <Text>
+                    TPM:{" "}
+                    {currentKeyData.tpm_limit !== null
+                      ? currentKeyData.tpm_limit
+                      : "Unlimited"}
+                  </Text>
+                  <Text>
+                    RPM:{" "}
+                    {currentKeyData.rpm_limit !== null
+                      ? currentKeyData.rpm_limit
+                      : "Unlimited"}
+                  </Text>
                 </div>
               </Card>
 
               <Card>
                 <Text>Models</Text>
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {keyData.models && keyData.models.length > 0 ? (
-                    keyData.models.map((model, index) => (
+                  {currentKeyData.models && currentKeyData.models.length > 0 ? (
+                    currentKeyData.models.map((model, index) => (
                       <Badge key={index} color="red">
                         {model}
                       </Badge>
@@ -314,14 +409,14 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
 
               <Card>
                 <ObjectPermissionsView
-                  objectPermission={keyData.object_permission}
+                  objectPermission={currentKeyData.object_permission}
                   variant="inline"
                   accessToken={accessToken}
                 />
               </Card>
 
               <LoggingSettingsView
-                loggingConfigs={extractLoggingSettings(keyData.metadata)}
+                loggingConfigs={extractLoggingSettings(currentKeyData.metadata)}
                 variant="card"
               />
             </Grid>
@@ -332,16 +427,18 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
             <Card className="overflow-y-auto max-h-[65vh]">
               <div className="flex justify-between items-center mb-4">
                 <Title>Key Settings</Title>
-                {!isEditing && userRole && rolesWithWriteAccess.includes(userRole) && (
-                  <Button variant="light" onClick={() => setIsEditing(true)}>
-                    Edit Settings
-                  </Button>
-                )}
+                {!isEditing &&
+                  userRole &&
+                  rolesWithWriteAccess.includes(userRole) && (
+                    <Button variant="light" onClick={() => setIsEditing(true)}>
+                      Edit Settings
+                    </Button>
+                  )}
               </div>
 
               {isEditing ? (
                 <KeyEditView
-                  keyData={keyData}
+                  keyData={currentKeyData}
                   onCancel={() => setIsEditing(false)}
                   onSubmit={handleKeyUpdate}
                   teams={teams}
@@ -353,49 +450,57 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                 <div className="space-y-4">
                   <div>
                     <Text className="font-medium">Key ID</Text>
-                    <Text className="font-mono">{keyData.token}</Text>
+                    <Text className="font-mono">{currentKeyData.token}</Text>
                   </div>
-                  
+
                   <div>
                     <Text className="font-medium">Key Alias</Text>
-                    <Text>{keyData.key_alias || "Not Set"}</Text>
+                    <Text>{currentKeyData.key_alias || "Not Set"}</Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Secret Key</Text>
-                    <Text className="font-mono">{keyData.key_name}</Text>
+                    <Text className="font-mono">{currentKeyData.key_name}</Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Team ID</Text>
-                    <Text>{keyData.team_id || "Not Set"}</Text>
+                    <Text>{currentKeyData.team_id || "Not Set"}</Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Organization</Text>
-                    <Text>{keyData.organization_id || "Not Set"}</Text>
+                    <Text>{currentKeyData.organization_id || "Not Set"}</Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Created</Text>
-                    <Text>{new Date(keyData.created_at).toLocaleString()}</Text>
+                    <Text>
+                      {new Date(currentKeyData.created_at).toLocaleString()}
+                    </Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Expires</Text>
-                    <Text>{keyData.expires ? new Date(keyData.expires).toLocaleString() : "Never"}</Text>
+                    <Text>
+                      {currentKeyData.expires
+                        ? new Date(currentKeyData.expires).toLocaleString()
+                        : "Never"}
+                    </Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Spend</Text>
-                    <Text>${formatNumberWithCommas(keyData.spend, 4)} USD</Text>
+                    <Text>
+                      ${formatNumberWithCommas(currentKeyData.spend, 4)} USD
+                    </Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Budget</Text>
                     <Text>
-                      {keyData.max_budget !== null
-                        ? `$${formatNumberWithCommas(keyData.max_budget, 2)}`
+                      {currentKeyData.max_budget !== null
+                        ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}`
                         : "Unlimited"}
                     </Text>
                   </div>
@@ -403,8 +508,9 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
                   <div>
                     <Text className="font-medium">Models</Text>
                     <div className="flex flex-wrap gap-2 mt-1">
-                      {keyData.models && keyData.models.length > 0 ? (
-                        keyData.models.map((model, index) => (
+                      {currentKeyData.models &&
+                      currentKeyData.models.length > 0 ? (
+                        currentKeyData.models.map((model, index) => (
                           <span
                             key={index}
                             className="px-2 py-1 bg-blue-100 rounded text-xs"
@@ -420,29 +526,60 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
 
                   <div>
                     <Text className="font-medium">Rate Limits</Text>
-                    <Text>TPM: {keyData.tpm_limit !== null ? keyData.tpm_limit : "Unlimited"}</Text>
-                    <Text>RPM: {keyData.rpm_limit !== null ? keyData.rpm_limit : "Unlimited"}</Text>
-                    <Text>Max Parallel Requests: {keyData.max_parallel_requests !== null ? keyData.max_parallel_requests : "Unlimited"}</Text>
-                    <Text>Model TPM Limits: {keyData.metadata?.model_tpm_limit ? JSON.stringify(keyData.metadata.model_tpm_limit) : "Unlimited"}</Text>
-                    <Text>Model RPM Limits: {keyData.metadata?.model_rpm_limit ? JSON.stringify(keyData.metadata.model_rpm_limit) : "Unlimited"}</Text>
+                    <Text>
+                      TPM:{" "}
+                      {currentKeyData.tpm_limit !== null
+                        ? currentKeyData.tpm_limit
+                        : "Unlimited"}
+                    </Text>
+                    <Text>
+                      RPM:{" "}
+                      {currentKeyData.rpm_limit !== null
+                        ? currentKeyData.rpm_limit
+                        : "Unlimited"}
+                    </Text>
+                    <Text>
+                      Max Parallel Requests:{" "}
+                      {currentKeyData.max_parallel_requests !== null
+                        ? currentKeyData.max_parallel_requests
+                        : "Unlimited"}
+                    </Text>
+                    <Text>
+                      Model TPM Limits:{" "}
+                      {currentKeyData.metadata?.model_tpm_limit
+                        ? JSON.stringify(
+                            currentKeyData.metadata.model_tpm_limit,
+                          )
+                        : "Unlimited"}
+                    </Text>
+                    <Text>
+                      Model RPM Limits:{" "}
+                      {currentKeyData.metadata?.model_rpm_limit
+                        ? JSON.stringify(
+                            currentKeyData.metadata.model_rpm_limit,
+                          )
+                        : "Unlimited"}
+                    </Text>
                   </div>
 
                   <div>
                     <Text className="font-medium">Metadata</Text>
                     <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto mt-1">
-                      {formatMetadataForDisplay(keyData.metadata)}
+                      {formatMetadataForDisplay(currentKeyData.metadata)}
                     </pre>
                   </div>
 
                   <ObjectPermissionsView
-                    objectPermission={keyData.object_permission}
+                    objectPermission={currentKeyData.object_permission}
                     variant="inline"
                     className="pt-4 border-t border-gray-200"
                     accessToken={accessToken}
                   />
 
                   <LoggingSettingsView
-                    loggingConfigs={extractLoggingSettings(keyData.metadata)}
+                    loggingConfigs={extractLoggingSettings(
+                      currentKeyData.metadata,
+                    )}
                     variant="inline"
                     className="pt-4 border-t border-gray-200"
                   />
@@ -454,4 +591,4 @@ export default function KeyInfoView({ keyId, onClose, keyData, accessToken, user
       </TabGroup>
     </div>
   );
-} 
+}

--- a/ui/litellm-dashboard/src/components/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/key_info_view.tsx
@@ -57,6 +57,7 @@ interface KeyInfoViewProps {
   userRole: string | null;
   teams: any[] | null;
   premiumUser: boolean;
+  setAccessToken: (token: string) => void;
 }
 
 export default function KeyInfoView({
@@ -70,6 +71,7 @@ export default function KeyInfoView({
   onKeyDataUpdate,
   onDelete,
   premiumUser,
+  setAccessToken,
 }: KeyInfoViewProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [form] = Form.useForm();
@@ -299,6 +301,7 @@ export default function KeyInfoView({
         visible={isRegenerateModalOpen}
         onClose={() => setIsRegenerateModalOpen(false)}
         accessToken={accessToken}
+        setAccessToken={setAccessToken}
         premiumUser={premiumUser}
         onKeyUpdate={handleRegenerateKeyUpdate}
       />

--- a/ui/litellm-dashboard/src/components/regenerate_key_modal.tsx
+++ b/ui/litellm-dashboard/src/components/regenerate_key_modal.tsx
@@ -12,6 +12,7 @@ interface RegenerateKeyModalProps {
   onClose: () => void;
   accessToken: string | null;
   premiumUser: boolean;
+  onKeyUpdate?: (updatedKeyData: Partial<KeyResponse>) => void;
 }
 
 export function RegenerateKeyModal({
@@ -20,6 +21,7 @@ export function RegenerateKeyModal({
   onClose,
   accessToken,
   premiumUser,
+  onKeyUpdate,
 }: RegenerateKeyModalProps) {
   const [form] = Form.useForm();
   const [regeneratedKey, setRegeneratedKey] = useState<string | null>(null);
@@ -87,12 +89,42 @@ export function RegenerateKeyModal({
       const formValues = await form.validateFields();
       const response = await regenerateKeyCall(accessToken, selectedToken.token, formValues);
       setRegeneratedKey(response.key);
+
+      if (onKeyUpdate) {
+        const updatedKeyData = {
+          key_name: response.key,
+          max_budget: formValues.max_budget,
+          tpm_limit: formValues.tpm_limit,
+          rpm_limit: formValues.rpm_limit,
+          expires: formValues.duration ? calculateNewExpiryTime(formValues.duration) : selectedToken.expires,
+          ...formValues,
+        };
+        onKeyUpdate(updatedKeyData);
+      }
+
       message.success("API Key regenerated successfully");
     } catch (error) {
       console.error("Error regenerating key:", error);
       message.error("Failed to regenerate API Key");
-      setIsRegenerating(false); // Reset regenerating state on error
+      setIsRegenerating(false);
     }
+  };
+
+  const calculateNewExpiryTime = (duration: string) => {
+    const now = new Date();
+    let newExpiry: Date;
+
+    if (duration.endsWith("s")) {
+      newExpiry = add(now, { seconds: parseInt(duration) });
+    } else if (duration.endsWith("h")) {
+      newExpiry = add(now, { hours: parseInt(duration) });
+    } else if (duration.endsWith("d")) {
+      newExpiry = add(now, { days: parseInt(duration) });
+    } else {
+      return null;
+    }
+
+    return newExpiry.toISOString();
   };
 
   const handleClose = () => {
@@ -107,49 +139,43 @@ export function RegenerateKeyModal({
       title="Regenerate API Key"
       open={visible}
       onCancel={handleClose}
-      footer={regeneratedKey ? [
-        <Button key="close" onClick={handleClose}>
-          Close
-        </Button>,
-      ] : [
-        <Button key="cancel" onClick={handleClose} className="mr-2">
-          Cancel
-        </Button>,
-        <Button 
-          key="regenerate" 
-          onClick={handleRegenerateKey}
-          disabled={isRegenerating}
-        >
-          {isRegenerating ? "Regenerating..." : "Regenerate"}
-        </Button>,
-      ]}
+      footer={
+        regeneratedKey
+          ? [
+              <Button key="close" onClick={handleClose}>
+                Close
+              </Button>,
+            ]
+          : [
+              <Button key="cancel" onClick={handleClose} className="mr-2">
+                Cancel
+              </Button>,
+              <Button key="regenerate" onClick={handleRegenerateKey} disabled={isRegenerating}>
+                {isRegenerating ? "Regenerating..." : "Regenerate"}
+              </Button>,
+            ]
+      }
     >
       {regeneratedKey ? (
         <Grid numItems={1} className="gap-2 w-full">
           <Title>Regenerated Key</Title>
           <Col numColSpan={1}>
             <p>
-              Please replace your old key with the new key generated. For
-              security reasons, <b>you will not be able to view it again</b>{" "}
-              through your LiteLLM account. If you lose this secret key, you
-              will need to generate a new one.
+              Please replace your old key with the new key generated. For security reasons,{" "}
+              <b>you will not be able to view it again</b> through your LiteLLM account. If you lose this secret key,
+              you will need to generate a new one.
             </p>
           </Col>
           <Col numColSpan={1}>
             <Text className="mt-3">Key Alias:</Text>
             <div className="bg-gray-100 p-2 rounded mb-2">
-              <pre className="break-words whitespace-normal">
-                {selectedToken?.key_alias || "No alias set"}
-              </pre>
+              <pre className="break-words whitespace-normal">{selectedToken?.key_alias || "No alias set"}</pre>
             </div>
             <Text className="mt-3">New API Key:</Text>
             <div className="bg-gray-100 p-2 rounded mb-2">
               <pre className="break-words whitespace-normal">{regeneratedKey}</pre>
             </div>
-            <CopyToClipboard
-              text={regeneratedKey}
-              onCopy={() => message.success("API Key copied to clipboard")}
-            >
+            <CopyToClipboard text={regeneratedKey} onCopy={() => message.success("API Key copied to clipboard")}>
               <Button className="mt-3">Copy API Key</Button>
             </CopyToClipboard>
           </Col>
@@ -182,11 +208,7 @@ export function RegenerateKeyModal({
           <div className="mt-2 text-sm text-gray-500">
             Current expiry: {selectedToken?.expires ? new Date(selectedToken.expires).toLocaleString() : "Never"}
           </div>
-          {newExpiryTime && (
-            <div className="mt-2 text-sm text-green-600">
-              New expiry: {newExpiryTime}
-            </div>
-          )}
+          {newExpiryTime && <div className="mt-2 text-sm text-green-600">New expiry: {newExpiryTime}</div>}
         </Form>
       )}
     </Modal>


### PR DESCRIPTION
## Title
Regenerate Key State Management and Authentication Issues
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Refer: [d98b190](https://github.com/BerriAI/litellm/pull/12729/commits/d98b190200ab807dd6c657acdd5cc05a645005c8)
Two critical bugs were affecting the key regeneration and editing workflow:
1. Values Not Reflected: When Max Budget, TPM, RPM, or Expire Key are set during key regeneration, these values are not reflected on the settings page without a manual refresh.
2. Edit Fails After Regeneration: After regenerating a key, attempting to edit settings fails with a 401 Unauthorized error, requiring a page refresh to work again.

`ui/litellm-dashboard/src/components/regenerate_key_modal.tsx`:
- Added setAccessToken prop to interface and component
- Enhanced handleRegenerateKey to detect own-key regeneration
- Fixed data structure in updatedKeyData to preserve all original key properties
- Added proper type handling for expires field
- Updated accessToken when user regenerates their own authentication key

`ui/litellm-dashboard/src/components/key_info_view.tsx`:
- Added setAccessToken prop to interface
- Passed setAccessToken to RegenerateKeyModal

https://www.loom.com/share/b3f47e9ebdd248a7b484f12bbc6a90ee?sid=97724363-4267-4434-8768-2708432097d4
