### PR TITLE
[Proxy] Add OpenShift Support to non root docker image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -71,6 +71,20 @@ RUN mkdir -p /nonexistent /.npm && \
     PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
     chown -R nobody:nogroup $PRISMA_PATH
 
+# --- OpenShift Compatibility: Apply Red Hat recommended pattern ---
+# Get paths for directories that need write access at runtime
+RUN PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
+    LITELLM_PROXY_EXTRAS_PATH=$(python -c "import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))" 2>/dev/null || echo "") && \
+    # Set group ownership to 0 (root group) for OpenShift compatibility && \
+    chgrp -R 0 $PRISMA_PATH && \
+    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chgrp -R 0 $LITELLM_PROXY_EXTRAS_PATH || true && \
+    # Mirror owner permissions to group (g=u) as recommended by Red Hat && \
+    chmod -R g=u $PRISMA_PATH && \
+    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g=u $LITELLM_PROXY_EXTRAS_PATH || true && \
+    # Ensure directories are writable by group && \
+    chmod -R g+w $PRISMA_PATH && \
+    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w $LITELLM_PROXY_EXTRAS_PATH || true
+
 # Switch to non-root user
 USER nobody
 


### PR DESCRIPTION
## [Proxy] Add OpenShift Support to non root docker image

## Relevant issues

Fixes #13208 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🆕 New Feature

## Changes


#### Before:
```dockerfile
# Create directories and set permissions for non-root user
RUN mkdir -p /nonexistent /.npm && \
    chown -R nobody:nogroup /app && \
    chown -R nobody:nogroup /nonexistent /.npm && \
    PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
    chown -R nobody:nogroup $PRISMA_PATH
```

#### After:
```dockerfile
# Create directories and set permissions for non-root user
RUN mkdir -p /nonexistent /.npm && \
    chown -R nobody:nogroup /app && \
    chown -R nobody:nogroup /nonexistent /.npm && \
    PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
    chown -R nobody:nogroup $PRISMA_PATH

# --- OpenShift Compatibility: Apply Red Hat recommended pattern ---
# Get paths for directories that need write access at runtime
RUN PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
    LITELLM_PROXY_EXTRAS_PATH=$(python -c "import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))" 2>/dev/null || echo "") && \
    # Set group ownership to 0 (root group) for OpenShift compatibility && \
    chgrp -R 0 $PRISMA_PATH && \
    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chgrp -R 0 $LITELLM_PROXY_EXTRAS_PATH || true && \
    # Mirror owner permissions to group (g=u) as recommended by Red Hat && \
    chmod -R g=u $PRISMA_PATH && \
    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g=u $LITELLM_PROXY_EXTRAS_PATH || true && \
    # Ensure directories are writable by group && \
    chmod -R g+w $PRISMA_PATH && \
    [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w $LITELLM_PROXY_EXTRAS_PATH || true
```

### What This Does

1. **Sets group ownership to 0** (root group) for writable directories
2. **Mirrors owner permissions to group** (`chmod -R g=u`) 
3. **Ensures group write access** (`chmod -R g+w`)
4. **Handles both Prisma and litellm_proxy_extras directories**


### Why This Was Needed

OpenShift runs containers with arbitrary UIDs and supplemental GID 0, but the original image had directories owned by `nobody:nogroup` (UID 65534, GID 65534), causing permission errors.

