### PR TITLE
add framework name to UserAgent header in AWS Bedrock API call

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -678,6 +678,12 @@ class BaseAWSLLM:
         headers: dict,
         api_key: Optional[str] = None,
     ) -> AWSPreparedRequest:
+        # update User-Agent field in headers to include framework name
+        if "User-Agent" in headers:
+            headers["User-Agent"] += " x-client-framework:litellm"
+        else:
+            headers["User-Agent"] = "x-client-framework:litellm"
+                
         if api_key is not None:
             aws_bearer_token: Optional[str] = api_key
         else:
@@ -733,6 +739,13 @@ class BaseAWSLLM:
         Returns:
             Tuple[dict, Optional[str]]: A tuple containing the headers and the json str body of the request
         """
+        # update User-Agent field in headers to include framework name
+        headers = headers or {}
+        if "User-Agent" in headers:
+            headers["User-Agent"] += " x-client-framework:litellm"
+        else:
+            headers["User-Agent"] = "x-client-framework:litellm"
+                
         if api_key is not None:
             aws_bearer_token: Optional[str] = api_key
         else:
@@ -740,7 +753,6 @@ class BaseAWSLLM:
 
         # If aws bearer token is set, use it directly in the header
         if aws_bearer_token:
-            headers = headers or {}
             headers["Content-Type"] = "application/json"
             headers["Authorization"] = f"Bearer {aws_bearer_token}"
             return headers, json.dumps(request_data).encode()


### PR DESCRIPTION
## Title

This PR adds the framework name `liteLLM` into the header of Bedrock API call, which is used to collect the Bedrock API usage from liteLLM. Similar change had been made to other framework such as [langchain](https://github.com/langchain-ai/langchain-aws/pull/558)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![Cursor_and_litellm_—_bash_—_bash__qterm__▸_bash_—_190×48](https://github.com/user-attachments/assets/b7144c0c-b362-489a-8398-199961db6cd2)


## Type

🆕 New Feature
✅ Test

## Changes

Add `x-client-framework:litellm` into UserAgent field of header in Bedrock API call. 
