### PR TITLE
Add supported text field to anthropic citation response

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -743,8 +743,6 @@ class ModelResponseIterator:
                 )
 
             text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)
-            if type_chunk:
-                provider_specific_fields["chunk_type"] = type_chunk
 
             returned_chunk = ModelResponseStream(
                 choices=[

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -743,6 +743,8 @@ class ModelResponseIterator:
                 )
 
             text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)
+            if type_chunk:
+                provider_specific_fields["chunk_type"] = type_chunk
 
             returned_chunk = ModelResponseStream(
                 choices=[

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -797,7 +797,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             if content.get("citations") is not None:
                 if citations is None:
                     citations = []
-                citations.append(content["citations"])
+                citations.append(
+                    [
+                        {
+                            **citation,
+                            "supported_text": content.get("text", ""),
+                        }
+                        for citation in content["citations"]
+                    ]
+                )
         if thinking_blocks is not None:
             reasoning_content = ""
             for block in thinking_blocks:

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -920,6 +920,14 @@ def test_anthropic_citations_api():
     citations = resp.choices[0].message.provider_specific_fields["citations"]
 
     assert citations is not None
+    if citations:
+        citation = citations[0][0]
+        assert "supported_text" in citation
+        assert "cited_text" in citation
+        assert "document_index" in citation
+        assert "document_title" in citation
+        assert "start_char_index" in citation
+        assert "end_char_index" in citation
 
 
 def test_anthropic_citations_api_streaming():
@@ -955,11 +963,11 @@ def test_anthropic_citations_api_streaming():
     has_citations = False
     for chunk in resp:
         print(f"returned chunk: {chunk}")
-        if (
-            chunk.choices[0].delta.provider_specific_fields
-            and "citation" in chunk.choices[0].delta.provider_specific_fields
-        ):
-            has_citations = True
+        if provider_specific_fields := chunk.choices[0].delta.provider_specific_fields:
+            if "citation" in provider_specific_fields:
+                has_citations = True
+
+            assert "chunk_type" in provider_specific_fields
 
     assert has_citations
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -115,16 +115,11 @@ def test_calculate_usage_nulls(usage_object, expected_usage):
         assert hasattr(usage, k)
         assert getattr(usage, k) == v
 
-@pytest.mark.parametrize("usage_object", [
-    {
-        "server_tool_use": {
-            "web_search_requests": None
-        }
-    },
-    {
-        "server_tool_use": None
-    }
-])
+
+@pytest.mark.parametrize(
+    "usage_object",
+    [{"server_tool_use": {"web_search_requests": None}}, {"server_tool_use": None}],
+)
 def test_calculate_usage_server_tool_null(usage_object):
     """
     Correctly deal with null values in usage object
@@ -132,9 +127,10 @@ def test_calculate_usage_server_tool_null(usage_object):
     Fixes https://github.com/BerriAI/litellm/issues/11920
     """
     config = AnthropicConfig()
-    
+
     usage = config.calculate_usage(usage_object=usage_object, reasoning_content=None)
     assert not hasattr(usage, "server_tool_use")
+
 
 def test_extract_response_content_with_citations():
     config = AnthropicConfig()
@@ -188,7 +184,30 @@ def test_extract_response_content_with_citations():
     }
 
     _, citations, _, _, _ = config.extract_response_content(completion_response)
-    assert citations is not None
+    assert citations == [
+        [
+            {
+                "type": "char_location",
+                "cited_text": "The grass is green. ",
+                "document_index": 0,
+                "document_title": "My Document",
+                "start_char_index": 0,
+                "end_char_index": 20,
+                "supported_text": "the grass is green",
+            },
+        ],
+        [
+            {
+                "type": "char_location",
+                "cited_text": "The sky is blue.",
+                "document_index": 0,
+                "document_title": "My Document",
+                "start_char_index": 20,
+                "end_char_index": 36,
+                "supported_text": "the sky is blue",
+            },
+        ],
+    ]
 
 
 def test_map_tool_helper():


### PR DESCRIPTION
## Title

Add a supported text field to the anthropic citation response

## Relevant issues

#7970

Resubmitted the change introduced in https://github.com/BerriAI/litellm/pull/14026

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1125" height="183" alt="image" src="https://github.com/user-attachments/assets/6d8a6104-1160-4a7b-941f-160e3e38361e" />

<img width="926" height="46" alt="image" src="https://github.com/user-attachments/assets/ae6fe1de-e382-406d-9c43-df934612a204" />


## Type

🆕 New Feature

## Changes

Add a supported text field to the anthropic citation response to tell which sentence is supported by each citation. 