### PR TITLE
Verify if cache entry has expired prior to serving it to client

### DIFF
--- a/litellm/caching/s3_cache.py
+++ b/litellm/caching/s3_cache.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 from functools import partial
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 from litellm._logging import print_verbose, verbose_logger
 
@@ -70,10 +70,9 @@ class S3Cache(BaseCache):
 
             if ttl is not None:
                 cache_control = f"immutable, max-age={ttl}, s-maxage={ttl}"
-                import datetime
 
                 # Calculate expiration time
-                expiration_time = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=ttl)
+                expiration_time = datetime.now(timezone.utc) + timedelta(seconds=ttl)
                 # Upload the data to S3 with the calculated expiration time
                 self.s3_client.put_object(
                     Bucket=self.bucket_name,


### PR DESCRIPTION
## Title

Verify if cache entry has expired prior to serving it to client

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
<img width="2539" height="209" alt="image" src="https://github.com/user-attachments/assets/126045d4-5d1c-4d53-ab5a-bc499e5ade1b" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
S3 does not remove expired objects automatically and it is not that straightforward to create such functionality for real-time expired object deletions. The verification has been added to double check if fetched object has not expired, so that cache entry is recalculated if it did.

