### PR TITLE
[Helm charts] Enhance proxy_config configuration: add support for existing configmap

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -44,6 +44,7 @@ If `db.useStackgresOperator` is used (not yet implemented):
 
 #### Example `proxy_config` ConfigMap from values (default):
 
+
 ```
 proxyConfigMap:
   create: true
@@ -61,6 +62,7 @@ proxy_config:
 
 #### Example using existing `proxyConfigMap` instead of creating it:
 
+
 ```
 proxyConfigMap:
   create: false
@@ -71,6 +73,7 @@ proxyConfigMap:
 ```
 
 #### Example `environmentSecrets` Secret 
+
 
 ```
 apiVersion: v1

--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -36,12 +36,11 @@ If `db.useStackgresOperator` is used (not yet implemented):
 | `service.port`                                             | TCP port that the Kubernetes Service will listen on.  Also the TCP port within the Pod that the proxy will listen on.                                                                 | `4000`  |
 | `service.loadBalancerClass`                                | Optional LoadBalancer implementation class (only used when `service.type` is `LoadBalancer`)                                                                                                          | `""`  |
 | `ingress.*`                                                | See [values.yaml](./values.yaml) for example settings                                                                                                                                 | N/A  |
-
-| `proxyConfigMap.create`      | When `true`, render a ConfigMap from `.Values.proxy_config` and mount it.                                 | `true`         |
-| `proxyConfigMap.name`        | When `create=false`, name of the existing ConfigMap to mount.                                             | `""`           |
-| `proxyConfigMap.key`         | Key in the ConfigMap that contains the proxy config file.                                                 | `"config.yaml"`|
-| `proxy_config.*`                                           | See [values.yaml](./values.yaml) for default settings. Rendered into the ConfigMap’s config.yaml only when proxyConfigMap.create=true. See [example_config_yaml](../../../litellm/proxy/example_config_yaml/) for configuration examples.                            | N/A  |
-| `extraContainers[]`                                        | An array of additional containers to be deployed as sidecars alongside the LiteLLM Proxy.                                                                                             | `[]`  |
+| `proxyConfigMap.create`     | When `true`, render a ConfigMap from `.Values.proxy_config` and mount it.                                                                                                                                      | `true` |
+| `proxyConfigMap.name`       | When `create=false`, name of the existing ConfigMap to mount.                                                                                                                                                  | `""`  |
+| `proxyConfigMap.key`        | Key in the ConfigMap that contains the proxy config file.                                                                                                                                                      | `"config.yaml"` |
+| `proxy_config.*`            | See [values.yaml](./values.yaml) for default settings. Rendered into the ConfigMap’s `config.yaml` only when `proxyConfigMap.create=true`. See [example_config_yaml](../../../litellm/proxy/example_config_yaml/) for configuration examples. | `N/A` |
+| `extraContainers[]`         | An array of additional containers to be deployed as sidecars alongside the LiteLLM Proxy.
 
 #### Example `proxy_config` ConfigMap from values (default):
 

--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -36,8 +36,40 @@ If `db.useStackgresOperator` is used (not yet implemented):
 | `service.port`                                             | TCP port that the Kubernetes Service will listen on.  Also the TCP port within the Pod that the proxy will listen on.                                                                 | `4000`  |
 | `service.loadBalancerClass`                                | Optional LoadBalancer implementation class (only used when `service.type` is `LoadBalancer`)                                                                                                          | `""`  |
 | `ingress.*`                                                | See [values.yaml](./values.yaml) for example settings                                                                                                                                 | N/A  |
-| `proxy_config.*`                                           | See [values.yaml](./values.yaml) for default settings.  See [example_config_yaml](../../../litellm/proxy/example_config_yaml/) for configuration examples.                            | N/A  |
+
+| `proxyConfigMap.create`      | When `true`, render a ConfigMap from `.Values.proxy_config` and mount it.                                 | `true`         |
+| `proxyConfigMap.name`        | When `create=false`, name of the existing ConfigMap to mount.                                             | `""`           |
+| `proxyConfigMap.key`         | Key in the ConfigMap that contains the proxy config file.                                                 | `"config.yaml"`|
+| `proxy_config.*`                                           | See [values.yaml](./values.yaml) for default settings. Rendered into the ConfigMap’s config.yaml only when proxyConfigMap.create=true. See [example_config_yaml](../../../litellm/proxy/example_config_yaml/) for configuration examples.                            | N/A  |
 | `extraContainers[]`                                        | An array of additional containers to be deployed as sidecars alongside the LiteLLM Proxy.                                                                                             | `[]`  |
+
+#### Example `proxy_config` ConfigMap from values (default):
+
+```
+proxyConfigMap:
+  create: true
+  key: "config.yaml"
+
+proxy_config:
+  general_settings:
+    master_key: os.environ/PROXY_MASTER_KEY
+  model_list:
+    - model_name: gpt-3.5-turbo
+      litellm_params:
+        model: gpt-3.5-turbo
+        api_key: eXaMpLeOnLy
+```
+
+#### Example using existing `proxyConfigMap` instead of creating it:
+
+```
+proxyConfigMap:
+  create: false
+  name: my-litellm-config
+  key: config.yaml
+
+# proxy_config is ignored in this mode
+```
 
 #### Example `environmentSecrets` Secret 
 

--- a/deploy/charts/litellm-helm/templates/configmap-litellm.yaml
+++ b/deploy/charts/litellm-helm/templates/configmap-litellm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.proxyConfigMap.create }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   config.yaml: |
 {{ .Values.proxy_config | toYaml | indent 6 }}
+{{- end }}

--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.proxyConfigMap.create }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap-litellm.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -183,9 +185,13 @@ spec:
         {{- end }}
         - name: litellm-config
           configMap:
+            {{- if .Values.proxyConfigMap.create }}
             name: {{ include "litellm.fullname" . }}-config
+            {{- else }}
+            name: {{ .Values.proxyConfigMap.name }}
+            {{- end }}
             items:
-              - key: "config.yaml"
+              - key: {{ .Values.proxyConfigMap.key | default "config.yaml" }}
                 path: "config.yaml"
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -115,3 +115,17 @@ tests:
           content:
             name: EXTRA_ENV_VAR
             value: EXTRA_ENV_VAR_VALUE
+  - it: should mount existing configmap when create=false
+    template: deployment.yaml
+    set:
+      proxyConfigMap:
+        create: false
+        name: my-litellm-config
+        key: custom.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="litellm-config")].configMap.name | first
+          value: my-litellm-config
+      - equal:
+          path: spec.template.spec.volumes[?(@.name=="litellm-config")].configMap.items[0].key
+          value: custom.yaml

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -123,9 +123,17 @@ tests:
         name: my-litellm-config
         key: custom.yaml
     asserts:
-      - equal:
-          path: spec.template.spec.volumes[?(@.name=="litellm-config")][0].configMap.name
-          value: my-litellm-config
-      - equal:
-          path: spec.template.spec.volumes[?(@.name=="litellm-config")][0].configMap.items[0].key
-          value: custom.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: litellm-config
+            configMap:
+              name: my-litellm-config
+              items:
+                - key: custom.yaml
+                  path: config.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: litellm-config
+            mountPath: /etc/litellm/

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -124,8 +124,8 @@ tests:
         key: custom.yaml
     asserts:
       - equal:
-          path: spec.template.spec.volumes[?(@.name=="litellm-config")].configMap.name | first
+          path: spec.template.spec.volumes[?(@.name=="litellm-config")][0].configMap.name
           value: my-litellm-config
       - equal:
-          path: spec.template.spec.volumes[?(@.name=="litellm-config")].configMap.items[0].key
+          path: spec.template.spec.volumes[?(@.name=="litellm-config")][0].configMap.items[0].key
           value: custom.yaml

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -93,6 +93,14 @@ masterkeySecretName: ""
 # if set, use this secret key for the master key; otherwise, use the default key
 masterkeySecretKey: ""
 
+proxyConfigMap:
+  # when true, creates a new configmap
+  create: true
+  # if create is false and name is set, use existing ConfigMap
+  # create: false
+  # name: ""
+  # key: "config.yaml"
+
 # The elements within proxy_config are rendered as config.yaml for the proxy
 #  Examples: https://github.com/BerriAI/litellm/tree/main/litellm/proxy/example_config_yaml
 #  Reference: https://docs.litellm.ai/docs/proxy/configs


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Allow LiteLLM to mount an existing ConfigMap as proxy_config instead of always generating a separate one.

## Relevant issues
Fixes #14009
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
Enhance helm proxy_config configuration: add support for mounting a separate pre-existing ConfigMap by updating the values.yaml file accordingly.
