### PR TITLE
feat(integrations): allow setting of braintrust callback base url

### DIFF
--- a/docs/my-website/docs/observability/braintrust.md
+++ b/docs/my-website/docs/observability/braintrust.md
@@ -15,6 +15,7 @@ import os
 
 # set env
 os.environ["BRAINTRUST_API_KEY"] = ""
+os.environ["BRAINTRUST_API_BASE"] = "https://api.braintrustdata.com/v1"
 os.environ['OPENAI_API_KEY']=""
 
 # set braintrust as a callback, litellm will send the data to braintrust
@@ -35,6 +36,7 @@ response = litellm.completion(
 
 ```env
 BRAINTRUST_API_KEY=""
+BRAINTRUST_API_BASE="https://api.braintrustdata.com/v1"
 ```
 
 2. Add braintrust to callbacks
@@ -156,6 +158,8 @@ For more examples, [**Click Here**](../proxy/user_keys.md#chatcompletions)
 
 </TabItem>
 </Tabs>
+
+You can use `BRAINTRUST_API_BASE` to point to your self-hosted Braintrust data plane. Read more about this [here](https://www.braintrust.dev/docs/guides/self-hosting).
 
 ## Full API Spec
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -58,6 +58,13 @@ litellm_settings:
     service_name: "mymaster"
     sentinel_nodes: [["localhost", 26379]]
 
+    # Optional - GCP IAM Authentication for Redis
+    gcp_service_account: "projects/-/serviceAccounts/your-sa@project.iam.gserviceaccount.com"  # GCP service account for IAM authentication
+    gcp_ssl_ca_certs: "./server-ca.pem"  # Path to SSL CA certificate file for GCP Memorystore Redis
+    ssl: true  # Enable SSL for secure connections
+    ssl_cert_reqs: null  # Set to null for self-signed certificates
+    ssl_check_hostname: false  # Set to false for self-signed certificates
+
     # Optional - Qdrant Semantic Cache Settings
     qdrant_semantic_cache_embedding_model: openai-embedding # the model should be defined on the model_list
     qdrant_collection_name: test_collection
@@ -362,6 +369,7 @@ router_settings:
 | BEDROCK_MAX_POLICY_SIZE | Maximum size for Bedrock policy. Default is 75
 | BERRISPEND_ACCOUNT_ID | Account ID for BerriSpend service
 | BRAINTRUST_API_KEY | API key for Braintrust integration
+| BRAINTRUST_API_BASE | Base URL for Braintrust API. Default is https://api.braintrustdata.com/v1
 | CACHED_STREAMING_CHUNK_DELAY | Delay in seconds for cached streaming chunks. Default is 0.02
 | CIRCLE_OIDC_TOKEN | OpenID Connect token for CircleCI
 | CIRCLE_OIDC_TOKEN_V2 | Version 2 of the OpenID Connect token for CircleCI
@@ -649,6 +657,8 @@ router_settings:
 | REDIS_PASSWORD | Password for Redis service
 | REDIS_PORT | Port number for Redis server
 | REDIS_SOCKET_TIMEOUT | Timeout in seconds for Redis socket operations. Default is 0.1
+| REDIS_GCP_SERVICE_ACCOUNT | GCP service account for IAM authentication with Redis. Format: "projects/-/serviceAccounts/name@project.iam.gserviceaccount.com"
+| REDIS_GCP_SSL_CA_CERTS | Path to SSL CA certificate file for secure GCP Memorystore Redis connections
 | REDOC_URL | The path to the Redoc Fast API documentation. **By default this is "/redoc"**
 | REPEATED_STREAMING_CHUNK_LIMIT | Limit for repeated streaming chunks to detect looping. Default is 100
 | REPLICATE_MODEL_NAME_WITH_ID_LENGTH | Length of Replicate model names with ID. Default is 64

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -58,13 +58,6 @@ litellm_settings:
     service_name: "mymaster"
     sentinel_nodes: [["localhost", 26379]]
 
-    # Optional - GCP IAM Authentication for Redis
-    gcp_service_account: "projects/-/serviceAccounts/your-sa@project.iam.gserviceaccount.com"  # GCP service account for IAM authentication
-    gcp_ssl_ca_certs: "./server-ca.pem"  # Path to SSL CA certificate file for GCP Memorystore Redis
-    ssl: true  # Enable SSL for secure connections
-    ssl_cert_reqs: null  # Set to null for self-signed certificates
-    ssl_check_hostname: false  # Set to false for self-signed certificates
-
     # Optional - Qdrant Semantic Cache Settings
     qdrant_semantic_cache_embedding_model: openai-embedding # the model should be defined on the model_list
     qdrant_collection_name: test_collection
@@ -657,8 +650,6 @@ router_settings:
 | REDIS_PASSWORD | Password for Redis service
 | REDIS_PORT | Port number for Redis server
 | REDIS_SOCKET_TIMEOUT | Timeout in seconds for Redis socket operations. Default is 0.1
-| REDIS_GCP_SERVICE_ACCOUNT | GCP service account for IAM authentication with Redis. Format: "projects/-/serviceAccounts/name@project.iam.gserviceaccount.com"
-| REDIS_GCP_SSL_CA_CERTS | Path to SSL CA certificate file for secure GCP Memorystore Redis connections
 | REDOC_URL | The path to the Redoc Fast API documentation. **By default this is "/redoc"**
 | REPEATED_STREAMING_CHUNK_LIMIT | Limit for repeated streaming chunks to detect looping. Default is 100
 | REPLICATE_MODEL_NAME_WITH_ID_LENGTH | Length of Replicate model names with ID. Default is 64

--- a/litellm/integrations/braintrust_logging.py
+++ b/litellm/integrations/braintrust_logging.py
@@ -42,7 +42,7 @@ class BraintrustLogger(CustomLogger):
     ) -> None:
         super().__init__()
         self.validate_environment(api_key=api_key)
-        self.api_base = api_base or API_BASE
+        self.api_base = api_base or os.getenv("BRAINTRUST_API_BASE") or API_BASE
         self.default_project_id = None
         self.api_key: str = api_key or os.getenv("BRAINTRUST_API_KEY")  # type: ignore
         self.headers = {

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -380,8 +380,6 @@ class LiteLLMRoutes(enum.Enum):
         "/health",
         "/key/list",
         "/user/filter/ui",
-        "/models",
-        "/v1/models",
     ]
 
     # NOTE: ROUTES ONLY FOR MASTER KEY - only the Master Key should be able to Reset Spend

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -380,6 +380,8 @@ class LiteLLMRoutes(enum.Enum):
         "/health",
         "/key/list",
         "/user/filter/ui",
+        "/models",
+        "/v1/models",
     ]
 
     # NOTE: ROUTES ONLY FOR MASTER KEY - only the Master Key should be able to Reset Spend
@@ -2208,7 +2210,7 @@ class AllCallbacks(LiteLLMPydanticObjectBase):
 
     braintrust: CallbackOnUI = CallbackOnUI(
         litellm_callback_name="braintrust",
-        litellm_callback_params=["BRAINTRUST_API_KEY"],
+        litellm_callback_params=["BRAINTRUST_API_KEY","BRAINTRUST_API_BASE"],
         ui_callback_name="Braintrust",
     )
 

--- a/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
+++ b/tests/logging_callback_tests/test_unit_tests_init_callbacks.py
@@ -33,6 +33,7 @@ expected_env_vars = {
     "LAGO_API_BASE": "mock_base",
     "LAGO_API_EVENT_CODE": "mock_event_code",
     "OPENMETER_API_KEY": "openmeter_api_key",
+    "BRAINTRUST_API_BASE": "braintrust_api_base",
     "BRAINTRUST_API_KEY": "braintrust_api_key",
     "GALILEO_API_KEY": "galileo_api_key",
     "LITERAL_API_KEY": "literal_api_key",

--- a/tests/test_litellm/integrations/test_braintrust_logging.py
+++ b/tests/test_litellm/integrations/test_braintrust_logging.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from litellm.integrations.braintrust_logging import BraintrustLogger
+
+class TestBraintrustLogger(unittest.TestCase):
+    @patch.dict(os.environ, {"BRAINTRUST_API_KEY": "test-env-api-key"})
+    @patch.dict(os.environ, {"BRAINTRUST_API_BASE": "https://test-env-api.com/v1"})
+    def test_init_with_env_var(self):
+        """Test BraintrustLogger initialization with environment variable."""
+        logger = BraintrustLogger()
+        self.assertEqual(logger.api_key, "test-env-api-key")
+        self.assertEqual(logger.api_base, "https://test-env-api.com/v1")
+        self.assertEqual(logger.headers["Authorization"], "Bearer test-env-api-key")
+        self.assertEqual(logger.headers["Content-Type"], "application/json")
+
+    def test_init_with_explicit_params(self):
+        """Test BraintrustLogger initialization with explicit parameters."""
+        logger = BraintrustLogger(api_key="explicit-key", api_base="https://custom-api.com/v1")
+        self.assertEqual(logger.api_key, "explicit-key")
+        self.assertEqual(logger.api_base, "https://custom-api.com/v1")
+        self.assertEqual(logger.headers["Authorization"], "Bearer explicit-key")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_missing_api_key(self):
+        """Test BraintrustLogger initialization fails without API key."""
+        with self.assertRaises(Exception) as context:
+            BraintrustLogger()
+        self.assertIn("Missing keys=['BRAINTRUST_API_KEY']", str(context.exception))
+
+    def test_validate_environment_with_api_key(self):
+        """Test validate_environment method with valid API key."""
+        logger = BraintrustLogger(api_key="test-key")
+        # Should not raise an exception
+        logger.validate_environment(api_key="test-key")
+
+    def test_validate_environment_missing_api_key(self):
+        """Test validate_environment method with missing API key."""
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(Exception) as context:
+                BraintrustLogger(api_key=None)
+            self.assertIn("Missing keys=['BRAINTRUST_API_KEY']", str(context.exception))


### PR DESCRIPTION
## Title

Allow setting of Braintrust API URL when setting Braintrust callback. This allows organisations that are self hosting Braintrust's data plane to use the Braintrust callback with a custom API base URL.

<img width="905" height="353" alt="image" src="https://github.com/user-attachments/assets/47cabfc2-88af-418a-875a-d295c0afd367" />

<img width="502" height="201" alt="image" src="https://github.com/user-attachments/assets/b7031940-70d7-4426-b77b-dbf8e62698c9" />


## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test

## Changes


