### PR TITLE
[Perf] 6.5x faster LiteLLM Python SDK Completion  

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1256,6 +1256,7 @@ def completion(  # type: ignore # noqa: PLR0915
             additional_drop_params=kwargs.get("additional_drop_params"),
             remove_sensitive_keys=True,
             add_provider_specific_params=True,
+            provider_config=provider_config,
         )
 
         if litellm.add_function_to_prompt and optional_params.get(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3088,6 +3088,7 @@ def pre_process_non_default_params(
     model: str,
     remove_sensitive_keys: bool = False,
     add_provider_specific_params: bool = False,
+    provider_config: Optional[BaseConfig] = None,
 ) -> dict:
     """
     Pre-process non-default params to a standardized format
@@ -3102,14 +3103,6 @@ def pre_process_non_default_params(
         default_param_values=DEFAULT_CHAT_COMPLETION_PARAM_VALUES,
         additional_endpoint_specific_params=["messages"],
     )
-
-    provider_config: Optional[BaseConfig] = None
-    if custom_llm_provider is not None and custom_llm_provider in [
-        provider.value for provider in LlmProviders
-    ]:
-        provider_config = ProviderConfigManager.get_provider_chat_config(
-            model=model, provider=LlmProviders(custom_llm_provider)
-        )
 
     if "response_format" in non_default_params:
         if provider_config is not None:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -957,7 +957,12 @@ def test_get_model_info_shows_supports_computer_use():
 def test_pre_process_non_default_params(model, custom_llm_provider):
     from pydantic import BaseModel
 
-    from litellm.utils import pre_process_non_default_params
+    from litellm.utils import ProviderConfigManager, pre_process_non_default_params
+
+    provider_config = ProviderConfigManager.get_provider_chat_config(
+        model=model, 
+        provider=LlmProviders(custom_llm_provider)
+    )
 
     class ResponseFormat(BaseModel):
         x: str
@@ -974,6 +979,7 @@ def test_pre_process_non_default_params(model, custom_llm_provider):
         special_params=special_params,
         custom_llm_provider=custom_llm_provider,
         additional_drop_params=None,
+        provider_config=provider_config,
     )
     print(processed_non_default_params)
     assert processed_non_default_params == {


### PR DESCRIPTION
## [Perf] 6.5x faster LiteLLM Python SDK Completion  

Optimizes code in litellm.completion to reduce duplicate computation of the llm provider config 

| Metric | Before | After (Run 1) | After (Run 2) | Improvement (Run 1) | Improvement (Run 2) |
|--------|--------|---------------|---------------|-------------------|-------------------|
| **preprocess_params Total Time** | 25.78s | 1.89s | 0.76s | **13.6x faster** | **33.9x faster** |
| **preprocess_params Avg per Call** | 2.58ms | 0.19ms | 0.08ms | **13.6x faster** | **32.3x faster** |
| **preprocess_params % of Total** | 15.8% | 4.5% | 3.0% | -71% | -81% |
| **Overall Total Time** | 163.08s | 41.82s | 25.12s | **3.9x faster** | **6.5x faster** |

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure
✅ Test

## Changes


