### PR TITLE
[Separate Health App] Pass through cmd args via supervisord

### DIFF
--- a/docker/prod_entrypoint.sh
+++ b/docker/prod_entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$SEPARATE_HEALTH_APP" = "1" ]; then
+    export LITELLM_ARGS="$@"
     exec supervisord -c /etc/supervisord.conf
 fi
 

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -6,7 +6,7 @@ loglevel=info
 programs=main,health
 
 [program:main]
-command=sh -c 'if [ "$USE_DDTRACE" = "true" ]; then export DD_TRACE_OPENAI_ENABLED="False"; exec ddtrace-run python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000; else exec python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000; fi'
+command=sh -c 'if [ "$USE_DDTRACE" = "true" ]; then export DD_TRACE_OPENAI_ENABLED="False"; exec ddtrace-run python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000 $LITELLM_ARGS; else exec python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000 $LITELLM_ARGS; fi'
 autostart=true
 autorestart=true
 startretries=3


### PR DESCRIPTION
[Separate Health App] Pass through cmd args via supervisord

## Relevant issues

Fixes where the user is not able to load the config via docker

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


