### PR TITLE
[Feat] - When using custom tags on prometheus allow using wildcard patterns 

### DIFF
--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -302,21 +302,19 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 ```
 
 **How Custom Tags Work:**
-- Each configured tag becomes a boolean label in prometheus metrics
-- If a tag is present in the request, the label value is `"true"`
-- If a tag is not present in the request, the label value is `"false"`
+- Each configured tag becomes a boolean label in prometheus metrics  
+- If a tag matches (exact or wildcard), the label value is `"true"`, otherwise `"false"`
 - Tag names are sanitized for prometheus compatibility (e.g., `"batch-job"` becomes `"tag_batch_job"`)
-- **Wildcard patterns** are supported using `*` for pattern matching
+- **Wildcard patterns** supported using `*` (e.g., `"User-Agent: RooCode/*"` matches `"User-Agent: RooCode/1.0.0"`)
 
-**Wildcard Pattern Examples:**
+**Example with wildcards:**
 ```yaml
 litellm_settings:
   callbacks: ["prometheus"]
+  custom_prometheus_tags:
     - "User-Agent: RooCode/*"
     - "User-Agent: claude-cli/*"
-```
-
-Any request with tags patching the pattern "User-Agent: RooCode/*" (e.g. "User-Agent: RooCode/1.0.0") will be tracked. 
+``` 
 
 **Use Cases:**
 - Environment tracking (`prod`, `staging`, `dev`)

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -261,7 +261,12 @@ model_list:
 litellm_settings:
   callbacks: ["prometheus"]
   custom_prometheus_metadata_labels: ["metadata.foo", "metadata.bar"]
-  custom_prometheus_tags: ["prod", "staging", "batch-job"]
+  custom_prometheus_tags: 
+    - "prod"
+    - "staging"
+    - "batch-job"
+    - "User-Agent: RooCode/*"
+    - "User-Agent: claude-cli/*"
 ```
 
 2. Make a request with tags
@@ -301,12 +306,24 @@ curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 - If a tag is present in the request, the label value is `"true"`
 - If a tag is not present in the request, the label value is `"false"`
 - Tag names are sanitized for prometheus compatibility (e.g., `"batch-job"` becomes `"tag_batch_job"`)
+- **Wildcard patterns** are supported using `*` for pattern matching
+
+**Wildcard Pattern Examples:**
+```yaml
+litellm_settings:
+  callbacks: ["prometheus"]
+    - "User-Agent: RooCode/*"
+    - "User-Agent: claude-cli/*"
+```
+
+Any request with tags patching the pattern "User-Agent: RooCode/*" (e.g. "User-Agent: RooCode/1.0.0") will be tracked. 
 
 **Use Cases:**
 - Environment tracking (`prod`, `staging`, `dev`)
 - Request type classification (`batch-job`, `user-facing`, `background`)
 - Feature flags (`new-feature`, `beta-users`)
 - Team or service identification (`team-a`, `service-xyz`)
+- User-Agent Tracking - use this to track how much Roo Code, Claude Code, Gemini CLI are used (`User-Agent: RooCode/*`, `User-Agent: claude-cli/*`, `User-Agent: gemini-cli/*`)
 
 
 ## Configuring Metrics and Labels

--- a/enterprise/litellm_enterprise/integrations/prometheus.py
+++ b/enterprise/litellm_enterprise/integrations/prometheus.py
@@ -2293,27 +2293,83 @@ def get_custom_labels_from_metadata(metadata: dict) -> Dict[str, str]:
     return result
 
 
+def _tag_matches_wildcard_configured_pattern(tags: List[str], configured_tag: str) -> bool:
+    """
+    Check if any of the request tags matches a wildcard configured pattern
+
+    Args:
+        tags: List[str] - The request tags
+        configured_tag: str - The configured tag
+
+    Returns:
+        bool - True if any of the request tags matches the configured tag, False otherwise
+
+    e.g.
+    tags = ["User-Agent: curl/7.68.0", "User-Agent: python-requests/2.28.1", "prod"]
+    configured_tag = "User-Agent: curl/*"
+    _tag_matches_wildcard_configured_pattern(tags=tags, configured_tag=configured_tag) # True
+
+    configured_tag = "User-Agent: python-requests/*"
+    _tag_matches_wildcard_configured_pattern(tags=tags, configured_tag=configured_tag) # True
+
+    configured_tag = "gm"
+    _tag_matches_wildcard_configured_pattern(tags=tags, configured_tag=configured_tag) # False
+    """
+    import re
+
+    from litellm.router_utils.pattern_match_deployments import PatternMatchRouter
+    pattern_router = PatternMatchRouter()
+    regex_pattern = pattern_router._pattern_to_regex(configured_tag)
+    return any(re.match(pattern=regex_pattern, string=tag) for tag in tags)
+
+
 def get_custom_labels_from_tags(tags: List[str]) -> Dict[str, str]:
     """
-    Get custom labels from tags based on admin configuration
+    Get custom labels from tags based on admin configuration.
+    
+    Supports both exact matches and wildcard patterns:
+    - Exact match: "prod" matches "prod" exactly
+    - Wildcard pattern: "User-Agent: curl/*" matches "User-Agent: curl/7.68.0" 
+    
+    Reuses PatternMatchRouter for wildcard pattern matching.
+
+    Returns dict of label_name: "true" if the tag matches the configured tag, "false" otherwise
+
+    {
+        "tag_User-Agent_curl": "true",
+        "tag_User-Agent_python_requests": "false",
+        "tag_Environment_prod": "true",
+        "tag_Environment_dev": "false",
+        "tag_Service_api_gateway_v2": "true",
+        "tag_Service_web_app_v1": "false",
+    }
     """
+    import re
+
+    from litellm.router_utils.pattern_match_deployments import PatternMatchRouter
     from litellm.types.integrations.prometheus import _sanitize_prometheus_label_name
 
     configured_tags = litellm.custom_prometheus_tags
-    if configured_tags is None or len(configured_tags) == 0:
+    if not configured_tags:
         return {}
 
     result: Dict[str, str] = {}
+    pattern_router = PatternMatchRouter()
 
-    # Map each configured tag to its presence in the request tags
     for configured_tag in configured_tags:
-        # Create a safe prometheus label name
         label_name = _sanitize_prometheus_label_name(f"tag_{configured_tag}")
-
-        # Check if this tag is present in the request tags
+        
+        # Check for exact match first (backwards compatibility)
         if configured_tag in tags:
             result[label_name] = "true"
-        else:
-            result[label_name] = "false"
+            continue
+            
+        # Use PatternMatchRouter for wildcard pattern matching
+        if "*" in configured_tag and _tag_matches_wildcard_configured_pattern(tags=tags, configured_tag=configured_tag):
+            result[label_name] = "true"
+            continue
+        
+        # No match found
+        result[label_name] = "false"
 
     return result

--- a/enterprise/litellm_enterprise/integrations/prometheus.py
+++ b/enterprise/litellm_enterprise/integrations/prometheus.py
@@ -2350,7 +2350,7 @@ def get_custom_labels_from_tags(tags: List[str]) -> Dict[str, str]:
     from litellm.types.integrations.prometheus import _sanitize_prometheus_label_name
 
     configured_tags = litellm.custom_prometheus_tags
-    if not configured_tags:
+    if configured_tags is None or len(configured_tags) == 0:
         return {}
 
     result: Dict[str, str] = {}


### PR DESCRIPTION
## [Feat] - When using custom tags on prometheus allow using wildcard patterns 

> possible to specify a single "parent" tag for a given user-agent "family" that covers all versions? e.g., User-Agent: RooCode instead of having to specify for every version (User-Agent: RooCode/3.25.4). It's tedious to add a label every time a new version is available, and we miss the data from usage before the label is added.


Now you can set it like this to track usage by prometheus tags - any request from RooCode will now get tracked irrespective of version 

```yaml
model_list:
  - model_name: vertex_ai/*
    litellm_params:
      model: vertex_ai/*
  - model_name: bedrock/*
    litellm_params:
      model: bedrock/*


litellm_settings:
  callbacks: ["prometheus"]
  custom_prometheus_tags: ["User-Agent: RooCode/*"]
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


