### PR TITLE
[Bug Fix] Token encoding inconsistency between encode and token_counter

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -5,8 +5,6 @@ import io
 import struct
 from typing import Callable, List, Literal, Optional, Tuple, Union, cast
 
-import tiktoken
-
 import litellm
 from litellm import verbose_logger
 from litellm.constants import (
@@ -507,7 +505,7 @@ def _get_count_function(
 ) -> TokenCounterFunction:
     """
     Get the function to count tokens based on the model and custom tokenizer."""
-    from litellm.utils import _select_tokenizer, print_verbose
+    from litellm.utils import _select_tokenizer
 
     if model is not None or custom_tokenizer is not None:
         tokenizer_json = custom_tokenizer or _select_tokenizer(model)  # type: ignore

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -518,15 +518,7 @@ def _get_count_function(
                 return len(enc.ids)
 
         elif tokenizer_json["type"] == "openai_tokenizer":
-            model_to_use = _fix_model_name(model)  # type: ignore
-            try:
-                if "gpt-4o" in model_to_use:
-                    encoding = tiktoken.get_encoding("o200k_base")
-                else:
-                    encoding = tiktoken.encoding_for_model(model_to_use)
-            except KeyError:
-                print_verbose("Warning: model not found. Using cl100k_base encoding.")
-                encoding = tiktoken.get_encoding("cl100k_base")
+            encoding = tokenizer_json["tokenizer"]
 
             def count_tokens(text: str) -> int:
                 return len(encoding.encode(text))

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1711,8 +1711,25 @@ def _select_tokenizer_helper(model: str) -> SelectTokenizerResponse:
     return _return_openai_tokenizer(model)
 
 
+
 def _return_openai_tokenizer(model: str) -> SelectTokenizerResponse:
-    return {"type": "openai_tokenizer", "tokenizer": encoding}
+    from litellm.litellm_core_utils.token_counter import _fix_model_name
+
+    model_to_use = _fix_model_name(model)
+
+    try:
+        # Special case: GPT-4o uses o200k_base
+        if "gpt-4o" in model_to_use:
+            tiktoken_encoding = tiktoken.get_encoding("o200k_base")
+        else:
+            # Use tiktoken's model-specific encoding
+            tiktoken_encoding = tiktoken.encoding_for_model(model_to_use)
+    except KeyError:
+        # Fallback to cl100k_base for unknown models
+        verbose_logger.debug(f"Warning: model {model} not found. Using cl100k_base encoding.")
+        tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
+
+    return {"type": "openai_tokenizer", "tokenizer": tiktoken_encoding}
 
 
 def _return_huggingface_tokenizer(model: str) -> Optional[SelectTokenizerResponse]:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -283,7 +283,7 @@ def test_encode_token_counter_consistency(model):
     encoded_tokens = encode(model=model, text=sample_text)
     encode_token_count = len(encoded_tokens)
     
-    assert counter_tokens == encode_token_count, f"Got={counter_tokens}, Expected={encode_token_count}, Params={{'model': {model}, 'text': {sample_text[:30]}}}"
+    assert counter_tokens == encode_token_count, f"Got={counter_tokens}, Expected={encode_token_count}, Params={'model': {model}}"
 
 # test_encode_decode_token_counter_consistency()
 

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -262,6 +262,31 @@ def test_encoding_and_decoding():
 # test_encoding_and_decoding()
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o",
+        "gpt-3.5-turbo",
+        "gpt-35-turbo",  # Azure naming
+        "claude-3-opus-20240229",
+        "command-nightly",
+        "mistral/mistral-tiny",
+    ],
+)
+def test_encode_token_counter_consistency(model):
+    sample_text = "Hellö World, this is my input string! My name is ishaan CTO"
+    
+    # Get token count from token_counter
+    counter_tokens = token_counter(model=model, text=sample_text)
+    
+    # Get token count from encode
+    encoded_tokens = encode(model=model, text=sample_text)
+    encode_token_count = len(encoded_tokens)
+    
+    assert counter_tokens == encode_token_count, f"Got={counter_tokens}, Expected={encode_token_count}, Params={{'model': {model}, 'text': {sample_text[:30]}}}"
+
+# test_encode_decode_token_counter_consistency()
+
 def test_gpt_vision_token_counting():
     messages = [
         {


### PR DESCRIPTION
## Title

Fix token encoding inconsistency between encode and token_counter

## Relevant issues

No relevant issues. But this PR resolves inconsistencies in token counting between the `encode` functions and `token_counter`, particularly for openai models. The fix ensures that both systems use the correct model-specific tokenizers, eliminating discrepancies and improving accuracy for multilingual text.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Modified the `_return_openai_tokenizer` in encode process to return a tokenizer that considers the model.
- In line with the above change, removed the tokenizer selection logic from `_get_count_function` since it's assumed to be unnecessary (internally, _select_tokenizer → _select_tokenizer_helper → _return_openai_tokenizer are called in sequence).

