### PR TITLE
Add DeepSeek-v3.1 pricing for Fireworks AI provider

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16674,6 +16674,18 @@
         "supports_tool_choice": false,
         "supports_response_schema": true
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v3p1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 5.6e-07,
+        "output_cost_per_token": 1.68e-06,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_response_schema": true,
+        "source": "https://fireworks.ai/pricing",
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,


### PR DESCRIPTION
- Add fireworks_ai/accounts/fireworks/models/deepseek-v3p1 model configuration
- Set context window: 128K input, 8K output tokens
- Pricing: /bin/zsh.56/1M input tokens, .68/1M output tokens
- Supports response schema and tool choice
- Based on DeepSeek API unified pricing effective Sept 2025

## Title

Add DeepSeek-v3.1 pricing for Fireworks AI provider

## Relevant issues



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🚄 Infrastructure

## Changes


