### PR TITLE
Route Chat Completions to OpenAI Responses API for reasoning

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
     # Needed for type annotations used as forward references
     from litellm.types.utils import Choices
+    # Use concrete Responses API type for mypy
+    from litellm.types.llms.openai import ResponsesAPIResponse
 
 
 class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
@@ -271,7 +273,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         return model_response
 
     def _extract_choices_and_reasoning(
-        self, raw_response: "BaseModel"
+        self, raw_response: "ResponsesAPIResponse"
     ) -> Tuple[List["Choices"], Optional[str]]:
         from openai.types.responses import (
             ResponseFunctionToolCall,

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
         OpenAIMessageContentListBlock,
     )
     from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
+    # Needed for type annotations used as forward references
+    from litellm.types.utils import Choices
 
 
 class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
@@ -224,7 +226,6 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         from litellm.responses.utils import ResponseAPILoggingUtils
         from litellm.types.llms.openai import ResponsesAPIResponse
-        from litellm.types.utils import Choices
 
         if not isinstance(raw_response, ResponsesAPIResponse):
             raise ValueError(f"Unexpected response type: {type(raw_response)}")
@@ -331,7 +332,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         if reasoning_text is not None:
             return reasoning_text
         try:
-            summary = getattr(getattr(raw_response, "reasoning", None), "summary", None)
+            reasoning_obj = getattr(raw_response, "reasoning", None)
+            if isinstance(reasoning_obj, dict):
+                summary = reasoning_obj.get("summary")
+            else:
+                summary = getattr(reasoning_obj, "summary", None)
             if isinstance(summary, str) and summary.strip():
                 return summary.strip()
         except Exception:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1344,12 +1344,37 @@ def completion(  # type: ignore # noqa: PLR0915
                 timeout=timeout,
             )
 
-        ## RESPONSES API BRIDGE LOGIC ## - check if model has 'mode: responses' in litellm.model_cost map
+        ## RESPONSES API BRIDGE LOGIC ##
+        # 1) Check model map for 'mode: responses'
         model_info, model = responses_api_bridge_check(
             model=model, custom_llm_provider=custom_llm_provider
         )
 
-        if model_info.get("mode") == "responses":
+        # 2) Optional heuristic: if reasoning requested/supported, prefer Responses API for OpenAI/Azure
+        should_route_via_responses = model_info.get("mode") == "responses"
+        if not should_route_via_responses:
+            try:
+                wants_reasoning = reasoning_effort is not None
+                supports_reasoning = bool(model_info.get("supports_reasoning"))
+                is_azure_o_series = False
+                if custom_llm_provider == "azure":
+                    try:
+                        is_azure_o_series = (
+                            litellm.AzureOpenAIO1Config().is_o_series_model(model=model)
+                        )
+                    except Exception:
+                        is_azure_o_series = False
+                if (
+                    custom_llm_provider in ("openai", "azure")
+                    and (wants_reasoning or supports_reasoning)
+                    and not is_azure_o_series
+                ):
+                    should_route_via_responses = True
+            except Exception:
+                # Do not block normal flow if heuristic check fails
+                pass
+
+        if should_route_via_responses:
             from litellm.completion_extras import responses_api_bridge
 
             return responses_api_bridge.completion(
@@ -1369,46 +1394,6 @@ def completion(  # type: ignore # noqa: PLR0915
                 encoding=encoding,
                 stream=stream,
             )
-
-        # Optional routing heuristic: if reasoning requested or supported, prefer Responses API for OpenAI/Azure
-        try:
-            wants_reasoning = reasoning_effort is not None
-            supports_reasoning = bool(model_info.get("supports_reasoning"))
-            is_azure_o_series = False
-            if custom_llm_provider == "azure":
-                try:
-                    is_azure_o_series = litellm.AzureOpenAIO1Config().is_o_series_model(
-                        model=model
-                    )
-                except Exception:
-                    is_azure_o_series = False
-            if (
-                custom_llm_provider in ("openai", "azure")
-                and (wants_reasoning or supports_reasoning)
-                and not is_azure_o_series
-            ):
-                from litellm.completion_extras import responses_api_bridge
-
-                return responses_api_bridge.completion(
-                    model=model,
-                    messages=messages,
-                    headers=headers,
-                    model_response=model_response,
-                    api_key=api_key,
-                    api_base=api_base,
-                    acompletion=acompletion,
-                    logging_obj=logging,
-                    optional_params=optional_params,
-                    litellm_params=litellm_params,
-                    timeout=timeout,  # type: ignore
-                    client=client,  # pass AsyncOpenAI, OpenAI client
-                    custom_llm_provider=custom_llm_provider,
-                    encoding=encoding,
-                    stream=stream,
-                )
-        except Exception:
-            # Do not block normal flow if heuristic check fails
-            pass
 
         if custom_llm_provider == "azure":
             # azure configs

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -530,6 +530,79 @@ def test_responses_api_bridge_check_handles_exception():
         assert model_info["mode"] == "responses"
 
 
+def test_responses_bridge_triggered_by_reasoning_effort(monkeypatch):
+    """Ensure reasoning_effort triggers Responses API bridge even without mode in model map."""
+    import litellm
+    from litellm.types.utils import ModelResponse, Choices, Message
+
+    # Make bridge return a simple ModelResponse and record invocation
+    called = {"value": False}
+
+    def fake_bridge_completion(**kwargs):
+        called["value"] = True
+        return ModelResponse(
+            id="resp_test",
+            model=kwargs.get("model", "gpt-5"),
+            choices=[
+                Choices(
+                    message=Message(role="assistant", content="ok"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            created=0,
+        )
+
+    # Avoid default 'mode: responses' branch
+    monkeypatch.setattr(
+        "litellm.main.responses_api_bridge_check", lambda model, custom_llm_provider: ({}, model)
+    )
+    monkeypatch.setattr(
+        "litellm.completion_extras.responses_api_bridge.completion",
+        fake_bridge_completion,
+    )
+
+    resp = litellm.completion(
+        model="gpt-5",
+        messages=[{"role": "user", "content": "hi"}],
+        reasoning_effort="low",
+    )
+
+    assert called["value"] is True
+    assert resp.choices[0].message.content == "ok"
+
+
+def test_nonstream_reasoning_summary_added_to_chat_message():
+    """Responses transformation should include reasoning_content for non-stream responses."""
+    import litellm
+    from litellm.responses.main import mock_responses_api_response
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.utils import ModelResponse
+
+    handler = LiteLLMResponsesTransformationHandler()
+    raw = mock_responses_api_response("hello")
+    # Inject a reasoning summary
+    raw.reasoning = {"summary": "this is why"}
+
+    base = ModelResponse(id="id1", model="gpt-5", choices=[], created=0)
+
+    out = handler.transform_response(
+        model="gpt-5",
+        raw_response=raw,
+        model_response=base,
+        logging_obj=litellm.Logging(),
+        request_data={},
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert out.choices and out.choices[0].message.reasoning_content == "this is why"
+
+
 @pytest.mark.asyncio
 async def test_async_mock_delay():
     """Use asyncio await for mock delay on acompletion"""

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -592,7 +592,7 @@ def test_nonstream_reasoning_summary_added_to_chat_message():
         model="gpt-5",
         raw_response=raw,
         model_response=base,
-        logging_obj=litellm.Logging(),
+        logging_obj=None,
         request_data={},
         messages=[{"role": "user", "content": "hi"}],
         optional_params={},


### PR DESCRIPTION
## Title

Route Chat Completions to OpenAI Responses API for reasoning; add non‑stream reasoning summaries; refactor routing logic

## Relevant issues

Fixes #13780 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🧹 Refactoring
✅ Test

## Changes

- Route to Responses API when reasoning is requested/supported:
    - Add a single flag should_route_via_responses to decide routing in completion().
    - True if model map has mode: responses, or for OpenAI/Azure when reasoning_effort is set or supports_reasoning=True (excluding Azure O-series, which keeps its dedicated path).
    - Refactor to avoid duplicate responses_api_bridge.completion(...) calls.
- Surface non‑stream reasoning summaries in Chat responses:
    - In Responses→Chat transform, collect reasoning text from ResponseReasoningItem (preferred) or response.reasoning.summary (fallback).
    - Attach it to choices[0].message.reasoning_content for non-stream responses.
- Tests:
    - Ensure reasoning_effort triggers the bridge even without model map mode: responses.
    - Validate that non‑stream transforms include message.reasoning_content when reasoning.summary is present.
- Safety:
    - Azure O-series (o1/o3) still uses the existing Azure O1 path (no behavioral change).
    - If the heuristic evaluation fails, gracefully fall back to the normal flow.