### PR TITLE
[LLM Translation] Add bytedance/ui-tars-1.5-7b on openrouter

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10237,6 +10237,7 @@
         "output_cost_per_token": 2e-01,
         "litellm_provider": "openrouter",
         "mode": "chat",
+        "source": "https://openrouter.ai/api/v1/models/bytedance/ui-tars-1.5-7b",
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-r1": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10229,6 +10229,16 @@
         "supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "openrouter/bytedance/ui-tars-1.5-7b":{
+        "max_tokens": 2048,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 1e-01,
+        "output_cost_per_token": 2e-01,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
     "openrouter/deepseek/deepseek-r1": {
         "max_tokens": 8192,
         "max_input_tokens": 65336,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10237,6 +10237,7 @@
         "output_cost_per_token": 2e-01,
         "litellm_provider": "openrouter",
         "mode": "chat",
+        "source": "https://openrouter.ai/api/v1/models/bytedance/ui-tars-1.5-7b",
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-r1": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10229,6 +10229,16 @@
         "supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "openrouter/bytedance/ui-tars-1.5-7b":{
+        "max_tokens": 2048,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 2048,
+        "input_cost_per_token": 1e-01,
+        "output_cost_per_token": 2e-01,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
     "openrouter/deepseek/deepseek-r1": {
         "max_tokens": 8192,
         "max_input_tokens": 65336,


### PR DESCRIPTION
[LLM Translation] Add bytedance/ui-tars-1.5-7b on openrouter

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes


