### PR TITLE
UI - Fix image overflow in LiteLLM model

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -399,9 +399,14 @@ export default function ModelInfoView({
               </Card>
               <Card>
                 <Text>LiteLLM Model</Text>
-                <pre>
-                  <Title>{modelData.litellm_model_name || "Not Set"}</Title>
-                </pre>
+                <div className="mt-2 overflow-hidden">
+                  <div 
+                    className="break-all text-sm font-medium leading-relaxed cursor-pointer"
+                    title={modelData.litellm_model_name || "Not Set"}
+                  >
+                    {modelData.litellm_model_name || "Not Set"}
+                  </div>
+                </div>
               </Card>
               <Card>
                 <Text>Pricing</Text>

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -400,12 +400,13 @@ export default function ModelInfoView({
               <Card>
                 <Text>LiteLLM Model</Text>
                 <div className="mt-2 overflow-hidden">
-                  <div 
-                    className="break-all text-sm font-medium leading-relaxed cursor-pointer"
-                    title={modelData.litellm_model_name || "Not Set"}
-                  >
-                    {modelData.litellm_model_name || "Not Set"}
-                  </div>
+                  <Tooltip title={modelData.litellm_model_name || "Not Set"}>
+                    <div 
+                      className="break-all text-sm font-medium leading-relaxed cursor-pointer"
+                    >
+                      {modelData.litellm_model_name || "Not Set"}
+                    </div>
+                  </Tooltip>
                 </div>
               </Card>
               <Card>


### PR DESCRIPTION
## Title

Fix: LiteLLM Model text overflow in Model Info View

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Addresses text overflow for long LiteLLM model names in the Model Info View. Previously, long names were truncated due to the use of `<pre>` and `<Title>` tags.

- Replaced `<pre>` and `<Title>` tags with a `div` structure.
- Applied CSS classes (`break-all`, `overflow-hidden`) to ensure text wraps properly within the UI card.
- Added a `title` attribute to display the full model name on hover, improving UX without sacrificing space.

---
[Slack Thread](https://berriaillm.slack.com/archives/C07Q2CUDA57/p1755217267077189?thread_ts=1755217267.077189&cid=C07Q2CUDA57)

<a href="https://cursor.com/background-agent?bcId=bc-98756d67-65ed-447b-b990-ae9b7eb4fbc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98756d67-65ed-447b-b990-ae9b7eb4fbc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

