### PR TITLE
[Bug]: `/responses` endpoint proxy ignores extra_headers in GitHub Copilot

### DIFF
--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -2,7 +2,7 @@
 Handler for transforming responses api requests to litellm.completion requests
 """
 
-from typing import Any, Coroutine, Optional, Union
+from typing import Any, Coroutine, Dict, Optional, Union
 
 import litellm
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
@@ -30,6 +30,7 @@ class LiteLLMCompletionTransformationHandler:
         custom_llm_provider: Optional[str] = None,
         _is_async: bool = False,
         stream: Optional[bool] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Union[
         ResponsesAPIResponse,
@@ -45,6 +46,7 @@ class LiteLLMCompletionTransformationHandler:
                 responses_api_request=responses_api_request,
                 custom_llm_provider=custom_llm_provider,
                 stream=stream,
+                extra_headers=extra_headers,
                 **kwargs,
             )
         )

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -99,6 +99,7 @@ class LiteLLMCompletionResponsesConfig:
         responses_api_request: ResponsesAPIOptionalRequestParams,
         custom_llm_provider: Optional[str] = None,
         stream: Optional[bool] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> dict:
         """
@@ -126,6 +127,7 @@ class LiteLLMCompletionResponsesConfig:
             "web_search_options": web_search_options,
             # litellm specific params
             "custom_llm_provider": custom_llm_provider,
+            "extra_headers": extra_headers,
         }
 
         # Responses API `Completed` events require usage, we pass `stream_options` to litellm.completion to include usage

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -455,6 +455,7 @@ def responses(
                 custom_llm_provider=custom_llm_provider,
                 _is_async=_is_async,
                 stream=stream,
+                extra_headers=extra_headers,
                 **kwargs,
             )
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -541,7 +541,8 @@ class TestFunctionCallTransformation:
         result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
             model="gemini/gemini-2.0-flash",
             input=test_input,
-            responses_api_request=responses_api_request
+            responses_api_request=responses_api_request,
+            extra_headers={"X-Test-Header": "test-value"}
         )
         
         assert "messages" in result
@@ -562,6 +563,8 @@ class TestFunctionCallTransformation:
         
         tool_msg = messages[2]
         assert tool_msg["role"] == "tool"
+
+        assert result["extra_headers"] == {"X-Test-Header": "test-value"}
 
     def test_function_call_without_call_id_fallback_to_id(self):
         """Test that function_call items can use 'id' field when 'call_id' is missing"""


### PR DESCRIPTION
This PR passes the extra_headers parameter through the responses API transformation chain.

## Relevant issues

Resolves #13743

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Ensure extra_headers parameter is properly forwarded from the responses() function through the transformation handler and config to maintain header propagation in litellm_completion_request dict.
