### PR TITLE
Remove vector store methods from global scope

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1195,7 +1195,6 @@ from .router import Router
 from .assistants.main import *
 from .batches.main import *
 from .images.main import *
-from .vector_stores import *
 from .batch_completion.main import *  # type: ignore
 from .rerank_api.main import *
 from .llms.anthropic.experimental_pass_through.messages.handler import *

--- a/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
+++ b/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
@@ -8,6 +8,7 @@ It searches the vector store for relevant context and appends it to the messages
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 
 import litellm
+import litellm.vector_stores
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionUserMessage
@@ -192,4 +193,4 @@ class VectorStorePreCallHook(CustomLogger):
             modified_messages.insert(-1, cast(AllMessageValues, context_message))
             return modified_messages
         
-        return messages 
+        return messages


### PR DESCRIPTION
## Title

Several methods of `vector_stores` submodule have ambiguous meaning in the global scope, and may shadow other methods. This PR simply removes them.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/12881
Also related to https://github.com/Akshay-Dongare/langchain-litellm/issues/21

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

The following methods are removed from the global scope: `"search", "asearch", "create", "acreate"`, making `utils.acreate` un-shadowed.

