### PR TITLE
[Bug Fix] OpenAI gpt-5 series does not support "max_tokens" parameter and `temperature` values that are not = 1

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -163,6 +163,14 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 
 | Model Name            | Function Call                                                   |
 |-----------------------|-----------------------------------------------------------------|
+| gpt-5 | `response = completion(model="gpt-5", messages=messages)` |
+| gpt-5-mini | `response = completion(model="gpt-5-mini", messages=messages)` |
+| gpt-5-nano | `response = completion(model="gpt-5-nano", messages=messages)` |
+| gpt-5-chat | `response = completion(model="gpt-5-chat", messages=messages)` |
+| gpt-5-chat-latest | `response = completion(model="gpt-5-chat-latest", messages=messages)` |
+| gpt-5-2025-08-07 | `response = completion(model="gpt-5-2025-08-07", messages=messages)` |
+| gpt-5-mini-2025-08-07 | `response = completion(model="gpt-5-mini-2025-08-07", messages=messages)` |
+| gpt-5-nano-2025-08-07 | `response = completion(model="gpt-5-nano-2025-08-07", messages=messages)` |
 | gpt-4.1 | `response = completion(model="gpt-4.1", messages=messages)` |
 | gpt-4.1-mini | `response = completion(model="gpt-4.1-mini", messages=messages)` |
 | gpt-4.1-nano | `response = completion(model="gpt-4.1-nano", messages=messages)` |

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1145,6 +1145,9 @@ openaiOSeriesConfig = OpenAIOSeriesConfig()
 from .llms.openai.chat.gpt_transformation import (
     OpenAIGPTConfig,
 )
+from .llms.openai.chat.gpt_5_transformation import (
+    OpenAIGPT5Config,
+)
 from .llms.openai.transcriptions.whisper_transformation import (
     OpenAIWhisperAudioTranscriptionConfig,
 )
@@ -1158,6 +1161,7 @@ from .llms.openai.chat.gpt_audio_transformation import (
 )
 
 openAIGPTAudioConfig = OpenAIGPTAudioConfig()
+openAIGPT5Config = OpenAIGPT5Config()
 
 from .llms.nvidia_nim.chat.transformation import NvidiaNimConfig
 from .llms.nvidia_nim.embed import NvidiaNimEmbeddingConfig

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -1,0 +1,58 @@
+"""Support for OpenAI gpt-5 model family."""
+
+from typing import Optional
+
+import litellm
+
+from .gpt_transformation import OpenAIGPTConfig
+
+
+class OpenAIGPT5Config(OpenAIGPTConfig):
+    """Configuration for gpt-5 models.
+
+    Handles OpenAI API quirks for the gpt-5 series like:
+
+    - Mapping ``max_tokens`` -> ``max_completion_tokens``.
+    - Dropping unsupported ``temperature`` values when requested.
+    """
+    @classmethod
+    def is_model_gpt_5_model(cls, model: str) -> bool:
+        return "gpt-5" in model
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        ################################################################
+        # max_tokens is not supported for gpt-5 models on OpenAI API
+        # Relevant issue: https://github.com/BerriAI/litellm/issues/13381
+        ################################################################
+        if "max_tokens" in non_default_params:
+            optional_params["max_completion_tokens"] = non_default_params.pop(
+                "max_tokens"
+            )
+
+        if "temperature" in non_default_params:
+            temperature_value: Optional[float] = non_default_params.pop("temperature")
+            if temperature_value is not None:
+                if temperature_value == 1:
+                    optional_params["temperature"] = temperature_value
+                elif litellm.drop_params or drop_params:
+                    pass
+                else:
+                    raise litellm.utils.UnsupportedParamsError(
+                        message=(
+                            "gpt-5 models don't support temperature={}. Only temperature=1 is supported. To drop unsupported params set `litellm.drop_params = True`"
+                        ).format(temperature_value),
+                        status_code=400,
+                    )
+        return super()._map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -47,6 +47,7 @@ from litellm.utils import (
 
 from ...types.llms.openai import *
 from ..base import BaseLLM
+from .chat.gpt_5_transformation import OpenAIGPT5Config
 from .chat.o_series_transformation import OpenAIOSeriesConfig
 from .common_utils import (
     BaseOpenAILLM,
@@ -55,6 +56,7 @@ from .common_utils import (
 )
 
 openaiOSeriesConfig = OpenAIOSeriesConfig()
+openAIGPT5Config = OpenAIGPT5Config()
 
 
 class MistralEmbeddingConfig:
@@ -183,6 +185,8 @@ class OpenAIConfig(BaseConfig):
         """
         if openaiOSeriesConfig.is_model_o_series_model(model=model):
             return openaiOSeriesConfig.get_supported_openai_params(model=model)
+        elif openAIGPT5Config.is_model_gpt_5_model(model=model):
+            return openAIGPT5Config.get_supported_openai_params(model=model)
         elif litellm.openAIGPTAudioConfig.is_model_gpt_audio_model(model=model):
             return litellm.openAIGPTAudioConfig.get_supported_openai_params(model=model)
         else:
@@ -212,6 +216,13 @@ class OpenAIConfig(BaseConfig):
         """ """
         if openaiOSeriesConfig.is_model_o_series_model(model=model):
             return openaiOSeriesConfig.map_openai_params(
+                non_default_params=non_default_params,
+                optional_params=optional_params,
+                model=model,
+                drop_params=drop_params,
+            )
+        elif openAIGPT5Config.is_model_gpt_5_model(model=model):
+            return openAIGPT5Config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
                 model=model,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1,0 +1,40 @@
+import pytest
+
+import litellm
+from litellm.llms.openai.openai import OpenAIConfig
+
+
+@pytest.fixture()
+def config() -> OpenAIConfig:
+    return OpenAIConfig()
+
+
+def test_gpt5_maps_max_tokens(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"max_tokens": 10},
+        optional_params={},
+        model="gpt-5",
+        drop_params=False,
+    )
+    assert params["max_completion_tokens"] == 10
+    assert "max_tokens" not in params
+
+
+def test_gpt5_temperature_drop(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="gpt-5",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_gpt5_temperature_error(config: OpenAIConfig):
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.2},
+            optional_params={},
+            model="gpt-5",
+            drop_params=False,
+        )


### PR DESCRIPTION
## [Bug Fix] OpenAI gpt-5 series does not support "max_tokens" parameter and `temperature` values that are not = 1

Fixes: https://github.com/BerriAI/litellm/issues/13381

Problem:
- OpenAI gpt-5 does not support max_tokens as param
- OpenAI gpt-5 temperature - Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported. This error is from OpenAI API

Summary of fixes on LiteLLM side
- max_tokens, litellm should map max_tokens to max_completion tokens for gpt-5 models
- temperature=0.2, litellm should allow using drop_params here, like we do for o-series


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


