### PR TITLE
[Bug fix] s3 v2 log uploader crashes when using with guardrails

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -7,7 +7,6 @@ NOTE 1: S3 does not provide a BATCH PUT API endpoint, so we create tasks to uplo
 """
 
 import asyncio
-import json
 from datetime import datetime
 from typing import List, Optional, cast
 

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -15,6 +15,7 @@ import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import DEFAULT_S3_BATCH_SIZE, DEFAULT_S3_FLUSH_INTERVAL_SECONDS
 from litellm.integrations.s3 import get_s3_object_key
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
@@ -281,7 +282,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 url = self.s3_endpoint_url + "/" + batch_logging_element.s3_object_key
 
             # Convert JSON to string
-            json_string = json.dumps(batch_logging_element.payload)
+            json_string = safe_dumps(batch_logging_element.payload)
 
             # Calculate SHA256 hash of the content
             content_hash = hashlib.sha256(json_string.encode("utf-8")).hexdigest()
@@ -421,7 +422,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 url = self.s3_endpoint_url + "/" + batch_logging_element.s3_object_key
 
             # Convert JSON to string
-            json_string = json.dumps(batch_logging_element.payload)
+            json_string = safe_dumps(batch_logging_element.payload)
 
             # Calculate SHA256 hash of the content
             content_hash = hashlib.sha256(json_string.encode("utf-8")).hexdigest()

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1,0 +1,24 @@
+import asyncio
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.integrations.s3_v2 import S3Logger
+from litellm.types.utils import StandardLoggingPayload
+
+
+class TestS3V2UnitTests:
+    """Test that S3 v2 integration only uses safe_dumps and not json.dumps"""
+    def test_s3_v2_source_code_analysis(self):
+        """Test that S3 v2 source code only imports and uses safe_dumps"""
+        import inspect
+
+        from litellm.integrations import s3_v2
+
+        # Get the source code of the s3_v2 module
+        source_code = inspect.getsource(s3_v2)
+        
+        # Verify that json.dumps is not used directly in the code
+        assert "json.dumps(" not in source_code, \
+            "S3 v2 should not use json.dumps directly"


### PR DESCRIPTION
## [Bug fix] s3 v2 log uploader crashes when using with guardrails

Fixes https://github.com/BerriAI/litellm/issues/12731 

The function used to serialize the payload with **`json.dumps()`**:

```python
json_string = json.dumps(batch_logging_element.payload)  # L284
```

However, Guardrails metadata may contain self-referencing objects, causing `json.dumps()` to raise:

```
ValueError: Circular reference detected
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


