### PR TITLE
Fix double slash issue in SSO login URL construction

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -145,6 +145,12 @@ async def serve_login_page(
 
     sso_button = ""
     if sso_available:
+        sso_login_url = base_url_to_redirect_to
+        if sso_login_url.endswith("/"):
+            sso_login_url += "sso/login"
+        else:
+            sso_login_url += "/sso/login"
+        
         sso_button = f"""
         <div style="
             margin-top: 20px;
@@ -157,7 +163,7 @@ async def serve_login_page(
                 font-size: 14px;
                 margin-bottom: 16px;
             ">or</p>
-            <a href="{base_url_to_redirect_to}/sso/login" style="
+            <a href="{sso_login_url}" style="
                 display: inline-block;
                 background-color: #f8fafc;
                 border: 1px solid #e2e8f0;
@@ -175,8 +181,11 @@ async def serve_login_page(
         </div>
         """
 
-    # Get the base URL for form action using proper URL construction
-    url_to_redirect_to = f"{base_url_to_redirect_to}/login"
+    if base_url_to_redirect_to.endswith("/"):
+        url_to_redirect_to = base_url_to_redirect_to + "login"
+    else:
+        url_to_redirect_to = base_url_to_redirect_to + "/login"
+
     unified_login_html = f"""
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Title
Fix double slash issue in SSO login URL construction
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
This PR fixes a URL construction issue in the SSO login page where double slashes (//) would appear in URLs when PROXY_BASE_URL ends with a trailing slash.
Testing
✅ PROXY_BASE_URL=https://localhost:4000/ → generates https://localhost:4000/login
✅ PROXY_BASE_URL=https://localhost:4000 → generates https://localhost:4000/login
✅ SSO login URLs follow the same pattern and avoid double slashes

https://www.loom.com/share/4dd45ce54b874cdd8a5b06a15ba49605?sid=c62e2f76-d837-479b-8524-53fd2c9568e5
