### PR TITLE
[Fix] Hide sensitive data in /model/info - azure entra client_secret

### DIFF
--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -20,6 +20,7 @@ def remove_sensitive_info_from_deployment(deployment_dict: dict) -> dict:
         dict: The modified deployment dictionary with sensitive information removed.
     """
     deployment_dict["litellm_params"].pop("api_key", None)
+    deployment_dict["litellm_params"].pop("client_secret", None)
     deployment_dict["litellm_params"].pop("vertex_credentials", None)
     deployment_dict["litellm_params"].pop("aws_access_key_id", None)
     deployment_dict["litellm_params"].pop("aws_secret_access_key", None)

--- a/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_openai_endpoint_utils.py
@@ -1,0 +1,87 @@
+import pytest
+
+from litellm.proxy.common_utils.openai_endpoint_utils import remove_sensitive_info_from_deployment
+
+
+@pytest.mark.parametrize(
+    "model_config, expected_config",
+    [
+        # Test case 1: Empty litellm_params
+        (
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {}
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {}
+                }
+        ),
+        # Test case 2: Full sensitive data removal, mixed secrets of azure, aws, gcp, and typical api_key
+        (
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {
+                        "model": "openai/gpt-4",
+                        "api_key": "sk-sensitive-key-123",
+                        "client_secret": "~v8Q4W:Zp9gJ-3sTqX5aB@LkR2mNfYdC",
+                        "vertex_credentials": {"type": "service_account"},
+                        "aws_access_key_id": "AKIA123456789",
+                        "aws_secret_access_key": "secret-access-key",
+                        "api_base": "https://api.openai.com/v1",
+                        "temperature": 0.7
+                    },
+                    "model_info": {"id": "test-id"}
+                },
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {
+                        "model": "openai/gpt-4",
+                        "api_base": "https://api.openai.com/v1",
+                        "temperature": 0.7
+                    },
+                    "model_info": {"id": "test-id"}
+                }
+        ),
+        # Test case 3: Partial sensitive data, api_key
+        (
+            {
+                "model_name": "claude-3",
+                "litellm_params": {
+                    "model": "anthropic/claude-3",
+                    "api_key": "sk-anthropic-key",
+                    "temperature": 0.5
+                }
+            },
+            {
+                "model_name": "claude-3",
+                "litellm_params": {
+                    "model": "anthropic/claude-3",
+                    "temperature": 0.5
+                }
+            }
+        ),
+        # Test case 4: No sensitive data
+        (
+            {
+                "model_name": "local-model",
+                "litellm_params": {
+                    "model": "local/model",
+                    "temperature": 0.8,
+                    "max_tokens": 100
+                }
+            },
+            {
+                "model_name": "local-model",
+                "litellm_params": {
+                    "model": "local/model",
+                    "temperature": 0.8,
+                    "max_tokens": 100
+                }
+            }
+        )
+    ]
+)
+def test_remove_sensitive_info_from_deployment(model_config: dict, expected_config: dict):
+    sanitized_config = remove_sensitive_info_from_deployment(model_config)
+    assert sanitized_config == expected_config


### PR DESCRIPTION
## Title

Hide azure entraid client_secret from /model/info litellm_params.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1140" height="248" alt="Screenshot from 2025-08-12 19-47-51" src="https://github.com/user-attachments/assets/c2830839-81ae-4753-87fb-4003b8480469" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Fix: Hiding Azure EntraID client_secret in response at /model/info endpoints
