### PR TITLE
[Bug]: Set user from token user_id for OpenMeter integration

### DIFF
--- a/litellm/integrations/openmeter.py
+++ b/litellm/integrations/openmeter.py
@@ -66,8 +66,18 @@ class OpenMeterLogger(CustomLogger):
             }
 
         user_param = kwargs.get("user", None)  # end-user passed in via 'user' param
+        
+        # If no user provided directly, try to get it from token user_id
         if user_param is None:
-            raise Exception("OpenMeter: user is required")
+            # Check if user_id is available from the API key metadata
+            litellm_params = kwargs.get("litellm_params", {})
+            metadata = litellm_params.get("metadata", {})
+            user_api_key_user_id = metadata.get("user_api_key_user_id", None)
+            
+            if user_api_key_user_id is not None:
+                user_param = user_api_key_user_id
+            else:
+                raise Exception("OpenMeter: user is required")
         
         # Ensure subject is always a string for OpenMeter API
         subject = str(user_param)


### PR DESCRIPTION
## Title
[Bug]: Set user from token user_id for OpenMeter integration

## Relevant issues
Fixes https://github.com/BerriAI/litellm/issues/7569
Related to revert PR #13107 (original PR #13029)

## Pre-Submission checklist
- [x] I have Added testing in the tests/litellm/ directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on make test-unit
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix
✅ Test

## Changes

### Problem
OpenMeter integration was failing with "user is required" error when tokens contained user_id but request didn't explicitly include user parameter.

### Root Cause  
OpenMeter integration requires a `user` parameter, but when using API tokens with embedded `user_id`, the integration wasn't checking for `user_api_key_user_id` in the metadata passed from the proxy layer.

### Solution
Following maintainer feedback from #13107 , implemented the fix directly in the OpenMeter integration:

- Modified `litellm/integrations/openmeter.py` `_common_logic` method to check for `user_api_key_user_id` in metadata when:
  - No user is provided in request data
  - Metadata contains a valid `user_api_key_user_id` from the token
- Maintains priority: request body user > token user_id
- Ensures backward compatibility

### Testing
Added 7 comprehensive tests to `tests/test_litellm/integrations/test_openmeter.py`:
- `test_common_logic_user_from_token_user_id` - User extracted from token user_id
- `test_common_logic_direct_user_takes_priority_over_token` - Direct user overrides token
- `test_common_logic_missing_user_and_token_user_id` - Error when neither available
- `test_common_logic_token_user_id_none` - Error when token user_id is None
- `test_common_logic_no_metadata` - Error when no metadata available
- `test_common_logic_integer_token_user_id` - Integer user_id converted to string
- `test_integration_token_user_id_scenario` - Full integration test simulating the failing scenario

All 18 OpenMeter tests pass (11 existing + 7 new).

### Files Changed
- `litellm/integrations/openmeter.py` - Core fix in OpenMeter integration
- `tests/test_litellm/integrations/test_openmeter.py` - Comprehensive test coverage

### Test Results
```bash
============================== 18 passed in 5.18s ==============================
```

This fix ensures that users with API tokens containing `user_id` can use OpenMeter integration without explicitly passing the user parameter in every request.