### PR TITLE
[Fix] Ensure Service Account Keys require team_id field on API Endpoints 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15253,36 +15253,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/Qwen/Qwen3-Reranker-8B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5e-8,
-        "output_cost_per_token": 5e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/Qwen3-Reranker-4B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 2.5e-8,
-        "output_cost_per_token": 2.5e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/Qwen3-Reranker-0.6B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 1e-8,
-        "output_cost_per_token": 1e-8,
-        "litellm_provider": "deepinfra",
-        "mode": "rerank",
-        "supports_tool_choice": true
-    },
     "perplexity/codellama-34b-instruct": {
         "max_tokens": 16384,
         "max_input_tokens": 16384,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -367,6 +367,16 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         premium_user=premium_user,
     )
 
+    if (
+        data.metadata is not None
+        and data.metadata.get("service_account_id") is not None
+        and data.team_id is None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="team_id is required for service account keys. Please specify `team_id` in the request body.",
+        )
+
     # check if user set default key/generate params on config.yaml
     if litellm.default_key_generate_params is not None:
         for elem in data:
@@ -860,6 +870,15 @@ async def prepare_key_update_data(
     data_json: dict = data.model_dump(exclude_unset=True)
     data_json.pop("key", None)
     data_json.pop("new_key", None)
+    if (
+        data.metadata is not None
+        and data.metadata.get("service_account_id") is not None
+        and (data.team_id or existing_key_row.team_id) is None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="team_id is required for service account keys. Please specify `team_id` in the request body.",
+        )
     non_default_values = {}
     for k, v in data_json.items():
         if (


### PR DESCRIPTION
## [Fix] Ensure Service Account Keys require team_id field on API Endpoints 

- Enforced that service account keys can only be generated when a team_id is supplied, returning a 400 error if missing
- Added a similar team_id check to key updates, blocking promotion to service account status without a team association
- Added unit tests for both cases above ^ 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


