### PR TITLE
feat: Add conditional auth header for Ollama Turbo

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -229,6 +229,12 @@ class OllamaChatConfig(BaseConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        # Add authorization header if api_key is provided
+        if api_key is not None:
+            if api_base and api_base.startswith("https://ollama.com"):
+                headers["Authorization"] = api_key
+            else:
+                headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
     def get_complete_url(

--- a/litellm/llms/ollama/completion/handler.py
+++ b/litellm/llms/ollama/completion/handler.py
@@ -13,7 +13,6 @@ from litellm.types.utils import EmbeddingResponse
 def _prepare_ollama_embedding_payload(
     model: str, prompts: List[str], optional_params: Dict[str, Any]
 ) -> Dict[str, Any]:
-
     data: Dict[str, Any] = {"model": model, "input": prompts}
     special_optional_params = ["truncate", "options", "keep_alive"]
 
@@ -78,13 +77,23 @@ async def ollama_aembeddings(
     optional_params: dict,
     logging_obj: Any,
     encoding: Any,
+    api_key: str = None,
 ):
     if not api_base.endswith("/api/embed"):
         api_base += "/api/embed"
 
     data = _prepare_ollama_embedding_payload(model, prompts, optional_params)
 
-    response = await litellm.module_level_aclient.post(url=api_base, json=data)
+    headers = {}
+    if api_key is not None:
+        if api_base.startswith("https://ollama.com"):
+            headers["Authorization"] = api_key
+        else:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+    response = await litellm.module_level_aclient.post(
+        url=api_base, json=data, headers=headers
+    )
     response_json = response.json()
 
     return _process_ollama_embedding_response(
@@ -105,13 +114,23 @@ def ollama_embeddings(
     model_response: EmbeddingResponse,
     logging_obj: Any,
     encoding: Any = None,
+    api_key: str = None,
 ):
     if not api_base.endswith("/api/embed"):
         api_base += "/api/embed"
 
     data = _prepare_ollama_embedding_payload(model, prompts, optional_params)
 
-    response = litellm.module_level_client.post(url=api_base, json=data)
+    headers = {}
+    if api_key is not None:
+        if api_base.startswith("https://ollama.com"):
+            headers["Authorization"] = api_key
+        else:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+    response = litellm.module_level_client.post(
+        url=api_base, json=data, headers=headers
+    )
     response_json = response.json()
 
     return _process_ollama_embedding_response(

--- a/litellm/llms/ollama/completion/handler.py
+++ b/litellm/llms/ollama/completion/handler.py
@@ -4,7 +4,7 @@ Ollama /chat/completion calls handled in llm_http_handler.py
 [TODO]: migrate embeddings to a base handler as well.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import litellm
 from litellm.types.utils import EmbeddingResponse
@@ -77,7 +77,7 @@ async def ollama_aembeddings(
     optional_params: dict,
     logging_obj: Any,
     encoding: Any,
-    api_key: str = None,
+    api_key: Optional[str] = None,
 ):
     if not api_base.endswith("/api/embed"):
         api_base += "/api/embed"
@@ -114,7 +114,7 @@ def ollama_embeddings(
     model_response: EmbeddingResponse,
     logging_obj: Any,
     encoding: Any = None,
-    api_key: str = None,
+    api_key: Optional[str] = None,
 ):
     if not api_base.endswith("/api/embed"):
         api_base += "/api/embed"

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -379,6 +379,12 @@ class OllamaConfig(BaseConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
+        # Add authorization header if api_key is provided
+        if api_key is not None:
+            if api_base and api_base.startswith("https://ollama.com"):
+                headers["Authorization"] = api_key
+            else:
+                headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
     def get_complete_url(
@@ -425,7 +431,9 @@ class OllamaTextCompletionResponseIterator(BaseModelResponseIterator):
     ) -> Union[GenericStreamingChunk, ModelResponseStream]:
         return self.chunk_parser(json.loads(str_line))
 
-    def chunk_parser(self, chunk: dict) -> Union[GenericStreamingChunk, ModelResponseStream]:
+    def chunk_parser(
+        self, chunk: dict
+    ) -> Union[GenericStreamingChunk, ModelResponseStream]:
         try:
             if "error" in chunk:
                 raise Exception(f"Ollama Error - {chunk}")

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -137,7 +137,10 @@ def get_ollama_response(  # noqa: PLR0915
 
     headers: Optional[dict] = None
     if api_key is not None:
-        headers = {"Authorization": "Bearer {}".format(api_key)}
+        if api_base.startswith("https://ollama.com"):
+            headers = {"Authorization": api_key}
+        else:
+            headers = {"Authorization": "Bearer {}".format(api_key)}
 
     sync_client = litellm.module_level_client
     if client is not None and isinstance(client, HTTPHandler):
@@ -214,7 +217,10 @@ def ollama_completion_stream(url, api_key, data, logging_obj):
         "follow_redirects": True,
     }
     if api_key is not None:
-        _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
+        if url.startswith("https://ollama.com"):
+            _request["headers"] = {"Authorization": api_key}
+        else:
+            _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
     with httpx.stream(**_request) as response:
         try:
             if response.status_code != 200:
@@ -283,7 +289,10 @@ async def ollama_async_streaming(
             "timeout": litellm.request_timeout,
         }
         if api_key is not None:
-            _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
+            if url.startswith("https://ollama.com"):
+                _request["headers"] = {"Authorization": api_key}
+            else:
+                _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
         async with client.stream(**_request) as response:
             if response.status_code != 200:
                 raise OllamaError(
@@ -370,7 +379,10 @@ async def ollama_acompletion(
                 "json": data,
             }
             if api_key is not None:
-                _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
+                if url.startswith("https://ollama.com"):
+                    _request["headers"] = {"Authorization": api_key}
+                else:
+                    _request["headers"] = {"Authorization": "Bearer {}".format(api_key)}
             resp = await session.post(**_request)
 
             if resp.status != 200:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4232,6 +4232,7 @@ def embedding(  # noqa: PLR0915
                 logging_obj=logging,
                 optional_params=optional_params,
                 model_response=EmbeddingResponse(),
+                api_key=api_key,
             )
         elif custom_llm_provider == "sagemaker":
             response = sagemaker_llm.embedding(

--- a/tests/local_testing/test_ollama.py
+++ b/tests/local_testing/test_ollama.py
@@ -140,6 +140,7 @@ def test_ollama_embeddings(mock_embeddings):
             logging_obj=mock.ANY,
             model_response=mock.ANY,
             encoding=mock.ANY,
+            api_key=None,
         )
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
@@ -167,6 +168,7 @@ def test_ollama_aembeddings(mock_aembeddings):
             logging_obj=mock.ANY,
             model_response=mock.ANY,
             encoding=mock.ANY,
+            api_key=None,
         )
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")

--- a/tests/local_testing/test_ollama_turbo_integration.py
+++ b/tests/local_testing/test_ollama_turbo_integration.py
@@ -45,8 +45,8 @@ class TestOllamaTurboAuthHeaders:
                     api_key="test_key_123",
                     client=client,
                 )
-            except Exception as e:
-                print(e)
+            except Exception:
+                pass
 
             mock_post.assert_called()
 
@@ -78,8 +78,8 @@ class TestOllamaTurboAuthHeaders:
                         api_base="https://ollama.com",
                         client=client,
                     )
-                except Exception as e:
-                    print(e)
+                except Exception:
+                    pass
 
                 mock_post.assert_called()
 
@@ -117,8 +117,8 @@ class TestOllamaTurboAuthHeaders:
                     api_base="https://ollama.com",
                     api_key="test_embed_key",
                 )
-            except Exception as e:
-                print(e)
+            except Exception:
+                pass
 
             mock_post.assert_called()
 
@@ -132,8 +132,6 @@ class TestOllamaTurboAuthHeaders:
     def test_ollama_turbo_vision_auth_header(self):
         """Test that vision/multimodal calls to ollama.com get correct auth header."""
         from litellm.llms.custom_httpx.http_handler import HTTPHandler
-        from litellm.llms.ollama.common_utils import _convert_image
-        import json
 
         client = HTTPHandler()
 
@@ -165,8 +163,8 @@ class TestOllamaTurboAuthHeaders:
                         api_key="test_vision_key",
                         client=client,
                     )
-                except Exception as e:
-                    print(e)
+                except Exception:
+                    pass
 
                 mock_post.assert_called()
 
@@ -205,7 +203,6 @@ class TestOllamaTurboIntegration:
             "Ollama Turbo" in response.choices[0].message.content
             or "Hello" in response.choices[0].message.content
         )
-        print(f"LiteLLM Response: {response.choices[0].message.content}")
 
     @integration_tests
     @pytest.mark.skipif(
@@ -244,13 +241,11 @@ class TestOllamaTurboIntegration:
         full_response = "".join(response_parts)
         assert full_response
         assert "Ollama Turbo" in full_response or "Hello" in full_response
-        print(f"Native Ollama Response: {full_response}")
 
     @integration_tests
     @pytest.mark.asyncio
     async def test_litellm_ollama_turbo_async_streaming(self):
         """Test async streaming with Ollama Turbo via LiteLLM."""
-        import asyncio
         from litellm import acompletion
 
         api_key = os.getenv("OLLAMA_API_KEY")
@@ -269,38 +264,3 @@ class TestOllamaTurboIntegration:
 
         full_response = "".join(response_parts)
         assert full_response
-        print(f"Async Streaming Response: {full_response}")
-
-
-if __name__ == "__main__":
-    # Allow running directly for quick testing
-
-    # First run auth header tests (these don't need API key)
-    print("=== Testing Auth Headers ===")
-    auth_test = TestOllamaTurboAuthHeaders()
-    auth_test.test_ollama_turbo_auth_header_without_bearer()
-    print("✓ Auth header test passed")
-
-    auth_test.test_ollama_env_var_pickup()
-    print("✓ Environment variable test passed")
-
-    # Now run integration tests if API key is available
-    if not os.getenv("OLLAMA_API_KEY"):
-        print("\nSet OLLAMA_API_KEY environment variable to run integration tests")
-        sys.exit(0)
-
-    test = TestOllamaTurboIntegration()
-
-    print("\n=== Testing LiteLLM Ollama Turbo ===")
-    test.test_litellm_ollama_turbo_completion()
-
-    print("\n=== Testing Native Ollama Turbo ===")
-    try:
-        test.test_native_ollama_turbo_completion()
-    except Exception as e:
-        print(f"Native test skipped: {e}")
-
-    print("\n=== Testing Async Streaming ===")
-    import asyncio
-
-    asyncio.run(test.test_litellm_ollama_turbo_async_streaming())

--- a/tests/local_testing/test_ollama_turbo_integration.py
+++ b/tests/local_testing/test_ollama_turbo_integration.py
@@ -1,0 +1,306 @@
+"""
+Integration test for Ollama Turbo via LiteLLM and native Ollama client.
+
+This test requires a valid Ollama Turbo API key to run.
+Set the OLLAMA_API_KEY environment variable before running.
+
+Run with: pytest tests/local_testing/test_ollama_turbo_integration.py -v -s
+
+Tests:
+1. Auth header format (without Bearer prefix for ollama.com)
+2. Environment variable pickup (OLLAMA_API_KEY)
+3. Real API calls to Ollama Turbo
+"""
+import os
+import sys
+
+import pytest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from litellm import completion
+
+# Skip integration tests if no API key is provided
+integration_tests = pytest.mark.skipif(
+    not os.getenv("OLLAMA_API_KEY"), reason="OLLAMA_API_KEY not set"
+)
+
+
+class TestOllamaTurboAuthHeaders:
+    """Test auth header formatting for Ollama Turbo."""
+
+    def test_ollama_turbo_auth_header_without_bearer(self):
+        """Test that ollama.com URLs get auth header without Bearer prefix."""
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+        client = HTTPHandler()
+
+        with mock.patch.object(client, "post") as mock_post:
+            try:
+                completion(
+                    model="ollama_chat/gpt-oss:120b",
+                    messages=[{"role": "user", "content": "test"}],
+                    api_base="https://ollama.com",
+                    api_key="test_key_123",
+                    client=client,
+                )
+            except Exception as e:
+                print(e)
+
+            mock_post.assert_called()
+
+            # Check the headers
+            headers = mock_post.call_args.kwargs.get("headers", {})
+
+            # Should NOT have Bearer prefix for ollama.com
+            assert headers.get("Authorization") == "test_key_123"
+            assert "Bearer" not in headers.get("Authorization", "")
+
+    def test_ollama_env_var_pickup(self):
+        """Test that OLLAMA_API_KEY environment variable is picked up."""
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+        # Set the environment variable
+        test_api_key = "env_test_key_789"
+        original_key = os.environ.get("OLLAMA_API_KEY")
+        os.environ["OLLAMA_API_KEY"] = test_api_key
+
+        try:
+            client = HTTPHandler()
+
+            with mock.patch.object(client, "post") as mock_post:
+                try:
+                    # Don't pass api_key explicitly - it should pick up from env
+                    completion(
+                        model="ollama_chat/gpt-oss:120b",
+                        messages=[{"role": "user", "content": "test"}],
+                        api_base="https://ollama.com",
+                        client=client,
+                    )
+                except Exception as e:
+                    print(e)
+
+                mock_post.assert_called()
+
+                # Check the headers
+                headers = mock_post.call_args.kwargs.get("headers", {})
+
+                # Should have the env var value without Bearer prefix
+                assert headers.get("Authorization") == test_api_key
+                assert "Bearer" not in headers.get("Authorization", "")
+
+        finally:
+            # Restore original value
+            if original_key is not None:
+                os.environ["OLLAMA_API_KEY"] = original_key
+            else:
+                del os.environ["OLLAMA_API_KEY"]
+
+    def test_ollama_turbo_embedding_auth_header(self):
+        """Test that embedding calls to ollama.com get correct auth header."""
+        import litellm
+
+        with mock.patch.object(litellm.module_level_client, "post") as mock_post:
+            # Mock the embedding response
+            mock_response = mock.Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"embeddings": [[0.1, 0.2, 0.3]]}
+            mock_post.return_value = mock_response
+
+            try:
+                from litellm import embedding
+
+                embedding(
+                    model="ollama/nomic-embed-text",
+                    input=["test embedding"],
+                    api_base="https://ollama.com",
+                    api_key="test_embed_key",
+                )
+            except Exception as e:
+                print(e)
+
+            mock_post.assert_called()
+
+            # Check the headers for embedding call
+            headers = mock_post.call_args.kwargs.get("headers", {})
+
+            # Should NOT have Bearer prefix for ollama.com
+            assert headers.get("Authorization") == "test_embed_key"
+            assert "Bearer" not in headers.get("Authorization", "")
+
+    def test_ollama_turbo_vision_auth_header(self):
+        """Test that vision/multimodal calls to ollama.com get correct auth header."""
+        from litellm.llms.custom_httpx.http_handler import HTTPHandler
+        from litellm.llms.ollama.common_utils import _convert_image
+        import json
+
+        client = HTTPHandler()
+
+        # Mock the image conversion to avoid PIL dependency
+        with mock.patch(
+            "litellm.llms.ollama.common_utils._convert_image"
+        ) as mock_convert:
+            mock_convert.return_value = "base64_image_data"
+
+            with mock.patch.object(client, "post") as mock_post:
+                try:
+                    completion(
+                        model="ollama/llama3.2-vision:11b",
+                        messages=[
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "What's in this image?"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "https://dummyimage.com/100/100/fff&text=Test+image"
+                                        },
+                                    },
+                                ],
+                            }
+                        ],
+                        api_base="https://ollama.com",
+                        api_key="test_vision_key",
+                        client=client,
+                    )
+                except Exception as e:
+                    print(e)
+
+                mock_post.assert_called()
+
+                # Check the headers for vision call
+                headers = mock_post.call_args.kwargs.get("headers", {})
+
+                # Should NOT have Bearer prefix for ollama.com
+                assert headers.get("Authorization") == "test_vision_key"
+                assert "Bearer" not in headers.get("Authorization", "")
+
+
+class TestOllamaTurboIntegration:
+    """Integration tests for Ollama Turbo service."""
+
+    @integration_tests
+    def test_litellm_ollama_turbo_completion(self):
+        """Test Ollama Turbo via LiteLLM completion."""
+        api_key = os.getenv("OLLAMA_API_KEY")
+
+        response = completion(
+            model="ollama/gpt-oss:120b",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {
+                    "role": "user",
+                    "content": "Say 'Hello from Ollama Turbo via LiteLLM' and nothing else.",
+                },
+            ],
+            api_base="https://ollama.com",
+            api_key=api_key,
+            max_tokens=50,
+        )
+
+        assert response.choices[0].message.content
+        assert (
+            "Ollama Turbo" in response.choices[0].message.content
+            or "Hello" in response.choices[0].message.content
+        )
+        print(f"LiteLLM Response: {response.choices[0].message.content}")
+
+    @integration_tests
+    @pytest.mark.skipif(
+        not os.path.exists(
+            os.path.expanduser(
+                "~/.local/share/pipx/venvs/poetry/lib/python3.12/site-packages/ollama"
+            )
+        ),
+        reason="ollama package not installed",
+    )
+    def test_native_ollama_turbo_completion(self):
+        """Test Ollama Turbo via native Ollama client."""
+        try:
+            from ollama import Client
+        except ImportError:
+            pytest.skip("ollama package not installed")
+
+        api_key = os.getenv("OLLAMA_API_KEY")
+
+        client = Client(
+            host="https://ollama.com", headers={"Authorization": f"{api_key}"}
+        )
+
+        messages = [
+            {
+                "role": "user",
+                "content": 'Say "Hello from Ollama Turbo native client" and nothing else.',
+            },
+        ]
+
+        response_parts = []
+        for part in client.chat("gpt-oss:120b", messages=messages, stream=True):
+            if "message" in part and "content" in part["message"]:
+                response_parts.append(part["message"]["content"])
+
+        full_response = "".join(response_parts)
+        assert full_response
+        assert "Ollama Turbo" in full_response or "Hello" in full_response
+        print(f"Native Ollama Response: {full_response}")
+
+    @integration_tests
+    @pytest.mark.asyncio
+    async def test_litellm_ollama_turbo_async_streaming(self):
+        """Test async streaming with Ollama Turbo via LiteLLM."""
+        import asyncio
+        from litellm import acompletion
+
+        api_key = os.getenv("OLLAMA_API_KEY")
+
+        response_parts = []
+        async for chunk in await acompletion(
+            model="ollama/gpt-oss:120b",
+            messages=[{"role": "user", "content": "Count from 1 to 3"}],
+            api_base="https://ollama.com",
+            api_key=api_key,
+            stream=True,
+            max_tokens=50,
+        ):
+            if chunk.choices[0].delta.content:
+                response_parts.append(chunk.choices[0].delta.content)
+
+        full_response = "".join(response_parts)
+        assert full_response
+        print(f"Async Streaming Response: {full_response}")
+
+
+if __name__ == "__main__":
+    # Allow running directly for quick testing
+
+    # First run auth header tests (these don't need API key)
+    print("=== Testing Auth Headers ===")
+    auth_test = TestOllamaTurboAuthHeaders()
+    auth_test.test_ollama_turbo_auth_header_without_bearer()
+    print("✓ Auth header test passed")
+
+    auth_test.test_ollama_env_var_pickup()
+    print("✓ Environment variable test passed")
+
+    # Now run integration tests if API key is available
+    if not os.getenv("OLLAMA_API_KEY"):
+        print("\nSet OLLAMA_API_KEY environment variable to run integration tests")
+        sys.exit(0)
+
+    test = TestOllamaTurboIntegration()
+
+    print("\n=== Testing LiteLLM Ollama Turbo ===")
+    test.test_litellm_ollama_turbo_completion()
+
+    print("\n=== Testing Native Ollama Turbo ===")
+    try:
+        test.test_native_ollama_turbo_completion()
+    except Exception as e:
+        print(f"Native test skipped: {e}")
+
+    print("\n=== Testing Async Streaming ===")
+    import asyncio
+
+    asyncio.run(test.test_litellm_ollama_turbo_async_streaming())


### PR DESCRIPTION
## Summary

This PR adds conditional authorization header formatting to support Ollama Turbo (ollama.com), which requires a different authentication format than self-hosted Ollama instances.

- When api_base starts with 'https://ollama.com', use raw API key without 'Bearer' prefix
- For all other URLs, use standard 'Bearer {api_key}' format
- Updated auth headers in chat completion, text completion, and embeddings
- Added tests to verify the authorization header behavior

This change enables LiteLLM to work with Ollama Turbo (ollama.com) which requires a different authentication format than self-hosted Ollama instances.

## Title

feat: Add conditional auth header for Ollama Turbo

## Relevant issues

N/A - Feature addition

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/`](https://github.com/BerriAI/litellm/tree/main/tests/) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

- Added conditional logic to check if `api_base` starts with `'https://ollama.com'`
- Updated 4 locations in `ollama_chat.py` to use conditional auth headers
- Updated `chat/transformation.py` for chat completions
- Updated `completion/transformation.py` for text completions
- Updated `completion/handler.py` for embeddings
- Added `api_key` parameter to embedding calls in `main.py`
- Created comprehensive test suite in `test_ollama_turbo_integration.py`

## Test Results

<img width="1176" height="762" alt="image" src="https://github.com/user-attachments/assets/e4516648-4ad6-4a12-8b0b-ab0fe03ee01f" />

All 4 auth header tests pass successfully, verifying:
- ✅ Ollama.com URLs receive auth header without "Bearer" prefix
- ✅ Environment variable OLLAMA_API_KEY is correctly handled
- ✅ All endpoints (chat, embeddings, vision) use correct auth format
- ✅ No regressions - existing Ollama functionality preserved