### PR TITLE
[Bug Fix] Using gpt-5 models with Claude Code

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,15 +1,17 @@
 model_list:
-  - model_name: gemini/*
+  - model_name: openai/*
     litellm_params:
-      model: gemini/*
+      model: openai/*
+  - model_name: anthropic/*
+    litellm_params:
+      model: anthropic/*
+  - model_name: auto_router1
+    litellm_params:
+      model: auto_router/auto_router1
+      auto_router_config_path: router.json
+      auto_router_default_model: "gpt-4o"
+      auto_router_embedding_model: "text-embedding-3-small"
 
 litellm_settings:
-  callbacks: ["s3_v2"]
-  s3_callback_params:
-    s3_bucket_name: litellm-logs   # AWS Bucket Name for S3
-    s3_region_name: us-west-2       
-
-general_settings:
-  cold_storage_custom_logger: s3_v2
-  store_prompts_in_cold_storage: true
-  store_prompts_in_spend_logs: true
+  callbacks:
+    - langfuse


### PR DESCRIPTION
## [Bug Fix] Using gpt-5 models with Claude Code

- Streaming responses on /v1/messages with OpenAI models + tool calling we're returning bad content block starts/stop like this 

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_5ec093eb-eff6-47f7-a947-f75f1246a3fa", "type": "message", "role": "assistant", "content": [], "model": "gpt-5", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0}}}

event: content_block_start
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}

event: content_block_stop
data: {"type": "content_block_stop", "index": 0}
```

<img width="1280" height="690" alt="Screenshot 2025-08-11 at 7 16 35 PM" src="https://github.com/user-attachments/assets/8677ca06-e158-461b-90d6-7f65a110e4af" />


Fixes: https://github.com/BerriAI/litellm/issues/13373 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


