### PR TITLE
Add support for anthropic citation api in Databricks

### DIFF
--- a/docs/my-website/docs/providers/databricks.md
+++ b/docs/my-website/docs/providers/databricks.md
@@ -282,6 +282,11 @@ ModelResponse(
 )
 ```
 
+### Citations
+
+Anthropic models served through Databricks can return citation metadata. LiteLLM
+exposes these via `response.choices[0].message.provider_specific_fields["citations"]`.
+
 ### Pass `thinking` to Anthropic models
 
 You can also pass the `thinking` parameter to Anthropic models.

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -382,20 +382,18 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
     ) -> Optional[List[Any]]:
         if content is None:
             return None
-        citations: Optional[List[Any]] = None
+        citations = []
         if isinstance(content, list):
             for item in content:
                 text = item.get("text", None)
-                if item.get("citations") is not None:
-                    if citations is None:
-                        citations = []
+                if citations_item := item.get("citations"):
                     citations.append(
                         [
                             {**citation, "supported_text": text}
-                            for citation in item["citations"]
+                            for citation in citations_item
                         ]
                     )
-        return citations
+        return citations or None
 
     def _transform_dbrx_choices(
         self, choices: List[DatabricksChoice], json_mode: Optional[bool] = None

--- a/litellm/types/llms/databricks.py
+++ b/litellm/types/llms/databricks.py
@@ -36,9 +36,10 @@ class DatabricksReasoningSummary(TypedDict):
     signature: str
 
 
-class DatabricksReasoningContent(TypedDict):
+class DatabricksReasoningContent(TypedDict, total=False):
     type: Literal["reasoning"]
-    summary: List[DatabricksReasoningSummary]
+    summary: Required[List[DatabricksReasoningSummary]]
+    citations: Optional[List[Dict[str, Any]]]
 
 
 AllDatabricksContentListValues = Union[

--- a/litellm/types/llms/databricks.py
+++ b/litellm/types/llms/databricks.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Literal, Optional, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from pydantic import BaseModel
 from typing_extensions import (
@@ -24,9 +24,10 @@ class GenericStreamingChunk(TypedDict, total=False):
     usage: Optional[BaseModel]
 
 
-class DatabricksTextContent(TypedDict):
+class DatabricksTextContent(TypedDict, total=False):
     type: Literal["text"]
     text: Required[str]
+    citations: Optional[List[Dict[str, Any]]]
 
 
 class DatabricksReasoningSummary(TypedDict):

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -10,7 +10,10 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
-from litellm.llms.databricks.chat.transformation import DatabricksConfig
+from litellm.llms.databricks.chat.transformation import (
+    DatabricksChatResponseIterator,
+    DatabricksConfig,
+)
 
 
 def test_transform_choices():
@@ -90,3 +93,51 @@ def test_transform_choices_without_signature():
     thinking_block = choices[0].message.thinking_blocks[0]
     assert thinking_block["type"] == "thinking"
     assert thinking_block["thinking"] == "i'm thinking without signature."
+
+
+def test_transform_choices_with_citations():
+    config = DatabricksConfig()
+    databricks_choices = [
+        {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Paris",
+                        "citations": [{"source": "wiki"}],
+                    }
+                ],
+            },
+            "index": 0,
+            "finish_reason": "stop",
+        }
+    ]
+
+    choices = config._transform_dbrx_choices(choices=databricks_choices)
+
+    assert choices[0].message.provider_specific_fields == {
+        "citations": [[{"source": "wiki"}]]
+    }
+
+
+def test_chunk_parser_with_citation():
+    iterator = DatabricksChatResponseIterator(None, sync_stream=True)
+    chunk = {
+        "id": "1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "test",
+        "choices": [
+            {
+                "delta": {"citation": {"source": "wiki"}},
+                "index": 0,
+                "finish_reason": None,
+            }
+        ],
+    }
+
+    parsed = iterator.chunk_parser(chunk)
+    assert parsed.choices[0].delta.provider_specific_fields == {
+        "citation": {"source": "wiki"}
+    }


### PR DESCRIPTION
## Title

Add support for anthropic citation api in Databricks

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="817" height="167" alt="image" src="https://github.com/user-attachments/assets/d96d8bc7-6e0f-4110-97c8-1ec7c34dd169" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

Support for Anthropic citation api for Claude models hosted on Databricks
