### PR TITLE
[QA] Allow viewing redacted standard callback dynamic params 

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2087,6 +2087,7 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     # Logging settings
     turn_off_message_logging: Optional[bool]  # when true will not log messages
     litellm_disabled_callbacks: Optional[List[str]]
+    debug_dynamic_params: Optional[bool]
 
 
 all_litellm_params = [


### PR DESCRIPTION
## [QA] Allow viewing redacted standard callback dynamic params 

## Usage 

Pass `debug_dynamic_params: true` in the request body, litellm will log the standard callback dynamic params

```
curl -X POST http://localhost:4000/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-zb1KDnuokS9ZbzMRulSQSQ" \
  -d '{
    "model": "openai/gpt-4.1",
    "messages": [
      {
        "role": "user",
        "content": "hi"
      }
    ],
    "debug_dynamic_params": true
  }'
```


- Check trace metadata 
<img width="499" height="155" alt="Screenshot 2025-07-21 at 10 00 47 PM" src="https://github.com/user-attachments/assets/0c655ee5-ea7e-4fa1-8129-0ccebe40570e" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


