### PR TITLE
feat(helm): Allow no DATABASE_URL to be set on migration job to keep the behaviour same as deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install-test-deps: install-proxy-dev
 	cd enterprise && python -m pip install -e . && cd ..
 
 install-helm-unittest:
-	helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4
+	helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4 || echo "ignore error if plugin exists"
 
 # Formatting
 format: install-dev

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               value: {{ .Values.db.database }}
             - name: DATABASE_URL
               value: {{ .Values.db.url | quote }}
-            {{- else if .Values.db.deployStandalone }}}}
+            {{- else if .Values.db.deployStandalone }}
             - name: DATABASE_URL
               value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
             {{- end }}

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -54,7 +54,7 @@ spec:
               value: {{ .Values.db.database }}
             - name: DATABASE_URL
               value: {{ .Values.db.url | quote }}
-            {{- else }}
+            {{- else if .Values.db.deployStandalone }}}}
             - name: DATABASE_URL
               value: postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql/{{ .Values.postgresql.auth.database }}
             {{- end }}

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -111,3 +111,17 @@ tests:
           content:
             name: CUSTOM_VAR
             value: "custom_value"
+
+  - it: should not include DATABASE_URL when deployStandalone is false
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+      db:
+        deployStandalone: false
+        useExisting: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL


### PR DESCRIPTION
## Title

Currently the [if/else block within the migration job yaml file ](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/templates/migrations-job.yaml#L57) has the else logic always setting the `DATABASE_URL`.

This is different to the [deployment.yaml](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/templates/deployment.yaml#L62) which uses if/else if.

I want to mount the `DATABASE_URL` inside the migration-job.yaml file from the `extraEnvVars` yaml block from a pre-existing secret which I can do in the deployment.yaml but currently cannot in the migration-job.yaml

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

Test passing:
<img width="882" height="545" alt="image" src="https://github.com/user-attachments/assets/3bc4a508-6a94-4e58-bcd5-232ac4e37d01" />


## Type

🆕 New Feature
🚄 Infrastructure

## Changes

* Update to the if/else if logic in migration-job.yaml helm template
* Add unit test to ensure the DATABASE_URL is not set when both `useExisting` and `deployStandalone` is false
* Tweak Makefile to swallow failure when the helm plugin is already installed
