### PR TITLE
Update mlflow logger usage span attributes

### DIFF
--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -189,9 +189,9 @@ class MlflowLogger(CustomLogger):
                 {
                     "api_base": standard_obj.get("api_base"),
                     "cache_hit": standard_obj.get("cache_hit"),
-                    "usage": {
-                        "completion_tokens": standard_obj.get("completion_tokens"),
-                        "prompt_tokens": standard_obj.get("prompt_tokens"),
+                    "mlflow.chat.tokenUsage": {
+                        "input_tokens": standard_obj.get("prompt_tokens"),
+                        "output_tokens": standard_obj.get("completion_tokens"),
                         "total_tokens": standard_obj.get("total_tokens"),
                     },
                     "raw_llm_response": standard_obj.get("response"),

--- a/tests/test_litellm/integrations/test_mlflow.py
+++ b/tests/test_litellm/integrations/test_mlflow.py
@@ -1,18 +1,16 @@
-import asyncio
+import importlib
 import os
 import sys
 from unittest.mock import MagicMock, patch
+import time
 
 # Adds the grandparent directory to sys.path to allow importing project modules
 sys.path.insert(0, os.path.abspath("../.."))
 
-import pytest
-
 import litellm
 
 
-@pytest.mark.asyncio
-async def test_mlflow_request_tags_functionality():
+def test_mlflow_request_tags_functionality():
     """Test that request_tags are properly extracted and transformed into tags for MLflow traces."""
     
     # Mock MLflow client and dependencies
@@ -34,42 +32,72 @@ async def test_mlflow_request_tags_functionality():
     mock_mlflow = MagicMock()
     mock_mlflow.get_current_active_span.return_value = None
     
-    with patch.dict('sys.modules', {
-        'mlflow': mock_mlflow,
-        'mlflow.tracking': mock_mlflow_tracking,
-        'mlflow.entities': mock_mlflow_entities,
-        'mlflow.tracing.utils': MagicMock(),
-    }):
-        # Now we can safely import MlflowLogger
+    with patch.dict(
+        'sys.modules',
+        {
+            'mlflow': mock_mlflow,
+            'mlflow.tracking': mock_mlflow_tracking,
+            'mlflow.entities': mock_mlflow_entities,
+            'mlflow.tracing.utils': MagicMock(),
+        },
+    ):
         from litellm.integrations.mlflow import MlflowLogger
 
-        # Create MlflowLogger instance
         mlflow_logger = MlflowLogger()
         litellm.callbacks = [mlflow_logger]
-        
-        # Test completion with request_tags
-        await litellm.acompletion(
+
+        litellm.completion(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "test message"}],
             mock_response="test response",
-            metadata={
-                "tags": ["tag1", "tag2", "production"]
-            }
+            metadata={"tags": ["tag1", "tag2", "production"]},
         )
-        
-        # Allow time for async processing
-        await asyncio.sleep(1)
-        
-        # Verify start_trace was called with tags parameter
+
+        time.sleep(2)
+
         assert mock_client.start_trace.called, "start_trace should have been called"
-        
-        # Get the call arguments
+
         call_args = mock_client.start_trace.call_args
         assert call_args is not None, "start_trace call args should not be None"
-        
-        # Check that tags parameter was included and properly transformed
+
         tags_param = call_args.kwargs.get('tags', {})
         expected_tags = {"tag1": "", "tag2": "", "production": ""}
         assert tags_param == expected_tags, f"Expected tags {expected_tags}, got {tags_param}"
-        
-        print("✅ Request tags properly transformed and passed to MLflow trace")
+
+
+
+def test_mlflow_token_usage_attribute_structure():
+    """Ensure token usage attributes are formatted with mlflow.chat.tokenUsage."""
+
+    mock_mlflow_tracking = MagicMock()
+    mock_mlflow_tracking.MlflowClient = MagicMock()
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "mlflow": MagicMock(),
+            "mlflow.tracking": mock_mlflow_tracking,
+            "mlflow.tracing.utils": MagicMock(),
+        },
+    ):
+        mlflow_module = importlib.import_module("litellm.integrations.mlflow")
+        mlflow_logger = mlflow_module.MlflowLogger()
+
+        attrs = mlflow_logger._extract_attributes(  # type: ignore
+            {
+                "litellm_call_id": "123",
+                "call_type": "completion",
+                "model": "gpt-3.5-turbo",
+                "standard_logging_object": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 7,
+                    "total_tokens": 12,
+                },
+            }
+        )
+
+        assert attrs["mlflow.chat.tokenUsage"] == {
+            "input_tokens": 5,
+            "output_tokens": 7,
+            "total_tokens": 12,
+        }


### PR DESCRIPTION
## Title

Update mlflow logger span attributes for token usage

## Relevant issues

https://github.com/mlflow/mlflow/issues/16233

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem



## Type
🧹 Refactoring

## Changes

As part of token usage standarlization of MLflow tracing, we want to update the span attribute key names of token usage.
