### PR TITLE
Back to Keys should say Back to Logs

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -43,6 +43,7 @@ interface KeyInfoViewProps {
   teams: any[] | null
   premiumUser: boolean
   setAccessToken?: (token: string) => void
+  backButtonText?: string
 }
 
 export default function KeyInfoView({
@@ -57,6 +58,7 @@ export default function KeyInfoView({
   onDelete,
   premiumUser,
   setAccessToken,
+  backButtonText = "Back to Keys",
 }: KeyInfoViewProps) {
   const [isEditing, setIsEditing] = useState(false)
   const [form] = Form.useForm()
@@ -92,7 +94,7 @@ export default function KeyInfoView({
     return (
       <div className="p-4">
         <Button icon={ArrowLeftIcon} variant="light" onClick={onClose} className="mb-4">
-          Back to Keys
+          {backButtonText}
         </Button>
         <Text>Key not found</Text>
       </div>
@@ -261,7 +263,7 @@ export default function KeyInfoView({
       <div className="flex justify-between items-center mb-6">
         <div>
           <Button icon={ArrowLeftIcon} variant="light" onClick={onClose} className="mb-4">
-            Back to Keys
+            {backButtonText}
           </Button>
           <Title>{currentKeyData.key_alias || "API Key"}</Title>
 

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -500,6 +500,7 @@ export default function SpendLogsTable({
                 teams={allTeams}
                 onClose={() => setSelectedKeyIdInfoView(null)}
                 premiumUser={premiumUser}
+                backButtonText="Back to Logs"
               />
             ) : selectedSessionId ? (
               <div className="bg-white rounded-lg shadow">


### PR DESCRIPTION
## Title
Back to Keys should say Back to Logs
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- When you click on key hash in the logs table -> Key info page opens and it has a "Back to Keys" button which now says "Back to Logs"
Before:
<img width="1470" height="876" alt="Screenshot 2025-09-01 at 9 09 06 PM" src="https://github.com/user-attachments/assets/1a42667a-809f-4d0f-b214-f90e60c9c566" />
After:
<img width="1470" height="876" alt="Screenshot 2025-09-01 at 9 08 44 PM" src="https://github.com/user-attachments/assets/02c6f89f-87a8-4ce7-8c92-4015b6c1ae99" />