### PR TITLE
⚡️ Speed up function `default_pt` by 54%

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -40,7 +40,8 @@ from .image_handling import convert_url_to_base64
 
 
 def default_pt(messages):
-    return " ".join(message["content"] for message in messages)
+    # Use list comprehension for better performance over generator in join
+    return " ".join([msg["content"] for msg in messages])
 
 
 def prompt_injection_detection_default_pt():

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -40,7 +40,7 @@ from .image_handling import convert_url_to_base64
 
 
 def default_pt(messages):
-    return " ".join([msg["content"] for msg in messages])
+    return " ".join([message["content"] for message in messages])
 
 
 def prompt_injection_detection_default_pt():

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -40,7 +40,6 @@ from .image_handling import convert_url_to_base64
 
 
 def default_pt(messages):
-    # Use list comprehension for better performance over generator in join
     return " ".join([msg["content"] for msg in messages])
 
 


### PR DESCRIPTION
## Title

### 📄 54% (0.54x) speedup for ***`default_pt` in `litellm/litellm_core_utils/prompt_templates/factory.py`***

⏱️ Runtime :   **`356 microseconds`**  **→** **`231 microseconds`** (best of `5` runs)


Saurabh's comment - Contributing a really easy to merge optimization. Will appreciate your feedback as I attempt to open more optimization PRs.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
⚡ Performance

## Changes

### 📝 Explanation and details

`" ".join(message["content"] for message in messages)` can suffer from generator overhead and repeated dict lookups. To speed this up, we can.

- Use a list comprehension instead of a generator expression (the list comp can be faster because `str.join` can precompute the final size).


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **41 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import random
import string

# imports
import pytest  # used for our unit tests
from litellm.litellm_core_utils.prompt_templates.factory import default_pt

# unit tests

# ------------------------
# Basic Test Cases
# ------------------------

def test_single_message():
    # Test with a single message in the list
    messages = [{"content": "Hello"}]
    codeflash_output = default_pt(messages) # 2.45μs -> 1.21μs (102% faster)

def test_two_messages():
    # Test with two messages
    messages = [{"content": "Hello"}, {"content": "World"}]
    codeflash_output = default_pt(messages) # 2.80μs -> 1.27μs (119% faster)

def test_multiple_messages():
    # Test with more than two messages
    messages = [{"content": "A"}, {"content": "B"}, {"content": "C"}]
    codeflash_output = default_pt(messages) # 3.01μs -> 1.52μs (98.1% faster)

def test_message_with_spaces():
    # Test with message contents that have spaces
    messages = [{"content": "Hello there"}, {"content": "General Kenobi"}]
    codeflash_output = default_pt(messages) # 2.93μs -> 1.47μs (99.0% faster)

def test_message_with_special_characters():
    # Test with message contents that have special characters
    messages = [{"content": "Hi!"}, {"content": "@#$%^&*()"}]
    codeflash_output = default_pt(messages) # 3.19μs -> 1.27μs (151% faster)

# ------------------------
# Edge Test Cases
# ------------------------

def test_empty_list():
    # Test with an empty list of messages
    messages = []
    codeflash_output = default_pt(messages) # 2.63μs -> 967ns (172% faster)

def test_empty_content_strings():
    # Test with messages that have empty content
    messages = [{"content": ""}, {"content": ""}]
    codeflash_output = default_pt(messages) # 2.77μs -> 1.48μs (87.9% faster)

def test_mixed_empty_and_nonempty_content():
    # Test with a mix of empty and non-empty content
    messages = [{"content": ""}, {"content": "foo"}, {"content": ""}, {"content": "bar"}]
    codeflash_output = default_pt(messages) # 2.99μs -> 1.57μs (89.9% faster)

def test_content_with_only_spaces():
    # Test with content that is only spaces
    messages = [{"content": "   "}, {"content": " "}]
    codeflash_output = default_pt(messages) # 3.12μs -> 1.30μs (140% faster)

def test_content_with_newlines_and_tabs():
    # Test with newlines and tabs in content
    messages = [{"content": "Hello\nWorld"}, {"content": "\tTabbed"}]
    codeflash_output = default_pt(messages) # 2.86μs -> 1.48μs (93.1% faster)

def test_content_with_unicode():
    # Test with unicode characters in content
    messages = [{"content": "こんにちは"}, {"content": "😊"}]
    codeflash_output = default_pt(messages) # 3.35μs -> 1.61μs (108% faster)

def test_content_with_long_string():
    # Test with a very long string in content
    long_str = "a" * 1000
    messages = [{"content": long_str}]
    codeflash_output = default_pt(messages) # 2.97μs -> 1.18μs (152% faster)

def test_content_with_leading_and_trailing_spaces():
    # Test with content that has leading and trailing spaces
    messages = [{"content": "  foo"}, {"content": "bar  "}]
    codeflash_output = default_pt(messages) # 2.84μs -> 1.39μs (105% faster)

def test_content_with_dicts_missing_content_key():
    # Test with a message missing the "content" key should raise KeyError
    messages = [{"content": "foo"}, {"not_content": "bar"}]
    with pytest.raises(KeyError):
        default_pt(messages) # 4.62μs -> 2.05μs (125% faster)

def test_content_with_non_string_content():
    # Test with a message where content is not a string (should work as str() is not called, so should raise)
    messages = [{"content": 123}]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.70μs -> 5.20μs (48.1% faster)

# ------------------------
# Large Scale Test Cases
# ------------------------

def test_large_number_of_short_messages():
    # Test with a large number of messages (up to 1000)
    messages = [{"content": str(i)} for i in range(1000)]
    expected = " ".join(str(i) for i in range(1000))
    codeflash_output = default_pt(messages) # 35.0μs -> 23.8μs (46.9% faster)

def test_large_number_of_empty_messages():
    # Test with a large number of empty messages
    messages = [{"content": ""} for _ in range(1000)]
    # 1000 empty strings joined by 999 spaces
    codeflash_output = default_pt(messages) # 32.3μs -> 22.0μs (47.3% faster)

def test_large_messages_with_long_content():
    # Test with fewer messages but very long content
    long_content = "x" * 500
    messages = [{"content": long_content} for _ in range(10)]
    expected = (" ".join([long_content]*10))
    codeflash_output = default_pt(messages) # 3.65μs -> 1.94μs (88.5% faster)

def test_large_mixed_content():
    # Test with a large number of messages with random content
    random.seed(42)
    messages = []
    expected_list = []
    for _ in range(500):
        length = random.randint(1, 20)
        s = ''.join(random.choices(string.ascii_letters + string.digits, k=length))
        messages.append({"content": s})
        expected_list.append(s)
    codeflash_output = default_pt(messages) # 25.1μs -> 19.7μs (27.5% faster)

def test_performance_large_scale():
    # Test that the function runs efficiently for 1000 elements
    messages = [{"content": "foo"} for _ in range(1000)]
    codeflash_output = default_pt(messages); result = codeflash_output # 36.8μs -> 23.8μs (54.5% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import pytest  # used for our unit tests
from litellm.litellm_core_utils.prompt_templates.factory import default_pt

# unit tests

# -----------------------------
# Basic Test Cases
# -----------------------------

def test_single_message():
    # Test with a single message in the list
    messages = [{"content": "Hello world"}]
    codeflash_output = default_pt(messages) # 2.95μs -> 1.16μs (154% faster)

def test_multiple_messages():
    # Test with multiple messages, simple concatenation
    messages = [
        {"content": "Hello"},
        {"content": "world"},
        {"content": "!"}
    ]
    codeflash_output = default_pt(messages) # 3.22μs -> 1.48μs (117% faster)

def test_empty_content():
    # Test with messages that have empty content
    messages = [
        {"content": ""},
        {"content": "foo"},
        {"content": ""}
    ]
    codeflash_output = default_pt(messages) # 2.95μs -> 1.40μs (111% faster)

def test_all_empty():
    # Test with all messages having empty content
    messages = [
        {"content": ""},
        {"content": ""},
        {"content": ""}
    ]
    codeflash_output = default_pt(messages) # 3.21μs -> 1.66μs (93.8% faster)

def test_leading_trailing_spaces():
    # Test with leading/trailing spaces in message content
    messages = [
        {"content": "  Hello"},
        {"content": "world  "},
        {"content": " ! "}
    ]
    codeflash_output = default_pt(messages) # 2.83μs -> 1.33μs (112% faster)

def test_content_with_newlines_and_tabs():
    # Test with message content containing newlines and tabs
    messages = [
        {"content": "Hello\n"},
        {"content": "\tworld"},
        {"content": "!\n"}
    ]
    codeflash_output = default_pt(messages) # 3.17μs -> 1.35μs (135% faster)

# -----------------------------
# Edge Test Cases
# -----------------------------

def test_empty_list():
    # Test with an empty list of messages
    messages = []
    codeflash_output = default_pt(messages) # 2.43μs -> 825ns (194% faster)

def test_missing_content_key():
    # Test with a message missing the 'content' key (should raise KeyError)
    messages = [
        {"content": "Hello"},
        {"not_content": "world"}
    ]
    with pytest.raises(KeyError):
        default_pt(messages) # 3.84μs -> 2.19μs (75.5% faster)

def test_content_is_none():
    # Test with a message where content is None (should raise TypeError)
    messages = [
        {"content": "Hello"},
        {"content": None}
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.35μs -> 5.88μs (25.0% faster)

def test_content_is_not_string():
    # Test with a message where content is not a string (should raise TypeError)
    messages = [
        {"content": "Hello"},
        {"content": 123}
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.39μs -> 5.31μs (39.3% faster)

def test_non_dict_message():
    # Test with a message that is not a dict (should raise TypeError)
    messages = [
        {"content": "Hello"},
        ["content", "world"]
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 4.98μs -> 2.62μs (90.3% faster)

def test_content_is_boolean():
    # Test with a message where content is a boolean (should raise TypeError)
    messages = [
        {"content": "Hello"},
        {"content": True}
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.43μs -> 5.87μs (26.6% faster)

def test_content_is_list():
    # Test with a message where content is a list (should raise TypeError)
    messages = [
        {"content": "Hello"},
        {"content": ["world"]}
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.22μs -> 6.18μs (16.9% faster)

def test_content_is_dict():
    # Test with a message where content is a dict (should raise TypeError)
    messages = [
        {"content": "Hello"},
        {"content": {"foo": "bar"}}
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 7.41μs -> 5.63μs (31.6% faster)

def test_message_is_none():
    # Test with a message that is None (should raise TypeError)
    messages = [
        {"content": "Hello"},
        None
    ]
    with pytest.raises(TypeError):
        default_pt(messages) # 4.84μs -> 2.42μs (99.7% faster)

def test_messages_is_none():
    # Test with messages being None (should raise TypeError)
    with pytest.raises(TypeError):
        default_pt(None) # 2.46μs -> 1.76μs (39.5% faster)

def test_messages_is_not_list():
    # Test with messages being a string (should raise TypeError)
    with pytest.raises(TypeError):
        default_pt("not a list") # 4.77μs -> 2.75μs (73.2% faster)

# -----------------------------
# Large Scale Test Cases
# -----------------------------

def test_large_number_of_messages():
    # Test with a large number of messages (1000)
    messages = [{"content": str(i)} for i in range(1000)]
    expected = " ".join(str(i) for i in range(1000))
    codeflash_output = default_pt(messages) # 33.5μs -> 22.7μs (47.4% faster)

def test_large_messages_with_long_content():
    # Test with 100 messages, each with 100-character content
    base = "x" * 100
    messages = [{"content": base} for _ in range(100)]
    expected = " ".join([base] * 100)
    codeflash_output = default_pt(messages) # 7.10μs -> 4.65μs (52.9% faster)

def test_large_messages_with_varied_content():
    # Test with 500 messages, alternating between short and long content
    messages = []
    expected_parts = []
    for i in range(500):
        if i % 2 == 0:
            content = str(i)
        else:
            content = "y" * (i % 50)
        messages.append({"content": content})
        expected_parts.append(content)
    expected = " ".join(expected_parts)
    codeflash_output = default_pt(messages) # 20.4μs -> 15.2μs (34.3% faster)

def test_large_all_empty_content():
    # Test with 1000 messages, all with empty content
    messages = [{"content": ""} for _ in range(1000)]
    # There are 999 spaces between 1000 empty strings
    codeflash_output = default_pt(messages) # 33.9μs -> 22.2μs (52.4% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)
