### PR TITLE
Add Perplexity citation annotations support

### DIFF
--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -13,6 +13,8 @@ from litellm.types.utils import Usage, PromptTokensDetailsWrapper
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.utils import ModelResponse
+from litellm.types.llms.openai import ChatCompletionAnnotation
+from litellm.types.llms.openai import ChatCompletionAnnotationURLCitation
 
 
 class PerplexityChatConfig(OpenAIGPTConfig):
@@ -102,7 +104,10 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         # Extract and enhance usage with Perplexity-specific fields
         try:
             raw_response_json = raw_response.json()
-            self._enhance_usage_with_perplexity_fields(model_response, raw_response_json)
+            self._enhance_usage_with_perplexity_fields(
+                model_response, raw_response_json
+            )
+            self._add_citations_as_annotations(model_response, raw_response_json)
         except Exception as e:
             verbose_logger.debug(f"Error extracting Perplexity-specific usage fields: {e}")
 
@@ -131,7 +136,9 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         if citations:
             # Count total characters in citations as a proxy for citation tokens
             # This is an estimation - in practice, you might want to use proper tokenization
-            total_citation_chars = sum(len(str(citation)) for citation in citations if citation)
+            total_citation_chars = sum(
+                len(str(citation)) for citation in citations if citation
+            )
             # Rough estimation: ~4 characters per token (OpenAI's general rule)
             if total_citation_chars > 0:
                 citation_tokens = max(1, total_citation_chars // 4)
@@ -150,7 +157,9 @@ class PerplexityChatConfig(OpenAIGPTConfig):
             num_search_queries = raw_response_json.get("search_queries")
         
         # Create or update prompt_tokens_details to include web search requests and citation tokens
-        if citation_tokens > 0 or (num_search_queries is not None and num_search_queries > 0):
+        if citation_tokens > 0 or (
+            num_search_queries is not None and num_search_queries > 0
+        ):
             if usage.prompt_tokens_details is None:
                 usage.prompt_tokens_details = PromptTokensDetailsWrapper()
             
@@ -161,3 +170,82 @@ class PerplexityChatConfig(OpenAIGPTConfig):
             # Store search queries count in the standard web_search_requests field
             if num_search_queries is not None and num_search_queries > 0:
                 usage.prompt_tokens_details.web_search_requests = num_search_queries
+
+    def _add_citations_as_annotations(
+        self, model_response: ModelResponse, raw_response_json: dict
+    ) -> None:
+        """
+        Extract citations and search_results from Perplexity API response
+        and add them as ChatCompletionAnnotation objects to the message.
+        """
+        if not model_response.choices:
+            return
+
+        # Get the first choice (assuming single response)
+        choice = model_response.choices[0]
+        if not hasattr(choice, "message") or choice.message is None:
+            return
+
+        message = choice.message
+        annotations = []
+
+        # Extract citations from the response
+        citations = raw_response_json.get("citations", [])
+        search_results = raw_response_json.get("search_results", [])
+
+        # Create a mapping of URLs to search result titles
+        url_to_title = {}
+        for result in search_results:
+            if isinstance(result, dict) and "url" in result and "title" in result:
+                url_to_title[result["url"]] = result["title"]
+
+        # Get the message content to find citation positions
+        content = getattr(message, "content", "")
+        if not content:
+            return
+
+        # Find all citation markers like [1], [2], [3], [4] in the text
+        import re
+
+        citation_pattern = r"\[(\d+)\]"
+        citation_matches = list(re.finditer(citation_pattern, content))
+
+        # Create a mapping of citation numbers to URLs
+        citation_number_to_url = {}
+        for i, citation in enumerate(citations):
+            if isinstance(citation, str):
+                citation_number_to_url[i + 1] = citation  # 1-indexed
+
+        # Create annotations for each citation match found in the text
+        for match in citation_matches:
+            citation_number = int(match.group(1))
+            if citation_number in citation_number_to_url:
+                url = citation_number_to_url[citation_number]
+                title = url_to_title.get(url, "")
+
+                # Create the URL citation annotation with actual text positions
+                url_citation: ChatCompletionAnnotationURLCitation = {
+                    "url": url,
+                    "title": title,
+                    "start_index": match.start(),
+                    "end_index": match.end(),
+                }
+
+                annotation: ChatCompletionAnnotation = {
+                    "type": "url_citation",
+                    "url_citation": url_citation,
+                }
+
+                annotations.append(annotation)
+
+        # Add annotations to the message if we have any
+        if annotations:
+            if not hasattr(message, "annotations") or message.annotations is None:
+                message.annotations = []
+            message.annotations.extend(annotations)
+
+        # Also add the raw citations and search_results as attributes for backward compatibility
+        if citations:
+            setattr(model_response, "citations", citations)
+        if search_results:
+            setattr(model_response, "search_results", search_results)


### PR DESCRIPTION
## Add Perplexity citation annotations support

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Overview

This PR addresses a critical integration issue where the OpenAI agents SDK expects annotations in `ChatCompletionAnnotation` format from LiteLLM, but Perplexity responses only provide citations as separate attributes, leaving the `annotations` field empty. Since LiteLLM converts responses into OpenAI-compatible responses, this PR adds proper OpenAI-compatible annotation handling.

### Key Features

- **Citation Position Mapping**: Accurately maps citation markers `[1]`, `[2]`, etc. to their exact character positions in the text using regex.
- **Title Integration**: Maps URLs to titles from `search_results` for rich citation metadata.
- **Backward Compatibility**: Maintains existing `citations` and `search_results` attributes for compatibility.
- **Edge Case Handling**: Robust handling of edge cases such as:
  - Empty `citations`
  - Missing patterns
  - Malformed or partial citation data

### Implementation Details

**Core Changes**

**File:** `litellm/llms/perplexity/chat/transformation.py`

- Added `_add_citations_as_annotations()` method to convert Perplexity citations to `ChatCompletionAnnotation` format.
- Implemented regex-based position mapping for citation markers.
- Added title mapping using `search_results`.
- Integrated citation transformation into the `transform_response()` pipeline.

### Test Coverage

**File:** `tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py`

- Added 9 comprehensive test cases covering:
  - Basic citation annotation creation
  - Empty citation handling
  - Malformed data handling
  - Title integration verification
