### PR TITLE
[Bug Fix] OpenAI / Azure Responses API - Add `service_tier` , `safety_identifier` supported params

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -4,6 +4,9 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    _safe_convert_created_field,
+)
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import *
@@ -11,7 +14,6 @@ from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
 
 from ..common_utils import OpenAIError
-from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import _safe_convert_created_field
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -47,6 +49,8 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
             "top_p",
             "truncation",
             "user",
+            "service_tier",
+            "safety_identifier",
             "extra_headers",
             "extra_query",
             "extra_body",

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -243,6 +243,8 @@ async def aresponses(
     top_p: Optional[float] = None,
     truncation: Optional[Literal["auto", "disabled"]] = None,
     user: Optional[str] = None,
+    service_tier: Optional[str] = None,
+    safety_identifier: Optional[str] = None,
     # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
     # The extra values given here take precedence over values defined on the client or passed to this method.
     extra_headers: Optional[Dict[str, Any]] = None,
@@ -294,6 +296,8 @@ async def aresponses(
             extra_body=extra_body,
             timeout=timeout,
             custom_llm_provider=custom_llm_provider,
+            service_tier=service_tier,
+            safety_identifier=safety_identifier,
             **kwargs,
         )
 
@@ -350,6 +354,8 @@ def responses(
     top_p: Optional[float] = None,
     truncation: Optional[Literal["auto", "disabled"]] = None,
     user: Optional[str] = None,
+    service_tier: Optional[str] = None,
+    safety_identifier: Optional[str] = None,
     # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
     # The extra values given here take precedence over values defined on the client or passed to this method.
     extra_headers: Optional[Dict[str, Any]] = None,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -965,6 +965,8 @@ class ResponsesAPIOptionalRequestParams(TypedDict, total=False):
     top_p: Optional[float]
     truncation: Optional[Literal["auto", "disabled"]]
     user: Optional[str]
+    service_tier: Optional[str]
+    safety_identifier: Optional[str]
     prompt: Optional[PromptObject]
 
 


### PR DESCRIPTION
## [Bug Fix] OpenAI / Azure Responses API - Add `service_tier` , `safety_identifier` supported params

Fixes: https://github.com/BerriAI/litellm/issues/13257 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


