### PR TITLE
[Bug]: Fix Can't set reasoning_effort for DeepSeek-V3.1 on DeepInfra by default

### DIFF
--- a/litellm/llms/deepinfra/chat/transformation.py
+++ b/litellm/llms/deepinfra/chat/transformation.py
@@ -12,6 +12,9 @@ class DeepInfraConfig(OpenAIGPTConfig):
 
     The class `DeepInfra` provides configuration for the DeepInfra's Chat Completions API interface. Below are the parameters:
     """
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "deepinfra"
 
     frequency_penalty: Optional[int] = None
     function_call: Optional[Union[str, dict]] = None
@@ -68,8 +71,15 @@ class DeepInfraConfig(OpenAIGPTConfig):
             "top_p",
             "response_format",
             "tools",
-            "tool_choice",
+            "tool_choice"
         ]
+
+        if litellm.supports_reasoning(
+            model=model,
+            custom_llm_provider_info=self.custom_llm_provider,
+        ):
+            supported_openai_params.append("reasoning_effort")
+        return supported_openai_params
 
     def map_openai_params(
         self,

--- a/litellm/llms/deepinfra/chat/transformation.py
+++ b/litellm/llms/deepinfra/chat/transformation.py
@@ -56,7 +56,7 @@ class DeepInfraConfig(OpenAIGPTConfig):
         return super().get_config()
 
     def get_supported_openai_params(self, model: str):
-        return [
+        supported_openai_params = [
             "stream",
             "frequency_penalty",
             "function_call",
@@ -76,7 +76,7 @@ class DeepInfraConfig(OpenAIGPTConfig):
 
         if litellm.supports_reasoning(
             model=model,
-            custom_llm_provider_info=self.custom_llm_provider,
+            custom_llm_provider=self.custom_llm_provider,
         ):
             supported_openai_params.append("reasoning_effort")
         return supported_openai_params

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15626,7 +15626,8 @@
         "output_cost_per_token": 2.18e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1": {
         "max_tokens": 163840,
@@ -15636,7 +15637,8 @@
         "output_cost_per_token": 2.15e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528": {
         "max_tokens": 163840,
@@ -15646,7 +15648,8 @@
         "output_cost_per_token": 2.15e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo": {
         "max_tokens": 32768,
@@ -15656,7 +15659,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
         "max_tokens": 131072,
@@ -15666,7 +15670,8 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
         "max_tokens": 131072,
@@ -15676,7 +15681,8 @@
         "output_cost_per_token": 1.5e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Turbo": {
         "max_tokens": 163840,
@@ -15686,7 +15692,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3": {
         "max_tokens": 163840,
@@ -15696,7 +15703,8 @@
         "output_cost_per_token": 8.9e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324": {
         "max_tokens": 163840,
@@ -15706,7 +15714,8 @@
         "output_cost_per_token": 8.8e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324-Turbo": {
         "max_tokens": 32768,
@@ -15716,7 +15725,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3.1": {
         "max_tokens": 163840,
@@ -15726,7 +15736,8 @@
         "output_cost_per_token": 1e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/google/codegemma-7b-it": {
         "max_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15626,7 +15626,8 @@
         "output_cost_per_token": 2.18e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1": {
         "max_tokens": 163840,
@@ -15636,7 +15637,8 @@
         "output_cost_per_token": 2.15e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528": {
         "max_tokens": 163840,
@@ -15646,7 +15648,8 @@
         "output_cost_per_token": 2.15e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo": {
         "max_tokens": 32768,
@@ -15656,7 +15659,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
         "max_tokens": 131072,
@@ -15666,7 +15670,8 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
         "max_tokens": 131072,
@@ -15676,7 +15681,8 @@
         "output_cost_per_token": 1.5e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Turbo": {
         "max_tokens": 163840,
@@ -15686,7 +15692,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3": {
         "max_tokens": 163840,
@@ -15696,7 +15703,8 @@
         "output_cost_per_token": 8.9e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324": {
         "max_tokens": 163840,
@@ -15706,7 +15714,8 @@
         "output_cost_per_token": 8.8e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324-Turbo": {
         "max_tokens": 32768,
@@ -15716,7 +15725,8 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3.1": {
         "max_tokens": 163840,
@@ -15726,7 +15736,8 @@
         "output_cost_per_token": 1e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false
+        "supports_tool_choice": false,
+        "supports_reasoning": true
     },
     "deepinfra/google/codegemma-7b-it": {
         "max_tokens": 8192,

--- a/tests/test_litellm/llms/deepinfra/test_deepinfra_chat_transformation.py
+++ b/tests/test_litellm/llms/deepinfra/test_deepinfra_chat_transformation.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Add litellm to path
+sys.path.insert(0, os.path.abspath("../../../.."))
+import litellm
+
+
+def test_deepseek_supported_openai_params():
+    """
+    Test "reasoning_effort" is an openai param supported for the DeepSeek model on deepinfra
+    """
+    from litellm.llms.deepinfra.chat.transformation import DeepInfraConfig
+
+    supported_openai_params = DeepInfraConfig().get_supported_openai_params(model="deepinfra/deepseek-ai/DeepSeek-V3.1")
+    print(supported_openai_params)
+    assert "reasoning_effort" in supported_openai_params


### PR DESCRIPTION
## [Bug]: Fix Can't set reasoning_effort for DeepSeek-V3.1 on DeepInfra by default

Fixes https://github.com/BerriAI/litellm/issues/14039

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


