### PR TITLE
fix: support negative indexes in cache_control_injection_points for Anthropic Claude (#10226)

### DIFF
--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -167,3 +167,589 @@ async def test_anthropic_cache_control_hook_user_message():
             assert request_body["messages"][1]["content"][1]["cachePoint"] == {
                 "type": "default"
             }
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_negative_indices():
+    """
+    Test the bug fix for handling negative indices in cache control injection points.
+    This test verifies that negative indices (-1, -2) are properly converted to positive indices
+    and cache control is applied to the correct messages.
+    """
+    # Use patch.dict to mock environment variables instead of setting them directly
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Here is my analysis of the key terms and conditions...",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 200,
+                "totalTokens": 300,
+                "cacheReadInputTokens": 100,
+                "cacheWriteInputTokens": 200,
+            },
+        }
+        mock_response.status_code = 200
+
+        # Mock AsyncHTTPHandler.post method
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            # Test with multiple messages and negative indices
+            response = await litellm.acompletion(
+                model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are an AI assistant tasked with analyzing legal documents.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Here is the first part of the document.",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "I understand. Please provide the document.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Here is the full legal document text that should be cached.",
+                    },
+                ],
+                cache_control_injection_points=[
+                    {
+                        "location": "message",
+                        "index": -1,  # Should target the last message (index 3)
+                    },
+                    {
+                        "location": "message",
+                        "index": -2,  # Should target the second-to-last message (index 2)
+                    },
+                ],
+                client=client,
+            )
+
+            mock_post.assert_called_once()
+            request_body = json.loads(mock_post.call_args.kwargs["data"])
+
+            print("request_body: ", json.dumps(request_body, indent=4))
+
+            # The input `messages` has 4 elements. After removing the system message,
+            # the `request_body["messages"]` will have 3 elements (indices 0, 1, 2).
+
+            # Verify the last message (input index -1 -> request index 2) has cache control
+            last_message_content = request_body["messages"][2]["content"]
+            assert isinstance(
+                last_message_content, list
+            ), "Last message content should be a list"
+            assert any(
+                "cachePoint" in item
+                for item in last_message_content
+                if isinstance(item, dict)
+            ), "CachePoint missing in last message"
+
+            # Note: Based on debug output, the hook correctly applies cache control to both messages,
+            # but the Bedrock API transformation appears to only preserve cache control for user messages,
+            # not assistant messages. This is a limitation of the API transformation layer.
+            #
+            # The second-to-last message (assistant) gets cache_control from the hook but loses it
+            # during API transformation. This test documents this behavior.
+            second_last_message_content = request_body["messages"][1]["content"]
+            assert isinstance(
+                second_last_message_content, list
+            ), "Second-to-last message content should be a list"
+
+            # Check if assistant message cache control is preserved (currently it's not)
+            assistant_has_cache_control = any(
+                "cachePoint" in item
+                for item in second_last_message_content
+                if isinstance(item, dict)
+            )
+            print(
+                f"Assistant message has cache control in final request: {assistant_has_cache_control}"
+            )
+
+            # Verify the first user message (request index 0) was NOT modified
+            first_user_message_content = request_body["messages"][0]["content"]
+            assert isinstance(
+                first_user_message_content, list
+            ), "First user message content should be a list"
+            assert not any(
+                "cachePoint" in item
+                for item in first_user_message_content
+                if isinstance(item, dict)
+            ), "CachePoint unexpectedly found in first user message"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_out_of_bounds_logging():
+    """
+    Test that warning logs are generated when out-of-bounds indices are used.
+    This verifies that the verbose_logger.warning is called with the correct message.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 50,
+                "outputTokens": 100,
+                "totalTokens": 150,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+
+        # Mock the verbose_logger to capture warning calls
+        with patch(
+            "litellm.integrations.anthropic_cache_control_hook.verbose_logger"
+        ) as mock_logger:
+            with patch.object(client, "post", return_value=mock_response) as mock_post:
+                messages = [
+                    {"role": "user", "content": "Message 1"},
+                    {"role": "user", "content": "Message 2"},
+                ]
+
+                await litellm.acompletion(
+                    model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                    messages=messages,
+                    cache_control_injection_points=[
+                        {"location": "message", "index": 10}
+                    ],  # Out of bounds index
+                    client=client,
+                )
+
+                # Verify that warning was called with the expected message
+                mock_logger.warning.assert_called_once()
+                warning_call = mock_logger.warning.call_args[0][0]
+
+                # Check that the warning message contains the expected information
+                assert (
+                    "AnthropicCacheControlHook: Provided index 10 is out of bounds"
+                    in warning_call
+                )
+                assert "message list of length 2" in warning_call
+                assert "Targeted index was 10" in warning_call
+                assert "Skipping cache control injection for this point" in warning_call
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_negative_out_of_bounds_logging():
+    """
+    Test that warning logs are generated for negative indices that are out of bounds.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 50,
+                "outputTokens": 100,
+                "totalTokens": 150,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+
+        # Mock the verbose_logger to capture warning calls
+        with patch(
+            "litellm.integrations.anthropic_cache_control_hook.verbose_logger"
+        ) as mock_logger:
+            with patch.object(client, "post", return_value=mock_response) as mock_post:
+                messages = [
+                    {"role": "user", "content": "Single message"},
+                ]
+
+                await litellm.acompletion(
+                    model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                    messages=messages,
+                    cache_control_injection_points=[
+                        {
+                            "location": "message",
+                            "index": -5,
+                        }  # Negative out of bounds index
+                    ],
+                    client=client,
+                )
+
+                # Verify that warning was called with the expected message
+                mock_logger.warning.assert_called_once()
+                warning_call = mock_logger.warning.call_args[0][0]
+
+                # Check that the warning message contains the original negative index
+                assert (
+                    "AnthropicCacheControlHook: Provided index -5 is out of bounds"
+                    in warning_call
+                )
+                assert "message list of length 1" in warning_call
+                assert (
+                    "Targeted index was -4" in warning_call
+                )  # -5 + 1 = -4 (converted index)
+                assert "Skipping cache control injection for this point" in warning_call
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_multiple_user_messages():
+    """
+    Test cache control injection on multiple user messages specifically.
+    Note: Bedrock API combines consecutive user messages into a single message with multiple content blocks.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 100,
+                "outputTokens": 200,
+                "totalTokens": 300,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            # Test with multiple user messages and negative indices
+            response = await litellm.acompletion(
+                model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "First user message.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Second user message.",
+                    },
+                    {
+                        "role": "user",
+                        "content": "Third user message that should be cached.",
+                    },
+                ],
+                cache_control_injection_points=[
+                    {
+                        "location": "message",
+                        "index": -1,  # Should target the last message (index 2)
+                    },
+                    {
+                        "location": "message",
+                        "index": -2,  # Should target the second-to-last message (index 1)
+                    },
+                ],
+                client=client,
+            )
+
+            mock_post.assert_called_once()
+            request_body = json.loads(mock_post.call_args.kwargs["data"])
+
+            print(
+                "Multiple user messages request_body: ",
+                json.dumps(request_body, indent=4),
+            )
+
+            # Bedrock API combines consecutive user messages into a single message
+            assert len(request_body["messages"]) == 1
+
+            # The combined message should have multiple content blocks with cache control
+            combined_message_content = request_body["messages"][0]["content"]
+            assert isinstance(combined_message_content, list)
+
+            # Count cache control points - should have 2 since both injection points were applied
+            cache_control_count = sum(
+                1
+                for item in combined_message_content
+                if isinstance(item, dict) and "cachePoint" in item
+            )
+            assert cache_control_count == 2
+
+            print(
+                f"Found {cache_control_count} cache control points in the combined message"
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_index", [10, -10])
+async def test_anthropic_cache_control_hook_out_of_bounds(bad_index):
+    """
+    Verify the hook does not raise an error and makes no changes
+    when an out-of-bounds index is provided.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 50,
+                "outputTokens": 100,
+                "totalTokens": 150,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            messages = [
+                {"role": "user", "content": "Message 1"},
+                {"role": "user", "content": "Message 2"},
+            ]
+
+            await litellm.acompletion(
+                model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                messages=messages,
+                cache_control_injection_points=[
+                    {"location": "message", "index": bad_index}
+                ],
+                client=client,
+            )
+
+            mock_post.assert_called_once()
+            request_body = json.loads(mock_post.call_args.kwargs["data"])
+
+            # Assert that NO cache control was applied to any message
+            for msg in request_body["messages"]:
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    assert not any(
+                        "cachePoint" in item
+                        for item in content
+                        if isinstance(item, dict)
+                    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message_list",
+    [
+        [{"role": "user", "content": "Single message"}]
+    ],  # Single message only - empty list will fail at API level
+)
+async def test_anthropic_cache_control_hook_single_message(message_list):
+    """
+    Verify the hook runs without error on very short message lists.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 50,
+                "outputTokens": 100,
+                "totalTokens": 150,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            await litellm.acompletion(
+                model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                messages=message_list,
+                cache_control_injection_points=[{"location": "message", "index": -1}],
+                client=client,
+            )
+
+            mock_post.assert_called_once()
+            request_body = json.loads(mock_post.call_args.kwargs["data"])
+            # For the single message, verify cache control was applied
+            content = request_body["messages"][0]["content"]
+            assert isinstance(content, list)
+            assert any(
+                "cachePoint" in item for item in content if isinstance(item, dict)
+            )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_empty_message_list():
+    """
+    Verify that empty message lists are handled appropriately (should fail at API level, not hook level).
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=MagicMock()) as mock_post:
+            # This should fail at the API level, not the hook level
+            with pytest.raises(
+                litellm.BadRequestError,
+                match="bedrock requires at least one non-system message",
+            ):
+                await litellm.acompletion(
+                    model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                    messages=[],
+                    cache_control_injection_points=[
+                        {"location": "message", "index": -1}
+                    ],
+                    client=client,
+                )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_cache_control_hook_no_op():
+    """
+    Verify that if no injection points are specified, messages remain unmodified.
+    """
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ACCESS_KEY_ID": "fake_access_key_id",
+            "AWS_SECRET_ACCESS_KEY": "fake_secret_access_key",
+            "AWS_REGION_NAME": "us-west-2",
+        },
+    ):
+        anthropic_cache_control_hook = AnthropicCacheControlHook()
+        litellm.callbacks = [anthropic_cache_control_hook]
+
+        # Mock response data
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": "Response",
+                }
+            },
+            "stopReason": "stop_sequence",
+            "usage": {
+                "inputTokens": 50,
+                "outputTokens": 100,
+                "totalTokens": 150,
+            },
+        }
+        mock_response.status_code = 200
+
+        client = AsyncHTTPHandler()
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            messages = [
+                {"role": "user", "content": "Message 1"},
+                {"role": "user", "content": "Message 2"},
+            ]
+
+            await litellm.acompletion(
+                model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                messages=messages,
+                # No cache_control_injection_points parameter
+                client=client,
+            )
+
+            mock_post.assert_called_once()
+            request_body = json.loads(mock_post.call_args.kwargs["data"])
+
+            # Assert that NO cache control was applied
+            for msg in request_body["messages"]:
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    assert not any(
+                        "cachePoint" in item
+                        for item in content
+                        if isinstance(item, dict)
+                    )


### PR DESCRIPTION
## Title

Fix for AnthropicCacheControlHook did not correctly handle negative indices (e.g., -1, -2) for cache_control_injection_points. 

## Relevant issues

Fixes #10226 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

### Changes

This PR fixes a bug where the `AnthropicCacheControlHook` did not correctly handle negative indexes (e.g., -1, -2) in `cache_control_injection_points`.

#### Specifically:
- Negative indexes are now properly converted to positive equivalents based on the `messages` list length.
- This allows users to inject cache control directives at the correct position (e.g., the last message, second-last message) in multi-turn Claude conversations.
- This behavior is necessary to support AWS Bedrock's multi-turn prompt caching via LiteLLM, as documented here: [Bedrock Prompt Caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).

#### Additional:
- Unit tests were added in `test_anthropic_cache_control_hook.py` to validate:
  - Support for single and multiple negative index injection points
  - Behavior when invalid or out-of-bound indexes are provided

###Testing 
Unit tests
<img width="3786" height="424" alt="image" src="https://github.com/user-attachments/assets/78202bc6-ad3e-4be9-9641-73647cd64085" />


simple_bedrock_proxy.yaml
```
model_list:
  - model_name: bedrock-claude-cache-test
    litellm_params:
      # FIX: Changed to the required Inference Profile ID for Claude 3.7 Sonnet
      model: bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0
      cache_control_injection_points:
        - location: message
          index: -1
        - location: message
          index: -2
```
Test script 
```
import openai
import os

# Point the OpenAI client to your local LiteLLM proxy
client = openai.OpenAI(
    api_key="anything",  # The API key can be anything when talking to the local proxy
    base_url="http://0.0.0.0:4000"
)

long_context = "This is a long piece of text to simulate a document that needs to be cached. " * 400

# A multi-turn conversation history is needed to test caching.
# This simulates a user asking a follow-up question.
messages = [
    {"role": "user", "content": long_context},
    {"role": "assistant", "content": "Thanks for sharing the document."},
    {"role": "user", "content": "Can you summarize it?"}
]

print("Sending request to LiteLLM proxy...")

try:
    response = client.chat.completions.create(
        model="bedrock-claude-cache-test", # This must match the model_name in your config.yaml
        messages=messages
    )
    print("\nResponse received:")
    print(response)
except Exception as e:
    print(f"\nAn error occurred: {e}")
```
Ran as 
```
python -m litellm.proxy.proxy_cli --config simple_bedrock_config.yaml --port 4000
```
Code snippet, prints for debugging purposes
```
        targetted_role = point.get("role", None)
        print(f"anand Determined Target Index: {targetted_index}")
        print(f"anand Determined Target Role: {targetted_role}")
        # Case 1: Target by specific index
        if targetted_index is not None:
            # Handle negative indices (convert to positive)
            if targetted_index < 0:
                original_negative_index = targetted_index
                targetted_index += len(messages)
                print(f"anand Converted negative index {original_negative_index} to positive index {targetted_index}")
```
output
```
07:48:50 - LiteLLM Router:DEBUG: router.py:6715 - cooldown deployments: []
DEBUG:LiteLLM Router:cooldown deployments: []
anand Determined Target Index: -1
anand Determined Target Role: None
anand Converted negative index -1 to positive index 2
anand Determined Target Index: -2
anand Determined Target Role: None
anand Converted negative index -2 to positive index 1
07:48:50 - LiteLLM:INFO: utils.py:3230 -
LiteLLM completion() model= us.anthropic.claude-3-7-sonnet-20250219-v1:0; provider = bedrock
```
This confirms the core logic of the fix is working as intended within LiteLLM.

First API Call: Cache Creation The usage object from the response of the first API call shows that AWS Bedrock has received the cache_control directive and successfully created the cache.
Key Indicators:

cached_tokens: 0: Correct, as no cache existed yet.

cache_creation_input_tokens: 6822: Correct, showing that 6,822 tokens were identified and stored in the cache by the provider.

JSON
```
{
  "usage": {
    "completion_tokens": 84,
    "prompt_tokens": 4,
    "total_tokens": 6910,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "text_tokens": null,
      "image_tokens": null
    },
    "cache_creation_input_tokens": 6822,
    "cache_read_input_tokens": 0
  }
}
```
Second API Call: Cache Hit Verification The usage object from the second API call provides definitive proof of a successful cache hit.
Key Indicators:

cached_tokens: 6822: Success! This shows that 6,822 tokens were served directly from the provider's cache.

cache_read_input_tokens: 6822: Confirms that the provider read the tokens from its cache.

cache_creation_input_tokens: 0: Correct, as no new content needed to be cached.

JSON
```

{
  "usage": {
    "completion_tokens": 81,
    "prompt_tokens": 6826,
    "total_tokens": 6907,
    "prompt_tokens_details": {
      "cached_tokens": 6822,
      "text_tokens": null,
      "image_tokens": null
    },
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 6822
  }
}
```
Final Verification The logs clearly demonstrate that the fix is working end-to-end. The hook correctly processes negative indices, and the provider correctly creates and then reads from the cache on subsequent calls.

Metric First Run (Cache Creation) Second Run (Cache Hit) Status

cached_tokens      0                        6,822                       ✅ Success

cache_creation_input_tokens 6,822 0 ✅ Correct

cache_read_input_tokens 0 6,822 ✅ Correc