### PR TITLE
feat: added `/v1/models/{model}/next-fallback` endpoint

### DIFF
--- a/tests/local_testing/test_router_next_fallback.py
+++ b/tests/local_testing/test_router_next_fallback.py
@@ -1,0 +1,481 @@
+"""
+Router integration tests for the next fallback functionality
+
+Tests the fallback endpoint with real Router configurations and complex scenarios.
+"""
+import asyncio
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm import Router
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.model_checks import get_next_fallback
+
+
+class TestRouterNextFallbackIntegration:
+    """Integration tests with real Router instances"""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method"""
+        # Create a realistic model list for testing
+        self.model_list = [
+            {
+                "model_name": "claude-4-sonnet",
+                "litellm_params": {
+                    "model": "anthropic/claude-3-5-sonnet-20241022"
+                }
+            },
+            {
+                "model_name": "bedrock-claude-sonnet-4", 
+                "litellm_params": {
+                    "model": "bedrock/claude-3-5-sonnet-20241022-v2:0"
+                }
+            },
+            {
+                "model_name": "google-claude-sonnet-4",
+                "litellm_params": {
+                    "model": "vertex_ai/claude-3-5-sonnet-v2@20241022"
+                }
+            },
+            {
+                "model_name": "gpt-4o",
+                "litellm_params": {
+                    "model": "openai/gpt-4o"
+                }
+            },
+            {
+                "model_name": "azure-gpt-4o",
+                "litellm_params": {
+                    "model": "azure/gpt-4o-deployment"
+                }
+            },
+            {
+                "model_name": "github-gpt-4o",
+                "litellm_params": {
+                    "model": "github/gpt-4o"
+                }
+            }
+        ]
+        
+        # User configuration matching the test scenario
+        self.user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user", 
+            models=["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4", 
+                   "gpt-4o", "azure-gpt-4o", "github-gpt-4o"],
+            team_models=[],
+        )
+
+    def test_real_router_with_complex_fallbacks(self):
+        """Test with a real Router instance and complex fallback configuration"""
+        # Complex fallback configuration matching user's requirements
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4-failing": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-3-7-sonnet": ["bedrock-claude-3-7-sonnet", "google-claude-3-7-sonnet"]},
+            {"claude-3-7-sonnet-thinking": ["bedrock-claude-3-7-sonnet-thinking", "google-claude-3-7-sonnet-thinking"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]},
+            {"gpt-4.1": ["github-gpt-4.1"]},
+            {"gpt-4.1-mini": ["azure-gpt-4.1-mini", "github-gpt-4.1-mini"]},
+            {"gpt-4.5-preview": ["azure-gpt-4.5-preview"]},
+            {"gpt-4o-mini": ["github-gpt-4o-mini"]},
+            {"gpt-o4-mini-high": ["github-gpt-o4-mini-high"]},
+        ]
+        
+        # Create real router with fallbacks
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Test the main fallback chain from user's requirements
+        test_cases = [
+            ("claude-4-sonnet", "bedrock-claude-sonnet-4"),
+            ("bedrock-claude-sonnet-4", "google-claude-sonnet-4"),
+            ("google-claude-sonnet-4", None),
+            ("gpt-4o", "azure-gpt-4o"),
+            ("azure-gpt-4o", "github-gpt-4o"),
+            ("github-gpt-4o", None),
+        ]
+        
+        for model, expected_fallback in test_cases:
+            result = get_next_fallback(
+                model=model,
+                user_api_key_dict=self.user_api_key_dict,
+                llm_router=router,
+                fallback_type="general"
+            )
+            assert result == expected_fallback, f"Failed for {model}: expected {expected_fallback}, got {result}"
+
+    def test_context_window_fallbacks_integration(self):
+        """Test context window fallbacks with real router"""
+        context_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]},
+            {"gpt-4o": ["azure-gpt-4o"]}
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            context_window_fallbacks=context_fallbacks
+        )
+        
+        # Test context window fallbacks
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="context_window"
+        )
+        assert result == "bedrock-claude-sonnet-4"
+        
+        result = get_next_fallback(
+            model="gpt-4o",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="context_window"
+        )
+        assert result == "azure-gpt-4o"
+
+    def test_content_policy_fallbacks_integration(self):
+        """Test content policy fallbacks with real router"""
+        content_policy_fallbacks = [
+            {"claude-4-sonnet": ["google-claude-sonnet-4"]},
+            {"gpt-4o": ["github-gpt-4o"]}
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            content_policy_fallbacks=content_policy_fallbacks
+        )
+        
+        # Test content policy fallbacks
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="content_policy"
+        )
+        assert result == "google-claude-sonnet-4"
+        
+        result = get_next_fallback(
+            model="gpt-4o",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="content_policy"
+        )
+        assert result == "github-gpt-4o"
+
+    def test_generic_wildcard_fallbacks_integration(self):
+        """Test generic wildcard fallbacks with real router"""
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]},
+            {"*": ["google-claude-sonnet-4"]}  # Generic fallback for any model
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Test specific fallback
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "bedrock-claude-sonnet-4"
+        
+        # Test generic fallback for model not in specific config
+        result = get_next_fallback(
+            model="gpt-4o",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "google-claude-sonnet-4"
+
+    def test_router_model_name_resolution(self):
+        """Test that the router properly resolves model names with provider prefixes"""
+        # Test model list with provider prefixes
+        prefixed_model_list = [
+            {
+                "model_name": "openai/gpt-3.5-turbo",
+                "litellm_params": {
+                    "model": "openai/gpt-3.5-turbo"
+                }
+            },
+            {
+                "model_name": "anthropic/claude-3-haiku",
+                "litellm_params": {
+                    "model": "anthropic/claude-3-haiku"
+                }
+            }
+        ]
+        
+        # Fallback config uses base model names
+        fallbacks = [
+            {"gpt-3.5-turbo": ["claude-3-haiku"]}
+        ]
+        
+        router = Router(
+            model_list=prefixed_model_list,
+            fallbacks=fallbacks
+        )
+        
+        user_with_prefixed_models = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            models=["openai/gpt-3.5-turbo", "anthropic/claude-3-haiku"],
+            team_models=[],
+        )
+        
+        # Test that provider-prefixed model matches base fallback config
+        result = get_next_fallback(
+            model="openai/gpt-3.5-turbo",
+            user_api_key_dict=user_with_prefixed_models,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "claude-3-haiku"
+
+    def test_router_with_empty_fallback_chains(self):
+        """Test router behavior with empty or incomplete fallback chains"""
+        fallbacks = [
+            {"claude-4-sonnet": []},  # Empty fallback list
+            {"gpt-4o": ["azure-gpt-4o"]},  # Single fallback
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Test empty fallback list
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None
+        
+        # Test single fallback chain
+        result = get_next_fallback(
+            model="gpt-4o",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "azure-gpt-4o"
+        
+        # Test end of single fallback chain
+        result = get_next_fallback(
+            model="azure-gpt-4o",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None
+
+    def test_router_multiple_fallback_types_priority(self):
+        """Test behavior when multiple fallback types are configured"""
+        general_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]}
+        ]
+        
+        context_fallbacks = [
+            {"claude-4-sonnet": ["google-claude-sonnet-4"]}  # Different order
+        ]
+        
+        content_policy_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]}  # Different fallback
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=general_fallbacks,
+            context_window_fallbacks=context_fallbacks,
+            content_policy_fallbacks=content_policy_fallbacks
+        )
+        
+        # Each fallback type should return its configured fallback
+        general_result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert general_result == "bedrock-claude-sonnet-4"
+        
+        context_result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="context_window"
+        )
+        assert context_result == "google-claude-sonnet-4"
+        
+        policy_result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="content_policy"
+        )
+        assert policy_result == "bedrock-claude-sonnet-4"
+
+    def test_router_with_access_control_scenarios(self):
+        """Test various user access control scenarios with real router"""
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]}
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Test user with limited model access
+        limited_user = UserAPIKeyAuth(
+            api_key="limited-key",
+            user_id="limited-user",
+            models=["claude-4-sonnet", "google-claude-sonnet-4"],  # Missing bedrock-claude-sonnet-4
+            team_models=[],
+        )
+        
+        # Function should find the next accessible fallback (skipping inaccessible ones)
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=limited_user,
+            llm_router=router,
+            fallback_type="general"
+        )
+        # Should return the first fallback that the user can access
+        assert result == "bedrock-claude-sonnet-4"  # This will be checked by the endpoint logic
+
+    def test_router_performance_with_large_fallback_config(self):
+        """Test performance with a large number of fallback configurations"""
+        # Create a large fallback configuration
+        large_fallbacks = []
+        for i in range(100):
+            large_fallbacks.append({
+                f"model-{i}": [f"fallback-{i}-1", f"fallback-{i}-2", f"fallback-{i}-3"]
+            })
+        
+        # Add our test models
+        large_fallbacks.extend([
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]}
+        ])
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=large_fallbacks
+        )
+        
+        # Test that our fallback lookup still works correctly with large config
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "bedrock-claude-sonnet-4"
+        
+        # Test fallback chain progression
+        result = get_next_fallback(
+            model="bedrock-claude-sonnet-4",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "google-claude-sonnet-4"
+
+    def test_router_edge_cases_and_error_conditions(self):
+        """Test edge cases and potential error conditions"""
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]}
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Test with None user_api_key_dict (should not crash)
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,  # Still provide valid dict for this test
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "bedrock-claude-sonnet-4"
+        
+        # Test with invalid fallback type (should default to general)
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="invalid_type"  # Should default to general
+        )
+        assert result == "bedrock-claude-sonnet-4"
+        
+        # Test with empty model string
+        result = get_next_fallback(
+            model="",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None
+
+    def test_router_fallback_consistency_with_litellm_completion(self):
+        """Test that our fallback logic is consistent with how LiteLLM handles fallbacks internally"""
+        # This is more of a documentation test to ensure we understand the expected behavior
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]}
+        ]
+        
+        router = Router(
+            model_list=self.model_list,
+            fallbacks=fallbacks
+        )
+        
+        # Our next fallback function should return what would be tried next
+        # if claude-4-sonnet failed in a real completion call
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        # This should match the first fallback model that Router would try
+        assert result == "bedrock-claude-sonnet-4"
+        
+        # And the progression should continue correctly
+        result = get_next_fallback(
+            model="bedrock-claude-sonnet-4",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "google-claude-sonnet-4"
+        
+        # Finally, no more fallbacks
+        result = get_next_fallback(
+            model="google-claude-sonnet-4",
+            user_api_key_dict=self.user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None

--- a/tests/proxy_unit_tests/test_next_fallback_endpoint.py
+++ b/tests/proxy_unit_tests/test_next_fallback_endpoint.py
@@ -1,0 +1,403 @@
+"""
+Integration tests for the /v1/models/{model}/next-fallback API endpoint
+
+Tests the HTTP endpoint functionality including authentication, authorization, 
+request/response handling, and error cases.
+"""
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, Mock
+from fastapi.testclient import TestClient
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.proxy_server import app
+from litellm.router import Router
+
+
+class TestNextFallbackEndpoint:
+    """Test cases for the /v1/models/{model}/next-fallback endpoint"""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method"""
+        self.client = TestClient(app)
+        self.test_token = "Bearer sk-test-key"
+        self.base_url = "/v1/models"
+        
+        # Mock user API key dict
+        self.mock_user_api_key_dict = UserAPIKeyAuth(
+            api_key="sk-test-key",
+            user_id="test-user",
+            models=["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4"],
+            team_models=[],
+        )
+        
+        # Sample fallback configuration
+        self.sample_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]},
+        ]
+
+    def create_mock_router(self):
+        """Create a mock router with test configuration"""
+        mock_router = Mock(spec=Router)
+        mock_router.fallbacks = self.sample_fallbacks
+        mock_router.context_window_fallbacks = []
+        mock_router.content_policy_fallbacks = []
+        mock_router.get_model_names.return_value = [
+            "claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4",
+            "gpt-4o", "azure-gpt-4o", "github-gpt-4o"
+        ]
+        mock_router.get_model_access_groups.return_value = {}
+        return mock_router
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_successful_fallback_request(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test successful fallback request returns correct next fallback"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        # Mock the model access functions
+        accessible_models = ["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert data["current_model"] == "claude-4-sonnet"
+        assert data["next_fallback"] == "bedrock-claude-sonnet-4"
+        assert data["fallback_type"] == "general"
+        assert data["object"] == "next_fallback"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_fallback_chain_progression(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test the complete fallback chain progression"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        accessible_models = ["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        test_cases = [
+            ("claude-4-sonnet", 200, "bedrock-claude-sonnet-4"),
+            ("bedrock-claude-sonnet-4", 200, "google-claude-sonnet-4"),
+            ("google-claude-sonnet-4", 404, None),  # No more fallbacks
+        ]
+        
+        for model, expected_status, expected_fallback in test_cases:
+            with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+                response = self.client.get(
+                    f"{self.base_url}/{model}/next-fallback",
+                    headers={"Authorization": self.test_token}
+                )
+            
+            assert response.status_code == expected_status
+            
+            if expected_status == 200:
+                data = response.json()
+                assert data["current_model"] == model
+                assert data["next_fallback"] == expected_fallback
+            else:
+                # 404 case
+                data = response.json()
+                assert "error" in data
+                assert data["error"]["code"] == "no_fallback_available"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_different_fallback_types(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test different fallback types via query parameter"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        mock_router.context_window_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]}
+        ]
+        
+        accessible_models = ["claude-4-sonnet", "bedrock-claude-sonnet-4"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback?fallback_type=context_window",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["fallback_type"] == "context_window"
+        assert data["next_fallback"] == "bedrock-claude-sonnet-4"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    def test_invalid_fallback_type(self, mock_router, mock_auth):
+        """Test invalid fallback_type parameter returns 400"""
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback?fallback_type=invalid",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 400
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "invalid_fallback_type"
+        assert "Invalid fallback_type" in data["error"]["message"]
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router', None)
+    def test_no_router_configured(self, mock_auth):
+        """Test error when no router is configured"""
+        mock_auth.return_value = self.mock_user_api_key_dict
+        
+        response = self.client.get(
+            f"{self.base_url}/claude-4-sonnet/next-fallback",
+            headers={"Authorization": self.test_token}
+        )
+        
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "no_router_configured"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_model_not_found(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test 404 when model is not accessible to user"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        # Model not in accessible models list
+        accessible_models = ["other-model"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "model_not_found"
+
+    def test_missing_authorization_header(self):
+        """Test that missing Authorization header is handled properly"""
+        # Note: The actual auth behavior depends on the user_api_key_auth dependency
+        # This test may need adjustment based on actual auth implementation
+        response = self.client.get(f"{self.base_url}/claude-4-sonnet/next-fallback")
+        
+        # Expect some form of authentication error (status code may vary based on implementation)
+        assert response.status_code in [401, 403, 422]
+
+    def test_invalid_authorization_header(self):
+        """Test that invalid Authorization header is handled properly"""
+        response = self.client.get(
+            f"{self.base_url}/claude-4-sonnet/next-fallback",
+            headers={"Authorization": "Bearer invalid-token"}
+        )
+        
+        # Expect some form of authentication error
+        assert response.status_code in [401, 403, 422]
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_user_no_access_to_fallback_model(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test when user has access to primary model but not the fallback"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        # User only has access to primary model, not fallback
+        accessible_models = ["claude-4-sonnet"]  # Missing bedrock-claude-sonnet-4
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback",
+                headers={"Authorization": self.test_token}
+            )
+        
+        # Should try to find next accessible fallback or return 404
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "no_accessible_fallback"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_skip_inaccessible_fallback_to_next_accessible(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test that inaccessible fallbacks are skipped to find next accessible one"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        # User has access to primary and last fallback, but not the first fallback
+        accessible_models = ["claude-4-sonnet", "google-claude-sonnet-4"]  # Missing bedrock-claude-sonnet-4
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should skip bedrock-claude-sonnet-4 and return google-claude-sonnet-4
+        assert data["next_fallback"] == "google-claude-sonnet-4"
+
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_response_format_compliance(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth
+    ):
+        """Test that response format matches the expected schema"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        accessible_models = ["claude-4-sonnet", "bedrock-claude-sonnet-4"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback",
+                headers={"Authorization": self.test_token}
+            )
+        
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check required fields
+        required_fields = ["current_model", "next_fallback", "fallback_type", "object"]
+        for field in required_fields:
+            assert field in data, f"Missing required field: {field}"
+        
+        # Check field types and values
+        assert isinstance(data["current_model"], str)
+        assert isinstance(data["next_fallback"], str)
+        assert isinstance(data["fallback_type"], str)
+        assert data["object"] == "next_fallback"
+        assert data["fallback_type"] in ["general", "context_window", "content_policy"]
+
+    @pytest.mark.parametrize("fallback_type", ["general", "context_window", "content_policy"])
+    @patch('litellm.proxy.proxy_server.user_api_key_auth')
+    @patch('litellm.proxy.proxy_server.llm_router')
+    @patch('litellm.proxy.proxy_server.general_settings')
+    @patch('litellm.proxy.proxy_server.get_key_models')
+    @patch('litellm.proxy.proxy_server.get_team_models')
+    @patch('litellm.proxy.proxy_server.get_complete_model_list')
+    def test_all_valid_fallback_types(
+        self, mock_get_complete_model_list, mock_get_team_models, 
+        mock_get_key_models, mock_general_settings, mock_router, mock_auth, fallback_type
+    ):
+        """Test all valid fallback_type parameter values"""
+        # Setup mocks
+        mock_auth.return_value = self.mock_user_api_key_dict
+        mock_router = self.create_mock_router()
+        
+        # Set up fallbacks for all types
+        mock_router.context_window_fallbacks = [{"claude-4-sonnet": ["bedrock-claude-sonnet-4"]}]
+        mock_router.content_policy_fallbacks = [{"claude-4-sonnet": ["google-claude-sonnet-4"]}]
+        
+        accessible_models = ["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4"]
+        mock_get_key_models.return_value = []
+        mock_get_team_models.return_value = []
+        mock_get_complete_model_list.return_value = accessible_models
+        mock_general_settings.get.return_value = False
+        
+        with patch('litellm.proxy.proxy_server.llm_router', mock_router):
+            response = self.client.get(
+                f"{self.base_url}/claude-4-sonnet/next-fallback?fallback_type={fallback_type}",
+                headers={"Authorization": self.test_token}
+            )
+        
+        # Should either return 200 with fallback or 404 if no fallback configured for this type
+        assert response.status_code in [200, 404]
+        
+        if response.status_code == 200:
+            data = response.json()
+            assert data["fallback_type"] == fallback_type

--- a/tests/test_litellm/proxy/auth/test_model_checks_next_fallback.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks_next_fallback.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for the get_next_fallback() function in model_checks.py
+
+Tests the core logic for finding the next fallback model in a fallback chain.
+"""
+from unittest.mock import MagicMock, Mock
+from typing import List, Dict, Any, Optional
+
+import pytest
+
+from litellm.proxy._types import UserAPIKeyAuth  
+from litellm.proxy.auth.model_checks import get_next_fallback
+from litellm.router import Router
+
+
+class TestGetNextFallback:
+    """Test cases for get_next_fallback function"""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method"""
+        # Create a mock user API key dict
+        self.mock_user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="test-user",
+            models=["claude-4-sonnet", "bedrock-claude-sonnet-4", "google-claude-sonnet-4"],
+            team_models=[],
+        )
+        
+        # Sample fallback configuration matching the user's requirements
+        self.sample_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4-failing": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-3-7-sonnet": ["bedrock-claude-3-7-sonnet", "google-claude-3-7-sonnet"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]},
+            {"gpt-4.1": ["github-gpt-4.1"]},
+        ]
+
+    def create_mock_router(self, fallbacks: List[Dict[str, List[str]]] = None) -> Mock:
+        """Create a mock router with fallback configuration"""
+        mock_router = Mock(spec=Router)
+        mock_router.fallbacks = fallbacks if fallbacks is not None else self.sample_fallbacks
+        mock_router.context_window_fallbacks = []
+        mock_router.content_policy_fallbacks = []
+        return mock_router
+
+    def test_primary_model_returns_first_fallback(self):
+        """Test that a primary model returns its first fallback"""
+        router = self.create_mock_router()
+        
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result == "bedrock-claude-sonnet-4"
+
+    def test_fallback_model_returns_next_in_chain(self):
+        """Test that a fallback model returns the next model in the chain"""
+        router = self.create_mock_router()
+        
+        result = get_next_fallback(
+            model="bedrock-claude-sonnet-4",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result == "google-claude-sonnet-4"
+
+    def test_last_fallback_returns_none(self):
+        """Test that the last model in a fallback chain returns None"""
+        router = self.create_mock_router()
+        
+        result = get_next_fallback(
+            model="google-claude-sonnet-4",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result is None
+
+    def test_nonexistent_model_returns_none(self):
+        """Test that a model not in any fallback configuration returns None"""
+        router = self.create_mock_router()
+        
+        result = get_next_fallback(
+            model="non-existent-model",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result is None
+
+    def test_single_fallback_chain(self):
+        """Test a model with only one fallback"""
+        router = self.create_mock_router()
+        
+        # Test primary model with single fallback
+        result = get_next_fallback(
+            model="gpt-4.1",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "github-gpt-4.1"
+        
+        # Test the single fallback returns None
+        result = get_next_fallback(
+            model="github-gpt-4.1",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None
+
+    def test_context_window_fallbacks(self):
+        """Test context window fallback type"""
+        router = self.create_mock_router()
+        router.context_window_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]}
+        ]
+        
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="context_window"
+        )
+        
+        assert result == "bedrock-claude-sonnet-4"
+
+    def test_content_policy_fallbacks(self):
+        """Test content policy fallback type"""
+        router = self.create_mock_router()
+        router.content_policy_fallbacks = [
+            {"claude-4-sonnet": ["google-claude-sonnet-4"]}
+        ]
+        
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="content_policy"
+        )
+        
+        assert result == "google-claude-sonnet-4"
+
+    def test_empty_fallbacks(self):
+        """Test behavior with empty fallback configurations"""
+        router = self.create_mock_router(fallbacks=[])
+        
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result is None
+
+    def test_no_router(self):
+        """Test behavior when no router is provided"""
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=None,
+            fallback_type="general"
+        )
+        
+        assert result is None
+
+    def test_stripped_model_names(self):
+        """Test fallback resolution with provider-prefixed model names"""
+        # Test with fallback config that uses base model names
+        fallbacks = [
+            {"gpt-3.5-turbo": ["claude-3-haiku"]}
+        ]
+        router = self.create_mock_router(fallbacks=fallbacks)
+        
+        # Test that provider-prefixed model matches base name in config
+        result = get_next_fallback(
+            model="openai/gpt-3.5-turbo",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result == "claude-3-haiku"
+
+    def test_multiple_fallback_chains(self):
+        """Test with multiple independent fallback chains"""
+        router = self.create_mock_router()
+        
+        # Test gpt-4o chain
+        result = get_next_fallback(
+            model="gpt-4o",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "azure-gpt-4o"
+        
+        result = get_next_fallback(
+            model="azure-gpt-4o",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result == "github-gpt-4o"
+        
+        result = get_next_fallback(
+            model="github-gpt-4o",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        assert result is None
+
+    def test_generic_wildcard_fallbacks(self):
+        """Test generic fallbacks using wildcard (*) key"""
+        fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4"]},
+            {"*": ["generic-fallback-model"]}  # Generic fallback
+        ]
+        router = self.create_mock_router(fallbacks=fallbacks)
+        
+        # Test that model not in specific fallbacks uses generic fallback
+        result = get_next_fallback(
+            model="unknown-model",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result == "generic-fallback-model"
+
+    @pytest.mark.parametrize("fallback_type,expected_attr", [
+        ("general", "fallbacks"),
+        ("context_window", "context_window_fallbacks"),
+        ("content_policy", "content_policy_fallbacks"),
+    ])
+    def test_fallback_type_attribute_mapping(self, fallback_type, expected_attr):
+        """Test that different fallback types access the correct router attribute"""
+        router = self.create_mock_router()
+        
+        # Clear all fallback types
+        router.fallbacks = []
+        router.context_window_fallbacks = []
+        router.content_policy_fallbacks = []
+        
+        # Set only the specific fallback type being tested
+        test_fallbacks = [{"test-model": ["test-fallback"]}]
+        setattr(router, expected_attr, test_fallbacks)
+        
+        result = get_next_fallback(
+            model="test-model",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type=fallback_type
+        )
+        
+        assert result == "test-fallback"
+
+    def test_edge_case_empty_fallback_list(self):
+        """Test edge case where fallback list is empty"""
+        fallbacks = [
+            {"claude-4-sonnet": []},  # Empty fallback list
+        ]
+        router = self.create_mock_router(fallbacks=fallbacks)
+        
+        result = get_next_fallback(
+            model="claude-4-sonnet",
+            user_api_key_dict=self.mock_user_api_key_dict,
+            llm_router=router,
+            fallback_type="general"
+        )
+        
+        assert result is None
+
+    def test_complex_fallback_scenario(self):
+        """Test complex scenario with user's exact configuration"""
+        complex_fallbacks = [
+            {"claude-4-sonnet": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-sonnet-4-failing": ["bedrock-claude-sonnet-4", "google-claude-sonnet-4"]},
+            {"claude-3-7-sonnet": ["bedrock-claude-3-7-sonnet", "google-claude-3-7-sonnet"]},
+            {"claude-3-7-sonnet-thinking": ["bedrock-claude-3-7-sonnet-thinking", "google-claude-3-7-sonnet-thinking"]},
+            {"gpt-4o": ["azure-gpt-4o", "github-gpt-4o"]},
+            {"gpt-4.1": ["github-gpt-4.1"]},
+            {"gpt-4.1-mini": ["azure-gpt-4.1-mini", "github-gpt-4.1-mini"]},
+            {"gpt-4.5-preview": ["azure-gpt-4.5-preview"]},
+            {"gpt-4o-mini": ["github-gpt-4o-mini"]},
+            {"gpt-o4-mini-high": ["github-gpt-o4-mini-high"]},
+        ]
+        
+        router = self.create_mock_router(fallbacks=complex_fallbacks)
+        
+        # Test multiple chains from user's config
+        test_cases = [
+            ("claude-4-sonnet", "bedrock-claude-sonnet-4"),
+            ("bedrock-claude-sonnet-4", "google-claude-sonnet-4"),
+            ("google-claude-sonnet-4", None),
+            ("gpt-4.5-preview", "azure-gpt-4.5-preview"),
+            ("azure-gpt-4.5-preview", None),
+            ("non-existent-model", None),
+        ]
+        
+        for model, expected in test_cases:
+            result = get_next_fallback(
+                model=model,
+                user_api_key_dict=self.mock_user_api_key_dict,
+                llm_router=router,
+                fallback_type="general"
+            )
+            assert result == expected, f"Failed for model {model}: expected {expected}, got {result}"


### PR DESCRIPTION
## Type

  🆕 New Feature

  ## Changes

  ### Summary
  This PR implements a new REST API endpoint `/v1/models/{model}/next-fallback` that provides progressive fallback
  discovery for LiteLLM models. Instead of returning all fallbacks at once, this endpoint returns only the immediate next fallback model in the chain, enabling clients to discover fallbacks step-by-step.

  ### Key Features
  - **Progressive Discovery**: Returns only the next immediate fallback model
  - **Fallback Type Support**: Supports `general`, `context_window`, and `content_policy` fallback types
  - **Authentication & Authorization**: Integrates with existing LiteLLM auth system
  - **Access Control**: Respects user/team model permissions and filters inaccessible fallbacks
  - **Provider Prefix Handling**: Works with model names like `openai/gpt-4`
  and `bedrock/claude-3`
  - **OpenAI-Compatible Response Format**: Consistent with existing LiteLLM API patterns

  ### API Behavior Example
  For fallback configuration:
  ```yaml
  fallbacks:
    - claude-4-sonnet: [bedrock-claude-sonnet-4, google-claude-sonnet-4]

  API calls return:
  - GET /v1/models/claude-4-sonnet/next-fallback → bedrock-claude-sonnet-4
  - GET /v1/models/bedrock-claude-sonnet-4/next-fallback →  google-claude-sonnet-4
  - GET /v1/models/google-claude-sonnet-4/next-fallback → 404 Not Found

  Response Format

  Success (200 OK):
  {
    "current_model": "claude-4-sonnet",
    "next_fallback": "bedrock-claude-sonnet-4",
    "fallback_type": "general",
    "object": "next_fallback"
  }

  No Fallback (404 Not Found):
  {
    "error": {
      "message": "No fallback available for model: google-claude-sonnet-4",
      "type": "not_found",
      "code": "no_fallback_available"
    }
  }
 

```
<img width="956" height="545" alt="image" src="https://github.com/user-attachments/assets/46ef3149-7956-4e68-9625-e65d1bc993db" />