### PR TITLE
Fix internal users table overflow

### DIFF
--- a/ui/litellm-dashboard/src/components/view_users.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.tsx
@@ -243,7 +243,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
   )
 
   return (
-    <div className="w-full p-6">
+    <div className="w-full p-6 overflow-hidden">
       <div className="flex items-center justify-between mb-4">
         <div className="flex space-x-3">
           <CreateUser userID={userID} accessToken={accessToken} teams={teams} possibleUIRoles={possibleUIRoles} />
@@ -435,7 +435,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
                   </div>
                 </div>
               </div>
-
+              <div className="h-[75vh] overflow-auto">
               <UserDataTable
                 data={userListQuery.data?.users || []}
                 columns={tableColumns}
@@ -455,6 +455,8 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
                 handleDelete={handleDelete}
                 handleResetPassword={handleResetPassword}
               />
+              </div>
+              
             </div>
           </TabPanel>
 

--- a/ui/litellm-dashboard/src/components/view_users.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.tsx
@@ -435,7 +435,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({ accessToken, toke
                   </div>
                 </div>
               </div>
-              <div className="h-[75vh] overflow-auto">
+              <div className="overflow-auto">
               <UserDataTable
                 data={userListQuery.data?.users || []}
                 columns={tableColumns}

--- a/ui/litellm-dashboard/src/components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/columns.tsx
@@ -22,7 +22,7 @@ export const columns = (
     ),
   },
   {
-    header: "User Email",
+    header: "Email",
     accessorKey: "user_email",
     cell: ({ row }) => (
       <span className="text-xs">{row.original.user_email || "-"}</span>
@@ -38,7 +38,7 @@ export const columns = (
     ),
   },
   {
-    header: "User Spend ($ USD)",
+    header: "Spend (USD)",
     accessorKey: "spend",
     cell: ({ row }) => (
       <span className="text-xs">
@@ -47,7 +47,7 @@ export const columns = (
     ),
   },
   {
-    header: "User Max Budget ($ USD)",
+    header: "Budget (USD)",
     accessorKey: "max_budget",
     cell: ({ row }) => (
       <span className="text-xs">


### PR DESCRIPTION
## Title
Fix internal users table overflow
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Modified Column Names:
1. `User Email` -> `Email`
2. `User Max Budget ($ USD)` -> `Budget (USD)`
Using "Budget" in itself is sufficient. Unless we have a "Min Budget" too adding "Max" is not meaningful.
I choose to add either $ or USD not both.
3. `User Spend ($ USD)` ->  `Spend (USD)`
We are on the Users tab, which is should signify that the Spend is by the User, no need to add User here.
- Used `overflow-hidden` property to make the internal users table scrollable.
<img width="1512" height="982" alt="Screenshot 2025-07-19 at 1 30 44" src="https://github.com/user-attachments/assets/a05f54fe-f41d-49bc-a1ae-c2f9080246e2" />
