### PR TITLE
Fix - Ensure Helm chart auto generated master keys follow sk-xxxx format 

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -24,7 +24,7 @@ If `db.useStackgresOperator` is used (not yet implemented):
 | `replicaCount`                                             | The number of LiteLLM Proxy pods to be deployed                                                                                                                                       | `1`  |
 | `masterkeySecretName`                                      | The name of the Kubernetes Secret that contains the Master API Key for LiteLLM.  If not specified, use the generated secret name.                                                                                                         | N/A  |
 | `masterkeySecretKey`                                      | The key within the Kubernetes Secret that contains the Master API Key for LiteLLM.  If not specified, use `masterkey` as the key.                                                                                                         | N/A  |
-| `masterkey`                                                | The Master API Key for LiteLLM.  If not specified, a random key is generated.                                                                                                         | N/A  |
+| `masterkey`                                                | The Master API Key for LiteLLM.  If not specified, a random key in the `sk-...` format is generated.                                                                                   | N/A  |
 | `environmentSecrets`                                       | An optional array of Secret object names.  The keys and values in these secrets will be presented to the LiteLLM proxy pod as environment variables.  See below for an example Secret object.  | `[]`  |
 | `environmentConfigMaps`                                       | An optional array of ConfigMap object names.  The keys and values in these configmaps will be presented to the LiteLLM proxy pod as environment variables.  See below for an example Secret object.  | `[]`  |
 | `image.repository`                                         | LiteLLM Proxy image repository                                                                                                                                                        | `ghcr.io/berriai/litellm`  |
@@ -135,7 +135,7 @@ service, the **Proxy Endpoint** should be set to `http://<RELEASE>-litellm:4000`
 
 The **Proxy Key** is the value specified for `masterkey` or, if a `masterkey`
 was not provided to the helm command line, the `masterkey` is a randomly
-generated string stored in the `<RELEASE>-litellm-masterkey` Kubernetes Secret.
+generated string in the `sk-...` format stored in the `<RELEASE>-litellm-masterkey` Kubernetes Secret.
 
 ```bash
 kubectl -n litellm get secret <RELEASE>-litellm-masterkey -o jsonpath="{.data.masterkey}"

--- a/deploy/charts/litellm-helm/templates/secret-masterkey.yaml
+++ b/deploy/charts/litellm-helm/templates/secret-masterkey.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.masterkeySecretName }}
-{{ $masfixterkey := (.Values.masterkey | default (printf "sk-%s" (randAlphaNum 18))) }}
+{{ $masterkey := (.Values.masterkey | default (printf "sk-%s" (randAlphaNum 18))) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/charts/litellm-helm/templates/secret-masterkey.yaml
+++ b/deploy/charts/litellm-helm/templates/secret-masterkey.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.masterkeySecretName }}
-{{ $masterkey := (.Values.masterkey | default (randAlphaNum 17)) }}
+{{ $masfixterkey := (.Values.masterkey | default (printf "sk-%s" (randAlphaNum 18))) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/charts/litellm-helm/tests/masterkey-secret_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/masterkey-secret_tests.yaml
@@ -2,13 +2,19 @@ suite: test masterkey secret
 templates:
   - secret-masterkey.yaml
 tests:
-  - it: should create a secret if masterkeySecretName is not set
+  - it: should create a secret if masterkeySecretName is not set. should start with sk-xxxx (base64 encoded as c2st*)
     template: secret-masterkey.yaml
     set:
       masterkeySecretName: ""
     asserts:
       - isKind:
           of: Secret
+      - matchRegex:
+          path: data.masterkey
+          pattern: ^c2st
+          # Note: The masterkey is generated as "sk-<18-random-chars>" in plain text,
+          # but stored as base64 encoded in Kubernetes secret (requirement).
+          # "sk-" base64 encodes to "c2st", so we check for "^c2st" pattern.
   - it: should not create a secret if masterkeySecretName is set
     template: secret-masterkey.yaml
     set:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15253,36 +15253,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/Qwen/Qwen3-Reranker-8B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-8,
-        "output_cost_per_token": 5e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/Qwen3-Reranker-4B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 2.5e-8,
-        "output_cost_per_token": 2.5e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/Qwen3-Reranker-0.6B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 1e-8,
-        "output_cost_per_token": 1e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
     "perplexity/codellama-34b-instruct": {
         "max_tokens": 16384,
         "max_input_tokens": 16384,


### PR DESCRIPTION
## Fix - Ensure Helm chart auto generated master keys follow sk-xxxx format 

- Updated the Helm chart to generate proxy master keys with an sk- prefix, matching common secret key formats
- Added a unit test ensuring the generated secret's base64-encoded value begins with the expected sk- prefix and documented the new default format in the chart README

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


