### PR TITLE
[MCP Gateway] Move cost tracking and permission management to OSS

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -19,7 +19,7 @@ LiteLLM Proxy provides an MCP Gateway that allows you to use a fixed endpoint fo
 |---------|-------------|
 | MCP Operations | • List Tools<br/>• Call Tools |
 | Supported MCP Transports | • Streamable HTTP<br/>• SSE<br/>• Standard Input/Output (stdio) |
-| LiteLLM Permission Management | ✨ Enterprise Only<br/>• By Key<br/>• By Team<br/>• By Organization |
+| LiteLLM Permission Management | • By Key<br/>• By Team<br/>• By Organization |
 
 ## Adding your MCP
 
@@ -606,7 +606,7 @@ curl --location '<your-litellm-proxy-base-url>/v1/responses' \
 
 
 
-## ✨ MCP Cost Tracking
+## MCP Cost Tracking
 
 LiteLLM provides two ways to track costs for MCP tool calls:
 
@@ -722,7 +722,7 @@ When MCP tools are called, your custom hook will:
 2. Modify the response if needed
 3. Track costs in LiteLLM's logging system
 
-## ✨ MCP Permission Management
+## MCP Permission Management
 
 LiteLLM supports managing permissions for MCP Servers by Keys, Teams, Organizations (entities) on LiteLLM. When a MCP client attempts to list tools, LiteLLM will only return the tools the entity has permissions to access.
 

--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -37,7 +37,6 @@ import {
 } from "./networking";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import PremiumVectorStoreSelector from "./common_components/PremiumVectorStoreSelector";
-import PremiumMCPSelector from "./common_components/PremiumMCPSelector";
 import { Team } from "./key_team_helpers/key_list";
 import TeamDropdown from "./common_components/team_dropdown";
 import { InfoCircleOutlined } from '@ant-design/icons';
@@ -49,6 +48,7 @@ import { rolesWithWriteAccess } from '../utils/roles';
 import BudgetDurationDropdown from "./common_components/budget_duration_dropdown";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { callback_map, mapDisplayToInternalNames } from "./callback_info_helpers";
+import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
 
 
 const { Option } = Select;
@@ -896,12 +896,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                         className="mt-4"
                         help="Select MCP servers or access groups this key can access. "
                       >
-                        <PremiumMCPSelector
-                          onChange={val => form.setFieldValue('allowed_mcp_servers_and_groups', val)}
+                        <MCPServerSelector
+                          onChange={(val: any) => form.setFieldValue('allowed_mcp_servers_and_groups', val)}
                           value={form.getFieldValue('allowed_mcp_servers_and_groups')}
                           accessToken={accessToken}
                           placeholder="Select MCP servers or access groups (optional)"
-                          premiumUser={premiumUser}
                         />
                       </Form.Item>
 

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -70,10 +70,10 @@ import { CogIcon } from "@heroicons/react/outline";
 import AvailableTeamsPanel from "@/components/team/available_teams";
 import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import PremiumVectorStoreSelector from "./common_components/PremiumVectorStoreSelector";
-import PremiumMCPSelector from "./common_components/PremiumMCPSelector";
 import PremiumLoggingSettings from "./common_components/PremiumLoggingSettings";
 import type { KeyResponse, Team } from "./key_team_helpers/key_list";
 import { formatNumberWithCommas } from "../utils/dataUtils";
+import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
 
 interface TeamProps {
   teams: Team[] | null;
@@ -1428,8 +1428,8 @@ const Teams: React.FC<TeamProps> = ({
                         className="mt-8"
                         help="Select MCP servers or access groups this team can access. "
                       >
-                        <PremiumMCPSelector
-                          onChange={(val) =>
+                        <MCPServerSelector
+                          onChange={(val: any) =>
                             form.setFieldValue(
                               "allowed_mcp_servers_and_groups",
                               val
@@ -1440,7 +1440,6 @@ const Teams: React.FC<TeamProps> = ({
                           )}
                           accessToken={accessToken || ""}
                           placeholder="Select MCP servers or access groups (optional)"
-                          premiumUser={premiumUser}
                         />
                       </Form.Item>
                     </AccordionBody>


### PR DESCRIPTION
[MCP Gateway] Move cost tracking and permission management to OSS

## Relevant issues

Fixes LIT-366 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

<img width="497" height="302" alt="Screenshot 2025-07-25 at 10 42 54 AM" src="https://github.com/user-attachments/assets/4487b891-9418-4d08-8ea7-7dfd725d0d47" />

