### PR TITLE
feat: add image headers for Copilot

### DIFF
--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -362,3 +362,99 @@ def test_x_initiator_header_system_only_messages():
     )
     
     assert headers["X-Initiator"] == "user"
+
+
+def test_copilot_vision_request_header_with_image():
+    """Test that Copilot-Vision-Request header is added when messages contain images"""
+    config = GithubCopilotConfig()
+    
+    # Mock the authenticator
+    config.authenticator = MagicMock()
+    config.authenticator.get_api_key.return_value = "gh.test-key-123"
+    config.authenticator.get_api_base.return_value = None
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,abc123"}
+                }
+            ]
+        }
+    ]
+    
+    headers = config.validate_environment(
+        headers={},
+        model="github_copilot/gpt-4-vision-preview",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        api_key=None,
+        api_base=None,
+    )
+    
+    assert headers["Copilot-Vision-Request"] == "true"
+    assert headers["X-Initiator"] == "user"
+
+
+def test_copilot_vision_request_header_text_only():
+    """Test that Copilot-Vision-Request header is not added for text-only messages"""
+    config = GithubCopilotConfig()
+    
+    # Mock the authenticator
+    config.authenticator = MagicMock()
+    config.authenticator.get_api_key.return_value = "gh.test-key-123"
+    config.authenticator.get_api_base.return_value = None
+
+    messages = [
+        {"role": "user", "content": "Just a text message"},
+    ]
+    
+    headers = config.validate_environment(
+        headers={},
+        model="github_copilot/gpt-4",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        api_key=None,
+        api_base=None,
+    )
+    
+    assert "Copilot-Vision-Request" not in headers
+    assert headers["X-Initiator"] == "user"
+
+
+def test_copilot_vision_request_header_with_type_image_url():
+    """Test that Copilot-Vision-Request header is added for content with type: image_url"""
+    config = GithubCopilotConfig()
+    
+    # Mock the authenticator
+    config.authenticator = MagicMock()
+    config.authenticator.get_api_key.return_value = "gh.test-key-123"
+    config.authenticator.get_api_base.return_value = None
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Analyze this image"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+            ]
+        }
+    ]
+    
+    headers = config.validate_environment(
+        headers={},
+        model="github_copilot/gpt-4-vision-preview",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        api_key=None,
+        api_base=None,
+    )
+    
+    assert headers["Copilot-Vision-Request"] == "true"
+    assert headers["X-Initiator"] == "user"


### PR DESCRIPTION
## Add image headers for Copilot

These are required for Copilot to include images in the request. See linked issue for details; other apps have done the same thing.

## Relevant issues

Fixes #13696

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1429" height="224" alt="Screenshot 2025-08-25 at 18 26 38" src="https://github.com/user-attachments/assets/f49abe02-2a7f-4332-aa81-ab5391df640f" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes


