### PR TITLE
Add supported text field to anthropic citation response

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -743,6 +743,8 @@ class ModelResponseIterator:
                 )
 
             text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)
+            if type_chunk:
+                provider_specific_fields["chunk_type"] = type_chunk
 
             returned_chunk = ModelResponseStream(
                 choices=[

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -797,7 +797,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             if content.get("citations") is not None:
                 if citations is None:
                     citations = []
-                citations.append(content["citations"])
+                citations.append(
+                    [
+                        {
+                            **citation,
+                            "supported_text": content.get("text", ""),
+                        }
+                        for citation in content["citations"]
+                    ]
+                )
         if thinking_blocks is not None:
             reasoning_content = ""
             for block in thinking_blocks:

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -920,6 +920,14 @@ def test_anthropic_citations_api():
     citations = resp.choices[0].message.provider_specific_fields["citations"]
 
     assert citations is not None
+    if citations:
+        citation = citations[0][0]
+        assert "supported_text" in citation
+        assert "cited_text" in citation
+        assert "document_index" in citation
+        assert "document_title" in citation
+        assert "start_char_index" in citation
+        assert "end_char_index" in citation
 
 
 def test_anthropic_citations_api_streaming():
@@ -955,11 +963,11 @@ def test_anthropic_citations_api_streaming():
     has_citations = False
     for chunk in resp:
         print(f"returned chunk: {chunk}")
-        if (
-            chunk.choices[0].delta.provider_specific_fields
-            and "citation" in chunk.choices[0].delta.provider_specific_fields
-        ):
-            has_citations = True
+        if provider_specific_fields := chunk.choices[0].delta.provider_specific_fields:
+            if "citation" in provider_specific_fields:
+                has_citations = True
+
+            assert "chunk_type" in provider_specific_fields
 
     assert has_citations
 


### PR DESCRIPTION
## Title

Add supported text field to anthropic citation response

## Relevant issues

#7970

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1125" height="183" alt="image" src="https://github.com/user-attachments/assets/6d8a6104-1160-4a7b-941f-160e3e38361e" />



## Type

🆕 New Feature

## Changes

Add supported text field to anthropic citation response to tell which sentence is supported by each citation. 

