### PR TITLE
Bug Fix - Responses API raises error with Gemini Tool Calls in `input`

### DIFF
--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -187,8 +187,8 @@ class BaseResponsesAPITest(ABC):
         # basic test assert the usage seems reasonable
         print("response_completed_event.response.usage=", response_completed_event.response.usage)
         assert response_completed_event.response.usage.input_tokens > 0 and response_completed_event.response.usage.input_tokens < 100
-        assert response_completed_event.response.usage.output_tokens > 0 and response_completed_event.response.usage.output_tokens < 1000
-        assert response_completed_event.response.usage.total_tokens > 0 and response_completed_event.response.usage.total_tokens < 1000
+        assert response_completed_event.response.usage.output_tokens > 0 and response_completed_event.response.usage.output_tokens < 2000
+        assert response_completed_event.response.usage.total_tokens > 0 and response_completed_event.response.usage.total_tokens < 2000
 
         # total tokens should be the sum of input and output tokens
         assert response_completed_event.response.usage.total_tokens == response_completed_event.response.usage.input_tokens + response_completed_event.response.usage.output_tokens

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -25,6 +25,9 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     IncompleteDetails,
 )
+from openai.types.responses.response_create_params import (
+    ResponseInputParam,
+)
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
 
@@ -364,3 +367,73 @@ class BaseResponsesAPITest(ABC):
         # assert the response is not None
         assert response_1 is not None
         assert response_2 is not None
+    
+    @pytest.mark.asyncio
+    async def test_responses_api_with_tool_calls(self):
+        """Test that calls the Responses API with tool calls including function call and output"""
+        litellm._turn_on_debug()
+        litellm.set_verbose = True
+        base_completion_call_args = self.get_base_completion_call_args()
+        
+        # Define the input with message, function call, and function call output
+        input_data: ResponseInputParam = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": "How is the weather in São Paulo today ?"
+            },
+            {
+                "type": "function_call",
+                "arguments": "{\"location\": \"São Paulo, Brazil\"}",
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "name": "get_weather",
+                "id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "status": "completed"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "output": "Rainy"
+            }
+        ]
+        
+        # Define the tools
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get current temperature for a given location.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City and country e.g. Bogotá, Colombia"
+                        }
+                    },
+                    "required": ["location"],
+                    "additionalProperties": False
+                }
+            }
+        ]
+        
+        try:
+            # Make the responses API call
+            response = await litellm.aresponses(
+                input=input_data,
+                store=False,
+                tools=tools,
+                **base_completion_call_args
+            )
+        except litellm.InternalServerError:
+            pytest.skip("Skipping test due to litellm.InternalServerError")
+        
+        print("litellm response=", json.dumps(response, indent=4, default=str))
+        
+        # Validate the response structure
+        validate_responses_api_response(response, final_chunk=True)
+        
+        # Additional assertions specific to tool calls
+        assert response is not None
+        assert "output" in response
+        assert len(response["output"]) > 0

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -392,7 +392,7 @@ class BaseResponsesAPITest(ABC):
             },
             {
                 "type": "function_call_output",
-                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "call_id": "fc_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
                 "output": "Rainy"
             }
         ]

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -385,9 +385,9 @@ class BaseResponsesAPITest(ABC):
             {
                 "type": "function_call",
                 "arguments": "{\"location\": \"São Paulo, Brazil\"}",
-                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "call_id": "fc_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
                 "name": "get_weather",
-                "id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "id": "fc_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
                 "status": "completed"
             },
             {

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -232,6 +232,7 @@ class BaseResponsesAPITest(ABC):
     
 
     @pytest.mark.parametrize("sync_mode", [True, False])
+    @pytest.mark.flaky(retries=3, delay=2)
     @pytest.mark.asyncio
     async def test_basic_openai_responses_streaming_delete_endpoint(self, sync_mode):
         #litellm._turn_on_debug()
@@ -281,6 +282,7 @@ class BaseResponsesAPITest(ABC):
             )
 
     @pytest.mark.parametrize("sync_mode", [False, True])
+    @pytest.mark.flaky(retries=3, delay=2)
     @pytest.mark.asyncio
     async def test_basic_openai_responses_get_endpoint(self, sync_mode):
         litellm._turn_on_debug()
@@ -321,6 +323,7 @@ class BaseResponsesAPITest(ABC):
                 raise ValueError("response is not a ResponsesAPIResponse")
 
     @pytest.mark.asyncio
+    @pytest.mark.flaky(retries=3, delay=2)
     async def test_basic_openai_list_input_items_endpoint(self):
         """Test that calls the OpenAI List Input Items endpoint"""
         litellm._turn_on_debug()

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -89,7 +89,8 @@ class TestGoogleAIStudioResponsesAPITest(BaseResponsesAPITest):
     def get_base_completion_call_args(self):
         #litellm._turn_on_debug()
         return {
-            "model": "gemini/gemini-2.5-flash",
+            "model": "gemini/gemini-2.5-flash-lite",
+            "max_output_tokens": 100,
         }
     
     async def test_basic_openai_responses_delete_endpoint(self, sync_mode=False):

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, AsyncMock
 sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 import json
-
+from base_responses_api import BaseResponsesAPITest
 @pytest.mark.asyncio
 async def test_basic_google_ai_studio_responses_api_with_tools():
     litellm._turn_on_debug()
@@ -85,10 +85,22 @@ async def test_mock_basic_google_ai_studio_responses_api_with_tools():
         assert call_kwargs["messages"][0]["content"] == "what is the latest version of supabase python package and when was it released?"
         assert call_kwargs["tools"] == []  # web search tools are converted to web_search_options, not kept as tools
 
-
+class TestGoogleAIStudioResponsesAPITest(BaseResponsesAPITest):
+    def get_base_completion_call_args(self):
+        #litellm._turn_on_debug()
+        return {
+            "model": "gemini/gemini-2.5-flash",
+        }
     
+    async def test_basic_openai_responses_delete_endpoint(self, sync_mode=False):
+        pass
+    
+    async def test_basic_openai_responses_streaming_delete_endpoint(self, sync_mode=False):
+        pass
 
-
+    async def test_basic_openai_responses_get_endpoint(self, sync_mode=False):
+        pass
+    
     
 
 

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -89,8 +89,7 @@ class TestGoogleAIStudioResponsesAPITest(BaseResponsesAPITest):
     def get_base_completion_call_args(self):
         #litellm._turn_on_debug()
         return {
-            "model": "gemini/gemini-2.5-flash-lite",
-            "max_output_tokens": 100,
+            "model": "gemini/gemini-2.5-flash-lite"
         }
     
     async def test_basic_openai_responses_delete_endpoint(self, sync_mode=False):

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -8,7 +8,11 @@ sys.path.insert(
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
-from litellm.types.utils import ModelResponse, Choices, Message
+from litellm.types.llms.openai import (
+    ChatCompletionResponseMessage,
+    ChatCompletionToolMessage,
+)
+from litellm.types.utils import Choices, Message, ModelResponse
 
 
 class TestLiteLLMCompletionResponsesConfig:
@@ -364,3 +368,218 @@ class TestLiteLLMCompletionResponsesConfig:
             item for item in responses_api_response.output if item.type == "message"
         ]
         assert len(message_items) == 2, "Should have two message items"
+
+
+
+
+class TestFunctionCallTransformation:
+    """Test cases for function_call input transformation"""
+
+    def test_function_call_detection(self):
+        """Test that function_call items are correctly detected"""
+        function_call_item = {
+            "type": "function_call",
+            "name": "get_weather",
+            "arguments": '{"location": "test"}',
+            "call_id": "test_id"
+        }
+        
+        function_call_output_item = {
+            "type": "function_call_output",
+            "call_id": "test_id",
+            "output": "result"
+        }
+        
+        regular_message = {
+            "type": "message",
+            "role": "user",
+            "content": "Hello"
+        }
+        
+        # Test function_call detection
+        assert LiteLLMCompletionResponsesConfig._is_input_item_function_call(function_call_item)
+        assert not LiteLLMCompletionResponsesConfig._is_input_item_function_call(function_call_output_item)
+        assert not LiteLLMCompletionResponsesConfig._is_input_item_function_call(regular_message)
+        
+        # Test function_call_output detection (should still work)
+        assert LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(function_call_output_item)
+        assert not LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(function_call_item)
+        assert not LiteLLMCompletionResponsesConfig._is_input_item_tool_call_output(regular_message)
+
+    def test_function_call_transformation(self):
+        """Test that function_call items are correctly transformed to assistant messages with tool calls"""
+        function_call_item = {
+            "type": "function_call",
+            "name": "get_weather",
+            "arguments": '{"location": "São Paulo, Brazil"}',
+            "call_id": "call_123",
+            "id": "call_123",
+            "status": "completed"
+        }
+        
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
+            function_call=function_call_item
+        )
+        
+        assert len(result) == 1
+        message = result[0]
+        
+        # Should be an assistant message
+        assert message.get("role") == "assistant"
+        assert message.get("content") is None  # Function calls don't have content
+        
+        # Should have tool calls
+        tool_calls = message.get("tool_calls", [])
+        assert len(tool_calls) == 1
+        
+        tool_call = tool_calls[0]
+        assert tool_call.get("id") == "call_123"
+        assert tool_call.get("type") == "function"
+        
+        function = tool_call.get("function", {})
+        assert function.get("name") == "get_weather"
+        assert function.get("arguments") == '{"location": "São Paulo, Brazil"}'
+
+    def test_complete_input_transformation_with_function_calls(self):
+        """Test the complete transformation with the exact input from the issue"""
+        test_input = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": "How is the weather in São Paulo today ?"
+            },
+            {
+                "type": "function_call",
+                "arguments": '{"location": "São Paulo, Brazil"}',
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "name": "get_weather",
+                "id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "status": "completed"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "output": "Rainy"
+            }
+        ]
+        
+        # This should not raise an error (previously would raise "Invalid content type: <class 'NoneType'>")
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=test_input
+        )
+        
+        assert len(messages) == 3
+        
+        # First message: user message
+        user_msg = messages[0]
+        assert user_msg.get("role") == "user"
+        assert user_msg.get("content") == "How is the weather in São Paulo today ?"
+        
+        # Second message: assistant message with tool call
+        assistant_msg = messages[1]
+        assert assistant_msg.get("role") == "assistant"
+        assert assistant_msg.get("tool_calls") is not None
+        assert len(assistant_msg.get("tool_calls", [])) == 1
+        
+        tool_call = assistant_msg.get("tool_calls")[0]
+        assert tool_call.get("function", {}).get("name") == "get_weather"
+        
+        # Third message: tool output
+        tool_msg = messages[2]
+        assert tool_msg.get("role") == "tool"
+        assert tool_msg.get("content") == "Rainy"
+        assert tool_msg.get("tool_call_id") == "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5"
+
+    def test_complete_request_transformation_with_function_calls(self):
+        """Test the complete request transformation that would be used by the responses API"""
+        test_input = [
+            {
+                "type": "message",
+                "role": "user", 
+                "content": "How is the weather in São Paulo today ?"
+            },
+            {
+                "type": "function_call",
+                "arguments": '{"location": "São Paulo, Brazil"}',
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "name": "get_weather",
+                "id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "status": "completed"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5",
+                "output": "Rainy"
+            }
+        ]
+        
+        tools = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get current temperature for a given location.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City and country e.g. Bogotá, Colombia"
+                        }
+                    },
+                    "required": ["location"],
+                    "additionalProperties": False
+                }
+            }
+        ]
+        
+        responses_api_request = {
+            "store": False,
+            "tools": tools
+        }
+        
+        # This should work without errors for non-OpenAI models
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="gemini/gemini-2.0-flash",
+            input=test_input,
+            responses_api_request=responses_api_request
+        )
+        
+        assert "messages" in result
+        assert "model" in result
+        assert "tools" in result
+        
+        messages = result["messages"]
+        assert len(messages) == 3
+        assert result["model"] == "gemini/gemini-2.0-flash"
+        
+        # Verify the structure is correct for chat completion
+        user_msg = messages[0]
+        assert user_msg["role"] == "user"
+        
+        assistant_msg = messages[1]  
+        assert assistant_msg["role"] == "assistant"
+        assert "tool_calls" in assistant_msg
+        
+        tool_msg = messages[2]
+        assert tool_msg["role"] == "tool"
+
+    def test_function_call_without_call_id_fallback_to_id(self):
+        """Test that function_call items can use 'id' field when 'call_id' is missing"""
+        function_call_item = {
+            "type": "function_call",
+            "name": "get_weather",
+            "arguments": '{"location": "test"}',
+            "id": "fallback_id"  # Only has 'id', not 'call_id'
+        }
+        
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
+            function_call=function_call_item
+        )
+        
+        assert len(result) == 1
+        message = result[0]
+        tool_calls = message.get("tool_calls", [])
+        assert len(tool_calls) == 1
+        
+        tool_call = tool_calls[0]
+        assert tool_call.get("id") == "fallback_id"


### PR DESCRIPTION
## Bug Fix - Responses API raises error with Gemini Tool Calls in `input`

When using the /responses endpoint via the proxy server with non-OpenAI models (e.g., Gemini or Anthropic), the request fails if the input includes messages of type function_call or function_call_output.
The following exception is raised:

litellm.APIConnectionError: Invalid content type: <class 'NoneType'>

Fixes https://github.com/BerriAI/litellm/issues/12670

Responses I now see from responses API 

```json
"response": {
        "id": "7_KQaLS_HdegqtsP2qTW-As",
        "created": 1754329839,
        "model": "gemini-2.5-flash",
        "object": "chat.completion",
        "system_fingerprint": null,
        "choices": [
            {
                "finish_reason": "stop",
                "index": 0,
                "message": {
                    "content": "The weather in S\u00e3o Paulo today is Rainy.",
                    "role": "assistant",
                    "tool_calls": null,
                    "function_call": null
                }
            }
        ],
        "usage": {
            "completion_tokens": 9,
            "prompt_tokens": 92,
            "total_tokens": 101,
            "completion_tokens_details": null,
            "prompt_tokens_details": {
                "audio_tokens": null,
                "cached_tokens": null,
                "text_tokens": 92,
                "image_tokens": null
            }
        },
        "vertex_ai_grounding_metadata": [],
        "vertex_ai_url_context_metadata": [],
        "vertex_ai_safety_results": [],
        "vertex_ai_citation_metadata": []
    },
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


