### PR TITLE
[Bug Fix] Fix  Server root path regression on UI when using "Login"

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -116,6 +116,14 @@ async def serve_login_page(
     missing_env_vars = show_missing_vars_in_env()
     if missing_env_vars is not None:
         return missing_env_vars
+    #########################################################
+    # Construct Redirect URL
+    base_url_to_redirect_to: Optional[str] = None
+    base_url_to_redirect_to = os.getenv("PROXY_BASE_URL", "")
+    server_root_path = os.getenv("SERVER_ROOT_PATH", "")
+    if server_root_path != "":
+        base_url_to_redirect_to += server_root_path
+    #########################################################
 
     # Build the unified login page HTML
     error_message = ""
@@ -137,7 +145,7 @@ async def serve_login_page(
 
     sso_button = ""
     if sso_available:
-        sso_button = """
+        sso_button = f"""
         <div style="
             margin-top: 20px;
             padding-top: 20px;
@@ -149,7 +157,7 @@ async def serve_login_page(
                 font-size: 14px;
                 margin-bottom: 16px;
             ">or</p>
-            <a href="/sso/login" style="
+            <a href="{base_url_to_redirect_to}/sso/login" style="
                 display: inline-block;
                 background-color: #f8fafc;
                 border: 1px solid #e2e8f0;
@@ -168,12 +176,7 @@ async def serve_login_page(
         """
 
     # Get the base URL for form action using proper URL construction
-    url_to_redirect_to = os.getenv("PROXY_BASE_URL", "")
-    server_root_path = os.getenv("SERVER_ROOT_PATH", "")
-    if server_root_path != "":
-        url_to_redirect_to += server_root_path
-    url_to_redirect_to += "/login"
-
+    url_to_redirect_to = f"{base_url_to_redirect_to}/login"
     unified_login_html = f"""
 <!DOCTYPE html>
 <html lang="en">

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1245,3 +1245,47 @@ class TestCustomUISSO:
                     # Verify the result is the redirect response
                     assert result == mock_redirect_response
                     assert result.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_serve_login_page_server_root_path():
+    """
+    Test that serve_login_page includes SERVER_ROOT_PATH in the SSO login URL
+    when SERVER_ROOT_PATH is set.
+    """
+    # Arrange
+    mock_request = MagicMock(spec=Request)
+    captured_html = ""
+    
+    # Mock environment variables
+    env_vars = {
+        "PROXY_BASE_URL": "https://example.com",
+        "SERVER_ROOT_PATH": "/api/v1",
+        "GOOGLE_CLIENT_ID": "mock_google_client_id",  # Enable SSO
+        "DATABASE_URL": "mock_db_url",  # Satisfy show_missing_vars_in_env
+        "LITELLM_MASTER_KEY": "mock_master_key",  # Satisfy show_missing_vars_in_env
+    }
+    
+    # Patch HTMLResponse to capture the content
+    def mock_html_response(content, status_code=200):
+        nonlocal captured_html
+        captured_html = content
+        return MagicMock()
+    
+    with patch.dict(os.environ, env_vars):
+        with patch("litellm.proxy.proxy_server.premium_user", True):
+            with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()):
+                with patch("litellm.proxy.proxy_server.master_key", "mock_master_key"):
+                    with patch("fastapi.responses.HTMLResponse", side_effect=mock_html_response):
+                        # Import the function to test
+                        from litellm.proxy.management_endpoints.ui_sso import (
+                            serve_login_page,
+                        )
+
+                        # Act
+                        result = await serve_login_page(request=mock_request)
+    
+    # Assert
+    assert result is not None
+    expected_url = "https://example.com/api/v1/sso/login"
+    assert expected_url in captured_html, f"Expected URL '{expected_url}' not found in HTML content"


### PR DESCRIPTION
## [Bug Fix] Fix  Server root path regression on UI when using "Login"

Fixes a regression where the new "Login" flow did not use the server root path for SSO sign ins

Manually tested to confirm the fix: 
<img width="801" height="82" alt="Screenshot 2025-08-04 at 12 18 06 PM" src="https://github.com/user-attachments/assets/aec865cf-a492-4358-bd0e-3b367a36a55c" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


