### PR TITLE
[Bug Fix] /messages endpoint - ensure tool use arguments are returned for non-anthropic models

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -489,7 +489,7 @@ class LiteLLMAnthropicMessagesAdapter:
         text: str = ""
         partial_json: Optional[str] = None
         for choice in choices:
-            if choice.delta.content is not None:
+            if choice.delta.content is not None and len(choice.delta.content) > 0:
                 text += choice.delta.content
             elif choice.delta.tool_calls is not None:
                 partial_json = ""
@@ -499,7 +499,6 @@ class LiteLLMAnthropicMessagesAdapter:
                         and tool.function.arguments is not None
                     ):
                         partial_json += tool.function.arguments
-
         if partial_json is not None:
             return "input_json_delta", ContentJsonBlockDelta(
                 type="input_json_delta", partial_json=partial_json

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,7 +1,4 @@
 model_list:
-  - model_name: vertex_ai/*
-    litellm_params:
-      model: vertex_ai/*
   - model_name: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
     litellm_params:
       model: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0


### PR DESCRIPTION
## [Bug Fix] /messages endpoint - ensure tool use arguments are returned for non-anthropic models

- When processing streaming responses that contain tool calls with partial arguments, the Anthropic experimental pass-through adapter was incorrectly returning text_delta events instead of input_json_delta events (this impacted using `bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0`, `gpt-5` etc 


For example the adapter got a chunk like this - client side did not get the arguments - this PR fixes that 

```python
tool_calls=[ChatCompletionDeltaToolCall(
    id=None, 
    function=Function(arguments=': "San ', name=None), 
    type='function', 
    index=0
)]
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


