### PR TITLE
feat: Add Tracing Support For Anthropic/Claude Code With Arize/Phoenix Integration

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -165,8 +165,8 @@ def build_single_message_attributes(
     Builds OpenInference-compliant LLM attributes for a single user or assistant message.
     """
     return {
-        f"llm.message.role": role,
-        f"llm.message.index": index,
+        "llm.message.role": role,
+        "llm.message.index": index,
         (
             SpanAttributes.INPUT_VALUE
             if role == "user"

--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1,16 +1,33 @@
+import ast
 import json
-from typing import TYPE_CHECKING, Any, Optional, Union
+import os
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from litellm._logging import verbose_logger
+from litellm.integrations._types.open_inference import (
+    MessageAttributes,
+    OpenInferenceLLMProviderValues,
+    OpenInferenceLLMSystemValues,
+    OpenInferenceMimeTypeValues,
+    OpenInferenceSpanKindValues,
+    SpanAttributes,
+    ToolCallAttributes,
+)
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.utils import StandardLoggingPayload
 
+from opentelemetry import trace
+
 if TYPE_CHECKING:
-    from opentelemetry.trace import Span as _Span
+    from opentelemetry.trace import Span as _Span, Tracer as _Tracer
 
     Span = Union[_Span, Any]
+    Tracer = Union[_Tracer, Any]
 else:
     Span = Any
+    Tracer = Any
+
+LITELLM_TRACER_NAME = os.getenv("OTEL_TRACER_NAME", "litellm")
 
 
 def cast_as_primitive_value_type(value) -> Union[str, bool, int, float]:
@@ -35,17 +52,204 @@ def safe_set_attribute(span: Span, key: str, value: Any):
     span.set_attribute(key, primitive_value)
 
 
+def try_parse_json(value: str) -> Any:
+    """
+    Tries parsing a string as a JSON object.
+    """
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def try_parse_literal(value: str) -> Any:
+    """
+    Tries parsing a string as a Python literal.
+    """
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        return None
+
+
+def to_json_string(obj: Any) -> str:
+    """
+    Safely converts a Python object to JSON string.
+    """
+    try:
+        return safe_dumps(obj)
+    except (TypeError, ValueError):
+        return str(obj)
+
+
+def detect_mimetype_and_serialize(value: Any) -> Tuple[str, str]:
+    """
+    Detects MIME type for a given value & returns stringified value with MIME type for Arize/Phoenix.
+    """
+    if isinstance(value, (dict, list)):
+        return to_json_string(value), OpenInferenceMimeTypeValues.JSON.value
+
+    if isinstance(value, str):
+        json_like_chars = ('{', '}', '[', ']', ':')
+        if any(c in value for c in json_like_chars):
+            parsed = try_parse_json(value)
+            if isinstance(parsed, (dict, list)):
+                return to_json_string(parsed), OpenInferenceMimeTypeValues.JSON.value
+
+        parsed = try_parse_literal(value)
+        if isinstance(parsed, (dict, list)):
+            return to_json_string(parsed), OpenInferenceMimeTypeValues.JSON.value
+
+    return str(value), OpenInferenceMimeTypeValues.TEXT.value
+
+
+def create_anthropic_llm_child_span(
+    tracer: Tracer,
+    parent_span: Span,
+    span_name: str,
+    attributes: Dict[str, Any],
+    model_name: Optional[str] = None,
+) -> None:
+    """
+    Creates a child span with OpenInference-compliant LLM attributes for Anthropic LLM.
+    """
+    with tracer.start_as_current_span(
+        span_name, context=trace.set_span_in_context(parent_span)
+    ) as child_span:
+        for key, value in attributes.items():
+            safe_set_attribute(child_span, key, value)
+        safe_set_attribute(
+            child_span,
+            SpanAttributes.OPENINFERENCE_SPAN_KIND,
+            OpenInferenceSpanKindValues.LLM.value,
+        )
+        safe_set_attribute(
+            child_span,
+            SpanAttributes.LLM_PROVIDER,
+            OpenInferenceLLMProviderValues.ANTHROPIC.value,
+        )
+        safe_set_attribute(
+            child_span,
+            SpanAttributes.LLM_SYSTEM,
+            OpenInferenceLLMSystemValues.ANTHROPIC.value,
+        )
+        if model_name:
+            safe_set_attribute(child_span, SpanAttributes.LLM_MODEL_NAME, model_name)
+
+
+def build_input_output_attributes(
+    input_value: str,
+    input_mime: str,
+    output_value: str,
+    output_mime: str,
+    input_index: int,
+    output_index: int,
+) -> Dict[str, Any]:
+    """
+    Builds OpenInference-compliant LLM attributes dictionary for paired input/output messages.
+    """
+    return {
+        SpanAttributes.INPUT_VALUE: input_value,
+        SpanAttributes.INPUT_MIME_TYPE: input_mime,
+        SpanAttributes.OUTPUT_VALUE: output_value,
+        SpanAttributes.OUTPUT_MIME_TYPE: output_mime,
+        "llm.message.input_index": input_index,
+        "llm.message.output_index": output_index,
+    }
+
+
+def build_single_message_attributes(
+    role: str, index: int, value: str, mime_type: str
+) -> Dict[str, Any]:
+    """
+    Builds OpenInference-compliant LLM attributes for a single user or assistant message.
+    """
+    return {
+        f"llm.message.role": role,
+        f"llm.message.index": index,
+        (
+            SpanAttributes.INPUT_VALUE
+            if role == "user"
+            else SpanAttributes.OUTPUT_VALUE
+        ): value,
+        (
+            SpanAttributes.INPUT_MIME_TYPE
+            if role == "user"
+            else SpanAttributes.OUTPUT_MIME_TYPE
+        ): mime_type,
+    }
+
+
+def handle_anthropic_claude_code_tracing(
+    tracer: Tracer,
+    parent_span: Span,
+    kwargs: Dict[str, Any],
+    response_obj: Dict[str, Any],
+) -> None:
+    """
+    Handles child span creation with Anthropic / Claude Code message format for Arize/Phoenix.
+    """
+    messages: List[Dict[str, Any]] = kwargs.get("messages", [])
+    choices: List[Dict[str, Any]] = response_obj.get("choices", [])
+    model_name: Optional[str] = kwargs.get("model")
+
+    span_definitions: List[Tuple[str, Dict[str, Any]]] = []
+
+    # Build internal prompt span data
+    i = 0
+    span_index = 0
+    while i < len(messages):
+        role = messages[i].get("role", "")
+        content = messages[i].get("content", "")
+        next_msg = messages[i + 1] if i + 1 < len(messages) else None
+
+        span_name = f"Claude_Code_Internal_Prompt_{span_index}"
+
+        if role == "user" and next_msg and next_msg.get("role") == "assistant":
+            # paired messages (user & assistant)
+            input_value, input_mime = detect_mimetype_and_serialize(content)
+            output_value, output_mime = detect_mimetype_and_serialize(
+                next_msg.get("content", "")
+            )
+            attrs = build_input_output_attributes(
+                input_value, input_mime, output_value, output_mime, i, i + 1
+            )
+            span_definitions.append((span_name, attrs))
+            i += 2
+        else:
+            # single message (either user or assistant)
+            content_value, content_mime = detect_mimetype_and_serialize(content)
+            attrs = build_single_message_attributes(role, i, content_value, content_mime)
+            span_definitions.append((span_name, attrs))
+            i += 1
+
+        span_index += 1
+
+    # Build final output span data
+    for idx, choice in enumerate(choices):
+        msg = choice.get("message", {})
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        output_value, output_mime = detect_mimetype_and_serialize(content)
+
+        span_name = f"Claude_Code_Final_Output_{idx}"
+        attrs = {
+            SpanAttributes.OUTPUT_VALUE: output_value,
+            SpanAttributes.OUTPUT_MIME_TYPE: output_mime,
+            "llm.message.role": role,
+            "llm.message.index": idx,
+        }
+        span_definitions.append((span_name, attrs))
+
+    # Create spans in order
+    for span_name, attrs in reversed(span_definitions):
+        create_anthropic_llm_child_span(tracer, parent_span, span_name, attrs, model_name)
+
+
 def set_attributes(span: Span, kwargs, response_obj):  # noqa: PLR0915
     """
     Populates span with OpenInference-compliant LLM attributes for Arize and Phoenix tracing.
     """
-    from litellm.integrations._types.open_inference import (
-        MessageAttributes,
-        OpenInferenceSpanKindValues,
-        SpanAttributes,
-        ToolCallAttributes,
-    )
-
     try:
         optional_params = kwargs.get("optional_params", {})
         litellm_params = kwargs.get("litellm_params", {})
@@ -278,6 +482,15 @@ def set_attributes(span: Span, kwargs, response_obj):  # noqa: PLR0915
                     SpanAttributes.LLM_TOKEN_COUNT_PROMPT,
                     usage.get("prompt_tokens"),
                 )
+
+        #############################################
+        ########## Anthropic / Claude Code ##########
+        #############################################
+
+        llm_request_type = standard_logging_payload.get("call_type", "Unknown")
+        if llm_request_type == "anthropic_messages":
+            tracer = trace.get_tracer(LITELLM_TRACER_NAME)
+            handle_anthropic_claude_code_tracing(tracer, span, kwargs, response_obj)
 
     except Exception as e:
         verbose_logger.error(


### PR DESCRIPTION
## Title

This pull request adds tracing support for Anthropic/Claude Code in the LiteLLM Proxy, integrating with Arize/Phoenix for enhanced observability.

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- I have added multiple spans to represent internal Claude Code prompts and a final output span for end-to-end visibility.

- I have integrated proper JSON detection and rendering for structured Claude outputs.

- I have ensured the span ordering, which reflects logical execution.

- I have improved observability for Arize/Phoenix integrations by capturing internal reasoning steps for debugging and monitoring.

**Anthropic / Claude Code Trace - Internal Prompt**

<img width="1920" height="976" alt="LiteLLM-Proxy-Anthropic-Claude-Code-1" src="https://github.com/user-attachments/assets/c284412c-1bb9-4289-ba6d-df4cae0676a7" />

**Anthropic / Claude Code Trace - Final Output**

<img width="1920" height="974" alt="LiteLLM-Proxy-Anthropic-Claude-Code-2" src="https://github.com/user-attachments/assets/99a0fd97-66e1-461e-86c2-d66e049563e3" />

