### PR TITLE
fix: helm migration job not running schema update

### DIFF
--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -47,8 +47,6 @@ spec:
             - name: DATABASE_URL
               value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
             {{- end }}
-            - name: DISABLE_SCHEMA_UPDATE
-              value: "false" # always run the migration from the Helm PreSync hook, override the value set
             {{- if .Values.envVars }}
             {{- range $key, $val := .Values.envVars }}
             - name: {{ $key }}
@@ -58,6 +56,8 @@ spec:
             {{- with .Values.extraEnvVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            - name: DISABLE_SCHEMA_UPDATE
+              value: "false" # always run the migration from the Helm PreSync hook, override the value set
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Title

The order of `DISABLE_SCHEMA_UPDATE` is important here, k8s will take the last value as truth. Push down to be sure schema update is done by migration job as best practices suggest to set this for litellm pods and will now be included into the migration job by #12591

https://docs.litellm.ai/docs/proxy/prod#7-use-helm-presync-hook-for-database-migrations-beta

`When a key exists in multiple sources, the value associated with the last source will take precedence.`
https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables

## Relevant issues

https://github.com/BerriAI/litellm/pull/12591

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

Push `DISABLE_SCHEMA_UPDATE: false` to the bottom of env vars to ensure it is always false for the migration job and schema is being updated

