### PR TITLE
fix(proxy): fix wildcard model expansion in /v1/models endpoint

### DIFF
--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -67,7 +67,7 @@ def test_get_complete_model_list_order(key_models, team_models, proxy_model_list
 @pytest.mark.parametrize(
     "wildcard_model,litellm_params,expected_models",
     [
-        # Test case 1: litellm_params is None (the main bug we fixed)
+        # Test case 1: litellm_params is None (the main bug fixed in https://github.com/BerriAI/litellm/pull/14125)
         (
             "openai/*",
             None,

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
@@ -62,3 +62,143 @@ def test_get_complete_model_list_order(key_models, team_models, proxy_model_list
         infer_model_from_keys=False,
         llm_router=Router(model_list=model_list),
     ) == expected
+
+
+@pytest.mark.parametrize(
+    "wildcard_model,litellm_params,expected_models",
+    [
+        # Test case 1: litellm_params is None (the main bug we fixed)
+        (
+            "openai/*",
+            None,
+            ["openai/gpt-4", "openai/gpt-3.5-turbo", "openai/gpt-4o"]  # Mock static models
+        ),
+        # Test case 2: litellm_params provided (existing functionality)
+        (
+            "anthropic/*", 
+            MagicMock(model="anthropic/claude-3-haiku"),
+            ["anthropic/claude-3-haiku", "anthropic/claude-3-sonnet"]  # Mock static models
+        ),
+    ],
+)
+def test_get_known_models_from_wildcard_with_none_params(wildcard_model, litellm_params, expected_models):
+    """
+    Test that get_known_models_from_wildcard correctly handles the case when litellm_params is None.
+    This tests the fix for the bug where wildcard models were not being expanded when litellm_params was None.
+    """
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+    
+    # Mock the get_provider_models function to return our expected models without the provider prefix
+    with patch("litellm.proxy.auth.model_checks.get_provider_models") as mock_get_provider_models:
+        if wildcard_model.startswith("openai/"):
+            mock_get_provider_models.return_value = ["gpt-4", "gpt-3.5-turbo", "gpt-4o"]
+        elif wildcard_model.startswith("anthropic/"):
+            mock_get_provider_models.return_value = ["claude-3-haiku", "claude-3-sonnet"]
+        
+        result = get_known_models_from_wildcard(wildcard_model, litellm_params)
+        
+        # Verify the result contains the expected models with the correct provider prefix
+        assert result == expected_models
+        assert len(result) > 0, "Should return expanded models, not empty list"
+
+
+def test_get_wildcard_models_with_router_fallback():
+    """
+    Test that _get_wildcard_models falls back to direct expansion when router lookup fails.
+    This tests the fix for the router fallback logic.
+    """
+    from litellm.proxy.auth.model_checks import _get_wildcard_models
+    
+    # Create a mock router that returns None for wildcard model lookup
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = None  # Simulate router lookup failure
+    
+    unique_models = ["openai/*", "anthropic/*"]
+    
+    # Mock the get_known_models_from_wildcard to return expanded models
+    with patch("litellm.proxy.auth.model_checks.get_known_models_from_wildcard") as mock_expand:
+        mock_expand.side_effect = [
+            ["openai/gpt-4", "openai/gpt-3.5-turbo"],  # For openai/*
+            ["anthropic/claude-3-haiku", "anthropic/claude-3-sonnet"]  # For anthropic/*
+        ]
+        
+        result = _get_wildcard_models(
+            unique_models=unique_models,
+            return_wildcard_routes=False,
+            llm_router=mock_router
+        )
+        
+        # Verify that the wildcard models were expanded despite router lookup failure
+        expected_models = [
+            "openai/gpt-4", "openai/gpt-3.5-turbo",
+            "anthropic/claude-3-haiku", "anthropic/claude-3-sonnet"
+        ]
+        assert result == expected_models
+        
+        # Verify router was called but fallback was used
+        mock_router.get_model_list.assert_called()
+        
+        # Verify direct expansion was called for both models
+        assert mock_expand.call_count == 2
+
+
+def test_get_provider_models_fallback_to_static():
+    """
+    Test that get_provider_models falls back to static model list when API calls fail.
+    This tests the error handling and fallback logic.
+    """
+    from litellm.proxy.auth.model_checks import get_provider_models
+    import litellm
+    
+    # Mock the static models list
+    mock_static_models = ["gpt-4", "gpt-3.5-turbo", "gpt-4o"]
+    
+    with patch("litellm.models_by_provider", {"openai": mock_static_models}):
+        # Test case 1: get_valid_models returns empty list
+        with patch("litellm.proxy.auth.model_checks.get_valid_models") as mock_get_valid:
+            mock_get_valid.return_value = []  # Simulate API failure returning empty
+            
+            result = get_provider_models("openai")
+            
+            # Should fall back to static model list
+            assert result == mock_static_models
+        
+        # Test case 2: get_valid_models raises exception
+        with patch("litellm.proxy.auth.model_checks.get_valid_models") as mock_get_valid:
+            mock_get_valid.side_effect = Exception("API Error")  # Simulate API exception
+            
+            result = get_provider_models("openai")
+            
+            # Should fall back to static model list
+            assert result == mock_static_models
+
+
+def test_wildcard_expansion_integration():
+    """
+    Integration test for the complete wildcard expansion flow.
+    This tests the full flow from configuration to expanded model list.
+    """
+    from litellm.proxy.auth.model_checks import get_complete_model_list
+    
+    # Mock the static models
+    mock_openai_models = ["gpt-4", "gpt-3.5-turbo", "gpt-4o"]
+    
+    with patch("litellm.models_by_provider", {"openai": mock_openai_models}):
+        with patch("litellm.proxy.auth.model_checks.get_valid_models") as mock_get_valid:
+            # Simulate API failure to test fallback
+            mock_get_valid.return_value = []
+            
+            result = get_complete_model_list(
+                key_models=[],
+                team_models=[],
+                proxy_model_list=["openai/*"],  # Wildcard model in proxy config
+                user_model=None,
+                infer_model_from_keys=False,
+                return_wildcard_routes=False,  # Should expand, not return wildcard
+                llm_router=None  # No router, should use direct expansion
+            )
+            
+            # Should return expanded models with provider prefix
+            expected = ["openai/gpt-4", "openai/gpt-3.5-turbo", "openai/gpt-4o"]
+            assert result == expected
+            assert "openai/*" not in result, "Should not contain the original wildcard"


### PR DESCRIPTION
## Title

### Problems

The `/v1/models` endpoint was not properly expanding wildcard models like `"openai/*"` and `"anthropic/*"`. Instead of returning the actual available models (e.g., `gpt-4`, `gpt-3.5-turbo`, etc.), it was returning the literal wildcard string `"openai/*"` in the response.

The issue had multiple contributing factors:

1. Missing fallback for `litellm_params=None`: The `get_known_models_from_wildcard()` function would return an empty list when `litellm_params` was `None`, even though it could extract the provider from the wildcard string itself.
2. Router lookup failure: When `llm_router` was available but couldn't find the wildcard model in its deployment list, the expansion would fail silently without falling back to direct expansion.
3. API call failures: When `get_valid_models()` failed due to missing API keys or network issues, it would return an empty list instead of falling back to the static model list.

### Solution

This PR implements three key fixes:

1. Enhanced `get_known_models_from_wildcard()`
    - Added logic to extract provider from wildcard string when `litellm_params` is `None`
    - Enables wildcard expansion even without router context

2. Improved `_get_wildcard_models()` fallback logic
    - Added fallback mechanism when router-based expansion fails
    - Ensures direct expansion is attempted when router lookup returns `None`
    - Prevents wildcard models from being silently ignored

3. Robust error handling in `get_provider_models()`
    - Added try-catch for API call failures
    - Falls back to static model list from `litellm.models_by_provider` when API calls fail
    - Includes warning logs for debugging

### Quality

<details><summary>Before fix</summary>

```json
{
  "data": [
    {
      "id": "openai/*",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    }
  ],
  "object": "list"
}
```
</details>

<details><summary>After fix</summary>

```json
{
  "data": [
    {
      "id": "openai/o1-preview-2024-09-12",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    },
    {
      "id": "openai/gpt-4o-search-preview",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    },
    {
      "id": "openai/gpt-5-chat-latest",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    },
    {
      "id": "openai/gpt-4-1106-preview",
      "object": "model",
      "created": 1677610602,
      "owned_by": "openai"
    },
    // ... more models
  ],
  "object": "list"
}
```
</details>
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

- https://github.com/BerriAI/litellm/issues/13643
- https://github.com/BerriAI/litellm/pull/11784#issuecomment-3149698470

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
   
   <img width="758" height="354" alt="image" src="https://github.com/user-attachments/assets/5109d927-0f58-4a3f-a0bd-a491c0043b65" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


