### PR TITLE
Fix missing end_user parameter in uiSpendLogsCall method calls

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -193,6 +193,7 @@ export default function SpendLogsTable({
         currentPage,
         pageSize,
         filterByCurrentUser ? userID : undefined,
+        undefined,
         selectedStatus,
         selectedModel,
       )


### PR DESCRIPTION
## Title

Fix missing end_user parameter in uiSpendLogsCall method calls

## Relevant issues

Fixes missing parameter issue introduced in PR #12663

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Added `undefined` as the end_user parameter value since the feature uses frontend filtering
