### PR TITLE
Enhance lowest cost routing by adding TPD and RPD metrics

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5333,6 +5333,8 @@ class Router:
 
         total_tpm: Optional[int] = None
         total_rpm: Optional[int] = None
+        total_tpd: Optional[int] = None
+        total_rpd: Optional[int] = None
         configurable_clientside_auth_params: CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS = None
         model_list = self.get_model_list(model_name=model_group)
         if model_list is None:
@@ -5374,6 +5376,24 @@ class Router:
                 _deployment_rpm = model.get("litellm_params", {}).get("rpm", None)  # type: ignore
             if _deployment_rpm is None:
                 _deployment_rpm = model.get("model_info", {}).get("rpm", None)  # type: ignore
+
+            # get model tpd
+            _deployment_tpd: Optional[int] = None
+            if _deployment_tpd is None:
+                _deployment_tpd = model.get("tpd", None)  # type: ignore
+            if _deployment_tpd is None:
+                _deployment_tpd = model.get("litellm_params", {}).get("tpd", None)  # type: ignore
+            if _deployment_tpd is None:
+                _deployment_tpd = model.get("model_info", {}).get("tpd", None)  # type: ignore
+
+            # get model rpd
+            _deployment_rpd: Optional[int] = None
+            if _deployment_rpd is None:
+                _deployment_rpd = model.get("rpd", None)  # type: ignore
+            if _deployment_rpd is None:
+                _deployment_rpd = model.get("litellm_params", {}).get("rpd", None)  # type: ignore
+            if _deployment_rpd is None:
+                _deployment_rpd = model.get("model_info", {}).get("rpd", None)  # type: ignore
 
             # get model info
             try:
@@ -5515,6 +5535,10 @@ class Router:
                     _deployment_tpm = model_info.get("tpm")
                 if model_info.get("rpm", None) is not None and _deployment_rpm is None:
                     _deployment_rpm = model_info.get("rpm")
+                if model_info.get("tpd", None) is not None and _deployment_tpd is None:
+                    _deployment_tpd = model_info.get("tpd")
+                if model_info.get("rpd", None) is not None and _deployment_rpd is None:
+                    _deployment_rpd = model_info.get("rpd")
 
             if _deployment_tpm is not None:
                 if total_tpm is None:
@@ -5525,6 +5549,16 @@ class Router:
                 if total_rpm is None:
                     total_rpm = 0
                 total_rpm += _deployment_rpm  # type: ignore
+
+            if _deployment_tpd is not None:
+                if total_tpd is None:
+                    total_tpd = 0
+                total_tpd += _deployment_tpd  # type: ignore
+
+            if _deployment_rpd is not None:
+                if total_rpd is None:
+                    total_rpd = 0
+                total_rpd += _deployment_rpd  # type: ignore
         if model_group_info is not None:
             ## UPDATE WITH TOTAL TPM/RPM FOR MODEL GROUP
             if total_tpm is not None:
@@ -5532,6 +5566,12 @@ class Router:
 
             if total_rpm is not None:
                 model_group_info.rpm = total_rpm
+
+            if total_tpd is not None:
+                model_group_info.tpd = total_tpd
+
+            if total_rpd is not None:
+                model_group_info.rpd = total_rpd
 
             ## UPDATE WITH CONFIGURABLE CLIENTSIDE AUTH PARAMS FOR MODEL GROUP
             if configurable_clientside_auth_params is not None:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -183,6 +183,8 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     custom_llm_provider: Optional[str] = None
     tpm: Optional[int] = None
     rpm: Optional[int] = None
+    tpd: Optional[int] = None
+    rpd: Optional[int] = None
     timeout: Optional[Union[float, str, httpx.Timeout]] = (
         None  # if str, pass in as os.environ/
     )
@@ -222,6 +224,8 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
         max_retries: Optional[Union[int, str]] = None,
         tpm: Optional[int] = None,
         rpm: Optional[int] = None,
+        tpd: Optional[int] = None,
+        rpd: Optional[int] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
@@ -312,6 +316,8 @@ class LiteLLM_Params(GenericLiteLLMParams):
         max_retries: Optional[Union[int, str]] = None,
         tpm: Optional[int] = None,
         rpm: Optional[int] = None,
+        tpd: Optional[int] = None,
+        rpd: Optional[int] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
@@ -381,6 +387,8 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     custom_llm_provider: Optional[str]
     tpm: Optional[int]
     rpm: Optional[int]
+    tpd: Optional[int]
+    rpd: Optional[int]
     order: Optional[int]
     weight: Optional[int]
     max_parallel_requests: Optional[int]

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -211,7 +211,6 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     model_info: Optional[Dict] = None
     mock_response: Optional[Union[str, ModelResponse, Exception, Any]] = None
 
-
     # auto-router params
     auto_router_config_path: Optional[str] = None
     auto_router_config: Optional[str] = None
@@ -349,7 +348,7 @@ class LiteLLM_Params(GenericLiteLLMParams):
         if max_retries is not None and isinstance(max_retries, str):
             max_retries = int(max_retries)  # cast to int
         args["max_retries"] = max_retries
-        super().__init__(**{ **args, **params })
+        super().__init__(**{**args, **params})
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
@@ -592,6 +591,8 @@ class ModelGroupInfo(BaseModel):
     ] = Field(default="chat")
     tpm: Optional[int] = None
     rpm: Optional[int] = None
+    tpd: Optional[int] = None
+    rpd: Optional[int] = None
     supports_parallel_function_calling: bool = Field(default=False)
     supports_vision: bool = Field(default=False)
     supports_web_search: bool = Field(default=False)
@@ -784,8 +785,10 @@ class MockRouterTestingParams:
             ),
         )
 
+
 class ModelGroupSettings(BaseModel):
     forward_client_headers_to_llm_api: Optional[List[str]] = None
+
 
 class PreRoutingHookResponse(BaseModel):
     """
@@ -795,5 +798,6 @@ class PreRoutingHookResponse(BaseModel):
 
     Add fields that you expect to be modified by the pre-routing hook.
     """
+
     model: str
     messages: Optional[List[Dict[str, str]]]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -174,6 +174,8 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     ]
     tpm: Optional[int]
     rpm: Optional[int]
+    tpd: Optional[int]
+    rpd: Optional[int]
 
 
 class ModelInfo(ModelInfoBase, total=False):

--- a/ui/litellm-dashboard/src/components/edit_model/edit_model_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_model/edit_model_modal.tsx
@@ -177,6 +177,22 @@ const EditModelModal: React.FC<EditModelModalProps> = ({
             <InputNumber min={0} step={1} />
           </Form.Item>
 
+          <Form.Item
+            label="tpd"
+            name="tpd"
+            tooltip="int (optional) - Tokens limit for this deployment: in tokens per day (tpd). Find this information on your model/providers website"
+          >
+            <InputNumber min={0} step={1} />
+          </Form.Item>
+
+          <Form.Item
+            label="rpd"
+            name="rpd"
+            tooltip="int (optional) - Rate limit for this deployment: in requests per day (rpd). Find this information on your model/providers website"
+          >
+            <InputNumber min={0} step={1} />
+          </Form.Item>
+
           <Form.Item label="max_retries" name="max_retries">
             <InputNumber min={0} step={1} />
           </Form.Item>

--- a/ui/litellm-dashboard/src/components/model_hub_table.tsx
+++ b/ui/litellm-dashboard/src/components/model_hub_table.tsx
@@ -39,6 +39,8 @@ interface ModelGroupInfo {
   mode?: string;
   tpm?: number;
   rpm?: number;
+  tpd?: number;
+  rpd?: number;
   supports_parallel_function_calling: boolean;
   supports_vision: boolean;
   supports_function_calling: boolean;
@@ -195,7 +197,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({
   if (publicPage && publicPageAllowed) {
     return <PublicModelHub accessToken={accessToken} />;
   }
-  
+  debugger;
   return (
     <div className="w-full mx-4 h-[75vh]">
       {publicPage == false ? (
@@ -393,7 +395,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({
             </div>
 
             {/* Rate Limits */}
-            {(selectedModel.tpm || selectedModel.rpm) && (
+            {(selectedModel.tpm || selectedModel.rpm || selectedModel.tpd || selectedModel.rpd) && (
               <div>
                 <Text className="text-lg font-semibold mb-4">Rate Limits</Text>
                 <div className="grid grid-cols-2 gap-4">
@@ -407,6 +409,18 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({
                     <div>
                       <Text className="font-medium">Requests per Minute:</Text>
                       <Text>{selectedModel.rpm.toLocaleString()}</Text>
+                    </div>
+                  )}
+                  {selectedModel.tpd && (
+                    <div>
+                      <Text className="font-medium">Tokens per Day:</Text>
+                      <Text>{selectedModel.tpd.toLocaleString()}</Text>
+                    </div>
+                  )}
+                  {selectedModel.rpd && (
+                    <div>
+                      <Text className="font-medium">Requests per Day:</Text>
+                      <Text>{selectedModel.rpd.toLocaleString()}</Text>
                     </div>
                   )}
                 </div>
@@ -465,4 +479,4 @@ print(response.choices[0].message.content)`}
   );
 };
 
-export default ModelHubTable; 
+export default ModelHubTable;

--- a/ui/litellm-dashboard/src/components/model_hub_table_columns.tsx
+++ b/ui/litellm-dashboard/src/components/model_hub_table_columns.tsx
@@ -1,8 +1,8 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { Button, Badge, Text } from "@tremor/react";
 import { Tooltip, Tag } from "antd";
-import { 
-  CopyOutlined, 
+import {
+  CopyOutlined,
   InfoCircleOutlined
 } from "@ant-design/icons";
 
@@ -16,6 +16,8 @@ interface ModelHubData {
   mode?: string;
   tpm?: number;
   rpm?: number;
+  tpd?: number;
+  rpd?: number;
   supports_parallel_function_calling: boolean;
   supports_vision: boolean;
   supports_function_calling: boolean;
@@ -57,211 +59,211 @@ export const modelHubColumns = (
   publicPage: boolean = false,
 ): ColumnDef<ModelHubData>[] => {
   const allColumns: ColumnDef<ModelHubData>[] = [
-  {
-    header: "Public Model Name",
-    accessorKey: "model_group",
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return (
-        <div className="space-y-1">
-          <div className="flex items-center space-x-2">
-            <Text className="font-medium text-sm">{model.model_group}</Text>
-            <Tooltip title="Copy model name">
-              <CopyOutlined
-                onClick={() => copyToClipboard(model.model_group)}
-                className="cursor-pointer text-gray-500 hover:text-blue-500 text-xs"
-              />
-            </Tooltip>
+    {
+      header: "Public Model Name",
+      accessorKey: "model_group",
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return (
+          <div className="space-y-1">
+            <div className="flex items-center space-x-2">
+              <Text className="font-medium text-sm">{model.model_group}</Text>
+              <Tooltip title="Copy model name">
+                <CopyOutlined
+                  onClick={() => copyToClipboard(model.model_group)}
+                  className="cursor-pointer text-gray-500 hover:text-blue-500 text-xs"
+                />
+              </Tooltip>
+            </div>
+            {/* Show provider on mobile when provider column is hidden */}
+            <div className="md:hidden">
+              <Text className="text-xs text-gray-600">
+                {model.providers.join(", ")}
+              </Text>
+            </div>
           </div>
-          {/* Show provider on mobile when provider column is hidden */}
-          <div className="md:hidden">
-            <Text className="text-xs text-gray-600">
-              {model.providers.join(", ")}
+        );
+      },
+    },
+    {
+      header: "Provider",
+      accessorKey: "providers",
+      enableSorting: true,
+      sortingFn: (rowA, rowB) => {
+        const providersA = rowA.original.providers.join(", ");
+        const providersB = rowB.original.providers.join(", ");
+        return providersA.localeCompare(providersB);
+      },
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return (
+          <div className="flex flex-wrap gap-1">
+            {model.providers.slice(0, 2).map(provider => (
+              <Tag key={provider} color="blue" className="text-xs">
+                {provider}
+              </Tag>
+            ))}
+            {model.providers.length > 2 && (
+              <Text className="text-xs text-gray-500">+{model.providers.length - 2}</Text>
+            )}
+          </div>
+        );
+      },
+      meta: {
+        className: "hidden md:table-cell",
+      },
+    },
+    {
+      header: "Mode",
+      accessorKey: "mode",
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return model.mode ? (
+          <Badge color="green" size="sm">{model.mode}</Badge>
+        ) : (
+          <Text className="text-gray-500">-</Text>
+        );
+      },
+      meta: {
+        className: "hidden lg:table-cell",
+      },
+    },
+    {
+      header: "Tokens",
+      accessorKey: "max_input_tokens",
+      enableSorting: true,
+      sortingFn: (rowA, rowB) => {
+        const tokensA = (rowA.original.max_input_tokens || 0) + (rowA.original.max_output_tokens || 0);
+        const tokensB = (rowB.original.max_input_tokens || 0) + (rowB.original.max_output_tokens || 0);
+        return tokensA - tokensB;
+      },
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return (
+          <div className="space-y-1">
+            <Text className="text-xs">
+              {model.max_input_tokens ? formatTokens(model.max_input_tokens) : "-"} / {model.max_output_tokens ? formatTokens(model.max_output_tokens) : "-"}
             </Text>
           </div>
-        </div>
-      );
+        );
+      },
+      meta: {
+        className: "hidden lg:table-cell",
+      },
     },
-  },
-  {
-    header: "Provider",
-    accessorKey: "providers",
-    enableSorting: true,
-    sortingFn: (rowA, rowB) => {
-      const providersA = rowA.original.providers.join(", ");
-      const providersB = rowB.original.providers.join(", ");
-      return providersA.localeCompare(providersB);
+    {
+      header: "Cost/1M",
+      accessorKey: "input_cost_per_token",
+      enableSorting: true,
+      sortingFn: (rowA, rowB) => {
+        const costA = (rowA.original.input_cost_per_token || 0) + (rowA.original.output_cost_per_token || 0);
+        const costB = (rowB.original.input_cost_per_token || 0) + (rowB.original.output_cost_per_token || 0);
+        return costA - costB;
+      },
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return (
+          <div className="space-y-1">
+            <Text className="text-xs">
+              {model.input_cost_per_token ? formatCost(model.input_cost_per_token) : "-"}
+            </Text>
+            <Text className="text-xs text-gray-500">
+              {model.output_cost_per_token ? formatCost(model.output_cost_per_token) : "-"}
+            </Text>
+          </div>
+        );
+      },
     },
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return (
-        <div className="flex flex-wrap gap-1">
-          {model.providers.slice(0, 2).map(provider => (
-            <Tag key={provider} color="blue" className="text-xs">
-              {provider}
-            </Tag>
-          ))}
-          {model.providers.length > 2 && (
-            <Text className="text-xs text-gray-500">+{model.providers.length - 2}</Text>
-          )}
-        </div>
-      );
+    {
+      header: "Features",
+      accessorKey: "capabilities",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const model = row.original;
+        const capabilities = getModelCapabilities(model);
+        const colors = ['green', 'blue', 'purple', 'orange', 'red', 'yellow'];
+
+        return (
+          <div className="flex flex-wrap gap-1">
+            {capabilities.length === 0 ? (
+              <Text className="text-gray-500 text-xs">-</Text>
+            ) : (
+              capabilities.map((capability, index) => (
+                <Badge
+                  key={capability}
+                  color={colors[index % colors.length]}
+                  size="xs"
+                >
+                  {formatCapabilityName(capability)}
+                </Badge>
+              ))
+            )}
+          </div>
+        );
+      },
     },
-    meta: {
-      className: "hidden md:table-cell",
+    {
+      header: "Public",
+      accessorKey: "is_public_model_group",
+      enableSorting: true,
+      sortingFn: (rowA, rowB) => {
+        const publicA = rowA.original.is_public_model_group === true ? 1 : 0;
+        const publicB = rowB.original.is_public_model_group === true ? 1 : 0;
+        return publicA - publicB;
+      },
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return model.is_public_model_group === true ? (
+          <Badge color="green" size="xs">Yes</Badge>
+        ) : (
+          <Badge color="gray" size="xs">No</Badge>
+        );
+      },
+      meta: {
+        className: "hidden md:table-cell",
+      },
     },
-  },
-  {
-    header: "Mode",
-    accessorKey: "mode",
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return model.mode ? (
-        <Badge color="green" size="sm">{model.mode}</Badge>
-      ) : (
-        <Text className="text-gray-500">-</Text>
-      );
+    {
+      header: "Details",
+      id: "details",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const model = row.original;
+
+        return (
+          <Button
+            size="xs"
+            variant="secondary"
+            onClick={() => showModal(model)}
+            icon={InfoCircleOutlined}
+          >
+            <span className="hidden lg:inline">Details</span>
+            <span className="lg:hidden">Info</span>
+          </Button>
+        );
+      },
     },
-    meta: {
-      className: "hidden lg:table-cell",
-    },
-  },
-  {
-    header: "Tokens",
-    accessorKey: "max_input_tokens",
-    enableSorting: true,
-    sortingFn: (rowA, rowB) => {
-      const tokensA = (rowA.original.max_input_tokens || 0) + (rowA.original.max_output_tokens || 0);
-      const tokensB = (rowB.original.max_input_tokens || 0) + (rowB.original.max_output_tokens || 0);
-      return tokensA - tokensB;
-    },
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return (
-        <div className="space-y-1">
-          <Text className="text-xs">
-            {model.max_input_tokens ? formatTokens(model.max_input_tokens) : "-"} / {model.max_output_tokens ? formatTokens(model.max_output_tokens) : "-"}
-          </Text>
-        </div>
-      );
-    },
-    meta: {
-      className: "hidden lg:table-cell",
-    },
-  },
-  {
-    header: "Cost/1M",
-    accessorKey: "input_cost_per_token",
-    enableSorting: true,
-    sortingFn: (rowA, rowB) => {
-      const costA = (rowA.original.input_cost_per_token || 0) + (rowA.original.output_cost_per_token || 0);
-      const costB = (rowB.original.input_cost_per_token || 0) + (rowB.original.output_cost_per_token || 0);
-      return costA - costB;
-    },
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return (
-        <div className="space-y-1">
-          <Text className="text-xs">
-            {model.input_cost_per_token ? formatCost(model.input_cost_per_token) : "-"}
-          </Text>
-          <Text className="text-xs text-gray-500">
-            {model.output_cost_per_token ? formatCost(model.output_cost_per_token) : "-"}
-          </Text>
-        </div>
-      );
-    },
-  },
-  {
-    header: "Features",
-    accessorKey: "capabilities",
-    enableSorting: false,
-    cell: ({ row }) => {
-      const model = row.original;
-      const capabilities = getModelCapabilities(model);
-      const colors = ['green', 'blue', 'purple', 'orange', 'red', 'yellow'];
-      
-      return (
-        <div className="flex flex-wrap gap-1">
-          {capabilities.length === 0 ? (
-            <Text className="text-gray-500 text-xs">-</Text>
-          ) : (
-            capabilities.map((capability, index) => (
-              <Badge 
-                key={capability} 
-                color={colors[index % colors.length]} 
-                size="xs"
-              >
-                {formatCapabilityName(capability)}
-              </Badge>
-            ))
-          )}
-        </div>
-      );
-    },
-  },
-  {
-    header: "Public",
-    accessorKey: "is_public_model_group",
-    enableSorting: true,
-    sortingFn: (rowA, rowB) => {
-      const publicA = rowA.original.is_public_model_group === true ? 1 : 0;
-      const publicB = rowB.original.is_public_model_group === true ? 1 : 0;
-      return publicA - publicB;
-    },
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return model.is_public_model_group === true ? (
-        <Badge color="green" size="xs">Yes</Badge>
-      ) : (
-        <Badge color="gray" size="xs">No</Badge>
-      );
-    },
-    meta: {
-      className: "hidden md:table-cell",
-    },
-  },
-  {
-    header: "Details",
-    id: "details",
-    enableSorting: false,
-    cell: ({ row }) => {
-      const model = row.original;
-      
-      return (
-        <Button
-          size="xs"
-          variant="secondary"
-          onClick={() => showModal(model)}
-          icon={InfoCircleOutlined}
-        >
-          <span className="hidden lg:inline">Details</span>
-          <span className="lg:hidden">Info</span>
-        </Button>
-      );
-    },
-  },
-];
+  ];
 
   // Filter out columns based on publicPage setting
   if (publicPage) {
     return allColumns.filter(column => {
       // Remove the public column
       if ('accessorKey' in column && column.accessorKey === "is_public_model_group") return false;
-      
+
       return true;
     });
   }
-  
+
   return allColumns;
 };

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -176,6 +176,8 @@ export default function ModelInfoView({
         organization: values.organization,
         tpm: values.tpm,
         rpm: values.rpm,
+        tpd: values.tpd,
+        rpd: values.rpd,
         max_retries: values.max_retries,
         timeout: values.timeout,
         stream_timeout: values.stream_timeout,
@@ -319,16 +321,15 @@ export default function ModelInfoView({
               {modelData.model_info.id}
             </Text>
             <Button
-                type="text"
-                size="small"
-                icon={copiedStates["model-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
-                onClick={() => copyToClipboard(modelData.model_info.id, "model-id")}
-                className={`left-2 z-10 transition-all duration-200 ${
-                  copiedStates["model-id"] 
-                    ? 'text-green-600 bg-green-50 border-green-200' 
-                    : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+              type="text"
+              size="small"
+              icon={copiedStates["model-id"] ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+              onClick={() => copyToClipboard(modelData.model_info.id, "model-id")}
+              className={`left-2 z-10 transition-all duration-200 ${copiedStates["model-id"]
+                ? 'text-green-600 bg-green-50 border-green-200'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
                 }`}
-              />
+            />
           </div>
         </div>
         <div className="flex gap-2">
@@ -430,12 +431,12 @@ export default function ModelInfoView({
                 Created At{" "}
                 {modelData.model_info.created_at
                   ? new Date(
-                      modelData.model_info.created_at
-                    ).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })
+                    modelData.model_info.created_at
+                  ).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })
                   : "Not Set"}
               </div>
               <div className="flex items-center gap-x-2">
@@ -494,6 +495,8 @@ export default function ModelInfoView({
                     organization: localModelData.litellm_params.organization,
                     tpm: localModelData.litellm_params.tpm,
                     rpm: localModelData.litellm_params.rpm,
+                    tpd: localModelData.litellm_params.tpd,
+                    rpd: localModelData.litellm_params.rpd,
                     max_retries: localModelData.litellm_params.max_retries,
                     timeout: localModelData.litellm_params.timeout,
                     stream_timeout:
@@ -501,15 +504,15 @@ export default function ModelInfoView({
                     input_cost: localModelData.litellm_params
                       .input_cost_per_token
                       ? localModelData.litellm_params.input_cost_per_token *
-                        1_000_000
+                      1_000_000
                       : localModelData.model_info?.input_cost_per_token *
-                          1_000_000 || null,
+                      1_000_000 || null,
                     output_cost: localModelData.litellm_params
                       ?.output_cost_per_token
                       ? localModelData.litellm_params.output_cost_per_token *
-                        1_000_000
+                      1_000_000
                       : localModelData.model_info?.output_cost_per_token *
-                          1_000_000 || null,
+                      1_000_000 || null,
                     cache_control: localModelData.litellm_params
                       ?.cache_control_injection_points
                       ? true
@@ -572,14 +575,14 @@ export default function ModelInfoView({
                             {localModelData?.litellm_params
                               ?.input_cost_per_token
                               ? (
-                                  localModelData.litellm_params
-                                    ?.input_cost_per_token * 1_000_000
-                                ).toFixed(4)
+                                localModelData.litellm_params
+                                  ?.input_cost_per_token * 1_000_000
+                              ).toFixed(4)
                               : localModelData?.model_info?.input_cost_per_token
                                 ? (
-                                    localModelData.model_info
-                                      .input_cost_per_token * 1_000_000
-                                  ).toFixed(4)
+                                  localModelData.model_info
+                                    .input_cost_per_token * 1_000_000
+                                ).toFixed(4)
                                 : null}
                           </div>
                         )}
@@ -598,15 +601,15 @@ export default function ModelInfoView({
                             {localModelData?.litellm_params
                               ?.output_cost_per_token
                               ? (
-                                  localModelData.litellm_params
+                                localModelData.litellm_params
+                                  .output_cost_per_token * 1_000_000
+                              ).toFixed(4)
+                              : localModelData?.model_info
+                                ?.output_cost_per_token
+                                ? (
+                                  localModelData.model_info
                                     .output_cost_per_token * 1_000_000
                                 ).toFixed(4)
-                              : localModelData?.model_info
-                                    ?.output_cost_per_token
-                                ? (
-                                    localModelData.model_info
-                                      .output_cost_per_token * 1_000_000
-                                  ).toFixed(4)
                                 : null}
                           </div>
                         )}
@@ -688,6 +691,36 @@ export default function ModelInfoView({
                       </div>
 
                       <div>
+                        <Text className="font-medium">
+                          TPD (Tokens per Day)
+                        </Text>
+                        {isEditing ? (
+                          <Form.Item name="tpd" className="mb-0">
+                            <NumericalInput placeholder="Enter TPD" />
+                          </Form.Item>
+                        ) : (
+                          <div className="mt-1 p-2 bg-gray-50 rounded">
+                            {localModelData.litellm_params?.tpd || "Not Set"}
+                          </div>
+                        )}
+                      </div>
+
+                      <div>
+                        <Text className="font-medium">
+                          RPD (Requests per Day)
+                        </Text>
+                        {isEditing ? (
+                          <Form.Item name="rpd" className="mb-0">
+                            <NumericalInput placeholder="Enter RPD" />
+                          </Form.Item>
+                        ) : (
+                          <div className="mt-1 p-2 bg-gray-50 rounded">
+                            {localModelData.litellm_params?.rpd || "Not Set"}
+                          </div>
+                        )}
+                      </div>
+
+                      <div>
                         <Text className="font-medium">Max Retries</Text>
                         {isEditing ? (
                           <Form.Item name="max_retries" className="mb-0">
@@ -757,7 +790,7 @@ export default function ModelInfoView({
                                 localModelData.model_info.access_groups
                               ) ? (
                                 localModelData.model_info.access_groups.length >
-                                0 ? (
+                                  0 ? (
                                   <div className="flex flex-wrap gap-1">
                                     {localModelData.model_info.access_groups.map(
                                       (group: string, index: number) => (
@@ -787,14 +820,14 @@ export default function ModelInfoView({
                         <Text className="font-medium">
                           Guardrails{' '}
                           <Tooltip title="Apply safety guardrails to this model to filter content or enforce policies">
-                            <a 
-                              href="https://docs.litellm.ai/docs/proxy/guardrails/quick_start" 
-                              target="_blank" 
+                            <a
+                              href="https://docs.litellm.ai/docs/proxy/guardrails/quick_start"
+                              target="_blank"
                               rel="noopener noreferrer"
                               onClick={(e) => e.stopPropagation()}
                             >
                               <InfoCircleOutlined style={{ marginLeft: '4px' }} />
-                            </a>  
+                            </a>
                           </Tooltip>
                         </Text>
                         {isEditing ? (
@@ -814,34 +847,34 @@ export default function ModelInfoView({
                               }))}
                             />
                           </Form.Item>
-                                                 ) : (
-                           <div className="mt-1 p-2 bg-gray-50 rounded">
-                             {localModelData.litellm_params?.guardrails ? (
-                               Array.isArray(localModelData.litellm_params.guardrails) ? (
-                                 localModelData.litellm_params.guardrails.length > 0 ? (
-                                   <div className="flex flex-wrap gap-1">
-                                     {localModelData.litellm_params.guardrails.map(
-                                       (guardrail: string, index: number) => (
-                                         <span
-                                           key={index}
-                                           className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
-                                         >
-                                           {guardrail}
-                                         </span>
-                                       )
-                                     )}
-                                   </div>
-                                 ) : (
-                                   "No guardrails assigned"
-                                 )
-                               ) : (
-                                 localModelData.litellm_params.guardrails
-                               )
-                             ) : (
-                               "Not Set"
-                             )}
-                           </div>
-                         )}
+                        ) : (
+                          <div className="mt-1 p-2 bg-gray-50 rounded">
+                            {localModelData.litellm_params?.guardrails ? (
+                              Array.isArray(localModelData.litellm_params.guardrails) ? (
+                                localModelData.litellm_params.guardrails.length > 0 ? (
+                                  <div className="flex flex-wrap gap-1">
+                                    {localModelData.litellm_params.guardrails.map(
+                                      (guardrail: string, index: number) => (
+                                        <span
+                                          key={index}
+                                          className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800"
+                                        >
+                                          {guardrail}
+                                        </span>
+                                      )
+                                    )}
+                                  </div>
+                                ) : (
+                                  "No guardrails assigned"
+                                )
+                              ) : (
+                                localModelData.litellm_params.guardrails
+                              )
+                            ) : (
+                              "Not Set"
+                            )}
+                          </div>
+                        )}
                       </div>
 
                       {/* Cache Control Section */}

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -30,6 +30,8 @@ interface ModelGroupInfo {
   mode?: string;
   tpm?: number;
   rpm?: number;
+  tpd?: number;
+  rpd?: number;
   supports_parallel_function_calling: boolean;
   supports_vision: boolean;
   supports_function_calling: boolean;
@@ -253,10 +255,12 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
     return tokens.toString();
   };
 
-  const formatLimits = (rpm?: number, tpm?: number) => {
+  const formatLimits = (rpm?: number, tpm?: number, rpd?: number, tpd?: number) => {
     const limits = [];
     if (rpm) limits.push(`RPM: ${rpm.toLocaleString()}`);
     if (tpm) limits.push(`TPM: ${tpm.toLocaleString()}`);
+    if (rpd) limits.push(`RPD: ${rpd.toLocaleString()}`);
+    if (tpd) limits.push(`TPD: ${tpd.toLocaleString()}`);
     return limits.length > 0 ? limits.join(", ") : "N/A";
   };
 
@@ -467,7 +471,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
         const model = row.original;
         return (
           <Text className="text-xs text-gray-600">
-            {formatLimits(model.rpm, model.tpm)}
+            {formatLimits(model.rpm, model.tpm, model.rpd, model.tpd)}
           </Text>
         );
       },
@@ -770,7 +774,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
             </div>
 
             {/* Rate Limits */}
-            {(selectedModel.tpm || selectedModel.rpm) && (
+            {(selectedModel.tpm || selectedModel.rpm || selectedModel.tpd || selectedModel.rpd) && (
               <div>
                 <Text className="text-lg font-semibold mb-4">Rate Limits</Text>
                 <div className="grid grid-cols-2 gap-4">
@@ -784,6 +788,18 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
                     <div>
                       <Text className="font-medium">Requests per Minute:</Text>
                       <Text>{selectedModel.rpm.toLocaleString()}</Text>
+                    </div>
+                  )}
+                  {selectedModel.tpd && (
+                    <div>
+                      <Text className="font-medium">Tokens per Day:</Text>
+                      <Text>{selectedModel.tpd.toLocaleString()}</Text>
+                    </div>
+                  )}
+                  {selectedModel.rpd && (
+                    <div>
+                      <Text className="font-medium">Requests per Day:</Text>
+                      <Text>{selectedModel.rpd.toLocaleString()}</Text>
                     </div>
                   )}
                 </div>
@@ -860,4 +876,4 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken }) => {
   );
 };
 
-export default PublicModelHub; 
+export default PublicModelHub;

--- a/ui/litellm-dashboard/src/components/public_model_hub_columns.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub_columns.tsx
@@ -14,6 +14,8 @@ interface ModelGroupInfo {
   mode?: string;
   tpm?: number;
   rpm?: number;
+  tpd?: number;
+  rpd?: number;
   supports_parallel_function_calling: boolean;
   supports_vision: boolean;
   supports_function_calling: boolean;
@@ -33,10 +35,12 @@ const formatTokens = (tokens: number | undefined) => {
   return tokens.toString();
 };
 
-const formatLimits = (rpm?: number, tpm?: number) => {
+const formatLimits = (rpm?: number, tpm?: number, rpd?: number, tpd?: number) => {
   const limits = [];
   if (rpm) limits.push(`RPM: ${rpm.toLocaleString()}`);
   if (tpm) limits.push(`TPM: ${tpm.toLocaleString()}`);
+  if (rpd) limits.push(`RPD: ${rpd.toLocaleString()}`);
+  if (tpd) limits.push(`TPD: ${tpd.toLocaleString()}`);
   return limits.length > 0 ? limits.join(", ") : "N/A";
 };
 
@@ -209,10 +213,10 @@ export const publicModelHubColumns = (): ColumnDef<ModelGroupInfo>[] => [
       const model = row.original;
       return (
         <Text className="text-xs text-gray-600">
-          {formatLimits(model.rpm, model.tpm)}
+          {formatLimits(model.rpm, model.tpm, model.rpd, model.tpd)}
         </Text>
       );
     },
     size: 150,
   },
-]; 
+];


### PR DESCRIPTION
## Title

Add support for tracking and enforcing TPD and RPD limits

## Relevant issues

NA

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Add the ability to set RPD and RPD limits on a model, and updates `lowest_cost_router.py` to respect those limits.   Its possible to extend this to the other routers, but that would violate the project expectations of "My PR's scope is as isolated as possible, it only solves 1 specific problem".

<img width="1435" height="257" alt="Screenshot 2025-07-30 at 8 17 43 AM" src="https://github.com/user-attachments/assets/9c617509-3ea6-46b3-affb-2a711e398f66" />
