### PR TITLE
[Feature]: Support Gemini requests with only system prompt 

### DIFF
--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -119,6 +119,28 @@ class BaseLLMChatTest(ABC):
             pytest.skip("Model is overloaded")
 
         assert response.choices[0].message.content is not None
+    
+    def test_system_message_with_no_user_message(self):
+        """
+        Test that the system message is translated correctly for non-OpenAI providers.
+        """
+        base_completion_call_args = self.get_base_completion_call_args()
+        messages = [
+            {
+                "role": "system",
+                "content": "Be a good bot!",
+            },
+        ]
+        try:
+            response = self.completion_function(
+                **base_completion_call_args,
+                messages=messages,
+            )
+            assert response is not None
+        except litellm.InternalServerError:
+            pytest.skip("Model is overloaded")
+
+        assert response.choices[0].message.content is not None
 
     def test_content_list_handling(self):
         """Check if content list is supported by LLM API"""


### PR DESCRIPTION
## [Feature]: Support Gemini requests with only system prompt 

Fixes: https://github.com/BerriAI/litellm/issues/13769


## Context
Currently, when sending a request to Gemini through LiteLLM that only includes a system prompt (and no user message), the request fails. Gemini’s API requires at least one user message, so these calls break.

Request:

```json
{
    "model": "vertex_ai/gemini-2.5-flash",
    "messages": [
      {
        "role": "system",
        "content": "can gemini handle a request with only a system prompt?"
      }
    ]
}
```

Reponse: 
```json
{
    "error": {
        "message": "litellm.BadRequestError: VertexAIException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Unable to submit request because at least one contents field is required. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n. Received Model Group=vertex_ai/gemini-2.5-flash\nAvailable Model Group Fallbacks=None",
        "type": null,
        "param": null,
        "code": "400"
    }
}
```

## Expected behavior:
LiteLLM should gracefully handle requests with only a system message.


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


