### PR TITLE
Allow unsetting TPM and RPM - Teams Settings

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -782,8 +782,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Rate Limits</Text>
-                    <div>TPM: {info.tpm_limit !== null && info.tpm_limit !== undefined ? info.tpm_limit : "Not set"}</div>
-                    <div>RPM: {info.rpm_limit !== null && info.rpm_limit !== undefined ? info.rpm_limit : "Not set"}</div>
+                    <div>TPM: {info.tpm_limit || "Unlimited"}</div>
+                    <div>RPM: {info.rpm_limit || "Unlimited"}</div>
                   </div>
                   <div>
                     <Text className="font-medium">Team Budget</Text>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -320,12 +320,19 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         return;
       }
 
+      const sanitizeNumeric = (v: any) => {
+        if (v === null || v === undefined) return null;
+        if (typeof v === "string" && v.trim() === "") return null;
+        if (typeof v === "number" && Number.isNaN(v)) return null;
+        return v;
+      };
+
       const updateData: any = {
         team_id: teamId,
         team_alias: values.team_alias,
         models: values.models,
-        tpm_limit: values.tpm_limit,
-        rpm_limit: values.rpm_limit,
+        tpm_limit: sanitizeNumeric(values.tpm_limit),
+        rpm_limit: sanitizeNumeric(values.rpm_limit),
         max_budget: values.max_budget,
         budget_duration: values.budget_duration,
         metadata: {
@@ -349,10 +356,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         servers: [],
         accessGroups: [],
       };
-      if (
-        (servers && servers.length > 0) ||
-        (accessGroups && accessGroups.length > 0)
-      ) {
+      if ((servers && servers.length > 0) || (accessGroups && accessGroups.length > 0)) {
         updateData.object_permission = {};
         if (servers && servers.length > 0) {
           updateData.object_permission.mcp_servers = servers;
@@ -472,8 +476,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
               <Card>
                 <Text>Rate Limits</Text>
                 <div className="mt-2">
-                  <Text>TPM: {info.tpm_limit || "Unlimited"}</Text>
-                  <Text>RPM: {info.rpm_limit || "Unlimited"}</Text>
+                  <Text>
+                    TPM: {info.tpm_limit !== null && info.tpm_limit !== undefined ? info.tpm_limit : "Not set"}
+                  </Text>
+                  <Text>
+                    RPM: {info.rpm_limit !== null && info.rpm_limit !== undefined ? info.rpm_limit : "Not set"}
+                  </Text>
                   {info.max_parallel_requests && (
                     <Text>
                       Max Parallel Requests: {info.max_parallel_requests}
@@ -774,8 +782,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                   </div>
                   <div>
                     <Text className="font-medium">Rate Limits</Text>
-                    <div>TPM: {info.tpm_limit || "Unlimited"}</div>
-                    <div>RPM: {info.rpm_limit || "Unlimited"}</div>
+                    <div>TPM: {info.tpm_limit !== null && info.tpm_limit !== undefined ? info.tpm_limit : "Not set"}</div>
+                    <div>RPM: {info.rpm_limit !== null && info.rpm_limit !== undefined ? info.rpm_limit : "Not set"}</div>
                   </div>
                   <div>
                     <Text className="font-medium">Team Budget</Text>

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -477,10 +477,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 <Text>Rate Limits</Text>
                 <div className="mt-2">
                   <Text>
-                    TPM: {info.tpm_limit !== null && info.tpm_limit !== undefined ? info.tpm_limit : "Not set"}
+                    TPM: {info.tpm_limit || "Unlimited"}
                   </Text>
                   <Text>
-                    RPM: {info.rpm_limit !== null && info.rpm_limit !== undefined ? info.rpm_limit : "Not set"}
+                    RPM: {info.rpm_limit || "Unlimited"}
                   </Text>
                   {info.max_parallel_requests && (
                     <Text>


### PR DESCRIPTION
## Title
Allow unsetting TPM and RPM - Teams
<!-- e.g. "Implement user authentication feature" -->


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Allow unsetting TPM and RPM in team settings
- In the Team Settings View Mode, if you set TPM/RPM to 0 or leave it empty, it will display as "Unlimited".

<img width="1071" height="816" alt="Screenshot 2025-08-09 at 1 29 27" src="https://github.com/user-attachments/assets/a860eea4-6c7a-432c-8074-4159d8e99d40" />
<img width="1512" height="816" alt="Screenshot 2025-08-09 at 1 29 32" src="https://github.com/user-attachments/assets/16dc7bb1-4adc-48f9-a211-bf2feeda52f3" />



