### PR TITLE
[Bug]: grok-4 does not support frequency_penalty, litellm should drop this param for grok-4 

### DIFF
--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -31,7 +31,6 @@ class XAIChatConfig(OpenAIGPTConfig):
 
     def get_supported_openai_params(self, model: str) -> list:
         base_openai_params = [
-            "frequency_penalty",
             "logit_bias",
             "logprobs",
             "max_tokens",
@@ -50,8 +49,22 @@ class XAIChatConfig(OpenAIGPTConfig):
             "web_search_options",
         ]
         # for some reason, grok-3-mini does not support stop tokens
+        #########################################################
+        # stop tokens check
+        #########################################################
         if self._supports_stop_reason(model):
             base_openai_params.append("stop")
+        
+
+        #########################################################
+        # frequency penalty check
+        #########################################################
+        if self._supports_frequency_penalty(model):
+            base_openai_params.append("frequency_penalty")
+        
+        #########################################################
+        # reasoning check
+        #########################################################
         try:
             if litellm.supports_reasoning(
                 model=model, custom_llm_provider=self.custom_llm_provider
@@ -66,6 +79,11 @@ class XAIChatConfig(OpenAIGPTConfig):
         if "grok-3-mini" in model:
             return False
         elif "grok-4" in model:
+            return False
+        return True
+    
+    def _supports_frequency_penalty(self, model: str) -> bool:
+        if "grok-4" in model:
             return False
         return True
 

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -83,7 +83,14 @@ class XAIChatConfig(OpenAIGPTConfig):
         return True
     
     def _supports_frequency_penalty(self, model: str) -> bool:
+        """
+        From manual testing grok-4 does not support `frequency_penalty`
+
+        When sent the model fails from xAI API
+        """
         if "grok-4" in model:
+            return False
+        if "grok-code-fast" in model:
             return False
         return True
 

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,23 +1,4 @@
 model_list:
-  - model_name: anthropic/*
+  - model_name: xai/*
     litellm_params:
-      model: anthropic/*
-      api_key: os.environ/OPENAI_API_KEY_IJ
-  - model_name: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
-    litellm_params:
-      model: bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0
-  - model_name: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
-    litellm_params:
-      model: bedrock/converse/us.anthropic.claude-sonnet-4-20250514-v1:0
-
-router_settings:
-  fallbacks: [
-    {"anthropic/claude-opus-4-20250514": 
-      {
-        "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0"
-      }
-    }
-  ]
-litellm_settings:
-  callbacks: ["datadog_llm_observability"]
-
+      model: xai/*

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -130,6 +130,15 @@ def test_xai_grok_4_stop_not_supported(model):
     assert "stop" not in supported_params
 
 
+@pytest.mark.parametrize("model", ["xai/grok-4", "xai/grok-4-0709", "xai/grok-4-latest"])
+def test_xai_grok_4_frequency_penalty_not_supported(model):
+    """
+    Test that grok-4 models do not support the frequency_penalty parameter
+    """
+    supported_params = XAIChatConfig().get_supported_openai_params(model=model)
+    assert "frequency_penalty" not in supported_params
+
+
 
 def test_xai_message_name_filtering():
     messages = [

--- a/tests/llm_translation/test_xai.py
+++ b/tests/llm_translation/test_xai.py
@@ -130,7 +130,7 @@ def test_xai_grok_4_stop_not_supported(model):
     assert "stop" not in supported_params
 
 
-@pytest.mark.parametrize("model", ["xai/grok-4", "xai/grok-4-0709", "xai/grok-4-latest"])
+@pytest.mark.parametrize("model", ["xai/grok-4", "xai/grok-4-0709", "xai/grok-4-latest", "xai/grok-code-fast", "xai/grok-code-fast-1"])
 def test_xai_grok_4_frequency_penalty_not_supported(model):
     """
     Test that grok-4 models do not support the frequency_penalty parameter


### PR DESCRIPTION
## [Bug]: grok-4 does not support frequency_penalty, litellm should drop this param for grok-4 

https://github.com/BerriAI/litellm/issues/14056

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


