### PR TITLE
[Bug Fix] Fix imports from proxy_server

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -160,7 +160,7 @@ class MCPRequestHandler:
             1. `LITELLM_MCP_CLIENT_SIDE_AUTH_HEADER_NAME` as an environment variable
             2. `mcp_client_side_auth_header_name` in the general settings on the config.yaml file
         """
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
         from litellm.secret_managers.main import get_secret_str
         MCP_CLIENT_SIDE_AUTH_HEADER_NAME: str = MCPRequestHandler.LITELLM_MCP_AUTH_HEADER_NAME
         if get_secret_str("LITELLM_MCP_CLIENT_SIDE_AUTH_HEADER_NAME") is not None:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -195,7 +195,8 @@ async def pre_db_read_auth_checks(
     Raises:
     - HTTPException if request fails initial auth checks
     """
-    from litellm.proxy.proxy_server import general_settings, llm_router, premium_user
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import llm_router, premium_user
 
     # Check 1. request size
     await check_if_request_size_is_safe(request=request)
@@ -262,7 +263,8 @@ def route_in_additonal_public_routes(current_route: str):
     """
 
     # check if user is premium_user - if not do nothing
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import premium_user
 
     try:
         if premium_user is not True:
@@ -317,7 +319,8 @@ async def check_if_request_size_is_safe(request: Request) -> bool:
         ProxyException: If the request size is too large
 
     """
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import premium_user
 
     max_request_size_mb = general_settings.get("max_request_size_mb", None)
 
@@ -382,7 +385,8 @@ async def check_response_size_is_safe(response: Any) -> bool:
 
     """
 
-    from litellm.proxy.proxy_server import general_settings, premium_user
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import premium_user
 
     max_response_size_mb = general_settings.get("max_response_size_mb", None)
     if max_response_size_mb is not None:
@@ -479,7 +483,7 @@ def get_end_user_id_from_request_body(
 ) -> Optional[str]:
     # Import general_settings here to avoid potential circular import issues at module level
     # and to ensure it's fetched at runtime.
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
 
     # Check 1: Custom Header from general_settings.user_header_name (only if request_headers is provided)
     # User query: "system not respecting user_header_name property"

--- a/litellm/proxy/auth/oauth2_proxy_hook.py
+++ b/litellm/proxy/auth/oauth2_proxy_hook.py
@@ -10,7 +10,7 @@ async def handle_oauth2_proxy_request(request: Request) -> UserAPIKeyAuth:
     """
     Handle request from oauth2 proxy.
     """
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
 
     verbose_proxy_logger.debug("Handling oauth2 proxy request")
     # Define the OAuth2 config mappings

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -226,7 +226,8 @@ class RouteChecks:
 
     @staticmethod
     def custom_admin_only_route_check(route: str):
-        from litellm.proxy.proxy_server import general_settings, premium_user
+        from litellm.proxy.general_settings import general_settings
+        from litellm.proxy.proxy_server import premium_user
 
         if "admin_only_routes" in general_settings:
             if premium_user is not True:

--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -9,7 +9,7 @@ def get_budget_reset_timezone():
     Falls back to UTC if not specified.
     """
     # Import at function level to avoid circular imports
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
 
     if general_settings:
         litellm_settings = general_settings.get("litellm_settings", {})

--- a/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
+++ b/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
@@ -59,7 +59,7 @@ class RedisUpdateBuffer:
         This setting enables buffering database transactions in Redis
         to improve reliability and reduce database contention
         """
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
 
         _use_redis_transaction_buffer: Optional[Union[bool, str]] = (
             general_settings.get("use_redis_transaction_buffer", False)

--- a/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
@@ -23,7 +23,7 @@ class SpendLogCleanup:
     def __init__(self, general_settings=None, redis_cache: Optional[RedisCache] = None):
         self.batch_size = SPEND_LOG_CLEANUP_BATCH_SIZE
         self.retention_seconds: Optional[int] = None
-        from litellm.proxy.proxy_server import general_settings as default_settings
+        from litellm.proxy.general_settings import general_settings as default_settings
 
         self.general_settings = general_settings or default_settings
         from litellm.proxy.proxy_server import proxy_logging_obj

--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -18,7 +18,7 @@ class PrismaDBExceptionHandler:
         """
         Returns True if the request should be allowed to proceed despite the DB connection error
         """
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
 
         _allow_requests_on_db_unavailable: Union[bool, str] = general_settings.get(
             "allow_requests_on_db_unavailable", False

--- a/litellm/proxy/general_settings.py
+++ b/litellm/proxy/general_settings.py
@@ -1,0 +1,14 @@
+"""
+Lightweight shared storage for proxy general settings.
+
+This module intentionally has no side effects so it can be safely imported
+by other parts of the codebase (e.g., cold storage handlers) without causing
+proxy_server to execute.
+
+The proxy_server will mutate this dict in-place at runtime to reflect the
+current configuration.
+"""
+from typing import Any, Dict
+
+# Shared mutable dict for general settings
+general_settings: Dict[str, Any] = {}

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -670,7 +670,8 @@ async def active_callbacks():
     ```
     """
 
-    from litellm.proxy.proxy_server import general_settings, proxy_logging_obj
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import proxy_logging_obj
 
     _alerting = str(general_settings.get("alerting"))
     # get success callbacks

--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -320,7 +320,8 @@ class KeyManagementEventHooks:
                 + CommonProxyErrors.missing_enterprise_package.value
             )
 
-        from litellm.proxy.proxy_server import general_settings, proxy_logging_obj
+        from litellm.proxy.general_settings import general_settings
+        from litellm.proxy.proxy_server import proxy_logging_obj
 
         try:
             from litellm_enterprise.types.enterprise_callbacks.send_emails import (

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -567,7 +567,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         return pipeline_operations
 
     def get_rate_limit_type(self) -> Literal["output", "input", "total"]:
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
 
         specified_rate_limit_type = general_settings.get(
             "token_rate_limit_type", "output"

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -225,7 +225,7 @@ class _ProxyDBLogger(CustomLogger):
 
         If users want to disable error tracking, they can set the disable_error_logs flag in the general_settings
         """
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
 
         if general_settings.get("disable_error_logs") is True:
             return False

--- a/litellm/proxy/hooks/user_management_event_hooks.py
+++ b/litellm/proxy/hooks/user_management_event_hooks.py
@@ -153,7 +153,8 @@ class UserManagementEventHooks:
         """
         Send a user invitation email to the user
         """
-        from litellm.proxy.proxy_server import general_settings, proxy_logging_obj
+        from litellm.proxy.general_settings import general_settings
+        from litellm.proxy.proxy_server import proxy_logging_obj
 
         # check if user has setup email alerting
         if "email" not in general_settings.get("alerting", []):

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -705,7 +705,8 @@ def _process_keys_for_user_info(
     keys: Optional[List[LiteLLM_VerificationToken]],
     all_teams: Optional[Union[List[LiteLLM_TeamTable], List[TeamListResponseObject]]],
 ):
-    from litellm.proxy.proxy_server import general_settings, litellm_master_key_hash
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import litellm_master_key_hash
 
     returned_keys = []
     if keys is None:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3018,7 +3018,8 @@ async def test_key_logging(
     from io import StringIO
 
     from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
-    from litellm.proxy.proxy_server import general_settings, proxy_config
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import proxy_config
 
     logging_callbacks: List[str] = []
     for callback in key_logging:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -781,7 +781,8 @@ async def insert_sso_user(
     dependencies=[Depends(user_api_key_auth)],
 )
 async def get_ui_settings(request: Request):
-    from litellm.proxy.proxy_server import general_settings, proxy_state
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import proxy_state
 
     _proxy_base_url = os.getenv("PROXY_BASE_URL", None)
     _logout_url = os.getenv("PROXY_LOGOUT_URL", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2705,12 +2705,8 @@ class ProxyConfig:
                     "alerting"
                 ]
             elif general_settings is None:
-                general_settings = {}
-                general_settings["alerting"] = _general_settings["alerting"]
-                proxy_logging_obj.alerting = general_settings["alerting"]
-                proxy_logging_obj.slack_alerting_instance.alerting = general_settings[
-                    "alerting"
-                ]
+                proxy_logging_obj.alerting = _general_settings["alerting"]
+                proxy_logging_obj.slack_alerting_instance.alerting = _general_settings["alerting"]
             elif isinstance(general_settings, dict):
                 general_settings["alerting"] = _general_settings["alerting"]
                 proxy_logging_obj.alerting = general_settings["alerting"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1988,8 +1988,6 @@ class ProxyConfig:
 
         ## GENERAL SERVER SETTINGS (e.g. master key,..) # do this after initializing litellm, to ensure sentry logging works for proxylogging
         general_settings = config.get("general_settings", {})
-        if general_settings is None:
-            general_settings = {}
         if general_settings:
             ### LOAD SECRET MANAGER ###
             key_management_system = general_settings.get("key_management_system", None)

--- a/litellm/proxy/spend_tracking/cold_storage_handler.py
+++ b/litellm/proxy/spend_tracking/cold_storage_handler.py
@@ -73,10 +73,10 @@ class ColdStorageHandler:
         """
 
         try:
-            from litellm.proxy.proxy_server import general_settings
+            from litellm.proxy.general_settings import general_settings
         except Exception as e:
             verbose_proxy_logger.debug(
-                f"Unable to import proxy_server for cold storage logging: {e}"
+                f"Unable to import general_settings for cold storage logging: {e}"
             )
             return None
 

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -144,7 +144,8 @@ def get_spend_logs_id(
 def get_logging_payload(  # noqa: PLR0915
     kwargs, response_obj, start_time, end_time
 ) -> SpendLogsPayload:
-    from litellm.proxy.proxy_server import general_settings, master_key
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import master_key
 
     if kwargs is None:
         kwargs = {}
@@ -563,7 +564,7 @@ def _get_response_for_spend_logs_payload(
 
 
 def _should_store_prompts_and_responses_in_spend_logs() -> bool:
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
     from litellm.secret_managers.main import get_secret_bool
 
     return (

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -70,7 +70,7 @@ class UIThemeSettingsResponse(SettingsResponse):
     include_in_schema=False,
 )
 async def get_allowed_ips():
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
 
     _allowed_ip = general_settings.get("allowed_ips")
     return {"data": _allowed_ip}
@@ -133,7 +133,8 @@ async def add_allowed_ip(ip_address: IPAddress):
     dependencies=[Depends(user_api_key_auth)],
 )
 async def delete_allowed_ip(ip_address: IPAddress):
-    from litellm.proxy.proxy_server import general_settings, proxy_config
+    from litellm.proxy.general_settings import general_settings
+    from litellm.proxy.proxy_server import proxy_config
 
     _allowed_ips: List = general_settings.get("allowed_ips", [])
     if ip_address.ip in _allowed_ips:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3243,7 +3243,7 @@ class ProxyUpdateSpend:
         returns True if should not update spend in db
         Skips writing spend logs and updates to key, team, user spend to DB
         """
-        from litellm.proxy.proxy_server import general_settings
+        from litellm.proxy.general_settings import general_settings
 
         if general_settings.get("disable_spend_updates") is True:
             return True

--- a/tests/logging_callback_tests/test_spend_logs.py
+++ b/tests/logging_callback_tests/test_spend_logs.py
@@ -323,7 +323,7 @@ def test_spend_logs_payload_with_prompts_enabled(monkeypatch):
     Test that messages and responses are logged in spend logs when store_prompts_in_spend_logs is enabled
     """
     # Mock general_settings
-    from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.general_settings import general_settings
 
     general_settings["store_prompts_in_spend_logs"] = True
 


### PR DESCRIPTION
## Fix imports from proxy_server

SDK code can inadvertently spin up the proxy server due to the way imports are structured. This PR moves the `general_settings` object from `proxy_server.py` so that when it is imported, it doesn't run all the top level instantiations (spin up the FastAPI server, monkey patch swagger etc) found in `proxy_server.py`. 
#13347 [introduced a dependency](https://github.com/BerriAI/litellm/commit/4d941c914ed43aae326ab5a6a9e93e5ec166d0a7#diff-202545f3ab4f290ac9967d9ba19689aafe15902296a2ef5a6ca5410a93eaa38bR4109) in `litellm_core_utils/litellm_logging` on [`proxy_server`](https://github.com/BerriAI/litellm/commit/4d941c914ed43aae326ab5a6a9e93e5ec166d0a7#diff-4777020f78743dd87e451857f07e7f37467bf49466826490a5c4ba276a479503R67) by way of `StandardLoggingPayloadSetup._generate_cold_storage_object_key`. As SDK code can also log, this ends up instantiating `proxy_server` when it would not otherwise be desired. 


## Relevant issues

I believe #13436 is a symptom of this issue and was fixed by wrapping in a `try` rather than removing the import. 
#13614 is also addressed here

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring

## Changes


