### PR TITLE
Fix missing and unused imports in custom_guardrail docs example

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
+++ b/docs/my-website/docs/proxy/guardrails/custom_guardrail.md
@@ -23,15 +23,14 @@ A CustomGuardrail has 4 methods to enforce guardrails
 
 Create a new file called `custom_guardrail.py` and add this code to it
 ```python
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, AsyncGenerator, Literal, Optional, Union
 
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
-from litellm.proxy.guardrails.guardrail_helpers import should_proceed_based_on_metadata
-from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import ModelResponseStream
 
 
 class myCustomGuardrail(CustomGuardrail):


### PR DESCRIPTION
## Title

Fix missing/unused imports in [custom_guardrail docs example](https://docs.litellm.ai/docs/proxy/guardrails/custom_guardrail)

## Relevant issues

N/A

I encountered an error when trying to start the proxy with a custom guardrail.  
Following the documentation’s example implementation of a custom guardrail, the startup failed with the following error (shortened for clarity):

```
14:02:10 - LiteLLM Proxy:DEBUG: guardrail_registry.py:468 - Initializing custom guardrail: custom_guardrail.myCustomGuardrail, file_name: custom_guardrail, class_name: myCustomGuardrail
ERROR: Traceback (most recent call last):
...
File "guardrail_registry.py", line 485, in initialize_custom_guardrail
spec.loader.exec_module(module)
File "custom_guardrail.py", line 113, in myCustomGuardrail
) -> AsyncGenerator[ModelResponseStream, None]:
NameError: name 'AsyncGenerator' is not defined

ERROR: Application startup failed. Exiting.
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

- Added missing imports in the `custom_guardrail` docs example:
  - `AsyncGenerator`
  - `ModelResponseStream`
- Removed unused imports from the same example:
  - `Dict`
  - `List`
  - `should_proceed_based_on_metadata`
  - `GuardrailEventHooks`
- Verified that the example runs correctly after the update

