### PR TITLE
#12800 Commit the codes for fixing the no model_group information in …

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1335,13 +1335,12 @@ class Router:
             kwargs=kwargs, data=deployment["litellm_params"]
         )
 
-        self._update_kwargs_with_default_litellm_params(
-            kwargs=kwargs, metadata_variable_name=metadata_variable_name
-        )
-        
         # Fix bug:
         # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
         # https://github.com/BerriAI/litellm/issues/12800
+        self._update_kwargs_with_default_litellm_params(model=model_group_name,
+            kwargs=kwargs, metadata_variable_name=metadata_variable_name
+        )
         self._update_kwargs_with_default_litellm_params(model=model_group_name,
             kwargs=kwargs, metadata_variable_name="metadata"
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1230,9 +1230,6 @@ class Router:
             {"model_group": model, "model_group_alias": model_group_alias}
         )
 
-    # Fix bug:
-    # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
-    # https://github.com/BerriAI/litellm/issues/12800
     def _update_kwargs_with_default_litellm_params(
         self, model: str, kwargs: dict, metadata_variable_name: Optional[str] = "metadata"
     ) -> None:
@@ -1253,10 +1250,6 @@ class Router:
 
         # 3) merge in metadata, this handles inserting this as either "metadata" or "litellm_metadata"
         kwargs.setdefault(metadata_variable_name, {}).update(metadata_defaults)
-        
-        # Fix bug:
-        # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
-        # https://github.com/BerriAI/litellm/issues/12800
         kwargs.setdefault(metadata_variable_name, {}).update({"model_group": model})
 
     def _handle_clientside_credential(
@@ -1303,10 +1296,6 @@ class Router:
         deployment_litellm_model_name = deployment["litellm_params"]["model"]
         deployment_api_base = deployment["litellm_params"].get("api_base")
         deployment_model_name = deployment["model_name"]
-        
-        # Fix bug:
-        # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
-        # https://github.com/BerriAI/litellm/issues/12800
         model_group_name = deployment["model_name"]
         
         if is_clientside_credential(request_kwargs=kwargs):
@@ -1335,9 +1324,6 @@ class Router:
             kwargs=kwargs, data=deployment["litellm_params"]
         )
 
-        # Fix bug:
-        # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
-        # https://github.com/BerriAI/litellm/issues/12800
         self._update_kwargs_with_default_litellm_params(model=model_group_name,
             kwargs=kwargs, metadata_variable_name=metadata_variable_name
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1233,7 +1233,6 @@ class Router:
     # Fix bug:
     # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
     # https://github.com/BerriAI/litellm/issues/12800
-    # tonny.huang@navercorp.com, yea.hb@navercorp.com
     def _update_kwargs_with_default_litellm_params(
         self, model: str, kwargs: dict, metadata_variable_name: Optional[str] = "metadata"
     ) -> None:
@@ -1258,7 +1257,6 @@ class Router:
         # Fix bug:
         # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
         # https://github.com/BerriAI/litellm/issues/12800
-        # tonny.huang@navercorp.com, yea.hb@navercorp.com
         kwargs.setdefault(metadata_variable_name, {}).update({"model_group": model})
 
     def _handle_clientside_credential(
@@ -1309,7 +1307,6 @@ class Router:
         # Fix bug:
         # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
         # https://github.com/BerriAI/litellm/issues/12800
-        # tonny.huang@navercorp.com, yea.hb@navercorp.com
         model_group_name = deployment["model_name"]
         
         if is_clientside_credential(request_kwargs=kwargs):
@@ -1345,7 +1342,6 @@ class Router:
         # Fix bug:
         # [Bug]: There is no model_group information in responses, image edit API, but chat/completions
         # https://github.com/BerriAI/litellm/issues/12800
-        # tonny.huang@navercorp.com, yea.hb@navercorp.com
         self._update_kwargs_with_default_litellm_params(model=model_group_name,
             kwargs=kwargs, metadata_variable_name="metadata"
         )


### PR DESCRIPTION
…responses, image edit API, but chat/completions bug.

## Title

There is no model_group information in responses, image edit API, but chat/completions

## Relevant issues
[Bug]: There is no model_group information in responses, image edit API, but chat/completions
https://github.com/BerriAI/litellm/issues/12800

<img width="1573" height="1149" alt="image" src="https://github.com/user-attachments/assets/3d095b54-1971-4289-8ee6-aa002074177e" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix


## Changes


