### PR TITLE
docs(moonshot): correct base url and document CN-specific endpoint

### DIFF
--- a/docs/my-website/docs/providers/moonshot.md
+++ b/docs/my-website/docs/providers/moonshot.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 | Description | Moonshot AI provides large language models including the moonshot-v1 series and kimi models. |
 | Provider Route on LiteLLM | `moonshot/` |
 | Link to Provider Doc | [Moonshot AI ↗](https://platform.moonshot.ai/) |
-| Base URL | `https://api.moonshot.cn/` |
+| Base URL | `https://api.moonshot.ai/` |
 | Supported Operations | [`/chat/completions`](#sample-usage) |
 
 <br />
@@ -24,6 +24,18 @@ https://platform.moonshot.ai/
 
 ```python showLineNumbers title="Environment Variables"
 os.environ["MOONSHOT_API_KEY"] = ""  # your Moonshot AI API key
+```
+
+**ATTENTION:**
+
+Moonshot AI offers two distinct API endpoints: a global one and a China-specific one.
+- Global API Base URL: `https://api.moonshot.ai/v1` (This is the one currently implemented)
+- China API Base URL: `https://api.moonshot.cn/v1`
+
+You can overwrite the base url with:
+
+```
+os.environ["MOONSHOT_API_BASE"] = "https://api.moonshot.cn/v1"
 ```
 
 ## Usage - LiteLLM Python SDK


### PR DESCRIPTION
## Correct base url and document CN-specific endpoint

I just want to highlight that Moonshot AI offers two distinct API endpoints: a global one and a China-specific one.

- Global API Base URL: https://api.moonshot.ai/v1 (This is the one currently implemented)
- China API Base URL: https://api.moonshot.cn/v1

As you can see, the difference is in the domain (.ai vs. .cn). It took me quite a while to identify this subtle difference when I was trying to use the API from within China.

This PR only modifies document.

## Relevant issues

No

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

- Fix the actual base url that used in the doc
- Add information about how to overwrite the base url

