### PR TITLE
GuardrailsAI: use validatedOutput to allow usage of "fix" guards

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
+++ b/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
@@ -25,9 +25,10 @@ guardrails:
   - guardrail_name: "guardrails_ai-guard"
     litellm_params:
       guardrail: guardrails_ai
-      guard_name: "gibberish_guard" # 👈 Guardrail AI guard name
-      mode: "post_call"
-      api_base: os.environ/GUARDRAILS_AI_API_BASE # 👈 Guardrails AI API Base. Defaults to "http://0.0.0.0:8000"
+      guard_name: "detect-secrets-guard"            # 👈 Guardrail AI guard name
+      mode: "pre_call"
+      guardrails_ai_api_input_format: "llmOutput"   # 👈 This is the only option that currently works (and it is a default), use it for both pre_call and post_call hooks
+      api_base: os.environ/GUARDRAILS_AI_API_BASE   # 👈 Guardrails AI API Base. Defaults to "http://0.0.0.0:8000"
 ```
 
 2. Start LiteLLM Gateway 

--- a/litellm/proxy/guardrails/guardrail_hooks/guardrails_ai/guardrails_ai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/guardrails_ai/guardrails_ai.py
@@ -121,6 +121,10 @@ class GuardrailsAI(CustomGuardrail):
     ) -> str:
         from httpx import URL
 
+        # This branch of code does not work with current version of GuardrailsAI API (as of July 2025), and it is unclear if it ever worked. 
+        # Use guardrails_ai_api_input_format: "llmOutput" config line for all guardrails (which is the default anyway)
+        # We can still use the "pre_call" mode to validate the inputs even if the API input format is technicallt "llmOutput"
+
         data = {
             "inputs": [
                 {
@@ -180,7 +184,7 @@ class GuardrailsAI(CustomGuardrail):
                 _result = await self.make_guardrails_ai_api_request(
                     llm_output=text, request_data=data
                 )
-                updated_text = _result.get("rawLlmOutput") or text
+                updated_text = _result.get("validatedOutput") or _result.get("rawLlmOutput") or text
             data["messages"] = set_last_user_message(data["messages"], updated_text)
 
         return data


### PR DESCRIPTION
GuardrailsAI: use validatedOutput to allow usage of "fix" guards. Previously, "fix" guards had no effect in llmOutput api format ("rawLlmOutput" was used, which is an unmodified original content).

## Title

GuardrailsAI: use validatedOutput to allow usage of "fix" guards

## Relevant issues

n/a, did not raise

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

In llmOutput API format mode, use "validatedOutput" response attribute as a content. This allows practical usage of GuardrailsAI "fix" guards (on_failure="fix"), where previously they had no impact. 

Also added comments and improved docs to highlight that "llmOutput" is the only API format that currently works. I could not make the other format work and it is unclear when was the last time it worked with Guardrails (?). Their documentation is really lacking. There is no documented API input parameter for inputs/prompts/messages except llmOutput.

<img width="1204" height="147" alt="CleanShot 2025-07-23 at 02 35 29" src="https://github.com/user-attachments/assets/4e17af4c-06a2-456d-b327-185eee821d76" />
