### PR TITLE
[Feat] Add `reasoning_effort` param for hosted_vllm provider

### DIFF
--- a/docs/my-website/docs/providers/vllm.md
+++ b/docs/my-website/docs/providers/vllm.md
@@ -104,6 +104,52 @@ Here's how to call an OpenAI-Compatible Endpoint with the LiteLLM Proxy Server
 
   </Tabs>
 
+  ## Reasoning Effort
+
+  <Tabs>
+  <TabItem value="sdk" label="SDK">
+
+  ```python
+  from litellm import completion
+
+  response = completion(
+      model="hosted_vllm/gpt-oss-120b",
+      messages=[{"role": "user", "content": "whats 2 + 2"}],
+      reasoning_effort="high",
+      api_base="https://hosted-vllm-api.co",
+  )
+  print(response)
+  ```
+  </TabItem>
+  <TabItem value="proxy" label="PROXY">
+
+  1. Setup config.yaml
+
+  ```yaml
+  model_list:
+    - model_name: gpt-oss-120b
+      litellm_params:
+        model: hosted_vllm/gpt-oss-120b
+        api_base: https://hosted-vllm-api.co
+  ```
+
+  2. Start the proxy
+
+  ```bash
+  litellm --config /path/to/config.yaml
+  ```
+
+  3. Test it!
+
+  ```bash
+  curl http://0.0.0.0:4000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model": "gpt-oss-120b", "messages": [{"role": "user", "content": "whats 2 + 2"}], "reasoning_effort": "high"}'
+  ```
+
+  </TabItem>
+  </Tabs>
+
 
 ## Embeddings
 

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -21,6 +21,11 @@ from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 
 class HostedVLLMChatConfig(OpenAIGPTConfig):
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        params = super().get_supported_openai_params(model)
+        params.append("reasoning_effort")
+        return params
+
     def map_openai_params(
         self,
         non_default_params: dict,

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
@@ -86,3 +86,18 @@ def test_hosted_vllm_chat_transformation_with_audio_url():
                 ],
             }
         ]
+
+
+def test_hosted_vllm_supports_reasoning_effort():
+    config = HostedVLLMChatConfig()
+    supported_params = config.get_supported_openai_params(
+        model="hosted_vllm/gpt-oss-120b"
+    )
+    assert "reasoning_effort" in supported_params
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model="hosted_vllm/gpt-oss-120b",
+        drop_params=False,
+    )
+    assert optional_params["reasoning_effort"] == "high"


### PR DESCRIPTION
## [Feat] Add `reasoning_effort` param for hosted_vllm provider

Fixes: https://github.com/BerriAI/litellm/issues/13608 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


