### PR TITLE
Remove duplicate test case verifying field filtering logic

### DIFF
--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -116,29 +116,6 @@ class TestLiteLLMCompletionResponsesConfig:
         assert "extra_field" not in result["file"]
         assert "another_field" not in result["file"]
 
-    def test_transform_input_file_item_to_file_item_ignores_other_fields(self):
-        """Test that transformation only includes file_id and file_data, ignoring other fields"""
-        # Setup
-        input_item = {
-            "type": "input_file",
-            "file_id": "file-abc123xyz",
-            "extra_field": "should_be_ignored",
-            "another_field": 123,
-        }
-
-        # Execute
-        result = (
-            LiteLLMCompletionResponsesConfig._transform_input_file_item_to_file_item(
-                input_item
-            )
-        )
-
-        # Assert
-        expected = {"type": "file", "file": {"file_id": "file-abc123xyz"}}
-        assert result == expected
-        assert "extra_field" not in result["file"]
-        assert "another_field" not in result["file"]
-
     def test_transform_input_image_item_to_image_item_with_image_url(self):
         """Test transformation of input_image item with image_url to Chat Completion image format"""
         # Setup


### PR DESCRIPTION
## Title
This small PR removes the duplicated `test_transform_input_file_item_to_file_item_ignores_other_fields` test case.

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes


