### PR TITLE
Add advanced date picker to all the tabs on the usage page

### DIFF
--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -21,7 +21,7 @@ import {
   TabPanels,
   Subtitle,
 } from "@tremor/react";
-import UsageDatePicker from "./shared/usage_date_picker";
+import AdvancedDatePicker from "./shared/advanced_date_picker";
 import { Select } from 'antd';
 import { ActivityMetrics, processActivityData } from './activity_metrics';
 import { DailyData, BreakdownMetrics, KeyMetricWithMetadata, EntityMetricWithMetadata } from './usage/types';
@@ -328,7 +328,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
     <div style={{ width: "100%" }}>
       <Grid numItems={2} className="gap-2 w-full mb-4">
         <Col>
-          <UsageDatePicker value={dateValue} onValueChange={setDateValue} />
+          <AdvancedDatePicker value={dateValue} onValueChange={setDateValue} />
         </Col>
         {entityList && entityList.length > 0 && (
           <Col>

--- a/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
@@ -197,12 +197,29 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
   const handleRelativeTimeSelect = (option: RelativeTimeOption) => {
     const { from, to } = option.getValue()
     const newValue = { from, to }
+
+    // Immediately apply the selected option
+    onValueChange(newValue)
+
+    // Apply the same background adjustment logic as the original component
+    requestIdleCallback(
+      () => {
+        const adjustedValue = adjustDateRange(newValue)
+        onValueChange(adjustedValue)
+      },
+      { timeout: 100 },
+    )
+
+    // Update local state to reflect the selection
     setTempValue(newValue)
     setSelectedOption(option.shortLabel)
 
     // Update the form inputs to reflect the selection
     setStartDate(moment(from).format("YYYY-MM-DD"))
     setEndDate(moment(to).format("YYYY-MM-DD"))
+
+    // Close the dropdown
+    setIsOpen(false)
   }
 
   const updateTempValueFromInputs = useCallback(() => {
@@ -303,7 +320,7 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
                 <div className="p-3 border-b border-gray-200">
                   <span className="text-sm font-semibold text-gray-900">Relative time (today, 7d, 30d, MTD, YTD)</span>
                 </div>
-                <div className="h-[500px] overflow-y-auto">
+                <div className="h-[350px] overflow-y-auto">
                   {relativeTimeOptions.map((option) => {
                     const isSelected = selectedOption === option.shortLabel
                     return (

--- a/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
@@ -71,12 +71,38 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [tempValue, setTempValue] = useState<DateRangePickerValue>(value)
+  const [selectedOption, setSelectedOption] = useState<string | null>(null)
 
   // Custom date inputs only - removed time inputs
   const [startDate, setStartDate] = useState("")
   const [endDate, setEndDate] = useState("")
 
   const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Function to check if current value matches a relative time option
+  const getMatchingOption = useCallback((currentValue: DateRangePickerValue): string | null => {
+    if (!currentValue.from || !currentValue.to) return null
+
+    for (const option of relativeTimeOptions) {
+      const optionRange = option.getValue()
+
+      // Compare dates with some tolerance (to account for time differences)
+      const fromMatches = moment(currentValue.from).isSame(moment(optionRange.from), "day")
+      const toMatches = moment(currentValue.to).isSame(moment(optionRange.to), "day")
+
+      if (fromMatches && toMatches) {
+        return option.shortLabel
+      }
+    }
+
+    return null
+  }, [])
+
+  // Update selected option when value changes
+  useEffect(() => {
+    const matchingOption = getMatchingOption(value)
+    setSelectedOption(matchingOption)
+  }, [value, getMatchingOption])
 
   // Validation logic - simplified for dates only
   const validateDateRange = useCallback(() => {
@@ -172,6 +198,7 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
     const { from, to } = option.getValue()
     const newValue = { from, to }
     setTempValue(newValue)
+    setSelectedOption(option.shortLabel)
 
     // Update the form inputs to reflect the selection
     setStartDate(moment(from).format("YYYY-MM-DD"))
@@ -186,13 +213,18 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
         const to = moment(endDate, "YYYY-MM-DD").endOf("day")
 
         if (from.isValid() && to.isValid()) {
-          setTempValue({ from: from.toDate(), to: to.toDate() })
+          const newValue = { from: from.toDate(), to: to.toDate() }
+          setTempValue(newValue)
+
+          // Check if this matches any preset option
+          const matchingOption = getMatchingOption(newValue)
+          setSelectedOption(matchingOption)
         }
       }
     } catch (error) {
       console.warn("Invalid date format:", error)
     }
-  }, [startDate, endDate, validation.isValid])
+  }, [startDate, endDate, validation.isValid, getMatchingOption])
 
   // Update tempValue when inputs change
   useEffect(() => {
@@ -228,6 +260,10 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
     if (value.to) {
       setEndDate(moment(value.to).format("YYYY-MM-DD"))
     }
+
+    // Reset selected option
+    const matchingOption = getMatchingOption(value)
+    setSelectedOption(matchingOption)
 
     setIsOpen(false)
   }
@@ -267,17 +303,30 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
                 <div className="p-3 border-b border-gray-200">
                   <span className="text-sm font-semibold text-gray-900">Relative time (today, 7d, 30d, MTD, YTD)</span>
                 </div>
-                <div className="h-[350px] overflow-y-auto">
-                  {relativeTimeOptions.map((option) => (
-                    <div
-                      key={option.label}
-                      className="flex items-center justify-between px-5 py-4 hover:bg-gray-50 cursor-pointer border-b border-gray-100"
-                      onClick={() => handleRelativeTimeSelect(option)}
-                    >
-                      <span className="text-sm text-gray-700">{option.label}</span>
-                      <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">{option.shortLabel}</span>
-                    </div>
-                  ))}
+                <div className="h-[500px] overflow-y-auto">
+                  {relativeTimeOptions.map((option) => {
+                    const isSelected = selectedOption === option.shortLabel
+                    return (
+                      <div
+                        key={option.label}
+                        className={`flex items-center justify-between px-5 py-4 cursor-pointer border-b border-gray-100 transition-colors ${
+                          isSelected ? "bg-blue-50 hover:bg-blue-100 border-blue-200" : "hover:bg-gray-50"
+                        }`}
+                        onClick={() => handleRelativeTimeSelect(option)}
+                      >
+                        <span className={`text-sm ${isSelected ? "text-blue-700 font-medium" : "text-gray-700"}`}>
+                          {option.label}
+                        </span>
+                        <span
+                          className={`text-xs px-2 py-1 rounded ${
+                            isSelected ? "text-blue-700 bg-blue-100" : "text-gray-500 bg-gray-100"
+                          }`}
+                        >
+                          {option.shortLabel}
+                        </span>
+                      </div>
+                    )
+                  })}
                 </div>
               </div>
 

--- a/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
+++ b/ui/litellm-dashboard/src/components/shared/advanced_date_picker.tsx
@@ -267,7 +267,7 @@ const AdvancedDatePicker: React.FC<AdvancedDatePickerProps> = ({
                 <div className="p-3 border-b border-gray-200">
                   <span className="text-sm font-semibold text-gray-900">Relative time (today, 7d, 30d, MTD, YTD)</span>
                 </div>
-                <div className="h-[500px] overflow-y-auto">
+                <div className="h-[350px] overflow-y-auto">
                   {relativeTimeOptions.map((option) => (
                     <div
                       key={option.label}


### PR DESCRIPTION
## Title
Add advanced date picker to all the tabs on the usage page
<!-- e.g. "Implement user authentication feature" -->
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement
🐛 Bug Fix

## Changes
- Added advanced date picker to team usage and tag usage.
<img width="1512" height="885" alt="Screenshot 2025-08-02 at 18 41 21" src="https://github.com/user-attachments/assets/a58b9abf-ec60-4078-83fd-76c95ef9fa7f" />
<img width="1512" height="885" alt="Screenshot 2025-08-02 at 18 41 30" src="https://github.com/user-attachments/assets/39ebfd48-cf9d-4012-9ddb-abfde8e94296" />
- Reduced white space in date picker. Selected option under Relative time will be highlighted.
<img width="1512" height="885" alt="Screenshot 2025-08-02 at 18 43 29" src="https://github.com/user-attachments/assets/1f7c42d4-361b-4303-9407-3b8992cae759" />
- The Apply button was originally introduced to prevent multiple rapid API calls when users were selecting an absolute time range, where start and end times are chosen separately. It ensures we don’t send concurrent or conflicting requests while the user is still interacting with the picker. Since relative time ranges don’t require multiple steps, we can safely trigger the request immediately without the risk of overlapping calls.
