### PR TITLE
[Feat] Add verbosity option to OpenAIGPT5Config

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -21,7 +21,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     
     def get_supported_openai_params(self, model: str) -> list:
         base_gpt_series_params = super().get_supported_openai_params(model=model)
-        gpt_5_only_params = ["reasoning_effort"]
+        gpt_5_only_params = ["reasoning_effort", "verbosity"]
         base_gpt_series_params.extend(gpt_5_only_params)
         return base_gpt_series_params
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -355,6 +355,7 @@ async def acompletion(
     top_logprobs: Optional[int] = None,
     deployment_id=None,
     reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None,
+    verbosity: Optional[Literal["low", "medium", "high"]] = None,
     # set api_base, api_version, api_key
     base_url: Optional[str] = None,
     api_version: Optional[str] = None,
@@ -491,6 +492,7 @@ async def acompletion(
         "api_key": api_key,
         "model_list": model_list,
         "reasoning_effort": reasoning_effort,
+        "verbosity": verbosity,
         "extra_headers": extra_headers,
         "acompletion": True,  # assuming this is a required parameter
         "thinking": thinking,
@@ -894,6 +896,7 @@ def completion(  # type: ignore # noqa: PLR0915
     user: Optional[str] = None,
     # openai v1.0+ new params
     reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None,
+    verbosity: Optional[Literal["low", "medium", "high"]] = None,
     response_format: Optional[Union[dict, Type[BaseModel]]] = None,
     seed: Optional[int] = None,
     tools: Optional[List] = None,
@@ -1239,6 +1242,7 @@ def completion(  # type: ignore # noqa: PLR0915
             "parallel_tool_calls": parallel_tool_calls,
             "messages": messages,
             "reasoning_effort": reasoning_effort,
+            "verbosity": verbosity,
             "thinking": thinking,
             "web_search_options": web_search_options,
             "allowed_openai_params": kwargs.get("allowed_openai_params"),

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3258,6 +3258,7 @@ def get_optional_params(  # noqa: PLR0915
     drop_params=None,
     allowed_openai_params: Optional[List[str]] = None,
     reasoning_effort=None,
+    verbosity=None,
     additional_drop_params=None,
     messages: Optional[List[AllMessageValues]] = None,
     thinking: Optional[AnthropicThinkingParam] = None,

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -664,3 +664,13 @@ async def test_openai_gpt5_reasoning():
     )
     print("response: ", response)
     assert response.choices[0].message.content is not None
+
+@pytest.mark.asyncio
+async def test_openai_gpt5_verbosity():
+    response = await litellm.acompletion(
+        model="openai/gpt-5-mini",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        verbosity="low",
+    )
+    print("response: ", response)
+    assert response.choices[0].message.content is not None

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -11,6 +11,12 @@ def config() -> OpenAIConfig:
 def test_gpt5_supports_reasoning_effort(config: OpenAIConfig):
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5")
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-mini")
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-nano")
+
+def test_gpt5_supports_verbosity(config: OpenAIConfig):
+    assert "verbosity" in config.get_supported_openai_params(model="gpt-5")
+    assert "verbosity" in config.get_supported_openai_params(model="gpt-5-mini")
+    assert "verbosity" in config.get_supported_openai_params(model="gpt-5-nano")
 
 def test_gpt5_maps_max_tokens(config: OpenAIConfig):
     params = config.map_openai_params(


### PR DESCRIPTION
## Title

Add `verbosity` option to `OpenAIGPT5Config`

This will allow the [`verbosity`](https://github.com/openai/openai-python/blob/a02ac0dd5b4797d4a782b4b75fd0790df3e14149/src/openai/types/chat/completion_create_params.py#L320-L326) parameter to be set for chat completions

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
✅ Test

## Changes
- Add `verbosity` string to GPT-5 list of supported params
- Add relevant tests

