### PR TITLE
Fix AsyncMock error in team endpoints test

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -44,6 +44,10 @@ client = TestClient(app)
 
 # Mock prisma_client
 mock_prisma_client = MagicMock()
+# Set up async mock for db operations
+mock_prisma_client.db = MagicMock()
+mock_prisma_client.db.litellm_teamtable = MagicMock()
+mock_prisma_client.db.litellm_teamtable.update = AsyncMock()
 
 
 # Fixture to provide the mock prisma client
@@ -287,6 +291,7 @@ async def test_new_team_with_object_permission(mock_db_client, mock_admin_auth):
     mock_db_client.db.litellm_teamtable = MagicMock()
     mock_db_client.db.litellm_teamtable.create = mock_team_create
     mock_db_client.db.litellm_teamtable.count = mock_team_count
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=team_create_result)
 
     # 4. Mock user table update behaviour (called for each member)
     mock_db_client.db.litellm_usertable = MagicMock()


### PR DESCRIPTION
## Title

Fix AsyncMock error in team endpoints test

## Relevant issues

Fixes test failure: `TypeError: object MagicMock can't be used in 'await' expression`

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Fixed `test_new_team_with_object_permission` test that was failing with `TypeError: object MagicMock can't be used in 'await' expression`
- Added `AsyncMock` for the `litellm_teamtable.update` method to properly handle async database operations
- The test now correctly mocks async database calls and passes successfully

## Test Results

```
============================= test session starts ==============================
tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::test_new_team_with_object_permission PASSED

============================== 1 passed in 0.86s ===============================
```

All tests in the file pass:
```
============================== 20 passed in 5.09s ==============================
```