### PR TITLE
fix tool aws bedrock call index when the function only have optional arg

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1384,7 +1384,9 @@ class AWSEventStreamDecoder:
                             "name": None,
                             "arguments": "{}",
                         },
-                        "index": chunk_data["contentBlockIndex"],
+                        "index": self.tool_calls_index
+                        if self.tool_calls_index is not None
+                        else index,
                     }
             elif "stopReason" in chunk_data:
                 finish_reason = map_finish_reason(chunk_data.get("stopReason", "stop"))

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -81,3 +81,89 @@ def test_transform_tool_calls_index():
         tool_call_hunk_dict = tool_call_hunk.model_dump()
         for tool_call in tool_call_hunk_dict["choices"][0]["delta"]["tool_calls"]:
             assert tool_call["index"] == 1
+
+
+def test_transform_tool_calls_index_with_optional_arg_func():
+    chunks = [
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": "To"},
+            "p": "abcdefghijklmnopqrstuv",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " get the current time, I"},
+            "p": "abcdefghijklmnopqrstuvwxyzABCD",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": ' can use the "get_time"'},
+            "p": "abcdefghijkl",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " function. Since the user"},
+            "p": "abcdefghijkl",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " didn't specify whether"},
+            "p": "abcdefghijklmnopqrstuvw",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " they want UTC time or local time,"},
+            "p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " I'll assume they"},
+            "p": "abcdefghijkl",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " want the local time. Here's"},
+            "p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": " how I"},
+            "p": "abcdefghijklmnopqrstuvw",
+        },
+        {
+            "contentBlockIndex": 0,
+            "delta": {"text": "'ll make the function call:"},
+            "p": "abcdefghijklmnopqrstuvwxyzAB",
+        },
+        {
+            "contentBlockIndex": 0,
+            "p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        },
+        {
+            "contentBlockIndex": 1,
+            "p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO",
+            "start": {
+                "toolUse": {
+                    "name": "get_time",
+                    "toolUseId": "tooluse_htgmgeJATsKTl4s_LW77sQ",
+                }
+            },
+        },
+        {
+            "contentBlockIndex": 1,
+            "delta": {"toolUse": {"input": ""}},
+            "p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
+        },
+        {"contentBlockIndex": 1, "p": "abcdefghijklmnopqrstuvw"},
+        {"p": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJK", "stopReason": "tool_use"},
+    ]
+    decoder = AWSEventStreamDecoder(model="test")
+    parsed_chunks = []
+    for chunk in chunks:
+        parsed_chunk = decoder._chunk_parser(chunk)
+        parsed_chunks.append(parsed_chunk)
+    tool_call_chunks = parsed_chunks[11:14]
+    for tool_call_hunk in tool_call_chunks:
+        tool_call_hunk_dict = tool_call_hunk.model_dump()
+        for tool_call in tool_call_hunk_dict["choices"][0]["delta"]["tool_calls"]:
+            assert tool_call["index"] == 0


### PR DESCRIPTION
## Title

How to reproduce:

``` shell
curl --location 'http://0.0.0.0:4000/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
  "model": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
  "messages": [
    {
      "role": "user",
      "content": "What is the time now?"
    }
  ],
  "tools": [
    {
        "type": "function",
        "function": {
            "name": "get_time",
            "description": "Get the current time",
            "parameters": {
                "type": "object",
                "properties": {
                    "is_utc": {
                        "type": "boolean",
                        "description": "Whether the time should be in UTC, default is false"
                    }
                }
            }
        }
    }
  ],
  "tool_choice": "auto",
  "stream": true
}
'
```
output:

```
data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"To","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" get the current time, I"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" can use the \"get_time\""}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" function. Since the user"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" didn't specify whether"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" they want UTC time or local time,"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" I'll assume they"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" want the local time. Here's"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" how I"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"'ll make the function call:"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"id":"tooluse_htgmgeJATsKTl4s_LW77sQ","function":{"arguments":"","name":"get_time"},"type":"function","index":0}]}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"function":{"arguments":""},"type":"function","index":0}]}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"function":{"arguments":"{}"},"type":"function","index":1}]}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"finish_reason":"tool_calls","index":0,"delta":{}}],"provider_specific_fields":{}}

data: [DONE]
```

the last 2nd chunk's tool call index is incorrect:

``` shell
data: {"id":"chatcmpl-aa788fb8-a05e-4161-87ab-638ad615a520","created":1753844693,"model":"us.anthropic.claude-3-5-sonnet-20240620-v1:0","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"","tool_calls":[{"function":{"arguments":"{}"},"type":"function","index":1}]}}],"provider_specific_fields":{}}
```

Expect to be 0, actual is 1.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


