### PR TITLE
Fix additional anyOf corner cases for Vertex AI Gemini tool calls - issue #11164

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -238,9 +238,7 @@ def _filter_anyof_fields(schema_dict: Dict[str, Any]) -> Dict[str, Any]:
                     item["title"] = title
                 if description:
                     item["description"] = description
-            return {"anyOf": any_of}
-        else:
-            return schema_dict
+        return {"anyOf": any_of}
     return schema_dict
 
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -495,6 +495,36 @@ def test_vertex_ai_map_tool_with_anyof():
         "anyOf": [{"type": "string", "nullable": True, "title": "Base Branch"}]
     }, f"Expected only anyOf field and its contents to be kept, but got {tools[0]['function_declarations'][0]['parameters']['properties']['base_branch']}"
 
+    new_value = [
+        {
+            "type": "function",
+            "function": {
+                "name": "git_create_branch",
+                "description": "Creates a new branch from an optional base branch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "repo_path": {"title": "Repo Path", "type": "string"},
+                        "branch_name": {"title": "Branch Name", "type": "string"},
+                        "base_branch": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "default": None,
+                        },
+                    },
+                    "required": ["repo_path", "branch_name"],
+                    "title": "GitCreateBranch",
+                },
+            },
+        }
+    ]
+    new_tools = v._map_function(value=new_value)
+
+    assert new_tools[0]["function_declarations"][0]["parameters"]["properties"][
+        "base_branch"
+    ] == {
+        "anyOf": [{"type": "string", "nullable": True}]
+    }, f"Expected only anyOf field and its contents to be kept, but got {new_tools[0]['function_declarations'][0]['parameters']['properties']['base_branch']}"
+
 
 def test_vertex_ai_streaming_usage_calculation():
     """


### PR DESCRIPTION
## Fix some additional anyof corner cases for BerriAI/litellm#11164

In issue #11164 and PR #11195. The fix adds `"title"` and `"description"` back into items in the `"anyOf"` key for tool calls. However, for cases where neither `"title"` or `"description"` exists the fix returns the original `schema_dict`.

Tool calls that include both `"anyOf"` and `"default"` keys at the same level (without `"title"` or `"description"`) still result in a Bad Request error. 

This PR fixes this issue.

## Relevant issues
Issue #11164
PR #11195

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="1904" height="213" alt="image" src="https://github.com/user-attachments/assets/968199f2-89d8-4c6c-9db6-1a273994bf24" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
### Vertex AI anyOf in tool calls
- `litellm/llms/vertex_ai/common_utils.py`: When no `"title"` or `"description"` exists we still filter to keep only the `"anyOf"` key.
- `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`: Added a second test case with only `"anyOf"` and `"default"` (without `"title"` or `"description"`).


