### PR TITLE
fix(audio): use duration for stt response cost, #11846

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -598,6 +598,7 @@ def completion_cost(  # noqa: PLR0915
     litellm_model_name: Optional[str] = None,
     router_model_id: Optional[str] = None,
     litellm_logging_obj: Optional[LitellmLoggingObject] = None,
+    **kwargs
 ) -> float:
     """
     Calculate the cost of a given completion call fot GPT-3.5-turbo, llama2, any litellm supported llm.
@@ -995,6 +996,7 @@ def response_cost_calculator(
     litellm_model_name: Optional[str] = None,
     router_model_id: Optional[str] = None,
     litellm_logging_obj: Optional[LitellmLoggingObject] = None,
+    **kwargs
 ) -> float:
     """
     Returns
@@ -1028,6 +1030,7 @@ def response_cost_calculator(
                 litellm_model_name=litellm_model_name,
                 router_model_id=router_model_id,
                 litellm_logging_obj=litellm_logging_obj,
+                **kwargs
             )
         return response_cost
     except Exception as e:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1158,6 +1158,7 @@ class Logging(LiteLLMLoggingBaseClass):
         cache_hit: Optional[bool] = None,
         litellm_model_name: Optional[str] = None,
         router_model_id: Optional[str] = None,
+        **kwargs
     ) -> Optional[float]:
         """
         Calculate response cost using result + logging object variables.
@@ -1210,6 +1211,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 "standard_built_in_tools_params": self.standard_built_in_tools_params,
                 "router_model_id": router_model_id,
                 "litellm_logging_obj": self,
+                "duration": kwargs.get("duration","")
             }
         except Exception as e:  # error creating kwargs for cost calculation
             debug_info = StandardLoggingModelCostFailureDebugInformation(

--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -45,7 +45,7 @@ class ResponseMetadata:
             "api_base": get_api_base(model=model or "", optional_params=kwargs),
             "model_id": model_id,
             "response_cost": logging_obj._response_cost_calculator(
-                result=self.result, litellm_model_name=model, router_model_id=model_id
+                result=self.result, litellm_model_name=model, router_model_id=model_id, kwargs=kwargs
             ),
             "additional_headers": process_response_headers(
                 self._get_value_from_hidden_params("additional_headers") or {}

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5249,8 +5249,6 @@ def transcription(
         )
     if isinstance(response, dict):
         response["duration"] = duration
-    else:
-        setattr(response, "duration", duration)
     if response is None:
         raise ValueError("Unmapped provider passed in. Unable to get the response.")
     return response

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5081,7 +5081,7 @@ def transcription(
     model_info = kwargs.get("model_info", None)
     metadata = kwargs.get("metadata", None)
     atranscription = kwargs.get("atranscription", False)
-    atranscription = kwargs.get("atranscription", False)
+    duration = kwargs.get("duration", 0.0)
     litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
     extra_headers = kwargs.get("extra_headers", None)
     kwargs.pop("tags", [])
@@ -5247,6 +5247,10 @@ def transcription(
             headers={},
             provider_config=provider_config,
         )
+    if isinstance(response, dict):
+        response["duration"] = duration
+    else:
+        setattr(response, "duration", duration)
     if response is None:
         raise ValueError("Unmapped provider passed in. Unable to get the response.")
     return response

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2194,6 +2194,7 @@ class Router:
             kwargs["model"] = model
             kwargs["file"] = file
             kwargs["original_function"] = self._atranscription
+            kwargs["duration"] = kwargs.get("duration", False)
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -2267,6 +2268,7 @@ class Router:
                 response = await response
 
             self.success_calls[model_name] += 1
+            response.duration = kwargs.get("duration")
             verbose_router_logger.info(
                 f"litellm.atranscription(model={model_name})\033[32m 200 OK\033[0m"
             )

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -589,7 +589,8 @@ class ModelGroupInfo(BaseModel):
     supports_web_search: bool = Field(default=False)
     supports_url_context: bool = Field(default=False)
     supports_reasoning: bool = Field(default=False)
-    supports_function_calling: bool = Field(default=False)
+    supports_audio_input: Optional[bool] = Field(default=False)
+    supports_function_calling: Optional[bool] = Field(default=False)
     supported_openai_params: Optional[List[str]] = Field(default=[])
     configurable_clientside_auth_params: CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS = None
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1692,6 +1692,7 @@ class ImageResponse(OpenAIImageResponse, BaseLiteLLMOpenAIResponseObject):
 
 class TranscriptionResponse(OpenAIObject):
     text: Optional[str] = None
+    duration: Optional[float] = 0.0
 
     _hidden_params: dict = {}
     _response_headers: Optional[dict] = None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1447,6 +1447,8 @@ def client(original_function):  # noqa: PLR0915
 
             # MODEL CALL
             result = await original_function(*args, **kwargs)
+            if kwargs.get("duration", False) is not False:
+                result.duration = kwargs.get("duration", False)
             end_time = datetime.datetime.now()
             if _is_streaming_request(
                 kwargs=kwargs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ tenacity==8.2.3  # for retrying requests, when litellm.num_retries set
 pydantic==2.10.2 # proxy + openai req.
 jsonschema==4.22.0 # validating json schema
 websockets==13.1.0 # for realtime API
+mutagen
 
 ########################
 # LITELLM ENTERPRISE DEPENDENCIES


### PR DESCRIPTION
## Title

Implements the `duration` parameter in the rest response for the audio transcription, include also a bugfix for the response_cost.
The issue was tested with vllm, I don't have time for tests but I want to share the code that fix the issue for someone else.

## Relevant issues

Fixes #11846

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


