### PR TITLE
Remove "/" or ":" from model name when being used as h11 header name

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -316,18 +316,21 @@ def get_remaining_tokens_and_requests_from_request_data(data: Dict) -> Dict[str,
     headers = {}
     _metadata = data.get("metadata", None) or {}
     model_group = get_model_group_from_request_data(data)
+    
+    # The h11 package considers "/" or ":" invalid and raise a LocalProtocolError
+    h11_model_group_name = model_group.replace('/', '-').replace(':', '-')
 
     # Remaining Requests
     remaining_requests_variable_name = f"litellm-key-remaining-requests-{model_group}"
     remaining_requests = _metadata.get(remaining_requests_variable_name, None)
     if remaining_requests:
-        headers[f"x-litellm-key-remaining-requests-{model_group}"] = remaining_requests
+        headers[f"x-litellm-key-remaining-requests-{h11_model_group_name}"] = remaining_requests
 
     # Remaining Tokens
     remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
     remaining_tokens = _metadata.get(remaining_tokens_variable_name, None)
     if remaining_tokens:
-        headers[f"x-litellm-key-remaining-tokens-{model_group}"] = remaining_tokens
+        headers[f"x-litellm-key-remaining-tokens-{h11_model_group_name}"] = remaining_tokens
 
     return headers
 

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -316,21 +316,27 @@ def get_remaining_tokens_and_requests_from_request_data(data: Dict) -> Dict[str,
     headers = {}
     _metadata = data.get("metadata", None) or {}
     model_group = get_model_group_from_request_data(data)
-    
+
     # The h11 package considers "/" or ":" invalid and raise a LocalProtocolError
-    h11_model_group_name = model_group.replace('/', '-').replace(':', '-')
+    h11_model_group_name = (
+        model_group.replace("/", "-").replace(":", "-") if model_group else None
+    )
 
     # Remaining Requests
     remaining_requests_variable_name = f"litellm-key-remaining-requests-{model_group}"
     remaining_requests = _metadata.get(remaining_requests_variable_name, None)
     if remaining_requests:
-        headers[f"x-litellm-key-remaining-requests-{h11_model_group_name}"] = remaining_requests
+        headers[f"x-litellm-key-remaining-requests-{h11_model_group_name}"] = (
+            remaining_requests
+        )
 
     # Remaining Tokens
     remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
     remaining_tokens = _metadata.get(remaining_tokens_variable_name, None)
     if remaining_tokens:
-        headers[f"x-litellm-key-remaining-tokens-{h11_model_group_name}"] = remaining_tokens
+        headers[f"x-litellm-key-remaining-tokens-{h11_model_group_name}"] = (
+            remaining_tokens
+        )
 
     return headers
 

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.common_utils.callback_utils import get_remaining_tokens_and_requests_from_request_data
+
+def test_get_remaining_tokens_and_requests_from_request_data():
+    model_group = "openrouter/google/gemini-2.0-flash-001"
+    casedata = {
+        "metadata": {
+            "model_group": model_group,
+            f"litellm-key-remaining-requests-{model_group}": 100,
+            f"litellm-key-remaining-tokens-{model_group}": 200
+        }
+    }
+
+    headers = get_remaining_tokens_and_requests_from_request_data(casedata)
+
+    expected_name = "openrouter-google-gemini-2.0-flash-001"
+    assert headers == {
+        f"x-litellm-key-remaining-requests-{expected_name}": 100,
+        f"x-litellm-key-remaining-tokens-{expected_name}": 200
+    }
+

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -5,7 +5,10 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.proxy.common_utils.callback_utils import get_remaining_tokens_and_requests_from_request_data
+from litellm.proxy.common_utils.callback_utils import (
+    get_remaining_tokens_and_requests_from_request_data,
+)
+
 
 def test_get_remaining_tokens_and_requests_from_request_data():
     model_group = "openrouter/google/gemini-2.0-flash-001"
@@ -13,7 +16,7 @@ def test_get_remaining_tokens_and_requests_from_request_data():
         "metadata": {
             "model_group": model_group,
             f"litellm-key-remaining-requests-{model_group}": 100,
-            f"litellm-key-remaining-tokens-{model_group}": 200
+            f"litellm-key-remaining-tokens-{model_group}": 200,
         }
     }
 
@@ -22,6 +25,5 @@ def test_get_remaining_tokens_and_requests_from_request_data():
     expected_name = "openrouter-google-gemini-2.0-flash-001"
     assert headers == {
         f"x-litellm-key-remaining-requests-{expected_name}": 100,
-        f"x-litellm-key-remaining-tokens-{expected_name}": 200
+        f"x-litellm-key-remaining-tokens-{expected_name}": 200,
     }
-


### PR DESCRIPTION
## Title

The PR tries to fix the issue related to [this discussion](https://github.com/open-webui/open-webui/discussions/12923#discussion-8209065)

The issue happens when tpm or rpm is enabled with a model whose name contains invalid characters, such as
- the ":" inside "us.anthropic.claude-sonnet-4-20250514-v1:0", and
- the "/" inside "openrouter/google/gemini-2.0-flash-001". 

Such characters are not allowed to be used as an http/1.1 header name and [considered invalid by h11](https://github.com/python-hyper/h11/blob/62c5068c971579d61fa1b55373390e12f25fd856/h11/_headers.py#L165). h11 will raise a LocalProtocolError and litellm won't be able to produce output.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Replace "/" or ":" with "-" when used as header names
- Add a unit test
