### PR TITLE
Fix: Shorten Gemini tool_call_id for Open AI compatibility

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -305,9 +305,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 return None
 
         for tool in value:
-            openai_function_object: Optional[ChatCompletionToolParamFunctionChunk] = (
-                None
-            )
+            openai_function_object: Optional[
+                ChatCompletionToolParamFunctionChunk
+            ] = None
             if "function" in tool:  # tools list
                 _openai_function_object = ChatCompletionToolParamFunctionChunk(  # type: ignore
                     **tool["function"]
@@ -597,14 +597,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif param == "seed":
                 optional_params["seed"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
-                optional_params["thinkingConfig"] = (
-                    VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(value)
-                )
+                optional_params[
+                    "thinkingConfig"
+                ] = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(value)
             elif param == "thinking":
-                optional_params["thinkingConfig"] = (
-                    VertexGeminiConfig._map_thinking_param(
-                        cast(AnthropicThinkingParam, value)
-                    )
+                optional_params[
+                    "thinkingConfig"
+                ] = VertexGeminiConfig._map_thinking_param(
+                    cast(AnthropicThinkingParam, value)
                 )
             elif param == "modalities" and isinstance(value, list):
                 response_modalities = self.map_response_modalities(value)
@@ -854,7 +854,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     function = _function_chunk
                 else:
                     _tool_response_chunk = ChatCompletionToolCallChunk(
-                        id=f"call_{str(uuid.uuid4())}",
+                        id=f"call_{uuid.uuid4().hex[:28]}",
                         type="function",
                         function=_function_chunk,
                         index=cumulative_tool_call_idx,
@@ -1077,10 +1077,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         elif (
             finish_reason and finish_reason in mapped_finish_reason.keys()
         ):  # vertex ai
-
             return mapped_finish_reason[finish_reason]
         else:
-
             return "stop"
 
     @staticmethod
@@ -1175,12 +1173,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 if reasoning_content is not None:
                     chat_completion_message["reasoning_content"] = reasoning_content
 
-                functions, tools, cumulative_tool_call_index = (
-                    VertexGeminiConfig._transform_parts(
-                        parts=candidate["content"]["parts"],
-                        cumulative_tool_call_idx=cumulative_tool_call_index,
-                        is_function_call=is_function_call(standard_optional_params),
-                    )
+                (
+                    functions,
+                    tools,
+                    cumulative_tool_call_index,
+                ) = VertexGeminiConfig._transform_parts(
+                    parts=candidate["content"]["parts"],
+                    cumulative_tool_call_idx=cumulative_tool_call_index,
+                    is_function_call=is_function_call(standard_optional_params),
                 )
 
             if "logprobsResult" in candidate:
@@ -1344,28 +1344,28 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             ## ADD METADATA TO RESPONSE ##
 
             setattr(model_response, "vertex_ai_grounding_metadata", grounding_metadata)
-            model_response._hidden_params["vertex_ai_grounding_metadata"] = (
-                grounding_metadata
-            )
+            model_response._hidden_params[
+                "vertex_ai_grounding_metadata"
+            ] = grounding_metadata
 
             setattr(
                 model_response, "vertex_ai_url_context_metadata", url_context_metadata
             )
 
-            model_response._hidden_params["vertex_ai_url_context_metadata"] = (
-                url_context_metadata
-            )
+            model_response._hidden_params[
+                "vertex_ai_url_context_metadata"
+            ] = url_context_metadata
 
             setattr(model_response, "vertex_ai_safety_results", safety_ratings)
-            model_response._hidden_params["vertex_ai_safety_results"] = (
-                safety_ratings  # older approach - maintaining to prevent regressions
-            )
+            model_response._hidden_params[
+                "vertex_ai_safety_results"
+            ] = safety_ratings  # older approach - maintaining to prevent regressions
 
             ## ADD CITATION METADATA ##
             setattr(model_response, "vertex_ai_citation_metadata", citation_metadata)
-            model_response._hidden_params["vertex_ai_citation_metadata"] = (
-                citation_metadata  # older approach - maintaining to prevent regressions
-            )
+            model_response._hidden_params[
+                "vertex_ai_citation_metadata"
+            ] = citation_metadata  # older approach - maintaining to prevent regressions
 
         except Exception as e:
             raise VertexAIError(


### PR DESCRIPTION
## Title
Fix: Shorten Gemini tool_call_id for Open AI compatibility

## Relevant issues

Fixes #11392

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
The tool call ID generation in Vertex AI Gemini implementation generated 41-character IDs, violating OpenAI's 40-character limit for tool call IDs. This caused BadRequestError when switching between Gemini and OpenAI-compatible models (including Azure OpenAI).

**Error encountered:**
```
Invalid 'messages[2].tool_calls[0].id': string too long. 
Expected a string with maximum length 40, but got a string with length 41 instead.
```

**Before:**
```python
id=f"call_{str(uuid.uuid4())}"  # 41 characters - violates OpenAI limit
```

**After:**
```python
id=f"call_{uuid.uuid4().hex[:28]}"  # 33 characters - complies with OpenAI limit
```

### Solution
- Shortened the UUID by using `.hex[:28]` instead of `str()` to remove hyphens and limit to 28 hex characters
- This maintains sufficient uniqueness (28 hex chars = 112 bits of entropy) while meeting the 40-character limit
- Tool call IDs remain unique and follow the same `call_` prefix format

### Testing
Added comprehensive tests to ensure:
1. **ID Format Validation** (`test_vertex_ai_tool_call_id_format`):
   - Verifies IDs start with "call_" prefix
   - Confirms exactly 33 total characters (call_ + 28 hex)
   - Validates hex character format
   - Ensures uniqueness across multiple generations

2. **Code Line Length Validation** (`test_vertex_ai_code_line_length`):
   - Meta-test to ensure the code line stays within 40 character limit
   - Prevents regression if code is modified in the future
   
<img width="945" height="185" alt="Screenshot 2025-07-24 at 12 17 31 PM" src="https://github.com/user-attachments/assets/8fc318f0-33e0-4e07-b734-e4220bf8039c" />

### Impact
- ✅ Maintains full functionality and uniqueness
- ✅ Fixes OpenAI compatibility issues  
- ✅ No breaking changes to existing behavior
- ✅ All linting and formatting checks pass
