### PR TITLE
[Documentation] Updated deprecation dates and MaxTokens in model_prices_and_context_window.json

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1356,7 +1356,8 @@
         "supports_pdf_input": true,
         "supports_vision": true,
         "supports_reasoning": true,
-        "supports_prompt_caching": true
+        "supports_prompt_caching": true,
+        "deprecation_date": "2025-10-27"
     },
     "o1-preview": {
         "max_tokens": 32768,
@@ -11613,7 +11614,8 @@
         "supports_function_calling": true,
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 264,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2025-03-01"
     },
     "openrouter/anthropic/claude-3-5-haiku-20241022": {
         "max_tokens": 8192,
@@ -11625,7 +11627,8 @@
         "mode": "chat",
         "supports_function_calling": true,
         "tool_use_system_prompt_tokens": 264,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2025-10-01"
     },
     "openrouter/anthropic/claude-3.5-sonnet": {
         "supports_computer_use": true,
@@ -11875,7 +11878,8 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": false,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "deprecation_date": "2025-10-27"
     },
     "openrouter/openai/o1-preview": {
         "max_tokens": 32768,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -741,9 +741,9 @@
         "supports_reasoning": true
     },
     "gpt-5-chat-latest": {
-        "max_tokens": 128000,
-        "max_input_tokens": 400000,
-        "max_output_tokens": 128000,
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
         "cache_read_input_token_cost": 1.25e-07,
@@ -2554,9 +2554,9 @@
         "source": "https://azure.microsoft.com/en-us/blog/gpt-5-in-azure-ai-foundry-the-future-of-ai-apps-and-agents-starts-here/"
     },
     "azure/gpt-5-chat-latest": {
-        "max_tokens": 128000,
-        "max_input_tokens": 272000,
-        "max_output_tokens": 128000,
+        "max_tokens": 16384,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 1e-05,
         "cache_read_input_token_cost": 1.25e-07,
@@ -6232,7 +6232,6 @@
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2025-03-01",
         "supports_tool_choice": true
     },
     "claude-3-5-haiku-20241022": {
@@ -6257,7 +6256,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2025-10-01",
+        "deprecation_date": "2025-10-22",
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -6322,7 +6321,7 @@
         "supports_assistant_prefill": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2025-03-01",
+        "deprecation_date": "2026-01-05",
         "supports_tool_choice": true
     },
     "claude-3-5-sonnet-latest": {
@@ -6369,7 +6368,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2025-06-01",
+        "deprecation_date": "2025-10-22",
         "supports_tool_choice": true
     },
     "claude-opus-4-20250514": {
@@ -6561,7 +6560,7 @@
     },
     "claude-3-7-sonnet-20250219": {
         "supports_computer_use": true,
-        "max_tokens": 128000,
+        "max_tokens": 64000,
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 3e-06,
@@ -6582,7 +6581,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2026-02-01",
+        "deprecation_date": "2026-02-19",
         "supports_tool_choice": true,
         "supports_reasoning": true,
         "supports_web_search": true
@@ -6610,7 +6609,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
-        "deprecation_date": "2025-10-01",
+        "deprecation_date": "2025-10-22",
         "supports_tool_choice": true,
         "supports_web_search": true
     },
@@ -7588,7 +7587,7 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supports_parallel_function_calling": true,
         "supports_web_search": true,
-        "cache_read_input_token_cost": 3.125e-07,
+        "cache_read_input_token_cost": 3.1e-07,
         "supports_prompt_caching": true
     },
     "gemini-2.0-pro-exp-02-05": {
@@ -7856,7 +7855,7 @@
         ],
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supports_web_search": true,
-        "cache_read_input_token_cost": 3.125e-07,
+        "cache_read_input_token_cost": 3.1e-07,
         "supports_prompt_caching": true
     },
     "gemini/gemini-2.5-pro-exp-03-25": {
@@ -8831,7 +8830,7 @@
         "supports_parallel_function_calling": true,
         "supports_web_search": true,
         "supports_pdf_input": true,
-        "cache_read_input_token_cost": 3.125e-07,
+        "cache_read_input_token_cost": 3.1e-07,
         "supports_prompt_caching": true
     },
     "gemini-2.0-flash-preview-image-generation": {


### PR DESCRIPTION
## Update 4 deprecation dates in model_prices_and_context_window.json
Deprecation Dates Added.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

Deprecation Date Updates

- o1-mini-2024-09-12 (OpenAI)
- Updated deprecation date to "2025-10-27"
- claude-3-5-sonnet-20240620 (Anthropic)
- Updated deprecation date to "2025-10-22"
- claude-3-opus-20240229 (Anthropic)
- Updated deprecation date to "2026-01-05"
- claude-3-5-sonnet-20241022 (Anthropic)
- Updated deprecation date to "2025-10-22"
- claude-3-5-haiku-20241022 (Anthropic)
- Updated deprecation date to "2025-10-22"
- claude-3-7-sonnet-20250219 (Anthropic)
- Updated deprecation date to "2026-02-19"

Context Length & Token Limits

- azure/gpt-5-chat-latest (Azure)
- Context length: 400000 → 128000 tokens
- Max tokens: 128000 → 16384 tokens
- openai/gpt-5-chat-latest (OpenAI)
- Context length: 400000 → 128000 tokens
- Max tokens: 128000 → 16384 tokens
- claude-3-7-sonnet-20250219 (Anthropic)
- Max tokens: 128000 → 64000 tokens
- Max output tokens: 128000 → 128000 (user manually adjusted)

💰 Cached Token Pricing Updates

- gemini-2.5-pro-exp-03-25 (Google)
- Cache pricing: 3.125e-07 → 3.1e-07 (per 1K tokens)
- gemini-2.5-pro (Google)
- Cache pricing: 3.125e-07 → 3.1e-07 (per 1K tokens)
- gemini-2.5-pro-preview-03-25 (Google)
- Cache pricing: 3.125e-07 → 3.1e-07 (per 1K tokens)