### PR TITLE
Litellm bedrock batch completion feat

### DIFF
--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -279,7 +279,7 @@ def create_batch(
 @client
 async def aretrieve_batch(
     batch_id: str,
-    custom_llm_provider: Literal["openai", "azure", "vertex_ai"] = "openai",
+    custom_llm_provider: Literal["openai", "azure", "vertex_ai","bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -321,7 +321,7 @@ async def aretrieve_batch(
 @client
 def retrieve_batch(
     batch_id: str,
-    custom_llm_provider: Literal["openai", "azure", "vertex_ai"] = "openai",
+    custom_llm_provider: Literal["openai", "azure", "vertex_ai","bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -463,6 +463,13 @@ def retrieve_batch(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
             )
+        elif custom_llm_provider == "bedrock":
+            response = bedrock_batches_instance.retrieve_batch(
+                _is_async=_is_async,
+                batch_id=batch_id,
+                api_base=optional_params.api_base,
+                litellm_params=litellm_params,
+            )
         else:
             raise litellm.exceptions.BadRequestError(
                 message="LiteLLM doesn't support {} for 'create_batch'. Only 'openai' is supported.".format(
@@ -485,7 +492,7 @@ def retrieve_batch(
 async def alist_batches(
     after: Optional[str] = None,
     limit: Optional[int] = None,
-    custom_llm_provider: Literal["openai", "azure"] = "openai",
+    custom_llm_provider: Literal["openai", "azure","bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -528,7 +535,7 @@ async def alist_batches(
 def list_batches(
     after: Optional[str] = None,
     limit: Optional[int] = None,
-    custom_llm_provider: Literal["openai", "azure"] = "openai",
+    custom_llm_provider: Literal["openai", "azure","bedrock"] = "openai",
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
     **kwargs,
@@ -625,9 +632,17 @@ def list_batches(
                 max_retries=optional_params.max_retries,
                 litellm_params=litellm_params,
             )
+        elif custom_llm_provider == "bedrock":
+            response = bedrock_batches_instance.list_batches(
+                _is_async=_is_async,
+                after=after,
+                limit=limit,
+                api_base=optional_params.api_base,
+                litellm_params=litellm_params,
+            )
         else:
             raise litellm.exceptions.BadRequestError(
-                message="LiteLLM doesn't support {} for 'list_batch'. Only 'openai' is supported.".format(
+                message="LiteLLM doesn't support {} for 'list_batch'. Only 'openai', 'azure', and 'bedrock' are supported.".format(
                     custom_llm_provider
                 ),
                 model="n/a",
@@ -645,7 +660,7 @@ def list_batches(
 
 async def acancel_batch(
     batch_id: str,
-    custom_llm_provider: Literal["openai", "azure"] = "openai",
+    custom_llm_provider: Literal["openai", "azure","bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -686,7 +701,7 @@ async def acancel_batch(
 
 def cancel_batch(
     batch_id: str,
-    custom_llm_provider: Literal["openai", "azure"] = "openai",
+    custom_llm_provider: Literal["openai", "azure","bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -791,6 +806,13 @@ def cancel_batch(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 cancel_batch_data=_cancel_batch_request,
+                litellm_params=litellm_params,
+            )
+        elif custom_llm_provider == "bedrock":
+            response = bedrock_batches_instance.cancel_batch(
+                _is_async=_is_async,
+                batch_id=batch_id,
+                api_base=optional_params.api_base,
                 litellm_params=litellm_params,
             )
         else:

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -21,6 +21,7 @@ import httpx
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.azure.batches.handler import AzureBatchesAPI
+from litellm.llms.bedrock.batches.handler import BedrockBatchesAPI
 from litellm.llms.openai.openai import OpenAIBatchesAPI
 from litellm.llms.vertex_ai.batches.handler import VertexAIBatchPrediction
 from litellm.secret_managers.main import get_secret_str
@@ -38,6 +39,7 @@ from litellm.utils import client, get_litellm_params, supports_httpx_timeout
 openai_batches_instance = OpenAIBatchesAPI()
 azure_batches_instance = AzureBatchesAPI()
 vertex_ai_batches_instance = VertexAIBatchPrediction(gcs_bucket_name="")
+bedrock_batches_instance = BedrockBatchesAPI()
 #################################################
 
 
@@ -46,7 +48,7 @@ async def acreate_batch(
     completion_window: Literal["24h"],
     endpoint: Literal["/v1/chat/completions", "/v1/embeddings", "/v1/completions"],
     input_file_id: str,
-    custom_llm_provider: Literal["openai", "azure", "vertex_ai"] = "openai",
+    custom_llm_provider: Literal["openai", "azure", "vertex_ai", "bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -94,7 +96,7 @@ def create_batch(
     completion_window: Literal["24h"],
     endpoint: Literal["/v1/chat/completions", "/v1/embeddings", "/v1/completions"],
     input_file_id: str,
-    custom_llm_provider: Literal["openai", "azure", "vertex_ai"] = "openai",
+    custom_llm_provider: Literal["openai", "azure", "vertex_ai", "bedrock"] = "openai",
     metadata: Optional[Dict[str, str]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
@@ -245,6 +247,17 @@ def create_batch(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 create_batch_data=_create_batch_request,
+            )
+        elif custom_llm_provider == "bedrock":
+            response = bedrock_batches_instance.create_batch(
+                _is_async=_is_async,
+                create_batch_data=_create_batch_request,
+                api_base=optional_params.api_base,
+                litellm_params=litellm_params,
+                logging_obj=litellm_logging_obj,
+                timeout=timeout,
+                max_retries=optional_params.max_retries,
+                
             )
         else:
             raise litellm.exceptions.BadRequestError(

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -257,7 +257,6 @@ def create_batch(
                 logging_obj=litellm_logging_obj,
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
-                
             )
         else:
             raise litellm.exceptions.BadRequestError(

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -96,7 +96,9 @@ async def acreate_file(
 def create_file(
     file: FileTypes,
     purpose: Literal["assistants", "batch", "fine-tune"],
-    custom_llm_provider: Optional[Literal["openai", "azure", "vertex_ai", "bedrock"]] = None,
+    custom_llm_provider: Optional[
+        Literal["openai", "azure", "vertex_ai", "bedrock"]
+    ] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
     **kwargs,
@@ -254,13 +256,16 @@ def create_file(
             )
         elif custom_llm_provider == "bedrock":
             response = bedrock_files_instance.create_file(
-                _is_async=_is_async,
                 create_file_data=_create_file_request,
-                api_base=optional_params.api_base,
                 litellm_params=litellm_params_dict,
+                provider_config=bedrock_files_instance.provider_config
+                if hasattr(bedrock_files_instance, "provider_config")
+                else None,
+                headers={},
+                api_base=optional_params.api_base,
                 logging_obj=logging_obj,
                 timeout=timeout,
-                max_retries=optional_params.max_retries,
+                _is_async=_is_async,
             )
         else:
             raise litellm.exceptions.BadRequestError(

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -18,6 +18,7 @@ from litellm import get_secret_str
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.azure.files.handler import AzureOpenAIFilesAPI
+from litellm.llms.bedrock.files.handler import BedrockFilesHandler
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.openai.openai import FileDeleted, FileObject, OpenAIFilesAPI
 from litellm.llms.vertex_ai.files.handler import VertexAIFilesHandler
@@ -43,6 +44,7 @@ base_llm_http_handler = BaseLLMHTTPHandler()
 openai_files_instance = OpenAIFilesAPI()
 azure_files_instance = AzureOpenAIFilesAPI()
 vertex_ai_files_instance = VertexAIFilesHandler()
+bedrock_files_instance = BedrockFilesHandler()
 #################################################
 
 
@@ -94,7 +96,7 @@ async def acreate_file(
 def create_file(
     file: FileTypes,
     purpose: Literal["assistants", "batch", "fine-tune"],
-    custom_llm_provider: Optional[Literal["openai", "azure", "vertex_ai"]] = None,
+    custom_llm_provider: Optional[Literal["openai", "azure", "vertex_ai", "bedrock"]] = None,
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
     **kwargs,
@@ -250,9 +252,19 @@ def create_file(
                 max_retries=optional_params.max_retries,
                 create_file_data=_create_file_request,
             )
+        elif custom_llm_provider == "bedrock":
+            response = bedrock_files_instance.create_file(
+                _is_async=_is_async,
+                create_file_data=_create_file_request,
+                api_base=optional_params.api_base,
+                litellm_params=litellm_params_dict,
+                logging_obj=logging_obj,
+                timeout=timeout,
+                max_retries=optional_params.max_retries,
+            )
         else:
             raise litellm.exceptions.BadRequestError(
-                message="LiteLLM doesn't support {} for 'create_file'. Only ['openai', 'azure', 'vertex_ai'] are supported.".format(
+                message="LiteLLM doesn't support {} for 'create_file'. Only ['openai', 'azure', 'vertex_ai', 'bedrock'] are supported.".format(
                     custom_llm_provider
                 ),
                 model="n/a",

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -1,0 +1,147 @@
+"""
+Bedrock Batches API Handler
+"""
+
+from typing import Any, Coroutine, Dict, Optional, Union, cast
+
+import httpx
+
+# from litellm.llms.bedrock.bedrock import AsyncBedrock, Bedrock
+from litellm.types.llms.openai import (
+    Batch, 
+    CancelBatchRequest, 
+    CreateBatchRequest, 
+    RetrieveBatchRequest
+)
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    HTTPHandler,
+    _get_httpx_client,
+    get_async_httpx_client,
+)
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+from litellm.types.utils import LiteLLMBatch
+from ..base_aws_llm import BaseAWSLLM
+from .transformation import transform_openai_create_batch_to_bedrock_job_request
+from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
+import litellm
+
+class BedrockBatchesAPI(BaseAWSLLM):
+    """
+    Bedrock methods to support for batches
+    - create_batch()
+    - retrieve_batch()
+    - cancel_batch()
+    - list_batch()
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+    
+    async def acreate_batch(
+        self,
+        create_batch_data: CreateBatchRequest,
+        client: Optional[Union[AsyncHTTPHandler, HTTPHandler]] = None,
+        api_key: Optional[str] = None,
+    ) -> LiteLLMBatch:
+        response = await client.batches.create(**create_batch_data)
+        return LiteLLMBatch(**response.model_dump())
+    
+    def create_batch(
+        self,
+        _is_async: bool,
+        create_batch_data: CreateBatchRequest,
+        timeout: Union[float, httpx.Timeout],
+        max_retries: Optional[int],
+        litellm_params: Optional[Dict[str, Any]] = None,
+        api_base: Optional[str]=None,
+        logging_obj: Optional[LiteLLMLoggingObj] = None,
+        client: Optional[Union[AsyncHTTPHandler, HTTPHandler]] = None,
+    ) -> LiteLLMBatch:
+        # Build boto3 client via existing BaseAWSLLM credential helpers
+        from litellm.llms.bedrock.common_utils import init_bedrock_service_client
+
+        # Derive input/output S3 URIs from the input_file_id returned by files.create
+        file_id = create_batch_data.get("input_file_id")
+        # The file_id is expected to be of the form f"s3://{bucket}/path/model_id/" or f"s3://{bucket}/{model_id}/"
+        # We need to extract both the input S3 URI and the model_id
+        # Example: file_id = "s3://my-bucket/path/anthropic.claude-3-sonnet-20240229-v1:0/"
+        if not isinstance(file_id, str) or not file_id.startswith("s3://"):
+            raise ValueError("input_file_id must be an s3:// URI for Bedrock batch jobs")
+        
+        # Remove the "s3://" prefix and parse the path
+        s3_path = file_id[len("s3://") :].rstrip("/")
+        path_parts = s3_path.split("/")
+        
+        if len(path_parts) < 1:
+            raise ValueError("Invalid S3 URI format")
+        
+        bucket = path_parts[0]
+        
+        # Use the S3 URI as-is for input (points to the JSONL file)
+        input_s3_uri = file_id
+        
+        # Extract model ID from the S3 path where it was embedded by the file transformation
+        # Expected format: s3://bucket/model_id/filename.jsonl
+        model_id = create_batch_data.get("model") or ""
+        
+        if not model_id and len(path_parts) >= 3:
+            # Extract model_id from S3 path (it's the second-to-last component before filename)
+            model_id = path_parts[-2]  # Get model_id from the path
+            print(f"Extracted model_id from S3 path: {model_id}")
+            
+        if not isinstance(input_s3_uri, str) or not input_s3_uri.startswith("s3://"):
+            raise ValueError("input_file_id must be an s3:// URI for Bedrock batch jobs")
+
+        # output path: same directory as input file (without the filename)
+        # s3://bucket/model_id/file.jsonl -> s3://bucket/model_id/
+        try:
+            without_scheme = input_s3_uri[len("s3://"):]
+            bucket_and_key = without_scheme.split("/", 1)
+            if len(bucket_and_key) == 1:
+                # no key, just bucket; place outputs at bucket root
+                output_s3_uri = f"s3://{bucket_and_key[0]}/"
+            else:
+                bucket, key = bucket_and_key[0], bucket_and_key[1]
+                # If key contains a filename (has extension), remove it to get directory
+                if "." in key and "/" in key:
+                    # Remove filename to get directory path
+                    prefix = key.rsplit("/", 1)[0]
+                    output_s3_uri = f"s3://{bucket}/{prefix}/"
+                elif "/" in key:
+                    # Already a directory path
+                    prefix = key.rstrip("/")
+                    output_s3_uri = f"s3://{bucket}/{prefix}/"
+                else:
+                    # Key is just a filename or single component
+                    output_s3_uri = f"s3://{bucket}/"
+        except Exception:
+            # Fallback to bucket root if parsing fails
+            output_s3_uri = f"s3://{bucket}/"
+
+        # Optional role from config
+        s3_params = getattr(litellm, "s3_callback_params", {}) or {}
+        role_arn = s3_params.get("s3_aws_role_name")
+        if isinstance(role_arn, str) and not role_arn.startswith("arn:"):
+            role_arn = None
+
+        # Ensure the model is set in the create_batch_data 
+        if model_id:
+            create_batch_data = dict(create_batch_data)  # Make a copy
+            create_batch_data["model"] = model_id
+
+        bedrock_job_request: CreateModelInvocationJobRequest = transform_openai_create_batch_to_bedrock_job_request(
+            create_batch_data,
+            s3_input_uri=input_s3_uri,
+            s3_output_uri=output_s3_uri,
+            role_arn=role_arn,
+        )
+        print(f"create_batch_data: {bedrock_job_request}")
+
+        # Create boto3 client (respects env/profile/role)
+        boto_client = init_bedrock_service_client()
+        resp = boto_client.create_model_invocation_job(**bedrock_job_request)  # type: ignore
+        job_arn = resp.get("jobArn")
+
+        return LiteLLMBatch(id=job_arn or "", status="in_progress")

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -2,30 +2,30 @@
 Bedrock Batches API Handler
 """
 
-from typing import Any, Coroutine, Dict, Optional, Union, cast
+import time
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
-# from litellm.llms.bedrock.bedrock import AsyncBedrock, Bedrock
-from litellm.types.llms.openai import (
-    Batch, 
-    CancelBatchRequest, 
-    CreateBatchRequest, 
-    RetrieveBatchRequest
-)
+import litellm
+from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
-    _get_httpx_client,
-    get_async_httpx_client,
 )
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
 
+# from litellm.llms.bedrock.bedrock import AsyncBedrock, Bedrock
+from litellm.types.llms.openai import (
+    CreateBatchRequest,
+    LiteLLMBatchCreateRequest,
+)
 from litellm.types.utils import LiteLLMBatch
+
 from ..base_aws_llm import BaseAWSLLM
 from .transformation import transform_openai_create_batch_to_bedrock_job_request
-from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
-import litellm
+
 
 class BedrockBatchesAPI(BaseAWSLLM):
     """
@@ -38,16 +38,31 @@ class BedrockBatchesAPI(BaseAWSLLM):
 
     def __init__(self) -> None:
         super().__init__()
-    
+
     async def acreate_batch(
         self,
         create_batch_data: CreateBatchRequest,
         client: Optional[Union[AsyncHTTPHandler, HTTPHandler]] = None,
         api_key: Optional[str] = None,
     ) -> LiteLLMBatch:
-        response = await client.batches.create(**create_batch_data)
-        return LiteLLMBatch(**response.model_dump())
-    
+        import asyncio
+        
+        def sync_create_batch():
+            return self.create_batch(
+                _is_async=True,
+                create_batch_data=create_batch_data,
+                timeout=3600.0,  # Default timeout
+                max_retries=None,
+                litellm_params={},
+                api_base=None,
+                logging_obj=None,
+                client=client,
+            )
+        
+        # Run the sync method in an executor to make it async
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, sync_create_batch)
+
     def create_batch(
         self,
         _is_async: bool,
@@ -55,7 +70,7 @@ class BedrockBatchesAPI(BaseAWSLLM):
         timeout: Union[float, httpx.Timeout],
         max_retries: Optional[int],
         litellm_params: Optional[Dict[str, Any]] = None,
-        api_base: Optional[str]=None,
+        api_base: Optional[str] = None,
         logging_obj: Optional[LiteLLMLoggingObj] = None,
         client: Optional[Union[AsyncHTTPHandler, HTTPHandler]] = None,
     ) -> LiteLLMBatch:
@@ -68,36 +83,40 @@ class BedrockBatchesAPI(BaseAWSLLM):
         # We need to extract both the input S3 URI and the model_id
         # Example: file_id = "s3://my-bucket/path/anthropic.claude-3-sonnet-20240229-v1:0/"
         if not isinstance(file_id, str) or not file_id.startswith("s3://"):
-            raise ValueError("input_file_id must be an s3:// URI for Bedrock batch jobs")
-        
+            raise ValueError(
+                "input_file_id must be an s3:// URI for Bedrock batch jobs"
+            )
+
         # Remove the "s3://" prefix and parse the path
         s3_path = file_id[len("s3://") :].rstrip("/")
         path_parts = s3_path.split("/")
-        
+
         if len(path_parts) < 1:
             raise ValueError("Invalid S3 URI format")
-        
+
         bucket = path_parts[0]
-        
+
         # Use the S3 URI as-is for input (points to the JSONL file)
         input_s3_uri = file_id
-        
+
         # Extract model ID from the S3 path where it was embedded by the file transformation
         # Expected format: s3://bucket/model_id/filename.jsonl
         model_id = create_batch_data.get("model") or ""
-        
+
         if not model_id and len(path_parts) >= 3:
             # Extract model_id from S3 path (it's the second-to-last component before filename)
             model_id = path_parts[-2]  # Get model_id from the path
-            print(f"Extracted model_id from S3 path: {model_id}")
-            
+            verbose_logger.debug(f"Extracted model_id from S3 path: {model_id}")
+
         if not isinstance(input_s3_uri, str) or not input_s3_uri.startswith("s3://"):
-            raise ValueError("input_file_id must be an s3:// URI for Bedrock batch jobs")
+            raise ValueError(
+                "input_file_id must be an s3:// URI for Bedrock batch jobs"
+            )
 
         # output path: same directory as input file (without the filename)
         # s3://bucket/model_id/file.jsonl -> s3://bucket/model_id/
         try:
-            without_scheme = input_s3_uri[len("s3://"):]
+            without_scheme = input_s3_uri[len("s3://") :]
             bucket_and_key = without_scheme.split("/", 1)
             if len(bucket_and_key) == 1:
                 # no key, just bucket; place outputs at bucket root
@@ -126,22 +145,34 @@ class BedrockBatchesAPI(BaseAWSLLM):
         if isinstance(role_arn, str) and not role_arn.startswith("arn:"):
             role_arn = None
 
-        # Ensure the model is set in the create_batch_data 
-        if model_id:
-            create_batch_data = dict(create_batch_data)  # Make a copy
-            create_batch_data["model"] = model_id
+        # Create a new dict with the required fields for Bedrock
+        bedrock_batch_data: LiteLLMBatchCreateRequest = {
+            "model": str(model_id),
+            "input_file_id": create_batch_data.get("input_file_id", ""),
+            "metadata": create_batch_data.get("metadata", {}),
+        }
 
-        bedrock_job_request: CreateModelInvocationJobRequest = transform_openai_create_batch_to_bedrock_job_request(
-            create_batch_data,
-            s3_input_uri=input_s3_uri,
-            s3_output_uri=output_s3_uri,
-            role_arn=role_arn,
+        bedrock_job_request: CreateModelInvocationJobRequest = (
+            transform_openai_create_batch_to_bedrock_job_request(
+                bedrock_batch_data,
+                s3_input_uri=input_s3_uri,
+                s3_output_uri=output_s3_uri,
+                role_arn=role_arn,
+            )
         )
-        print(f"create_batch_data: {bedrock_job_request}")
+        verbose_logger.debug(f"create_batch_data: {bedrock_job_request}")
 
         # Create boto3 client (respects env/profile/role)
         boto_client = init_bedrock_service_client()
         resp = boto_client.create_model_invocation_job(**bedrock_job_request)  # type: ignore
         job_arn = resp.get("jobArn")
 
-        return LiteLLMBatch(id=job_arn or "", status="in_progress")
+        return LiteLLMBatch(
+            id=job_arn or "",
+            status="in_progress",
+            object="batch",
+            created_at=int(time.time()),
+            endpoint="bedrock",
+            input_file_id=create_batch_data.get("input_file_id", ""),
+            completion_window=3600,  # Default 1 hour
+        )

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -174,5 +174,5 @@ class BedrockBatchesAPI(BaseAWSLLM):
             created_at=int(time.time()),
             endpoint="bedrock",
             input_file_id=create_batch_data.get("input_file_id", ""),
-            completion_window=3600,  # Default 1 hour
+            completion_window="1h",  # Default 1 hour
         )

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, Dict, Optional
 
 from litellm.llms.bedrock.common_utils import (
@@ -89,9 +90,11 @@ class BedrockBatchTransformation:
         job_id = cls._get_batch_id_from_bedrock_response(job_arn)
 
         # Convert timestamps to Unix epoch
-        created_at = convert_bedrock_datetime_to_openai_datetime(
+        created_at_raw = convert_bedrock_datetime_to_openai_datetime(
             bedrock_response.get("submitTime")
         )
+        # Ensure created_at is always an int (required by LiteLLMBatch)
+        created_at = created_at_raw if created_at_raw is not None else int(time.time())
 
         # Determine timestamps based on status
         in_progress_at = None

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
 from litellm.types.llms.openai import CreateBatchRequest
@@ -16,21 +16,22 @@ def transform_openai_create_batch_to_bedrock_job_request(
     using S3 input/output URIs.
     """
     model = req.get("model") or ""
-    job_name = req.get("metadata", {}).get("job_name") or req.get("custom_id") or "litellm-batch-job"
+    # Handle metadata safely
+    metadata = req.get("metadata") or {}
+    job_name = metadata.get("job_name") or req.get("custom_id") or "litellm-batch-job"
 
-    inputDataConfig: Dict = {
-        "s3InputDataConfig": {"s3Uri": s3_input_uri}
-    }
-    outputDataConfig: Dict = {
+    from litellm.types.llms.bedrock import InputDataConfig, OutputDataConfig
+
+    inputDataConfig: InputDataConfig = {"s3InputDataConfig": {"s3Uri": s3_input_uri}}
+    outputDataConfig: OutputDataConfig = {
         "s3OutputDataConfig": {"s3Uri": s3_output_uri}
     }
 
     payload: CreateModelInvocationJobRequest = {
-        "modelId": model,
-        "jobName": job_name,
+        "modelId": str(model),
+        "jobName": str(job_name),
         "inputDataConfig": inputDataConfig,
         "outputDataConfig": outputDataConfig,
+        "roleArn": str(role_arn) if role_arn else "",
     }
-    if role_arn:
-        payload["roleArn"] = role_arn
     return payload

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -1,37 +1,213 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
+from litellm.llms.bedrock.common_utils import convert_bedrock_datetime_to_openai_datetime
 from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
-from litellm.types.llms.openai import CreateBatchRequest
+from litellm.types.llms.openai import BatchJobStatus, CreateBatchRequest
+from litellm.types.utils import LiteLLMBatch
 
 
-def transform_openai_create_batch_to_bedrock_job_request(
-    req: CreateBatchRequest,
-    *,
-    s3_input_uri: str,
-    s3_output_uri: str,
-    role_arn: Optional[str],
-) -> CreateModelInvocationJobRequest:
+class BedrockBatchTransformation:
     """
-    Transform OpenAI CreateBatchRequest into Bedrock CreateModelInvocationJobRequest
-    using S3 input/output URIs.
+    Transforms OpenAI Batch requests to Bedrock Batch requests and vice versa
+
+    API Ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/get_model_invocation_job.html
     """
-    model = req.get("model") or ""
-    # Handle metadata safely
-    metadata = req.get("metadata") or {}
-    job_name = metadata.get("job_name") or req.get("custom_id") or "litellm-batch-job"
 
-    from litellm.types.llms.bedrock import InputDataConfig, OutputDataConfig
-
-    inputDataConfig: InputDataConfig = {"s3InputDataConfig": {"s3Uri": s3_input_uri}}
-    outputDataConfig: OutputDataConfig = {
-        "s3OutputDataConfig": {"s3Uri": s3_output_uri}
+    # Map Bedrock status to OpenAI status
+    _status_mapping: Dict[str, BatchJobStatus] = {
+        "Submitted": "validating",
+        "InProgress": "in_progress", 
+        "Completed": "completed",
+        "Failed": "failed",
+        "Stopping": "cancelling",
+        "Stopped": "cancelled",
+        "PartiallyCompleted": "completed",
+        "Expired": "expired",
+        "Validating": "validating",
+        "Scheduled": "validating",
     }
 
-    payload: CreateModelInvocationJobRequest = {
-        "modelId": str(model),
-        "jobName": str(job_name),
-        "inputDataConfig": inputDataConfig,
-        "outputDataConfig": outputDataConfig,
-        "roleArn": str(role_arn) if role_arn else "",
-    }
-    return payload
+    @classmethod
+    def transform_openai_batch_request_to_bedrock_job_request(
+        cls,
+        req: CreateBatchRequest,
+        *,
+        s3_input_uri: str,
+        s3_output_uri: str,
+        role_arn: Optional[str],
+    ) -> CreateModelInvocationJobRequest:
+        """
+        Transform OpenAI CreateBatchRequest into Bedrock CreateModelInvocationJobRequest
+        using S3 input/output URIs.
+        """
+        model = req.get("model") or ""
+        # Handle metadata safely
+        metadata = req.get("metadata") or {}
+        job_name = metadata.get("job_name") or req.get("custom_id") or "litellm-batch-job"
+
+        from litellm.types.llms.bedrock import InputDataConfig, OutputDataConfig
+
+        inputDataConfig: InputDataConfig = {"s3InputDataConfig": {"s3Uri": s3_input_uri}}
+        outputDataConfig: OutputDataConfig = {
+            "s3OutputDataConfig": {"s3Uri": s3_output_uri}
+        }
+
+        payload: CreateModelInvocationJobRequest = {
+            "modelId": str(model),
+            "jobName": str(job_name),
+            "inputDataConfig": inputDataConfig,
+            "outputDataConfig": outputDataConfig,
+            "roleArn": str(role_arn) if role_arn else "",
+        }
+        return payload
+
+    @classmethod
+    def transform_bedrock_response_to_openai_batch(
+        cls,
+        bedrock_response: Dict[str, Any],
+        input_file_id: Optional[str] = None,
+    ) -> LiteLLMBatch:
+        """
+        Transform Bedrock batch job response to OpenAI batch format.
+        
+        Maps Bedrock get_model_invocation_job response to LiteLLMBatch structure.
+        
+        Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock/client/get_model_invocation_job.html
+        """
+        
+        bedrock_status = bedrock_response.get("status", "Failed")
+        openai_status = cls._status_mapping.get(bedrock_status, "failed")
+        
+        # Extract job ID from jobArn
+        job_arn = bedrock_response.get("jobArn", "")
+        job_id = cls._get_batch_id_from_bedrock_response(job_arn)
+        
+        # Convert timestamps to Unix epoch
+        created_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("submitTime"))
+        
+        # Determine timestamps based on status
+        in_progress_at = None
+        completed_at = None
+        failed_at = None
+        cancelled_at = None
+        cancelling_at = None
+
+        if openai_status == "in_progress":
+            in_progress_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("lastModifiedTime"))
+        elif openai_status == "cancelling":
+            cancelling_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("lastModifiedTime"))
+        elif openai_status == "cancelled":
+            cancelled_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("lastModifiedTime"))
+        elif openai_status == "completed":
+            completed_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("endTime"))
+        elif openai_status == "failed":
+            failed_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("endTime"))
+
+        # Add expired_at mapped from jobExpirationTime
+        expires_at = convert_bedrock_datetime_to_openai_datetime(bedrock_response.get("jobExpirationTime"))
+        
+        # Extract file IDs from input/output configs
+        input_s3_uri = cls._get_input_file_id_from_bedrock_response(bedrock_response)
+        output_s3_uri = cls._get_output_file_id_from_bedrock_response(bedrock_response)
+        
+        # Use provided input_file_id or fall back to S3 URI
+        resolved_input_file_id = input_file_id or input_s3_uri
+        
+        # Handle error information
+        error_file_id, errors = cls._get_error_information_from_bedrock_response(bedrock_response, openai_status)
+
+        return LiteLLMBatch(
+            id=job_id,
+            object="batch",
+            endpoint="/v1/chat/completions",  # Default endpoint
+            status=openai_status,
+            input_file_id=resolved_input_file_id,
+            output_file_id=output_s3_uri or None,
+            error_file_id=error_file_id,
+            created_at=created_at,
+            in_progress_at=in_progress_at,
+            completed_at=completed_at,
+            cancelled_at=cancelled_at,
+            cancelling_at=cancelling_at,
+            failed_at=failed_at,
+            expires_at=expires_at,
+            completion_window="24h",  # Default completion window
+            errors=errors,
+            request_counts=None,  # Bedrock doesn't provide this information
+            metadata=cls._get_metadata_from_bedrock_response(bedrock_response, job_arn),
+        )
+
+    @classmethod
+    def _get_batch_id_from_bedrock_response(cls, job_arn: str) -> str:
+        """
+        Gets the batch id from the Bedrock response safely
+        
+        Bedrock response: `arn:aws:bedrock:region:account-id:model-invocation-job/job-id`
+        returns: `job-id`
+        """
+        if not job_arn:
+            return ""
+        
+        # Split by '/' and get the last part if it exists
+        parts = job_arn.split("/")
+        return parts[-1] if parts else job_arn
+
+    @classmethod
+    def _get_input_file_id_from_bedrock_response(cls, response: Dict[str, Any]) -> str:
+        """
+        Gets the input file id from the Bedrock response
+        """
+        input_config = response.get("inputDataConfig", {})
+        s3_input_config = input_config.get("s3InputDataConfig", {})
+        return s3_input_config.get("s3Uri", "")
+
+    @classmethod
+    def _get_output_file_id_from_bedrock_response(cls, response: Dict[str, Any]) -> str:
+        """
+        Gets the output file id from the Bedrock response
+        """
+        output_config = response.get("outputDataConfig", {})
+        s3_output_config = output_config.get("s3OutputDataConfig", {})
+        return s3_output_config.get("s3Uri", "")
+
+    @classmethod
+    def _get_error_information_from_bedrock_response(
+        cls, 
+        response: Dict[str, Any], 
+        openai_status: str
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+        """
+        Gets error information from the Bedrock response
+        """
+        error_file_id = None
+        errors = None
+
+        if response.get("message") and openai_status == "failed":
+            # Construct errors object as per OpenAI batch error schema
+            errors = {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "error",
+                        "code": response.get("status", "failed"),
+                        "message": response.get("message"),
+                        "line": None,
+                        "param": None
+                    }
+                ]
+            }
+            error_file_id = None  # Bedrock doesn't provide error files
+
+        return error_file_id, errors
+
+    @classmethod
+    def _get_metadata_from_bedrock_response(cls, response: Dict[str, Any], job_arn: str) -> Dict[str, Any]:
+        """
+        Gets metadata from the Bedrock response
+        """
+        return {
+            "job_name": response.get("jobName"),
+            "model_id": response.get("modelId"),
+            "job_arn": job_arn,
+            "failure_message": response.get("message")
+        }

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -1,0 +1,36 @@
+from typing import Dict, Optional
+
+from litellm.types.llms.bedrock import CreateModelInvocationJobRequest
+from litellm.types.llms.openai import CreateBatchRequest
+
+
+def transform_openai_create_batch_to_bedrock_job_request(
+    req: CreateBatchRequest,
+    *,
+    s3_input_uri: str,
+    s3_output_uri: str,
+    role_arn: Optional[str],
+) -> CreateModelInvocationJobRequest:
+    """
+    Transform OpenAI CreateBatchRequest into Bedrock CreateModelInvocationJobRequest
+    using S3 input/output URIs.
+    """
+    model = req.get("model") or ""
+    job_name = req.get("metadata", {}).get("job_name") or req.get("custom_id") or "litellm-batch-job"
+
+    inputDataConfig: Dict = {
+        "s3InputDataConfig": {"s3Uri": s3_input_uri}
+    }
+    outputDataConfig: Dict = {
+        "s3OutputDataConfig": {"s3Uri": s3_output_uri}
+    }
+
+    payload: CreateModelInvocationJobRequest = {
+        "modelId": model,
+        "jobName": job_name,
+        "inputDataConfig": inputDataConfig,
+        "outputDataConfig": outputDataConfig,
+    }
+    if role_arn:
+        payload["roleArn"] = role_arn
+    return payload

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -291,6 +291,196 @@ def init_bedrock_client(
 
     return client
 
+def init_bedrock_service_client(
+    region_name=None,
+    aws_access_key_id: Optional[str] = None,
+    aws_secret_access_key: Optional[str] = None,
+    aws_region_name: Optional[str] = None,
+    aws_bedrock_endpoint: Optional[str] = None,
+    aws_session_name: Optional[str] = None,
+    aws_profile_name: Optional[str] = None,
+    aws_role_name: Optional[str] = None,
+    aws_web_identity_token: Optional[str] = None,
+    extra_headers: Optional[dict] = None,
+    timeout: Optional[Union[float, httpx.Timeout]] = None,
+):
+    """
+    Initialize a Bedrock service client (not bedrock-runtime) for batch operations.
+    This client is used for management operations like creating batch jobs.
+    """
+    # check for custom AWS_REGION_NAME and use it if not passed to init_bedrock_service_client
+    litellm_aws_region_name = get_secret("AWS_REGION_NAME", None)
+    standard_aws_region_name = get_secret("AWS_REGION", None)
+    ## CHECK IS  'os.environ/' passed in
+    # Define the list of parameters to check
+    params_to_check = [
+        aws_access_key_id,
+        aws_secret_access_key,
+        aws_region_name,
+        aws_bedrock_endpoint,
+        aws_session_name,
+        aws_profile_name,
+        aws_role_name,
+        aws_web_identity_token,
+    ]
+
+    # Iterate over parameters and update if needed
+    for i, param in enumerate(params_to_check):
+        if param and param.startswith("os.environ/"):
+            params_to_check[i] = get_secret(param)  # type: ignore
+    # Assign updated values back to parameters
+    (
+        aws_access_key_id,
+        aws_secret_access_key,
+        aws_region_name,
+        aws_bedrock_endpoint,
+        aws_session_name,
+        aws_profile_name,
+        aws_role_name,
+        aws_web_identity_token,
+    ) = params_to_check
+
+    ssl_verify = os.getenv("SSL_VERIFY", litellm.ssl_verify)
+
+    ### SET REGION NAME
+    if region_name:
+        pass
+    elif aws_region_name:
+        region_name = aws_region_name
+    elif litellm_aws_region_name:
+        region_name = litellm_aws_region_name
+    elif standard_aws_region_name:
+        region_name = standard_aws_region_name
+    else:
+        raise BedrockError(
+            message="AWS region not set: set AWS_REGION_NAME or AWS_REGION env variable or in .env file",
+            status_code=401,
+        )
+
+    # check for custom AWS_BEDROCK_ENDPOINT and use it if not passed to init_bedrock_service_client
+    env_aws_bedrock_endpoint = get_secret("AWS_BEDROCK_ENDPOINT")
+    if aws_bedrock_endpoint:
+        endpoint_url = aws_bedrock_endpoint
+    elif env_aws_bedrock_endpoint:
+        endpoint_url = env_aws_bedrock_endpoint
+    else:
+        endpoint_url = f"https://bedrock.{region_name}.amazonaws.com"
+
+    import boto3
+
+    if isinstance(timeout, float):
+        config = boto3.session.Config(connect_timeout=timeout, read_timeout=timeout)  # type: ignore
+    elif isinstance(timeout, httpx.Timeout):
+        config = boto3.session.Config(  # type: ignore
+            connect_timeout=timeout.connect, read_timeout=timeout.read
+        )
+    else:
+        config = boto3.session.Config()  # type: ignore
+
+    ### CHECK STS ###
+    if (
+        aws_web_identity_token is not None
+        and aws_role_name is not None
+        and aws_session_name is not None
+    ):
+        # TODO: Add sts credentials - https://github.com/BerriAI/litellm/issues/1727
+        ...
+    
+    # create bedrock service client (for batch operations)
+    if aws_web_identity_token is not None:
+        if aws_role_name is None:
+            raise BedrockError(
+                message="AWS role name is required when using web identity token",
+                status_code=400,
+            )
+
+        # use sts if web identity token passed in
+        sts_client = boto3.client(
+            "sts",
+            region_name=region_name,
+            config=config,
+            verify=ssl_verify,
+        )
+
+        sts_response = sts_client.assume_role_with_web_identity(
+            RoleArn=aws_role_name,
+            RoleSessionName=aws_session_name or "litellm-session",
+            WebIdentityToken=aws_web_identity_token,
+        )
+
+        client = boto3.client(
+            service_name="bedrock",
+            aws_access_key_id=sts_response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=sts_response["Credentials"]["SecretAccessKey"],
+            aws_session_token=sts_response["Credentials"]["SessionToken"],
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            verify=ssl_verify,
+        )
+    elif aws_role_name is not None and aws_session_name is not None:
+        # use sts if role name passed in
+        sts_client = boto3.client(
+            "sts",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+        )
+
+        sts_response = sts_client.assume_role(
+            RoleArn=aws_role_name, RoleSessionName=aws_session_name
+        )
+
+        client = boto3.client(
+            service_name="bedrock",
+            aws_access_key_id=sts_response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=sts_response["Credentials"]["SecretAccessKey"],
+            aws_session_token=sts_response["Credentials"]["SessionToken"],
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            verify=ssl_verify,
+        )
+    elif aws_access_key_id is not None:
+        # uses auth params passed to completion
+        # aws_access_key_id is not None, assume user is trying to auth using litellm.completion
+
+        client = boto3.client(
+            service_name="bedrock",
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            verify=ssl_verify,
+        )
+    elif aws_profile_name is not None:
+        # uses auth values from AWS profile usually stored in ~/.aws/credentials
+
+        client = boto3.Session(profile_name=aws_profile_name).client(
+            service_name="bedrock",
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            verify=ssl_verify,
+        )
+    else:
+        # aws_access_key_id is None, assume user is trying to auth using env variables
+        # boto3 automatically reads env variables
+
+        client = boto3.client(
+            service_name="bedrock",
+            region_name=region_name,
+            endpoint_url=endpoint_url,
+            config=config,
+            verify=ssl_verify,
+        )
+    if extra_headers:
+        client.meta.events.register(
+            "before-sign.bedrock.*", add_custom_header(extra_headers)
+        )
+
+    return client
+
 
 class ModelResponseIterator:
     def __init__(self, model_response):

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -803,3 +803,20 @@ def get_anthropic_beta_from_headers(headers: dict) -> List[str]:
 
     # Split comma-separated values and strip whitespace
     return [beta.strip() for beta in anthropic_beta_header.split(",")]
+
+
+def convert_bedrock_datetime_to_openai_datetime(bedrock_datetime) -> Optional[int]:
+    """
+    Convert Bedrock datetime objects to OpenAI datetime format (Unix epoch).
+    
+    Args:
+        bedrock_datetime: Bedrock datetime object or None
+        
+    Returns:
+        Optional[int]: Unix epoch timestamp or None if input is None
+    """
+    if bedrock_datetime is None:
+        return None
+    if hasattr(bedrock_datetime, 'timestamp'):
+        return int(bedrock_datetime.timestamp())
+    return None

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -291,7 +291,8 @@ def init_bedrock_client(
 
     return client
 
-def init_bedrock_service_client(
+
+def init_bedrock_service_client(  # noqa: PLR0915
     region_name=None,
     aws_access_key_id: Optional[str] = None,
     aws_secret_access_key: Optional[str] = None,
@@ -385,7 +386,7 @@ def init_bedrock_service_client(
     ):
         # TODO: Add sts credentials - https://github.com/BerriAI/litellm/issues/1727
         ...
-    
+
     # create bedrock service client (for batch operations)
     if aws_web_identity_token is not None:
         if aws_role_name is None:
@@ -636,18 +637,20 @@ class BedrockModelInfo(BaseLLMModelInfo):
         """
         Get the bedrock route for the given model.
         """
-        route_mappings: Dict[str, Literal["invoke", "converse_like", "converse", "agent"]] = {
+        route_mappings: Dict[
+            str, Literal["invoke", "converse_like", "converse", "agent"]
+        ] = {
             "invoke/": "invoke",
-            "converse_like/": "converse_like", 
+            "converse_like/": "converse_like",
             "converse/": "converse",
-            "agent/": "agent"
+            "agent/": "agent",
         }
-        
+
         # Check explicit routes first
         for prefix, route_type in route_mappings.items():
             if prefix in model:
                 return route_type
-        
+
         base_model = BedrockModelInfo.get_base_model(model)
         alt_model = BedrockModelInfo.get_non_litellm_routing_model_name(model=model)
         if (
@@ -656,38 +659,39 @@ class BedrockModelInfo(BaseLLMModelInfo):
         ):
             return "converse"
         return "invoke"
-    
+
     @staticmethod
     def _explicit_converse_route(model: str) -> bool:
         """
         Check if the model is an explicit converse route.
         """
         return "converse/" in model
-    
+
     @staticmethod
     def _explicit_invoke_route(model: str) -> bool:
         """
         Check if the model is an explicit invoke route.
         """
         return "invoke/" in model
-    
+
     @staticmethod
     def _explicit_agent_route(model: str) -> bool:
         """
         Check if the model is an explicit agent route.
         """
         return "agent/" in model
-    
+
     @staticmethod
     def _explicit_converse_like_route(model: str) -> bool:
         """
         Check if the model is an explicit converse like route.
         """
         return "converse_like/" in model
-    
 
     @staticmethod
-    def get_bedrock_provider_config_for_messages_api(model: str) -> Optional[BaseAnthropicMessagesConfig]:
+    def get_bedrock_provider_config_for_messages_api(
+        model: str,
+    ) -> Optional[BaseAnthropicMessagesConfig]:
         """
         Get the bedrock provider config for the given model.
 
@@ -700,18 +704,19 @@ class BedrockModelInfo(BaseLLMModelInfo):
         # Converse routes should go through litellm.completion()
         if BedrockModelInfo._explicit_converse_route(model):
             return None
-        
+
         #########################################################
         # This goes through litellm.AmazonAnthropicClaude3MessagesConfig()
         # Since bedrock Invoke supports Native Anthropic Messages API
         #########################################################
         if "claude" in model:
             return litellm.AmazonAnthropicClaudeMessagesConfig()
-        
+
         #########################################################
         # These routes will go through litellm.completion()
         #########################################################
         return None
+
 
 class BedrockEventStreamDecoderBase:
     """
@@ -782,19 +787,19 @@ def get_anthropic_beta_from_headers(headers: dict) -> List[str]:
     """
     Extract anthropic-beta header values and convert them to a list.
     Supports comma-separated values from user headers.
-    
+
     Used by both converse and invoke transformations for consistent handling
     of anthropic-beta headers that should be passed to AWS Bedrock.
-    
+
     Args:
         headers (dict): Request headers dictionary
-        
+
     Returns:
         List[str]: List of anthropic beta feature strings, empty list if no header
     """
     anthropic_beta_header = headers.get("anthropic-beta")
     if not anthropic_beta_header:
         return []
-    
+
     # Split comma-separated values and strip whitespace
     return [beta.strip() for beta in anthropic_beta_header.split(",")]

--- a/litellm/llms/bedrock/files/handler.py
+++ b/litellm/llms/bedrock/files/handler.py
@@ -1,0 +1,162 @@
+import asyncio
+from typing import Any, Coroutine, Optional, Union, TYPE_CHECKING
+
+import httpx
+
+from litellm import LlmProviders
+from litellm.integrations.gcs_bucket.gcs_bucket_base import (
+    GCSBucketBase,
+    GCSLoggingConfig,
+)
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.types.llms.openai import CreateFileRequest, OpenAIFileObject
+from litellm.types.llms.vertex_ai import VERTEX_CREDENTIALS_TYPES
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+from .transformation import BedrockJsonlFilesTransformation
+
+bedrock_files_transformation = BedrockJsonlFilesTransformation()
+
+
+class BedrockFilesHandler(BaseLLMHTTPHandler):
+    """
+    Handles Calling Bedrock in OpenAI Files API format v1/files/*
+
+    This implementation uploads files on GCS Buckets
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.async_httpx_client = get_async_httpx_client(
+            llm_provider=LlmProviders.BEDROCK,
+        )
+
+    async def async_create_file(
+        self,
+        create_file_data: CreateFileRequest,
+        api_base: Optional[str],
+        litellm_params: dict,
+        logging_obj: LiteLLMLoggingObj,
+        timeout: Union[float, httpx.Timeout],
+        max_retries: Optional[int],
+    ) -> OpenAIFileObject:
+        try:
+            # First, prepare the S3 upload URL and object key
+            bedrock_files_transformation.get_complete_file_url(
+                api_base=api_base,
+                api_key=None,
+                litellm_params=litellm_params,
+                data=create_file_data,
+            )
+            
+            s3_upload_params = bedrock_files_transformation.transform_openai_file_content_to_bedrock_file_content(
+                create_file_data=create_file_data,
+                litellm_params=litellm_params,
+            )
+
+            # Actually upload the file to S3 using boto3
+            try:
+                import boto3
+                from botocore.exceptions import ClientError
+            except ImportError:
+                raise ImportError("Missing boto3 to upload to S3. Run 'pip install boto3'.")
+
+            # Get AWS credentials from the params
+            import litellm
+            s3_params = getattr(litellm, "s3_callback_params", {}) or {}
+            
+            # Create S3 client using credentials from BaseAWSLLM
+            credentials = bedrock_files_transformation.get_credentials(
+                aws_access_key_id=s3_params.get("s3_aws_access_key_id"),
+                aws_secret_access_key=s3_params.get("s3_aws_secret_access_key"),
+                aws_session_token=s3_params.get("s3_aws_session_token"),
+                aws_region_name=s3_upload_params["region"],
+                aws_session_name=s3_params.get("s3_aws_session_name"),
+                aws_profile_name=s3_params.get("s3_aws_profile_name"),
+                aws_role_name=s3_params.get("s3_aws_role_name"),
+                aws_web_identity_token=s3_params.get("s3_aws_web_identity_token"),
+                aws_sts_endpoint=s3_params.get("s3_aws_sts_endpoint"),
+            )
+
+            s3_client = boto3.client(
+                "s3",
+                region_name=s3_upload_params["region"],
+                endpoint_url=s3_params.get("s3_endpoint_url"),
+                aws_access_key_id=credentials.access_key,
+                aws_secret_access_key=credentials.secret_key,
+                aws_session_token=credentials.token,
+            )
+
+            # Upload the file content to S3
+            response = s3_client.put_object(
+                Bucket=s3_upload_params["bucket"],
+                Key=s3_upload_params["key"],
+                Body=s3_upload_params["content"],
+                ContentType=s3_upload_params["content_type"],
+            )
+            
+            print(f"S3 upload response: {response}")
+
+            # Create a response object that mimics httpx.Response
+            class S3UploadResponse:
+                def __init__(self, response_metadata):
+                    self.status_code = 200 if response_metadata.get("HTTPStatusCode") == 200 else response_metadata.get("HTTPStatusCode", 500)
+                    self.text = "S3 upload successful" if self.status_code == 200 else "S3 upload failed"
+            
+            upload_response = S3UploadResponse(response.get("ResponseMetadata", {}))
+                    
+        except Exception as e:
+            raise self._handle_error(e=e, provider_config=bedrock_files_transformation)
+
+        return bedrock_files_transformation.transform_s3_bucket_response_to_openai_file_object(
+            model=None,
+            raw_response=upload_response,
+            logging_obj=logging_obj,
+            litellm_params=litellm_params,
+            model_id=s3_upload_params["model_id"],
+        )
+
+    def create_file(
+        self,
+        _is_async: bool,
+        create_file_data: CreateFileRequest,
+        api_base: Optional[str],
+        timeout: Union[float, httpx.Timeout],
+        litellm_params: dict,
+        logging_obj: LiteLLMLoggingObj,
+        max_retries: Optional[int],
+    ) -> Union[OpenAIFileObject, Coroutine[Any, Any, OpenAIFileObject]]:
+        """
+        Creates a file on VertexAI GCS Bucket
+
+        Only supported for Async litellm.acreate_file
+        """
+
+        if _is_async:
+            return self.async_create_file(
+                create_file_data=create_file_data,
+                api_base=api_base,
+                litellm_params=litellm_params,
+                logging_obj=logging_obj,
+                timeout=timeout,
+                max_retries=max_retries,
+            )
+        else:
+            return asyncio.run(
+                self.async_create_file(
+                    create_file_data=create_file_data,
+                    api_base=api_base,
+                    litellm_params=litellm_params,
+                    logging_obj=logging_obj,
+                    timeout=timeout,
+                    max_retries=max_retries,
+                )
+            )

--- a/litellm/llms/bedrock/files/handler.py
+++ b/litellm/llms/bedrock/files/handler.py
@@ -6,6 +6,7 @@ import httpx
 
 from litellm import LlmProviders
 from litellm._logging import verbose_logger
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.files.transformation import BaseFilesConfig
 from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
@@ -149,9 +150,11 @@ class BedrockFilesHandler(BaseLLMHTTPHandler):
             upload_response = S3UploadResponse(response.get("ResponseMetadata", {}))
 
         except Exception as e:
-            # provider_config is not used in error handling, so we can pass a dummy object
-            # Using type ignore since this is just for error handling
-            raise self._handle_error(e=e, provider_config=object())  # type: ignore
+            raise BaseLLMException(
+                status_code=500,
+                message=str(e),
+                headers={},
+            )
 
         return bedrock_files_transformation.transform_s3_bucket_response_to_openai_file_object(
             model=None,

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1,32 +1,25 @@
 import json
-import os
 import time
 import uuid
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, Optional, Union
 
 from httpx import Headers, Response
 
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import extract_file_data
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.files.transformation import (
-    BaseFilesConfig,
     LiteLLMLoggingObj,
 )
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.types.llms.openai import (
-    AllMessageValues,
     CreateFileRequest,
-    FileTypes,
-    OpenAICreateFileRequestOptionalParams,
     OpenAIFileObject,
     PathLike,
 )
-from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
-from litellm.types.utils import LlmProviders
-from litellm._logging import verbose_logger
-import httpx
-from typing import Any, Dict, List, Optional, Tuple, Union
-import litellm
+
 from ..common_utils import BedrockError
+
 
 class BedrockJsonlFilesTransformation(BaseAWSLLM):
     """
@@ -67,9 +60,12 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
             raise ValueError("s3_bucket_name is required for Bedrock files")
 
         # Build object key (deterministic path using model if present; fallback to uuid)
-        extracted = extract_file_data(data.get("file"))
+        file_data = data.get("file")
+        if file_data is None:
+            raise ValueError("file data is required")
+        extracted = extract_file_data(file_data)
         filename = extracted.get("filename") or "upload.jsonl"
-        
+
         # For batch files, infer model_id and include it in the object key
         model_id = ""
         if data.get("purpose") == "batch":
@@ -80,12 +76,16 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
                 elif isinstance(content, str):
                     content_str = content
                 elif hasattr(content, "read"):
-                    content_str = content.read().decode("utf-8") if isinstance(content.read(), bytes) else content.read()
+                    content_str = (
+                        content.read().decode("utf-8")
+                        if isinstance(content.read(), bytes)
+                        else content.read()
+                    )
                 else:
                     content_str = ""
-                
+
                 model_id = self.infer_model_id_from_openai_jsonl(content_str) or ""
-        
+
         # Include model_id in object key for batch files to enable proper batch processing
         if model_id:
             object_key = f"{base_path.rstrip('/') + '/' if base_path else ''}{model_id}/{uuid.uuid4()}-{filename}"
@@ -117,41 +117,44 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
 
         Example OpenAI JSONL input:
         {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "anthropic.claude-v2", "messages": [{"role": "user", "content": "Hello!"}], "max_tokens": 10}}
-        
+
         Example Bedrock JSONL output:
         {"recordId": "request-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 10, "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]}}
         """
-        from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import AmazonInvokeConfig
         import uuid
 
-        bedrock_jsonl_lines = []  
+        from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+            AmazonInvokeConfig,
+        )
+
+        bedrock_jsonl_lines = []
         amazon_invoke_config = AmazonInvokeConfig()
-        print(f"openai_jsonl_content: {openai_jsonl_content}")
+        verbose_logger.debug(f"openai_jsonl_content: {openai_jsonl_content}")
         # Parse JSONL string into individual JSON objects
-        for line in openai_jsonl_content.strip().split('\n'):
+        for line in openai_jsonl_content.strip().split("\n"):
             line = line.strip()
             if not line:
                 continue
-                
+
             try:
                 openai_request = json.loads(line)
             except json.JSONDecodeError as e:
-                verbose_logger.warning(f"Skipping malformed JSONL line: {line}. Error: {e}")
+                verbose_logger.warning(
+                    f"Skipping malformed JSONL line: {line}. Error: {e}"
+                )
                 continue
-            
+
             # Extract request details from OpenAI format
             body = openai_request.get("body", {})
             custom_id = openai_request.get("custom_id", f"request-{uuid.uuid4()}")
             model = body.get("model", "")
             messages = body.get("messages", [])
-            
+
             # Extract optional parameters (everything except model and messages)
             optional_params = {
-                k: v
-                for k, v in body.items()
-                if k not in ("model", "messages")
+                k: v for k, v in body.items() if k not in ("model", "messages")
             }
-            
+
             try:
                 # Transform using Amazon invoke config
                 output_body = amazon_invoke_config.transform_request(
@@ -161,23 +164,19 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
                     litellm_params={},
                     headers={},
                 )
-                print(f"output_body: {output_body}")
-                
+                verbose_logger.debug(f"output_body: {output_body}")
+
                 # Create Bedrock JSONL format
-                bedrock_request = {
-                    "recordId": custom_id,
-                    "modelInput": output_body
-                }
-                
+                bedrock_request = {"recordId": custom_id, "modelInput": output_body}
+
                 bedrock_jsonl_lines.append(json.dumps(bedrock_request))
-                
+
             except Exception as e:
                 verbose_logger.warning(f"Failed to transform request {custom_id}: {e}")
                 continue
-        
-        return '\n'.join(bedrock_jsonl_lines)
-    
-    
+
+        return "\n".join(bedrock_jsonl_lines)
+
     def transform_openai_file_content_to_bedrock_file_content(
         self,
         create_file_data: CreateFileRequest,
@@ -193,36 +192,35 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
             raise ValueError("file is required")
         extracted = extract_file_data(file_data)
         content = extracted.get("content")
-        print(f"content: {content}")
+        verbose_logger.debug(f"content: {content!r}")
         content_type = extracted.get("content_type") or "application/octet-stream"
-        
+
         # For batch files, assume JSONL content type if purpose is batch
         filename = extracted.get("filename") or ""
         if create_file_data.get("purpose") == "batch":
             # Try to detect if it's JSONL content
-            if filename.endswith(".jsonl") or content_type in ["application/jsonl", "text/jsonl"]:
+            if filename.endswith(".jsonl") or content_type in [
+                "application/jsonl",
+                "text/jsonl",
+            ]:
                 content_type = "application/jsonl"
             else:
                 # For batch purpose, assume it's JSONL even if we can't detect from filename
                 content_type = "application/jsonl"
-        
+
         if hasattr(self, "_s3_object_key") is False:
             raise ValueError("S3 upload URL/object key not prepared")
 
-        url = self.get_complete_file_url(
-            api_base=None,
-            api_key=None,
-            litellm_params=litellm_params,
-            data=create_file_data,
-        )
-
-        headers = {"Content-Type": content_type}
+        # Get the S3 URL (stored from previous call)
+        s3_url = getattr(self, "_s3_object_key", None)
+        if not s3_url:
+            raise ValueError("S3 upload URL/object key not prepared")
         # For S3 PUT
         if isinstance(content, bytes):
             raw_bytes = content
         elif isinstance(content, str):
             raw_bytes = content.encode("utf-8")
-        elif hasattr(content, "read"):
+        elif hasattr(content, "read") and content is not None:
             raw_bytes = content.read()
         elif isinstance(content, PathLike):
             with open(str(content), "rb") as f:
@@ -233,33 +231,42 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
         # If batch JSONL, transform OpenAI JSONL → Bedrock JSONL before upload
         payload_bytes = raw_bytes
         bedrock_model_id = ""
-        print(f"Checking transformation conditions: purpose={create_file_data.get('purpose')}, content_type={content_type}, is_bytes={isinstance(raw_bytes, (bytes, bytearray))}")
+        verbose_logger.debug(
+            f"Checking transformation conditions: purpose={create_file_data.get('purpose')}, content_type={content_type}, is_bytes={isinstance(raw_bytes, (bytes, bytearray))}"
+        )
         if (
             create_file_data.get("purpose") == "batch"
             and content_type == "application/jsonl"
             and isinstance(raw_bytes, (bytes, bytearray))
         ):
             try:
-                print(f"Starting JSONL transformation...")
+                verbose_logger.debug("Starting JSONL transformation...")
                 # try infer model id from first line
-                bedrock_model_id = self.infer_model_id_from_openai_jsonl(
-                    raw_bytes.decode("utf-8")
-                ) or ""
-                print(f"Inferred model ID: {bedrock_model_id}")
-                transformed_jsonl_str = self.transform_openai_file_content_to_bedrock_jsonl_str(
-                    raw_bytes.decode("utf-8")
+                bedrock_model_id = (
+                    self.infer_model_id_from_openai_jsonl(raw_bytes.decode("utf-8"))
+                    or ""
                 )
-                print(f"Transformed JSONL: {transformed_jsonl_str[:200]}...")
+                verbose_logger.debug(f"Inferred model ID: {bedrock_model_id}")
+                transformed_jsonl_str = (
+                    self.transform_openai_file_content_to_bedrock_jsonl_str(
+                        raw_bytes.decode("utf-8")
+                    )
+                )
+                verbose_logger.debug(
+                    f"Transformed JSONL: {transformed_jsonl_str[:200]}..."
+                )
                 payload_bytes = transformed_jsonl_str.encode("utf-8")
-                print(f"Transformation completed. Original size: {len(raw_bytes)}, Transformed size: {len(payload_bytes)}")
+                verbose_logger.debug(
+                    f"Transformation completed. Original size: {len(raw_bytes)}, Transformed size: {len(payload_bytes)}"
+                )
             except Exception as e:
                 verbose_logger.exception(
                     f"Error transforming batch JSONL for Bedrock: {e}"
                 )
-                print(f"Transformation failed, using original content")
+                verbose_logger.warning("Transformation failed, using original content")
                 payload_bytes = raw_bytes
         else:
-            print(f"Skipping transformation - conditions not met")
+            verbose_logger.debug("Skipping transformation - conditions not met")
 
         # Stash content length for response object
         self._uploaded_payload_len = len(payload_bytes)
@@ -273,7 +280,7 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
             "region": self._s3_region,
             "model_id": getattr(self, "_model_id", "") or bedrock_model_id,
         }
-    
+
     def transform_s3_bucket_response_to_openai_file_object(
         self,
         model: Optional[str],
@@ -286,20 +293,26 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
         if raw_response.status_code not in (200, 201):
             raise BaseLLMException(
                 status_code=raw_response.status_code,
-                message=f"S3 upload failed with status {raw_response.status_code}: {raw_response.text}"
+                message=f"S3 upload failed with status {raw_response.status_code}: {raw_response.text!r}",
             )
 
         # Get the model_id from parameter or stored value
         effective_model_id = model_id or getattr(self, "_model_id", "")
-        
+
         # Build S3 URI - for batch files, we want the path up to the model_id folder
         # so the batch handler can extract the model_id properly
         if getattr(self, "_s3_bucket", None) and getattr(self, "_s3_object_key", None):
             if effective_model_id and f"/{effective_model_id}/" in self._s3_object_key:
                 # For batch files with model_id in path, return S3 URI pointing to the model folder
                 # This allows batch handler to extract model_id: s3://bucket/path/model_id/
-                bucket_and_path = self._s3_object_key.split(f"/{effective_model_id}/")[0]
-                s3_uri = f"s3://{self._s3_bucket}/{bucket_and_path}/{effective_model_id}/" if bucket_and_path else f"s3://{self._s3_bucket}/{effective_model_id}/"
+                bucket_and_path = self._s3_object_key.split(f"/{effective_model_id}/")[
+                    0
+                ]
+                s3_uri = (
+                    f"s3://{self._s3_bucket}/{bucket_and_path}/{effective_model_id}/"
+                    if bucket_and_path
+                    else f"s3://{self._s3_bucket}/{effective_model_id}/"
+                )
             else:
                 # Standard S3 URI for non-batch files
                 s3_uri = f"s3://{self._s3_bucket}/{self._s3_object_key}"
@@ -308,12 +321,15 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
         return OpenAIFileObject(
             purpose="batch",
             id=s3_uri,
-            filename=self._s3_object_key.split("/")[-1] if getattr(self, "_s3_object_key", None) else "",
+            filename=self._s3_object_key.split("/")[-1]
+            if getattr(self, "_s3_object_key", None)
+            else "",
             created_at=int(time.time()),
             status="uploaded",
             bytes=getattr(self, "_uploaded_payload_len", 0),
             object="file",
         )
+
     def infer_model_id_from_openai_jsonl(self, file_content: str) -> Optional[str]:
         for raw in file_content.splitlines():
             raw = raw.strip()
@@ -328,5 +344,3 @@ class BedrockJsonlFilesTransformation(BaseAWSLLM):
             if isinstance(model, str) and model:
                 return model
         return None
-
-    

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1,0 +1,332 @@
+import json
+import os
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from httpx import Headers, Response
+
+from litellm.litellm_core_utils.prompt_templates.common_utils import extract_file_data
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.files.transformation import (
+    BaseFilesConfig,
+    LiteLLMLoggingObj,
+)
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    CreateFileRequest,
+    FileTypes,
+    OpenAICreateFileRequestOptionalParams,
+    OpenAIFileObject,
+    PathLike,
+)
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.types.utils import LlmProviders
+from litellm._logging import verbose_logger
+import httpx
+from typing import Any, Dict, List, Optional, Tuple, Union
+import litellm
+from ..common_utils import BedrockError
+
+class BedrockJsonlFilesTransformation(BaseAWSLLM):
+    """
+    Transforms OpenAI /v1/files/* requests to Bedrock /v1/files/* requests
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Union[Dict, Headers],
+    ) -> BaseLLMException:
+        return BedrockError(status_code=status_code, message=error_message)
+
+    def get_complete_file_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        litellm_params: Dict,
+        data: CreateFileRequest,
+    ) -> str:
+        """
+        Compose the S3 object URL to PUT the object (virtual-hosted-style URL)
+        https://{bucket}.s3.{region}.amazonaws.com/{key}
+        """
+        # Pull S3 config from global s3_callback_params
+        import litellm
+
+        s3_params = getattr(litellm, "s3_callback_params", {}) or {}
+        bucket = s3_params.get("s3_bucket_name")
+        region = s3_params.get("s3_region_name") or "us-west-2"
+        endpoint_url = s3_params.get("s3_endpoint_url")
+        base_path = s3_params.get("s3_path") or ""
+        if not bucket:
+            raise ValueError("s3_bucket_name is required for Bedrock files")
+
+        # Build object key (deterministic path using model if present; fallback to uuid)
+        extracted = extract_file_data(data.get("file"))
+        filename = extracted.get("filename") or "upload.jsonl"
+        
+        # For batch files, infer model_id and include it in the object key
+        model_id = ""
+        if data.get("purpose") == "batch":
+            content = extracted.get("content")
+            if content:
+                if isinstance(content, bytes):
+                    content_str = content.decode("utf-8")
+                elif isinstance(content, str):
+                    content_str = content
+                elif hasattr(content, "read"):
+                    content_str = content.read().decode("utf-8") if isinstance(content.read(), bytes) else content.read()
+                else:
+                    content_str = ""
+                
+                model_id = self.infer_model_id_from_openai_jsonl(content_str) or ""
+        
+        # Include model_id in object key for batch files to enable proper batch processing
+        if model_id:
+            object_key = f"{base_path.rstrip('/') + '/' if base_path else ''}{model_id}/{uuid.uuid4()}-{filename}"
+        else:
+            object_key = f"{base_path.rstrip('/') + '/' if base_path else ''}{uuid.uuid4()}-{filename}"
+
+        # Store values for response transformation
+        self._s3_bucket = bucket
+        self._s3_region = region
+        self._s3_endpoint_url = endpoint_url
+        self._s3_object_key = object_key
+        self._model_id = model_id
+
+        if endpoint_url:
+            return f"{endpoint_url}/{object_key}"
+        return f"https://{bucket}.s3.{region}.amazonaws.com/{object_key}"
+
+    def transform_openai_file_content_to_bedrock_jsonl_str(
+        self, openai_jsonl_content: str
+    ) -> str:
+        """
+        Transforms OpenAI JSONL content to Bedrock JSONL content
+
+        Args:
+            openai_jsonl_content: String containing JSONL formatted OpenAI batch requests
+
+        Returns:
+            String containing JSONL formatted Bedrock batch requests
+
+        Example OpenAI JSONL input:
+        {"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "anthropic.claude-v2", "messages": [{"role": "user", "content": "Hello!"}], "max_tokens": 10}}
+        
+        Example Bedrock JSONL output:
+        {"recordId": "request-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 10, "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}]}}
+        """
+        from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import AmazonInvokeConfig
+        import uuid
+
+        bedrock_jsonl_lines = []  
+        amazon_invoke_config = AmazonInvokeConfig()
+        print(f"openai_jsonl_content: {openai_jsonl_content}")
+        # Parse JSONL string into individual JSON objects
+        for line in openai_jsonl_content.strip().split('\n'):
+            line = line.strip()
+            if not line:
+                continue
+                
+            try:
+                openai_request = json.loads(line)
+            except json.JSONDecodeError as e:
+                verbose_logger.warning(f"Skipping malformed JSONL line: {line}. Error: {e}")
+                continue
+            
+            # Extract request details from OpenAI format
+            body = openai_request.get("body", {})
+            custom_id = openai_request.get("custom_id", f"request-{uuid.uuid4()}")
+            model = body.get("model", "")
+            messages = body.get("messages", [])
+            
+            # Extract optional parameters (everything except model and messages)
+            optional_params = {
+                k: v
+                for k, v in body.items()
+                if k not in ("model", "messages")
+            }
+            
+            try:
+                # Transform using Amazon invoke config
+                output_body = amazon_invoke_config.transform_request(
+                    model=model,
+                    messages=messages,
+                    optional_params=optional_params,
+                    litellm_params={},
+                    headers={},
+                )
+                print(f"output_body: {output_body}")
+                
+                # Create Bedrock JSONL format
+                bedrock_request = {
+                    "recordId": custom_id,
+                    "modelInput": output_body
+                }
+                
+                bedrock_jsonl_lines.append(json.dumps(bedrock_request))
+                
+            except Exception as e:
+                verbose_logger.warning(f"Failed to transform request {custom_id}: {e}")
+                continue
+        
+        return '\n'.join(bedrock_jsonl_lines)
+    
+    
+    def transform_openai_file_content_to_bedrock_file_content(
+        self,
+        create_file_data: CreateFileRequest,
+        litellm_params: dict,
+        optional_params: Optional[dict] = {},
+    ) -> Union[bytes, str, dict]:
+        """
+        Return a single SigV4-signed request definition for S3 PUT using httpx.
+        The BaseLLMHTTPHandler is extended to handle this format.
+        """
+        file_data = create_file_data.get("file")
+        if file_data is None:
+            raise ValueError("file is required")
+        extracted = extract_file_data(file_data)
+        content = extracted.get("content")
+        print(f"content: {content}")
+        content_type = extracted.get("content_type") or "application/octet-stream"
+        
+        # For batch files, assume JSONL content type if purpose is batch
+        filename = extracted.get("filename") or ""
+        if create_file_data.get("purpose") == "batch":
+            # Try to detect if it's JSONL content
+            if filename.endswith(".jsonl") or content_type in ["application/jsonl", "text/jsonl"]:
+                content_type = "application/jsonl"
+            else:
+                # For batch purpose, assume it's JSONL even if we can't detect from filename
+                content_type = "application/jsonl"
+        
+        if hasattr(self, "_s3_object_key") is False:
+            raise ValueError("S3 upload URL/object key not prepared")
+
+        url = self.get_complete_file_url(
+            api_base=None,
+            api_key=None,
+            litellm_params=litellm_params,
+            data=create_file_data,
+        )
+
+        headers = {"Content-Type": content_type}
+        # For S3 PUT
+        if isinstance(content, bytes):
+            raw_bytes = content
+        elif isinstance(content, str):
+            raw_bytes = content.encode("utf-8")
+        elif hasattr(content, "read"):
+            raw_bytes = content.read()
+        elif isinstance(content, PathLike):
+            with open(str(content), "rb") as f:
+                raw_bytes = f.read()
+        else:
+            raise ValueError("Unsupported file content type for Bedrock S3 upload")
+
+        # If batch JSONL, transform OpenAI JSONL → Bedrock JSONL before upload
+        payload_bytes = raw_bytes
+        bedrock_model_id = ""
+        print(f"Checking transformation conditions: purpose={create_file_data.get('purpose')}, content_type={content_type}, is_bytes={isinstance(raw_bytes, (bytes, bytearray))}")
+        if (
+            create_file_data.get("purpose") == "batch"
+            and content_type == "application/jsonl"
+            and isinstance(raw_bytes, (bytes, bytearray))
+        ):
+            try:
+                print(f"Starting JSONL transformation...")
+                # try infer model id from first line
+                bedrock_model_id = self.infer_model_id_from_openai_jsonl(
+                    raw_bytes.decode("utf-8")
+                ) or ""
+                print(f"Inferred model ID: {bedrock_model_id}")
+                transformed_jsonl_str = self.transform_openai_file_content_to_bedrock_jsonl_str(
+                    raw_bytes.decode("utf-8")
+                )
+                print(f"Transformed JSONL: {transformed_jsonl_str[:200]}...")
+                payload_bytes = transformed_jsonl_str.encode("utf-8")
+                print(f"Transformation completed. Original size: {len(raw_bytes)}, Transformed size: {len(payload_bytes)}")
+            except Exception as e:
+                verbose_logger.exception(
+                    f"Error transforming batch JSONL for Bedrock: {e}"
+                )
+                print(f"Transformation failed, using original content")
+                payload_bytes = raw_bytes
+        else:
+            print(f"Skipping transformation - conditions not met")
+
+        # Stash content length for response object
+        self._uploaded_payload_len = len(payload_bytes)
+
+        return {
+            "request": "boto3_s3",  # Flag to use boto3 S3 client
+            "bucket": self._s3_bucket,
+            "key": self._s3_object_key,
+            "content": payload_bytes,
+            "content_type": content_type,
+            "region": self._s3_region,
+            "model_id": getattr(self, "_model_id", "") or bedrock_model_id,
+        }
+    
+    def transform_s3_bucket_response_to_openai_file_object(
+        self,
+        model: Optional[str],
+        raw_response: Response,
+        logging_obj: LiteLLMLoggingObj,
+        litellm_params: dict,
+        model_id: Optional[str],
+    ) -> OpenAIFileObject:
+        # Build an OpenAI-like FileObject pointing to the S3 URI
+        if raw_response.status_code not in (200, 201):
+            raise BaseLLMException(
+                status_code=raw_response.status_code,
+                message=f"S3 upload failed with status {raw_response.status_code}: {raw_response.text}"
+            )
+
+        # Get the model_id from parameter or stored value
+        effective_model_id = model_id or getattr(self, "_model_id", "")
+        
+        # Build S3 URI - for batch files, we want the path up to the model_id folder
+        # so the batch handler can extract the model_id properly
+        if getattr(self, "_s3_bucket", None) and getattr(self, "_s3_object_key", None):
+            if effective_model_id and f"/{effective_model_id}/" in self._s3_object_key:
+                # For batch files with model_id in path, return S3 URI pointing to the model folder
+                # This allows batch handler to extract model_id: s3://bucket/path/model_id/
+                bucket_and_path = self._s3_object_key.split(f"/{effective_model_id}/")[0]
+                s3_uri = f"s3://{self._s3_bucket}/{bucket_and_path}/{effective_model_id}/" if bucket_and_path else f"s3://{self._s3_bucket}/{effective_model_id}/"
+            else:
+                # Standard S3 URI for non-batch files
+                s3_uri = f"s3://{self._s3_bucket}/{self._s3_object_key}"
+        else:
+            s3_uri = ""
+        return OpenAIFileObject(
+            purpose="batch",
+            id=s3_uri,
+            filename=self._s3_object_key.split("/")[-1] if getattr(self, "_s3_object_key", None) else "",
+            created_at=int(time.time()),
+            status="uploaded",
+            bytes=getattr(self, "_uploaded_payload_len", 0),
+            object="file",
+        )
+    def infer_model_id_from_openai_jsonl(self, file_content: str) -> Optional[str]:
+        for raw in file_content.splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except Exception:
+                continue
+            body = obj.get("body") or obj
+            model = body.get("model")
+            if isinstance(model, str) and model:
+                return model
+        return None
+
+    

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -3,13 +3,8 @@ from typing import Any, List, Literal, Optional, TypedDict, Union
 
 from typing_extensions import (
     TYPE_CHECKING,
-    Protocol,
     Required,
-    Self,
-    TypeGuard,
-    get_origin,
     override,
-    runtime_checkable,
 )
 
 from .openai import ChatCompletionToolCallChunk
@@ -574,25 +569,30 @@ class AmazonDeepSeekR1StreamingResponse(TypedDict):
     stop_reason: Optional[str]
     prompt_token_count: int
 
+
 class Tag(TypedDict):
     key: str
     value: str
 
+
 class S3DataConfig(TypedDict):
     s3Uri: str
+
 
 class InputDataConfig(TypedDict):
     s3InputDataConfig: S3DataConfig
 
+
 class OutputDataConfig(TypedDict):
     s3OutputDataConfig: S3DataConfig
 
-class CreateModelInvocationJobRequest(TypedDict):
-    clientRequestToken: Optional[str] = None  # Optional; AWS auto-generates if not provided
+
+class CreateModelInvocationJobRequest(TypedDict, total=False):
+    clientRequestToken: Optional[str]  # Optional; AWS auto-generates if not provided
     jobName: str
     modelId: str
     inputDataConfig: InputDataConfig
     outputDataConfig: OutputDataConfig
     roleArn: str
-    tags: Optional[List[Tag]] = None
-    timeoutDurationInHours: Optional[int] = None
+    tags: Optional[List[Tag]]
+    timeoutDurationInHours: Optional[int]

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -573,3 +573,26 @@ class AmazonDeepSeekR1StreamingResponse(TypedDict):
     generation_token_count: int
     stop_reason: Optional[str]
     prompt_token_count: int
+
+class Tag(TypedDict):
+    key: str
+    value: str
+
+class S3DataConfig(TypedDict):
+    s3Uri: str
+
+class InputDataConfig(TypedDict):
+    s3InputDataConfig: S3DataConfig
+
+class OutputDataConfig(TypedDict):
+    s3OutputDataConfig: S3DataConfig
+
+class CreateModelInvocationJobRequest(TypedDict):
+    clientRequestToken: Optional[str] = None  # Optional; AWS auto-generates if not provided
+    jobName: str
+    modelId: str
+    inputDataConfig: InputDataConfig
+    outputDataConfig: OutputDataConfig
+    roleArn: str
+    tags: Optional[List[Tag]] = None
+    timeoutDurationInHours: Optional[int] = None

--- a/tests/batches_tests/test_bedrock_batches.py
+++ b/tests/batches_tests/test_bedrock_batches.py
@@ -1,0 +1,502 @@
+# What is this?
+## Unit Tests for Bedrock Batches API and Transformation
+import os
+import sys
+from datetime import datetime
+from typing import Any, Dict
+
+import pytest
+
+# Add the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm.llms.bedrock.batches.transformation import BedrockBatchTransformation
+from litellm.types.llms.openai import CreateBatchRequest, LiteLLMBatchCreateRequest
+from litellm.types.utils import LiteLLMBatch
+
+
+class TestBedrockBatchTransformation:
+    """Test cases for BedrockBatchTransformation class"""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method"""
+        self.sample_create_batch_request: CreateBatchRequest = {
+            "completion_window": "24h",
+            "endpoint": "/v1/chat/completions",
+            "input_file_id": "s3://test-bucket/test-model/test-file.jsonl",
+            "metadata": {"job_name": "test-job", "description": "Test batch job"},
+        }
+
+        self.sample_bedrock_response: Dict[str, Any] = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job-123",
+            "jobName": "test-job",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "clientRequestToken": "test-token-123",
+            "roleArn": "arn:aws:iam::123456789012:role/BedrockBatchRole",
+            "status": "InProgress",
+            "message": None,
+            "submitTime": datetime(2024, 1, 15, 10, 0, 0),
+            "lastModifiedTime": datetime(2024, 1, 15, 10, 5, 0),
+            "endTime": None,
+            "inputDataConfig": {
+                "s3InputDataConfig": {
+                    "s3InputFormat": "JSONL",
+                    "s3Uri": "s3://test-bucket/test-model/test-file.jsonl",
+                    "s3BucketOwner": "123456789012",
+                }
+            },
+            "outputDataConfig": {
+                "s3OutputDataConfig": {
+                    "s3Uri": "s3://test-bucket/test-model/output/",
+                    "s3EncryptionKeyId": None,
+                    "s3BucketOwner": "123456789012",
+                }
+            },
+            "vpcConfig": None,
+            "timeoutDurationInHours": 24,
+            "jobExpirationTime": datetime(2024, 1, 16, 10, 0, 0),
+        }
+
+    def test_transform_openai_batch_request_to_bedrock_job_request(self):
+        """Test transforming OpenAI batch request to Bedrock job request"""
+        # Test with all parameters
+        result = BedrockBatchTransformation.transform_openai_batch_request_to_bedrock_job_request(
+            req=self.sample_create_batch_request,
+            s3_input_uri="s3://test-bucket/test-model/test-file.jsonl",
+            s3_output_uri="s3://test-bucket/test-model/output/",
+            role_arn="arn:aws:iam::123456789012:role/BedrockBatchRole",
+        )
+
+        assert result["modelId"] == ""  # No model specified in request
+        assert result["jobName"] == "test-job"
+        assert result["roleArn"] == "arn:aws:iam::123456789012:role/BedrockBatchRole"
+        assert (
+            result["inputDataConfig"]["s3InputDataConfig"]["s3Uri"]
+            == "s3://test-bucket/test-model/test-file.jsonl"
+        )
+        assert (
+            result["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"]
+            == "s3://test-bucket/test-model/output/"
+        )
+
+    def test_transform_openai_batch_request_to_bedrock_job_request_with_model(self):
+        """Test transforming OpenAI batch request with model specified"""
+        request_with_model = self.sample_create_batch_request.copy()
+        request_with_model["model"] = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+        result = BedrockBatchTransformation.transform_openai_batch_request_to_bedrock_job_request(
+            req=request_with_model,
+            s3_input_uri="s3://test-bucket/test-model/test-file.jsonl",
+            s3_output_uri="s3://test-bucket/test-model/output/",
+            role_arn="arn:aws:iam::123456789012:role/BedrockBatchRole",
+        )
+
+        assert result["modelId"] == "anthropic.claude-3-sonnet-20240229-v1:0"
+
+    def test_transform_openai_batch_request_to_bedrock_job_request_with_custom_id(self):
+        """Test transforming OpenAI batch request with custom_id instead of metadata job_name"""
+        request_with_custom_id = self.sample_create_batch_request.copy()
+        del request_with_custom_id["metadata"]
+        request_with_custom_id["custom_id"] = "custom-job-123"
+
+        result = BedrockBatchTransformation.transform_openai_batch_request_to_bedrock_job_request(
+            req=request_with_custom_id,
+            s3_input_uri="s3://test-bucket/test-model/test-file.jsonl",
+            s3_output_uri="s3://test-bucket/test-model/output/",
+            role_arn="arn:aws:iam::123456789012:role/BedrockBatchRole",
+        )
+
+        assert result["jobName"] == "custom-job-123"
+
+    def test_transform_openai_batch_request_to_bedrock_job_request_fallback_name(self):
+        """Test transforming OpenAI batch request with fallback job name"""
+        request_minimal = {
+            "completion_window": "24h",
+            "endpoint": "/v1/chat/completions",
+            "input_file_id": "s3://test-bucket/test-model/test-file.jsonl",
+        }
+
+        result = BedrockBatchTransformation.transform_openai_batch_request_to_bedrock_job_request(
+            req=request_minimal,
+            s3_input_uri="s3://test-bucket/test-model/test-file.jsonl",
+            s3_output_uri="s3://test-bucket/test-model/output/",
+            role_arn=None,
+        )
+
+        assert result["jobName"] == "litellm-batch-job"
+        assert result["roleArn"] == ""
+
+    def test_transform_bedrock_response_to_openai_batch_in_progress(self):
+        """Test transforming Bedrock response with InProgress status"""
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=self.sample_bedrock_response
+        )
+
+        assert isinstance(result, LiteLLMBatch)
+        assert result.id == "test-job-123"
+        assert result.status == "in_progress"
+        assert result.object == "batch"
+        assert result.endpoint == "/v1/chat/completions"
+        assert result.input_file_id == "s3://test-bucket/test-model/test-file.jsonl"
+        assert result.output_file_id == "s3://test-bucket/test-model/output/"
+        assert result.created_at == int(datetime(2024, 1, 15, 10, 0, 0).timestamp())
+        assert result.in_progress_at == int(datetime(2024, 1, 15, 10, 5, 0).timestamp())
+        assert result.completed_at is None
+        assert result.failed_at is None
+        assert result.completion_window == "24h"
+        assert result.errors is None
+        assert result.request_counts is None
+
+    def test_transform_bedrock_response_to_openai_batch_completed(self):
+        """Test transforming Bedrock response with Completed status"""
+        completed_response = self.sample_bedrock_response.copy()
+        completed_response["status"] = "Completed"
+        completed_response["endTime"] = datetime(2024, 1, 15, 11, 0, 0)
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=completed_response
+        )
+
+        assert result.status == "completed"
+        assert result.completed_at == int(datetime(2024, 1, 15, 11, 0, 0).timestamp())
+        assert result.in_progress_at is None
+        assert result.failed_at is None
+
+    def test_transform_bedrock_response_to_openai_batch_failed(self):
+        """Test transforming Bedrock response with Failed status"""
+        failed_response = self.sample_bedrock_response.copy()
+        failed_response["status"] = "Failed"
+        failed_response["endTime"] = datetime(2024, 1, 15, 10, 30, 0)
+        failed_response["message"] = "Job failed due to invalid input format"
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=failed_response
+        )
+
+        assert result.status == "failed"
+        assert result.failed_at == int(datetime(2024, 1, 15, 10, 30, 0).timestamp())
+        assert result.errors is not None
+        assert result.errors.object == "list"
+        assert len(result.errors.data) == 1
+        assert result.errors.data[0].object == "error"
+        assert result.errors.data[0].code == "Failed"
+        assert result.errors.data[0].message == "Job failed due to invalid input format"
+
+    def test_transform_bedrock_response_to_openai_batch_cancelled(self):
+        """Test transforming Bedrock response with Stopped status"""
+        cancelled_response = self.sample_bedrock_response.copy()
+        cancelled_response["status"] = "Stopped"
+        cancelled_response["endTime"] = datetime(2024, 1, 15, 10, 15, 0)
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=cancelled_response
+        )
+
+        assert result.status == "cancelled"
+        # The cancelled_at timestamp should come from lastModifiedTime, not endTime
+        assert result.cancelled_at == int(datetime(2024, 1, 15, 10, 5, 0).timestamp())
+
+    def test_transform_bedrock_response_to_openai_batch_cancelling(self):
+        """Test transforming Bedrock response with Stopping status"""
+        cancelling_response = self.sample_bedrock_response.copy()
+        cancelling_response["status"] = "Stopping"
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=cancelling_response
+        )
+
+        assert result.status == "cancelling"
+        assert result.cancelling_at == int(datetime(2024, 1, 15, 10, 5, 0).timestamp())
+
+    def test_transform_bedrock_response_to_openai_batch_with_input_file_id_override(
+        self,
+    ):
+        """Test transforming Bedrock response with custom input_file_id override"""
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=self.sample_bedrock_response,
+            input_file_id="custom-input-file-id",
+        )
+
+        assert result.input_file_id == "custom-input-file-id"
+
+    def test_transform_bedrock_response_to_openai_batch_metadata(self):
+        """Test transforming Bedrock response metadata extraction"""
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=self.sample_bedrock_response
+        )
+
+        assert result.metadata is not None
+        assert result.metadata["job_name"] == "test-job"
+        assert result.metadata["model_id"] == "anthropic.claude-3-sonnet-20240229-v1:0"
+        assert (
+            result.metadata["job_arn"]
+            == "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job-123"
+        )
+        assert result.metadata["failure_message"] == ""
+
+    def test_transform_bedrock_response_to_openai_batch_expired(self):
+        """Test transforming Bedrock response with Expired status"""
+        expired_response = self.sample_bedrock_response.copy()
+        expired_response["status"] = "Expired"
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=expired_response
+        )
+
+        assert result.status == "expired"
+        assert result.expires_at == int(datetime(2024, 1, 16, 10, 0, 0).timestamp())
+
+    def test_transform_bedrock_response_to_openai_batch_partially_completed(self):
+        """Test transforming Bedrock response with PartiallyCompleted status"""
+        partial_response = self.sample_bedrock_response.copy()
+        partial_response["status"] = "PartiallyCompleted"
+        partial_response["endTime"] = datetime(2024, 1, 15, 10, 45, 0)
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=partial_response
+        )
+
+        assert result.status == "completed"  # Maps to completed
+        assert result.completed_at == int(datetime(2024, 1, 15, 10, 45, 0).timestamp())
+
+    def test_transform_bedrock_response_to_openai_batch_unknown_status(self):
+        """Test transforming Bedrock response with unknown status"""
+        unknown_response = self.sample_bedrock_response.copy()
+        unknown_response["status"] = "UnknownStatus"
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=unknown_response
+        )
+
+        assert result.status == "failed"  # Default fallback
+
+    def test_transform_bedrock_response_to_openai_batch_missing_fields(self):
+        """Test transforming Bedrock response with missing optional fields"""
+        minimal_response = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/minimal-job",
+            "status": "InProgress",
+            "submitTime": datetime(2024, 1, 15, 10, 0, 0),  # Required for created_at
+        }
+
+        result = BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+            bedrock_response=minimal_response
+        )
+
+        assert result.id == "minimal-job"
+        assert result.status == "in_progress"
+        assert result.input_file_id == ""
+        assert result.output_file_id is None
+        assert result.created_at == int(datetime(2024, 1, 15, 10, 0, 0).timestamp())
+        assert result.metadata["job_name"] == ""
+        assert result.metadata["model_id"] == ""
+
+    def test_get_batch_id_from_bedrock_response(self):
+        """Test extracting batch ID from Bedrock ARN"""
+        job_arn = (
+            "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job-456"
+        )
+        job_id = BedrockBatchTransformation._get_batch_id_from_bedrock_response(job_arn)
+        assert job_id == "test-job-456"
+
+    def test_get_batch_id_from_bedrock_response_empty_arn(self):
+        """Test extracting batch ID from empty ARN"""
+        job_id = BedrockBatchTransformation._get_batch_id_from_bedrock_response("")
+        assert job_id == ""
+
+    def test_get_batch_id_from_bedrock_response_no_slashes(self):
+        """Test extracting batch ID from ARN with no slashes"""
+        job_id = BedrockBatchTransformation._get_batch_id_from_bedrock_response(
+            "simple-arn"
+        )
+        assert job_id == "simple-arn"
+
+    def test_get_input_file_id_from_bedrock_response(self):
+        """Test extracting input file ID from Bedrock response"""
+        input_uri = BedrockBatchTransformation._get_input_file_id_from_bedrock_response(
+            self.sample_bedrock_response
+        )
+        assert input_uri == "s3://test-bucket/test-model/test-file.jsonl"
+
+    def test_get_output_file_id_from_bedrock_response(self):
+        """Test extracting output file ID from Bedrock response"""
+        output_uri = (
+            BedrockBatchTransformation._get_output_file_id_from_bedrock_response(
+                self.sample_bedrock_response
+            )
+        )
+        assert output_uri == "s3://test-bucket/test-model/output/"
+
+    def test_get_error_information_from_bedrock_response_failed(self):
+        """Test extracting error information from failed Bedrock response"""
+        failed_response = self.sample_bedrock_response.copy()
+        failed_response["status"] = "Failed"
+        failed_response["message"] = "Test error message"
+
+        (
+            error_file_id,
+            errors,
+        ) = BedrockBatchTransformation._get_error_information_from_bedrock_response(
+            failed_response, "failed"
+        )
+
+        assert error_file_id is None
+        assert errors is not None
+        assert errors["data"][0]["message"] == "Test error message"
+
+    def test_get_error_information_from_bedrock_response_success(self):
+        """Test extracting error information from successful Bedrock response"""
+        (
+            error_file_id,
+            errors,
+        ) = BedrockBatchTransformation._get_error_information_from_bedrock_response(
+            self.sample_bedrock_response, "in_progress"
+        )
+
+        assert error_file_id is None
+        assert errors is None
+
+    def test_get_metadata_from_bedrock_response(self):
+        """Test extracting metadata from Bedrock response"""
+        metadata = BedrockBatchTransformation._get_metadata_from_bedrock_response(
+            self.sample_bedrock_response,
+            "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job-123",
+        )
+
+        assert metadata["job_name"] == "test-job"
+        assert metadata["model_id"] == "anthropic.claude-3-sonnet-20240229-v1:0"
+        assert (
+            metadata["job_arn"]
+            == "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job-123"
+        )
+        assert metadata["failure_message"] == ""
+
+
+class TestBedrockBatchTransformationIntegration:
+    """Integration tests for Bedrock batch transformation with real data structures"""
+
+    def test_full_transformation_cycle(self):
+        """Test complete transformation cycle from OpenAI request to Bedrock response"""
+        # Create OpenAI batch request
+        openai_request: LiteLLMBatchCreateRequest = {
+            "completion_window": "24h",
+            "endpoint": "/v1/chat/completions",
+            "input_file_id": "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/input.jsonl",
+            "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "metadata": {
+                "job_name": "integration-test",
+                "description": "Full cycle test",
+            },
+        }
+
+        # Transform to Bedrock request
+        bedrock_request = BedrockBatchTransformation.transform_openai_batch_request_to_bedrock_job_request(
+            req=openai_request,
+            s3_input_uri="s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/input.jsonl",
+            s3_output_uri="s3://test-bucket/claude-model/output/",
+            role_arn="arn:aws:iam::123456789012:role/BedrockBatchRole",
+        )
+
+        # Verify Bedrock request structure
+        assert bedrock_request["modelId"] == "anthropic.claude-3-sonnet-20240229-v1:0"
+        assert bedrock_request["jobName"] == "integration-test"
+        assert (
+            bedrock_request["inputDataConfig"]["s3InputDataConfig"]["s3Uri"]
+            == "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/input.jsonl"
+        )
+        assert (
+            bedrock_request["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"]
+            == "s3://test-bucket/claude-model/output/"
+        )
+
+        # Simulate Bedrock response
+        bedrock_response = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/integration-test-789",
+            "jobName": "integration-test",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "status": "Completed",
+            "submitTime": datetime(2024, 1, 15, 12, 0, 0),
+            "endTime": datetime(2024, 1, 15, 13, 0, 0),
+            "inputDataConfig": {
+                "s3InputDataConfig": {
+                    "s3Uri": "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/input.jsonl"
+                }
+            },
+            "outputDataConfig": {
+                "s3OutputDataConfig": {"s3Uri": "s3://test-bucket/claude-model/output/"}
+            },
+        }
+
+        # Transform back to OpenAI format
+        openai_response = (
+            BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+                bedrock_response=bedrock_response,
+                input_file_id=openai_request["input_file_id"],
+            )
+        )
+
+        # Verify OpenAI response structure
+        assert openai_response.id == "integration-test-789"
+        assert openai_response.status == "completed"
+        assert (
+            openai_response.input_file_id
+            == "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/input.jsonl"
+        )
+        assert openai_response.output_file_id == "s3://test-bucket/claude-model/output/"
+        assert openai_response.created_at == int(
+            datetime(2024, 1, 15, 12, 0, 0).timestamp()
+        )
+        assert openai_response.completed_at == int(
+            datetime(2024, 1, 15, 13, 0, 0).timestamp()
+        )
+
+    def test_status_mapping_coverage(self):
+        """Test that all Bedrock statuses are properly mapped"""
+        all_bedrock_statuses = [
+            "Submitted",
+            "InProgress",
+            "Completed",
+            "Failed",
+            "Stopping",
+            "Stopped",
+            "PartiallyCompleted",
+            "Expired",
+            "Validating",
+            "Scheduled",
+        ]
+
+        expected_openai_statuses = [
+            "validating",
+            "in_progress",
+            "completed",
+            "failed",
+            "cancelling",
+            "cancelled",
+            "completed",
+            "expired",
+            "validating",
+            "validating",
+        ]
+
+        for bedrock_status, expected_openai_status in zip(
+            all_bedrock_statuses, expected_openai_statuses
+        ):
+            response = {
+                "status": bedrock_status,
+                "jobArn": "test-arn",
+                "submitTime": datetime(
+                    2024, 1, 15, 10, 0, 0
+                ),  # Required for created_at
+            }
+            result = (
+                BedrockBatchTransformation.transform_bedrock_response_to_openai_batch(
+                    response
+                )
+            )
+            assert (
+                result.status == expected_openai_status
+            ), f"Status {bedrock_status} should map to {expected_openai_status}"
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v"])

--- a/tests/batches_tests/test_bedrock_batches_handler.py
+++ b/tests/batches_tests/test_bedrock_batches_handler.py
@@ -1,0 +1,460 @@
+# What is this?
+## Unit Tests for Bedrock Batches Handler
+import json
+import os
+import sys
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typing import Dict, Any
+
+# Add the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.llms.bedrock.batches.handler import BedrockBatchesAPI
+from litellm.types.llms.openai import CreateBatchRequest
+from litellm.types.utils import LiteLLMBatch
+
+
+class TestBedrockBatchesHandler:
+    """Test cases for BedrockBatchesAPI handler class"""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method"""
+        self.handler = BedrockBatchesAPI()
+        
+        self.sample_create_batch_data: CreateBatchRequest = {
+            "completion_window": "24h",
+            "endpoint": "/v1/chat/completions",
+            "input_file_id": "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/test-file.jsonl",
+            "metadata": {"job_name": "test-handler-job", "description": "Test handler job"},
+            "model": "anthropic.claude-3-sonnet-20240229-v1:0"
+        }
+
+        self.sample_bedrock_job_response = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-handler-job-123",
+            "jobName": "test-handler-job",
+            "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "status": "InProgress",
+            "submitTime": datetime(2024, 1, 15, 10, 0, 0),
+            "lastModifiedTime": datetime(2024, 1, 15, 10, 5, 0),
+            "endTime": None,
+            "inputDataConfig": {
+                "s3InputDataConfig": {
+                    "s3Uri": "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/test-file.jsonl"
+                }
+            },
+            "outputDataConfig": {
+                "s3OutputDataConfig": {
+                    "s3Uri": "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/"
+                }
+            }
+        }
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_create_batch_success(self, mock_init_client):
+        """Test successful batch creation"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock create_model_invocation_job response
+        mock_client.create_model_invocation_job.return_value = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-handler-job-123"
+        }
+        
+        # Mock get_model_invocation_job response
+        mock_client.get_model_invocation_job.return_value = self.sample_bedrock_job_response
+
+        result = self.handler.create_batch(
+            _is_async=False,
+            create_batch_data=self.sample_create_batch_data,
+            timeout=3600.0,
+            max_retries=None,
+            litellm_params={},
+            api_base=None,
+            logging_obj=None,
+            client=None
+        )
+
+        # Verify the result
+        assert isinstance(result, LiteLLMBatch)
+        assert result.id == "test-handler-job-123"
+        assert result.status == "in_progress"
+        assert result.object == "batch"
+        assert result.endpoint == "/v1/chat/completions"
+        assert result.input_file_id == "s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/test-file.jsonl"
+        assert result.completion_window == "24h"
+
+        # Verify client calls
+        mock_client.create_model_invocation_job.assert_called_once()
+        mock_client.get_model_invocation_job.assert_called_once()
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_create_batch_fallback_when_no_job_arn(self, mock_init_client):
+        """Test batch creation fallback when job ARN is not returned"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock create_model_invocation_job response without jobArn
+        mock_client.create_model_invocation_job.return_value = {}
+
+        result = self.handler.create_batch(
+            _is_async=False,
+            create_batch_data=self.sample_create_batch_data,
+            timeout=3600.0,
+            max_retries=None,
+            litellm_params={},
+            api_base=None,
+            logging_obj=None,
+            client=None
+        )
+
+        # Verify fallback result
+        assert isinstance(result, LiteLLMBatch)
+        assert result.status == "validating"
+        assert result.object == "batch"
+        assert result.endpoint == "/v1/chat/completions"
+        assert result.completion_window == "24h"
+
+    def test_create_batch_invalid_s3_uri(self):
+        """Test batch creation with invalid S3 URI"""
+        invalid_batch_data = self.sample_create_batch_data.copy()
+        invalid_batch_data["input_file_id"] = "invalid-uri"
+
+        with pytest.raises(ValueError, match="input_file_id must be an s3:// URI for Bedrock batch jobs"):
+            self.handler.create_batch(
+                _is_async=False,
+                create_batch_data=invalid_batch_data,
+                timeout=3600.0,
+                max_retries=None,
+                litellm_params={},
+                api_base=None,
+                logging_obj=None,
+                client=None
+            )
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_create_batch_extract_model_from_s3_path(self, mock_init_client):
+        """Test extracting model ID from S3 path when not explicitly provided"""
+        batch_data_without_model = self.sample_create_batch_data.copy()
+        del batch_data_without_model["model"]
+        
+        # The S3 path contains the model ID: s3://test-bucket/anthropic.claude-3-sonnet-20240229-v1:0/test-file.jsonl
+        # So the model should be extracted as: anthropic.claude-3-sonnet-20240229-v1:0
+        
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        mock_client.create_model_invocation_job.return_value = {
+            "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job"
+        }
+        
+        mock_client.get_model_invocation_job.return_value = self.sample_bedrock_job_response
+
+        result = self.handler.create_batch(
+            _is_async=False,
+            create_batch_data=batch_data_without_model,
+            timeout=3600.0,
+            max_retries=None,
+            litellm_params={},
+            api_base=None,
+            logging_obj=None,
+            client=None
+        )
+
+        # Verify the result
+        assert isinstance(result, LiteLLMBatch)
+        assert result.id == "test-handler-job-123"
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_retrieve_batch_success(self, mock_init_client):
+        """Test successful batch retrieval"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock get_model_invocation_job response
+        mock_client.get_model_invocation_job.return_value = self.sample_bedrock_job_response
+
+        result = self.handler.retrieve_batch(
+            batch_id="test-handler-job-123",
+            _is_async=False,
+            api_base=None,
+            litellm_params={}
+        )
+
+        # Verify the result
+        assert isinstance(result, LiteLLMBatch)
+        assert result.id == "test-handler-job-123"
+        assert result.status == "in_progress"
+        assert result.object == "batch"
+
+        # Verify client call
+        mock_client.get_model_invocation_job.assert_called_once_with(jobIdentifier="test-handler-job-123")
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_cancel_batch_success(self, mock_init_client):
+        """Test successful batch cancellation"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock stop_model_invocation_job response
+        mock_client.stop_model_invocation_job.return_value = {}
+        
+        # Mock get_model_invocation_job response for updated status
+        cancelled_response = self.sample_bedrock_job_response.copy()
+        cancelled_response["status"] = "Stopped"
+        cancelled_response["endTime"] = datetime(2024, 1, 15, 10, 15, 0)
+        mock_client.get_model_invocation_job.return_value = cancelled_response
+
+        result = self.handler.cancel_batch(
+            batch_id="test-handler-job-123",
+            _is_async=False,
+            api_base=None,
+            litellm_params={}
+        )
+
+        # Verify the result
+        assert isinstance(result, LiteLLMBatch)
+        assert result.id == "test-handler-job-123"
+        assert result.status == "cancelled"
+
+        # Verify client calls
+        mock_client.stop_model_invocation_job.assert_called_once_with(jobIdentifier="test-handler-job-123")
+        mock_client.get_model_invocation_job.assert_called_once_with(jobIdentifier="test-handler-job-123")
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_list_batches_success(self, mock_init_client):
+        """Test successful batch listing"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock list_model_invocation_jobs response
+        mock_client.list_model_invocation_jobs.return_value = {
+            "nextToken": "next-page-token",
+            "invocationJobSummaries": [
+                {
+                    "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/job-1",
+                    "status": "Completed",
+                    "submitTime": datetime(2024, 1, 15, 10, 0, 0),
+                    "endTime": datetime(2024, 1, 15, 11, 0, 0),
+                    "inputDataConfig": {
+                        "s3InputDataConfig": {
+                            "s3Uri": "s3://test-bucket/model/input1.jsonl"
+                        }
+                    },
+                    "outputDataConfig": {
+                        "s3OutputDataConfig": {
+                            "s3Uri": "s3://test-bucket/model/output1/"
+                        }
+                    }
+                },
+                {
+                    "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/job-2",
+                    "status": "InProgress",
+                    "submitTime": datetime(2024, 1, 15, 12, 0, 0),
+                    "lastModifiedTime": datetime(2024, 1, 15, 12, 5, 0),
+                    "inputDataConfig": {
+                        "s3InputDataConfig": {
+                            "s3Uri": "s3://test-bucket/model/input2.jsonl"
+                        }
+                    },
+                    "outputDataConfig": {
+                        "s3OutputDataConfig": {
+                            "s3Uri": "s3://test-bucket/model/output2/"
+                        }
+                    }
+                }
+            ]
+        }
+
+        result = self.handler.list_batches(
+            _is_async=False,
+            api_base=None,
+            litellm_params={},
+            after="2024-01-15T00:00:00Z",
+            limit=10
+        )
+
+        # Verify the result structure
+        assert result["object"] == "list"
+        assert len(result["data"]) == 2
+        assert result["has_more"] is True
+        assert result["first_id"] == "job-1"
+        assert result["last_id"] == "job-2"
+
+        # Verify the transformed batch data
+        first_batch = result["data"][0]
+        assert first_batch["id"] == "job-1"
+        assert first_batch["status"] == "completed"
+        assert first_batch["object"] == "batch"
+
+        second_batch = result["data"][1]
+        assert second_batch["id"] == "job-2"
+        assert second_batch["status"] == "in_progress"
+        assert second_batch["object"] == "batch"
+
+        # Verify client call
+        mock_client.list_model_invocation_jobs.assert_called_once()
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_list_batches_with_limit(self, mock_init_client):
+        """Test batch listing with limit parameter"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock empty response
+        mock_client.list_model_invocation_jobs.return_value = {
+            "invocationJobSummaries": []
+        }
+
+        result = self.handler.list_batches(
+            _is_async=False,
+            api_base=None,
+            litellm_params={},
+            after=None,
+            limit=5
+        )
+
+        # Verify the result
+        assert result["object"] == "list"
+        assert len(result["data"]) == 0
+        assert result["has_more"] is False
+        assert result["first_id"] is None
+        assert result["last_id"] is None
+
+        # Verify client call with limit and default parameters
+        mock_client.list_model_invocation_jobs.assert_called_once()
+        call_args = mock_client.list_model_invocation_jobs.call_args[1]
+        assert call_args["maxResults"] == 5
+        assert "sortBy" in call_args
+        assert "sortOrder" in call_args
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_list_batches_with_after_timestamp(self, mock_init_client):
+        """Test batch listing with after timestamp parameter"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock response
+        mock_client.list_model_invocation_jobs.return_value = {
+            "invocationJobSummaries": []
+        }
+
+        result = self.handler.list_batches(
+            _is_async=False,
+            api_base=None,
+            litellm_params={},
+            after="2024-01-15T10:00:00Z",
+            limit=None
+        )
+
+        # Verify client call includes timestamp conversion
+        mock_client.list_model_invocation_jobs.assert_called_once()
+        call_args = mock_client.list_model_invocation_jobs.call_args[1]
+        assert "submitTimeAfter" in call_args
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_list_batches_invalid_timestamp(self, mock_init_client):
+        """Test batch listing with invalid timestamp parameter"""
+        # Mock the boto3 client
+        mock_client = MagicMock()
+        mock_init_client.return_value = mock_client
+        
+        # Mock response
+        mock_client.list_model_invocation_jobs.return_value = {
+            "invocationJobSummaries": []
+        }
+
+        # Should handle invalid timestamp gracefully
+        result = self.handler.list_batches(
+            _is_async=False,
+            api_base=None,
+            litellm_params={},
+            after="invalid-timestamp",
+            limit=None
+        )
+
+        # Verify the result still works
+        assert result["object"] == "list"
+        assert len(result["data"]) == 0
+
+        # Verify client call without timestamp but with default parameters
+        mock_client.list_model_invocation_jobs.assert_called_once()
+        call_args = mock_client.list_model_invocation_jobs.call_args[1]
+        assert call_args["maxResults"] == 20
+        assert "sortBy" in call_args
+        assert "sortOrder" in call_args
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_create_batch_role_arn_from_config(self, mock_init_client):
+        """Test batch creation with role ARN from litellm config"""
+        # Mock litellm.s3_callback_params
+        with patch.object(litellm, 's3_callback_params', {'s3_aws_role_name': 'arn:aws:iam::123456789012:role/BedrockBatchRole'}):
+            # Mock the boto3 client
+            mock_client = MagicMock()
+            mock_init_client.return_value = mock_client
+            
+            mock_client.create_model_invocation_job.return_value = {
+                "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job"
+            }
+            
+            mock_client.get_model_invocation_job.return_value = self.sample_bedrock_job_response
+
+            result = self.handler.create_batch(
+                _is_async=False,
+                create_batch_data=self.sample_create_batch_data,
+                timeout=3600.0,
+                max_retries=None,
+                litellm_params={},
+                api_base=None,
+                logging_obj=None,
+                client=None
+            )
+
+            # Verify the result
+            assert isinstance(result, LiteLLMBatch)
+            assert result.id == "test-handler-job-123"
+
+    @patch('litellm.llms.bedrock.common_utils.init_bedrock_service_client')
+    def test_create_batch_invalid_role_arn(self, mock_init_client):
+        """Test batch creation with invalid role ARN from config"""
+        # Mock litellm.s3_callback_params with invalid role ARN
+        with patch.object(litellm, 's3_callback_params', {'s3_aws_role_name': 'invalid-role-name'}):
+            # Mock the boto3 client
+            mock_client = MagicMock()
+            mock_init_client.return_value = mock_client
+            
+            mock_client.create_model_invocation_job.return_value = {
+                "jobArn": "arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/test-job"
+            }
+            
+            mock_client.get_model_invocation_job.return_value = self.sample_bedrock_job_response
+
+            result = self.handler.create_batch(
+                _is_async=False,
+                create_batch_data=self.sample_create_batch_data,
+                timeout=3600.0,
+                max_retries=None,
+                litellm_params={},
+                api_base=None,
+                logging_obj=None,
+                client=None
+            )
+
+            # Verify the result still works (role ARN should be ignored)
+            assert isinstance(result, LiteLLMBatch)
+            assert result.id == "test-handler-job-123"
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Feat: Batch completion features for AWS Bedrock

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
Full implementation of OpenAI's batch API endpoints (/v1/batches) that automatically translates to Bedrock's Batch Inference API calls

### Breaking Changes

None. This is a purely additive feature that maintains full backward compatibility.



