### PR TITLE
[Bug Fix] litellm incompatible with newest release of openAI v1.100.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
             pip install opentelemetry-api==1.25.0
             pip install opentelemetry-sdk==1.25.0
             pip install opentelemetry-exporter-otlp==1.25.0
-            pip install openai==1.99.5
+            pip install openai==1.100.1
             pip install prisma==0.11.0
             pip install "detect_secrets==1.5.0"
             pip install "httpx==0.24.1"
@@ -220,7 +220,7 @@ jobs:
             pip install opentelemetry-api==1.25.0
             pip install opentelemetry-sdk==1.25.0
             pip install opentelemetry-exporter-otlp==1.25.0
-            pip install openai==1.99.5
+            pip install openai==1.100.1
             pip install prisma==0.11.0
             pip install "detect_secrets==1.5.0"
             pip install "httpx==0.24.1"
@@ -327,7 +327,7 @@ jobs:
             pip install opentelemetry-api==1.25.0
             pip install opentelemetry-sdk==1.25.0
             pip install opentelemetry-exporter-otlp==1.25.0
-            pip install openai==1.99.5
+            pip install openai==1.100.1
             pip install prisma==0.11.0
             pip install "detect_secrets==1.5.0"
             pip install "httpx==0.24.1"
@@ -602,7 +602,7 @@ jobs:
             pip install opentelemetry-api==1.25.0
             pip install opentelemetry-sdk==1.25.0
             pip install opentelemetry-exporter-otlp==1.25.0
-            pip install openai==1.99.5
+            pip install openai==1.100.1
             pip install prisma==0.11.0
             pip install "detect_secrets==1.5.0"
             pip install "httpx==0.24.1"
@@ -1522,7 +1522,7 @@ jobs:
             pip install "aiodynamo==23.10.1"
             pip install "asyncio==3.4.3"
             pip install "PyGithub==1.59.1"
-            pip install "openai==1.99.5"
+            pip install "openai==1.100.1"
       - run:
           name: Install dockerize
           command: |
@@ -1679,7 +1679,7 @@ jobs:
             pip install "aiodynamo==23.10.1"
             pip install "asyncio==3.4.3"
             pip install "PyGithub==1.59.1"
-            pip install "openai==1.99.5"
+            pip install "openai==1.100.1"
             # Run pytest and generate JUnit XML report
       - run:
           name: Install dockerize
@@ -1819,7 +1819,7 @@ jobs:
             pip install "aiodynamo==23.10.1"
             pip install "asyncio==3.4.3"
             pip install "PyGithub==1.59.1"
-            pip install "openai==1.99.5"
+            pip install "openai==1.100.1"
       - run:
           name: Install dockerize
           command: |
@@ -2399,7 +2399,7 @@ jobs:
             pip install "pytest-asyncio==0.21.1"
             pip install "google-cloud-aiplatform==1.43.0"
             pip install aiohttp
-            pip install "openai==1.99.5"
+            pip install "openai==1.100.1"
             pip install "assemblyai==0.37.0"
             python -m pip install --upgrade pip
             pip install "pydantic==2.10.2"
@@ -2790,7 +2790,7 @@ jobs:
             pip install "pytest-retry==1.6.3"
             pip install "pytest-asyncio==0.21.1"
             pip install aiohttp
-            pip install "openai==1.99.5"
+            pip install "openai==1.100.1"
             python -m pip install --upgrade pip
             pip install "pydantic==2.10.2"
             pip install "pytest==7.3.1"

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,5 +1,5 @@
 # used by CI/CD testing
-openai==1.99.5
+openai==1.100.1
 python-dotenv
 tiktoken
 importlib_metadata

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install --with dev
-        pip install openai==1.100.1
+        poetry run pip install openai==1.100.1
 
     - name: Run Black formatting
       run: |

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -37,6 +37,10 @@ jobs:
         poetry run ruff check .
         cd ..
 
+    - name: Print OpenAI version
+      run: |
+        poetry run python -c "import openai; print(f'OpenAI version: {openai.__version__}')"
+
     - name: Run MyPy type checking
       run: |
         cd litellm

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -22,11 +22,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install openai==1.99.5
         poetry install --with dev
-        pip install openai==1.99.5
-
-
+        pip install openai==1.100.1
 
     - name: Run Black formatting
       run: |

--- a/docker/build_from_pip/requirements.txt
+++ b/docker/build_from_pip/requirements.txt
@@ -2,4 +2,5 @@ litellm[proxy]==1.67.4.dev1 # Specify the litellm version you want to use
 prometheus_client
 langfuse
 prisma
+openai==1.99.9
 ddtrace==2.19.0 # for advanced DD tracing / profiling

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -33,7 +33,6 @@ from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
-    response_create_params,
 )
 from litellm.types.responses.main import (
     GenericResponseOutputItem,
@@ -659,7 +658,7 @@ class LiteLLMCompletionResponsesConfig:
             ),
             reasoning=Reasoning(),
             status=getattr(chat_completion_response, "status", "completed"),
-            text=response_create_params.Text(),
+            text={},
             truncation=getattr(chat_completion_response, "truncation", None),
             usage=LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
                 chat_completion_response=chat_completion_response

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -33,7 +33,7 @@ from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
-    ResponseTextConfig,
+    response_create_params,
 )
 from litellm.types.responses.main import (
     GenericResponseOutputItem,
@@ -659,7 +659,7 @@ class LiteLLMCompletionResponsesConfig:
             ),
             reasoning=Reasoning(),
             status=getattr(chat_completion_response, "status", "completed"),
-            text=ResponseTextConfig(),
+            text=response_create_params.Text(),
             truncation=getattr(chat_completion_response, "truncation", None),
             usage=LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
                 chat_completion_response=chat_completion_response

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -21,9 +21,9 @@ from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
-    ResponseTextConfigParam,
     ToolChoice,
     ToolParam,
+    response_create_params,
 )
 from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
@@ -104,7 +104,7 @@ async def aresponses_api_with_mcp(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[ResponseTextConfigParam] = None,
+    text: Optional[response_create_params.Text] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,
@@ -237,7 +237,7 @@ async def aresponses(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[ResponseTextConfigParam] = None,
+    text: Optional[response_create_params.Text] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,
@@ -348,7 +348,7 @@ def responses(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[ResponseTextConfigParam] = None,
+    text: Optional[response_create_params.Text] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -21,9 +21,9 @@ from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
+    ResponseText,
     ToolChoice,
     ToolParam,
-    response_create_params,
 )
 from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
@@ -104,7 +104,7 @@ async def aresponses_api_with_mcp(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[response_create_params.Text] = None,
+    text: Optional["ResponseText"] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,
@@ -237,7 +237,7 @@ async def aresponses(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[response_create_params.Text] = None,
+    text: Optional["ResponseText"] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,
@@ -348,7 +348,7 @@ def responses(
     background: Optional[bool] = None,
     stream: Optional[bool] = None,
     temperature: Optional[float] = None,
-    text: Optional[response_create_params.Text] = None,
+    text: Optional["ResponseText"] = None,
     tool_choice: Optional[ToolChoice] = None,
     tools: Optional[Iterable[ToolParam]] = None,
     top_p: Optional[float] = None,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1041,7 +1041,7 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     previous_response_id: Optional[str]
     reasoning: Optional[Reasoning]
     status: Optional[str]
-    text: Optional["ResponseText"]
+    text: Optional[Union["ResponseText", Dict[str, Any]]]
     truncation: Optional[Literal["auto", "disabled"]]
     usage: Optional[ResponseAPIUsage]
     user: Optional[str]

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -33,7 +33,6 @@ from openai.types.chat.chat_completion_prediction_content_param import (
 )
 from openai.types.embedding import Embedding as OpenAIEmbedding
 from openai.types.fine_tuning.fine_tuning_job import FineTuningJob
-from openai.types.responses import response_create_params
 from openai.types.responses.response import (
     IncompleteDetails,
     Response,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -33,11 +33,11 @@ from openai.types.chat.chat_completion_prediction_content_param import (
 )
 from openai.types.embedding import Embedding as OpenAIEmbedding
 from openai.types.fine_tuning.fine_tuning_job import FineTuningJob
+from openai.types.responses import response_create_params
 from openai.types.responses.response import (
     IncompleteDetails,
     Response,
     ResponseOutputItem,
-    ResponseTextConfig,
     Tool,
     ToolChoice,
 )
@@ -45,7 +45,6 @@ from openai.types.responses.response_create_params import (
     Reasoning,
     ResponseIncludable,
     ResponseInputParam,
-    ResponseTextConfigParam,
     ToolChoice,
     ToolParam,
 )
@@ -959,7 +958,7 @@ class ResponsesAPIOptionalRequestParams(TypedDict, total=False):
     background: Optional[bool]
     stream: Optional[bool]
     temperature: Optional[float]
-    text: Optional[ResponseTextConfigParam]
+    text: Optional[response_create_params.Text]
     tool_choice: Optional[ToolChoice]
     tools: Optional[List[ALL_RESPONSES_API_TOOL_PARAMS]]
     top_p: Optional[float]
@@ -1034,7 +1033,7 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     previous_response_id: Optional[str]
     reasoning: Optional[Reasoning]
     status: Optional[str]
-    text: Optional[ResponseTextConfig]
+    text: Optional[response_create_params.Text]
     truncation: Optional[Literal["auto", "disabled"]]
     usage: Optional[ResponseAPIUsage]
     user: Optional[str]

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -41,6 +41,14 @@ from openai.types.responses.response import (
     Tool,
     ToolChoice,
 )
+
+# Handle OpenAI SDK version compatibility for Text type
+try:
+    from openai.types.responses.response_create_params import Text as ResponseText
+except ImportError:
+    # Fall back to the concrete config type available in older SDKs
+    from openai.types.responses.response_text_config_param import ResponseTextConfigParam as ResponseText
+
 from openai.types.responses.response_create_params import (
     Reasoning,
     ResponseIncludable,
@@ -958,7 +966,7 @@ class ResponsesAPIOptionalRequestParams(TypedDict, total=False):
     background: Optional[bool]
     stream: Optional[bool]
     temperature: Optional[float]
-    text: Optional[response_create_params.Text]
+    text: Optional["ResponseText"]
     tool_choice: Optional[ToolChoice]
     tools: Optional[List[ALL_RESPONSES_API_TOOL_PARAMS]]
     top_p: Optional[float]
@@ -1033,7 +1041,7 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     previous_response_id: Optional[str]
     reasoning: Optional[Reasoning]
     status: Optional[str]
-    text: Optional[response_create_params.Text]
+    text: Optional["ResponseText"]
     truncation: Optional[Literal["auto", "disabled"]]
     usage: Optional[ResponseAPIUsage]
     user: Optional[str]

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -45,8 +45,8 @@ from openai.types.responses.response import (
 # Handle OpenAI SDK version compatibility for Text type
 try:
     from openai.types.responses.response_create_params import Text as ResponseText
-except ImportError:
-    # Fall back to the concrete config type available in older SDKs
+except (ImportError, AttributeError):
+    # Fall back to the concrete config type available in all SDK versions
     from openai.types.responses.response_text_config_param import ResponseTextConfigParam as ResponseText
 
 from openai.types.responses.response_create_params import (

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -21,7 +21,6 @@ from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,
     ResponsesAPIResponse,
-    ResponseTextConfig,
     ResponseAPIUsage,
     IncompleteDetails,
 )
@@ -78,7 +77,7 @@ def validate_responses_api_response(response, final_chunk: bool = False):
         "previous_response_id": (str, type(None)),
         "reasoning": dict,
         "status": str,
-        "text": ResponseTextConfig,
+        "text": dict,
         "truncation": (str, type(None)),
         "usage": ResponseAPIUsage,
         "user": (str, type(None)),

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -17,7 +17,6 @@ from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,
     ResponsesAPIResponse,
-    ResponseTextConfig,
     ResponseAPIUsage,
     IncompleteDetails,
 )

--- a/tests/llm_responses_api_testing/test_azure_responses_api.py
+++ b/tests/llm_responses_api_testing/test_azure_responses_api.py
@@ -13,7 +13,6 @@ from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,
     ResponsesAPIResponse,
-    ResponseTextConfig,
     ResponseAPIUsage,
     IncompleteDetails,
 )

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -18,7 +18,6 @@ from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,
     ResponsesAPIResponse,
-    ResponseTextConfig,
     ResponseAPIUsage,
     IncompleteDetails,
 )

--- a/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_deployment_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_deployment_check.py
@@ -17,7 +17,6 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponsesAPIResponse,
-    ResponseTextConfig,
 )
 from litellm.types.utils import StandardLoggingPayload
 


### PR DESCRIPTION
## [Bug Fix] litellm incompatible with newest release of openAI v1.100.0

OpenAI just released v1.100.0. LiteLLM allows for openAI package to be any version >= >=1.99.5, including v1.100.0.

However, v1.100.0 removes ResponseTextConfig, which breaks litellm upon import

Fixes: https://github.com/BerriAI/litellm/issues/13711

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


