### PR TITLE
GPT-5: Drop unsupported params

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -28,7 +28,18 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         base_gpt_series_params.extend(gpt_5_only_params)
         if not supports_tool_choice(model=model):
             base_gpt_series_params.remove("tool_choice")
-        return base_gpt_series_params
+
+        non_supported_params = [
+            "logprobs",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "top_logprobs",
+        ]
+
+        return [
+            param for param in base_gpt_series_params if param not in non_supported_params
+        ]
 
     def map_openai_params(
         self,

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -41,3 +41,14 @@ def test_gpt5_temperature_error(config: OpenAIConfig):
             model="gpt-5",
             drop_params=False,
         )
+
+
+def test_gpt5_unsupported_params_drop(config: OpenAIConfig):
+    assert "top_p" not in config.get_supported_openai_params(model="gpt-5")
+    params = config.map_openai_params(
+        non_default_params={"top_p": 0.5},
+        optional_params={},
+        model="gpt-5",
+        drop_params=True,
+    )
+    assert "top_p" not in params


### PR DESCRIPTION
## Title

GPT-5: Drop unsupported params

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1212" height="36" alt="image" src="https://github.com/user-attachments/assets/dbc6e998-dde4-4194-ab00-ec58b8e05080" />

## Type

🐛 Bug Fix

## Changes

GPT-5* is a reasoning model and it shares unsupported params with o-series.
This PR marks unsupported params and resolves errors like this:
```
litellm.BadRequestError: AzureException BadRequestError - Unsupported parameter: 'top_p' is not supported with this model.
```


