### PR TITLE
[Feat] Add inpainting support and corresponding tests for Amazon Nova…

### DIFF
--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -36,7 +36,9 @@ class ImageBlock(TypedDict):
     source: SourceBlock
 
 
-BedrockVideoTypes = Literal["mp4", "mov", "mkv", "webm", "flv", "mpeg", "mpg", "wmv", "3gp"]
+BedrockVideoTypes = Literal[
+    "mp4", "mov", "mkv", "webm", "flv", "mpeg", "mpg", "wmv", "3gp"
+]
 
 
 class VideoBlock(TypedDict):
@@ -475,12 +477,35 @@ class AmazonNovaCanvasTextToImageResponse(TypedDict, total=False):
     images: List[str]
 
 
+class AmazonNovaCanvasInpaintingParams(TypedDict, total=False):
+    """
+    Params for Amazon Nova Canvas Inpainting API
+    """
+
+    text: str
+    maskImage: str
+    inputImage: str
+    negativeText: str
+
+
+class AmazonNovaCanvasInpaintingRequest(
+    AmazonNovaCanvasRequestBase, TypedDict, total=False
+):
+    """
+    Request for Amazon Nova Canvas Inpainting API
+
+    Ref: https://docs.aws.amazon.com/nova/latest/userguide/image-gen-req-resp-structure.html
+    """
+
+    taskType: Literal["INPAINTING"]
+    inpaintingParams: AmazonNovaCanvasInpaintingParams
+    imageGenerationConfig: AmazonNovaCanvasImageGenerationConfig
+
+
 if TYPE_CHECKING:
     from botocore.awsrequest import AWSPreparedRequest
 else:
     AWSPreparedRequest = Any
-
-from pydantic import BaseModel
 
 
 class BedrockPreparedRequest(TypedDict):

--- a/tests/test_litellm/llms/bedrock/image/test_amazon_nova_canvas_transformation.py
+++ b/tests/test_litellm/llms/bedrock/image/test_amazon_nova_canvas_transformation.py
@@ -1,0 +1,75 @@
+import pytest
+from litellm.llms.bedrock.image.amazon_nova_canvas_transformation import AmazonNovaCanvasConfig
+from litellm.types.utils import ImageResponse
+
+def test_transform_request_body_text_to_image():
+    params = {
+        "imageGenerationConfig": {
+            "cfgScale": 7,
+            "seed": 42,
+            "quality": "standard",
+            "width": 512,
+            "height": 512,
+            "numberOfImages": 1,
+            "textToImageParams": {
+                "negativeText": "blurry"
+            }
+        }
+    }
+    req = AmazonNovaCanvasConfig.transform_request_body("cat", params.copy())
+    assert isinstance(req, dict)
+    assert "textToImageParams" in req
+    assert req["textToImageParams"]["text"] == "cat"
+    assert req["imageGenerationConfig"]["width"] == 512
+
+def test_transform_request_body_color_guided():
+    params = {
+        "taskType": "COLOR_GUIDED_GENERATION",
+        "imageGenerationConfig": {
+            "cfgScale": 7,
+            "seed": 42,
+            "quality": "standard",
+            "width": 512,
+            "height": 512,
+            "numberOfImages": 1,
+            "colorGuidedGenerationParams": {
+                "colors": ["#FFFFFF"],
+                "referenceImage": "img",
+                "negativeText": "blurry"
+            }
+        }
+    }
+    req = AmazonNovaCanvasConfig.transform_request_body("cat", params.copy())
+    assert "colorGuidedGenerationParams" in req
+    assert req["colorGuidedGenerationParams"]["text"] == "cat"
+    assert req["imageGenerationConfig"]["width"] == 512
+
+def test_transform_request_body_inpainting():
+    params = {
+        "taskType": "INPAINTING",
+        "imageGenerationConfig": {
+            "cfgScale": 7,
+            "seed": 42,
+            "quality": "standard",
+            "width": 512,
+            "height": 512,
+            "numberOfImages": 1,
+            "inpaintingParams": {
+                "maskImage": "mask",
+                "inputImage": "input",
+                "negativeText": "blurry"
+            }
+        }
+    }
+    req = AmazonNovaCanvasConfig.transform_request_body("cat", params.copy())
+    assert "inpaintingParams" in req
+    assert req["inpaintingParams"]["text"] == "cat"
+    assert req["imageGenerationConfig"]["width"] == 512
+
+def test_transform_response_dict_to_openai_response():
+    response_dict = {"images": ["b64img1", "b64img2"]}
+    model_response = ImageResponse()
+    result = AmazonNovaCanvasConfig.transform_response_dict_to_openai_response(model_response, response_dict)
+    assert hasattr(result, "data")
+    assert len(result.data) == 2
+    assert result.data[0].b64_json == "b64img1"


### PR DESCRIPTION
Title
feat: add inpainting support to Amazon Nova Canvas API
Pre-Submission checklist
I have added testing in the [tests/test_litellm/llms/bedrock/image/test_amazon_nova_canvas_transformation.py](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement – [see details](https://docs.litellm.ai/docs/extras/contributing_code)
I have added a screenshot of my new test passing locally
My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)
My PR's scope is as isolated as possible – it only solves 1 specific problem
Type
🆕 New Feature
✅ Test
Changes
Added support for inpainting with Amazon Nova Canvas API in the LiteLLM provider module
Implemented request formatting and response parsing logic for the new inpainting use-case
Added unit test to validate Amazon Nova Canvas inpainting functionality

