### PR TITLE
Fixed incorrect key info endpoint

### DIFF
--- a/litellm/proxy/client/keys.py
+++ b/litellm/proxy/client/keys.py
@@ -236,7 +236,7 @@ class KeysManagementClient:
             UnauthorizedError: If the request fails with a 401 status code
             requests.exceptions.RequestException: If the request fails with any other error
         """
-        url = f"{self._base_url}/keys/info?key={key}"
+        url = f"{self._base_url}/key/info?key={key}"
         request = requests.Request("GET", url, headers=self._get_headers())
 
         if return_request:

--- a/tests/test_litellm/proxy/client/test_keys.py
+++ b/tests/test_litellm/proxy/client/test_keys.py
@@ -370,7 +370,7 @@ def test_info_request_minimal(client, base_url, api_key):
     """Test info request with minimal parameters"""
     request = client.info(key="test-key", return_request=True)
     assert request.method == "GET"
-    assert request.url == f"{base_url}/keys/info?key=test-key"
+    assert request.url == f"{base_url}/key/info?key=test-key"
     assert request.headers["Content-Type"] == "application/json"
     assert request.headers["Authorization"] == f"Bearer {api_key}"
 
@@ -387,7 +387,7 @@ def test_info_mock_response(client):
     }
     responses.add(
         responses.GET,
-        f"{client._base_url}/keys/info?key=test-key",
+        f"{client._base_url}/key/info?key=test-key",
         json=mock_response,
         status=200,
     )
@@ -400,7 +400,7 @@ def test_info_unauthorized_error(client):
     """Test that info raises UnauthorizedError for 401 responses"""
     responses.add(
         responses.GET,
-        f"{client._base_url}/keys/info?key=test-key",
+        f"{client._base_url}/key/info?key=test-key",
         status=401,
         json={"error": "Unauthorized"},
     )
@@ -413,7 +413,7 @@ def test_info_server_error(client):
     """Test that info raises HTTPError for server errors"""
     responses.add(
         responses.GET,
-        f"{client._base_url}/keys/info?key=test-key",
+        f"{client._base_url}/key/info?key=test-key",
         status=500,
         json={"error": "Internal Server Error"},
     )


### PR DESCRIPTION
The correct endpoint should be `key/info`, not `keys/info`. 
Updated the endpoint in the client and the mocks in the relevant tests.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


<img width="812" height="822" alt="Screenshot 2025-08-14 at 3 11 58 PM" src="https://github.com/user-attachments/assets/a4400f37-7074-4964-8440-f8ba5903c77f" />
