### PR TITLE
feat: added alert type to alert messate to slack for easier handling

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1367,7 +1367,9 @@ Model Info:
         # Get the current timestamp
         current_time = datetime.now().strftime("%H:%M:%S")
         _proxy_base_url = os.getenv("PROXY_BASE_URL", None)
-        alert_type_formatted = f"Alert type: `{alert_type}`\n"
+        # Use .name if it's an enum, otherwise use as is
+        alert_type_name = getattr(alert_type, 'name', alert_type)
+        alert_type_formatted = f"Alert type: `{alert_type_name}`"
         if alert_type == "daily_reports" or alert_type == "new_model_added":
             formatted_message = alert_type_formatted + message
         else:

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1371,7 +1371,7 @@ Model Info:
         if alert_type == "daily_reports" or alert_type == "new_model_added":
             formatted_message = alert_type_formatted + message
         else:
-            formatted_message = f"{alert_type_formatted}\n Level: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
+            formatted_message = f"{alert_type_formatted}\nLevel: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
 
         if kwargs:
             for key, value in kwargs.items():

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -805,9 +805,9 @@ class SlackAlerting(CustomBatchLogger):
         ### UNIQUE CACHE KEY ###
         cache_key = provider + region_name
 
-        outage_value: Optional[ProviderRegionOutageModel] = (
-            await self.internal_usage_cache.async_get_cache(key=cache_key)
-        )
+        outage_value: Optional[
+            ProviderRegionOutageModel
+        ] = await self.internal_usage_cache.async_get_cache(key=cache_key)
 
         if (
             getattr(exception, "status_code", None) is None
@@ -1367,12 +1367,11 @@ Model Info:
         # Get the current timestamp
         current_time = datetime.now().strftime("%H:%M:%S")
         _proxy_base_url = os.getenv("PROXY_BASE_URL", None)
+        alert_type_formatted = f"Alert type: `{alert_type}`\n"
         if alert_type == "daily_reports" or alert_type == "new_model_added":
-            formatted_message = message
+            formatted_message = alert_type_formatted + message
         else:
-            formatted_message = (
-                f"Level: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
-            )
+            formatted_message = f"{alert_type_formatted}\n Level: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
 
         if kwargs:
             for key, value in kwargs.items():
@@ -1388,9 +1387,9 @@ Model Info:
             self.alert_to_webhook_url is not None
             and alert_type in self.alert_to_webhook_url
         ):
-            slack_webhook_url: Optional[Union[str, List[str]]] = (
-                self.alert_to_webhook_url[alert_type]
-            )
+            slack_webhook_url: Optional[
+                Union[str, List[str]]
+            ] = self.alert_to_webhook_url[alert_type]
         elif self.default_webhook_url is not None:
             slack_webhook_url = self.default_webhook_url
         else:

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -172,3 +172,27 @@ class TestSlackAlerting(unittest.TestCase):
 
         self.slack_alerting.update_values(alerting_args={"slack_alerting": "True"})
         assert self.slack_alerting.periodic_started == True
+        
+    @patch("litellm.integrations.SlackAlerting.slack_alerting.datetime")
+    def test_alert_type_in_formatted_message(self, mock_datetime):
+        # Setup mocks
+        mock_datetime.now.return_value.strftime.return_value = "12:34:56"
+        
+        # Import required types
+        from litellm.types.integrations.slack_alerting import AlertType
+        
+        # Create a simple test message to check formatting
+        alert_type = AlertType.llm_exceptions
+        level = "Medium"
+        message = "Test alert message"
+        current_time = "12:34:56"
+        
+        # Test the specific formatting logic we're interested in
+        alert_type_formatted = f"Alert type: `{alert_type}`\n"
+        formatted_message = f"{alert_type_formatted}\n Level: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
+        
+        # Verify alert_type is in the formatted message as expected
+        self.assertIn("Alert type: `AlertType.llm_exceptions`", formatted_message)
+        self.assertIn("Level: `Medium`", formatted_message)
+        self.assertIn("Timestamp: `12:34:56`", formatted_message)
+        self.assertIn("Message: Test alert message", formatted_message)

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -188,11 +188,11 @@ class TestSlackAlerting(unittest.TestCase):
         current_time = "12:34:56"
         
         # Test the specific formatting logic we're interested in
-        alert_type_formatted = f"Alert type: `{alert_type}`\n"
+        alert_type_formatted = f"Alert type: `{alert_type.name}`\n"
         formatted_message = f"{alert_type_formatted}\n Level: `{level}`\nTimestamp: `{current_time}`\n\nMessage: {message}"
         
         # Verify alert_type is in the formatted message as expected
-        self.assertIn("Alert type: `AlertType.llm_exceptions`", formatted_message)
+        self.assertIn("Alert type: `llm_exceptions`", formatted_message)
         self.assertIn("Level: `Medium`", formatted_message)
         self.assertIn("Timestamp: `12:34:56`", formatted_message)
         self.assertIn("Message: Test alert message", formatted_message)


### PR DESCRIPTION
## Slack Alert Messages with `alert_type`



## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

### Added unit test

`tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py::TestSlackAlerting::test_alert_type_in_formatted_messagea`

<img width="1049" height="277" alt="image" src="https://github.com/user-attachments/assets/2db46074-3876-43df-afdf-e63a3f1250bb" />

### Slack message
<img width="672" height="182" alt="image" src="https://github.com/user-attachments/assets/53ff6805-fc92-4876-8df8-fb2f86942942" />

## Type
🆕 New Feature
✅ Test

## Changes
- added a alert_type_formatted prefix to the slack alert message
- it does not conflict with outage messages alert subtypes.


