### PR TITLE
Fix/panw prisma airs post call hook

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/__init__.py
@@ -24,6 +24,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         **{
             **litellm_params.model_dump(),
             "guardrail_name": guardrail_name,
+            "event_hook": litellm_params.mode,
             "default_on": litellm_params.default_on or False,
         }
     )

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -293,7 +293,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         return None
 
     @log_guardrail_information
-    async def async_post_call_hook(
+    async def async_post_call_success_hook(
         self,
         data: Dict[str, Any],
         user_api_key_dict: UserAPIKeyAuth,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -280,7 +280,7 @@ class TestPanwAirsResponseScanning:
         mock_response = {"action": "allow", "category": "benign"}
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
-            result = await handler.async_post_call_hook(
+            result = await handler.async_post_call_success_hook(
                 data=request_data,
                 user_api_key_dict=user_api_key_dict,
                 response=safe_response,
@@ -299,7 +299,7 @@ class TestPanwAirsResponseScanning:
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
             with pytest.raises(HTTPException) as exc_info:
-                await handler.async_post_call_hook(
+                await handler.async_post_call_success_hook(
                     data=request_data,
                     user_api_key_dict=user_api_key_dict,
                     response=harmful_response,


### PR DESCRIPTION
## Title

Fix PANW Prisma AIRS post-call hook method name

## Relevant issues

N/A (discovered during additional testing , post-call hooks were not being invoked)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🐛 Bug Fix


## Changes

### Problem
The PANW Prisma AIRS guardrail was only scanning prompts (pre-call) but not responses (post-call) due to incorrect method name

### Solution
- Renamed `async_post_call_hook` to `async_post_call_success_hook` in `PanwPrismaAirsHandler`
- Added `event_hook: litellm_params.mode` to the guardrail initialization
- Updated tests to use the correct method name

### Testing
- All PANW tests pass
- Manual testing confirms response blocking now works
- Both pre-call and post-call hooks function correctly

<img width="1148" height="399" alt="Screenshot 2025-07-31 at 1 17 37 PM" src="https://github.com/user-attachments/assets/ef2d1cde-2a8c-4cc8-b9bf-a2ab289f76d7" />

