### PR TITLE
[Bug]: Fix Mimetype Resolution Error in Bedrock Document Understanding

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2479,7 +2479,9 @@ class BedrockImageProcessor:
         )
 
         if is_document:
-            potential_extensions = mimetypes.guess_all_extensions(mime_type)
+            potential_extensions = mimetypes.guess_all_extensions(
+                mime_type, strict=False
+            )
             valid_extensions = [
                 ext[1:]
                 for ext in potential_extensions
@@ -2950,7 +2952,10 @@ def process_empty_text_blocks(
         ]
 
     modified_message = message.copy()
-    modified_message["content"] = modified_content_block
+    modified_message["content"] = cast(
+        Union[List[ChatCompletionTextObject], List[ChatCompletionThinkingBlock]],
+        modified_content_block,
+    )
     return modified_message
 
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2353,7 +2353,6 @@ def stringify_json_tool_call_content(messages: List) -> List:
 ###### AMAZON BEDROCK #######
 
 import base64
-import mimetypes
 from email.message import Message
 
 import httpx

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -139,6 +139,20 @@ def test_bedrock_validate_format_image_or_video():
         result = BedrockImageProcessor._validate_format(f"video/{format}", format)
         assert result == format, f"Expected {format}, got {result}"
 
+    # Test valid document formats
+    valid_document_formats = {
+        "application/pdf": "pdf",
+        "text/csv": "csv",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    }
+    for mime, expected in valid_document_formats.items():
+        print("testing mime", mime, "expected", expected)
+        result = BedrockImageProcessor._validate_format(
+            mime, mime.split("/")[1]
+        )
+        assert result == expected, f"Expected {expected}, got {result}"
+
 
 # def test_ollama_pt_consecutive_system_messages():
 #     """Test handling consecutive system messages"""

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -154,6 +154,56 @@ def test_bedrock_validate_format_image_or_video():
         assert result == expected, f"Expected {expected}, got {result}"
 
 
+def test_bedrock_get_document_format_fallback_mimes():
+    """
+    Test the _get_document_format method with fallback MIME types for DOCX and XLSX.
+    
+    This tests the fallback mechanism when mimetypes.guess_all_extensions returns empty results,
+    which can happen in Docker containers where mimetypes depends on OS-installed MIME types.
+    """
+    from unittest.mock import patch
+
+    # Test DOCX fallback
+    docx_mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    supported_formats = ["pdf", "docx", "xlsx", "csv"]
+    
+    # Mock mimetypes.guess_all_extensions to return empty list (simulating Docker container scenario)
+    with patch('mimetypes.guess_all_extensions', return_value=[]):
+        result = BedrockImageProcessor._get_document_format(
+            mime_type=docx_mime,
+            supported_doc_formats=supported_formats
+        )
+        assert result == "docx", f"Expected 'docx', got '{result}'"
+    
+    # Test XLSX fallback  
+    xlsx_mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    
+    with patch('mimetypes.guess_all_extensions', return_value=[]):
+        result = BedrockImageProcessor._get_document_format(
+            mime_type=xlsx_mime,
+            supported_doc_formats=supported_formats
+        )
+        assert result == "xlsx", f"Expected 'xlsx', got '{result}'"
+
+
+def test_bedrock_get_document_format_mimetypes_success():
+    """
+    Test the _get_document_format method when mimetypes.guess_all_extensions works normally.
+    """
+    docx_mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    supported_formats = ["pdf", "docx", "xlsx", "csv"]
+    
+    # Test normal mimetypes behavior (should not hit fallback)
+    result = BedrockImageProcessor._get_document_format(
+        mime_type=docx_mime,
+        supported_doc_formats=supported_formats
+    )
+    assert result == "docx", f"Expected 'docx', got '{result}'"
+
+
+
+
+
 # def test_ollama_pt_consecutive_system_messages():
 #     """Test handling consecutive system messages"""
 #     messages = [
@@ -519,3 +569,5 @@ def test_bedrock_tools_unpack_defs():
     ]
 
     _bedrock_tools_pt(tools=tools)
+
+


### PR DESCRIPTION
## [Bug]: Fix Mimetype Resolution Error in Bedrock Document Understanding

> When attempting to pass supported documents to Bedrock as base64 encoded string, many document types are not working. The script below shows passing several document types to the Amazon Nova Premier model, which should support docx, xlsx, pdf, csv and a few other document types.

Fixes: https://github.com/BerriAI/litellm/issues/12260

## Root cause of issue
- we relied on `mimetype` for fetching the underlying MIME, but mimetype can have a different list of supported MIMEs. If LiteLLM is unable to recognize the MIME then use types/files.py as a fallback 

## Manual Test Validation 

<img width="1234" height="526" alt="Screenshot 2025-08-05 at 3 56 10 PM" src="https://github.com/user-attachments/assets/deae96ef-7058-4b99-981c-c923f924b308" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


