### PR TITLE
Add openrouter deepseek/deepseek-chat-v3.1 support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11236,6 +11236,21 @@
         "supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "openrouter/deepseek/deepseek-chat-v3.1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_cache_hit": 2e-08,
+        "output_cost_per_token": 8e-07,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_assistant_prefill": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true
+  },
     "openrouter/x-ai/grok-4": {
         "max_tokens": 256000,
         "max_input_tokens": 256000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11236,6 +11236,21 @@
         "supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "openrouter/deepseek/deepseek-chat-v3.1": {
+          "max_tokens": 8192,
+          "max_input_tokens": 163840,
+          "max_output_tokens": 163840,
+          "input_cost_per_token": 2e-07,
+          "input_cost_per_token_cache_hit": 2e-08,
+          "output_cost_per_token": 8e-07,
+          "litellm_provider": "openrouter",
+          "mode": "chat",
+          "supports_function_calling": true,
+          "supports_assistant_prefill": true,
+          "supports_reasoning": true,
+          "supports_tool_choice": true,
+          "supports_prompt_caching": true
+    },
     "openrouter/x-ai/grok-4": {
         "max_tokens": 256000,
         "max_input_tokens": 256000,


### PR DESCRIPTION
## Add openrouter deepseek/deepseek-chat-v3.1 support

## Relevant issues
Fixes #13889

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

<img width="2090" height="1606" alt="image" src="https://github.com/user-attachments/assets/22594209-f117-45e3-85b2-27ad45cee4f9" />


## Type
🆕 New Feature


## Changes
Added the cost mapping of the new model. All the other things remain the same for this model, as this model is also supported for OpenAI's `/v1/chat/completions` endpoint, like other openrouter models
