### PR TITLE
[BUG] Add back supervisor to non-root image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -33,11 +33,12 @@ WORKDIR /app
 # Install runtime dependencies
 USER root
 RUN apk upgrade --no-cache && \
-  apk add --no-cache bash libstdc++ ca-certificates openssl
+  apk add --no-cache bash libstdc++ ca-certificates openssl supervisor
 
 # Copy only necessary artifacts from builder stage for runtime
 COPY . .
 COPY --from=builder /app/docker/entrypoint.sh /app/docker/prod_entrypoint.sh /app/docker/
+COPY --from=builder /app/docker/supervisord.conf /etc/supervisord.conf
 COPY --from=builder /app/schema.prisma /app/schema.prisma
 COPY --from=builder /app/dist/*.whl .
 COPY --from=builder /wheels/ /wheels/


### PR DESCRIPTION
## Title

Add back supervisor to non-root image

## Relevant issues

When setting up the separate health app using the non-root Docker image, the container crashes immediately with an explicit error log. `supervisor` has been removed inadvertently by [this commit](https://github.com/BerriAI/litellm/commit/c65392cf815694ee899d76bb52185d754298d19c) (see thread with author there).
```
2025-08-24 15:20:29 /app/docker/prod_entrypoint.sh: exec: line 5: supervisord: not found
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

This PR adds back supervisor to the non-root Docker image.

Tested locally by 
- adding `dockerfile: ./docker/Dockerfile.non_root` to docker-compose.yml
- commenting `#image: ghcr.io/berriai/litellm:main-stable` in docker-compose.yml
-  adding `SEPARATE_HEALTH_APP="1"` to .env

See logs:
```
2025-08-24 15:34:46 2025-08-24 13:34:46,218 INFO supervisord started with pid 1
2025-08-24 15:34:47 2025-08-24 13:34:47,221 INFO spawned: 'process_monitor' with pid 6
2025-08-24 15:34:47 2025-08-24 13:34:47,225 INFO spawned: 'main' with pid 7
2025-08-24 15:34:47 2025-08-24 13:34:47,227 INFO spawned: 'health' with pid 8
2025-08-24 15:34:48 2025-08-24 13:34:48,546 INFO success: process_monitor entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-08-24 15:34:48 2025-08-24 13:34:48,546 INFO success: main entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2025-08-24 15:34:48 2025-08-24 13:34:48,546 INFO success: health entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
...
2025-08-24 15:34:54 INFO:     Uvicorn running on http://0.0.0.0:4001 (Press CTRL+C to quit)
...
2025-08-24 15:35:09 INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)
```

```
$ curl http://localhost:4001/health/liveness
"I'm alive!"
```

```
~ $ ps
PID   USER     TIME  COMMAND
    1 nobody    0:00 {supervisord} /usr/bin/python3.13 /usr/bin/supervisord -c /etc/supervisord.conf
    6 nobody    0:00 python -c from supervisor import childutils; import os, signal; [os.kill(os.getppid(), signal.SIGTER
    7 nobody    0:14 python -m litellm.proxy.proxy_cli --host 0.0.0.0 --port=4000 --port 4000
    8 nobody    0:07 {uvicorn} /usr/bin/python3.13 /usr/bin/uvicorn litellm.proxy.health_endpoints.health_app_factory:bui
  120 nobody    0:00 /nonexistent/node_modules/prisma/query-engine-debian-openssl-3.0.x -p 58123 --enable-metrics --enabl
  178 nobody    0:00 /bin/sh
  184 nobody    0:00 ps
```