### PR TITLE
[Fix] Ensure /messages works when using `bedrock/converse/<model> with LiteLLM

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -512,7 +512,7 @@ class BedrockModelInfo(BaseLLMModelInfo):
         # Since bedrock Invoke supports Native Anthropic Messages API
         #########################################################
         if "claude" in model:
-            return litellm.AmazonAnthropicClaude3MessagesConfig()
+            return litellm.AmazonAnthropicClaudeMessagesConfig()
         
         #########################################################
         # These routes will go through litellm.completion()

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -2,3 +2,9 @@ model_list:
   - model_name: vertex_ai/*
     litellm_params:
       model: vertex_ai/*
+  - model_name: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
+    litellm_params:
+      model: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
+  - model_name: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
+    litellm_params:
+      model: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7071,7 +7071,8 @@ class ProviderConfigManager:
         # The 'BEDROCK' provider corresponds to Amazon's implementation of Anthropic Claude v3.
         # This mapping ensures that the correct configuration is returned for BEDROCK.
         elif litellm.LlmProviders.BEDROCK == provider:
-            return litellm.AmazonAnthropicClaude3MessagesConfig()
+            from litellm.llms.bedrock.common_utils import BedrockModelInfo
+            return BedrockModelInfo.get_bedrock_provider_config_for_messages_api(model)
         elif litellm.LlmProviders.VERTEX_AI == provider:
             if "claude" in model:
                 from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (

--- a/tests/pass_through_unit_tests/test_bedrock_anthropic_messages_test.py
+++ b/tests/pass_through_unit_tests/test_bedrock_anthropic_messages_test.py
@@ -1,0 +1,68 @@
+
+import json
+import os
+import sys
+from datetime import datetime
+from typing import AsyncIterator, Dict, Any
+import asyncio
+import unittest.mock
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from litellm.router import Router
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+import litellm
+from base_anthropic_unified_messages_test import BaseAnthropicMessagesTest
+
+INSTANCE_BASE_ANTHROPIC_MESSAGES_TEST = BaseAnthropicMessagesTest()
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_litellm_router_bedrock():
+    """
+    Test the anthropic_messages with non-streaming request
+    """
+
+    litellm._turn_on_debug()
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0",
+                "litellm_params": {
+                    "model": "bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0",
+                },
+            },
+            {
+                "model_name": "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
+                },
+            }
+        ]
+    )
+    
+    # Set up test parameters
+    messages = [{"role": "user", "content": "Hello, can you tell me a short joke?"}]
+
+    # Call 1 using bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
+    response = await router.aanthropic_messages(
+        messages=messages,
+        model="bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0",
+        max_tokens=100,
+    )
+
+    # Verify response
+    INSTANCE_BASE_ANTHROPIC_MESSAGES_TEST._validate_response(response)
+
+    # Call 2 using bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
+    response = await router.aanthropic_messages(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
+        max_tokens=100,
+    )
+
+    # Verify response
+    INSTANCE_BASE_ANTHROPIC_MESSAGES_TEST._validate_response(response)
+
+


### PR DESCRIPTION
## [Fix] Ensure /messages works when using `bedrock/converse/<model> with LiteLLM

Fixes: https://github.com/BerriAI/litellm/issues/13618

- User used model = "bedrock/converse/<model>" and called /messages, this did not work for them 
- This PR fixes that behavior when using /messages 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


