### PR TITLE
fix(auth_utils): make header comparison case-insensitive

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -490,9 +490,11 @@ def get_end_user_id_from_request_body(
         custom_header_name_to_check = general_settings.get(user_id_header_config_key)
 
         if custom_header_name_to_check and isinstance(custom_header_name_to_check, str):
-            user_id_from_header = request_headers.get(custom_header_name_to_check)
-            if user_id_from_header is not None and user_id_from_header.strip():
-                return str(user_id_from_header)
+            for header_name, header_value in request_headers.items():
+                if header_name.lower() == custom_header_name_to_check.lower():
+                    user_id_from_header = header_value
+                    if user_id_from_header.strip():
+                        return str(user_id_from_header)
 
     # Check 2: 'user' field in request_body (commonly OpenAI)
     if "user" in request_body and request_body["user"] is not None:

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -169,6 +169,13 @@ def test_get_end_user_id_from_request_body_always_returns_str():
             },
             "header-priority"
         ),
+        # Test 12: user_header_name is matched case-insensitively
+        (
+            {"x-user-id": "lowercase-header-user"},
+            {"user_header_name": "X-User-ID"},
+            {"user": "body-user-456"},
+            "lowercase-header-user"
+        ),
     ]
 )
 def test_get_end_user_id_from_request_body_with_user_header_name(


### PR DESCRIPTION
## Title

If the user specified in the configuration e.g. "user_header_name: X-OpenWebUI-User-Email", here we were looking for a dict key "X-OpenWebUI-User-Email" when the dict actually contained "x-openwebui-user-email".

Switch to iteration and case insensitive string comparison instead to fix this.

This fixes customer budget enforcement when the customer ID is passed in as a header rather than as a "user" value in the body.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Tests do not work on my local machine because "error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)". Maybe you need to update your dependencies?

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


