### PR TITLE
[Fix] LiteLLM does not support new web_search tool (Responses API)

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -580,7 +580,9 @@ class StandardBuiltInToolCostTracking:
             return WebSearchOptions(**kwargs.get("web_search_options", {}))
 
         tools = StandardBuiltInToolCostTracking._get_tools_from_kwargs(
-            kwargs, "web_search_preview"
+            kwargs=kwargs, tool_type="web_search_preview"
+        ) or StandardBuiltInToolCostTracking._get_tools_from_kwargs(
+            kwargs=kwargs, tool_type="web_search"
         )
         if tools:
             # Look for web search tool in the tools array
@@ -611,6 +613,8 @@ class StandardBuiltInToolCostTracking:
     @staticmethod
     def _is_web_search_tool_call(tool: Dict) -> bool:
         if tool.get("type", None) == "web_search_preview":
+            return True
+        if tool.get("type", None) == "web_search":
             return True
         if "search_context_size" in tool:
             return True

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1038,7 +1038,7 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     parallel_tool_calls: bool
     temperature: Optional[float]
     tool_choice: ToolChoice
-    tools: Union[List[Tool], List[ResponseFunctionToolCall]]
+    tools: Union[List[Tool], List[ResponseFunctionToolCall], List[Dict[str, Any]]]
     top_p: Optional[float]
     max_output_tokens: Optional[int]
     previous_response_id: Optional[str]

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -1483,3 +1483,28 @@ async def test_openai_gpt5_reasoning_effort_parameter():
         # Validate the response
         print("Response:", json.dumps(response, indent=4, default=str))
 
+
+
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [True, False])
+async def test_basic_openai_responses_with_websearch(stream):
+    litellm._turn_on_debug()
+    request_model = "gpt-4o"
+    response = await litellm.aresponses(
+        model=request_model,
+        stream=stream,
+        input="hi",
+        tools=[
+            {
+                "type": "web_search",
+                "search_context_size": "low"
+            }
+        ]
+    )
+    if stream:
+        async for chunk in response:
+            print("chunk=", json.dumps(chunk, indent=4, default=str))
+    else:
+        print("response=", json.dumps(response, indent=4, default=str))


### PR DESCRIPTION
## [Fix] LiteLLM does not support new web_search tool (Responses API)

Fixes https://github.com/BerriAI/litellm/issues/14011

> OpenAI recently graduated their web_search_preview tool to GA as web_search.
Docs: https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses
LiteLLM rejects {"type": "web_search"} in the tools array with validation errors.
web_search_preview still works, but the new web_search tool (which is now the documented and supported version) does not.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


