### PR TITLE
[Feature]: Add header support for spend_logs_metadata

### DIFF
--- a/docs/my-website/docs/proxy/enterprise.md
+++ b/docs/my-website/docs/proxy/enterprise.md
@@ -439,6 +439,33 @@ response = client.chat.completions.create(
 
 print(response)
 ```
+
+**Using Headers:**
+
+```python
+import openai
+client = openai.OpenAI(
+    api_key="sk-1234",
+    base_url="http://0.0.0.0:4000"
+)
+
+# Pass spend logs metadata via headers
+response = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages = [
+        {
+            "role": "user",
+            "content": "this is a test request, write a short poem"
+        }
+    ],
+    extra_headers={
+        "x-litellm-spend-logs-metadata": '{"user_id": "12345", "project_id": "proj_abc", "request_type": "chat_completion"}'
+    }
+)
+
+print(response)
+```
+
 </TabItem>
 
 
@@ -478,6 +505,43 @@ async function runOpenAI() {
 // Call the asynchronous function
 runOpenAI();
 ```
+
+**Using Headers:**
+
+```js
+const openai = require('openai');
+
+async function runOpenAI() {
+  const client = new openai.OpenAI({
+    apiKey: 'sk-1234',
+    baseURL: 'http://0.0.0.0:4000'
+  });
+
+  try {
+    const response = await client.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'user',
+          content: "this is a test request, write a short poem"
+        },
+      ]
+    }, {
+      headers: {
+        'x-litellm-spend-logs-metadata': '{"user_id": "12345", "project_id": "proj_abc", "request_type": "chat_completion"}'
+      }
+    });
+    console.log(response);
+  } catch (error) {
+    console.log("got this exception from server");
+    console.error(error);
+  }
+}
+
+// Call the asynchronous function
+runOpenAI();
+```
+
 </TabItem>
 
 <TabItem value="Curl" label="Curl Request">
@@ -502,6 +566,29 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
     }
 }'
 ```
+
+</TabItem>
+
+<TabItem value="headers" label="Using Headers">
+
+Pass `x-litellm-spend-logs-metadata` as a request header with JSON string
+
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer sk-1234' \
+    --header 'x-litellm-spend-logs-metadata: {"user_id": "12345", "project_id": "proj_abc", "request_type": "chat_completion"}' \
+    --data '{
+    "model": "gpt-3.5-turbo",
+    "messages": [
+        {
+        "role": "user",
+        "content": "what llm are you"
+        }
+    ]
+}'
+```
+
 </TabItem>
 <TabItem value="langchain" label="Langchain">
 

--- a/docs/my-website/docs/proxy/request_headers.md
+++ b/docs/my-website/docs/proxy/request_headers.md
@@ -14,6 +14,8 @@ Special headers that are supported by LiteLLM.
 
 `x-litellm-num-retries`: Optional[int]: The number of retries for the request.
 
+`x-litellm-spend-logs-metadata`: Optional[str]: JSON string containing custom metadata to include in spend logs. Example: `{"user_id": "12345", "project_id": "proj_abc", "request_type": "chat_completion"}`. [Learn More](./logging#tracking-spend-with-custom-metadata)
+
 ## Anthropic Headers
 
 `anthropic-version` Optional[str]: The version of the Anthropic API to use.  

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2902,40 +2902,17 @@ class SpecialHeaders(enum.Enum):
 
 class LitellmDataForBackendLLMCall(TypedDict, total=False):
     headers: dict
-    """
-    Dict of the headers
-    """
-
     organization: str
-    """
-    organization id for this request
-    """
-
     timeout: Optional[float]
-    """
-    timeout in seconds for this request
-    """
-
     stream_timeout: Optional[float]
-    """
-    stream timeout in seconds for this request
-    """
-
     user: Optional[str]
-    """
-    user id for this request
-    """
-
-
     num_retries: Optional[int]
-    """
-    number of retries for this request
-    """
 
+class LitellmMetadataFromRequestHeaders(TypedDict, total=False):
+    """
+    Headers a user can pass that will get added to litellm metadata for the request
+    """
     spend_logs_metadata: Optional[dict]
-    """
-    Dict of the spend logs metadata
-    """
 
 
 class JWTKeyItem(TypedDict, total=False):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2902,11 +2902,40 @@ class SpecialHeaders(enum.Enum):
 
 class LitellmDataForBackendLLMCall(TypedDict, total=False):
     headers: dict
+    """
+    Dict of the headers
+    """
+
     organization: str
+    """
+    organization id for this request
+    """
+
     timeout: Optional[float]
+    """
+    timeout in seconds for this request
+    """
+
     stream_timeout: Optional[float]
+    """
+    stream timeout in seconds for this request
+    """
+
     user: Optional[str]
+    """
+    user id for this request
+    """
+
+
     num_retries: Optional[int]
+    """
+    number of retries for this request
+    """
+
+    spend_logs_metadata: Optional[dict]
+    """
+    Dict of the spend logs metadata
+    """
 
 
 class JWTKeyItem(TypedDict, total=False):

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -477,6 +477,11 @@ class LiteLLMProxyRequestSetup:
         data: dict,
         _metadata_variable_name: str,
     ) -> dict:
+        """
+        Add litellm metadata from request headers
+
+        Relevant issue: https://github.com/BerriAI/litellm/issues/14008
+        """
         from litellm.proxy._types import LitellmMetadataFromRequestHeaders
         metadata_from_headers = LitellmMetadataFromRequestHeaders()
         spend_logs_metadata = LiteLLMProxyRequestSetup._get_spend_logs_metadata_from_request_headers(headers)

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -488,8 +488,9 @@ class LiteLLMProxyRequestSetup:
         if spend_logs_metadata is not None:
             metadata_from_headers["spend_logs_metadata"] = spend_logs_metadata
         
-        ###################
+        #########################################################################################
         # Finally update the requests metadata with the `metadata_from_headers`
+        #########################################################################################
         data[_metadata_variable_name].update(metadata_from_headers)
         return data
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -291,6 +291,17 @@ class LiteLLMProxyRequestSetup:
         if num_retries_header is not None:
             return int(num_retries_header)
         return None
+    
+    @staticmethod
+    def _get_spend_logs_metadata_from_request_headers(headers: dict) -> Optional[dict]:
+        """
+        Get the `spend_logs_metadata` from the request headers.
+        """
+        from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
+        spend_logs_metadata_header = headers.get("x-litellm-spend-logs-metadata", None)
+        if spend_logs_metadata_header is not None:
+            return safe_json_loads(spend_logs_metadata_header)
+        return None
 
     @staticmethod
     def _get_forwardable_headers(
@@ -457,6 +468,10 @@ class LiteLLMProxyRequestSetup:
         num_retries = LiteLLMProxyRequestSetup._get_num_retries_from_request(headers)
         if num_retries is not None:
             data["num_retries"] = num_retries
+
+        spend_logs_metadata = LiteLLMProxyRequestSetup._get_spend_logs_metadata_from_request_headers(headers)
+        if spend_logs_metadata is not None:
+            data["spend_logs_metadata"] = spend_logs_metadata
 
         return data
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -477,9 +477,15 @@ class LiteLLMProxyRequestSetup:
         data: dict,
         _metadata_variable_name: str,
     ) -> dict:
+        from litellm.proxy._types import LitellmMetadataFromRequestHeaders
+        metadata_from_headers = LitellmMetadataFromRequestHeaders()
         spend_logs_metadata = LiteLLMProxyRequestSetup._get_spend_logs_metadata_from_request_headers(headers)
         if spend_logs_metadata is not None:
-            data[_metadata_variable_name]["spend_logs_metadata"] = spend_logs_metadata
+            metadata_from_headers["spend_logs_metadata"] = spend_logs_metadata
+        
+        ###################
+        # Finally update the requests metadata with the `metadata_from_headers`
+        data[_metadata_variable_name].update(metadata_from_headers)
         return data
 
     @staticmethod

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -491,7 +491,8 @@ class LiteLLMProxyRequestSetup:
         #########################################################################################
         # Finally update the requests metadata with the `metadata_from_headers`
         #########################################################################################
-        data[_metadata_variable_name].update(metadata_from_headers)
+        if isinstance(data[_metadata_variable_name], dict):
+            data[_metadata_variable_name].update(metadata_from_headers)
         return data
 
     @staticmethod

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -3,4 +3,3 @@ model_list:
     litellm_params:
       model: openai/*
       api_base: https://exampleopenaiendpoint-production-0ee2.up.railway.app/
-      mock_response: "hi"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import Request
 
+import litellm
 from litellm.proxy._types import TeamCallbackMetadata, UserAPIKeyAuth
 from litellm.proxy.litellm_pre_call_utils import (
     KeyAndTeamLoggingSettings,
@@ -935,3 +936,124 @@ def test_add_headers_to_llm_call_by_model_group_existing_headers_in_data():
     finally:
         # Restore original model_group_settings
         litellm.model_group_settings = original_model_group_settings
+
+import json
+import time
+from typing import Optional
+from unittest.mock import AsyncMock
+
+from fastapi.responses import Response
+
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.utils import ProxyLogging
+from litellm.types.utils import StandardLoggingPayload
+
+
+class TestCustomLogger(CustomLogger):
+    def __init__(self):
+        self.standard_logging_object: Optional[StandardLoggingPayload] = None
+        super().__init__()
+        
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        print(f"SUCCESS CALLBACK CALLED! kwargs keys: {list(kwargs.keys())}")
+        self.standard_logging_object = kwargs.get("standard_logging_object")
+        print(f"Captured standard_logging_object: {self.standard_logging_object}")
+        
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        print(f"FAILURE CALLBACK CALLED! kwargs keys: {list(kwargs.keys())}")
+
+@pytest.mark.asyncio
+async def test_add_litellm_metadata_from_request_headers():
+    """
+    Test that add_litellm_metadata_from_request_headers properly adds litellm metadata from request headers,
+    makes an LLM request using base_process_llm_request, sleeps for 3 seconds, and checks standard_logging_payload has spend_logs_metadata from headers
+    """
+    # Set up test logger
+    litellm._turn_on_debug()
+    test_logger = TestCustomLogger()
+    litellm.callbacks = [test_logger]
+
+    # Prepare test data (ensure no streaming, add mock_response and api_key to route to litellm.acompletion)
+    headers = {"x-litellm-spend-logs-metadata": '{"user_id": "12345", "project_id": "proj_abc", "request_type": "chat_completion", "timestamp": "2025-09-02T10:30:00Z"}'}
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "stream": False, "mock_response": "Hi", "api_key": "fake-key"}
+    
+    # Create mock request with headers
+    mock_request = MagicMock(spec=Request)
+    mock_request.headers = headers
+    mock_request.url.path = "/chat/completions"
+    
+    # Create mock response
+    mock_fastapi_response = MagicMock(spec=Response)
+    
+    # Create mock user API key dict
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        org_id="test-org"
+    )
+    
+    # Create mock proxy logging object
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    
+    # Create async functions for the hooks
+    async def mock_during_call_hook(*args, **kwargs):
+        return None
+        
+    async def mock_pre_call_hook(*args, **kwargs):
+        return data
+        
+    async def mock_post_call_success_hook(*args, **kwargs):
+        # Return the response unchanged
+        return kwargs.get('response', args[2] if len(args) > 2 else None)
+        
+    mock_proxy_logging_obj.during_call_hook = mock_during_call_hook
+    mock_proxy_logging_obj.pre_call_hook = mock_pre_call_hook
+    mock_proxy_logging_obj.post_call_success_hook = mock_post_call_success_hook
+    
+    # Create mock proxy config
+    mock_proxy_config = MagicMock()
+    
+    # Create mock general settings
+    general_settings = {}
+    
+    # Create mock select_data_generator with correct signature
+    def mock_select_data_generator(response=None, user_api_key_dict=None, request_data=None):
+        async def mock_generator():
+            yield "data: " + json.dumps({"choices": [{"delta": {"content": "Hello"}}]}) + "\n\n"
+            yield "data: [DONE]\n\n"
+        return mock_generator()
+    
+    # Create the processor
+    processor = ProxyBaseLLMRequestProcessing(data=data)
+    
+    # Call base_process_llm_request (it will use the mock_response="Hi" parameter)
+    result = await processor.base_process_llm_request(
+        request=mock_request,
+        fastapi_response=mock_fastapi_response,
+        user_api_key_dict=mock_user_api_key_dict,
+        route_type="acompletion",
+        proxy_logging_obj=mock_proxy_logging_obj,
+        general_settings=general_settings,
+        proxy_config=mock_proxy_config,
+        select_data_generator=mock_select_data_generator,
+        llm_router=None,
+        model="gpt-4",
+        is_streaming_request=False
+    )
+    
+    # Sleep for 3 seconds to allow logging to complete
+    await asyncio.sleep(3)
+    
+    # Check if standard_logging_object was set
+    assert test_logger.standard_logging_object is not None, "standard_logging_object should be populated after LLM request"
+    
+    # Verify the logging object contains expected metadata
+    standard_logging_obj = test_logger.standard_logging_object
+
+    print(f"Standard logging object captured: {json.dumps(standard_logging_obj, indent=4, default=str)}")
+
+    SPEND_LOGS_METADATA = standard_logging_obj["metadata"]["spend_logs_metadata"]
+    assert SPEND_LOGS_METADATA == dict(json.loads(headers["x-litellm-spend-logs-metadata"])), "spend_logs_metadata should be the same as the headers"
+
+        

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -968,6 +968,8 @@ async def test_add_litellm_metadata_from_request_headers():
     """
     Test that add_litellm_metadata_from_request_headers properly adds litellm metadata from request headers,
     makes an LLM request using base_process_llm_request, sleeps for 3 seconds, and checks standard_logging_payload has spend_logs_metadata from headers
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/14008
     """
     # Set up test logger
     litellm._turn_on_debug()


### PR DESCRIPTION
## [Feature]: Add header support for spend_logs_metadata

## Request 
Send `x-litellm-spend-logs-metadata` header in request 
```curl
curl -i -X POST http://localhost:4000/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -H "x-litellm-spend-logs-metadata: {\"user_id\": \"12345\", \"project_id\": \"proj_abc\", \"request_type\": \"chat_completion\", \"timestamp\": \"2025-09-02T10:30:00Z\"}" \
  -d '{
    "model": "db-openai-endpoint",
    "messages": [
      {
        "role": "user",
        "content": "hi"
      }
    ],
    "frequency_penalty": 0.1,
    "drop_params": true
  }'
```

### Logged Standard Logging Payload 
```
{
    "id": "chatcmpl-c62aa8bb918a42dab1541d06338cd266",
    "call_type": "acompletion",
    "model": "*",
    "metadata": {
        "user_api_key_hash": "88dc28d0f030c55ed4ab77ed8faf098196cb1c05df778539800c9f1243fe6b4b",
        "spend_logs_metadata": {
            "user_id": "12345",
            "project_id": "proj_abc",
            "request_type": "chat_completion",
            "timestamp": "2025-09-02T10:30:00Z"
        },
      }
}
```

Fixes https://github.com/BerriAI/litellm/issues/14008

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


