### PR TITLE
[Feat] Background Health Checks - Allow disabling background health checks for a specific 

### DIFF
--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -219,7 +219,7 @@ Here's how to use it:
 ```
 general_settings: 
   background_health_checks: True # enable background health checks
-  health_check_interval: 300 # frequency of background health checks
+ health_check_interval: 300 # frequency of background health checks
 ```
 
 2. Start server 
@@ -229,7 +229,24 @@ $ litellm /path/to/config.yaml
 
 3. Query health endpoint: 
 ```
-curl --location 'http://0.0.0.0:4000/health'
+ curl --location 'http://0.0.0.0:4000/health'
+```
+
+### Disable Background Health Checks For Specific Models
+
+Use this if you want to disable background health checks for specific models.
+
+If `background_health_checks` is enabled you can skip individual models by
+setting `disable_background_health_check: true` in the model's `model_info`.
+
+```yaml
+model_list:
+  - model_name: openai/gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+    model_info:
+      disable_background_health_check: true
 ```
 
 ### Hide details

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1353,6 +1353,13 @@ async def _run_background_health_check():
         # make 1 deep copy of llm_model_list on every health check iteration
         _llm_model_list = copy.deepcopy(llm_model_list) or []
 
+        # filter out models that have disabled background health checks
+        _llm_model_list = [
+            m
+            for m in _llm_model_list
+            if not m.get("model_info", {}).get("disable_background_health_check", False)
+        ]
+
         healthy_endpoints, unhealthy_endpoints = await perform_health_check(
             model_list=_llm_model_list, details=health_check_details
         )


### PR DESCRIPTION
## [Feat] Background Health Checks - Allow disabling background health checks for a specific 

> is there any way to disable background health checks only for specific models? I think it makes sense in our case to e.g. disable them for VertexAI provider but keeping the hosted_vllm ones

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


