### PR TITLE
Fix Y-axis labels overlap on Spend per Tag 

### DIFF
--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -312,6 +312,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
   const getProcessedEntityBreakdownForChart = () => {
     const data = getEntityBreakdown();
     const topEntities = data.slice(0, 5);
+    console.log("topEntities", topEntities);
     return topEntities.map((e) => ({
       ...e,
       metadata: {
@@ -514,8 +515,8 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                       <Col numColSpan={1}>
                         <BarChart
                           className="mt-4 h-52"
-                          data={getEntityBreakdown()}
-                          index="metadata.alias"
+                          data={getProcessedEntityBreakdownForChart()}
+                          index="metadata.alias_display"
                           categories={["metrics.spend"]}
                           colors={["cyan"]}
                           valueFormatter={valueFormatterSpend}
@@ -633,7 +634,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
                   <BarChart
                     className="mt-4 h-40"
                     data={getTopModels()}
-                    index="key"
+                    index="display_key"
                     categories={["spend"]}
                     colors={["cyan"]}
                     valueFormatter={(value) =>

--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -312,7 +312,6 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
   const getProcessedEntityBreakdownForChart = () => {
     const data = getEntityBreakdown();
     const topEntities = data.slice(0, 5);
-    console.log("topEntities", topEntities);
     return topEntities.map((e) => ({
       ...e,
       metadata: {


### PR DESCRIPTION
## Title
Fix Y-axis labels overlap on Spend per Tag 
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Truncated Y-Axis Labels: Long tag names are now truncated on the Y-axis of vertical bar charts to prevent text from overlapping and overflowing its container.
<img width="698" height="193" alt="Screenshot 2025-07-19 at 23 18 33" src="https://github.com/user-attachments/assets/6b25af96-4eb0-45cc-9f50-6ed5be9ab0f1" />

