### PR TITLE
[Azure OpenAI Feature] - Support DefaultAzureCredential without hard-coded environment variables

### DIFF
--- a/docs/my-website/docs/providers/azure/azure.md
+++ b/docs/my-website/docs/providers/azure/azure.md
@@ -618,29 +618,51 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 
 ### Azure AD Token Refresh - `DefaultAzureCredential`
 
-Use this if you want to use Azure `DefaultAzureCredential` for Authentication on your requests
+Use this if you want to use Azure `DefaultAzureCredential` for Authentication on your requests. `DefaultAzureCredential` automatically discovers and uses available Azure credentials from multiple sources.
 
 <Tabs>
 <TabItem value="sdk" label="SDK">
 
+**Option 1: Explicit DefaultAzureCredential (Recommended)**
 ```python
 from litellm import completion
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
+# DefaultAzureCredential automatically discovers credentials from:
+# - Environment variables (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)
+# - Managed Identity (AKS, Azure VMs, etc.)
+# - Azure CLI credentials
+# - And other Azure identity sources
 token_provider = get_bearer_token_provider(DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default")
-
 
 response = completion(
     model = "azure/<your deployment name>",             # model = azure/<your deployment name> 
     api_base = "",                                      # azure api base
     api_version = "",                                   # azure api version
-    azure_ad_token_provider=token_provider
+    azure_ad_token_provider=token_provider,
+    messages = [{"role": "user", "content": "good morning"}],
+)
+```
+
+**Option 2: LiteLLM Auto-Fallback to DefaultAzureCredential**
+```python
+import litellm
+
+# Enable automatic fallback to DefaultAzureCredential
+litellm.enable_azure_ad_token_refresh = True
+
+response = litellm.completion(
+    model = "azure/<your deployment name>",
+    api_base = "",
+    api_version = "",
     messages = [{"role": "user", "content": "good morning"}],
 )
 ```
 
 </TabItem>
 <TabItem value="proxy" label="PROXY config.yaml">
+
+**Scenario 1: With Environment Variables (Traditional)**
 
 1. Add relevant env vars
 
@@ -663,11 +685,47 @@ litellm_settings:
     enable_azure_ad_token_refresh: true # 👈 KEY CHANGE
 ```
 
+**Scenario 2: Managed Identity (AKS, Azure VMs) - No Hard-coded Credentials Required**
+
+Perfect for AKS clusters, Azure VMs, or other managed environments where Azure automatically injects credentials.
+
+```yaml
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: azure/your-deployment-name
+      api_base: https://openai-gpt-4-test-v-1.openai.azure.com/
+
+litellm_settings:
+    enable_azure_ad_token_refresh: true # 👈 KEY CHANGE
+```
+
+**Scenario 3: Azure CLI Authentication**
+
+If you're authenticated via `az login`, no additional configuration needed:
+
+```yaml
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: azure/your-deployment-name
+      api_base: https://openai-gpt-4-test-v-1.openai.azure.com/
+
+litellm_settings:
+    enable_azure_ad_token_refresh: true # 👈 KEY CHANGE
+```
+
 3. Start proxy
 
 ```bash
 litellm --config /path/to/config.yaml
 ```
+
+**How it works**: 
+- LiteLLM first tries Service Principal authentication (if environment variables are available)
+- If that fails, it automatically falls back to `DefaultAzureCredential`
+- `DefaultAzureCredential` will use Managed Identity, Azure CLI credentials, or other available Azure identity sources
+- This eliminates the need for hard-coded credentials in managed environments like AKS
 
 </TabItem>
 </Tabs>

--- a/litellm/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/secret_managers/get_azure_ad_token_provider.py
@@ -6,7 +6,10 @@ from litellm.types.secret_managers.get_azure_ad_token_provider import (
 )
 
 
-def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[], str]:
+def get_azure_ad_token_provider(
+    azure_scope: Optional[str] = None,
+    azure_credential: Optional[AzureCredentialType] = None,
+) -> Callable[[], str]:
     """
     Get Azure AD token provider based on Service Principal with Secret workflow.
 
@@ -38,8 +41,9 @@ def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[
             or "https://cognitiveservices.azure.com/.default"
         )
 
-    cred: str = os.environ.get(
-        "AZURE_CREDENTIAL", AzureCredentialType.ClientSecretCredential
+    cred: str = (
+        azure_credential.value if azure_credential else None
+        or os.environ.get("AZURE_CREDENTIAL", AzureCredentialType.ClientSecretCredential)
     )
     credential: Optional[
         Union[

--- a/litellm/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/secret_managers/get_azure_ad_token_provider.py
@@ -27,6 +27,7 @@ def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[
     from azure.identity import (
         CertificateCredential,
         ClientSecretCredential,
+        DefaultAzureCredential,
         ManagedIdentityCredential,
         get_bearer_token_provider,
     )
@@ -45,6 +46,7 @@ def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[
             ClientSecretCredential,
             ManagedIdentityCredential,
             CertificateCredential,
+            DefaultAzureCredential,
             Any,
         ]
     ] = None
@@ -62,10 +64,15 @@ def get_azure_ad_token_provider(azure_scope: Optional[str] = None) -> Callable[[
             tenant_id=os.environ["AZURE_TENANT_ID"],
             certificate_path=os.environ["AZURE_CERTIFICATE_PATH"],
         )
+    elif cred == AzureCredentialType.DefaultAzureCredential:
+        # DefaultAzureCredential doesn't require explicit environment variables
+        # It automatically discovers credentials from the environment (managed identity, CLI, etc.)
+        credential = DefaultAzureCredential()
     else:
         cred_cls = getattr(identity, cred)
         credential = cred_cls()
 
     if credential is None:
         raise ValueError("No credential provided")
+
     return get_bearer_token_provider(credential, azure_scope)

--- a/litellm/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/secret_managers/get_azure_ad_token_provider.py
@@ -44,6 +44,7 @@ def get_azure_ad_token_provider(
     cred: str = (
         azure_credential.value if azure_credential else None
         or os.environ.get("AZURE_CREDENTIAL", AzureCredentialType.ClientSecretCredential)
+        or AzureCredentialType.ClientSecretCredential
     )
     credential: Optional[
         Union[

--- a/litellm/types/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/types/secret_managers/get_azure_ad_token_provider.py
@@ -5,3 +5,4 @@ class AzureCredentialType(str, Enum):
     ClientSecretCredential = "ClientSecretCredential"
     ManagedIdentityCredential = "ManagedIdentityCredential"
     CertificateCredential = "CertificateCredential"
+    DefaultAzureCredential = "DefaultAzureCredential"

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -12,7 +12,13 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 import litellm
 from litellm.llms.azure.common_utils import BaseAzureLLM, get_azure_ad_token
+from litellm.secret_managers.get_azure_ad_token_provider import (
+    get_azure_ad_token_provider,
+)
 from litellm.types.router import GenericLiteLLMParams
+from litellm.types.secret_managers.get_azure_ad_token_provider import (
+    AzureCredentialType,
+)
 from litellm.types.utils import CallTypes
 
 
@@ -1298,7 +1304,7 @@ def test_get_azure_ad_token_with_token_refresh(setup_mocks, monkeypatch):
 
     # Verify the debug message was logged
     setup_mocks["logger"].debug.assert_any_call(
-        "Using Azure AD token provider based on Service Principal with Secret workflow for Azure Auth"
+        "Using Azure AD token provider based on Service Principal with Secret workflow or DefaultAzureCredential for Azure Auth"
     )
 
     # Verify get_azure_ad_token_provider was called
@@ -1325,7 +1331,7 @@ def test_get_azure_ad_token_with_token_refresh_error(setup_mocks):
 
     # Verify the debug message was logged
     setup_mocks["logger"].debug.assert_any_call(
-        "Using Azure AD token provider based on Service Principal with Secret workflow for Azure Auth"
+        "Using Azure AD token provider based on Service Principal with Secret workflow or DefaultAzureCredential for Azure Auth"
     )
 
     # Verify error was logged
@@ -1333,8 +1339,8 @@ def test_get_azure_ad_token_with_token_refresh_error(setup_mocks):
         "Azure AD Token Provider could not be used."
     )
 
-    # Verify get_azure_ad_token_provider was called
-    setup_mocks["token_provider"].assert_called_once()
+    # Verify get_azure_ad_token_provider was called twice (once for service principal, once for DefaultAzureCredential)
+    assert setup_mocks["token_provider"].call_count == 2
 
     # Verify the token is None since the provider raised an error
     assert token is None
@@ -1380,3 +1386,38 @@ def test_token_provider_raises_exception(setup_mocks):
 
     # Verify the error was logged
     setup_mocks["logger"].error.assert_called()
+
+
+def test_get_azure_ad_token_provider_with_default_azure_credential():
+    """
+    Test that get_azure_ad_token_provider correctly uses DefaultAzureCredential 
+    when explicitly specified as the credential type. This verifies that the function
+    can dynamically instantiate DefaultAzureCredential and return a working token provider.
+    """
+    # Mock Azure identity classes
+    with patch('azure.identity.DefaultAzureCredential') as mock_default_cred, \
+         patch('azure.identity.get_bearer_token_provider') as mock_token_provider:
+        
+        # Configure mocks
+        mock_credential_instance = MagicMock()
+        mock_default_cred.return_value = mock_credential_instance
+        mock_token_provider.return_value = lambda: "test-default-azure-token"
+        
+        # Test with DefaultAzureCredential specified explicitly
+        token_provider = get_azure_ad_token_provider(
+            azure_scope="https://cognitiveservices.azure.com/.default",
+            azure_credential=AzureCredentialType.DefaultAzureCredential
+        )
+        
+        # Verify DefaultAzureCredential was instantiated
+        mock_default_cred.assert_called_once_with()
+        
+        # Verify get_bearer_token_provider was called with the right parameters
+        mock_token_provider.assert_called_once_with(
+            mock_credential_instance, 
+            "https://cognitiveservices.azure.com/.default"
+        )
+        
+        # Verify the returned token provider works
+        token = token_provider()
+        assert token == "test-default-azure-token"


### PR DESCRIPTION
## [Azure OpenAI Feature] - Support DefaultAzureCredential without hard-coded environment variables

Enables Azure AD authentication in managed environments (AKS, Azure VMs) without requiring hard-coded credentials.


## When to use this

For AKS deployments where Azure automatically injects service principal credentials onto nodes, eliminating the need for hard-coded AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID environment variables.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


