### PR TITLE
Update litellm claude code docs for anthropic

### DIFF
--- a/docs/my-website/docs/tutorials/claude_responses_api.md
+++ b/docs/my-website/docs/tutorials/claude_responses_api.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 
 # Claude Code
 
-This tutorial shows how to call the Responses API models like `codex-mini` and `o3-pro` from the Claude Code endpoint on LiteLLM.
+This tutorial shows how to use Anthropic Claude models with Claude Code through LiteLLM, and also supports Responses API models like `codex-mini` and `o3-pro`.
 
 :::info 
 
@@ -28,6 +28,41 @@ pip install 'litellm[proxy]'
 ### 1. Setup config.yaml
 
 Create a secure configuration using environment variables:
+
+<Tabs>
+<TabItem value="anthropic" label="Anthropic Claude (Recommended)" default>
+
+```yaml
+model_list:
+  # Anthropic Claude models
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+  
+  - model_name: claude-3-5-haiku
+    litellm_params:
+      model: anthropic/claude-3-5-haiku-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-opus
+    litellm_params:
+      model: anthropic/claude-3-opus-20240229
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+litellm_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+```
+
+Set your environment variables:
+
+```bash
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+export LITELLM_MASTER_KEY="sk-1234567890"  # Generate a secure key
+```
+
+</TabItem>
+<TabItem value="responses-api" label="Responses API Models">
 
 ```yaml
 model_list:
@@ -55,6 +90,9 @@ export OPENAI_API_KEY="your-openai-api-key"
 export LITELLM_MASTER_KEY="sk-1234567890"  # Generate a secure key
 ```
 
+</TabItem>
+</Tabs>
+
 ### 2. Start proxy
 
 ```bash
@@ -67,6 +105,22 @@ litellm --config /path/to/config.yaml
 
 Test that your proxy is working correctly:
 
+<Tabs>
+<TabItem value="anthropic-test" label="Test Anthropic Claude" default>
+
+```bash
+curl -X POST http://0.0.0.0:4000/v1/messages \
+-H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+-H "Content-Type: application/json" \
+-d '{
+    "model": "claude-3-5-sonnet",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}]
+}'
+```
+
+</TabItem>
+<TabItem value="responses-test" label="Test Responses API">
+
 ```bash
 curl -X POST http://0.0.0.0:4000/v1/messages \
 -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
@@ -76,6 +130,9 @@ curl -X POST http://0.0.0.0:4000/v1/messages \
     "messages": [{"role": "user", "content": "What is the capital of France?"}]
 }'
 ```
+
+</TabItem>
+</Tabs>
 
 ### 4. Configure Claude Code
 
@@ -90,6 +147,19 @@ export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 
 Start Claude Code with any configured model:
 
+<Tabs>
+<TabItem value="anthropic-usage" label="Use Anthropic Claude" default>
+
+```bash
+# Use Anthropic Claude models
+claude --model claude-3-5-sonnet
+claude --model claude-3-5-haiku
+claude --model claude-3-opus
+```
+
+</TabItem>
+<TabItem value="responses-usage" label="Use Responses API">
+
 ```bash
 # Use Responses API models
 claude --model codex-mini
@@ -98,6 +168,9 @@ claude --model o3-pro
 # Or use the latest model alias
 claude --model codex-mini-latest
 ```
+
+</TabItem>
+</Tabs>
 
 Example conversation:
 
@@ -112,7 +185,8 @@ Common issues and solutions:
 
 **Authentication errors:**
 - Verify your environment variables are set: `echo $LITELLM_MASTER_KEY`
-- Check that your OpenAI API key is valid and has sufficient credits
+- Check that your Anthropic API key is valid and has sufficient credits: `echo $ANTHROPIC_API_KEY`
+- For Responses API models, check that your OpenAI API key is valid and has sufficient credits
 
 **Model not found:**
 - Ensure the model name in Claude Code matches exactly with your `config.yaml`
@@ -123,10 +197,26 @@ Common issues and solutions:
 Expand your configuration to support multiple providers and models:
 
 <Tabs>
-<TabItem value="responses-plus" label="Responses + Standard Models">
+<TabItem value="all-models" label="Anthropic + Responses API + Other Models" default>
 
 ```yaml
 model_list:
+  # Anthropic Claude models (Recommended)
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-5-haiku
+    litellm_params:
+      model: anthropic/claude-3-5-haiku-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-opus
+    litellm_params:
+      model: anthropic/claude-3-opus-20240229
+      api_key: os.environ/ANTHROPIC_API_KEY
+
   # Responses API models
   - model_name: codex-mini
     litellm_params:
@@ -140,16 +230,11 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
       api_base: https://api.openai.com/v1
 
-  # Standard models
+  # Other standard models
   - model_name: gpt-4o
     litellm_params:
       model: openai/gpt-4o
       api_key: os.environ/OPENAI_API_KEY
-
-  - model_name: claude-3-5-sonnet
-    litellm_params:
-      model: anthropic/claude-3-5-sonnet-20241022
-      api_key: os.environ/ANTHROPIC_API_KEY
 
 litellm_settings:
   master_key: os.environ/LITELLM_MASTER_KEY
@@ -158,13 +243,47 @@ litellm_settings:
 Switch between models seamlessly:
 
 ```bash
+# Use Anthropic Claude models for general tasks
+claude --model claude-3-5-sonnet
+claude --model claude-3-5-haiku
+claude --model claude-3-opus
+
 # Use Responses API models for advanced reasoning
 claude --model o3-pro
 claude --model codex-mini
 
-# Use standard models for general tasks
+# Use other models as needed
 claude --model gpt-4o
-claude --model claude-3-5-sonnet
+```
+
+</TabItem>
+<TabItem value="anthropic-only" label="Anthropic Claude Only">
+
+```yaml
+model_list:
+  # Anthropic Claude models
+  - model_name: claude-3-5-sonnet
+    litellm_params:
+      model: anthropic/claude-3-5-sonnet-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-5-haiku
+    litellm_params:
+      model: anthropic/claude-3-5-haiku-20241022
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-opus
+    litellm_params:
+      model: anthropic/claude-3-opus-20240229
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-3-7-sonnet
+    litellm_params:
+      model: anthropic/claude-3-7-sonnet-20250219
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+litellm_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
 ```
 
 </TabItem>


### PR DESCRIPTION
## Title

Update Claude Code documentation to prioritize Anthropic models

## Relevant issues

Addresses user feedback from Slack thread regarding incorrect model focus in Claude Code documentation.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

The existing Claude Code documentation incorrectly focused on OpenAI/Responses API models. This PR updates the `docs/my-website/docs/tutorials/claude_responses_api.md` file to:
- **Prioritize Anthropic Claude models** as the primary example and configuration throughout the tutorial.
- Implement **tabbed sections** for setup, verification, and usage, allowing users to easily switch between Anthropic Claude and Responses API examples.
- Correctly reference **Anthropic API keys** and relevant Anthropic model names.
- Ensure the documentation accurately reflects the intended use of LiteLLM with Claude Code for Anthropic models, as requested by users.

---
[Slack Thread](https://berriaillm.slack.com/archives/C091JL13GFQ/p1755622495563019?thread_ts=1755622495.563019&cid=C091JL13GFQ)

<a href="https://cursor.com/background-agent?bcId=bc-c2a0f29c-fa35-4290-a2b8-cc25d832191c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2a0f29c-fa35-4290-a2b8-cc25d832191c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

