### PR TITLE
[Bug Fix] Add cachePoint support for assistant and tool messages in Bedrock

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -25,6 +25,7 @@ from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMExcepti
 from litellm.types.llms.bedrock import *
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAssistantMessage,
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionResponseMessage,
     ChatCompletionSystemMessage,
@@ -505,6 +506,7 @@ class AmazonConverseConfig(BaseConfig):
             OpenAIMessageContentListBlock,
             ChatCompletionUserMessage,
             ChatCompletionSystemMessage,
+            ChatCompletionAssistantMessage,
         ],
         block_type: Literal["system"],
     ) -> Optional[SystemContentBlock]:
@@ -517,6 +519,7 @@ class AmazonConverseConfig(BaseConfig):
             OpenAIMessageContentListBlock,
             ChatCompletionUserMessage,
             ChatCompletionSystemMessage,
+            ChatCompletionAssistantMessage,
         ],
         block_type: Literal["content_block"],
     ) -> Optional[ContentBlock]:
@@ -528,6 +531,7 @@ class AmazonConverseConfig(BaseConfig):
             OpenAIMessageContentListBlock,
             ChatCompletionUserMessage,
             ChatCompletionSystemMessage,
+            ChatCompletionAssistantMessage,
         ],
         block_type: Literal["system", "content_block"],
     ) -> Optional[Union[SystemContentBlock, ContentBlock]]:


### PR DESCRIPTION
## Title

Add cachePoint support for assistant and tool messages in Bedrock

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes #12900
Fixes #12695


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes

- Add cachePoint support for assistant messages (both string and list content)
- Add cachePoint support for tool messages (both message-level and content-level cache_control)
- Add cachePoint support for assistant tool_calls

This enables comprehensive cache control across all message types in Bedrock conversations.

Example test code:

``` python
payload = {
    "model": "bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant. " * 150,
            # "cache_control": {"type": "ephemeral"},  #  ⬅️ already support
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "Check the weather of New York",
                    # "cache_control": {"type": "ephemeral"},  #  ⬅️ already support
                },
            ]
        },
        {
            "role": "assistant",
            "content": [
                {
                    "type": "text",
                    "text": "Hello.",
                    "cache_control": {"type": "ephemeral"},  #  ⬅️✅ new support
                },
            ],
            "tool_calls": [
                {
                    "id": "call_proxy_123",
                    "type": "function",
                    "function": {"name": "get_weather", "arguments": "{\"city\": \"New York\"}"},
                    "cache_control": {"type": "ephemeral"},  #  ⬅️✅ new support
                },
            ],
        },
        {
            "role": "tool",
            "tool_call_id": "call_proxy_123",
            "content": [
                {
                    "type": "text",
                    "text": "sunny",
                    "cache_control": {"type": "ephemeral"},  #  ⬅️✅ new support
                },
            ],
        },
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "get_weather",
                "description": "get the weather of one city",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "city": {
                            "type": "string",
                            "description": "city name"
                        },
                    },
                    "required": ["city"]
                }
            },
            # "cache_control": {"type": "ephemeral"},  #  ⬅️ already support
        }
    ],
}


import litellm

response = litellm.completion(
    **payload,
)

print(response)


```