### PR TITLE
add Perplexity citation annotations support

### DIFF
--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -13,6 +13,8 @@ from litellm.types.utils import Usage, PromptTokensDetailsWrapper
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.utils import ModelResponse
+from litellm.types.llms.openai import ChatCompletionAnnotation
+from litellm.types.llms.openai import ChatCompletionAnnotationURLCitation
 
 
 class PerplexityChatConfig(OpenAIGPTConfig):
@@ -59,7 +61,7 @@ class PerplexityChatConfig(OpenAIGPTConfig):
                 base_openai_params.append("reasoning_effort")
         except Exception as e:
             verbose_logger.debug(f"Error checking if model supports reasoning: {e}")
-        
+
         try:
             if litellm.supports_web_search(
                 model=model, custom_llm_provider=self.custom_llm_provider
@@ -67,7 +69,7 @@ class PerplexityChatConfig(OpenAIGPTConfig):
                 base_openai_params.append("web_search_options")
         except Exception as e:
             verbose_logger.debug(f"Error checking if model supports web search: {e}")
-        
+
         return base_openai_params
 
     def transform_response(
@@ -102,9 +104,12 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         # Extract and enhance usage with Perplexity-specific fields
         try:
             raw_response_json = raw_response.json()
-            self._enhance_usage_with_perplexity_fields(model_response, raw_response_json)
+            self._enhance_usage_with_perplexity_fields(
+                model_response, raw_response_json
+            )
+            self._add_citations_as_annotations(model_response, raw_response_json)
         except Exception as e:
-            verbose_logger.debug(f"Error extracting Perplexity-specific usage fields: {e}")
+            verbose_logger.debug(f"Error extracting Perplexity-specific fields: {e}")
 
         return model_response
 
@@ -118,9 +123,7 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         if not hasattr(model_response, "usage") or model_response.usage is None:
             # Create a usage object if it doesn't exist (when usage was None)
             model_response.usage = Usage(  # type: ignore[attr-defined]
-                prompt_tokens=0,
-                completion_tokens=0,
-                total_tokens=0
+                prompt_tokens=0, completion_tokens=0, total_tokens=0
             )
 
         usage = model_response.usage  # type: ignore[attr-defined]
@@ -131,7 +134,9 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         if citations:
             # Count total characters in citations as a proxy for citation tokens
             # This is an estimation - in practice, you might want to use proper tokenization
-            total_citation_chars = sum(len(str(citation)) for citation in citations if citation)
+            total_citation_chars = sum(
+                len(str(citation)) for citation in citations if citation
+            )
             # Rough estimation: ~4 characters per token (OpenAI's general rule)
             if total_citation_chars > 0:
                 citation_tokens = max(1, total_citation_chars // 4)
@@ -139,7 +144,7 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         # Extract search queries count from usage or response metadata
         # Perplexity might include this in the usage object or as separate metadata
         perplexity_usage = raw_response_json.get("usage", {})
-        
+
         # Try to extract search queries from usage field first, then root level
         num_search_queries = perplexity_usage.get("num_search_queries")
         if num_search_queries is None:
@@ -148,16 +153,97 @@ class PerplexityChatConfig(OpenAIGPTConfig):
             num_search_queries = perplexity_usage.get("search_queries")
         if num_search_queries is None:
             num_search_queries = raw_response_json.get("search_queries")
-        
+
         # Create or update prompt_tokens_details to include web search requests and citation tokens
-        if citation_tokens > 0 or (num_search_queries is not None and num_search_queries > 0):
+        if citation_tokens > 0 or (
+            num_search_queries is not None and num_search_queries > 0
+        ):
             if usage.prompt_tokens_details is None:
                 usage.prompt_tokens_details = PromptTokensDetailsWrapper()
-            
+
             # Store citation tokens count for cost calculation
             if citation_tokens > 0:
                 setattr(usage, "citation_tokens", citation_tokens)
-            
+
             # Store search queries count in the standard web_search_requests field
             if num_search_queries is not None and num_search_queries > 0:
                 usage.prompt_tokens_details.web_search_requests = num_search_queries
+
+    def _add_citations_as_annotations(
+        self, model_response: ModelResponse, raw_response_json: dict
+    ) -> None:
+        """
+        Extract citations and search_results from Perplexity API response
+        and add them as ChatCompletionAnnotation objects to the message.
+        """
+        if not model_response.choices:
+            return
+
+        # Get the first choice (assuming single response)
+        choice = model_response.choices[0]
+        if not hasattr(choice, "message") or choice.message is None:
+            return
+
+        message = choice.message
+        annotations = []
+
+        # Extract citations from the response
+        citations = raw_response_json.get("citations", [])
+        search_results = raw_response_json.get("search_results", [])
+
+        # Create a mapping of URLs to search result titles
+        url_to_title = {}
+        for result in search_results:
+            if isinstance(result, dict) and "url" in result and "title" in result:
+                url_to_title[result["url"]] = result["title"]
+
+        # Get the message content to find citation positions
+        content = getattr(message, "content", "")
+        if not content:
+            return
+
+        # Find all citation markers like [1], [2], [3], [4] in the text
+        import re
+
+        citation_pattern = r"\[(\d+)\]"
+        citation_matches = list(re.finditer(citation_pattern, content))
+
+        # Create a mapping of citation numbers to URLs
+        citation_number_to_url = {}
+        for i, citation in enumerate(citations):
+            if isinstance(citation, str):
+                citation_number_to_url[i + 1] = citation  # 1-indexed
+
+        # Create annotations for each citation match found in the text
+        for match in citation_matches:
+            citation_number = int(match.group(1))
+            if citation_number in citation_number_to_url:
+                url = citation_number_to_url[citation_number]
+                title = url_to_title.get(url, "")
+
+                # Create the URL citation annotation with actual text positions
+                url_citation: ChatCompletionAnnotationURLCitation = {
+                    "url": url,
+                    "title": title,
+                    "start_index": match.start(),
+                    "end_index": match.end(),
+                }
+
+                annotation: ChatCompletionAnnotation = {
+                    "type": "url_citation",
+                    "url_citation": url_citation,
+                }
+
+                annotations.append(annotation)
+
+        # Add annotations to the message if we have any
+        if annotations:
+            if not hasattr(message, "annotations") or message.annotations is None:
+                message.annotations = []
+            message.annotations.extend(annotations)
+
+        # Also add the raw citations and search_results as attributes for backward compatibility
+        if citations:
+            setattr(model_response, "citations", citations)
+        if search_results:
+            setattr(model_response, "search_results", search_results)


### PR DESCRIPTION
## Add Perplexity citation annotations support

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
### Overview
This PR addresses a critical integration issue where the **OpenAI agents SDK** expects annotations in `ChatCompletionAnnotation` format from LiteLLM, but Perplexity responses only provide citations as separate attributes, leaving the annotations field empty. Since litellm converts responses into openai compatible responses, I have added openai compatible annotation handling as well in it.

### Key Features
- **Citation Position Mapping**: Accurately maps citation markers [1], [2], etc. to their exact character positions in the text using regex
- **Title Integration**: Maps URLs to titles from search results for rich citation metadata
- **Backward Compatibility**: Maintains existing citations and search_results attributes
- **Edge Case Handling**: Robust handling of empty citations, missing patterns, malformed data, etc.

### Implementation Details
**Core Changes**

- `litellm/llms/perplexity/chat/transformation.py`:
  - Added _add_citations_as_annotations() method to convert Perplexity citations to ChatCompletionAnnotation format
  - Implemented regex-based position mapping for citation markers
  - Added title mapping from search results
  - Integrated with existing transform_response() method

### Test Coverage
- tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py:
- Added 9 comprehensive test cases covering:
   - Basic citation annotation creation
   - Empty citations handling



