### PR TITLE
fix log event_name for llm response

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -570,6 +570,10 @@ router_settings:
 | LITELLM_LICENSE | License key for LiteLLM usage
 | LITELLM_LOCAL_MODEL_COST_MAP | Local configuration for model cost mapping in LiteLLM
 | LITELLM_LOG | Enable detailed logging for LiteLLM
+| LITELLM_LOGGER_NAME | Name for OTEL logger 
+| LITELLM_METER_NAME | Name for OTEL Meter 
+| LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS | Optionally enable semantic logs for OTEL
+| LITELLM_OTEL_INTEGRATION_ENABLE_METRICS | Optionally enable emantic metrics for OTEL
 | LITELLM_MASTER_KEY | Master key for proxy authentication
 | LITELLM_MODE | Operating mode for LiteLLM (e.g., production, development)
 | LITELLM_RATE_LIMIT_WINDOW_SIZE | Rate limit window size for LiteLLM. Default is 60

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -675,7 +675,7 @@ class OpenTelemetry(CustomLogger):
         # per-choice events
         for idx, choice in enumerate(response_obj.get("choices", [])):
             attrs = {
-                "event_name": "gen_ai.content.prompt",
+                "event_name": "gen_ai.content.completion",
                 "gen_ai.system": provider,
                 "index": idx,
                 "finish_reason": choice.get("finish_reason"),


### PR DESCRIPTION
## Title

Fix the event name for llm response. It was copied over from the prompt event

## Relevant issues

Bugfix while troubleshooting https://app.circleci.com/pipelines/github/BerriAI/litellm/41366/workflows/5ac0a13f-d727-4b92-ab01-51fefc1c8417/jobs/649073/tests

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes
<img width="1445" height="608" alt="image" src="https://github.com/user-attachments/assets/9e0d1037-9c0b-49a1-9ca0-4249f3973ac7" />


