### PR TITLE
Fix GCS bucket async project_id resolution

### DIFF
--- a/litellm/integrations/gcs_bucket/gcs_bucket_base.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket_base.py
@@ -40,9 +40,14 @@ class GCSBucketBase(CustomBatchLogger):
         if vertex_instance is None:
             vertex_instance = vertex_chat_completion
 
+        # Get project_id from environment if available, otherwise None
+        # This helps support use of this library to auth to pull secrets 
+        # from Secret Manager.
+        project_id = os.getenv("GOOGLE_SECRET_MANAGER_PROJECT_ID")
+        
         _auth_header, vertex_project = await vertex_instance._ensure_access_token_async(
             credentials=service_account_json,
-            project_id=None,
+            project_id=project_id,
             custom_llm_provider="vertex_ai",
         )
 

--- a/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
+++ b/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
@@ -1,5 +1,6 @@
 import os
-from unittest.mock import patch
+import pytest
+from unittest.mock import patch, AsyncMock
 from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
 
 
@@ -76,6 +77,89 @@ class TestGCSBucketBase:
 
             # Verify _ensure_access_token was called with project_id as None
             mock_ensure_token.assert_called_once_with(
+                credentials=None,  # No service account in this test
+                project_id=None,  # Should be None when no env var is set
+                custom_llm_provider="vertex_ai",
+            )
+
+    @pytest.mark.asyncio
+    async def test_async_construct_request_headers_with_project_id(self):
+        """Test that async construct_request_headers correctly uses project_id if passed from env"""
+        test_project_id = "test-project"
+        os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"] = test_project_id
+
+        try:
+            # Create handler
+            handler = GCSBucketBase(bucket_name="test-bucket")
+
+            # Mock the Vertex AI auth calls
+            mock_auth_header = "mock-auth-header"
+            mock_token = "mock-token"
+
+            with patch(
+                "litellm.vertex_chat_completion._ensure_access_token_async"
+            ) as mock_ensure_token_async, patch(
+                "litellm.vertex_chat_completion._get_token_and_url"
+            ) as mock_get_token:
+                mock_ensure_token_async.return_value = (mock_auth_header, test_project_id)
+                mock_get_token.return_value = (mock_token, "mock-url")
+
+                # Call async construct_request_headers
+                headers = await handler.construct_request_headers(
+                    service_account_json=None
+                )
+
+                # Verify headers
+                assert headers == {
+                    "Authorization": f"Bearer {mock_token}",
+                    "Content-Type": "application/json",
+                }
+
+                # Verify _ensure_access_token_async was called with correct project_id
+                mock_ensure_token_async.assert_called_once_with(
+                    credentials=None,  # No service account in this test
+                    project_id=test_project_id,  # Should use project_id from env
+                    custom_llm_provider="vertex_ai",
+                )
+        finally:
+            # Clean up environment variable
+            del os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"]
+
+    @pytest.mark.asyncio
+    async def test_async_construct_request_headers_without_project_id(self):
+        """Test that async construct_request_headers works when no project_id is in env"""
+        # Ensure environment variable is not set
+        if "GOOGLE_SECRET_MANAGER_PROJECT_ID" in os.environ:
+            del os.environ["GOOGLE_SECRET_MANAGER_PROJECT_ID"]
+
+        # Create handler
+        handler = GCSBucketBase(bucket_name="test-bucket")
+
+        # Mock the Vertex AI auth calls
+        mock_auth_header = "mock-auth-header"
+        mock_token = "mock-token"
+
+        with patch(
+            "litellm.vertex_chat_completion._ensure_access_token_async"
+        ) as mock_ensure_token_async, patch(
+            "litellm.vertex_chat_completion._get_token_and_url"
+        ) as mock_get_token:
+            mock_ensure_token_async.return_value = (mock_auth_header, None)
+            mock_get_token.return_value = (mock_token, "mock-url")
+
+            # Call async construct_request_headers
+            headers = await handler.construct_request_headers(
+                service_account_json=None
+            )
+
+            # Verify headers
+            assert headers == {
+                "Authorization": f"Bearer {mock_token}",
+                "Content-Type": "application/json",
+            }
+
+            # Verify _ensure_access_token_async was called with project_id as None
+            mock_ensure_token_async.assert_called_once_with(
                 credentials=None,  # No service account in this test
                 project_id=None,  # Should be None when no env var is set
                 custom_llm_provider="vertex_ai",


### PR DESCRIPTION
## Summary
- Fixes "Could not resolve project_id" error in GCS bucket logging by making async method consistent with sync version
- Adds environment variable check for `GOOGLE_SECRET_MANAGER_PROJECT_ID` in async `construct_request_headers`
- Adds comprehensive async tests modeled after existing sync tests

## Test plan
- [x] Added async tests that mirror the existing sync test patterns using @patch decorators
- [x] Verified all existing sync tests still pass
- [x] Verified new async tests pass with proper project_id handling