### PR TITLE
Fix missing extra_headers support for vLLM/openai_like embeddings

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3896,6 +3896,9 @@ def embedding(  # noqa: PLR0915
                     or get_secret_str("OPENAI_LIKE_API_KEY")
                 )
 
+            if extra_headers is not None:
+                optional_params["extra_headers"] = extra_headers
+
             ## EMBEDDING CALL
             response = openai_like_embedding.embedding(
                 model=model,


### PR DESCRIPTION
## Title

Fix missing extra_headers support for vLLM/openai_like embeddings

## Relevant issues

Fixes #13088

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Added missing `extra_headers` parameter handling for `hosted_vllm`/`openai_like` embedding providers
- The fix adds the same pattern used in OpenAI embeddings section: `if extra_headers is not None: optional_params["extra_headers"] = extra_headers`
- Located in `litellm/main.py` lines 3899-3900
- Resolves issue where custom headers were being dropped for vLLM and OpenAI-compatible embedding requests

**Before:** Custom headers passed to vLLM/openai_like embeddings were ignored
**After:** Custom headers are properly forwarded to the embedding provider

This is a minimal 2-line fix that maintains consistency with existing code patterns.