### PR TITLE
OpenRouter model from API automatically

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -76,6 +76,9 @@ class OpenrouterConfig(OpenAIGPTConfig):
             dict: The transformed request. Sent as the body of the API call.
         """
         extra_body = optional_params.pop("extra_body", {})
+        if optional_params.get("usage") is None:
+            optional_params["usage"] = {}
+        optional_params["usage"]["include"] = True  # Get the cost of the request
         response = super().transform_request(
             model, messages, optional_params, litellm_params, headers
         )


### PR DESCRIPTION
## Title

Get the model information of OpenRouter model automatically

## Relevant issues

Fixes #13653

Partially, I couldn't find the way to have LiteLLM use the usage.cost parameter to return the actual cost of the request.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes
 Make the mode_info provider use the OpenRouter API to get missing data automatically.
