### PR TITLE
[Bug Fix] /health checks should not use hardcoded trace_id

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5514,9 +5514,9 @@ async def ahealth_check(
         messages=[],
         stream=False,
         call_type="acompletion",
-        litellm_call_id="1234",
+        litellm_call_id=str(uuid.uuid4()),
         start_time=datetime.datetime.now(),
-        function_id="1234",
+        function_id=str(uuid.uuid4()),
         log_raw_request_response=True,
     )
     model_params["litellm_logging_obj"] = litellm_logging_obj


### PR DESCRIPTION
## [Bug Fix] /health checks should not use hardcoded trace_id

Fix: Generate unique trace IDs for Langfuse health checks

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Langfuse health checks were using a hardcoded trace ID (`"1234"`), which caused all health check traces to overwrite each other. This change replaces the hardcoded `litellm_call_id` and `function_id` in the `ahealth_check` function with dynamically generated UUIDs, ensuring each health check creates a unique trace for proper observability.

---
[Slack Thread](https://berriaillm.slack.com/archives/C083298T755/p1754764699836089?thread_ts=1754764699.836089&cid=C083298T755)

<a href="https://cursor.com/background-agent?bcId=bc-87231bda-58ac-450a-8914-93af0c39f720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87231bda-58ac-450a-8914-93af0c39f720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

