### PR TITLE
🐛 Bug Fix: Updated URL handling for DataRobot provider URL

### DIFF
--- a/litellm/llms/datarobot/chat/transformation.py
+++ b/litellm/llms/datarobot/chat/transformation.py
@@ -6,7 +6,10 @@ Calls done in OpenAI/openai.py as DataRobot is openai-compatible.
 
 from typing import Optional, Tuple
 from litellm.secret_managers.main import get_secret_str
+from urllib.parse import urlparse, urlunparse
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
+
+LLMGW_PATH = "/genai/llmgw/chat/completions"
 
 
 class DataRobotConfig(OpenAILikeChatConfig):
@@ -32,22 +35,28 @@ class DataRobotConfig(OpenAILikeChatConfig):
         if api_base is None:
             api_base = "https://app.datarobot.com"
 
-        # If the api_base is a deployment URL, we do not append the chat completions path
-        if "api/v2/deployments" not in api_base:
-            # If the api_base is not a deployment URL, we need to append the chat completions path
-            if "api/v2/genai/llmgw/chat/completions" not in api_base:
-                api_base += "/api/v2/genai/llmgw/chat/completions"
+        parsed = urlparse(api_base)
+        path = parsed.path
+
+        if not path or path == "/":  # Add full path to LLMGW
+            path += f"/api/v2/{LLMGW_PATH}"
+        elif "api/v2/deployments" in path:  # Dedicated deployment, leave it
+            pass
+        elif (
+            "api/v2" in path and LLMGW_PATH not in path
+        ):  # Standard ENDPOINT path, add LLMGW
+            path += LLMGW_PATH
 
         # Ensure the url ends with a trailing slash
-        if not api_base.endswith("/"):
-            api_base += "/"
+        if not path.endswith("/"):
+            path += "/"
+        path = path.replace("//", "/")
+        updated_parsed = parsed._replace(path=path)
 
-        return api_base  # type: ignore
+        return urlunparse(updated_parsed)
 
     def _get_openai_compatible_provider_info(
-        self,
-        api_base: Optional[str],
-        api_key: Optional[str]
+        self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
         """Attempts to ensure that the API base and key are set, preferring user-provided values,
         before falling back to secret manager values (``DATAROBOT_ENDPOINT`` and ``DATAROBOT_API_TOKEN``

--- a/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
+++ b/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
@@ -18,6 +18,8 @@ class TestDataRobotConfig:
             (None, "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),
             ("http://localhost:5001", "http://localhost:5001/api/v2/genai/llmgw/chat/completions/"),
             ("https://app.datarobot.com", "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),
+            ("https://app.datarobot.com/api/v2/", "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),
+            ("https://app.datarobot.com/api/v2", "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),            
             ("https://app.datarobot.com/api/v2/genai/llmgw/chat/completions", "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),
             ("https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/", "https://app.datarobot.com/api/v2/genai/llmgw/chat/completions/"),
             ("https://staging.datarobot.com", "https://staging.datarobot.com/api/v2/genai/llmgw/chat/completions/"),


### PR DESCRIPTION
## Title

Bug fix: Updated URL handling for DataRobot provider base
<!-- e.g. "Implement user authentication feature" -->



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Test passing screenshot
<img width="1123" height="528" alt="image" src="https://github.com/user-attachments/assets/2eaa0f3b-7f3d-46e3-8db3-c7ea1c4f2097" />

## Type

🐛 Bug Fix

## Changes

Corrected a typical situation where DATAROBOT_ENDPOINT is set to include the `/api/v2` path as documented in the official client docs: https://pypi.org/project/datarobot/
