### PR TITLE
fix permission access on prisma migrate in non-root image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -70,7 +70,9 @@ RUN mkdir -p /nonexistent /.npm && \
   chown -R nobody:nogroup /app && \
   chown -R nobody:nogroup /nonexistent /.npm && \
   PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
-  chown -R nobody:nogroup $PRISMA_PATH
+  chown -R nobody:nogroup $PRISMA_PATH && \
+  LITELLM_PKG_MIGRATIONS_PATH="$(python -c 'import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))' 2>/dev/null || echo '')/migrations" && \
+  [ -n "$LITELLM_PKG_MIGRATIONS_PATH" ] && chown -R nobody:nogroup $LITELLM_PKG_MIGRATIONS_PATH
 
 # --- OpenShift Compatibility: Apply Red Hat recommended pattern ---
 # Get paths for directories that need write access at runtime


### PR DESCRIPTION
## Fix prisma migrations in non-root Docker image

In https://github.com/BerriAI/litellm/blob/0e6e8af1c39f7625e7716e5592b3906988b1113c/litellm-proxy-extras/litellm_proxy_extras/utils.py#L50 write access is required in `/usr/lib/python3.13/site-packages/litellm_proxy_extras/migrations/` if `LITELLM_MIGRATION_DIR` isn't set to a custom path. Otherwise, prisma migrate would fail with a permission denied error. This happened at least in the non-root Docker image.

This PR fixes the issue for the non-root image (didn't check if others need it too!) by making the migrations directory owned by nobody:nogroup (similar to `PRISMA_PATH`). The specific permissions for OpenShift Compatibility are imposed afterwards and should remain unaffected.

## Relevant issues

https://github.com/BerriAI/litellm/issues/13746

## Type

🐛 Bug Fix

## Changes
Let `/usr/lib/python3.13/site-packages/litellm_proxy_extras/migrations/` (not hard-coded) be owned by nogroup:nobody, just like `/usr/lib/python3.13/site-packages/prisma`.

