### PR TITLE
fix: sonnet 3.5 should not report support of reasoning_effort

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -127,15 +127,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "parallel_tool_calls",
             "response_format",
             "user",
-            "reasoning_effort",
             "web_search_options",
         ]
 
-        if "claude-3-7-sonnet" in model or supports_reasoning(
+        if supports_reasoning(
             model=model,
             custom_llm_provider=self.custom_llm_provider,
         ):
             params.append("thinking")
+            params.append("reasoning_effort")
 
         return params
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 
+import litellm
 import pytest
 from fastapi.testclient import TestClient
 
@@ -342,7 +343,24 @@ def test_transform_response_with_prefix_prompt():
     )
 
 
-def test_get_supported_params_thinking():
+def test_get_supported_params_thinking_and_reasoning_effort():
+    """
+    Tests that `thinking` and `reasoning_effort` are returned as supported params ONLY for models that support it.
+    """
     config = AnthropicConfig()
-    params = config.get_supported_openai_params(model="claude-sonnet-4-20250514")
-    assert "thinking" in params
+
+    # No reasoningf or unsupported
+    params_no_reasoning = config.get_supported_openai_params(
+        model="claude-3-5-sonnet-latest"
+    )
+    assert params_no_reasoning
+    assert "thinking" not in params_no_reasoning
+    assert "reasoning_effort" not in params_no_reasoning
+
+    for model in ("claude-3-7-sonnet-latest", "claude-4-opus-20250514", "claude-4-sonnet-20250514"):
+        params_with_reasoning = config.get_supported_openai_params(
+          model=model
+        )
+        assert params_no_reasoning
+        assert "thinking" in params_with_reasoning
+        assert "reasoning_effort" in params_with_reasoning


### PR DESCRIPTION
fixes #12833


- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="933" height="311" alt="image" src="https://github.com/user-attachments/assets/0f406330-9877-4131-9392-e2d53f76652b" />
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test
