### PR TITLE
fix: correct Groq model naming convention for moonshotai/kimi-k2-instruct

### DIFF
--- a/docs/my-website/docs/providers/groq.md
+++ b/docs/my-website/docs/providers/groq.md
@@ -156,7 +156,9 @@ We support ALL Groq models, just set `groq/` as a prefix when sending completion
 | llama3-70b-8192    | `completion(model="groq/llama3-70b-8192", messages)`    | 
 | llama2-70b-4096    | `completion(model="groq/llama2-70b-4096", messages)`    | 
 | mixtral-8x7b-32768 | `completion(model="groq/mixtral-8x7b-32768", messages)` |
-| gemma-7b-it        | `completion(model="groq/gemma-7b-it", messages)`        |  
+| gemma-7b-it        | `completion(model="groq/gemma-7b-it", messages)`        |
+| moonshotai/kimi-k2-instruct | `completion(model="groq/moonshotai/kimi-k2-instruct", messages)` |
+| qwen-qwq-32b       | `completion(model="groq/qwen-qwq-32b", messages)`       |  
 
 ## Groq - Tool / Function Calling Example
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5430,7 +5430,7 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
-    "groq/moonshotai-kimi-k2-instruct": {
+    "groq/moonshotai/kimi-k2-instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 16384,


### PR DESCRIPTION
## Title

fix: correct Groq model naming convention for moonshotai/kimi-k2-instruct

## Relevant issues

Fixes the issue reported in #12648 (comment)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
📖 Documentation

## Changes

- Fixed incorrect model naming `groq/moonshotai-kimi-k2-instruct` to `groq/moonshotai/kimi-k2-instruct` in `model_prices_and_context_window.json`
  - This fixes the error reported where Groq expects `moonshotai/kimi-k2-instruct` but was receiving `moonshotai-kimi-k2-instruct`
- Updated Groq provider documentation to include two new models in the supported models table:
  - `groq/moonshotai/kimi-k2-instruct`
  - `groq/qwen-qwq-32b`

These changes ensure the model names follow the correct naming convention with provider/model format that Groq expects.