### PR TITLE
Added Qwen3, Deepseek R1 0528 Throughput, GLM 4.5 and GPT-OSS models for Together AI

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14657,7 +14657,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
     },
     "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -14668,7 +14668,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -14679,7 +14679,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
@@ -14690,7 +14690,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-fp8-tput"
     },
     "together_ai/deepseek-ai/DeepSeek-V3": {
@@ -14725,7 +14725,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/deepseek-r1-0528-throughput"
     },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14649,7 +14649,7 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+    "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 6e-06,
         "max_input_tokens": 262000,
@@ -14660,7 +14660,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
     },
-    "deepseek-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+    "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
         "input_cost_per_token": 2e-06,
         "output_cost_per_token": 2e-06,
         "max_input_tokens": 256000,
@@ -14671,7 +14671,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+    "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
         "input_cost_per_token": 6.5e-07,
         "output_cost_per_token": 3e-06,
         "max_input_tokens": 256000,
@@ -14682,7 +14682,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+    "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 6e-07,
         "max_input_tokens": 40000,
@@ -14717,7 +14717,7 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepseek-ai/DeepSeek-R1-0528-tput": {
+    "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
         "input_cost_per_token": 5.5e-07,
         "output_cost_per_token": 2.19e-06,
         "max_input_tokens": 128000,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14649,6 +14649,50 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 6e-06,
+        "max_input_tokens": 262000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
+    },
+    "deepseek-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 2e-06,
+        "max_input_tokens": 256000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
+    },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input_cost_per_token": 6.5e-07,
+        "output_cost_per_token": 3e-06,
+        "max_input_tokens": 256000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
+    },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 6e-07,
+        "max_input_tokens": 40000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-fp8-tput"
+    },
     "together_ai/deepseek-ai/DeepSeek-V3": {
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1.25e-06,
@@ -14673,6 +14717,17 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "deepseek-ai/DeepSeek-R1-0528-tput": {
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 2.19e-06,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/deepseek-r1-0528-throughput"
+    },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {
         "litellm_provider": "together_ai",
         "supports_function_calling": true,
@@ -14689,6 +14744,39 @@
         "supports_parallel_function_calling": true,
         "mode": "chat",
         "source": "https://www.together.ai/models/kimi-k2-instruct"
+    },
+    "together_ai/openai/gpt-oss-120b": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/gpt-oss-120b"
+    },
+    "together_ai/OpenAI/gpt-oss-20B": {
+        "input_cost_per_token": 5e-08,
+        "output_cost_per_token": 2e-07,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/gpt-oss-20b"
+    },
+    "together_ai/zai-org/GLM-4.5-Air-FP8": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 1.1e-06,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/glm-4-5-air"
     },
     "ollama/codegemma": {
         "max_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14657,7 +14657,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
     },
     "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
@@ -14668,7 +14668,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -14679,7 +14679,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
@@ -14690,7 +14690,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/qwen3-235b-a22b-fp8-tput"
     },
     "together_ai/deepseek-ai/DeepSeek-V3": {
@@ -14725,7 +14725,7 @@
         "supports_function_calling": false,
         "supports_parallel_function_calling": false,
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
         "source": "https://www.together.ai/models/deepseek-r1-0528-throughput"
     },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14649,7 +14649,7 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+    "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 6e-06,
         "max_input_tokens": 262000,
@@ -14660,7 +14660,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
     },
-    "deepseek-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+    "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
         "input_cost_per_token": 2e-06,
         "output_cost_per_token": 2e-06,
         "max_input_tokens": 256000,
@@ -14671,7 +14671,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+    "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
         "input_cost_per_token": 6.5e-07,
         "output_cost_per_token": 3e-06,
         "max_input_tokens": 256000,
@@ -14682,7 +14682,7 @@
         "supports_tool_choice": false
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
     },
-    "deepseek-ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+    "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 6e-07,
         "max_input_tokens": 40000,
@@ -14717,7 +14717,7 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepseek-ai/DeepSeek-R1-0528-tput": {
+    "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
         "input_cost_per_token": 5.5e-07,
         "output_cost_per_token": 2.19e-06,
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14649,6 +14649,50 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 6e-06,
+        "max_input_tokens": 262000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8"
+    },
+    "deepseek-ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 2e-06,
+        "max_input_tokens": 256000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct"
+    },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "input_cost_per_token": 6.5e-07,
+        "output_cost_per_token": 3e-06,
+        "max_input_tokens": 256000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507"
+    },
+    "deepseek-ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 6e-07,
+        "max_input_tokens": 40000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/qwen3-235b-a22b-fp8-tput"
+    },
     "together_ai/deepseek-ai/DeepSeek-V3": {
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1.25e-06,
@@ -14673,6 +14717,17 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "deepseek-ai/DeepSeek-R1-0528-tput": {
+        "input_cost_per_token": 5.5e-07,
+        "output_cost_per_token": 2.19e-06,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "supports_tool_choice": false
+        "source": "https://www.together.ai/models/deepseek-r1-0528-throughput"
+    },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {
         "litellm_provider": "together_ai",
         "supports_function_calling": true,
@@ -14689,6 +14744,39 @@
         "supports_parallel_function_calling": true,
         "mode": "chat",
         "source": "https://www.together.ai/models/kimi-k2-instruct"
+    },
+    "together_ai/openai/gpt-oss-120b": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/gpt-oss-120b"
+    },
+    "together_ai/OpenAI/gpt-oss-20B": {
+        "input_cost_per_token": 5e-08,
+        "output_cost_per_token": 2e-07,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/gpt-oss-20b"
+    },
+    "together_ai/zai-org/GLM-4.5-Air-FP8": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 1.1e-06,
+        "max_input_tokens": 128000,
+        "litellm_provider": "together_ai",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_parallel_function_calling": false,
+        "mode": "chat",
+        "source": "https://www.together.ai/models/glm-4-5-air"
     },
     "ollama/codegemma": {
         "max_tokens": 8192,


### PR DESCRIPTION
## Added models - Qwen3 Family, DeepSeek R1 0528 Throughput, GLM 4.5 Air, and GPT-OSS (120b, 20b):
- together_ai/openai/gpt-oss-120b
- together_ai/OpenAI/gpt-oss-20B
- together_ai/zai-org/GLM-4.5-Air-FP8
- together_ai/deepseek-ai/DeepSeek-R1-0528-tput
- together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput
- together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8
- together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507
- together_ai/Qwen/Qwen3-235B-A22B-fp8-tput

## Relevant issues
Closes #13636

## Pre-Submission checklist
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

Note: Tests and all not needed since only model configs are added

## Type
🆕 New Feature
🐛 Bug Fix

## Changes
Changed files:
- litellm/model_prices_and_context_window_backup.json
- model_prices_and_context_window.json