### PR TITLE
[Bug]: Fix tests to reference moved attributes in `braintrust_logging` module

### DIFF
--- a/tests/test_litellm/integrations/test_braintrust_logging.py
+++ b/tests/test_litellm/integrations/test_braintrust_logging.py
@@ -44,16 +44,19 @@ class TestBraintrustLogger(unittest.TestCase):
                 BraintrustLogger(api_key=None)
             self.assertIn("Missing keys=['BRAINTRUST_API_KEY']", str(context.exception))
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_log_success_event_with_default_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_log_success_event_with_default_span_name(self, MockHTTPHandler):
         """Test log_success_event uses default span name when not provided."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-project-id"}
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = mock_response
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        mock_response = Mock()
-        mock_response.json.return_value = {"id": "test-project-id"}
-        mock_http_handler.post.return_value = mock_response
         
         # Create a mock response object
         message_mock = Mock()
@@ -90,16 +93,19 @@ class TestBraintrustLogger(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Chat Completion')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_log_success_event_with_custom_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_log_success_event_with_custom_span_name(self, MockHTTPHandler):
         """Test log_success_event uses custom span name when provided."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-project-id"}
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = mock_response
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        mock_response = Mock()
-        mock_response.json.return_value = {"id": "test-project-id"}
-        mock_http_handler.post.return_value = mock_response
         
         # Create a mock response object
         message_mock = Mock()
@@ -135,16 +141,19 @@ class TestBraintrustLogger(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Custom Operation')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_http_handler')
-    async def test_async_log_success_event_with_default_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.get_async_httpx_client')
+    async def test_async_log_success_event_with_default_span_name(self, mock_get_http_handler):
         """Test async_log_success_event uses default span name when not provided."""
+        # Mock async HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-project-id"}
+        mock_http_handler = MagicMock()
+        mock_http_handler.post = MagicMock(return_value=mock_response)
+        mock_get_http_handler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        mock_response = Mock()
-        mock_response.json.return_value = {"id": "test-project-id"}
-        mock_http_handler.post = MagicMock(return_value=mock_response)
         
         # Create a mock response object
         message_mock = Mock()
@@ -180,16 +189,19 @@ class TestBraintrustLogger(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Chat Completion')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_http_handler')
-    async def test_async_log_success_event_with_custom_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.get_async_httpx_client')
+    async def test_async_log_success_event_with_custom_span_name(self, mock_get_http_handler):
         """Test async_log_success_event uses custom span name when provided."""
+        # Mock async HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-project-id"}
+        mock_http_handler = MagicMock()
+        mock_http_handler.post = MagicMock(return_value=mock_response)
+        mock_get_http_handler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        mock_response = Mock()
-        mock_response.json.return_value = {"id": "test-project-id"}
-        mock_http_handler.post = MagicMock(return_value=mock_response)
         
         # Create a mock response object
         message_mock = Mock()
@@ -225,16 +237,19 @@ class TestBraintrustLogger(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Async Custom Operation')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_span_name_with_multiple_metadata_fields(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_span_name_with_multiple_metadata_fields(self, MockHTTPHandler):
         """Test that span_name works correctly alongside other metadata fields."""
+        # Mock HTTP response
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": "test-project-id"}
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = mock_response
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        mock_response = Mock()
-        mock_response.json.return_value = {"id": "test-project-id"}
-        mock_http_handler.post.return_value = mock_response
         
         # Create a mock response object
         message_mock = Mock()

--- a/tests/test_litellm/integrations/test_braintrust_logging.py
+++ b/tests/test_litellm/integrations/test_braintrust_logging.py
@@ -65,6 +65,8 @@ class TestBraintrustLogger(unittest.TestCase):
         choice_mock = Mock()
         choice_mock.message = message_mock
         choice_mock.dict = Mock(return_value={"message": {"content": "test"}})
+        # Mock the __getitem__ to support response_obj["choices"][0]["message"]
+        choice_mock.__getitem__ = Mock(return_value=message_mock)
         
         response_obj = Mock(spec=litellm.ModelResponse)
         response_obj.choices = [choice_mock]
@@ -114,6 +116,7 @@ class TestBraintrustLogger(unittest.TestCase):
         choice_mock = Mock()
         choice_mock.message = message_mock
         choice_mock.dict = Mock(return_value={"message": {"content": "test"}})
+        choice_mock.__getitem__ = Mock(return_value=message_mock)
         
         response_obj = Mock(spec=litellm.ModelResponse)
         response_obj.choices = [choice_mock]
@@ -162,6 +165,7 @@ class TestBraintrustLogger(unittest.TestCase):
         choice_mock = Mock()
         choice_mock.message = message_mock
         choice_mock.dict = Mock(return_value={"message": {"content": "test"}})
+        choice_mock.__getitem__ = Mock(return_value=message_mock)
         
         response_obj = Mock(spec=litellm.ModelResponse)
         response_obj.choices = [choice_mock]
@@ -210,6 +214,7 @@ class TestBraintrustLogger(unittest.TestCase):
         choice_mock = Mock()
         choice_mock.message = message_mock
         choice_mock.dict = Mock(return_value={"message": {"content": "test"}})
+        choice_mock.__getitem__ = Mock(return_value=message_mock)
         
         response_obj = Mock(spec=litellm.ModelResponse)
         response_obj.choices = [choice_mock]
@@ -258,6 +263,7 @@ class TestBraintrustLogger(unittest.TestCase):
         choice_mock = Mock()
         choice_mock.message = message_mock
         choice_mock.dict = Mock(return_value={"message": {"content": "test"}})
+        choice_mock.__getitem__ = Mock(return_value=message_mock)
         
         response_obj = Mock(spec=litellm.ModelResponse)
         response_obj.choices = [choice_mock]

--- a/tests/test_litellm/integrations/test_braintrust_span_name.py
+++ b/tests/test_litellm/integrations/test_braintrust_span_name.py
@@ -11,15 +11,17 @@ from litellm.integrations.braintrust_logging import BraintrustLogger
 class TestBraintrustSpanName(unittest.TestCase):
     """Test custom span_name functionality in Braintrust logging."""
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_default_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_default_span_name(self, MockHTTPHandler):
         """Test that default span name is 'Chat Completion' when not provided."""
+        # Mock HTTP response
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = Mock()
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        # Mock HTTP response
-        mock_http_handler.post.return_value = Mock()
         
         # Create a properly structured mock response
         response_obj = litellm.ModelResponse(
@@ -52,15 +54,17 @@ class TestBraintrustSpanName(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Chat Completion')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_custom_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_custom_span_name(self, MockHTTPHandler):
         """Test that custom span name is used when provided in metadata."""
+        # Mock HTTP response
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = Mock()
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        # Mock HTTP response
-        mock_http_handler.post.return_value = Mock()
         
         # Create a properly structured mock response
         response_obj = litellm.ModelResponse(
@@ -93,15 +97,17 @@ class TestBraintrustSpanName(unittest.TestCase):
         json_data = call_args.kwargs['json']
         self.assertEqual(json_data['events'][0]['span_attributes']['name'], 'Custom Operation')
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_sync_http_handler')
-    def test_span_name_with_other_metadata(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.HTTPHandler')
+    def test_span_name_with_other_metadata(self, MockHTTPHandler):
         """Test that span_name works alongside other metadata fields."""
+        # Mock HTTP response
+        mock_http_handler = Mock()
+        mock_http_handler.post.return_value = Mock()
+        MockHTTPHandler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        # Mock HTTP response
-        mock_http_handler.post.return_value = Mock()
         
         # Create a properly structured mock response
         response_obj = litellm.ModelResponse(
@@ -153,15 +159,17 @@ class TestBraintrustSpanName(unittest.TestCase):
         # Span name should be in span_attributes, not in metadata
         self.assertIn('span_name', event_metadata)  # span_name is also kept in metadata
 
-    @patch('litellm.integrations.braintrust_logging.global_braintrust_http_handler')
-    async def test_async_custom_span_name(self, mock_http_handler):
+    @patch('litellm.integrations.braintrust_logging.get_async_httpx_client')
+    async def test_async_custom_span_name(self, mock_get_http_handler):
         """Test async logging with custom span name."""
+        # Mock async HTTP response
+        mock_http_handler = MagicMock()
+        mock_http_handler.post = MagicMock(return_value=Mock())
+        mock_get_http_handler.return_value = mock_http_handler
+
         # Setup
         logger = BraintrustLogger(api_key="test-key")
         logger.default_project_id = "test-project-id"
-        
-        # Mock async HTTP response
-        mock_http_handler.post = MagicMock(return_value=Mock())
         
         # Create a properly structured mock response
         response_obj = litellm.ModelResponse(


### PR DESCRIPTION
## Title

Fix tests to reference moved attributes in `braintrust_logging` module

## Relevant issues

Fixes #13977

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
  <img width="660" height="73" alt="image" src="https://github.com/user-attachments/assets/24c6c259-6448-4d61-a689-a49b70d202e2" />
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes


