### PR TITLE
[UI Bug Fix] Show correct guardrails when editing a team

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14791,7 +14791,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "lambda_ai/deepseek-r1-0528": {
         "max_tokens": 131072,
@@ -14804,7 +14805,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "lambda_ai/deepseek-r1-671b": {
         "max_tokens": 131072,
@@ -14817,7 +14819,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "lambda_ai/deepseek-v3-0324": {
         "max_tokens": 131072,
@@ -15039,7 +15042,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "voyage/voyage-01": {
         "max_tokens": 4096,

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -30,6 +30,7 @@ import {
   teamMemberUpdateCall,
   Member,
   teamUpdateCall,
+  getGuardrailsList,
 } from "@/components/networking";
 import { Button, Form, Input, Select, message, Tooltip } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
@@ -147,6 +148,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
   const [mcpAccessGroups, setMcpAccessGroups] = useState<string[]>([]);
   const [mcpAccessGroupsLoaded, setMcpAccessGroupsLoaded] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({})
+  const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
 
   console.log("userModels in team info", userModels);
 
@@ -181,6 +183,23 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
       console.error("Failed to fetch MCP access groups:", error);
     }
   };
+
+  useEffect(() => {
+    const fetchGuardrails = async () => {
+      try {
+        if (!accessToken) return;
+        const response = await getGuardrailsList(accessToken);
+        const guardrailNames = response.guardrails.map(
+          (g: { guardrail_name: string }) => g.guardrail_name
+        );
+        setGuardrailsList(guardrailNames);
+      } catch (error) {
+        console.error("Failed to fetch guardrails:", error);
+      }
+    };
+
+    fetchGuardrails();
+  }, [accessToken]);
 
   const handleMemberCreate = async (values: any) => {
     try {
@@ -673,13 +692,14 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     <Select
                       mode="tags"
                       placeholder="Select or enter guardrails"
+                      options={guardrailsList.map(name => ({ value: name, label: name }))}
                     />
                   </Form.Item>
 
                   <Form.Item label="Vector Stores" name="vector_stores">
                     <VectorStoreSelector
                       onChange={(values) =>
-                        form.setFieldValue("vector_stores", values)
+                         form.setFieldValue("vector_stores", values)
                       }
                       value={form.getFieldValue("vector_stores")}
                       accessToken={accessToken || ""}


### PR DESCRIPTION
## [UI Bug Fix] Show correct guardrails when editing a team

Fixes https://github.com/BerriAI/litellm/issues/12786

Fixes a bug where the list of guardrails did not appear when editing a team

<img width="1023" height="190" alt="Screenshot 2025-07-21 at 11 05 07 AM" src="https://github.com/user-attachments/assets/ca6d3acb-df6c-47f3-80ca-1c0c718865e6" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


