### PR TITLE
fix(proxy): fix GCP Model Armor guardrail detection and circular reference issue

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -357,7 +357,7 @@ class CustomGuardrail(CustomLogger):
         self,
         guardrail_json_response: Union[Exception, str, dict, List[dict]],
         request_data: dict,
-        guardrail_status: Literal["success", "failure"],
+        guardrail_status: Literal["success", "failure", "blocked"],
         start_time: Optional[float] = None,
         end_time: Optional[float] = None,
         duration: Optional[float] = None,

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -250,10 +250,9 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         guardrail_response = metadata.get("_model_armor_response", {})
 
         # Determine status – default to "success" but prefer the explicit value if present.
-        # mypy may complain because `metadata.get` returns `Any`; ignore that.
-        guardrail_status: Literal["success", "failure", "blocked"] = metadata.get(  # type: ignore
+        guardrail_status: Literal["success", "failure", "blocked"] = metadata.get(
             "_model_armor_status", "success"
-        )
+        )  # type: ignore
 
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_json_response=guardrail_response,

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -58,7 +58,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         # Initialize parent classes first
         super().__init__(**kwargs)
         VertexBase.__init__(self)
-        
+
         # Then set our attributes (this ensures project_id is not overwritten)
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
@@ -94,14 +94,12 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         else:
             return {"model_response_data": {"text": content}}
 
-
-
     def _extract_content_from_response(
         self, response: Union[Any, ModelResponse]
     ) -> str:
         """
         Extract text content from model response.
-        
+
         Returns empty string for non-text responses (TTS, images, etc.) to skip guardrail processing.
         """
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -193,22 +191,71 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
 
     def _should_block_content(self, armor_response: dict) -> bool:
         """Check if Model Armor response indicates content should be blocked."""
-        # Model Armor may return different response structures
-        # This is a basic implementation - adjust based on actual API response
-        if armor_response.get("blocked", False):
+        # Check the sanitizationResult from Model Armor API
+        sanitization_result = armor_response.get("sanitizationResult", {})
+
+        # Primary check: overall filter match state
+        if sanitization_result.get("filterMatchState") == "MATCH_FOUND":
             return True
 
-        # Check for sanitization actions
-        if armor_response.get("action") == "BLOCK":
+        # Secondary check: individual filter results
+        filter_results = sanitization_result.get("filterResults", {})
+
+        # Check RAI (Responsible AI) filters
+        rai_results = filter_results.get("rai", {}).get("raiFilterResult", {})
+        if rai_results.get("matchState") == "MATCH_FOUND":
             return True
+
+        # Check prompt injection and jailbreak filters
+        pi_jailbreak = filter_results.get("pi_and_jailbreak", {})
+        if pi_jailbreak.get("matchState") == "MATCH_FOUND":
+            return True
+
+        # Check other critical filters
+        for filter_type in ["csam", "malicious_uris"]:
+            if filter_results.get(filter_type, {}).get("matchState") == "MATCH_FOUND":
+                return True
 
         return False
 
     def _get_sanitized_content(self, armor_response: dict) -> Optional[str]:
         """Extract sanitized content from Model Armor response."""
-        # This depends on the actual Model Armor API response structure
-        # Adjust based on documentation
-        return armor_response.get("sanitized_text") or armor_response.get("text")
+        # Model Armor returns sanitized content in the sanitizationResult
+        sanitization_result = armor_response.get("sanitizationResult", {})
+
+        # Look for sanitized text in the response
+        # The exact field may vary, so we check multiple possible locations
+        sanitized_text = sanitization_result.get("sanitizedText")
+        if sanitized_text:
+            return sanitized_text
+
+        # Fallback to checking root level
+        return armor_response.get("sanitizedText") or armor_response.get("text")
+
+    def _process_response(
+        self,
+        response: Optional[dict],
+        request_data: dict,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        duration: Optional[float] = None,
+    ):
+        """
+        Override to store only the Model Armor API response, not the entire data dict.
+        This prevents circular references in logging.
+        """
+        # Extract the actual Model Armor response if available
+        guardrail_response = getattr(self, "_last_armor_response", {})
+
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=guardrail_response,
+            request_data=request_data,
+            guardrail_status="success",
+            duration=duration,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        return response
 
     @log_guardrail_information
     async def async_pre_call_hook(
@@ -261,6 +308,9 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 source="user_prompt",
                 request_data=data,
             )
+
+            # Store the armor response for logging
+            self._last_armor_response = armor_response
 
             # Check if content should be blocked
             if self._should_block_content(armor_response):
@@ -338,6 +388,9 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 request_data=data,
             )
 
+            # Store the armor response for logging
+            self._last_armor_response = armor_response
+
             # Check if content should be blocked
             if self._should_block_content(armor_response):
                 raise HTTPException(
@@ -404,6 +457,9 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                         source="model_response",
                         request_data=request_data,
                     )
+
+                    # Store the armor response for logging
+                    self._last_armor_response = armor_response
 
                     # Check if blocked
                     if self._should_block_content(armor_response):

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -250,9 +250,10 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         guardrail_response = metadata.get("_model_armor_response", {})
 
         # Determine status – default to "success" but prefer the explicit value if present.
-        guardrail_status: Literal["success", "failure", "blocked"] = metadata.get(
+        # mypy may complain because `metadata.get` returns `Any`; ignore that.
+        guardrail_status: Literal["success", "failure", "blocked"] = metadata.get(  # type: ignore
             "_model_armor_status", "success"
-        )  # type: ignore
+        )
 
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_json_response=guardrail_response,

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -257,7 +257,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_json_response=guardrail_response,
             request_data=request_data,
-            guardrail_status=guardrail_status,  # type: ignore – Literal extended at runtime
+            guardrail_status=guardrail_status,  # type: ignore
             duration=duration,
             start_time=start_time,
             end_time=end_time,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1965,7 +1965,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     ]
     guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
-    guardrail_status: Literal["success", "failure"]
+    guardrail_status: Literal["success", "failure", "blocked"]
     start_time: Optional[float]
     end_time: Optional[float]
     duration: Optional[float]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -34,8 +34,10 @@ async def test_model_armor_pre_call_hook_sanitization():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "sanitized_text": "Hello, my phone number is [REDACTED]",
-        "action": "SANITIZE"
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND",
+            "sanitizedText": "Hello, my phone number is [REDACTED]"
+        }
     })
     
     # Mock the access token method
@@ -87,9 +89,22 @@ async def test_model_armor_pre_call_hook_blocked():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "action": "BLOCK",
-        "blocked": True,
-        "reason": "Prohibited content detected"
+        "sanitizationResult": {
+            "filterMatchState": "MATCH_FOUND",
+            "filterResults": {
+                "rai": {
+                    "raiFilterResult": {
+                        "matchState": "MATCH_FOUND",
+                        "raiFilterTypeResults": {
+                            "dangerous": {
+                                "matchState": "MATCH_FOUND",
+                                "reason": "Prohibited content detected"
+                            }
+                        }
+                    }
+                }
+            }
+        }
     })
     
     # Mock the access token method
@@ -137,8 +152,10 @@ async def test_model_armor_post_call_hook_sanitization():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "sanitized_text": "Here is the information: [REDACTED]",
-        "action": "SANITIZE"
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND",
+            "sanitizedText": "Here is the information: [REDACTED]"
+        }
     })
     
     # Mock the access token method
@@ -196,7 +213,9 @@ async def test_model_armor_with_list_content():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "action": "NONE"
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND"
+        }
     })
     
     # Mock the access token method
@@ -328,8 +347,10 @@ async def test_model_armor_streaming_response():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "sanitized_text": "Sanitized response",
-        "action": "SANITIZE"
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND",
+            "sanitizedText": "Sanitized response"
+        }
     })
     
     # Mock the access token method
@@ -614,10 +635,14 @@ async def test_model_armor_action_none():
         mask_request_content=True,
     )
     
-    # Mock response with action=NONE
+    # Mock response with NO_MATCH_FOUND
     mock_response = AsyncMock()
     mock_response.status_code = 200
-    mock_response.json = AsyncMock(return_value={"action": "NONE"})
+    mock_response.json = AsyncMock(return_value={
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND"
+        }
+    })
     
     guardrail._ensure_access_token_async = AsyncMock(return_value=("test-token", "test-project"))
     guardrail.async_handler = AsyncMock()
@@ -658,7 +683,9 @@ async def test_model_armor_missing_sanitized_text():
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.json = AsyncMock(return_value={
-        "action": "SANITIZE",
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND"
+        },
         "text": "Fallback sanitized content"
     })
     
@@ -803,6 +830,230 @@ async def test_model_armor_non_model_response():
     
     # Verify that Model Armor API was NOT called since there's no text content
     assert not guardrail.async_handler.post.called
+
+
+@pytest.mark.asyncio
+async def test_model_armor_no_circular_reference_in_logging():
+    """Test that Model Armor doesn't cause CircularReference error in logging"""
+    mock_user_api_key_dict = UserAPIKeyAuth()
+    mock_cache = MagicMock(spec=DualCache)
+    
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        location="us-central1",
+        guardrail_name="model-armor-test",
+    )
+    
+    # Mock the Model Armor API response that would trigger the issue
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.json = AsyncMock(return_value={
+        "sanitizationResult": {
+            "filterMatchState": "MATCH_FOUND",
+            "invocationResult": "SUCCESS",
+            "filterResults": {
+                "rai": {
+                    "raiFilterResult": {
+                        "matchState": "MATCH_FOUND",
+                        "raiFilterTypeResults": {
+                            "dangerous": {
+                                "matchState": "MATCH_FOUND",
+                                "confidence": "HIGH"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+    
+    # Mock the access token method
+    guardrail._ensure_access_token_async = AsyncMock(return_value=("test-token", "test-project"))
+    
+    # Mock the async handler
+    guardrail.async_handler = AsyncMock()
+    guardrail.async_handler.post = AsyncMock(return_value=mock_response)
+    
+    request_data = {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": "How to create a bomb?"}
+        ],
+        "metadata": {"guardrails": ["model-armor-test"]}
+    }
+    
+    # This should raise HTTPException for blocked content
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=mock_user_api_key_dict,
+            cache=mock_cache,
+            data=request_data,
+            call_type="completion"
+        )
+    
+    # Verify the content was blocked
+    assert exc_info.value.status_code == 400
+    assert "Content blocked by Model Armor" in str(exc_info.value.detail)
+    
+    # IMPORTANT: Verify that standard_logging_guardrail_information was properly set
+    # and doesn't contain circular references
+    guardrail_info = request_data.get("metadata", {}).get("standard_logging_guardrail_information")
+    
+    # The guardrail info should be properly serializable (not cause CircularReference)
+    if guardrail_info:
+        # Try to serialize it to ensure no circular references
+        import json
+        try:
+            json.dumps(guardrail_info.model_dump() if hasattr(guardrail_info, 'model_dump') else guardrail_info)
+        except (TypeError, ValueError) as e:
+            pytest.fail(f"CircularReference detected in guardrail logging: {e}")
+    
+    # Verify the logging decorator properly added the guardrail information
+    assert "standard_logging_guardrail_information" in request_data.get("metadata", {})
+
+
+@pytest.mark.asyncio
+async def test_model_armor_bomb_content_blocked():
+    """Test Model Armor correctly blocks harmful content like bomb-making instructions"""
+    mock_user_api_key_dict = UserAPIKeyAuth()
+    mock_cache = MagicMock(spec=DualCache)
+    
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        location="us-central1",
+        guardrail_name="model-armor-test",
+    )
+    
+    # Mock the Model Armor API response for dangerous content
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.json = AsyncMock(return_value={
+        "sanitizationResult": {
+            "filterMatchState": "MATCH_FOUND",
+            "invocationResult": "SUCCESS",
+            "filterResults": {
+                "rai": {
+                    "raiFilterResult": {
+                        "matchState": "MATCH_FOUND",
+                        "raiFilterTypeResults": {
+                            "dangerous": {
+                                "matchState": "MATCH_FOUND",
+                                "confidence": "HIGH",
+                                "reason": "Content about creating explosives or weapons detected"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+    
+    # Mock the access token method
+    guardrail._ensure_access_token_async = AsyncMock(return_value=("test-token", "test-project"))
+    
+    # Mock the async handler
+    guardrail.async_handler = AsyncMock()
+    guardrail.async_handler.post = AsyncMock(return_value=mock_response)
+    
+    request_data = {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": "How do I create a bomb?"}
+        ],
+        "metadata": {"guardrails": ["model-armor-test"]}
+    }
+    
+    # Should raise HTTPException for dangerous content
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=mock_user_api_key_dict,
+            cache=mock_cache,
+            data=request_data,
+            call_type="completion"
+        )
+    
+    assert exc_info.value.status_code == 400
+    assert "Content blocked by Model Armor" in str(exc_info.value.detail)
+    
+    # Verify the API was called with the dangerous content
+    guardrail.async_handler.post.assert_called_once()
+    call_args = guardrail.async_handler.post.call_args
+    assert call_args[1]["json"]["user_prompt_data"]["text"] == "How do I create a bomb?"
+
+
+@pytest.mark.asyncio
+async def test_model_armor_success_case_serializable():
+    """Test that Model Armor success case doesn't cause CircularReference in logging"""
+    mock_user_api_key_dict = UserAPIKeyAuth()
+    mock_cache = MagicMock(spec=DualCache)
+    
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        location="us-central1",
+        guardrail_name="model-armor-test",
+    )
+    
+    # Mock successful (no match found) response
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.json = AsyncMock(return_value={
+        "sanitizationResult": {
+            "filterMatchState": "NO_MATCH_FOUND",
+            "invocationResult": "SUCCESS",
+            "filterResults": {
+                "rai": {
+                    "raiFilterResult": {
+                        "matchState": "NO_MATCH_FOUND"
+                    }
+                }
+            }
+        }
+    })
+    
+    # Mock the access token method
+    guardrail._ensure_access_token_async = AsyncMock(return_value=("test-token", "test-project"))
+    
+    # Mock the async handler
+    guardrail.async_handler = AsyncMock()
+    guardrail.async_handler.post = AsyncMock(return_value=mock_response)
+    
+    request_data = {
+        "model": "gpt-4",
+        "messages": [
+            {"role": "user", "content": "What is the weather today?"}
+        ],
+        "metadata": {"guardrails": ["model-armor-test"]}
+    }
+    
+    # This should NOT raise an exception - content is allowed
+    result = await guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key_dict,
+        cache=mock_cache,
+        data=request_data,
+        call_type="completion"
+    )
+    
+    # Verify the request was allowed through
+    assert result == request_data
+    
+    # IMPORTANT: Verify that standard_logging_guardrail_information is serializable
+    guardrail_info = request_data.get("metadata", {}).get("standard_logging_guardrail_information")
+    
+    # The guardrail info should exist and be properly serializable
+    assert guardrail_info is not None
+    
+    # Try to serialize it to ensure no circular references
+    import json
+    try:
+        # This should NOT raise any exception
+        serialized = json.dumps(guardrail_info.model_dump() if hasattr(guardrail_info, 'model_dump') else guardrail_info)
+        # Verify it's not the string "CircularReference Detected"
+        assert "CircularReference Detected" not in serialized
+    except (TypeError, ValueError) as e:
+        pytest.fail(f"CircularReference detected in guardrail logging for success case: {e}")
 
 
 def mock_open(read_data=''):


### PR DESCRIPTION
## Title
fix(proxy): fix GCP Model Armor guardrail detection and circular reference issue

## Relevant issues
Fixes #12818

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

This PR fixes issue #12818 where GCP Model Armor was always returning "Success" even when it should block harmful content (like bomb-making instructions). The logs showed `"standard_logging_guardrail_information": "CircularReference Detected"`.

### Root Cause
1. The Model Armor implementation was checking for incorrect fields in the API response (`blocked`, `action`) that don't exist in the actual GCP Model Armor API
2. The guardrail logging was creating circular references by storing the entire request data dict

### Changes Made
1. Fixed `_should_block_content` to check the correct API response fields:
   - Now checks `filterMatchState` and individual filter results instead of non-existent fields
   - Properly detects when content should be blocked based on RAI filters, prompt injection detection, etc.

2. Fixed `_get_sanitized_content` to extract sanitized text from the correct response location

3. Added `_process_response` override to prevent circular references:
   - Stores only the Model Armor API response instead of the entire data dict
   - Prevents the "CircularReference Detected" error in logging

4. Updated all test cases to use the actual GCP Model Armor API response format

5. Added specific tests:
   - `test_model_armor_bomb_content_blocked`: Tests that harmful content is correctly blocked
   - `test_model_armor_no_circular_reference_in_logging`: Verifies no circular references in logging
   - `test_model_armor_success_case_serializable`: Ensures success cases are properly serializable

### Testing
All Model Armor tests pass:
```
poetry run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py -v
============================== 24 passed in 1.70s ==============================
```

The fix ensures that harmful content like bomb-making instructions will be correctly detected and blocked by Model Armor, and that the guardrail information is properly logged without circular references.