### PR TITLE
Add Azure Deployment Name Support in UI

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/litellm_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/litellm_model_name.tsx
@@ -32,10 +32,18 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
       if (JSON.stringify(currentModel) !== JSON.stringify(values)) {
 
         // Create mappings first
-        const mappings = values.map(model => ({
-          public_name: model,
-          litellm_model: model
-        }));
+        const mappings = values.map(model => {
+          if (selectedProvider === Providers.Azure) {
+            return {
+              public_name: model,
+              litellm_model: `azure/${model}`
+            };
+          }
+          return {
+            public_name: model,
+            litellm_model: model
+          };
+        });
         
         // Update both fields in one call to reduce re-renders
         form.setFieldsValue({ 
@@ -47,6 +55,22 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
     }
   };
 
+  const handleAzureDeploymentNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const deploymentName = e.target.value;
+
+    // Create mapping with Azure-specific format
+    const mappings = deploymentName ? [{
+      public_name: deploymentName,
+      litellm_model: `azure/${deploymentName}`
+    }] : [];
+    
+    // Update both fields
+    form.setFieldsValue({ 
+      model: deploymentName,
+      model_mappings: mappings
+    });
+  };
+
   // Handle custom model name changes
   const handleCustomModelNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const customName = e.target.value;
@@ -55,6 +79,12 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
     const currentMappings = form.getFieldValue('model_mappings') || [];
     const updatedMappings = currentMappings.map((mapping: any) => {
       if (mapping.public_name === 'custom' || mapping.litellm_model === 'custom') {
+        if (selectedProvider === Providers.Azure) {
+          return {
+            public_name: customName,
+            litellm_model: `azure/${customName}`
+          };
+        }
         return {
           public_name: customName,
           litellm_model: customName
@@ -75,7 +105,7 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
       >
         <Form.Item
           name="model"
-          rules={[{ required: true, message: "Please select at least one model." }]}
+          rules={[{ required: true, message: `Please enter ${selectedProvider === Providers.Azure ? 'a deployment name' : 'at least one model'}.` }]}
           noStyle
         >
           {(selectedProvider === Providers.Azure) || 
@@ -84,6 +114,7 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
             <>
               <TextInput 
                 placeholder={getPlaceholder(selectedProvider)} 
+                onChange={selectedProvider === Providers.Azure ? handleAzureDeploymentNameChange : undefined}
               />
             </>
           ) : providerModels.length > 0 ? (
@@ -135,7 +166,7 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
                 className="mt-2"
               >
                 <TextInput 
-                  placeholder="Enter custom model name" 
+                  placeholder={selectedProvider === Providers.Azure ? "Enter Azure deployment name" : "Enter custom model name"}
                   onChange={handleCustomModelNameChange}
                 />
               </Form.Item>
@@ -147,7 +178,10 @@ const LiteLLMModelNameField: React.FC<LiteLLMModelNameFieldProps> = ({
         <Col span={10}></Col>
         <Col span={14}>
           <Text className="mb-3 mt-1">
-          The model name LiteLLM will send to the LLM API
+            {selectedProvider === Providers.Azure 
+              ? "Your deployment name will be saved as the public model name, and LiteLLM will use 'azure/deployment-name' internally"
+              : "The model name LiteLLM will send to the LLM API"
+            }
           </Text>
         </Col>
       </Row>


### PR DESCRIPTION
## Title
Add Azure Deployment Name Support in UI

<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
- When users enter a deployment name like `gpt-4o-mini-test`, the system automatically:
  - Saves `gpt-4o-mini-test` as the public model name (what users call in API requests)
  - Saves `azure/gpt-4o-mini-test` as the LiteLLM model name (what LiteLLM uses internally)

https://www.loom.com/share/8cbe8f2af7fc455fa821f3053d81efac?sid=bd18b2dc-8ba9-423f-aaee-dd285cda0c29
