### PR TITLE
Implement GitHub Action to auto-label issues with provider keywords

### DIFF
--- a/.github/scripts/scan_keywords.py
+++ b/.github/scripts/scan_keywords.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+def read_event_payload() -> dict:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not os.path.exists(event_path):
+        return {}
+    with open(event_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_issue_text(event: dict) -> tuple[str, str, int, str]:
+    issue = event.get("issue") or {}
+    title = (issue.get("title") or "").strip()
+    body = (issue.get("body") or "").strip()
+    number = issue.get("number") or 0
+    html_url = issue.get("html_url") or ""
+    return title, body, number, html_url
+
+
+def detect_keywords(text: str, keywords: list[str]) -> list[str]:
+    lowered = text.lower()
+    matches = []
+    for keyword in keywords:
+        k = keyword.strip().lower()
+        if not k:
+            continue
+        if k in lowered:
+            matches.append(keyword.strip())
+    # Deduplicate while preserving order
+    seen = set()
+    unique_matches = []
+    for m in matches:
+        if m not in seen:
+            unique_matches.append(m)
+            seen.add(m)
+    return unique_matches
+
+
+def send_webhook(webhook_url: str, payload: dict) -> None:
+    if not webhook_url:
+        return
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+    except urllib.error.HTTPError as e:
+        print(f"Webhook HTTP error: {e.code} {e.reason}", file=sys.stderr)
+    except urllib.error.URLError as e:
+        print(f"Webhook URL error: {e.reason}", file=sys.stderr)
+    except Exception as e:
+        print(f"Webhook unexpected error: {e}", file=sys.stderr)
+
+
+def main() -> int:
+    event = read_event_payload()
+    if not event:
+        print("::warning::No event payload found; exiting without labeling.")
+        return 0
+
+    # Read issue details
+    title, body, number, html_url = get_issue_text(event)
+    combined_text = f"{title}\n\n{body}".strip()
+
+    # Keywords from env or defaults
+    keywords_env = os.environ.get("KEYWORDS", "")
+    default_keywords = ["azure", "openai", "bedrock", "vertexai", "vertex ai", "anthropic"]
+    keywords = [k.strip() for k in keywords_env.split(",")] if keywords_env else default_keywords
+
+    matches = detect_keywords(combined_text, keywords)
+    found = bool(matches)
+
+    # Emit outputs
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"found={'true' if found else 'false'}\n")
+            fh.write(f"matches={','.join(matches)}\n")
+
+    # Optional webhook notification
+    webhook_url = os.environ.get("PROVIDER_ISSUE_WEBHOOK_URL", "").strip()
+    if found and webhook_url:
+        repo_full = (event.get("repository") or {}).get("full_name", "")
+        payload = {
+            "text": (
+                f"Provider keyword(s) detected in issue {repo_full} #{number}: {title}\n"
+                f"Keywords: {', '.join(matches)}\n{html_url}"
+            )
+        }
+        send_webhook(webhook_url, payload)
+
+    # Print a short log line for Actions UI
+    if found:
+        print(f"Detected provider keywords: {', '.join(matches)}")
+    else:
+        print("No provider keywords detected.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/.github/scripts/scan_keywords.py
+++ b/.github/scripts/scan_keywords.py
@@ -108,9 +108,10 @@ def main() -> int:
         preview_block = f"\n{body_preview}" if body_preview else ""
         payload = {
             "text": (
-                f":memo: New issue in {repo_full} #{number}{author_part}\n"
-                f"{title_part}{preview_block}\n"
-                f"<{html_url}|View issue>"
+                f"New issue 🚨\n"
+                f"{title_part}\n\n{preview_block}\n"
+                f"<{html_url}|View issue>\n"
+                f"Author: {author}"
             )
         }
         send_webhook(webhook_url, payload)

--- a/.github/scripts/scan_keywords.py
+++ b/.github/scripts/scan_keywords.py
@@ -4,7 +4,6 @@ import os
 import sys
 import urllib.request
 import urllib.error
-import re
 
 
 def read_event_payload() -> dict:

--- a/.github/scripts/scan_keywords.py
+++ b/.github/scripts/scan_keywords.py
@@ -4,6 +4,7 @@ import os
 import sys
 import urllib.request
 import urllib.error
+import re
 
 
 def read_event_payload() -> dict:
@@ -67,10 +68,12 @@ def send_webhook(webhook_url: str, payload: dict) -> None:
 def _excerpt(text: str, max_len: int = 400) -> str:
     if not text:
         return ""
-    clean = " ".join(text.split())
-    if len(clean) <= max_len:
-        return clean
-    return clean[: max_len - 1] + "…"
+    
+    # Keep original formatting
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
 
 
 def main() -> int:

--- a/.github/scripts/scan_keywords.py
+++ b/.github/scripts/scan_keywords.py
@@ -90,6 +90,7 @@ def main() -> int:
 
     # Optional webhook notification
     webhook_url = os.environ.get("PROVIDER_ISSUE_WEBHOOK_URL", "").strip()
+    print(f"Webhook URL detected")
     if found and webhook_url:
         repo_full = (event.get("repository") or {}).get("full_name", "")
         payload = {

--- a/.github/workflows/issue-keyword-labeler.yml
+++ b/.github/workflows/issue-keyword-labeler.yml
@@ -1,0 +1,64 @@
+name: Issue Keyword Labeler
+
+on:
+  issues:
+    types: 
+        - opened
+
+jobs:
+  scan-and-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Scan for provider keywords
+        id: scan
+        env:
+          PROVIDER_ISSUE_WEBHOOK_URL: ${{ secrets.PROVIDER_ISSUE_WEBHOOK_URL }}
+          KEYWORDS: azure,openai,bedrock,vertexai,vertex ai,anthropic
+        run: python3 .github/scripts/scan_keywords.py
+
+      - name: Ensure label exists
+        if: steps.scan.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labelName = 'llm translation';
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelName,
+                  color: 'c1ff72',
+                  description: 'Issues related to LLM provider translation/mapping'
+                });
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Add label to the issue
+        if: steps.scan.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['llm translation']
+            });
+


### PR DESCRIPTION
## Title

Implement GitHub Action to auto-label issues with provider keywords

## Relevant issues

Fixes #13525

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
This PR implements a GitHub Action workflow that automatically scans new issues for LLM provider keywords and applies the `llm translation` label when matches are found.
**What was implemented:**
- Added `.github/workflows/issue-keyword-labeler.yml` workflow that triggers on new issues
- Added `.github/scripts/scan_keywords.py` Python script to detect provider keywords
- Workflow automatically creates the llm translation label if it doesn't exist
- Optional webhook notification support via PROVIDER_ISSUE_WEBHOOK_URL secret. We can discuss more comprehensive way too as per the need.


**Keywords detected**:
azure, openai, bedrock, vertexai, vertex ai, anthropic(I can add more to find the sweetspot for this)

**Benefits**:
- Automates issue categorization for LLM provider-related issues
- Streamlines review process for maintainers
- Reduces manual labeling effort
- Optional Slack/Teams notifications for immediate awareness

**Configuration**:
- Set PROVIDER_ISSUE_WEBHOOK_URL repository secret for webhook notifications
- Keywords can be customized via KEYWORDS environment variable in the workflow
- The workflow will start working immediately after creation of all newly opened issues.

<img width="929" height="60" alt="image" src="https://github.com/user-attachments/assets/eb3879ea-0799-4ee5-ad10-bd9aaa311a4c" />

I have tested it for slack, it sends a notification using the slack app webhook.

<img width="500" height="465" alt="image" src="https://github.com/user-attachments/assets/ccfd81e2-2058-4998-9529-8f2eb9b353ac" />



