### PR TITLE
Fixed mock related to pytest that was failing

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -11,6 +11,7 @@ sys.path.insert(
 
 import time
 
+import litellm
 from litellm.constants import SENTRY_DENYLIST, SENTRY_PII_DENYLIST
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
 from litellm.litellm_core_utils.litellm_logging import set_callbacks
@@ -453,7 +454,7 @@ async def test_e2e_generate_cold_storage_object_key_not_configured():
     response_id = "chatcmpl-test-67890"
     team_alias = "another-team"
     
-    with patch("litellm.configured_cold_storage_logger", return_value=None):
+    with patch.object(litellm, 'configured_cold_storage_logger', None):
         
         # Call the function
         result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(


### PR DESCRIPTION
## Title

Fixed mock related to pytest that was failing

## Relevant issues

CI(test) fail: e.g. https://github.com/BerriAI/litellm/actions/runs/17172368145/job/48723695129?pr=13907

Fix test mock for configured_cold_storage_logger attribute

- Problem: patch(..., return_value=None) is designed for mocking functions,
  but configured_cold_storage_logger is an attribute, making the mock
  ineffective.

- Solution: Use patch.object(litellm, 'configured_cold_storage_logger', None)
  to directly set the attribute value to None.

- Result: The condition if litellm.configured_cold_storage_logger is None: now
   evaluates to True, allowing the function to return None as expected.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [-] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [-] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


