### PR TITLE
fix: user budget is not working correctly

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -137,14 +137,16 @@ async def common_checks(
         valid_token=valid_token,
     )
 
-    # 4. If user is in budget
-    ## 4.1 check personal budget, if personal key
+    # 4. If user is in budget - check for all users with budget, regardless of team association
+    ## 4.1 check user budget for any key associated with user
     if (
-        (team_object is None or team_object.team_id is None)
-        and user_object is not None
+        user_object is not None
         and user_object.max_budget is not None
     ):
         user_budget = user_object.max_budget
+        verbose_proxy_logger.debug(
+            f"Checking user budget: user_id={user_object.user_id}, spend={user_object.spend}, budget={user_budget}"
+        )
         if user_budget < user_object.spend:
             raise litellm.BudgetExceededError(
                 current_cost=user_object.spend,


### PR DESCRIPTION
## Title

User-level budget enforcement is not working when a virtual key belongs to a team, even when the virtual key has no budget defined but the user does have a budget set. The system continues to allow requests even when the user exceeds their budget limit.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/12905

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix




