### PR TITLE
Make sure that no debug information is leaked by router through errors in Cooldown list

### DIFF
--- a/litellm/router_utils/handle_error.py
+++ b/litellm/router_utils/handle_error.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from litellm._logging import verbose_router_logger
 from litellm.constants import MAX_EXCEPTION_MESSAGE_LENGTH
 from litellm.router_utils.cooldown_handlers import (
-    _async_get_cooldown_deployments_with_debug_info,
+    _async_get_cooldown_deployments_with_debug_info, _async_get_cooldown_deployments,
 )
 from litellm.types.integrations.slack_alerting import AlertType
 from litellm.types.router import RouterRateLimitError
@@ -78,7 +78,7 @@ async def async_raise_no_deployment_exception(
     _cooldown_time = litellm_router_instance.cooldown_cache.get_min_cooldown(
         model_ids=model_ids, parent_otel_span=parent_otel_span
     )
-    _cooldown_list = await _async_get_cooldown_deployments_with_debug_info(
+    _cooldown_list = await _async_get_cooldown_deployments(
         litellm_router_instance=litellm_router_instance,
         parent_otel_span=parent_otel_span,
     )

--- a/litellm/router_utils/handle_error.py
+++ b/litellm/router_utils/handle_error.py
@@ -2,9 +2,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from litellm._logging import verbose_router_logger
 from litellm.constants import MAX_EXCEPTION_MESSAGE_LENGTH
-from litellm.router_utils.cooldown_handlers import (
-    _async_get_cooldown_deployments_with_debug_info, _async_get_cooldown_deployments,
-)
+from litellm.router_utils.cooldown_handlers import _async_get_cooldown_deployments
 from litellm.types.integrations.slack_alerting import AlertType
 from litellm.types.router import RouterRateLimitError
 


### PR DESCRIPTION
## Title
Make sure that no debug information is leaked by router through errors in Cooldown list

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/13329

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

Note, one test is failing but it seems like its flaky. Running it through Make test-unit fails. Running it independent works. I had to do a pip install of google-genai as this is not part of `pyproject.toml` file and required for a specific test.

<img width="3326" height="490" alt="image" src="https://github.com/user-attachments/assets/1f7d20b9-972d-4e3e-8f5c-54be02369565" />


## Type
🐛 Bug Fix


## Changes
When raising RouterRateLimitError the changes now don't include debug information i.e. the exception messages that occurred for the model to go on cooldown_list

