### PR TITLE
Fix langfuse test patch path causing CI failures

### DIFF
--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 import litellm
+from litellm.integrations.langfuse import langfuse as langfuse_module
 from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 
@@ -20,9 +21,7 @@ def test_max_langfuse_clients_limit():
     Test that the max langfuse clients limit is respected when initializing multiple clients
     """
     # Set max clients to 2 for testing
-    with patch(
-        "litellm.integrations.langfuse.langfuse.MAX_LANGFUSE_INITIALIZED_CLIENTS", 2
-    ):
+    with patch.object(langfuse_module, "MAX_LANGFUSE_INITIALIZED_CLIENTS", 2):
         # Reset the counter
         litellm.initialized_langfuse_clients = 0
 


### PR DESCRIPTION
## Title

Fix langfuse test patch path causing CI failures

## Relevant issues

Fixes CI test failure: `AttributeError: <module 'litellm.integrations.langfuse.langfuse'> does not have the attribute 'MAX_LANGFUSE_INITIALIZED_CLIENTS'`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Test

## Changes

### Problem
The `test_max_langfuse_clients_limit` test was failing on CI with:
```
AttributeError: <module 'litellm.integrations.langfuse.langfuse'> does not have the attribute 'MAX_LANGFUSE_INITIALIZED_CLIENTS'
```

### Root Cause  
The test was trying to patch `MAX_LANGFUSE_INITIALIZED_CLIENTS` using a string path that does not exist as a module attribute. The constant is imported from `litellm.constants` into the langfuse module namespace, so it needs to be patched at the imported reference location.

### Solution
- Import the langfuse module explicitly for patching
- Use `patch.object()` instead of string-based patching to patch the imported constant reference  
- This correctly patches the constant where it is actually used in the code

### Test Results
✅ `pytest tests/test_litellm/integrations/test_langfuse.py::test_max_langfuse_clients_limit` now passes
✅ All langfuse integration tests continue to pass

This fixes the CI failure without affecting the functionality of the langfuse integration.