### PR TITLE
fix: remove incorrect web search support for azure/gpt-4.1 family

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2658,12 +2658,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.03,
-            "search_context_size_medium": 0.035,
-            "search_context_size_high": 0.05
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-2025-04-14": {
         "max_tokens": 32768,
@@ -2696,12 +2691,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.03,
-            "search_context_size_medium": 0.035,
-            "search_context_size_high": 0.05
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-mini": {
         "max_tokens": 32768,
@@ -2734,12 +2724,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275,
-            "search_context_size_high": 0.03
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-mini-2025-04-14": {
         "max_tokens": 32768,
@@ -2772,12 +2757,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275,
-            "search_context_size_high": 0.03
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-nano": {
         "max_tokens": 32768,
@@ -12588,8 +12568,6 @@
         "output_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
         "mode": "chat",
-        "supports_function_calling": true,
-        "supports_vision": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_reasoning": true
@@ -12602,8 +12580,6 @@
         "output_cost_per_token": 6e-07,
         "litellm_provider": "bedrock_converse",
         "mode": "chat",
-        "supports_function_calling": true,
-        "supports_vision": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_reasoning": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2658,12 +2658,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.03,
-            "search_context_size_medium": 0.035,
-            "search_context_size_high": 0.05
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-2025-04-14": {
         "max_tokens": 32768,
@@ -2696,12 +2691,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.03,
-            "search_context_size_medium": 0.035,
-            "search_context_size_high": 0.05
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-mini": {
         "max_tokens": 32768,
@@ -2734,12 +2724,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275,
-            "search_context_size_high": 0.03
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-mini-2025-04-14": {
         "max_tokens": 32768,
@@ -2772,12 +2757,7 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_native_streaming": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275,
-            "search_context_size_high": 0.03
-        }
+        "supports_web_search": false
     },
     "azure/gpt-4.1-nano": {
         "max_tokens": 32768,


### PR DESCRIPTION
## Title
Incorrect support flag set for model cost map file

## Relevant issues
Fixes #13563

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Changed supports_web_search from true to false for azure/gpt-4.1 family



