### PR TITLE
[Bug Fix] Pass through logging handler VertexAI - ensure multimodal embedding responses are logged 

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -81,6 +81,9 @@ class VertexPassthroughLoggingHandler:
             from litellm.llms.vertex_ai.image_generation.image_generation_handler import (
                 VertexImageGeneration,
             )
+            from litellm.llms.vertex_ai.multimodal_embeddings.transformation import (
+                VertexAIMultimodalEmbeddingConfig,
+            )
             from litellm.types.utils import PassthroughCallTypes
 
             vertex_image_generation_class = VertexImageGeneration()
@@ -105,6 +108,23 @@ class VertexPassthroughLoggingHandler:
 
                 logging_obj.call_type = (
                     PassthroughCallTypes.passthrough_image_generation.value
+                )
+            elif VertexPassthroughLoggingHandler._is_multimodal_embedding_response(
+                json_response=_json_response, 
+            ):
+                # Use multimodal embedding transformation
+                vertex_multimodal_config = VertexAIMultimodalEmbeddingConfig()
+                litellm_prediction_response = (
+                    vertex_multimodal_config.transform_embedding_response(
+                        model=model,
+                        raw_response=httpx_response,
+                        model_response=litellm.EmbeddingResponse(),
+                        logging_obj=logging_obj,
+                        api_key="",
+                        request_data={},
+                        optional_params={},
+                        litellm_params={},
+                    )
                 )
             else:
                 litellm_prediction_response = litellm.vertexAITextEmbeddingConfig.transform_vertex_response_to_openai(
@@ -314,6 +334,35 @@ class VertexPassthroughLoggingHandler:
         ):
             return litellm.LlmProviders.GEMINI.value
         return litellm.LlmProviders.VERTEX_AI.value
+
+    @staticmethod
+    def _is_multimodal_embedding_response(json_response: dict) -> bool:
+        """
+        Detect if the response is from a multimodal embedding request.
+
+        Check if the response contains multimodal embedding fields: 
+            - Docs: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-embeddings-api#response-body 
+        
+        
+        Args:
+            json_response: The JSON response from Vertex AI
+            
+        Returns:
+            bool: True if this is a multimodal embedding response
+        """
+        # Check if response contains multimodal embedding fields
+        if "predictions" in json_response:
+            predictions = json_response["predictions"]
+            for prediction in predictions:
+                if isinstance(prediction, dict):
+                    # Check for multimodal embedding response fields
+                    if any(
+                        key in prediction
+                        for key in ["textEmbedding", "imageEmbedding", "videoEmbeddings"]
+                    ):
+                        return True
+        
+        return False
 
     @staticmethod
     def _create_vertex_response_logging_payload_for_generate_content(


### PR DESCRIPTION
## [Bug Fix] Pass through logging handler VertexAI - ensure multimodal embedding responses are logged 

- Ensures `vertex_ai/multimodalembedding@001` is logged on supported logging integrations 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


