### PR TITLE
Add support for reasoning_effort minimal

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -460,6 +460,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return Reasoning(effort="medium", summary="auto")
         elif reasoning_effort == "low":
             return Reasoning(effort="low", summary="auto")
+        elif reasoning_effort == "minimal":
+            return Reasoning(effort="minimal", summary="auto")
         return None
 
     def _map_responses_status_to_finish_reason(self, status: Optional[str]) -> str:

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1302,7 +1302,7 @@ ResponsesAPIStreamingResponse = Annotated[
 ]
 
 
-REASONING_EFFORT = Literal["low", "medium", "high"]
+REASONING_EFFORT = Literal["minimal", "low", "medium", "high"]
 
 
 class OpenAIRealtimeStreamSession(TypedDict, total=False):


### PR DESCRIPTION
## Add support for reasoning_effort minimal 

<!-- e.g. "Implement user authentication feature" -->

With the new GPT-5 models, there's a new possible reasoning_effort value: `minimal`. 
We'll want to be able to pass this value over to OpenAI.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


