### PR TITLE
Fix token count error for gemini cli

### DIFF
--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -38,8 +38,8 @@ class GenerateContentToCompletionHandler:
         completion_kwargs: Dict[str, Any] = dict(completion_request)
 
         # feed metadata for custom callback
-        if 'metadata' in extra_kwargs:
-            completion_kwargs['metadata'] = extra_kwargs['metadata']
+        if "metadata" in extra_kwargs:
+            completion_kwargs["metadata"] = extra_kwargs["metadata"]
 
         if stream:
             completion_kwargs["stream"] = stream

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -38,7 +38,7 @@ class GenerateContentToCompletionHandler:
         completion_kwargs: Dict[str, Any] = dict(completion_request)
 
         # feed metadata for custom callback
-        if "metadata" in extra_kwargs:
+        if extra_kwargs is not None and "metadata" in extra_kwargs:
             completion_kwargs["metadata"] = extra_kwargs["metadata"]
 
         if stream:

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -38,8 +38,8 @@ class GenerateContentToCompletionHandler:
         completion_kwargs: Dict[str, Any] = dict(completion_request)
 
         # feed metadata for custom callback
-        # if 'metadata' in extra_kwargs:
-        #     completion_kwargs['metadata'] = extra_kwargs['metadata']
+        if 'metadata' in extra_kwargs:
+            completion_kwargs['metadata'] = extra_kwargs['metadata']
 
         if stream:
             completion_kwargs["stream"] = stream

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -37,6 +37,10 @@ class GenerateContentToCompletionHandler:
 
         completion_kwargs: Dict[str, Any] = dict(completion_request)
 
+        # feed metadata for custom callback
+        # if 'metadata' in extra_kwargs:
+        #     completion_kwargs['metadata'] = extra_kwargs['metadata']
+
         if stream:
             completion_kwargs["stream"] = stream
 

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -181,9 +181,11 @@ async def google_count_tokens(request: Request, model_name: str):
     from litellm.proxy._types import TokenCountRequest
 
     # Translate contents to openai format messages using the adapter
-    messages = (GoogleGenAIAdapter()
-                .translate_generate_content_to_completion(model_name, contents)
-                .get("messages", []))
+    messages = (
+        GoogleGenAIAdapter()
+        .translate_generate_content_to_completion(model_name, contents)
+        .get("messages", [])
+    )
 
     token_request = TokenCountRequest(
         model=model_name,
@@ -209,7 +211,7 @@ async def google_count_tokens(request: Request, model_name: str):
                 totalTokens=token_response.total_tokens or 0,
                 promptTokensDetails=[],
             )
-    
+
     #########################################################
     # Return the response in the well known format
     #########################################################

--- a/litellm/proxy/google_endpoints/endpoints.py
+++ b/litellm/proxy/google_endpoints/endpoints.py
@@ -173,15 +173,22 @@ async def google_count_tokens(request: Request, model_name: str):
     """
     from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
     from litellm.proxy.proxy_server import token_counter as internal_token_counter
+    from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
 
     data = await _read_request_body(request=request)
     contents = data.get("contents", [])
     #Create TokenCountRequest for the internal endpoint
     from litellm.proxy._types import TokenCountRequest
 
+    # Translate contents to openai format messages using the adapter
+    messages = (GoogleGenAIAdapter()
+                .translate_generate_content_to_completion(model_name, contents)
+                .get("messages", []))
+
     token_request = TokenCountRequest(
         model=model_name,
-        contents=contents
+        contents=contents,
+        messages=messages,  # compatibility when use openai-like endpoint
     )
 
     # Call the internal token counter function with direct request flag set to False
@@ -192,10 +199,16 @@ async def google_count_tokens(request: Request, model_name: str):
     if token_response is not None:
         # cast the response to the well known format
         original_response: dict = token_response.original_response or {}
-        return TokenCountDetailsResponse(
-            totalTokens=original_response.get("totalTokens", 0),
-            promptTokensDetails=original_response.get("promptTokensDetails", []),
-        )
+        if original_response:
+            return TokenCountDetailsResponse(
+                totalTokens=original_response.get("totalTokens", 0),
+                promptTokensDetails=original_response.get("promptTokensDetails", []),
+            )
+        else:
+            return TokenCountDetailsResponse(
+                totalTokens=token_response.total_tokens or 0,
+                promptTokensDetails=[],
+            )
     
     #########################################################
     # Return the response in the well known format

--- a/tests/test_litellm/proxy/google_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_endpoints.py
@@ -1,0 +1,49 @@
+"""
+Test for google_endpoints/endpoints.py
+"""
+import pytest
+import sys, os
+from dotenv import load_dotenv
+
+
+from litellm.proxy.google_endpoints.endpoints import google_count_tokens
+from litellm.types.llms.vertex_ai import TokenCountDetailsResponse
+from starlette.requests import Request
+
+load_dotenv()
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)
+
+@pytest.mark.asyncio
+async def test_proxy_gemini_to_openai_like_model_token_counting():
+    """
+    Test the token counting endpoint for proxing gemini to openai-like models.
+    """
+    response: TokenCountDetailsResponse = await google_count_tokens(
+        request=Request(
+            scope={
+                "type": "http",
+                "parsed_body": (
+                    [
+                        "contents"
+                    ],
+                    {
+                        "contents": [
+                            {
+                                "parts": [
+                                    {
+                                        "text": "Hello, how are you?"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                )
+            }
+        ),
+        model_name="volcengine/foo",
+    )
+
+    assert response.get("totalTokens") > 0


### PR DESCRIPTION
## Title

Fix token count error when proxy gemini cli to openai like model

## Relevant issues

no

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [Y] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [Y] I have added a screenshot of my new test passing locally 
<img width="1296" height="210" alt="image" src="https://github.com/user-attachments/assets/4dbf24ff-10a9-48f6-86f2-143afd044fe2" />

- [N] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
<img width="1389" height="126" alt="image" src="https://github.com/user-attachments/assets/5f152eb3-1597-4b52-bc25-b973b7c73b31" />
Looks like not my fault.

- [Y] My PR's scope is as isolated as possible, it only solves 1 specific problem



## Type

🐛 Bug Fix

## Changes

When proxying Gemini CLI to OpenAI-like models, Gemini CLI throws an error because it cannot correctly count tokens.
This commit attempts to fix the issue:

- Make token count compatible with both contents and messages fields
- Provide metadata for custom callbacks when using Gemini CLI