### PR TITLE
Create New Key - Make Team Field Required for Service Account

### DIFF
--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -573,6 +573,13 @@ const CreateKey: React.FC<CreateKeyProps> = ({
               name="team_id"
               initialValue={team ? team.team_id : null}
               className="mt-4"
+              rules={[
+                { 
+                  required: keyOwner === "service_account", 
+                  message: "Please select a team for the service account" 
+                }
+              ]}
+              help={keyOwner === "service_account" ? "required" : ""}
             >
               <TeamDropdown 
                 teams={teams} 


### PR DESCRIPTION
## Title
Create New Key - Make Team Field Required for Service Account
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
- Added validation rules to the team field that make it required when the "Service Account" radio button is selected
<img width="1512" height="894" alt="Screenshot 2025-08-06 at 4 27 02" src="https://github.com/user-attachments/assets/3edfb036-16ca-4051-8ec2-28fe98b409f5" />


