### PR TITLE
Add deepseek-chat-v3-0324 to OpenRouter cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11223,6 +11223,17 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "openrouter/deepseek/deepseek-chat-v3-0324": {
+        "max_tokens": 8192,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "openrouter",
+        "supports_prompt_caching": true,
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
     "openrouter/deepseek/deepseek-coder": {
         "max_tokens": 8192,
         "max_input_tokens": 66000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11223,6 +11223,17 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "openrouter/deepseek/deepseek-chat-v3-0324": {
+        "max_tokens": 8192,
+        "max_input_tokens": 65536,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "openrouter",
+        "supports_prompt_caching": true,
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
     "openrouter/deepseek/deepseek-coder": {
         "max_tokens": 8192,
         "max_input_tokens": 66000,


### PR DESCRIPTION
## Title

Add deepseek-chat-v3-0324 to OpenRouter cost map

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Added deepseek-chat-v3-0324 models to model_prices_and_context_window.json:
  - openrouter/deepseek/deepseek-chat-v3-0324

- Added pricing and context window values aligning with provider sources
  - https://openrouter.ai/deepseek/deepseek-chat-v3-0324

- Both files updated:
  - model_prices_and_context_window.json
  - litellm/model_prices_and_context_window_backup.json
