### PR TITLE
[Perf] fix: just get `provider_config` once

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1246,7 +1246,9 @@ def completion(  # type: ignore # noqa: PLR0915
             "allowed_openai_params": kwargs.get("allowed_openai_params"),
         }
         optional_params = get_optional_params(
-            **optional_param_args, **non_default_params
+            **optional_param_args,
+            **non_default_params,
+            provider_config=provider_config,
         )
         processed_non_default_params = pre_process_non_default_params(
             model=model,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16688,6 +16688,18 @@
         "supports_tool_choice": false,
         "supports_response_schema": true
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v3p1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 5.6e-07,
+        "output_cost_per_token": 1.68e-06,
+        "litellm_provider": "fireworks_ai",
+        "mode": "chat",
+        "supports_response_schema": true,
+        "source": "https://fireworks.ai/pricing",
+        "supports_tool_choice": true
+    },
     "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3088,6 +3088,7 @@ def pre_process_non_default_params(
     model: str,
     remove_sensitive_keys: bool = False,
     add_provider_specific_params: bool = False,
+    provider_config: Optional[BaseConfig] = None,
 ) -> dict:
     """
     Pre-process non-default params to a standardized format
@@ -3103,13 +3104,6 @@ def pre_process_non_default_params(
         additional_endpoint_specific_params=["messages"],
     )
 
-    provider_config: Optional[BaseConfig] = None
-    if custom_llm_provider is not None and custom_llm_provider in [
-        provider.value for provider in LlmProviders
-    ]:
-        provider_config = ProviderConfigManager.get_provider_chat_config(
-            model=model, provider=LlmProviders(custom_llm_provider)
-        )
 
     if "response_format" in non_default_params:
         if provider_config is not None:
@@ -3307,6 +3301,7 @@ def get_optional_params(  # noqa: PLR0915
     messages: Optional[List[AllMessageValues]] = None,
     thinking: Optional[AnthropicThinkingParam] = None,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
+    provider_config: Optional[BaseConfig] = None,
     **kwargs,
 ):
     passed_params = locals().copy()
@@ -3317,19 +3312,14 @@ def get_optional_params(  # noqa: PLR0915
         custom_llm_provider=custom_llm_provider,
         additional_drop_params=additional_drop_params,
         model=model,
+        provider_config=provider_config,
     )
     optional_params = pre_process_optional_params(
         passed_params=passed_params,
         non_default_params=non_default_params,
         custom_llm_provider=custom_llm_provider,
     )
-    provider_config: Optional[BaseConfig] = None
-    if custom_llm_provider is not None and custom_llm_provider in [
-        provider.value for provider in LlmProviders
-    ]:
-        provider_config = ProviderConfigManager.get_provider_chat_config(
-            model=model, provider=LlmProviders(custom_llm_provider)
-        )
+
 
     def _check_valid_arg(supported_params: List[str]):
         """


### PR DESCRIPTION
## [Perf] fix: just get `provider_config` once

- RPS Perf improvement for /chat/completions. Prevents duplicate work 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


