### PR TITLE
Default Usage Chart Date Range: Last 7 Days

### DIFF
--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -81,7 +81,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({
 
   // Add date range state
   const [dateValue, setDateValue] = useState<DateRangePickerValue>({
-    from: new Date(Date.now() - 28 * 24 * 60 * 60 * 1000),
+    from: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
     to: new Date(),
   });
 


### PR DESCRIPTION
## Title
Default Usage Chart Date Range: Last 7 Days
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- This PR updates the default date range for the Usage chart in the dashboard from the previous "last 28 days" to "last 7 days." Now, when users open the Usage page, they will see data for the most recent week by default.
- The from date is now set to 7 days ago instead of 28 days ago.
<img width="1512" height="903" alt="Screenshot 2025-07-24 at 5 24 36" src="https://github.com/user-attachments/assets/b03534e2-e4d8-403a-95b9-1e8446d253e8" />


