### PR TITLE
[Fix] DB Track cost callback - only track logs for recognized llm api routes

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10905,8 +10905,7 @@
         "input_cost_per_token": 0.00021,
         "output_cost_per_token": 0.00063,
         "litellm_provider": "openrouter",
-        "mode": "chat",
-        "supports_tool_choice": false
+        "mode": "chat"
     },      
     "openrouter/switchpoint/router": {
         "max_tokens": 131072,

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -38,6 +38,12 @@ class _ProxyDBLogger(CustomLogger):
         request_route = user_api_key_dict.request_route
         if _ProxyDBLogger._should_track_errors_in_db() is False:
             return
+        #########################################################
+        # If we don't know the route, don't log it in the DB,
+        # we should not spam the DB with unknown routes
+        #########################################################
+        elif request_route is None:
+            return
         elif request_route is not None and not RouteChecks.is_llm_api_route(
             route=request_route
         ):

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10905,8 +10905,7 @@
         "input_cost_per_token": 0.00021,
         "output_cost_per_token": 0.00063,
         "litellm_provider": "openrouter",
-        "mode": "chat",
-        "supports_tool_choice": false
+        "mode": "chat"
     },      
     "openrouter/switchpoint/router": {
         "max_tokens": 131072,


### PR DESCRIPTION
## [Fix] DB Track cost callback - only track logs for recognized llm api routes

Fixes https://github.com/BerriAI/litellm/issues/12806 

- This ensures that we don't spam the DB when routes like /key/list are failing in a UI session 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


