### PR TITLE
Fix error saving latency as timedelta on Redis

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -108,7 +108,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                         if final_value is not None:
                             final_value = float(final_value)
                         else:
-                            final_value = response_ms
+                            final_value = response_seconds
 
                         if time_to_first_token_response_time is not None:
                             if isinstance(time_to_first_token_response_time, timedelta):


### PR DESCRIPTION
## Title

Saving latency as seconds instead of timedelta to avoid serialization errors

> LiteLLM Redis Caching: async set() - Got exception from REDIS Object of type timedelta is not JSON serializable, Writing value={'ede2189ff745be6817906d3ecf6a141b70a5ac7a4a743cc96453ad48927d011f': {'latency': [datetime.timedelta(microseconds=256357)], '2025-08-28-13-26': {'tpm': 0, 'rpm': 1}}}


## Relevant issues

Didn't found issue
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Using seconds instead of timedelta to save on Redis
