### PR TITLE
Add possibility to configure resources for migrations-job in Helm chart

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -73,6 +73,10 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.migrationJob.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.migrationJob.extraContainers }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -206,6 +206,10 @@ migrationJob:
   disableSchemaUpdate: false # Skip schema migrations for specific environments. When True, the job will exit with code 0.
   annotations: {}
   ttlSecondsAfterFinished: 120
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 100Mi
   extraContainers: []
   
   # Hook configuration


### PR DESCRIPTION
## Title

Add possibility to configure resource section on migrations-job main container. This will make sure you can set appropriate resources if your cluster for some reason requires it.

## Relevant issues

-

## Pre-Submission checklist

No tests for the Helm chart


## Type

🧹 Refactoring

## Changes

Expose .Values.migrationJob.resources in values.yaml to configure migrations-job.yaml main container resources.

