### PR TITLE
Added handling for pwd protected cert files in AOAI CertificateCreden…

### DIFF
--- a/litellm/secret_managers/get_azure_ad_token_provider.py
+++ b/litellm/secret_managers/get_azure_ad_token_provider.py
@@ -64,11 +64,19 @@ def get_azure_ad_token_provider(
     elif cred == AzureCredentialType.ManagedIdentityCredential:
         credential = ManagedIdentityCredential(client_id=os.environ["AZURE_CLIENT_ID"])
     elif cred == AzureCredentialType.CertificateCredential:
-        credential = CertificateCredential(
-            client_id=os.environ["AZURE_CLIENT_ID"],
-            tenant_id=os.environ["AZURE_TENANT_ID"],
-            certificate_path=os.environ["AZURE_CERTIFICATE_PATH"],
-        )
+        if os.getenv("AZURE_CERTIFICATE_PASSWORD"):
+            credential = CertificateCredential(
+                client_id=os.environ["AZURE_CLIENT_ID"],
+                tenant_id=os.environ["AZURE_TENANT_ID"],
+                certificate_path=os.environ["AZURE_CERTIFICATE_PATH"],
+                password=os.environ["AZURE_CERTIFICATE_PASSWORD"],
+            )
+        else:
+            credential = CertificateCredential(
+                client_id=os.environ["AZURE_CLIENT_ID"],
+                tenant_id=os.environ["AZURE_TENANT_ID"],
+                certificate_path=os.environ["AZURE_CERTIFICATE_PATH"],
+            )
     elif cred == AzureCredentialType.DefaultAzureCredential:
         # DefaultAzureCredential doesn't require explicit environment variables
         # It automatically discovers credentials from the environment (managed identity, CLI, etc.)

--- a/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
+++ b/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
@@ -140,6 +140,50 @@ class TestGetAzureAdTokenProvider:
     @patch.dict(
         os.environ,
         {
+            "AZURE_CLIENT_ID": "test-client-id",
+            "AZURE_TENANT_ID": "test-tenant-id",
+            "AZURE_CERTIFICATE_PATH": "/path/to/cert.pem",
+            "AZURE_SCOPE": "https://cognitiveservices.azure.com/.default",
+            "AZURE_CREDENTIAL": "CertificateCredential",
+            "AZURE_CERTIFICATE_PASSWORD": "pwd4cert.pem",
+        },
+    )
+    @patch("azure.identity.get_bearer_token_provider")
+    @patch("azure.identity.CertificateCredential")
+    def test_get_azure_ad_token_provider_password_protected_certificate_credential(
+        self, mock_certificate_credential, mock_get_bearer_token_provider
+    ):
+        """Test get_azure_ad_token_provider with password protected certificate in CertificateCredential."""
+        # Mock the Azure identity credential instance
+        mock_credential_instance = MagicMock()
+        mock_certificate_credential.return_value = mock_credential_instance
+
+        # Mock the bearer token provider
+        mock_token_provider = MagicMock(return_value="mock-certificate-token")
+        mock_get_bearer_token_provider.return_value = mock_token_provider
+
+        # Call the function
+        result = get_azure_ad_token_provider()
+
+        # Assertions
+        assert callable(result)
+        mock_certificate_credential.assert_called_once_with(
+            client_id="test-client-id",
+            tenant_id="test-tenant-id",
+            certificate_path="/path/to/cert.pem",
+            password="pwd4cert.pem",
+        )
+        mock_get_bearer_token_provider.assert_called_once_with(
+            mock_credential_instance, "https://cognitiveservices.azure.com/.default"
+        )
+
+        # Test that the returned callable works
+        token = result()
+        assert token == "mock-certificate-token"
+
+    @patch.dict(
+        os.environ,
+        {
             "AZURE_CREDENTIAL": "DefaultAzureCredential",
         },
     )


### PR DESCRIPTION
…tial auth

## Title

Added handling for pwd protected cert files in AOAI CertificateCredential auth. The CertificateCredential will now check to see if an "AZURE_CERTIFICATE_PASSWORD" has been supplied as an environment variable. If it has, we will send that along to CertificateCredential(), if not, we continue as previously (without supplying a password).

See [Microsoft documentation for CertificateCredential in python](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.certificatecredential?view=azure-python) :)

## Relevant issues

No relevant open issues - I decided to go for the PR myself instead :)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ X] I have added a screenshot of my new test passing locally 
- [ X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes
Changes in:
1. litellm/secret_managers/get_azure_ad_token_provider.py -> 71-78
2. tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py -> 140-182

## Screenshot of passed test:
<img width="1286" height="35" alt="Screenshot 2025-07-25 at 23 02 43" src="https://github.com/user-attachments/assets/776814df-2b1a-438e-aa78-6ec8c8633d1c" />

## Notes:
First PR to the repo, am happy to take any comments into consideration :)
I realise that ONLY allowing env vars passed for certificatecredential is a bit lacking but I think adding the possibility of passing this through the config.yaml will be another PR :)
