### PR TITLE
fix(azure): remove trailing semicolon in Content-Type header for image generation

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -311,7 +311,7 @@ def image_generation(  # noqa: PLR0915
             ) or get_secret_str("AZURE_AD_TOKEN")
 
             default_headers = {
-                "Content-Type": "application/json;",
+                "Content-Type": "application/json",
                 "api-key": api_key,
             }
             for k, v in default_headers.items():


### PR DESCRIPTION
## Title

Remove trailing semicolon in Content-Type header for image generation

## Relevant issues

Issue #13583

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Azure’s image generation endpoint was failing with:
```
15:29:31 - LiteLLM Proxy:ERROR: endpoints.py:158 - litellm.proxy.proxy_server.image_generation(): Exception occured - litellm.BadRequestError: AzureException - {"error":{"code":"invalid_header","message":"Header 'Content-Type' has invalid value `application/json;`","details":"Header 'Content-Type' has invalid value `application/json;`"}}. Received Model Group=FLUX-1.1-pro        
Available Model Group Fallbacks=None LiteLLM Retried: 1 times, LiteLLM Max Retries: 2
INFO:     127.0.0.1:57389 - "POST /images/generations HTTP/1.1" 400 Bad Request
```
This was caused by a trailing semicolon in the `Content-Type` header when sending requests to Azure with a newly added model.

**Change made:**

In `litellm/images/main.py`, updated:
```python
"Content-Type": "application/json;",
```
to:
```python
"Content-Type": "application/json",
```
**Regarding Tests**

This change is essentially a typo fix, so I didn’t add a unit test. Adding a unit test to validate HTTP headers in general didn’t seem appropriate in this context — such checks might be better suited for integration tests. That said, I’m happy to add a test if the reviewers think it’s worthwhile.