### PR TITLE
[QA] Viewing Agent Activity Headers on UI Usage Page

### DIFF
--- a/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
+++ b/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
@@ -1,214 +1,385 @@
 """
 User Agent Analytics Endpoints
 
-This module provides endpoints for tracking user agent activity metrics including:
-- Daily Active Users (DAU) by tags
-- Weekly Active Users (WAU) by tags  
-- Monthly Active Users (MAU) by tags
-- Successful requests by tags
-- Completed tokens by tags
+This module provides optimized endpoints for tracking user agent activity metrics including:
+- Daily Active Users (DAU) by tags for last 7 days
+- Weekly Active Users (WAU) by tags for last 7 weeks  
+- Monthly Active Users (MAU) by tags for last 7 months
+- Summary analytics by tags
 
-These endpoints extend the existing tag daily activity functionality to provide 
-user agent specific analytics by using the user-agent tags that are automatically
-tracked by the system.
+These endpoints use optimized single SQL queries with joins to efficiently calculate
+user metrics from tag activity data and return time series for dashboard visualization.
 """
 
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Set, cast
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from litellm.proxy._types import CommonProxyErrors, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
-from litellm.types.proxy.management_endpoints.common_daily_activity import (
-    DailySpendData,
-)
 
 router = APIRouter()
 
 
-class UserAgentMetrics(BaseModel):
-    """Metrics for user agent activity"""
-    dau: int = 0  # Daily Active Users
-    wau: int = 0  # Weekly Active Users  
-    mau: int = 0  # Monthly Active Users
-    successful_requests: int = 0
-    failed_requests: int = 0
-    total_requests: int = 0
-    completed_tokens: int = 0
-    total_tokens: int = 0
-    spend: float = 0.0
-
-
-class UserAgentActivityData(BaseModel):
-    """User agent activity data for a specific date"""
-    date: str
+class TagActiveUsersResponse(BaseModel):
+    """Response for tag active users metrics"""
     tag: str
-    user_agent: Optional[str] = None
-    metrics: UserAgentMetrics
+    active_users: int
+    date: str  # The specific date or period identifier
+    period_start: Optional[str] = None  # For WAU/MAU, this will be the start of the period
+    period_end: Optional[str] = None  # For WAU/MAU, this will be the end of the period
 
 
-class UserAgentAnalyticsResponse(BaseModel):
-    """Response for user agent analytics"""
-    results: List[UserAgentActivityData]
-    total_count: int
-    page: int
-    page_size: int
-    total_pages: int
+class ActiveUsersAnalyticsResponse(BaseModel):
+    """Response for active users analytics"""
+    results: List[TagActiveUsersResponse]
 
 
-class PerUserMetrics(BaseModel):
-    """Metrics for individual user"""
-    user_id: str
-    user_email: Optional[str] = None
-    user_agent: Optional[str] = None
-    successful_requests: int = 0
-    failed_requests: int = 0
-    total_requests: int = 0
-    total_tokens: int = 0
-    spend: float = 0.0
+class TagSummaryMetrics(BaseModel):
+    """Summary metrics for a tag"""
+    tag: str
+    unique_users: int
+    total_requests: int
+    successful_requests: int
+    failed_requests: int
+    total_tokens: int
+    total_spend: float
 
 
-class PerUserAnalyticsResponse(BaseModel):
-    """Response for per-user analytics"""
-    results: List[PerUserMetrics]
-    total_count: int
-    page: int
-    page_size: int
-    total_pages: int
-
-
-async def _get_unique_users_for_tags(
-    prisma_client,
-    tags: List[str],
-    start_date: str,
-    end_date: str,
-) -> Dict[str, Set[str]]:
-    """
-    Get unique users for each tag by looking up api_key -> user_id mappings
-    """
-    from litellm.proxy.proxy_server import prisma_client as db_client
-    
-    if not db_client:
-        return {}
-    
-    # Get all records for the specified tags and date range
-    tag_records = await db_client.db.litellm_dailytagspend.find_many(
-        where={
-            "tag": {"in": tags},
-            "date": {"gte": start_date, "lte": end_date}
-        }
-    )
-    
-    # Get unique api_keys
-    api_keys = set(record.api_key for record in tag_records if record.api_key)
-    
-    if not api_keys:
-        return {}
-    
-    # Lookup user_id for each api_key
-    api_key_records = await db_client.db.litellm_verificationtoken.find_many(
-        where={"token": {"in": list(api_keys)}}
-    )
-    
-    # Create mapping from api_key to user_id
-    api_key_to_user_id = {
-        record.token: record.user_id 
-        for record in api_key_records 
-        if record.user_id
-    }
-    
-    # Group unique users by tag
-    tag_users: Dict[str, Set[str]] = {}
-    for record in tag_records:
-        if record.api_key in api_key_to_user_id:
-            user_id = api_key_to_user_id[record.api_key]
-            tag = record.tag
-            if tag not in tag_users:
-                tag_users[tag] = set()
-            tag_users[tag].add(user_id)
-    
-    return tag_users
-
-
-async def _calculate_dau_wau_mau(
-    prisma_client,
-    tags: List[str],
-    target_date: str,
-) -> Dict[str, Dict[str, int]]:
-    """
-    Calculate DAU, WAU, MAU for given tags and date
-    """
-    target_dt = datetime.strptime(target_date, "%Y-%m-%d")
-    
-    # Calculate date ranges
-    dau_start = target_date
-    dau_end = target_date
-    
-    wau_start = (target_dt - timedelta(days=6)).strftime("%Y-%m-%d")
-    wau_end = target_date
-    
-    mau_start = (target_dt - timedelta(days=29)).strftime("%Y-%m-%d")
-    mau_end = target_date
-    
-    # Get unique users for each period
-    dau_users = await _get_unique_users_for_tags(prisma_client, tags, dau_start, dau_end)
-    wau_users = await _get_unique_users_for_tags(prisma_client, tags, wau_start, wau_end)
-    mau_users = await _get_unique_users_for_tags(prisma_client, tags, mau_start, mau_end)
-    
-    result = {}
-    for tag in tags:
-        result[tag] = {
-            "dau": len(dau_users.get(tag, set())),
-            "wau": len(wau_users.get(tag, set())),
-            "mau": len(mau_users.get(tag, set())),
-        }
-    
-    return result
+class TagSummaryResponse(BaseModel):
+    """Response for tag summary analytics"""
+    results: List[TagSummaryMetrics]
 
 
 @router.get(
-    "/tag/user-agent/analytics",
-    response_model=UserAgentAnalyticsResponse,
+    "/tag/dau",
+    response_model=ActiveUsersAnalyticsResponse,
     tags=["tag management", "user agent analytics"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def get_user_agent_analytics(
-    start_date: Optional[str] = Query(
-        default=None,
-        description="Start date in YYYY-MM-DD format",
+async def get_daily_active_users(
+    end_date: str = Query(
+        description="End date in YYYY-MM-DD format (will show DAU for last 7 days ending on this date)"
     ),
-    end_date: Optional[str] = Query(
+    tag_filter: Optional[str] = Query(
         default=None,
-        description="End date in YYYY-MM-DD format",
-    ),
-    user_agent_filter: Optional[str] = Query(
-        default=None,
-        description="Filter by specific user agent tag",
-    ),
-    page: int = Query(default=1, description="Page number for pagination", ge=1),
-    page_size: int = Query(
-        default=50, description="Items per page", ge=1, le=1000
+        description="Filter by specific tag (optional)",
     ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
-    Get user agent analytics including DAU, WAU, MAU, successful requests, and completed tokens by tags.
+    Get Daily Active Users (DAU) by tags for the last 7 days ending on the specified date.
     
-    This endpoint analyzes all tags that are tracked by the system and provides analytics 
-    broken down by individual tags.
+    This endpoint efficiently calculates unique users per tag for each of the last 7 days
+    using a single optimized SQL query, perfect for dashboard time series visualization.
+    
+    Args:
+        end_date: End date for DAU calculation (YYYY-MM-DD) - will show 7 days ending on this date
+        tag_filter: Optional filter to specific tag
+        
+    Returns:
+        ActiveUsersAnalyticsResponse: DAU data by tag for each of the last 7 days
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+    
+    try:
+        # Validate and calculate date range (last 7 days)
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+        start_dt = end_dt - timedelta(days=6)
+        start_date = start_dt.strftime("%Y-%m-%d")
+        
+        # Build SQL query with optional tag filter
+        where_clause = "WHERE dts.date >= $1 AND dts.date <= $2 AND vt.user_id IS NOT NULL"
+        params = [start_date, end_date]
+        
+        if tag_filter:
+            where_clause += " AND dts.tag ILIKE $3"
+            params.append(f"%{tag_filter}%")
+        
+        sql_query = f"""
+        SELECT 
+            dts.tag,
+            dts.date,
+            COUNT(DISTINCT vt.user_id) as active_users
+        FROM "LiteLLM_DailyTagSpend" dts
+        INNER JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
+        {where_clause}
+        GROUP BY dts.tag, dts.date
+        ORDER BY dts.date DESC, active_users DESC
+        """
+        
+        db_response = await prisma_client.db.query_raw(sql_query, *params)
+        
+        results = [
+            TagActiveUsersResponse(
+                tag=row["tag"],
+                active_users=row["active_users"],
+                date=row["date"]
+            )
+            for row in db_response
+        ]
+        
+        return ActiveUsersAnalyticsResponse(results=results)
+        
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid date format. Use YYYY-MM-DD: {str(e)}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to fetch DAU analytics: {str(e)}",
+        )
+
+
+@router.get(
+    "/tag/wau",
+    response_model=ActiveUsersAnalyticsResponse,
+    tags=["tag management", "user agent analytics"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_weekly_active_users(
+    end_date: str = Query(
+        description="End date in YYYY-MM-DD format (will show WAU for last 7 weeks ending on this date)"
+    ),
+    tag_filter: Optional[str] = Query(
+        default=None,
+        description="Filter by specific tag (optional)",
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get Weekly Active Users (WAU) by tags for the last 7 weeks ending on the specified date.
+    
+    Each week is a 7-day period ending on the same weekday as the end_date.
+    
+    Args:
+        end_date: End date for WAU calculation (YYYY-MM-DD) - will show 7 weeks ending on this date
+        tag_filter: Optional filter to specific tag
+        
+    Returns:
+        ActiveUsersAnalyticsResponse: WAU data by tag for each of the last 7 weeks
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+    
+    try:
+        # Validate date format
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+        
+        # Calculate date range for all 7 weeks (49 days total)
+        start_dt = end_dt - timedelta(days=48)  # 7 weeks * 7 days - 1
+        start_date = start_dt.strftime("%Y-%m-%d")
+        
+        # Build SQL query with optional tag filter
+        where_clause = "WHERE dts.date >= $1 AND dts.date <= $2 AND vt.user_id IS NOT NULL"
+        params = [start_date, end_date]
+        
+        if tag_filter:
+            where_clause += " AND dts.tag ILIKE $3"
+            params.append(f"%{tag_filter}%")
+        
+        # Use window function to group by weeks
+        sql_query = f"""
+        WITH weekly_data AS (
+            SELECT 
+                dts.tag,
+                dts.date,
+                vt.user_id,
+                -- Calculate week number (0 = most recent week)
+                FLOOR((DATE '$2' - dts.date::date) / 7) as week_offset
+            FROM "LiteLLM_DailyTagSpend" dts
+            INNER JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
+            {where_clause}
+        )
+        SELECT 
+            tag,
+            COUNT(DISTINCT user_id) as active_users,
+            -- Calculate week end date for each week
+            (DATE '$2' - (week_offset * 7 || ' days')::interval)::text as date,
+            (DATE '$2' - (week_offset * 7 || ' days')::interval - '6 days'::interval)::text as period_start,
+            (DATE '$2' - (week_offset * 7 || ' days')::interval)::text as period_end
+        FROM weekly_data
+        WHERE week_offset < 7
+        GROUP BY tag, week_offset
+        ORDER BY week_offset ASC, active_users DESC
+        """
+        
+        db_response = await prisma_client.db.query_raw(sql_query, *params)
+        
+        results = [
+            TagActiveUsersResponse(
+                tag=row["tag"],
+                active_users=row["active_users"],
+                date=row["date"],
+                period_start=row["period_start"],
+                period_end=row["period_end"]
+            )
+            for row in db_response
+        ]
+        
+        return ActiveUsersAnalyticsResponse(results=results)
+        
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid date format. Use YYYY-MM-DD: {str(e)}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to fetch WAU analytics: {str(e)}",
+        )
+
+
+@router.get(
+    "/tag/mau",
+    response_model=ActiveUsersAnalyticsResponse,
+    tags=["tag management", "user agent analytics"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_monthly_active_users(
+    end_date: str = Query(
+        description="End date in YYYY-MM-DD format (will show MAU for last 7 months ending on this date)"
+    ),
+    tag_filter: Optional[str] = Query(
+        default=None,
+        description="Filter by specific tag (optional)",
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get Monthly Active Users (MAU) by tags for the last 7 months ending on the specified date.
+    
+    Each month is a 30-day period ending on the same day of month as the end_date.
+    
+    Args:
+        end_date: End date for MAU calculation (YYYY-MM-DD) - will show 7 months ending on this date
+        tag_filter: Optional filter to specific tag
+        
+    Returns:
+        ActiveUsersAnalyticsResponse: MAU data by tag for each of the last 7 months
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+        )
+    
+    try:
+        # Validate date format
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+        
+        # Calculate date range for all 7 months (210 days total)
+        start_dt = end_dt - timedelta(days=209)  # 7 months * 30 days - 1
+        start_date = start_dt.strftime("%Y-%m-%d")
+        
+        # Build SQL query with optional tag filter
+        where_clause = "WHERE dts.date >= $1 AND dts.date <= $2 AND vt.user_id IS NOT NULL"
+        params = [start_date, end_date]
+        
+        if tag_filter:
+            where_clause += " AND dts.tag ILIKE $3"
+            params.append(f"%{tag_filter}%")
+        
+        # Use window function to group by months (30-day periods)
+        sql_query = f"""
+        WITH monthly_data AS (
+            SELECT 
+                dts.tag,
+                dts.date,
+                vt.user_id,
+                -- Calculate month number (0 = most recent month)
+                FLOOR((DATE '$2' - dts.date::date) / 30) as month_offset
+            FROM "LiteLLM_DailyTagSpend" dts
+            INNER JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
+            {where_clause}
+        )
+        SELECT 
+            tag,
+            COUNT(DISTINCT user_id) as active_users,
+            -- Calculate month end date for each month
+            (DATE '$2' - (month_offset * 30 || ' days')::interval)::text as date,
+            (DATE '$2' - (month_offset * 30 || ' days')::interval - '29 days'::interval)::text as period_start,
+            (DATE '$2' - (month_offset * 30 || ' days')::interval)::text as period_end
+        FROM monthly_data
+        WHERE month_offset < 7
+        GROUP BY tag, month_offset
+        ORDER BY month_offset ASC, active_users DESC
+        """
+        
+        db_response = await prisma_client.db.query_raw(sql_query, *params)
+        
+        results = [
+            TagActiveUsersResponse(
+                tag=row["tag"],
+                active_users=row["active_users"],
+                date=row["date"],
+                period_start=row["period_start"],
+                period_end=row["period_end"]
+            )
+            for row in db_response
+        ]
+        
+        return ActiveUsersAnalyticsResponse(results=results)
+        
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid date format. Use YYYY-MM-DD: {str(e)}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to fetch MAU analytics: {str(e)}",
+        )
+
+
+@router.get(
+    "/tag/summary",
+    response_model=TagSummaryResponse,
+    tags=["tag management", "user agent analytics"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def get_tag_summary(
+    start_date: str = Query(
+        description="Start date in YYYY-MM-DD format"
+    ),
+    end_date: str = Query(
+        description="End date in YYYY-MM-DD format"
+    ),
+    tag_filter: Optional[str] = Query(
+        default=None,
+        description="Filter by specific tag (optional)",
+    ),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get summary analytics for tags including unique users, requests, tokens, and spend.
     
     Args:
         start_date: Start date for the analytics period (YYYY-MM-DD)
         end_date: End date for the analytics period (YYYY-MM-DD)
-        user_agent_filter: Filter results to specific tag
-        page: Page number for pagination
-        page_size: Number of items per page
+        tag_filter: Optional filter to specific tag
         
     Returns:
-        UserAgentAnalyticsResponse: Analytics data broken down by tag and date
+        TagSummaryResponse: Summary analytics data by tag
     """
     from litellm.proxy.proxy_server import prisma_client
     
@@ -218,402 +389,59 @@ async def get_user_agent_analytics(
             detail={"error": CommonProxyErrors.db_not_connected_error.value},
         )
     
-    if start_date is None or end_date is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Please provide start_date and end_date"},
-        )
-    
     try:
-        # Get all tags from the database
-        where_clause = {"date": {"gte": start_date, "lte": end_date}}
-        if user_agent_filter:
-            where_clause["tag"] = {"contains": user_agent_filter}
-            
-        tag_records = await prisma_client.db.litellm_dailytagspend.find_many(
-            where=where_clause,
-            distinct=["tag"],
-        )
+        # Validate date format
+        datetime.strptime(start_date, "%Y-%m-%d")
+        datetime.strptime(end_date, "%Y-%m-%d")
         
-        tags = [record.tag for record in tag_records]
+        # Build SQL query with optional tag filter
+        where_clause = "WHERE dts.date >= $1 AND dts.date <= $2"
+        params = [start_date, end_date]
         
-        if not tags:
-            return UserAgentAnalyticsResponse(
-                results=[],
-                total_count=0,
-                page=page,
-                page_size=page_size,
-                total_pages=0,
+        if tag_filter:
+            where_clause += " AND dts.tag ILIKE $3"
+            params.append(f"%{tag_filter}%")
+        
+        sql_query = f"""
+        SELECT 
+            dts.tag,
+            COUNT(DISTINCT vt.user_id) as unique_users,
+            SUM(dts.api_requests) as total_requests,
+            SUM(dts.successful_requests) as successful_requests,
+            SUM(dts.failed_requests) as failed_requests,
+            SUM(dts.prompt_tokens + dts.completion_tokens) as total_tokens,
+            SUM(dts.spend) as total_spend
+        FROM "LiteLLM_DailyTagSpend" dts
+        LEFT JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
+        {where_clause}
+        GROUP BY dts.tag
+        ORDER BY total_requests DESC
+        """
+        
+        db_response = await prisma_client.db.query_raw(sql_query, *params)
+        
+        results = [
+            TagSummaryMetrics(
+                tag=row["tag"],
+                unique_users=row["unique_users"] or 0,
+                total_requests=int(row["total_requests"] or 0),
+                successful_requests=int(row["successful_requests"] or 0),
+                failed_requests=int(row["failed_requests"] or 0),
+                total_tokens=int(row["total_tokens"] or 0),
+                total_spend=float(row["total_spend"] or 0.0)
             )
+            for row in db_response
+        ]
         
-        # Get daily activity data for tags
-        daily_activity_response = await get_daily_activity(
-            prisma_client=prisma_client,
-            table_name="litellm_dailytagspend",
-            entity_id_field="tag",
-            entity_id=tags,
-            entity_metadata_field=None,
-            start_date=start_date,
-            end_date=end_date,
-            model=None,
-            api_key=None,
-            page=1,  # Get all data first, then paginate our results
-            page_size=10000,  # Large page size to get all data
-        )
+        return TagSummaryResponse(results=results)
         
-        # Process the results to calculate DAU/WAU/MAU and organize by tag
-        results = []
-        daily_data_by_tag_and_date: Dict[str, Dict[str, DailySpendData]] = {}
-        
-        # Organize data by tag and date
-        for daily_data in daily_activity_response.results:
-            date_str = daily_data.date.strftime("%Y-%m-%d")
-            
-            # Get tag from breakdown data
-            for tag, tag_metrics in daily_data.breakdown.entities.items():
-                if tag not in daily_data_by_tag_and_date:
-                    daily_data_by_tag_and_date[tag] = {}
-                daily_data_by_tag_and_date[tag][date_str] = daily_data
-        
-        # Calculate DAU/WAU/MAU for each date and tag combination
-        unique_dates: set[str] = set()
-        for tag_data in daily_data_by_tag_and_date.values():
-            unique_dates.update(tag_data.keys())
-        
-        for tag in tags:
-            for date_str in sorted(unique_dates):
-                if tag in daily_data_by_tag_and_date and date_str in daily_data_by_tag_and_date[tag]:
-                    daily_data = daily_data_by_tag_and_date[tag][date_str]
-                    tag_breakdown = daily_data.breakdown.entities.get(tag)
-                    
-                    if tag_breakdown:
-                        # Calculate DAU/WAU/MAU for this specific date and tag
-                        dau_wau_mau = await _calculate_dau_wau_mau(
-                            prisma_client, [tag], date_str
-                        )
-                        
-                        metrics = UserAgentMetrics(
-                            dau=dau_wau_mau.get(tag, {}).get("dau", 0),
-                            wau=dau_wau_mau.get(tag, {}).get("wau", 0),
-                            mau=dau_wau_mau.get(tag, {}).get("mau", 0),
-                            successful_requests=tag_breakdown.metrics.successful_requests,
-                            failed_requests=tag_breakdown.metrics.failed_requests,
-                            total_requests=tag_breakdown.metrics.api_requests,
-                            completed_tokens=tag_breakdown.metrics.completion_tokens,
-                            total_tokens=tag_breakdown.metrics.total_tokens,
-                            spend=tag_breakdown.metrics.spend,
-                        )
-                        
-                        results.append(
-                            UserAgentActivityData(
-                                date=date_str,
-                                tag=tag,
-                                user_agent=tag,  # Use the full tag as user_agent
-                                metrics=metrics,
-                            )
-                        )
-        
-        # Sort results by date (most recent first) and then by tag
-        results.sort(key=lambda x: (x.date, x.tag), reverse=True)
-        
-        # Apply pagination
-        total_count = len(results)
-        total_pages = (total_count + page_size - 1) // page_size
-        start_idx = (page - 1) * page_size
-        end_idx = start_idx + page_size
-        paginated_results = results[start_idx:end_idx]
-        
-        return UserAgentAnalyticsResponse(
-            results=paginated_results,
-            total_count=total_count,
-            page=page,
-            page_size=page_size,
-            total_pages=total_pages,
-        )
-        
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to fetch user agent analytics: {str(e)}",
-        )
-
-
-@router.get(
-    "/tag/user-agent/summary",
-    tags=["tag management", "user agent analytics"],
-    dependencies=[Depends(user_api_key_auth)],
-)
-async def get_user_agent_summary(
-    start_date: Optional[str] = Query(
-        default=None,
-        description="Start date in YYYY-MM-DD format",
-    ),
-    end_date: Optional[str] = Query(
-        default=None,
-        description="End date in YYYY-MM-DD format",
-    ),
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
-    """
-    Get summary statistics for tag activity.
-    
-    Returns aggregated metrics across all tags for the specified time period.
-    """
-    from litellm.proxy.proxy_server import prisma_client
-    
-    if prisma_client is None:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
-        )
-    
-    if start_date is None or end_date is None:
+    except ValueError as e:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Please provide start_date and end_date"},
+            detail=f"Invalid date format. Use YYYY-MM-DD: {str(e)}",
         )
-    
-    try:
-        # Get all tags
-        tag_records = await prisma_client.db.litellm_dailytagspend.find_many(
-            where={
-                "date": {"gte": start_date, "lte": end_date},
-            },
-            distinct=["tag"],
-        )
-        
-        tags = [record.tag for record in tag_records]
-        
-        if not tags:
-            return {
-                "total_tags": 0,
-                "total_requests": 0,
-                "total_successful_requests": 0,
-                "total_failed_requests": 0,
-                "total_tokens": 0,
-                "total_spend": 0.0,
-                "top_tags": [],
-            }
-        
-        # Get aggregated data
-        daily_activity_response = await get_daily_activity(
-            prisma_client=prisma_client,
-            table_name="litellm_dailytagspend",
-            entity_id_field="tag",
-            entity_id=tags,
-            entity_metadata_field=None,
-            start_date=start_date,
-            end_date=end_date,
-            model=None,
-            api_key=None,
-            page=1,
-            page_size=10000,
-        )
-        
-        # Aggregate metrics by tag
-        tag_totals: Dict[str, UserAgentMetrics] = {}
-        
-        for daily_data in daily_activity_response.results:
-            for tag, tag_metrics in daily_data.breakdown.entities.items():
-                if tag not in tag_totals:
-                    tag_totals[tag] = UserAgentMetrics()
-                
-                totals = tag_totals[tag]
-                totals.successful_requests += tag_metrics.metrics.successful_requests
-                totals.failed_requests += tag_metrics.metrics.failed_requests
-                totals.total_requests += tag_metrics.metrics.api_requests
-                totals.completed_tokens += tag_metrics.metrics.completion_tokens
-                totals.total_tokens += tag_metrics.metrics.total_tokens
-                totals.spend += tag_metrics.metrics.spend
-        
-        # Calculate summary statistics
-        total_requests = sum(tag.total_requests for tag in tag_totals.values())
-        total_successful_requests = sum(tag.successful_requests for tag in tag_totals.values())
-        total_failed_requests = sum(tag.failed_requests for tag in tag_totals.values())
-        total_tokens = sum(tag.total_tokens for tag in tag_totals.values())
-        total_spend = sum(tag.spend for tag in tag_totals.values())
-        
-        # Get top tags by request count
-        top_tags = sorted(
-            [
-                {
-                    "tag": tag,
-                    "requests": metrics.total_requests,
-                    "successful_requests": metrics.successful_requests,
-                    "failed_requests": metrics.failed_requests,
-                    "tokens": metrics.total_tokens,
-                    "spend": metrics.spend,
-                }
-                for tag, metrics in tag_totals.items()
-            ],
-            key=lambda x: cast(int, x["requests"]),
-            reverse=True,
-        )[:10]  # Top 10
-        
-        return {
-            "total_tags": len(tag_totals),
-            "total_requests": total_requests,
-            "total_successful_requests": total_successful_requests,
-            "total_failed_requests": total_failed_requests,
-            "total_tokens": total_tokens,
-            "total_spend": total_spend,
-            "top_tags": top_tags,
-        }
-        
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch user agent summary: {str(e)}",
-        )
-
-
-@router.get(
-    "/tag/user-agent/per-user-analytics",
-    response_model=PerUserAnalyticsResponse,
-    tags=["tag management", "user agent analytics"],
-    dependencies=[Depends(user_api_key_auth)],
-)
-async def get_per_user_analytics(
-    start_date: Optional[str] = Query(
-        default=None,
-        description="Start date in YYYY-MM-DD format",
-    ),
-    end_date: Optional[str] = Query(
-        default=None,
-        description="End date in YYYY-MM-DD format",
-    ),
-    page: int = Query(default=1, description="Page number for pagination", ge=1),
-    page_size: int = Query(
-        default=50, description="Items per page", ge=1, le=1000
-    ),
-    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
-):
-    """
-    Get per-user analytics including successful requests, tokens, and spend by individual users.
-    
-    This endpoint provides usage metrics broken down by individual users based on their
-    tag activity during the specified time period.
-    
-    Args:
-        start_date: Start date for the analytics period (YYYY-MM-DD)
-        end_date: End date for the analytics period (YYYY-MM-DD)
-        page: Page number for pagination
-        page_size: Number of items per page
-        
-    Returns:
-        PerUserAnalyticsResponse: Analytics data broken down by individual users
-    """
-    from litellm.proxy.proxy_server import prisma_client
-    
-    if prisma_client is None:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
-        )
-    
-    if start_date is None or end_date is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Please provide start_date and end_date"},
-        )
-    
-    try:
-        # Get all tag records in the date range
-        tag_records = await prisma_client.db.litellm_dailytagspend.find_many(
-            where={
-                "date": {"gte": start_date, "lte": end_date}
-            }
-        )
-        
-        # Get unique api_keys
-        api_keys = set(record.api_key for record in tag_records if record.api_key)
-        
-        if not api_keys:
-            return PerUserAnalyticsResponse(
-                results=[],
-                total_count=0,
-                page=page,
-                page_size=page_size,
-                total_pages=0,
-            )
-        
-        # Lookup user_id for each api_key
-        api_key_records = await prisma_client.db.litellm_verificationtoken.find_many(
-            where={"token": {"in": list(api_keys)}}
-        )
-        
-        # Create mapping from api_key to user_id
-        api_key_to_user_id = {
-            record.token: record.user_id 
-            for record in api_key_records 
-            if record.user_id
-        }
-        
-        # Get user emails for the user_ids
-        user_ids = list(set(api_key_to_user_id.values()))
-        user_records = await prisma_client.db.litellm_usertable.find_many(
-            where={"user_id": {"in": user_ids}}
-        )
-        
-        # Create mapping from user_id to user_email
-        user_id_to_email = {
-            record.user_id: record.user_email 
-            for record in user_records
-        }
-        
-        # Aggregate metrics by user
-        user_metrics: Dict[str, PerUserMetrics] = {}
-
-        for record in tag_records:
-            if record.api_key in api_key_to_user_id:
-                user_id = api_key_to_user_id[record.api_key]
-                tag = record.tag  # Use the full tag as user_agent
-                
-                if user_id not in user_metrics:
-                    user_metrics[user_id] = PerUserMetrics(
-                        user_id=user_id,
-                        user_email=user_id_to_email.get(user_id),
-                        user_agent=tag
-                    )
-                else:
-                    # If tag is different, keep the first one or prioritize certain ones
-                    if tag and not user_metrics[user_id].user_agent:
-                        user_metrics[user_id].user_agent = tag
-                
-                # Aggregate metrics
-                user_metrics[user_id].successful_requests += record.successful_requests or 0
-                user_metrics[user_id].failed_requests += record.failed_requests or 0
-                user_metrics[user_id].total_requests += record.api_requests or 0
-                # Calculate total_tokens from prompt_tokens + completion_tokens
-                prompt_tokens = record.prompt_tokens or 0
-                completion_tokens = record.completion_tokens or 0
-                user_metrics[user_id].total_tokens += int(prompt_tokens + completion_tokens)
-                user_metrics[user_id].spend += record.spend or 0.0
-        
-        # Convert to list and sort by successful requests (descending)
-        results = sorted(
-            list(user_metrics.values()),
-            key=lambda x: x.successful_requests,
-            reverse=True
-        )
-        
-        # Apply pagination
-        total_count = len(results)
-        total_pages = (total_count + page_size - 1) // page_size
-        start_idx = (page - 1) * page_size
-        end_idx = start_idx + page_size
-        paginated_results = results[start_idx:end_idx]
-        
-        return PerUserAnalyticsResponse(
-            results=paginated_results,
-            total_count=total_count,
-            page=page,
-            page_size=page_size,
-            total_pages=total_pages,
-        )
-        
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to fetch per-user analytics: {str(e)}",
+            detail=f"Failed to fetch tag summary analytics: {str(e)}",
         )

--- a/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
+++ b/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
@@ -201,7 +201,7 @@ async def get_weekly_active_users(
                 dts.date,
                 vt.user_id,
                 -- Calculate week number (0 = most recent week)
-                FLOOR((DATE '$2' - dts.date::date) / 7) as week_offset
+                FLOOR((DATE '{end_date}' - dts.date::date) / 7) as week_offset
             FROM "LiteLLM_DailyTagSpend" dts
             INNER JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
             {where_clause}
@@ -210,9 +210,9 @@ async def get_weekly_active_users(
             tag,
             COUNT(DISTINCT user_id) as active_users,
             -- Calculate week end date for each week
-            (DATE '$2' - (week_offset * 7 || ' days')::interval)::text as date,
-            (DATE '$2' - (week_offset * 7 || ' days')::interval - '6 days'::interval)::text as period_start,
-            (DATE '$2' - (week_offset * 7 || ' days')::interval)::text as period_end
+            (DATE '{end_date}' - (week_offset * 7 || ' days')::interval)::text as date,
+            (DATE '{end_date}' - (week_offset * 7 || ' days')::interval - '6 days'::interval)::text as period_start,
+            (DATE '{end_date}' - (week_offset * 7 || ' days')::interval)::text as period_end
         FROM weekly_data
         WHERE week_offset < 7
         GROUP BY tag, week_offset
@@ -306,7 +306,7 @@ async def get_monthly_active_users(
                 dts.date,
                 vt.user_id,
                 -- Calculate month number (0 = most recent month)
-                FLOOR((DATE '$2' - dts.date::date) / 30) as month_offset
+                FLOOR((DATE '{end_date}' - dts.date::date) / 30) as month_offset
             FROM "LiteLLM_DailyTagSpend" dts
             INNER JOIN "LiteLLM_VerificationToken" vt ON dts.api_key = vt.token
             {where_clause}
@@ -315,9 +315,9 @@ async def get_monthly_active_users(
             tag,
             COUNT(DISTINCT user_id) as active_users,
             -- Calculate month end date for each month
-            (DATE '$2' - (month_offset * 30 || ' days')::interval)::text as date,
-            (DATE '$2' - (month_offset * 30 || ' days')::interval - '29 days'::interval)::text as period_start,
-            (DATE '$2' - (month_offset * 30 || ' days')::interval)::text as period_end
+            (DATE '{end_date}' - (month_offset * 30 || ' days')::interval)::text as date,
+            (DATE '{end_date}' - (month_offset * 30 || ' days')::interval - '29 days'::interval)::text as period_start,
+            (DATE '{end_date}' - (month_offset * 30 || ' days')::interval)::text as period_end
         FROM monthly_data
         WHERE month_offset < 7
         GROUP BY tag, month_offset

--- a/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
+++ b/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
@@ -69,6 +69,28 @@ class DistinctTagsResponse(BaseModel):
     results: List[DistinctTagResponse]
 
 
+
+class PerUserMetrics(BaseModel):
+    """Metrics for individual user"""
+    user_id: str
+    user_email: Optional[str] = None
+    user_agent: Optional[str] = None
+    successful_requests: int = 0
+    failed_requests: int = 0
+    total_requests: int = 0
+    total_tokens: int = 0
+    spend: float = 0.0
+
+
+class PerUserAnalyticsResponse(BaseModel):
+    """Response for per-user analytics"""
+    results: List[PerUserMetrics]
+    total_count: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
 @router.get(
     "/tag/distinct",
     response_model=DistinctTagsResponse,

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6498,6 +6498,175 @@ export const userAgentAnalyticsCall = async (
   }
 };
 
+// New endpoint functions for DAU, WAU, MAU
+export const tagDauCall = async (
+  accessToken: string,
+  endDate: Date,
+  tagFilter?: string
+) => {
+  /**
+   * Get Daily Active Users (DAU) for last 7 days ending on endDate
+   */
+  try {
+    let url = proxyBaseUrl
+      ? `${proxyBaseUrl}/tag/dau`
+      : `/tag/dau`;
+    
+    const queryParams = new URLSearchParams();
+    
+    // Format date as YYYY-MM-DD for the API
+    const formatDate = (date: Date) => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+    
+    queryParams.append("end_date", formatDate(endDate));
+    
+    if (tagFilter) {
+      queryParams.append("tag_filter", tagFilter);
+    }
+    
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch DAU:", error);
+    throw error;
+  }
+};
+
+export const tagWauCall = async (
+  accessToken: string,
+  endDate: Date,
+  tagFilter?: string
+) => {
+  /**
+   * Get Weekly Active Users (WAU) for last 7 weeks ending on endDate
+   */
+  try {
+    let url = proxyBaseUrl
+      ? `${proxyBaseUrl}/tag/wau`
+      : `/tag/wau`;
+    
+    const queryParams = new URLSearchParams();
+    
+    // Format date as YYYY-MM-DD for the API
+    const formatDate = (date: Date) => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+    
+    queryParams.append("end_date", formatDate(endDate));
+    
+    if (tagFilter) {
+      queryParams.append("tag_filter", tagFilter);
+    }
+    
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch WAU:", error);
+    throw error;
+  }
+};
+
+export const tagMauCall = async (
+  accessToken: string,
+  endDate: Date,
+  tagFilter?: string
+) => {
+  /**
+   * Get Monthly Active Users (MAU) for last 7 months ending on endDate
+   */
+  try {
+    let url = proxyBaseUrl
+      ? `${proxyBaseUrl}/tag/mau`
+      : `/tag/mau`;
+    
+    const queryParams = new URLSearchParams();
+    
+    // Format date as YYYY-MM-DD for the API
+    const formatDate = (date: Date) => {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    };
+    
+    queryParams.append("end_date", formatDate(endDate));
+    
+    if (tagFilter) {
+      queryParams.append("tag_filter", tagFilter);
+    }
+    
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch MAU:", error);
+    throw error;
+  }
+};
+
 export const userAgentSummaryCall = async (
   accessToken: string,
   startTime: Date,
@@ -6508,8 +6677,8 @@ export const userAgentSummaryCall = async (
    */
   try {
     let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/tag/user-agent/summary`
-      : `/tag/user-agent/summary`;
+      ? `${proxyBaseUrl}/tag/summary`
+      : `/tag/summary`;
     
     const queryParams = new URLSearchParams();
     

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6502,7 +6502,8 @@ export const userAgentAnalyticsCall = async (
 export const tagDauCall = async (
   accessToken: string,
   endDate: Date,
-  tagFilter?: string
+  tagFilter?: string,
+  tagFilters?: string[]
 ) => {
   /**
    * Get Daily Active Users (DAU) for last 7 days ending on endDate
@@ -6524,7 +6525,12 @@ export const tagDauCall = async (
     
     queryParams.append("end_date", formatDate(endDate));
     
-    if (tagFilter) {
+    // Handle multiple tag filters (takes precedence over single tag filter)
+    if (tagFilters && tagFilters.length > 0) {
+      tagFilters.forEach(tag => {
+        queryParams.append("tag_filters", tag);
+      });
+    } else if (tagFilter) {
       queryParams.append("tag_filter", tagFilter);
     }
     
@@ -6558,7 +6564,8 @@ export const tagDauCall = async (
 export const tagWauCall = async (
   accessToken: string,
   endDate: Date,
-  tagFilter?: string
+  tagFilter?: string,
+  tagFilters?: string[]
 ) => {
   /**
    * Get Weekly Active Users (WAU) for last 7 weeks ending on endDate
@@ -6580,7 +6587,12 @@ export const tagWauCall = async (
     
     queryParams.append("end_date", formatDate(endDate));
     
-    if (tagFilter) {
+    // Handle multiple tag filters (takes precedence over single tag filter)
+    if (tagFilters && tagFilters.length > 0) {
+      tagFilters.forEach(tag => {
+        queryParams.append("tag_filters", tag);
+      });
+    } else if (tagFilter) {
       queryParams.append("tag_filter", tagFilter);
     }
     
@@ -6614,7 +6626,8 @@ export const tagWauCall = async (
 export const tagMauCall = async (
   accessToken: string,
   endDate: Date,
-  tagFilter?: string
+  tagFilter?: string,
+  tagFilters?: string[]
 ) => {
   /**
    * Get Monthly Active Users (MAU) for last 7 months ending on endDate
@@ -6636,7 +6649,12 @@ export const tagMauCall = async (
     
     queryParams.append("end_date", formatDate(endDate));
     
-    if (tagFilter) {
+    // Handle multiple tag filters (takes precedence over single tag filter)
+    if (tagFilters && tagFilters.length > 0) {
+      tagFilters.forEach(tag => {
+        queryParams.append("tag_filters", tag);
+      });
+    } else if (tagFilter) {
       queryParams.append("tag_filter", tagFilter);
     }
     
@@ -6667,10 +6685,44 @@ export const tagMauCall = async (
   }
 };
 
+export const tagDistinctCall = async (
+  accessToken: string
+) => {
+  /**
+   * Get all distinct user agent tags (up to 250)
+   */
+  try {
+    let url = proxyBaseUrl
+      ? `${proxyBaseUrl}/tag/distinct`
+      : `/tag/distinct`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      handleError(errorData);
+      throw new Error("Network response was not ok");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch distinct tags:", error);
+    throw error;
+  }
+};
+
 export const userAgentSummaryCall = async (
   accessToken: string,
   startTime: Date,
-  endTime: Date
+  endTime: Date,
+  tagFilters?: string[]
 ) => {
   /**
    * Get user agent summary statistics
@@ -6692,6 +6744,13 @@ export const userAgentSummaryCall = async (
     
     queryParams.append("start_date", formatDate(startTime));
     queryParams.append("end_date", formatDate(endTime));
+    
+    // Handle multiple tag filters
+    if (tagFilters && tagFilters.length > 0) {
+      tagFilters.forEach(tag => {
+        queryParams.append("tag_filters", tag);
+      });
+    }
     
     const queryString = queryParams.toString();
     if (queryString) {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6781,13 +6781,12 @@ export const userAgentSummaryCall = async (
 
 export const perUserAnalyticsCall = async (
   accessToken: string,
-  startTime: Date,
-  endTime: Date,
   page: number = 1,
-  pageSize: number = 50
+  pageSize: number = 50,
+  tagFilters?: string[]
 ) => {
   /**
-   * Get per-user analytics data
+   * Get per-user analytics data for the last 30 days
    */
   try {
     let url = proxyBaseUrl
@@ -6796,18 +6795,15 @@ export const perUserAnalyticsCall = async (
     
     const queryParams = new URLSearchParams();
     
-    // Format dates as YYYY-MM-DD for the API
-    const formatDate = (date: Date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-    
-    queryParams.append("start_date", formatDate(startTime));
-    queryParams.append("end_date", formatDate(endTime));
     queryParams.append("page", page.toString());
     queryParams.append("page_size", pageSize.toString());
+    
+    // Handle multiple tag filters
+    if (tagFilters && tagFilters.length > 0) {
+      tagFilters.forEach(tag => {
+        queryParams.append("tag_filters", tag);
+      });
+    }
     
     const queryString = queryParams.toString();
     if (queryString) {

--- a/ui/litellm-dashboard/src/components/per_user_usage.tsx
+++ b/ui/litellm-dashboard/src/components/per_user_usage.tsx
@@ -42,13 +42,13 @@ interface PerUserAnalyticsResponse {
 
 interface PerUserUsageProps {
   accessToken: string | null;
-  dateValue: DateRangePickerValue;
+  selectedTags: string[];
   formatAbbreviatedNumber: (value: number, decimalPlaces?: number) => string;
 }
 
 const PerUserUsage: React.FC<PerUserUsageProps> = ({
   accessToken,
-  dateValue,
+  selectedTags,
   formatAbbreviatedNumber,
 }) => {
   const [perUserData, setPerUserData] = useState<PerUserAnalyticsResponse>({
@@ -63,16 +63,15 @@ const PerUserUsage: React.FC<PerUserUsageProps> = ({
   const [currentPage, setCurrentPage] = useState(1);
 
   const fetchPerUserData = async () => {
-    if (!accessToken || !dateValue.from || !dateValue.to) return;
+    if (!accessToken) return;
 
     setLoading(true);
     try {
       const response = await perUserAnalyticsCall(
         accessToken,
-        dateValue.from,
-        dateValue.to,
         currentPage,
-        50
+        50,
+        selectedTags.length > 0 ? selectedTags : undefined
       );
       setPerUserData(response);
     } catch (error) {
@@ -84,7 +83,7 @@ const PerUserUsage: React.FC<PerUserUsageProps> = ({
 
   useEffect(() => {
     fetchPerUserData();
-  }, [accessToken, dateValue, currentPage]);
+  }, [accessToken, selectedTags, currentPage]);
 
   const handleNextPage = () => {
     if (currentPage < perUserData.total_pages) {

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -320,25 +320,6 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* User Agent Filter */}
-      <Grid numItems={1} className="gap-2 w-full">
-        <Col>
-          <Select
-            value={userAgentFilter}
-            onValueChange={setUserAgentFilter}
-            placeholder="Filter by User Agent"
-          >
-            <SelectItem value="">All User Agents</SelectItem>
-            <SelectItem value="curl">curl</SelectItem>
-            <SelectItem value="litellm">litellm</SelectItem>
-            <SelectItem value="python">python</SelectItem>
-            <SelectItem value="postman">postman</SelectItem>
-            <SelectItem value="axios">axios</SelectItem>
-            <SelectItem value="fetch">fetch</SelectItem>
-          </Select>
-        </Col>
-      </Grid>
-
       {/* Summary Section Card */}
       <Card>
         <div className="space-y-6">

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -500,7 +500,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
         <TabGroup>
           <TabList className="mb-6">
             <Tab>DAU/WAU/MAU</Tab>
-            <Tab>Per User Usage</Tab>
+            <Tab>Per User Usage (Last 30 Days)</Tab>
           </TabList>
           
           <TabPanels>

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -583,7 +583,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
             <TabPanel>
               <PerUserUsage
                 accessToken={accessToken}
-                dateValue={dateValue}
+                selectedTags={selectedTags}
                 formatAbbreviatedNumber={formatAbbreviatedNumber}
               />
             </TabPanel>

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -319,7 +319,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 mt-6">
       {/* Summary Section Card */}
       <Card>
         <div className="space-y-6">

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -419,6 +419,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}
+                        stack={true}
                       />
                     )}
                   </TabPanel>
@@ -438,6 +439,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}
+                        stack={true}
                       />
                     )}
                   </TabPanel>
@@ -457,6 +459,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}
+                        stack={true}
                       />
                     )}
                   </TabPanel>

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -210,24 +210,23 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
     return userAgent;
   };
 
-  // Get top user agents for each chart type based on their specific data
-  const getTopTagsForData = (data: TagActiveUsersResponse[], limit: number = 3) => {
+  // Get all user agents for each chart type based on their specific data
+  const getAllTagsForData = (data: TagActiveUsersResponse[]) => {
     // Aggregate total active users per tag
     const tagTotals = data.reduce((acc, item) => {
       acc[item.tag] = (acc[item.tag] || 0) + item.active_users;
       return acc;
     }, {} as Record<string, number>);
 
-    // Sort by total active users and return top tags
+    // Sort by total active users and return all tags
     return Object.entries(tagTotals)
       .sort(([, a], [, b]) => b - a)
-      .slice(0, limit)
       .map(([tag]) => tag);
   };
 
-  const topDauTags = getTopTagsForData(dauData.results);
-  const topWauTags = getTopTagsForData(wauData.results);
-  const topMauTags = getTopTagsForData(mauData.results);
+  const allDauTags = getAllTagsForData(dauData.results);
+  const allWauTags = getAllTagsForData(wauData.results);
+  const allMauTags = getAllTagsForData(mauData.results);
 
   // Prepare daily chart data (DAU)
   const dailyChartData = dauData.results.reduce((acc, item) => {
@@ -423,8 +422,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                       <BarChart
                         data={dailyChartData}
                         index="date"
-                        categories={topDauTags.map(extractUserAgent)}
-                        colors={["blue", "green", "orange"]}
+                        categories={allDauTags.map(extractUserAgent)}
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}
@@ -443,8 +441,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                       <BarChart
                         data={weeklyChartData}
                         index="week"
-                        categories={topWauTags.map(extractUserAgent)}
-                        colors={["blue", "green", "orange"]}
+                        categories={allWauTags.map(extractUserAgent)}
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}
@@ -463,8 +460,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
                       <BarChart
                         data={monthlyChartData}
                         index="month"
-                        categories={topMauTags.map(extractUserAgent)}
-                        colors={["blue", "green", "orange"]}
+                        categories={allMauTags.map(extractUserAgent)}
                         valueFormatter={(value: number) => formatAbbreviatedNumber(value)}
                         yAxisWidth={60}
                         showLegend={true}

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -15,8 +15,6 @@ import {
   DonutChart,
   Metric,
   Subtitle,
-  Select,
-  SelectItem,
   Button,
   Tab,
   TabGroup,
@@ -24,6 +22,7 @@ import {
   TabPanel,
   TabPanels,
 } from "@tremor/react";
+import { Select } from "antd";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { userAgentSummaryCall, tagDauCall, tagWauCall, tagMauCall, tagDistinctCall } from "./networking";
 import AdvancedDatePicker from "./shared/advanced_date_picker";
@@ -92,7 +91,6 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagsLoading, setTagsLoading] = useState(false);
-  const [tagSearchFilter, setTagSearchFilter] = useState<string>("");
   
   // Separate loading states for each endpoint
   const [dauLoading, setDauLoading] = useState(false);
@@ -251,15 +249,7 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
     return userAgent;
   };
 
-  // Helper function to filter tags based on search
-  const filterTags = (tags: string[]) => {
-    if (!tagSearchFilter) return tags;
-    return tags.filter(tag => {
-      const userAgent = extractUserAgent(tag);
-      return userAgent.toLowerCase().includes(tagSearchFilter.toLowerCase()) ||
-             tag.toLowerCase().includes(tagSearchFilter.toLowerCase());
-    });
-  };
+
 
   // Get all user agents for each chart type based on their specific data
   const getAllTagsForData = (data: TagActiveUsersResponse[]) => {
@@ -415,91 +405,32 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
               <Subtitle>Performance metrics for different user agents</Subtitle>
             </div>
             
-            {/* User Agent Filter */}
-            <div className="w-80">
-              <div className="flex items-center justify-between mb-2">
-                <Text className="text-sm font-medium">Filter by User Agents</Text>
-                {selectedTags.length > 0 && (
-                  <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
-                    {selectedTags.length} selected
-                  </span>
-                )}
-              </div>
-                                            <div className="border border-gray-300 rounded-md bg-white">
-                 {/* Search input */}
-                 <div className="p-3 border-b border-gray-200">
-                   <input
-                     type="text"
-                     placeholder="Search user agents..."
-                     value={tagSearchFilter}
-                     onChange={(e) => setTagSearchFilter(e.target.value)}
-                     className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                   />
-                 </div>
-                 
-                 {/* Tag list */}
-                 <div className="p-3 max-h-56 overflow-y-auto">
-                   <div className="space-y-2">
-                     <div className="flex items-center space-x-2">
-                       <input
-                         type="checkbox"
-                         id="all-agents"
-                         checked={selectedTags.length === 0}
-                         onChange={() => setSelectedTags([])}
-                         className="rounded border-gray-300"
-                       />
-                       <label htmlFor="all-agents" className="text-sm font-medium text-gray-700">
-                         All User Agents
-                       </label>
-                     </div>
-                                     {tagsLoading ? (
-                     <div className="text-sm text-gray-500">Loading...</div>
-                   ) : (
-                     filterTags(availableTags).map((tag) => {
-                       const userAgent = extractUserAgent(tag);
-                       const displayName = userAgent.length > 35 ? `${userAgent.substring(0, 35)}...` : userAgent;
-                       const isSelected = selectedTags.includes(tag);
-                       
-                       return (
-                         <div key={tag} className="flex items-center space-x-2">
-                           <input
-                             type="checkbox"
-                             id={`tag-${tag}`}
-                             checked={isSelected}
-                             onChange={(e) => {
-                               if (e.target.checked) {
-                                 setSelectedTags([...selectedTags, tag]);
-                               } else {
-                                 setSelectedTags(selectedTags.filter(t => t !== tag));
-                               }
-                             }}
-                             className="rounded border-gray-300"
-                           />
-                           <label 
-                             htmlFor={`tag-${tag}`} 
-                             className="text-sm text-gray-600 cursor-pointer"
-                             title={userAgent}
-                           >
-                             {displayName}
-                           </label>
-                         </div>
-                       );
-                     })
-                   )}
-                                        {availableTags.length > 0 && (
-                       <div className="text-xs text-gray-500 pt-1">
-                         {tagSearchFilter ? (
-                           <>
-                             Showing {filterTags(availableTags).length} of {availableTags.length} user agents
-                           </>
-                         ) : (
-                           <>Showing {availableTags.length} user agent{availableTags.length !== 1 ? 's' : ''}</>
-                         )}
-                       </div>
-                     )}
-                   </div>
-                 </div>
-               </div>
+                        {/* User Agent Filter */}
+            <div className="w-96">
+              <Text className="text-sm font-medium block mb-2">Filter by User Agents</Text>
+              <Select
+                mode="multiple"
+                placeholder="All User Agents"
+                value={selectedTags}
+                onChange={setSelectedTags}
+                style={{ width: "100%" }}
+                showSearch={true}
+                allowClear={true}
+                loading={tagsLoading}
+                optionFilterProp="label"
+                className="rounded-md"
+                maxTagCount="responsive"
+              >
+                {availableTags.map((tag) => {
+                  const userAgent = extractUserAgent(tag);
+                  const displayName = userAgent.length > 50 ? `${userAgent.substring(0, 50)}...` : userAgent;
+                  return (
+                    <Select.Option key={tag} value={tag} label={displayName} title={userAgent}>
+                      {displayName}
+                    </Select.Option>
+                  );
+                })}
+              </Select>
             </div>
           </div>
           

--- a/ui/litellm-dashboard/src/components/user_agent_activity.tsx
+++ b/ui/litellm-dashboard/src/components/user_agent_activity.tsx
@@ -320,14 +320,8 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Date Range Picker */}
-      <Grid numItems={2} className="gap-2 w-full">
-        <Col>
-          <AdvancedDatePicker
-            value={dateValue}
-            onValueChange={handleDateChange}
-          />
-        </Col>
+      {/* User Agent Filter */}
+      <Grid numItems={1} className="gap-2 w-full">
         <Col>
           <Select
             value={userAgentFilter}
@@ -345,60 +339,74 @@ const UserAgentActivity: React.FC<UserAgentActivityProps> = ({
         </Col>
       </Grid>
 
-      {/* Top 4 User Agents Cards */}
-      {summaryLoading ? (
-        <Card>
-          <ChartLoader isDateChanging={isDateChanging} />
-        </Card>
-      ) : (
-        <Grid numItems={4} className="gap-4">
-          {(summaryData.results || []).slice(0, 4).map((tag, index) => {
-            const userAgent = extractUserAgent(tag.tag);
-            const displayName = truncateUserAgent(userAgent);
-            return (
-              <Card key={index}>
-                <Title className="truncate" title={userAgent}>
-                  {displayName}
-                </Title>
-                <div className="mt-4 space-y-3">
-                  <div>
-                    <Text className="text-sm text-gray-600">Success Requests</Text>
-                    <Metric className="text-lg">{formatAbbreviatedNumber(tag.successful_requests)}</Metric>
+      {/* Summary Section Card */}
+      <Card>
+        <div className="space-y-6">
+          <div>
+            <Title>Summary by User Agent</Title>
+            <Subtitle>Performance metrics for different user agents</Subtitle>
+          </div>
+          
+          {/* Date Range Picker within Summary */}
+          <AdvancedDatePicker
+            value={dateValue}
+            onValueChange={handleDateChange}
+          />
+
+          {/* Top 4 User Agents Cards */}
+          {summaryLoading ? (
+            <ChartLoader isDateChanging={isDateChanging} />
+          ) : (
+            <Grid numItems={4} className="gap-4">
+              {(summaryData.results || []).slice(0, 4).map((tag, index) => {
+                const userAgent = extractUserAgent(tag.tag);
+                const displayName = truncateUserAgent(userAgent);
+                return (
+                  <Card key={index}>
+                    <Title className="truncate" title={userAgent}>
+                      {displayName}
+                    </Title>
+                    <div className="mt-4 space-y-3">
+                      <div>
+                        <Text className="text-sm text-gray-600">Success Requests</Text>
+                        <Metric className="text-lg">{formatAbbreviatedNumber(tag.successful_requests)}</Metric>
+                      </div>
+                      <div>
+                        <Text className="text-sm text-gray-600">Total Tokens</Text>
+                        <Metric className="text-lg">{formatAbbreviatedNumber(tag.total_tokens)}</Metric>
+                      </div>
+                      <div>
+                        <Text className="text-sm text-gray-600">Total Cost</Text>
+                        <Metric className="text-lg">${formatAbbreviatedNumber(tag.total_spend, 4)}</Metric>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
+              {/* Fill remaining slots if less than 4 agents */}
+              {Array.from({ length: Math.max(0, 4 - (summaryData.results || []).length) }).map((_, index) => (
+                <Card key={`empty-${index}`}>
+                  <Title>No Data</Title>
+                  <div className="mt-4 space-y-3">
+                    <div>
+                      <Text className="text-sm text-gray-600">Success Requests</Text>
+                      <Metric className="text-lg">-</Metric>
+                    </div>
+                    <div>
+                      <Text className="text-sm text-gray-600">Total Tokens</Text>
+                      <Metric className="text-lg">-</Metric>
+                    </div>
+                    <div>
+                      <Text className="text-sm text-gray-600">Total Cost</Text>
+                      <Metric className="text-lg">-</Metric>
+                    </div>
                   </div>
-                  <div>
-                    <Text className="text-sm text-gray-600">Total Tokens</Text>
-                    <Metric className="text-lg">{formatAbbreviatedNumber(tag.total_tokens)}</Metric>
-                  </div>
-                  <div>
-                    <Text className="text-sm text-gray-600">Total Cost</Text>
-                    <Metric className="text-lg">${formatAbbreviatedNumber(tag.total_spend, 4)}</Metric>
-                  </div>
-                </div>
-              </Card>
-            );
-          })}
-          {/* Fill remaining slots if less than 4 agents */}
-          {Array.from({ length: Math.max(0, 4 - (summaryData.results || []).length) }).map((_, index) => (
-            <Card key={`empty-${index}`}>
-              <Title>No Data</Title>
-              <div className="mt-4 space-y-3">
-                <div>
-                  <Text className="text-sm text-gray-600">Success Requests</Text>
-                  <Metric className="text-lg">-</Metric>
-                </div>
-                <div>
-                  <Text className="text-sm text-gray-600">Total Tokens</Text>
-                  <Metric className="text-lg">-</Metric>
-                </div>
-                <div>
-                  <Text className="text-sm text-gray-600">Total Cost</Text>
-                  <Metric className="text-lg">-</Metric>
-                </div>
-              </div>
-          </Card>
-          ))}
-        </Grid>
-      )}
+                </Card>
+              ))}
+            </Grid>
+          )}
+        </div>
+      </Card>
 
       {/* Main TabGroup for DAU/WAU/MAU vs Per User Usage */}
       <Card>


### PR DESCRIPTION
## [QA] Viewing Agent Activity Headers on UI Usage Page

- Fixes for rendering DAU, WAU and MAU 
- Clean up for using stacked bar charts 
- Faster load times for DAU, WAU and MAU

<img width="1031" height="647" alt="Screenshot 2025-08-01 at 2 34 38 PM" src="https://github.com/user-attachments/assets/ef565d55-5a4c-439f-b629-1da59bbfca4b" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


