### PR TITLE
Team Member Permissions Page - Access Column Changes

### DIFF
--- a/ui/litellm-dashboard/src/components/team/member_permissions.tsx
+++ b/ui/litellm-dashboard/src/components/team/member_permissions.tsx
@@ -107,12 +107,12 @@ const MemberPermissions: React.FC<MemberPermissionsProps> = ({ teamId, accessTok
           <Table className=" min-w-full">
             <TableHead>
               <TableRow>
-                <TableHeaderCell className="sticky left-0 bg-white shadow-[4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
-                  Allow Access
-                </TableHeaderCell>
                 <TableHeaderCell>Method</TableHeaderCell>
                 <TableHeaderCell>Endpoint</TableHeaderCell>
                 <TableHeaderCell>Description</TableHeaderCell>
+                <TableHeaderCell className="sticky right-0 bg-white shadow-[-4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
+                  Allow Access
+                </TableHeaderCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -120,13 +120,6 @@ const MemberPermissions: React.FC<MemberPermissionsProps> = ({ teamId, accessTok
                 const permInfo = getPermissionInfo(permission)
                 return (
                   <TableRow key={permission} className="hover:bg-gray-50 transition-colors">
-                    <TableCell className="sticky left-0 bg-white shadow-[4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
-                      <Checkbox
-                        checked={selectedPermissions.includes(permission)}
-                        onChange={(e) => handlePermissionChange(permission, e.target.checked)}
-                        disabled={!canEditTeam}
-                      />
-                    </TableCell>
                     <TableCell>
                       <span
                         className={`px-2 py-1 rounded text-xs font-medium ${
@@ -140,6 +133,13 @@ const MemberPermissions: React.FC<MemberPermissionsProps> = ({ teamId, accessTok
                       <span className="font-mono text-sm text-gray-800">{permInfo.endpoint}</span>
                     </TableCell>
                     <TableCell className="text-gray-700">{permInfo.description}</TableCell>
+                    <TableCell className="sticky right-0 bg-white shadow-[-4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
+                      <Checkbox
+                        checked={selectedPermissions.includes(permission)}
+                        onChange={(e) => handlePermissionChange(permission, e.target.checked)}
+                        disabled={!canEditTeam}
+                      />
+                    </TableCell>
                   </TableRow>
                 )
               })}

--- a/ui/litellm-dashboard/src/components/team/member_permissions.tsx
+++ b/ui/litellm-dashboard/src/components/team/member_permissions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react"
 import {
   Card,
   Title,
@@ -10,83 +10,79 @@ import {
   TableBody,
   TableRow,
   TableCell,
-} from "@tremor/react";
-import { Button, message, Checkbox, Empty } from "antd";
-import { ReloadOutlined, SaveOutlined } from "@ant-design/icons";
-import { getTeamPermissionsCall, teamPermissionsUpdateCall } from "@/components/networking";
-import { getPermissionInfo } from "./permission_definitions";
+} from "@tremor/react"
+import { Button, message, Checkbox, Empty } from "antd"
+import { ReloadOutlined, SaveOutlined } from "@ant-design/icons"
+import { getTeamPermissionsCall, teamPermissionsUpdateCall } from "@/components/networking"
+import { getPermissionInfo } from "./permission_definitions"
 
 interface MemberPermissionsProps {
-  teamId: string;
-  accessToken: string | null;
-  canEditTeam: boolean;
+  teamId: string
+  accessToken: string | null
+  canEditTeam: boolean
 }
 
-const MemberPermissions: React.FC<MemberPermissionsProps> = ({
-  teamId,
-  accessToken,
-  canEditTeam,
-}) => {
-  const [permissions, setPermissions] = useState<string[]>([]);
-  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [hasChanges, setHasChanges] = useState(false);
+const MemberPermissions: React.FC<MemberPermissionsProps> = ({ teamId, accessToken, canEditTeam }) => {
+  const [permissions, setPermissions] = useState<string[]>([])
+  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [hasChanges, setHasChanges] = useState(false)
 
   const fetchPermissions = async () => {
     try {
-      setLoading(true);
-      if (!accessToken) return;
-      const response = await getTeamPermissionsCall(accessToken, teamId);
-      const allPermissions = response.all_available_permissions || [];
-      setPermissions(allPermissions);
-      const teamPermissions = response.team_member_permissions || [];
-      setSelectedPermissions(teamPermissions);
-      setHasChanges(false);
+      setLoading(true)
+      if (!accessToken) return
+      const response = await getTeamPermissionsCall(accessToken, teamId)
+      const allPermissions = response.all_available_permissions || []
+      setPermissions(allPermissions)
+      const teamPermissions = response.team_member_permissions || []
+      setSelectedPermissions(teamPermissions)
+      setHasChanges(false)
     } catch (error) {
-      message.error("Failed to load permissions");
-      console.error("Error fetching permissions:", error);
+      message.error("Failed to load permissions")
+      console.error("Error fetching permissions:", error)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchPermissions();
-  }, [teamId, accessToken]);
+    fetchPermissions()
+  }, [teamId, accessToken])
 
   const handlePermissionChange = (permission: string, checked: boolean) => {
     const newSelectedPermissions = checked
       ? [...selectedPermissions, permission]
-      : selectedPermissions.filter((p) => p !== permission);
-    setSelectedPermissions(newSelectedPermissions);
-    setHasChanges(true);
-  };
+      : selectedPermissions.filter((p) => p !== permission)
+    setSelectedPermissions(newSelectedPermissions)
+    setHasChanges(true)
+  }
 
   const handleSave = async () => {
     try {
-      if (!accessToken) return;
-      setSaving(true);
-      await teamPermissionsUpdateCall(accessToken, teamId, selectedPermissions);
-      message.success("Permissions updated successfully");
-      setHasChanges(false);
+      if (!accessToken) return
+      setSaving(true)
+      await teamPermissionsUpdateCall(accessToken, teamId, selectedPermissions)
+      message.success("Permissions updated successfully")
+      setHasChanges(false)
     } catch (error) {
-      message.error("Failed to update permissions");
-      console.error("Error updating permissions:", error);
+      message.error("Failed to update permissions")
+      console.error("Error updating permissions:", error)
     } finally {
-      setSaving(false);
+      setSaving(false)
     }
-  };
-
-  const handleReset = () => {
-    fetchPermissions();
-  };
-
-  if (loading) {
-    return <div className="p-6 text-center">Loading permissions...</div>;
   }
 
-  const hasPermissions = permissions.length > 0;
+  const handleReset = () => {
+    fetchPermissions()
+  }
+
+  if (loading) {
+    return <div className="p-6 text-center">Loading permissions...</div>
+  }
+
+  const hasPermissions = permissions.length > 0
 
   return (
     <Card className="bg-white shadow-md rounded-md p-6">
@@ -97,79 +93,66 @@ const MemberPermissions: React.FC<MemberPermissionsProps> = ({
             <Button icon={<ReloadOutlined />} onClick={handleReset}>
               Reset
             </Button>
-            <TremorButton
-              onClick={handleSave}
-              loading={saving}
-              className="flex items-center gap-2"
-            >
+            <TremorButton onClick={handleSave} loading={saving} className="flex items-center gap-2">
               <SaveOutlined /> Save Changes
             </TremorButton>
           </div>
         )}
       </div>
 
-      <Text className="mb-6 text-gray-600">
-        Control what team members can do when they are not team admins.
-      </Text>
+      <Text className="mb-6 text-gray-600">Control what team members can do when they are not team admins.</Text>
 
       {hasPermissions ? (
-        <Table className="mt-4">
-          <TableHead>
-            <TableRow>
-              <TableHeaderCell>Method</TableHeaderCell>
-              <TableHeaderCell>Endpoint</TableHeaderCell>
-              <TableHeaderCell>Description</TableHeaderCell>
-              <TableHeaderCell className="text-right">Access</TableHeaderCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {permissions.map((permission) => {
-              const permInfo = getPermissionInfo(permission);
-              return (
-                <TableRow
-                  key={permission}
-                  className="hover:bg-gray-50 transition-colors"
-                >
-                  <TableCell>
-                    <span
-                      className={`px-2 py-1 rounded text-xs font-medium ${
-                        permInfo.method === "GET"
-                          ? "bg-blue-100 text-blue-800"
-                          : "bg-green-100 text-green-800"
-                      }`}
-                    >
-                      {permInfo.method}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <span className="font-mono text-sm text-gray-800">
-                      {permInfo.endpoint}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-gray-700">
-                    {permInfo.description}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <Checkbox
-                      checked={selectedPermissions.includes(permission)}
-                      onChange={(e) =>
-                        handlePermissionChange(permission, e.target.checked)
-                      }
-                      disabled={!canEditTeam}
-                    />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
+        <div className="overflow-x-auto">
+          <Table className=" min-w-full">
+            <TableHead>
+              <TableRow>
+                <TableHeaderCell className="sticky left-0 bg-white shadow-[4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
+                  Allow Access
+                </TableHeaderCell>
+                <TableHeaderCell>Method</TableHeaderCell>
+                <TableHeaderCell>Endpoint</TableHeaderCell>
+                <TableHeaderCell>Description</TableHeaderCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {permissions.map((permission) => {
+                const permInfo = getPermissionInfo(permission)
+                return (
+                  <TableRow key={permission} className="hover:bg-gray-50 transition-colors">
+                    <TableCell className="sticky left-0 bg-white shadow-[4px_0_4px_-4px_rgba(0,0,0,0.1)] text-center">
+                      <Checkbox
+                        checked={selectedPermissions.includes(permission)}
+                        onChange={(e) => handlePermissionChange(permission, e.target.checked)}
+                        disabled={!canEditTeam}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`px-2 py-1 rounded text-xs font-medium ${
+                          permInfo.method === "GET" ? "bg-blue-100 text-blue-800" : "bg-green-100 text-green-800"
+                        }`}
+                      >
+                        {permInfo.method}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-sm text-gray-800">{permInfo.endpoint}</span>
+                    </TableCell>
+                    <TableCell className="text-gray-700">{permInfo.description}</TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
       ) : (
         <div className="py-12">
           <Empty description="No permissions available" />
         </div>
       )}
     </Card>
-  );
-};
+  )
+}
 
-export default MemberPermissions;
+export default MemberPermissions


### PR DESCRIPTION
## Title
Team Member Permissions Page - Access Column Changes
<!-- e.g. "Implement user authentication feature" -->
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
- Modified column header name from "Access" to "Allow Access" 
  - "Allow Access" is explicit - it clearly tells users "checking this box will allow access to this permission"
- Added right sticky that doesn't block content when scrolling horizontally
   
:white_check_mark:　Tested that we are able to save the permissions.

Screenshot with smaller screen size:
<img width="1512" height="812" alt="Screenshot 2025-07-31 at 4 08 21" src="https://github.com/user-attachments/assets/b0c259da-9cb2-40c2-84c0-6480a877459f" />

