### PR TITLE
[Feat] Allow using query_params for setting API Key for generateContent routes

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -390,7 +390,9 @@ class RouteChecks:
     @staticmethod
     def is_generate_content_route(route: str) -> bool:
         """
-        Check if route is a generate content route
+        Returns True if this is a google generateContent or streamGenerateContent route
+
+        These routes from google allow passing key=api_key in the query params
         """
         if "generateContent" in route:
             return True

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -386,3 +386,14 @@ class RouteChecks:
         if "thread" in request.url.path or "assistant" in request.url.path:
             return True
         return False
+    
+    @staticmethod
+    def is_generate_content_route(route: str) -> bool:
+        """
+        Check if route is a generate content route
+        """
+        if "generateContent" in route:
+            return True
+        if "streamGenerateContent" in route:
+            return True
+        return False

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -255,6 +255,7 @@ def get_api_key(
     Returns:
         Tuple[Optional[str], Optional[str]]: Tuple of the api_key and the passed_in_key
     """
+    from litellm.proxy.auth.route_checks import RouteChecks
     api_key = api_key
     passed_in_key: Optional[str] = None
     if isinstance(custom_litellm_key_header, str):
@@ -275,6 +276,9 @@ def get_api_key(
     elif isinstance(azure_apim_header, str):
         passed_in_key = azure_apim_header
         api_key = azure_apim_header
+    elif RouteChecks.is_generate_content_route(route=route) and request is not None and request.query_params.get("key"):
+        passed_in_key = request.query_params.get("key")
+        api_key = request.query_params.get("key")
     elif pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
             if endpoint.get("path", "") == route:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -261,7 +261,7 @@ def get_api_key(
     if isinstance(custom_litellm_key_header, str):
         passed_in_key = custom_litellm_key_header
         api_key = _get_bearer_token_or_received_api_key(custom_litellm_key_header)
-    elif isinstance(api_key, str):
+    elif isinstance(api_key, str) and len(api_key) > 0:
         passed_in_key = api_key
         api_key = _get_bearer_token(api_key=api_key)
     elif isinstance(azure_api_key_header, str):
@@ -277,16 +277,17 @@ def get_api_key(
         passed_in_key = azure_apim_header
         api_key = azure_apim_header
     elif RouteChecks.is_generate_content_route(route=route) and request is not None and request.query_params.get("key"):
-        passed_in_key = request.query_params.get("key")
-        api_key = request.query_params.get("key")
+        google_auth_key: str = request.query_params.get("key") or ""
+        passed_in_key = google_auth_key
+        api_key = google_auth_key
     elif pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
             if endpoint.get("path", "") == route:
                 headers: Optional[dict] = endpoint.get("headers", None)
                 if headers is not None:
                     header_key: str = headers.get("litellm_user_api_key", "")
-                    if request.headers.get(key=header_key) is not None:
-                        api_key = request.headers.get(key=header_key)
+                    if request.headers.get(header_key) is not None:
+                        api_key = request.headers.get(header_key) or ""
                         passed_in_key = api_key
     return api_key, passed_in_key
 


### PR DESCRIPTION
## [Feat] Allow using query_params for setting API Key for generateContent routes

LiteLLM Auth should work when key is set in this manner: https://mydomain/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse&key=REDACTED 

<img width="1280" height="430" alt="Screenshot 2025-07-29 at 1 55 27 PM" src="https://github.com/user-attachments/assets/82a55224-ddd0-4b90-9d95-3598c35a9978" />



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


