### PR TITLE
fix: update test to use existing model name

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1046,7 +1046,7 @@ class TestProxyFunctionCalling:
         ), "Custom model names return False without proxy config context"
 
         # Case 2: Model name that can be resolved (matches pattern)
-        resolvable_model = "litellm_proxy/claude-3-sonnet-20240229"
+        resolvable_model = "litellm_proxy/claude-3-5-sonnet-20240620"
         result = supports_function_calling(resolvable_model)
         assert result is True, "Resolvable model names work with fallback logic"
 


### PR DESCRIPTION
## Title
fix: update test to use existing model name

## Relevant issues
N/A - Test fix

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes
- Updated test to use `claude-3-5-sonnet-20240620` because `claude-3-sonnet-20240229` does not exist in the model registry
- This fixes the failing test `test_proxy_model_resolution_with_custom_names_documentation`

## Test Results
```
tests/test_litellm/test_utils.py::TestProxyFunctionCalling::test_proxy_model_resolution_with_custom_names_documentation PASSED
```