### PR TITLE
[Feat] Add cost tracking for new vertex_ai/llama-3 API models 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9023,7 +9023,10 @@
         "supports_system_messages": true,
         "supports_vision": true,
         "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "metadata": {
+            "notes": "VertexAI states that The Llama 3.2 API service is at no cost during public preview, and will be priced as per dollar-per-1M-tokens at GA."
+        }
     },
     "vertex_ai/mistral-large@latest": {
         "max_tokens": 8191,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8970,6 +8970,48 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supports_tool_choice": true
     },
+    "vertex_ai/meta/llama-3.1-8b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true,
+        "metadata": {
+            "notes": "VertexAI states that The Llama 3.1 API service for llama-3.1-70b-instruct-maas and llama-3.1-8b-instruct-maas are in public preview and at no cost."
+        }
+    },
+    "vertex_ai/meta/llama-3.1-70b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true
+    },
+    "vertex_ai/meta/llama-3.1-405b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 16e-06,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true
+    },
     "vertex_ai/meta/llama-3.2-90b-vision-instruct-maas": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9023,7 +9023,10 @@
         "supports_system_messages": true,
         "supports_vision": true,
         "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "metadata": {
+            "notes": "VertexAI states that The Llama 3.2 API service is at no cost during public preview, and will be priced as per dollar-per-1M-tokens at GA."
+        }
     },
     "vertex_ai/mistral-large@latest": {
         "max_tokens": 8191,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8970,6 +8970,48 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supports_tool_choice": true
     },
+    "vertex_ai/meta/llama-3.1-8b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true,
+        "metadata": {
+            "notes": "VertexAI states that The Llama 3.1 API service for llama-3.1-70b-instruct-maas and llama-3.1-8b-instruct-maas are in public preview and at no cost."
+        }
+    },
+    "vertex_ai/meta/llama-3.1-70b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true
+    },
+    "vertex_ai/meta/llama-3.1-405b-instruct-maas": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 16e-06,
+        "litellm_provider": "vertex_ai-llama_models",
+        "mode": "chat",
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "source": "https://console.cloud.google.com/vertex-ai/publishers/meta/model-garden/llama-3.2-90b-vision-instruct-maas",
+        "supports_tool_choice": true
+    },
     "vertex_ai/meta/llama-3.2-90b-vision-instruct-maas": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,


### PR DESCRIPTION
## [Feat] Add cost tracking for new vertex_ai/llama-3 API models 

Adds the follow vertex ai meta models 

- `vertex_ai/meta/llama-3.1-405b-instruct-maas` 
- `vertex_ai/meta/llama-3.1-8b-instruct-maas` currently free and in public preview 
- `vertex_ai/meta/llama-3.2-90b-vision-instruct-maas` currently free and in public preview 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


