### PR TITLE
Added Configuration Support for the gemini-2.5-flash-lite Model

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7357,6 +7357,51 @@
         "cache_read_input_token_cost": 7.5e-08,
         "supports_prompt_caching": true
     },
+    "gemini-2.5-flash-lite": {
+        "max_tokens": 65535,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_images_per_prompt": 3000,
+        "max_videos_per_prompt": 10,
+        "max_video_length": 1,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_pdf_size_mb": 30,
+        "supports_pdf_input": true,
+        "supports_video_input": true,
+        "supports_audio_input": true,
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "input_cost_per_audio_token": 3e-07,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_reasoning_token": 4e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "supports_response_schema": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_url_context": true,
+        "supports_web_search": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_audio_output": false,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "source": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-lite"
+    },
     "gemini/gemini-2.5-flash-preview-tts": {
         "max_tokens": 65535,
         "max_input_tokens": 1048576,


### PR DESCRIPTION
## Added Configuration Support for the gemini-2.5-flash-lite Model

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
* Entry for the newly released _gemini-2.5-flash-lite_ model was missing in the _model\_prices\_and\_context\_window\_backup.json_ file.


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature


## Changes
* Added a corresponding entry in the _model\_prices\_and\_context\_window\_backup.json_ file with the json key "_gemini-2.5-flash-lite_".

