### PR TITLE
Region badges added in the credentials column on the All Models page

### DIFF
--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -3,19 +3,14 @@ import { Button, Badge, Icon } from "@tremor/react";
 import { Tooltip } from "antd";
 import { getProviderLogoAndName } from "../../provider_info_helpers";
 import { ModelData } from "../../model_dashboard/types";
-import { TrashIcon, PencilIcon, PencilAltIcon, KeyIcon } from "@heroicons/react/outline";
-import DeleteModelButton from "../../delete_model_button";
-import { useState } from "react";
+import { TrashIcon, KeyIcon } from "@heroicons/react/outline";
 
 export const columns = (
   userRole: string,
   userID: string,
-  premiumUser: boolean,
   setSelectedModelId: (id: string) => void,
   setSelectedTeamId: (id: string) => void,
   getDisplayModelName: (model: any) => string,
-  handleEditClick: (model: any) => void,
-  handleRefreshClick: () => void,
   setEditModel: (edit: boolean) => void,
   expandedRows: Set<string>,
   setExpandedRows: (expandedRows: Set<string>) => void,
@@ -103,14 +98,29 @@ export const columns = (
     cell: ({ row }) => {
       const model = row.original;
       const credentialName = model.litellm_params?.litellm_credential_name;
+      // const mockRegion = getMockRegion(model.provider, credentialName);
       
       return credentialName ? (
-        <Tooltip title={`Credential: ${credentialName}`}>
-          <div className="flex items-center space-x-2 max-w-[180px]">
-            <KeyIcon className="w-4 h-4 text-blue-500 flex-shrink-0" />
-            <span className="text-xs truncate" title={credentialName}>
-              {credentialName}
-            </span>
+        <Tooltip title={`Credential: ${credentialName}${mockRegion ? ` | Region: ${mockRegion}` : ''}`}>
+          <div className="flex flex-col space-y-1 max-w-[180px]">
+            {/* Credential Name */}
+            <div className="flex items-center space-x-2">
+              <KeyIcon className="w-4 h-4 text-blue-500 flex-shrink-0" />
+              <span className="text-xs truncate" title={credentialName}>
+                {credentialName}
+              </span>
+            </div>
+            
+            {/* Region Badge */}
+            <div className="flex items-center justify-start">
+              <Badge
+                size="xs"
+                color="blue"
+                className="text-xs px-1.5 py-0.5 h-5 leading-tight flex-shrink-0"
+              >
+                {mockRegion || 'no-region'}
+              </Badge>
+            </div>
           </div>
         </Tooltip>
       ) : (


### PR DESCRIPTION
## Title
Region badges added in the credentials column on the All Models page
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Enhancement

## Changes
- Enhanced the credentials cell in the models table to display region information
- Updated tooltip to include region information when available
- Cleaned up unused imports and parameters
- Falls back to 'no-region' text when region data is not available
- Maintains existing "No credentials" state for models without credentials
<img width="1320" height="848" alt="Screenshot 2025-08-27 at 8 54 41" src="https://github.com/user-attachments/assets/f448f162-dcb7-4a0d-98a6-262295bbf97f" />
