### PR TITLE
[Feat] Add `reasoning_effort` to OpenAIGPT5Config

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -18,6 +18,12 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
         return "gpt-5" in model
+    
+    def get_supported_openai_params(self, model: str) -> list:
+        base_gpt_series_params = super().get_supported_openai_params(model=model)
+        gpt_5_only_params = ["reasoning_effort"]
+        base_gpt_series_params.extend(gpt_5_only_params)
+        return base_gpt_series_params
 
     def map_openai_params(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -614,7 +614,7 @@
     },
     "gpt-5": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -646,7 +646,7 @@
     },
     "gpt-5-mini": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -678,7 +678,7 @@
     },
     "gpt-5-nano": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -709,14 +709,12 @@
         "supports_reasoning": true
     },
     "gpt-5-chat": {
-        "max_tokens": 32768,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-06,
-        "output_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 2.5e-06,
-        "output_cost_per_token_batches": 1e-05,
-        "cache_read_input_token_cost": 1.25e-06,
+        "max_tokens": 128000,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07,
         "litellm_provider": "openai",
         "mode": "chat",
         "supported_endpoints": [
@@ -739,11 +737,12 @@
         "supports_prompt_caching": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "supports_reasoning": true
     },
     "gpt-5-chat-latest": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -775,7 +774,7 @@
     },
     "gpt-5-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 2720000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -807,7 +806,7 @@
     },
     "gpt-5-mini-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -839,7 +838,7 @@
     },
     "gpt-5-nano-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2266,7 +2265,7 @@
     },
     "azure/gpt-5": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -2298,7 +2297,7 @@
     },
     "azure/gpt-5-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -2330,7 +2329,7 @@
     },
     "azure/gpt-5-mini": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -2362,7 +2361,7 @@
     },
     "azure/gpt-5-mini-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -2394,7 +2393,7 @@
     },
     "azure/gpt-5-nano-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2426,7 +2425,7 @@
     },
     "azure/gpt-5-nano": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2457,14 +2456,12 @@
         "supports_reasoning": true
     },
     "azure/gpt-5-chat": {
-        "max_tokens": 32768,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-06,
-        "output_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 2.5e-06,
-        "output_cost_per_token_batches": 1e-05,
-        "cache_read_input_token_cost": 1.25e-06,
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07,
         "litellm_provider": "azure",
         "mode": "chat",
         "supported_endpoints": [
@@ -2487,11 +2484,13 @@
         "supports_prompt_caching": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "source": "https://azure.microsoft.com/en-us/blog/gpt-5-in-azure-ai-foundry-the-future-of-ai-apps-and-agents-starts-here/"
     },
     "azure/gpt-5-chat-latest": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -8,6 +8,9 @@ from litellm.llms.openai.openai import OpenAIConfig
 def config() -> OpenAIConfig:
     return OpenAIConfig()
 
+def test_gpt5_supports_reasoning_effort(config: OpenAIConfig):
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5")
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-mini")
 
 def test_gpt5_maps_max_tokens(config: OpenAIConfig):
     params = config.map_openai_params(


### PR DESCRIPTION
## [Feat] Add `reasoning_effort` to OpenAIGPT5Config

Fixes this error 
```
litellm.exceptions.UnsupportedParamsError: litellm.UnsupportedParamsError: Error code: 400 - {'error': {'message': "litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=gpt-5-2025-08-0
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


