### PR TITLE
Prompt cache of bedrock tool result

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3527,7 +3527,15 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
         tool_content: List[BedrockContentBlock] = []
         while msg_i < len(messages) and messages[msg_i]["role"] == "tool":
             tool_call_result = _convert_to_bedrock_tool_call_result(messages[msg_i])
-
+            _cache_point_block = (
+                litellm.AmazonConverseConfig()._get_cache_point_block(
+                    message_block=cast(
+                        OpenAIMessageContentListBlock, messages[msg_i]
+                    ),
+                    block_type="content_block",
+                )
+            )
+      
             tool_content.append(tool_call_result)
             msg_i += 1
         if tool_content:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3527,14 +3527,6 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
         tool_content: List[BedrockContentBlock] = []
         while msg_i < len(messages) and messages[msg_i]["role"] == "tool":
             tool_call_result = _convert_to_bedrock_tool_call_result(messages[msg_i])
-            _cache_point_block = (
-                litellm.AmazonConverseConfig()._get_cache_point_block(
-                    message_block=cast(
-                        OpenAIMessageContentListBlock, messages[msg_i]
-                    ),
-                    block_type="content_block",
-                )
-            )
       
             tool_content.append(tool_call_result)
             msg_i += 1

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3196,9 +3196,8 @@ class BedrockConverseMessagesProcessor:
                 )
 
                 tool_content.append(tool_call_result)
-            if _cache_point_block is not None:
-                tool_content.append(_cache_point_block)
-                tool_content.append(tool_call_result)
+                if _cache_point_block is not None:
+                    tool_content.append(_cache_point_block)
                 msg_i += 1
             if tool_content:
                 # if last message was a 'user' message, then add a blank assistant message (bedrock requires alternating roles)
@@ -3527,8 +3526,18 @@ def _bedrock_converse_messages_pt(  # noqa: PLR0915
         tool_content: List[BedrockContentBlock] = []
         while msg_i < len(messages) and messages[msg_i]["role"] == "tool":
             tool_call_result = _convert_to_bedrock_tool_call_result(messages[msg_i])
-      
+            _cache_point_block = (
+                litellm.AmazonConverseConfig()._get_cache_point_block(
+                    message_block=cast(
+                        OpenAIMessageContentListBlock, messages[msg_i]
+                    ),
+                    block_type="content_block",
+                )
+            )
+
             tool_content.append(tool_call_result)
+            if _cache_point_block is not None:
+                tool_content.append(_cache_point_block)
             msg_i += 1
         if tool_content:
             # if last message was a 'user' message, then add a blank assistant message (bedrock requires alternating roles)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3186,7 +3186,18 @@ class BedrockConverseMessagesProcessor:
             tool_content: List[BedrockContentBlock] = []
             while msg_i < len(messages) and messages[msg_i]["role"] == "tool":
                 tool_call_result = _convert_to_bedrock_tool_call_result(messages[msg_i])
+                _cache_point_block = (
+                    litellm.AmazonConverseConfig()._get_cache_point_block(
+                        message_block=cast(
+                            OpenAIMessageContentListBlock, messages[msg_i]
+                        ),
+                        block_type="content_block",
+                    )
+                )
 
+                tool_content.append(tool_call_result)
+            if _cache_point_block is not None:
+                tool_content.append(_cache_point_block)
                 tool_content.append(tool_call_result)
                 msg_i += 1
             if tool_content:


### PR DESCRIPTION
## Title

<!-- e.g. "add support for prompt cache of bedrock tool result" -->

🆕 New Feature
<img width="762" height="33" alt="image" src="https://github.com/user-attachments/assets/53fa1e74-4765-419f-b8c6-8a495f125851" />
<img width="1022" height="395" alt="image" src="https://github.com/user-attachments/assets/afa4dc11-1259-4b65-af11-f7d90ab3a6fa" />


## Changes
I find that prompt cache of bedrock tool result is not supported now so I have create this PR to add the feature.