### PR TITLE
Bypass end-user budget check when listing models

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -439,6 +439,7 @@ async def get_end_user_object(
     user_api_key_cache: DualCache,
     parent_otel_span: Optional[Span] = None,
     proxy_logging_obj: Optional[ProxyLogging] = None,
+    check_budget=True,
 ) -> Optional[LiteLLM_EndUserTable]:
     """
     Returns end user object, if in db.
@@ -453,6 +454,8 @@ async def get_end_user_object(
     _key = "end_user_id:{}".format(end_user_id)
 
     def check_in_budget(end_user_obj: LiteLLM_EndUserTable):
+        if not check_budget:
+            return
         if end_user_obj.litellm_budget_table is None:
             return
         end_user_budget = end_user_obj.litellm_budget_table.max_budget

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -844,6 +844,7 @@ class JWTAuthManager:
         user_api_key_cache: DualCache,
         parent_otel_span: Optional[Span],
         proxy_logging_obj: ProxyLogging,
+        check_budget: bool,
     ) -> Tuple[
         Optional[LiteLLM_UserTable],
         Optional[LiteLLM_OrganizationTable],
@@ -892,6 +893,7 @@ class JWTAuthManager:
                     user_api_key_cache=user_api_key_cache,
                     parent_otel_span=parent_otel_span,
                     proxy_logging_obj=proxy_logging_obj,
+                    check_budget=check_budget,
                 )
                 if end_user_id
                 else None
@@ -1121,6 +1123,9 @@ class JWTAuthManager:
                 proxy_logging_obj=proxy_logging_obj,
             )
 
+        # Decide if we need to check the end-user budget
+        check_budget = route != "/v1/models" and route != "/models"
+
         # Get other objects
         user_object, org_object, end_user_object = await JWTAuthManager.get_objects(
             user_id=user_id,
@@ -1133,6 +1138,7 @@ class JWTAuthManager:
             user_api_key_cache=user_api_key_cache,
             parent_otel_span=parent_otel_span,
             proxy_logging_obj=proxy_logging_obj,
+            check_budget=check_budget,
         )
 
         await JWTAuthManager.sync_user_role_and_teams(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -608,6 +608,9 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             try:
                 end_user_params["end_user_id"] = end_user_id
 
+                # Decide if we need to check the end-user budget
+                check_budget = route != "/v1/models" and route != "/models"
+
                 # get end-user object
                 _end_user_object = await get_end_user_object(
                     end_user_id=end_user_id,
@@ -615,6 +618,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     user_api_key_cache=user_api_key_cache,
                     parent_otel_span=parent_otel_span,
                     proxy_logging_obj=proxy_logging_obj,
+                    check_budget=check_budget,
                 )
                 if _end_user_object is not None:
                     end_user_params["allowed_model_region"] = (


### PR DESCRIPTION
## Title

This is the same change as e49fe47d2ea25fea052635e16231a3db5720accf, except applied to end-user budgets.

The effect is that, e.g. in Open WebUI, previously, if the end-user's budget was exceeded, it would appear as if no models existed. The user would also not have any way to know what is wrong, since Open WebUI does not show an error message when it fails to retrieve the model list.

With this patch, the model list is retrieved successfully even when the end-user's budget is exceeded, but all other API requests (e.g. chat completions) will fail, this time with a nice error message.

## Relevant issues

- Fixes https://github.com/BerriAI/litellm/issues/13286

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~ https://github.com/BerriAI/litellm/issues/12951
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<details><summary>Tests log (the 1 failure is also broken without any changes)</summary>

```
------------------------------------------------------------------------------- Captured log setup --------------------------------------------------------------------------------
DEBUG    LiteLLM:http_handler.py:579 Using AiohttpTransport...
DEBUG    LiteLLM:http_handler.py:636 Creating AiohttpTransport...
DEBUG    LiteLLM Proxy:litellm_license.py:29 License Str value - None
DEBUG    LiteLLM Proxy:litellm_license.py:102 litellm.proxy.auth.litellm_license.py::is_premium() - ENTERING 'IS_PREMIUM' - LiteLLM License=None
DEBUG    LiteLLM Proxy:litellm_license.py:111 litellm.proxy.auth.litellm_license.py::is_premium() - Updated 'self.license_str' - None
DEBUG    LiteLLM:http_handler.py:579 Using AiohttpTransport...
DEBUG    LiteLLM:http_handler.py:636 Creating AiohttpTransport...
================================================================================ warnings summary =================================================================================
tests/test_litellm/integrations/test_custom_prompt_management.py:27
tests/test_litellm/integrations/test_custom_prompt_management.py:27
tests/test_litellm/integrations/test_custom_prompt_management.py:27
tests/test_litellm/integrations/test_custom_prompt_management.py:27
  /app/tests/test_litellm/integrations/test_custom_prompt_management.py:27: PytestCollectionWarning: cannot collect test class 'TestCustomPromptManagement' because it has a __init__ constructor (from: tests/test_litellm/integrations/test_custom_prompt_management.py)
    class TestCustomPromptManagement(CustomPromptManagement):

tests/test_litellm/integrations/arize/test_arize_utils.py:184
tests/test_litellm/integrations/arize/test_arize_utils.py:184
tests/test_litellm/integrations/arize/test_arize_utils.py:184
tests/test_litellm/integrations/arize/test_arize_utils.py:184
  /app/tests/test_litellm/integrations/arize/test_arize_utils.py:184: PytestCollectionWarning: cannot collect test class 'TestArizeLogger' because it has a __init__ constructor (from: tests/test_litellm/integrations/arize/test_arize_utils.py)
    class TestArizeLogger(CustomLogger):

tests/test_litellm/llms/azure/response/test_azure_transformation.py:15
tests/test_litellm/llms/azure/response/test_azure_transformation.py:15
tests/test_litellm/llms/azure/response/test_azure_transformation.py:15
tests/test_litellm/llms/azure/response/test_azure_transformation.py:15
  /app/tests/test_litellm/llms/azure/response/test_azure_transformation.py:15: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/llms/azure/response/test_azure_transformation.py:28
tests/test_litellm/llms/azure/response/test_azure_transformation.py:28
tests/test_litellm/llms/azure/response/test_azure_transformation.py:28
tests/test_litellm/llms/azure/response/test_azure_transformation.py:28
  /app/tests/test_litellm/llms/azure/response/test_azure_transformation.py:28: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/llms/azure/response/test_azure_transformation.py:42
tests/test_litellm/llms/azure/response/test_azure_transformation.py:42
tests/test_litellm/llms/azure/response/test_azure_transformation.py:42
tests/test_litellm/llms/azure/response/test_azure_transformation.py:42
  /app/tests/test_litellm/llms/azure/response/test_azure_transformation.py:42: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/llms/azure/response/test_azure_transformation.py:56
tests/test_litellm/llms/azure/response/test_azure_transformation.py:56
tests/test_litellm/llms/azure/response/test_azure_transformation.py:56
tests/test_litellm/llms/azure/response/test_azure_transformation.py:56
  /app/tests/test_litellm/llms/azure/response/test_azure_transformation.py:56: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/llms/azure/response/test_azure_transformation.py:76
tests/test_litellm/llms/azure/response/test_azure_transformation.py:76
tests/test_litellm/llms/azure/response/test_azure_transformation.py:76
tests/test_litellm/llms/azure/response/test_azure_transformation.py:76
  /app/tests/test_litellm/llms/azure/response/test_azure_transformation.py:76: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py:16
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py:16
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py:16
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py:16
  /app/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py:16: PytestCollectionWarning: cannot collect test class 'TestEvent' because it has a __init__ constructor (from: tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py)
    class TestEvent(BaseModel):

tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py:151
tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py:151
tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py:151
tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py:151
  /app/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py:151: PytestUnknownMarkWarning: Unknown pytest.mark.serial - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.serial

tests/test_litellm/proxy/db/db_transaction_queue/test_pod_lock_manager.py: 8 warnings
tests/test_litellm/llms/pg_vector/vector_stores/test_pg_vector_transformation.py: 8 warnings
tests/test_litellm/google_genai/test_google_genai_adapter.py: 20 warnings
tests/test_litellm/litellm_core_utils/llm_cost_calc/test_azure_assistant_cost_tracking.py: 8 warnings
tests/test_litellm/integrations/arize/test_arize_utils.py: 3 warnings
tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py: 15 warnings
tests/test_litellm/integrations/gcs_pubsub/test_pub_sub.py: 1 warning
tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py: 2 warnings
tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py: 19 warnings
tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py: 2 warnings
tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py: 5 warnings
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py: 4 warnings
tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py: 57 warnings
tests/test_litellm/llms/perplexity/test_perplexity_integration.py: 8 warnings
tests/test_litellm/types/test_types_utils.py: 3 warnings
tests/test_litellm/proxy/client/cli/test_chat_commands.py: 6 warnings
tests/test_litellm/test_cost_calculation_log_level.py: 2 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py: 2 warnings
tests/test_litellm/test_cost_calculator.py: 8 warnings
tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py: 15 warnings
tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py: 14 warnings
tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py: 5 warnings
tests/test_litellm/integrations/test_prometheus_services.py: 1 warning
tests/test_litellm/integrations/test_opentelemetry.py: 12 warnings
tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py: 24 warnings
tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py: 2 warnings
tests/test_litellm/litellm_core_utils/test_token_counter.py: 25 warnings
tests/test_litellm/proxy/client/test_credentials.py: 15 warnings
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py: 42 warnings
tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py: 4 warnings
tests/test_litellm/proxy/test_common_request_processing.py: 25 warnings
tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py: 6 warnings
tests/test_litellm/proxy/test_litellm_pre_call_utils.py: 8 warnings
tests/test_litellm/proxy/db/test_check_migration.py: 1 warning
tests/test_litellm/test_utils.py: 101 warnings
tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py: 20 warnings
tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py: 5 warnings
tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py: 2 warnings
tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py: 7 warnings
tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py: 6 warnings
tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py: 12 warnings
tests/test_litellm/proxy/test_spend_log_cleanup.py: 5 warnings
tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py: 13 warnings
tests/test_litellm/proxy/client/test_users.py: 8 warnings
tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py: 3 warnings
tests/test_litellm/proxy/client/cli/test_auth_commands.py: 20 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py: 17 warnings
tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py: 5 warnings
tests/test_litellm/integrations/test_openmeter.py: 11 warnings
tests/test_litellm/proxy/client/test_http_client.py: 6 warnings
tests/test_litellm/llms/nscale/chat/test_nscale_chat_transformation.py: 3 warnings
tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py: 24 warnings
tests/test_litellm/enterprise/enterprise_callbacks/test_callback_controls.py: 4 warnings
tests/test_litellm/proxy/client/cli/test_global_options.py: 2 warnings
tests/test_litellm/llms/huggingface/rerank/test_huggingface_rerank_transformation.py: 11 warnings
tests/test_litellm/integrations/test_custom_prompt_management.py: 3 warnings
tests/test_litellm/proxy/client/test_client.py: 4 warnings
tests/test_litellm/proxy/client/test_chat.py: 9 warnings
tests/test_litellm/test_main.py: 14 warnings
tests/test_litellm/proxy/client/test_keys.py: 25 warnings
tests/test_litellm/proxy/client/test_model_groups.py: 14 warnings
tests/test_litellm/proxy/test_proxy_server.py: 9 warnings
tests/test_litellm/proxy/client/test_models.py: 36 warnings
tests/test_litellm/proxy/db/test_db_spend_update_writer.py: 1 warning
tests/test_litellm/llms/azure/test_azure_common_utils.py: 44 warnings
tests/test_litellm/llms/dashscope/test_dashscope_chat_transformation.py: 2 warnings
tests/test_litellm/proxy/test_proxy_cli.py: 13 warnings
tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py: 3 warnings
tests/test_litellm/llms/databricks/test_databricks_common_utils.py: 1 warning
tests/test_litellm/litellm_core_utils/test_duration_parser.py: 4 warnings
tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py: 6 warnings
tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py: 3 warnings
tests/test_litellm/integrations/arize/test_arize.py: 2 warnings
tests/test_litellm/litellm_core_utils/test_dd_tracing.py: 5 warnings
tests/test_litellm/responses/test_responses_utils.py: 6 warnings
tests/test_litellm/llms/cohere/chat/test_transformation.py: 2 warnings
tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py: 1 warning
tests/test_litellm/llms/featherless_ai/chat/test_featherless_chat_transformation.py: 6 warnings
tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py: 9 warnings
tests/test_litellm/llms/nebius/test_nebius_chat_transformation.py: 2 warnings
tests/test_litellm/proxy/auth/test_auth_checks.py: 5 warnings
tests/test_litellm/llms/datarobot/test_datarobot.py: 3 warnings
tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py: 8 warnings
tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py: 2 warnings
tests/test_litellm/proxy/management_endpoints/test_delete_callbacks_endpoint.py: 1 warning
tests/test_litellm/llms/vertex_ai/test_vertex.py: 13 warnings
tests/test_litellm/test_router.py: 15 warnings
tests/test_litellm/llms/llamafile/chat/test_llamafile_chat_transformation.py: 15 warnings
tests/test_litellm/llms/github_copilot/test_github_copilot_authenticator.py: 13 warnings
tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_sse_wrapper.py: 1 warning
tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_endpoints.py: 6 warnings
tests/test_litellm/llms/test_volcengine.py: 2 warnings
tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py: 4 warnings
tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py: 1 warning
tests/test_litellm/llms/vertex_ai/test_http_status_201.py: 3 warnings
tests/test_litellm/llms/huggingface/embedding/test_handler.py: 2 warnings
tests/test_litellm/caching/test_azure_blob_cache.py: 7 warnings
tests/test_litellm/litellm_core_utils/test_litellm_logging.py: 11 warnings
tests/test_litellm/proxy/common_utils/test_load_config_utils.py: 1 warning
tests/test_litellm/llms/bedrock/image/test_bedrock_image_bearer_token.py: 4 warnings
tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py: 7 warnings
tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py: 7 warnings
tests/test_litellm/proxy/client/cli/test_keys_commands.py: 19 warnings
tests/test_litellm/experimental_mcp_client/test_tools.py: 3 warnings
tests/test_litellm/llms/bedrock/test_base_aws_llm.py: 9 warnings
tests/test_litellm/llms/chat/test_converse_handler.py: 1 warning
tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py: 9 warnings
tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py: 13 warnings
tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py: 7 warnings
tests/test_litellm/llms/bedrock/invoke_agent/test_bedrock_agent_transformation.py: 16 warnings
tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py: 8 warnings
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py: 2 warnings
tests/test_litellm/proxy/test_health_check_functions.py: 8 warnings
tests/test_litellm/llms/bytez/chat/test_bytez_chat_transformation.py: 3 warnings
tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py: 3 warnings
tests/test_litellm/router_utils/pre_call_checks/test_responses_api_deployment_check.py: 2 warnings
tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py: 2 warnings
tests/test_litellm/test_logging.py: 3 warnings
tests/test_litellm/router_strategy/test_base_routing_strategy.py: 4 warnings
tests/test_litellm/proxy/client/cli/test_models_commands.py: 34 warnings
tests/test_litellm/proxy/test_caching_routes.py: 7 warnings
tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py: 2 warnings
tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py: 4 warnings
tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py: 5 warnings
tests/test_litellm/litellm_core_utils/test_token_counter_tool.py: 40 warnings
tests/test_litellm/llms/gemini/test_gemini_tts.py: 10 warnings
tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py: 6 warnings
tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py: 7 warnings
tests/test_litellm/llms/vertex_ai/context_caching/test_context_caching_ttl.py: 8 warnings
tests/test_litellm/types/llms/test_types_llms_openai.py: 2 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/guardrails_ai/test_guardrails_ai.py: 1 warning
tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py: 38 warnings
tests/test_litellm/proxy/auth/test_auth_exception_handler.py: 12 warnings
tests/test_litellm/integrations/test_agentops.py: 2 warnings
tests/test_litellm/proxy/db/mcp_server/test_db.py: 1 warning
tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py: 7 warnings
tests/test_litellm/router_utils/test_router_utils_common_utils.py: 12 warnings
tests/test_litellm/proxy/db/test_exception_handler.py: 16 warnings
tests/test_litellm/proxy/auth/test_user_api_key_auth.py: 5 warnings
tests/test_litellm/llms/custom_httpx/test_http_handler.py: 6 warnings
tests/test_litellm/proxy/common_utils/test_get_routes.py: 4 warnings
tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py: 7 warnings
tests/test_litellm/integrations/arize/test_arize_phoenix.py: 2 warnings
tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py: 4 warnings
tests/test_litellm/caching/test_redis_cache.py: 5 warnings
tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py: 1 warning
tests/test_litellm/proxy/common_utils/test_timezone_utils.py: 1 warning
tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py: 3 warnings
tests/test_litellm/proxy/middleware/test_prometheus_auth_middleware.py: 2 warnings
tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py: 2 warnings
tests/test_litellm/llms/deepgram/audio_transcription/test_deepgram_audio_transcription_transformation.py: 8 warnings
tests/test_litellm/litellm_core_utils/test_audio_utils.py: 14 warnings
tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py: 2 warnings
tests/test_litellm/llms/recraft/image_generation/test_recraft_image_gen_transformation.py: 6 warnings
tests/test_litellm/litellm_core_utils/test_streaming_handler.py: 14 warnings
tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py: 11 warnings
tests/test_litellm/vector_stores/test_vector_store_registry.py: 1 warning
tests/test_litellm/integrations/test_langfuse_otel.py: 7 warnings
tests/test_litellm/proxy/test_proxy_utils.py: 4 warnings
tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py: 1 warning
tests/test_litellm/litellm_core_utils/test_core_helpers.py: 2 warnings
tests/test_litellm/caching/test_in_memory_cache.py: 4 warnings
tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoints_common_utils.py: 1 warning
tests/test_litellm/llms/openai/test_o_series_transformation.py: 20 warnings
tests/test_litellm/proxy/experimental/mcp_server/test_tool_registry.py: 3 warnings
tests/test_litellm/integrations/test_athina.py: 5 warnings
tests/test_litellm/integrations/test_deepeval.py: 2 warnings
tests/test_litellm/llms/novita/chat/test_novita_chat_transformation.py: 2 warnings
tests/test_litellm/llms/ollama/test_ollama_model_info.py: 3 warnings
tests/test_litellm/proxy/auth/test_litellm_license.py: 1 warning
tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py: 6 warnings
tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py: 1 warning
tests/test_litellm/proxy/guardrails/test_init_guardrails.py: 1 warning
tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py: 1 warning
tests/test_litellm/proxy/auth/test_handle_jwt.py: 7 warnings
tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py: 2 warnings
tests/test_litellm/llms/meta_llama/test_meta_llama_chat_transformation.py: 2 warnings
tests/test_litellm/llms/lm_studio/test_lm_studio_chat_transformation.py: 2 warnings
tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py: 3 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py: 21 warnings
tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py: 1 warning
tests/test_litellm/litellm_core_utils/specialty_caches/test_dynamic_logging_cache.py: 2 warnings
tests/test_litellm/integrations/SlackAlerting/test_slack_alerting_utils.py: 1 warning
tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py: 8 warnings
tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py: 3 warnings
tests/test_litellm/responses/litellm_completion_transformation/test_reasoning_content_transformation.py: 6 warnings
tests/test_litellm/integrations/test_langfuse.py: 1 warning
tests/test_litellm/experimental_mcp_client/test_mcp_client.py: 3 warnings
tests/test_litellm/proxy/db/db_transaction_queue/test_spend_update_queue.py: 7 warnings
tests/test_litellm/llms/nebius/test_nebius_embedding_transformation.py: 1 warning
tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py: 2 warnings
tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py: 2 warnings
tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py: 1 warning
tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py: 1 warning
tests/test_litellm/proxy/auth/test_model_checks.py: 1 warning
tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py: 9 warnings
tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py: 1 warning
tests/test_litellm/proxy/auth/test_route_checks.py: 2 warnings
tests/test_litellm/llms/mistral/test_mistral_completion.py: 6 warnings
tests/test_litellm/llms/bedrock/chat/test_mistral_config.py: 1 warning
tests/test_litellm/passthrough/test_passthrough_main.py: 1 warning
tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py: 2 warnings
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py: 14 warnings
tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py: 3 warnings
tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py: 4 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_pangea.py: 6 warnings
tests/test_litellm/caching/test_qdrant_semantic_cache.py: 7 warnings
tests/test_litellm/proxy/db/db_transaction_queue/test_base_update_queue.py: 1 warning
tests/test_litellm/llms/ollama/test_ollama_embedding.py: 3 warnings
tests/test_litellm/litellm_core_utils/test_realtime_streaming.py: 1 warning
tests/test_litellm/proxy/management_endpoints/scim/test_scim_patch_user.py: 2 warnings
tests/test_litellm/secret_managers/test_secret_managers_main.py: 12 warnings
tests/test_litellm/caching/test_redis_cluster_cache.py: 2 warnings
tests/test_litellm/caching/test_redis_semantic_cache.py: 3 warnings
tests/test_litellm/llms/openai/test_openai_common_utils.py: 11 warnings
tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py: 1 warning
tests/test_litellm/caching/test_caching_handler.py: 1 warning
tests/test_litellm/proxy/client/test_http_commands.py: 5 warnings
tests/test_litellm/proxy/common_utils/test_reset_budget_job.py: 5 warnings
tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py: 12 warnings
tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py: 6 warnings
tests/test_litellm/llms/gemini/test_gemini_common_utils.py: 4 warnings
tests/test_litellm/proxy/test_route_llm_request.py: 11 warnings
tests/test_litellm/llms/bedrock/image/test_amazon_stability3_transformation.py: 1 warning
tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py: 3 warnings
tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py: 1 warning
tests/test_litellm/integrations/test_s3_v2.py: 1 warning
tests/test_litellm/litellm_core_utils/test_safe_divide_seconds.py: 4 warnings
tests/test_litellm/proxy/db/test_prisma_client.py: 1 warning
  /app/litellm/litellm_core_utils/get_model_cost_map.py:24: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with importlib.resources.open_text(

tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py::TestPerplexityCostCalculator::test_cost_calculation_combinations[0-0-0]
tests/test_litellm/proxy/test_caching_routes.py::test_cache_ping_failure
  /usr/lib/python3.12/importlib/__init__.py:131: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    _bootstrap._exec(spec, module)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/google_genai/test_google_genai_adapter.py::test_api_base_and_api_key_passthrough[agenerate_content_stream-True-True]
tests/test_litellm/google_genai/test_google_genai_adapter.py::test_api_base_and_api_key_passthrough[generate_content-False-False]
  /usr/lib/python3.12/json/decoder.py:353: RuntimeWarning: coroutine 'test_api_base_and_api_key_passthrough.<locals>.mock_async_return' was never awaited
    obj, end = self.scan_once(s, idx)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/litellm_core_utils/test_duration_parser.py::TestStandardizedResetTime::test_day_based_resets
  /usr/lib/python3.12/re/__init__.py:325: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    del _cache2[next(iter(_cache2))]
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py::TestPanwAirsInitialization::test_initialize_guardrail_function
  /usr/lib/python3.12/json/decoder.py:353: RuntimeWarning: coroutine 'serve' was never awaited
    obj, end = self.scan_once(s, idx)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/llms/nebius/test_nebius_embedding_transformation.py::test_nebius_embeddings
  /root/.cache/pypoetry/virtualenvs/litellm-9TtSrW0h-py3.12/lib/python3.12/site-packages/pydantic/main.py:426: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue: Expected 9 fields but got 5 for type `Message` with value `Message(content='```python\nprint("Hey from LiteLL...None, provider_specific_fields={'refusal': None})` - serialized value may not be as expected.
    PydanticSerializationUnexpectedValue: Expected `StreamingChoices` but got `Choices` with value `Choices(finish_reason='st...ider_specific_fields={})` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(

tests/test_litellm/proxy/client/cli/test_auth_commands.py::TestTokenUtilities::test_get_token_file_path
  /usr/lib/python3.12/json/decoder.py:353: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    obj, end = self.scan_once(s, idx)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/litellm_core_utils/test_streaming_handler.py::test_streaming_handler_with_stop_chunk
tests/test_litellm/google_genai/test_google_genai_adapter.py::test_streaming_multiple_partial_tool_calls
  /root/.cache/pypoetry/virtualenvs/litellm-9TtSrW0h-py3.12/lib/python3.12/site-packages/pydantic/main.py:426: UserWarning: Pydantic serializer warnings:
    PydanticSerializationUnexpectedValue: Expected 9 fields but got 5 for type `Message` with value `Message(content="I'm Claude, an AI", role='assista...unction_call=None, provider_specific_fields=None)` - serialized value may not be as expected.
    PydanticSerializationUnexpectedValue: Expected `StreamingChoices` but got `Choices` with value `Choices(finish_reason='st...r_specific_fields=None))` - serialized value may not be as expected
    return self.__pydantic_serializer__.to_python(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= short test summary info =============================================================================
FAILED tests/test_litellm/litellm_core_utils/test_duration_parser.py::TestStandardizedResetTime::test_timezone_handling - zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key US/Eastern'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================== 1 failed, 1915 passed, 6 skipped, 1778 warnings in 287.66s (0:04:47) =======================================================
root@1d7d57893d3e:/app# 
```

</details>




## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


