### PR TITLE
[Bug Fix] Bedrock KB - Using LiteLLM Managed Credentials for Query 

### DIFF
--- a/litellm/vector_stores/main.py
+++ b/litellm/vector_stores/main.py
@@ -358,6 +358,22 @@ def search(
         litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
         _is_async = kwargs.pop("asearch", False) is True
 
+        # pull credentials from registry if available
+        vector_store_id_for_credentials = kwargs.get("vector_store_id", vector_store_id)
+        if (
+            litellm.vector_store_registry is not None
+            and vector_store_id_for_credentials is not None
+        ):
+            try:
+                registry_credentials = (
+                    litellm.vector_store_registry.get_credentials_for_vector_store(
+                        vector_store_id_for_credentials
+                    )
+                )
+                kwargs.update(registry_credentials)
+            except Exception:
+                pass
+
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)
 

--- a/tests/vector_store_tests/test_bedrock_vector_store.py
+++ b/tests/vector_store_tests/test_bedrock_vector_store.py
@@ -112,3 +112,114 @@ async def test_bedrock_search_with_router():
         custom_llm_provider="bedrock",
     )
     print(search_response)
+
+
+
+@pytest.mark.asyncio
+async def test_bedrock_search_with_credentials_managed_registry():
+    """
+    Test that the vector store search uses the credential accessor from the registry
+    when AWS environment variables are not set, ensuring credentials are managed properly.
+    """
+    from unittest.mock import patch, MagicMock
+    from litellm.router import Router
+    from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
+    from litellm.types.utils import CredentialItem
+    from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+    from datetime import datetime, timezone
+    import litellm
+
+    # Store original registry and credential list
+    original_registry = getattr(litellm, "vector_store_registry", None)
+    original_credential_list = getattr(litellm, "credential_list", [])
+    
+    try:
+        # Set up test AWS credentials in the credential system
+        test_credentials = CredentialItem(
+            credential_name="bedrock-litellm-website-knowledgebase",
+            credential_info={
+                "provider": "aws",
+                "description": "Test AWS credentials for bedrock"
+            },
+            credential_values={
+                "aws_access_key_id": "test_access_key",
+                "aws_secret_access_key": "test_secret_key", 
+                "aws_region_name": "us-east-1",
+            }
+        )
+        
+        # Set up the credential list
+        litellm.credential_list = [test_credentials]
+        
+        # Create vector store with credential reference
+        vector_store = LiteLLM_ManagedVectorStore(
+            vector_store_id="T37J8R4WTM",
+            custom_llm_provider="bedrock",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            litellm_credential_name="bedrock-litellm-website-knowledgebase",
+        )
+        
+        # Set up registry
+        registry = VectorStoreRegistry([vector_store])
+        litellm.vector_store_registry = registry
+        
+        # Verify credentials can be retrieved from registry
+        retrieved_credentials = registry.get_credentials_for_vector_store("T37J8R4WTM")
+        assert retrieved_credentials, "Should retrieve credentials from registry"
+        assert retrieved_credentials.get("aws_access_key_id") == "test_access_key"
+        assert retrieved_credentials.get("aws_secret_access_key") == "test_secret_key"
+        assert retrieved_credentials.get("aws_region_name") == "us-east-1"
+        
+        # Create router and perform search
+        _router = Router(model_list=[])
+        
+        # Mock the credential injection process to verify it's called
+        with patch.object(registry, 'get_credentials_for_vector_store', wraps=registry.get_credentials_for_vector_store) as mock_get_creds:
+            # Mock the actual search call to avoid making real API calls
+            with patch('litellm.vector_stores.main.base_llm_http_handler.vector_store_search_handler') as mock_handler:
+                mock_handler.return_value = {
+                    "data": [
+                        {
+                            "id": "test_result",
+                            "text": "Mock search result",
+                            "score": 0.9,
+                            "metadata": {}
+                        }
+                    ]
+                }
+                
+                search_response = await _router.avector_store_search(
+                    query="what happens after we add a model",
+                    vector_store_id="T37J8R4WTM",
+                    custom_llm_provider="bedrock",
+                )
+                
+                # Verify the search was called
+                mock_handler.assert_called_once()
+                call_kwargs = mock_handler.call_args[1]
+                
+                # Verify that the credential accessor was called with the correct vector store ID
+                mock_get_creds.assert_called_with("T37J8R4WTM")
+                
+                # Verify the credentials were injected into the search call
+                litellm_params = call_kwargs.get("litellm_params", {})
+                
+                # The key test: verify that credentials from the registry were used
+                # Since we have a registry with credentials, they should be present in the params
+                assert hasattr(litellm_params, 'aws_access_key_id'), "aws_access_key_id should be in litellm_params"
+                assert hasattr(litellm_params, 'aws_secret_access_key'), "aws_secret_access_key should be in litellm_params"
+                assert hasattr(litellm_params, 'aws_region_name'), "aws_region_name should be in litellm_params"
+                
+                # Verify we got the expected response
+                assert search_response["data"][0]["id"] == "test_result"
+                
+                print(f"✅ Test passed: Credential accessor was called with vector store ID: T37J8R4WTM")
+                print(f"✅ Retrieved credentials: {retrieved_credentials}")
+                print(f"✅ Credentials were injected into search call")
+                print(f"✅ Search completed successfully using registry credentials")
+    
+    finally:
+        # Restore original state
+        litellm.vector_store_registry = original_registry
+        litellm.credential_list = original_credential_list


### PR DESCRIPTION
## [Bug Fix] Bedrock KB - Using LiteLLM Managed Credentials for Query 

- Fixes for using Vector Stores with LiteLLM. Previously the "litellm credentials" were not getting added when searching a vector store 
- This fixes that + adds unit testing to ensure the vector store creds get used 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


