### PR TITLE
Cleanup global variable declaration in proxy_server

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2737,7 +2737,6 @@ class ProxyConfig:
         """
         Pull from DB, read general settings value
         """
-        global general_settings
         if db_general_settings is None:
             return
         _general_settings = dict(db_general_settings)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1592,7 +1592,7 @@ class ProxyConfig:
         self,
         cache_params: dict,
     ):
-        global redis_usage_cache, llm_router
+        global redis_usage_cache
         from litellm import Cache
 
         if "default_in_memory_ttl" in cache_params:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -548,7 +548,7 @@ async def proxy_shutdown_event():
 
 @asynccontextmanager
 async def proxy_startup_event(app: FastAPI):
-    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval
+    global prisma_client, master_key, llm_router, llm_model_list, general_settings, premium_user
     import json
 
     init_verbose_loggers()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2945,6 +2945,7 @@ class ProxyConfig:
         Check if model cost map needs to be reloaded based on database configuration.
         This function runs every 10 seconds as part of _init_non_llm_objects_in_db.
         """
+        global last_model_cost_map_reload
         try:
             # Get model cost map reload configuration from database
             config_record = await prisma_client.db.litellm_config.find_unique(
@@ -2971,7 +2972,6 @@ class ProxyConfig:
                 verbose_proxy_logger.info("Model cost map reload triggered by force reload flag")
             elif interval_hours is not None:
                 # Use pod's in-memory last reload time
-                global last_model_cost_map_reload
                 if last_model_cost_map_reload is not None:
                     try:
                         last_reload_time = datetime.fromisoformat(last_model_cost_map_reload)
@@ -3000,7 +3000,6 @@ class ProxyConfig:
                 litellm.model_cost = new_model_cost_map
                 
                 # Update pod's in-memory last reload time
-                #TODO(yf): How does this work? the global was set in the other if branch 29 lines up?!
                 last_model_cost_map_reload = current_time.isoformat()
                 
                 # Clear force reload flag in database

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1624,7 +1624,6 @@ class ProxyConfig:
             dict: config
 
         """
-        global prisma_client, store_model_in_db
         # Load existing config
 
         if os.environ.get("LITELLM_CONFIG_BUCKET_NAME") is not None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -517,7 +517,6 @@ def cleanup_router_config_variables():
 
 
 async def proxy_shutdown_event():
-    global prisma_client, master_key, user_custom_auth, user_custom_key_generate
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
@@ -1084,7 +1083,6 @@ def load_from_azure_key_vault(use_azure_key_vault: bool = False):
 
 
 def cost_tracking():
-    global prisma_client
     if prisma_client is not None:
         litellm.logging_callback_manager.add_litellm_callback(_ProxyDBLogger())
 
@@ -1357,7 +1355,6 @@ async def _run_background_health_check():
 
     Update health_check_results, based on this.
     """
-    global health_check_results, llm_model_list, health_check_interval, health_check_details
 
     if (
         health_check_interval is None
@@ -1429,7 +1426,7 @@ class ProxyConfig:
         Returns:
             dict: config
         """
-        global prisma_client, user_config_file_path
+        global user_config_file_path
 
         file_path = config_file_path or user_config_file_path
         if config_file_path is not None:
@@ -1499,7 +1496,6 @@ class ProxyConfig:
         return config
 
     async def save_config(self, new_config: dict):
-        global prisma_client, general_settings, user_config_file_path, store_model_in_db
         # Load existing config
         ## DB - writes valid config to db
         """
@@ -8699,7 +8695,6 @@ async def delete_callback(
     """
     Delete specific logging callback from configuration.
     """
-    global prisma_client, proxy_config
 
     if prisma_client is None:
         raise HTTPException(
@@ -8791,7 +8786,6 @@ async def get_config():  # noqa: PLR0915
     # return the callbacks and the env variables for the callback
 
     """
-    global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key
     try:
         import base64
 


### PR DESCRIPTION
## Title

`proxy_server.py` methods unnecessarily declare many variables as `global`. This can make the code hard to read and understand. This PR removes those declarations where they are not necessary i.e. a global variable is not being modified from inside a method. 


## Type
🧹 Refactoring

## Changes


