### PR TITLE
fix: enable metadata parameter for OpenAI API calls

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -331,6 +331,7 @@ OPENAI_CHAT_COMPLETION_PARAMS = [
     "extra_headers",
     "thinking",
     "web_search_options",
+    "metadata",
 ]
 
 OPENAI_TRANSCRIPTION_PARAMS = [
@@ -385,6 +386,7 @@ DEFAULT_CHAT_COMPLETION_PARAM_VALUES = {
     "reasoning_effort": None,
     "thinking": None,
     "web_search_options": None,
+    "metadata": None,
 }
 
 openai_compatible_endpoints: List = [

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -158,6 +158,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             "parallel_tool_calls",
             "audio",
             "web_search_options",
+            "metadata",
         ]  # works across all models
 
         model_specific_params = []

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3224,6 +3224,7 @@ def get_optional_params(  # noqa: PLR0915
     messages: Optional[List[AllMessageValues]] = None,
     thinking: Optional[AnthropicThinkingParam] = None,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
+    metadata=None,
     **kwargs,
 ):
     passed_params = locals().copy()


### PR DESCRIPTION
## Enable metadata parameter for OpenAI API calls
Fixes issue where metadata was not being sent to OpenAI API despite being passed to litellm.completion(). The metadata field is now properly supported for OpenAI and tracked in logging integrations like Langfuse.

## Relevant issues
Fixes #12997 

## Type
🐛 Bug Fix

## Changes
- Add metadata to OPENAI_CHAT_COMPLETION_PARAMS and DEFAULT_CHAT_COMPLETION_PARAM_VALUES
- Add metadata to OpenAIGPTConfig.get_supported_openai_params()
- Add metadata parameter to get_optional_params() function signature
- Pass metadata through to optional_params in completion flow
- Remove preview features gate for metadata support
- Ensure metadata is available in logging for all integrations
