### PR TITLE
Update release notes with correct docker tag

### DIFF
--- a/docs/my-website/release_notes/v1.75.8/index.md
+++ b/docs/my-website/release_notes/v1.75.8/index.md
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 docker run \
 -e STORE_MODEL_IN_DB=True \
 -p 4000:4000 \
-ghcr.io/berriai/litellm:v1.75.8
+ghcr.io/berriai/litellm:v1.75.8-stable
 ```
 </TabItem>
 


### PR DESCRIPTION
## Title

Update Docker tag for v1.75.8 release notes

## Relevant issues

<!-- No specific issue number, but related to user feedback in Slack. -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Corrected the Docker tag in the `v1.75.8` release notes from `ghcr.io/berriai/litellm:v1.75.8` to `ghcr.io/berriai/litellm:v1.75.8-stable`. This ensures users deploy the correct stable version of LiteLLM as per the official stable release tag.

---
[Slack Thread](https://berriaillm.slack.com/archives/C07LGTQ15QC/p1756337027771439?thread_ts=1756337027.771439&cid=C07LGTQ15QC)

<a href="https://cursor.com/background-agent?bcId=bc-b5584ba0-c950-404b-acda-d9c674ae6b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5584ba0-c950-404b-acda-d9c674ae6b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

