### PR TITLE
[Bug Fix] LLM Translation - Allow using dynamic `api_key` for image generation requests 

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextvars
 from functools import partial
-from typing import Any, Coroutine, Dict, Literal, Optional, Union, cast, overload, List
+from typing import Any, Coroutine, Dict, List, Literal, Optional, Union, cast, overload
 
 import httpx
 
@@ -347,6 +347,7 @@ def image_generation(  # noqa: PLR0915
                 raise ValueError(f"image generation config is not supported for {custom_llm_provider}")
             
             return llm_http_handler.image_generation_handler(
+                api_key=api_key,
                 model=model,
                 prompt=prompt,
                 image_generation_provider_config=image_generation_config,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2681,6 +2681,7 @@ class BaseLLMHTTPHandler:
         _is_async: bool = False,
         fake_stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
     ) -> Union[
         ImageResponse,
         Coroutine[Any, Any, ImageResponse],
@@ -2705,6 +2706,7 @@ class BaseLLMHTTPHandler:
                 client=client if isinstance(client, AsyncHTTPHandler) else None,
                 fake_stream=fake_stream,
                 litellm_metadata=litellm_metadata,
+                api_key=api_key,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2715,7 +2717,7 @@ class BaseLLMHTTPHandler:
             sync_httpx_client = client
 
         headers = image_generation_provider_config.validate_environment(
-            api_key=litellm_params.get("api_key", None),
+            api_key=api_key,
             headers=image_generation_optional_request_params.get("extra_headers", {})
             or {},
             model=model,
@@ -2798,6 +2800,7 @@ class BaseLLMHTTPHandler:
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         fake_stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        api_key: Optional[str] = None,
     ) -> ImageResponse:
         """
         Async version of the image generation handler.
@@ -2812,7 +2815,7 @@ class BaseLLMHTTPHandler:
             async_httpx_client = client
 
         headers = image_generation_provider_config.validate_environment(
-            api_key=litellm_params.get("api_key", None),
+            api_key=api_key,
             headers=image_generation_optional_request_params.get("extra_headers", {})
             or {},
             model=model,


### PR DESCRIPTION
## [Bug Fix] LLM Translation - Allow using dynamic `api_key` for image generation requests 

Fixes a bug where /images/generations did not accept a dynamic api_key 

<img width="615" height="488" alt="Screenshot 2025-08-27 at 9 00 47 AM" src="https://github.com/user-attachments/assets/098132f7-fbc0-4d65-80e3-ef0727686005" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


