### PR TITLE
[Bug fix] - Error creating standard logging object - can't register atexit after shutdownLitellm fixes standard logging payload

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4106,7 +4106,16 @@ class StandardLoggingPayloadSetup:
         from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 
         # Only generate object key if cold storage is configured
-        configured_cold_storage_logger = ColdStorageHandler._get_configured_cold_storage_custom_logger()
+        try:
+            configured_cold_storage_logger = (
+                ColdStorageHandler._get_configured_cold_storage_custom_logger()
+            )
+        except Exception as e:
+            verbose_logger.debug(
+                f"Cold storage custom logger unavailable: {e}"
+            )
+            return None
+
         if configured_cold_storage_logger is None:
             return None
             

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -614,7 +614,7 @@
     },
     "gpt-5": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -646,7 +646,7 @@
     },
     "gpt-5-mini": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -678,7 +678,7 @@
     },
     "gpt-5-nano": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -709,14 +709,12 @@
         "supports_reasoning": true
     },
     "gpt-5-chat": {
-        "max_tokens": 32768,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-06,
-        "output_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 2.5e-06,
-        "output_cost_per_token_batches": 1e-05,
-        "cache_read_input_token_cost": 1.25e-06,
+        "max_tokens": 128000,
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07,
         "litellm_provider": "openai",
         "mode": "chat",
         "supported_endpoints": [
@@ -739,11 +737,12 @@
         "supports_prompt_caching": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "supports_reasoning": true
     },
     "gpt-5-chat-latest": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -775,7 +774,7 @@
     },
     "gpt-5-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 2720000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -807,7 +806,7 @@
     },
     "gpt-5-mini-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -839,7 +838,7 @@
     },
     "gpt-5-nano-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2266,7 +2265,7 @@
     },
     "azure/gpt-5": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -2298,7 +2297,7 @@
     },
     "azure/gpt-5-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
@@ -2330,7 +2329,7 @@
     },
     "azure/gpt-5-mini": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -2362,7 +2361,7 @@
     },
     "azure/gpt-5-mini-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 2.5e-07,
         "output_cost_per_token": 2e-06,
@@ -2394,7 +2393,7 @@
     },
     "azure/gpt-5-nano-2025-08-07": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2426,7 +2425,7 @@
     },
     "azure/gpt-5-nano": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 4e-07,
@@ -2457,14 +2456,12 @@
         "supports_reasoning": true
     },
     "azure/gpt-5-chat": {
-        "max_tokens": 32768,
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-06,
-        "output_cost_per_token": 2e-05,
-        "input_cost_per_token_batches": 2.5e-06,
-        "output_cost_per_token_batches": 1e-05,
-        "cache_read_input_token_cost": 1.25e-06,
+        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 1e-05,
+        "cache_read_input_token_cost": 1.25e-07,
         "litellm_provider": "azure",
         "mode": "chat",
         "supported_endpoints": [
@@ -2487,11 +2484,13 @@
         "supports_prompt_caching": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_native_streaming": true
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "source": "https://azure.microsoft.com/en-us/blog/gpt-5-in-azure-ai-foundry-the-future-of-ai-apps-and-agents-starts-here/"
     },
     "azure/gpt-5-chat-latest": {
         "max_tokens": 128000,
-        "max_input_tokens": 400000,
+        "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -464,3 +464,30 @@ async def test_e2e_generate_cold_storage_object_key_not_configured():
         
         # Verify the result is None when cold storage is not configured
         assert result is None
+
+
+@pytest.mark.asyncio
+async def test_e2e_generate_cold_storage_object_key_runtime_error_handled():
+    """Ensure runtime errors while loading cold storage logger are ignored."""
+    from datetime import datetime, timezone
+    from unittest.mock import patch
+
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    start_time = datetime(2025, 1, 15, 10, 30, 45, 123456, timezone.utc)
+    response_id = "chatcmpl-test-runtime"
+    team_alias = "team"
+
+    with patch(
+        "litellm.proxy.spend_tracking.cold_storage_handler.ColdStorageHandler._get_configured_cold_storage_custom_logger",
+        side_effect=RuntimeError("can't register atexit after shutdown"),
+    ):
+        result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
+            start_time=start_time,
+            response_id=response_id,
+            team_alias=team_alias,
+        )
+
+    # When an exception occurs retrieving the cold storage logger, the
+    # function should return None instead of raising.
+    assert result is None


### PR DESCRIPTION
## [Bug fix] - Error creating standard logging object - can't register atexit after shutdownLitellm fixes standard logging payload

Fixes: https://github.com/BerriAI/litellm/issues/13424 

Fixes this error 

```
17:52:14 - LiteLLM:ERROR: litellm_logging.py:4483 - Error creating standard logging object - can't register atexit after shutdown
Traceback (most recent call last):
  File "/Users/REDACTED/.pyenv/versions/REDACTED/lib/python3.12/site-packages/litellm/litellm_core_utils/litellm_logging.py", line 4370, in get_standard_logging_object_payload
    clean_metadata = StandardLoggingPayloadSetup.get_standard_logging_metadata(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/REDACTED/.pyenv/versions/REDACTED/lib/python3.12/site-packages/litellm/litellm_core_utils/litellm_logging.py", line 3921, in get_standard_logging_metadata
    cold_storage_object_key = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


