### PR TITLE
BUGFIX: Jitter should be added not multiplied (#12877)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5625,8 +5625,8 @@ def _calculate_retry_after(
 
     # Apply some jitter, plus-or-minus half a second.
     jitter = JITTER * random.random()
-    timeout = sleep_seconds * jitter
-    return timeout if timeout >= min_timeout else min_timeout
+    timeout = sleep_seconds + jitter
+    return max(timeout, min_timeout)
 
 
 # custom prompt helper function

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5623,10 +5623,9 @@ def _calculate_retry_after(
     # Apply exponential backoff, but not more than the max.
     sleep_seconds = min(initial_retry_delay * pow(2.0, nb_retries), max_retry_delay)
 
-    # Apply some jitter, plus-or-minus half a second.
+    # Apply some jitter (default JITTER is 0.75 - so upto 0.75s)
     jitter = JITTER * random.random()
-    timeout = sleep_seconds + jitter
-    return max(timeout, min_timeout)
+    return max(sleep_seconds, min_timeout) + jitter
 
 
 # custom prompt helper function

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5616,16 +5616,17 @@ def _calculate_retry_after(
     if retry_after is not None and 0 < retry_after <= 60:
         return retry_after
 
-    initial_retry_delay = INITIAL_RETRY_DELAY
-    max_retry_delay = MAX_RETRY_DELAY
-    nb_retries = max_retries - remaining_retries
+    # Apply exponential backoff
+    num_retries = max_retries - remaining_retries
+    sleep_seconds = INITIAL_RETRY_DELAY * pow(2.0, num_retries)
 
-    # Apply exponential backoff, but not more than the max.
-    sleep_seconds = min(initial_retry_delay * pow(2.0, nb_retries), max_retry_delay)
+    # Make sure sleep_seconds is between MAX_RETRY_DELAY and min_timeout
+    sleep_seconds = min(sleep_seconds, MAX_RETRY_DELAY)
+    sleep_seconds = max(min_timeout, min_timeout)
 
     # Apply some jitter (default JITTER is 0.75 - so upto 0.75s)
     jitter = JITTER * random.random()
-    return max(sleep_seconds, min_timeout) + jitter
+    return sleep_seconds + jitter
 
 
 # custom prompt helper function


### PR DESCRIPTION
This fixes a bug mentioned in https://github.com/BerriAI/litellm/issues/12877

`JITTER=0.75` is multiplied by `random.random()` so `sleep_seconds*jitter` is a tiny number that is always less than `min_timeout`.

This resolves couple of issues:
1. jitter should be added not multiplied
2. jitter should be added even if we are defaulting to the `min_timeout` threshold

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


