### PR TITLE
Fix LangfuseOtelSpanAttributes constants to match expected values at langfuse

### DIFF
--- a/litellm/types/integrations/langfuse_otel.py
+++ b/litellm/types/integrations/langfuse_otel.py
@@ -25,8 +25,8 @@ class LangfuseSpanAttributes(str, Enum):
     MASK_OUTPUT = "langfuse.generation.mask_output"
 
     # ---- Trace-level metadata ----
-    TRACE_USER_ID = "langfuse.trace.user_id"
-    SESSION_ID = "langfuse.trace.session_id"
+    TRACE_USER_ID = "user.id"
+    SESSION_ID = "session.id"
     TAGS = "langfuse.trace.tags"
     TRACE_NAME = "langfuse.trace.name"
     TRACE_ID = "langfuse.trace.id"


### PR DESCRIPTION
## Fix LangfuseOtelSpanAttributes constants to match expected values at langfuse

Langfuse expect the following attributes:  https://python.reference.langfuse.com/langfuse#LangfuseOtelSpanAttributes

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

This is a small bug fix and is only really testable on the langfuse website.

- [x] I have added a screenshot of my new test passing locally 

<img width="1510" height="466" alt="Screenshot 2025-08-15 at 18 08 45" src="https://github.com/user-attachments/assets/5106126b-69c7-4a26-9340-905e87b3988c" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
All except 2 which depend on redis - but its a tiny fix - no code has changed.

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
- Update TRACE_USER_ID from 'langfuse.trace.user_id' to 'user.id'
- Update SESSION_ID from 'langfuse.trace.session_id' to 'session.id'

