### PR TITLE
[Feat] Datadog LLM Observability - Add support for Failure Logging

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -102,6 +102,24 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             verbose_logger.exception(
                 f"DataDogLLMObs: Error logging success event - {str(e)}"
             )
+    
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        try:
+            verbose_logger.debug(
+                f"DataDogLLMObs: Logging failure event for model {kwargs.get('model', 'unknown')}"
+            )
+            payload = self.create_llm_obs_payload(
+                kwargs, start_time, end_time
+            )
+            verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
+            self.log_queue.append(payload)
+
+            if len(self.log_queue) >= self.batch_size:
+                await self.async_send_batch()
+        except Exception as e:
+            verbose_logger.exception(
+                f"DataDogLLMObs: Error logging failure event - {str(e)}"
+            )
 
     async def async_send_batch(self):
         try:

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -5,3 +5,5 @@ model_list:
   - model_name: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
     litellm_params:
       model: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
+litellm_settings:
+  callbacks: ["datadog_llm_observability"]

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -18,12 +18,20 @@ class OutputMeta(TypedDict):
     messages: List[Any]
 
 
-class Meta(TypedDict):
+class DDLLMObsError(TypedDict, total=False):
+    """Error information on the span according to DD LLM Obs API spec"""
+    message: str  # The error message
+    stack: Optional[str]  # The stack trace
+    type: Optional[str]  # The error type
+
+
+class Meta(TypedDict, total=False):
     # The span kind: "agent", "workflow", "llm", "tool", "task", "embedding", or "retrieval".
     kind: Literal["llm", "tool", "task", "embedding", "retrieval"]
-    input: InputMeta  # The span’s input information.
-    output: OutputMeta  # The span’s output information.
+    input: InputMeta  # The span's input information.
+    output: OutputMeta  # The span's output information.
     metadata: Dict[str, Any]
+    error: Optional[DDLLMObsError]  # Error information on the span
 
 
 class LLMMetrics(TypedDict, total=False):
@@ -35,7 +43,7 @@ class LLMMetrics(TypedDict, total=False):
     total_cost: float
 
 
-class LLMObsPayload(TypedDict):
+class LLMObsPayload(TypedDict, total=False):
     parent_id: str
     trace_id: str
     span_id: str
@@ -45,6 +53,7 @@ class LLMObsPayload(TypedDict):
     duration: int
     metrics: LLMMetrics
     tags: List
+    status: Literal["ok", "error"] # Error status ("ok" or "error"). Defaults to "ok".
 
 
 class DDSpanAttributes(TypedDict):

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -81,6 +81,60 @@ def create_standard_logging_payload_with_cache() -> StandardLoggingPayload:
     )
 
 
+def create_standard_logging_payload_with_failure() -> StandardLoggingPayload:
+    """Create a StandardLoggingPayload object for failure testing"""
+    return StandardLoggingPayload(
+        id="test-request-id-failure-789",
+        call_type="completion",
+        response_cost=0.0,
+        response_cost_failure_debug_info=None,
+        status="failure",
+        total_tokens=0,
+        prompt_tokens=10,
+        completion_tokens=0,
+        startTime=1234567890.0,
+        endTime=1234567891.0,
+        completionStartTime=1234567890.5,
+        model_map_information=StandardLoggingModelInformation(
+            model_map_key="gpt-4", model_map_value=None
+        ),
+        model="gpt-4",
+        model_id="model-123",
+        model_group="openai-gpt",
+        api_base="https://api.openai.com",
+        metadata=StandardLoggingMetadata(
+            user_api_key_hash="test_hash",
+            user_api_key_org_id=None,
+            user_api_key_alias="test_alias",
+            user_api_key_team_id="test_team",
+            user_api_key_user_id="test_user",
+            user_api_key_team_alias="test_team_alias",
+            spend_logs_metadata=None,
+            requester_ip_address="127.0.0.1",
+            requester_metadata=None,
+        ),
+        cache_hit=False,
+        cache_key=None,
+        saved_cache_cost=0.0,
+        request_tags=[],
+        end_user=None,
+        requester_ip_address="127.0.0.1",
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        response=None,
+        error_str="RateLimitError: You exceeded your current quota",
+        model_parameters={"stream": False},
+        hidden_params=StandardLoggingHiddenParams(
+            model_id="model-123",
+            cache_key=None,
+            api_base="https://api.openai.com",
+            response_cost="0.0",
+            additional_headers=None,
+        ),
+        trace_id="test-trace-id-failure-456",
+        custom_llm_provider="openai",
+    )
+
+
 class TestDataDogLLMObsLogger:
     """Test suite for DataDog LLM Observability Logger"""
 
@@ -118,7 +172,7 @@ class TestDataDogLLMObsLogger:
             start_time = datetime.now()
             end_time = datetime.now()
             
-            payload = logger.create_llm_obs_payload(kwargs, mock_response_obj, start_time, end_time)
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
             
             # Test 1: Verify total_cost is correctly extracted from response_cost
             assert payload["metrics"].get("total_cost") == 0.05
@@ -148,7 +202,7 @@ class TestDataDogLLMObsLogger:
             start_time = datetime.now()
             end_time = datetime.now()
             
-            payload = logger.create_llm_obs_payload(kwargs, mock_response_obj, start_time, end_time)
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
             
             # Test the _get_dd_llm_obs_payload_metadata method directly
             metadata = logger._get_dd_llm_obs_payload_metadata(standard_payload)
@@ -217,9 +271,56 @@ class TestDataDogLLMObsLogger:
         assert logger._get_datadog_span_kind("unknown_call_type") == "llm"
         assert logger._get_datadog_span_kind(None) == "llm"
 
+    @pytest.mark.asyncio
+    async def test_async_log_failure_event(self, mock_env_vars):
+        """Test that async_log_failure_event correctly processes failure payloads according to DD LLM Obs API spec"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+            
+            # Ensure log_queue starts empty
+            logger.log_queue = []
+            
+            standard_failure_payload = create_standard_logging_payload_with_failure()
+            
+            kwargs = {
+                "standard_logging_object": standard_failure_payload,
+                "model": "gpt-4",
+                "litellm_params": {"metadata": {}}
+            }
+            
+            start_time = datetime.now()
+            end_time = datetime.now() + timedelta(seconds=2)
+            
+            # Mock async_send_batch to prevent actual network calls
+            with patch.object(logger, 'async_send_batch') as mock_send_batch:
+                # Call the method under test
+                await logger.async_log_failure_event(kwargs, None, start_time, end_time)
+                
+                # Verify payload was added to queue
+                assert len(logger.log_queue) == 1
+                
+                # Verify the payload has correct failure characteristics according to DD LLM Obs API spec
+                payload = logger.log_queue[0]
+                assert payload["trace_id"] == "test-trace-id-failure-456"
+                assert payload["meta"]["metadata"]["id"] == "test-request-id-failure-789"
+                assert payload["status"] == "error"
+                
+                # Verify error information follows DD LLM Obs API spec
+                assert payload["meta"]["error"]["message"] == "RateLimitError: You exceeded your current quota"
+                assert payload["meta"]["error"]["type"] == "RateLimitError"
+                assert payload["meta"]["error"]["stack"] is None
+                
+                assert payload["metrics"]["total_cost"] == 0.0
+                assert payload["metrics"]["total_tokens"] == 0
+                assert payload["metrics"]["output_tokens"] == 0
+                
+                # Verify batch sending not triggered (queue size < batch_size)
+                mock_send_batch.assert_not_called()
 
 
-class TestDataDogLLMObsLogger(DataDogLLMObsLogger):
+
+class TestDataDogLLMObsLoggerForRedaction(DataDogLLMObsLogger):
     """Test suite for DataDog LLM Observability Logger"""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -24,6 +24,7 @@ from litellm.types.utils import (
     StandardLoggingMetadata,
     StandardLoggingModelInformation,
     StandardLoggingPayload,
+    StandardLoggingPayloadErrorInformation,
 )
 
 
@@ -122,6 +123,13 @@ def create_standard_logging_payload_with_failure() -> StandardLoggingPayload:
         messages=[{"role": "user", "content": "Hello, world!"}],
         response=None,
         error_str="RateLimitError: You exceeded your current quota",
+        error_information=StandardLoggingPayloadErrorInformation(
+            error_code="rate_limit_exceeded",
+            error_class="RateLimitError",
+            llm_provider="openai",
+            traceback="Traceback (most recent call last):\n  File test.py, line 1\n    RateLimitError: You exceeded your current quota",
+            error_message="RateLimitError: You exceeded your current quota"
+        ),
         model_parameters={"stream": False},
         hidden_params=StandardLoggingHiddenParams(
             model_id="model-123",
@@ -309,7 +317,7 @@ class TestDataDogLLMObsLogger:
                 # Verify error information follows DD LLM Obs API spec
                 assert payload["meta"]["error"]["message"] == "RateLimitError: You exceeded your current quota"
                 assert payload["meta"]["error"]["type"] == "RateLimitError"
-                assert payload["meta"]["error"]["stack"] is None
+                assert payload["meta"]["error"]["stack"] == "Traceback (most recent call last):\n  File test.py, line 1\n    RateLimitError: You exceeded your current quota"
                 
                 assert payload["metrics"]["total_cost"] == 0.0
                 assert payload["metrics"]["total_tokens"] == 0


### PR DESCRIPTION
## [Feat] Datadog LLM Observability - Add support for Failure Logging

<!-- e.g. "Implement user authentication feature" -->
<img width="1148" height="663" alt="Screenshot 2025-08-18 at 2 20 50 PM" src="https://github.com/user-attachments/assets/387fb451-08aa-42d6-be6a-6787b10927bf" />


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


