### PR TITLE
Fix key edit settings after regenerating key

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -130,6 +130,7 @@ export function KeyEditView({
   // Set initial form values
   const initialValues = {
     ...keyData,
+    token: keyData.token || keyData.token_id,
     budget_duration: getBudgetDuration(keyData.budget_duration),
     metadata: formatMetadataForDisplay(keyData.metadata),
     guardrails: keyData.metadata?.guardrails || [],
@@ -144,6 +145,26 @@ export function KeyEditView({
       ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
       : [],
   }
+
+  useEffect(() => {
+    form.setFieldsValue({
+      ...keyData,
+      token: keyData.token || keyData.token_id,
+      budget_duration: getBudgetDuration(keyData.budget_duration),
+      metadata: formatMetadataForDisplay(keyData.metadata),
+      guardrails: keyData.metadata?.guardrails || [],
+      prompts: keyData.metadata?.prompts || [],
+      vector_stores: keyData.object_permission?.vector_stores || [],
+      mcp_servers_and_groups: {
+        servers: keyData.object_permission?.mcp_servers || [],
+        accessGroups: keyData.object_permission?.mcp_access_groups || [],
+      },
+      logging_settings: extractLoggingSettings(keyData.metadata),
+      disabled_callbacks: Array.isArray(keyData.metadata?.litellm_disabled_callbacks)
+        ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
+        : [],
+    })
+  }, [keyData, form])
 
   console.log("premiumUser:", premiumUser)
 


### PR DESCRIPTION
## Title
Fix key edit settings after regenerating key
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- After regenerating an API key, users encountered an error when attempting to edit key settings. This occurred because the token field was being sent as null to the API during key update operations.
- Added explicit token field initialization in initialValues
- Added useEffect hook to update form values when keyData changes

Testing
- [x] Regenerate an API key
- [x] Immediately attempt to edit key settings
https://www.loom.com/share/7ec7425531ee45d1bd3400bf3a52bcdc?sid=dcb75433-8e6d-407f-a0a2-0e34a32a3da6