### PR TITLE
Disable logging settings for non-enterprise users - Create Key

### DIFF
--- a/ui/litellm-dashboard/src/components/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_key_button.tsx
@@ -1009,22 +1009,58 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                     />
                   </Form.Item>
 
-                  <Accordion className="mt-4 mb-4">
-                    <AccordionHeader>
-                      <b>Logging Settings</b>
-                    </AccordionHeader>
-                    <AccordionBody>
-                      <div className="mt-4">
-                        <PremiumLoggingSettings
-                          value={loggingSettings}
-                          onChange={setLoggingSettings}
-                          premiumUser={premiumUser}
-                          disabledCallbacks={disabledCallbacks}
-                          onDisabledCallbacksChange={setDisabledCallbacks}
-                        />
+                  {premiumUser ? (
+                    <Accordion className="mt-4 mb-4">
+                      <AccordionHeader>
+                        <b>Logging Settings</b>
+                      </AccordionHeader>
+                      <AccordionBody>
+                        <div className="mt-4">
+                          <PremiumLoggingSettings
+                            value={loggingSettings}
+                            onChange={setLoggingSettings}
+                            premiumUser={true}
+                            disabledCallbacks={disabledCallbacks}
+                            onDisabledCallbacksChange={setDisabledCallbacks}
+                          />
+                        </div>
+                      </AccordionBody>
+                    </Accordion>
+                  ) : (
+                    <Tooltip 
+                      title={
+                        <span>
+                          Key-level logging settings is an enterprise feature, get in touch -
+                          <a href="https://www.litellm.ai/enterprise" target="_blank">
+                            https://www.litellm.ai/enterprise
+                          </a>
+                        </span>
+                      }
+                      placement="top"
+                    >
+                      <div style={{ position: 'relative' }}>
+                        <div style={{ opacity: 0.5 }}>
+                          <Accordion className="mt-4 mb-4">
+                            <AccordionHeader>
+                              <b>Logging Settings</b>
+                            </AccordionHeader>
+                            <AccordionBody>
+                              <div className="mt-4">
+                                <PremiumLoggingSettings
+                                  value={loggingSettings}
+                                  onChange={setLoggingSettings}
+                                  premiumUser={false}
+                                  disabledCallbacks={disabledCallbacks}
+                                  onDisabledCallbacksChange={setDisabledCallbacks}
+                                />
+                              </div>
+                            </AccordionBody>
+                          </Accordion>
+                        </div>
+                        <div style={{ position: 'absolute', inset: 0, cursor: 'not-allowed' }} />
                       </div>
-                    </AccordionBody>
-                  </Accordion>
+                    </Tooltip>
+                  )}
 
                   <Accordion className="mt-4 mb-4">
                     <AccordionHeader>


### PR DESCRIPTION
## Title
Disable logging settings for non-enterprise users
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
- Show tooltip for non-enterprise users on the logging settings in create key modal.
<img width="802" height="187" alt="Screenshot 2025-08-09 at 1 43 52" src="https://github.com/user-attachments/assets/da2cab6a-24e5-4979-8985-a71d2077a02e" />
