### PR TITLE
New models - add fireworks_ai/glm-4p5 model family 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14809,6 +14809,32 @@
         "source": "https://fireworks.ai/pricing",
         "supports_tool_choice": false
     },
+    "fireworks_ai/glm-4p5": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 20480,
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 2.19e-06,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p5"
+    },
+    "fireworks_ai/glm-4p5-air": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 20480,
+        "input_cost_per_token": 2.2e-07,
+        "output_cost_per_token": 8.8e-07,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "source": "https://artificialanalysis.ai/models/glm-4-5-air"
+    },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14812,7 +14812,7 @@
     "fireworks_ai/glm-4p5": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 20480,
+        "max_output_tokens": 96000,
         "input_cost_per_token": 5.5e-07,
         "output_cost_per_token": 2.19e-06,
         "litellm_provider": "fireworks_ai",
@@ -14825,7 +14825,7 @@
     "fireworks_ai/glm-4p5-air": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 20480,
+        "max_output_tokens": 96000,
         "input_cost_per_token": 2.2e-07,
         "output_cost_per_token": 8.8e-07,
         "litellm_provider": "fireworks_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14809,6 +14809,32 @@
         "source": "https://fireworks.ai/pricing",
         "supports_tool_choice": false
     },
+    "fireworks_ai/glm-4p5": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 20480,
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 2.19e-06,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "source": "https://fireworks.ai/models/fireworks/glm-4p5"
+    },
+    "fireworks_ai/glm-4p5-air": {
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 20480,
+        "input_cost_per_token": 2.2e-07,
+        "output_cost_per_token": 8.8e-07,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "source": "https://artificialanalysis.ai/models/glm-4-5-air"
+    },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14812,7 +14812,7 @@
     "fireworks_ai/glm-4p5": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 20480,
+        "max_output_tokens": 96000,
         "input_cost_per_token": 5.5e-07,
         "output_cost_per_token": 2.19e-06,
         "litellm_provider": "fireworks_ai",
@@ -14825,7 +14825,7 @@
     "fireworks_ai/glm-4p5-air": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
-        "max_output_tokens": 20480,
+        "max_output_tokens": 96000,
         "input_cost_per_token": 2.2e-07,
         "output_cost_per_token": 8.8e-07,
         "litellm_provider": "fireworks_ai",


### PR DESCRIPTION
## New models - add fireworks_ai/glm-4p5 model family

Adds the following models to LiteLLM with cost tracking:
- fireworks_ai/glm-4p5
- fireworks_ai/glm-4p5-air


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


