### PR TITLE
[Feat] Support reasoning_effort in Groq

### DIFF
--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -20,6 +20,7 @@ Supported Providers:
 - Vertex AI (`vertex_ai/`)
 - Perplexity (`perplexity/`)
 - Mistral AI (Magistral models) (`mistral/`)
+- Groq (`groq/`)
 
 LiteLLM will standardize the `reasoning_content` in the response and `thinking_blocks` in the assistant message.
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -356,7 +356,7 @@ async def acompletion(
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,
     deployment_id=None,
-    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None,
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "default"]] = None,
     safety_identifier: Optional[str] = None,
     # set api_base, api_version, api_key
     base_url: Optional[str] = None,
@@ -897,7 +897,7 @@ def completion(  # type: ignore # noqa: PLR0915
     logit_bias: Optional[dict] = None,
     user: Optional[str] = None,
     # openai v1.0+ new params
-    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None,
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "default"]] = None,
     response_format: Optional[Union[dict, Type[BaseModel]]] = None,
     seed: Optional[int] = None,
     tools: Optional[List] = None,

--- a/tests/llm_translation/test_groq.py
+++ b/tests/llm_translation/test_groq.py
@@ -1,5 +1,15 @@
-from base_llm_unit_tests import BaseLLMChatTest
+import os
+import sys
 
+
+import pytest
+
+# sys.path.insert(
+#     0, os.path.abspath("../..")
+# )  # Adds the parent directory to the system path
+
+from base_llm_unit_tests import BaseLLMChatTest
+from litellm.llms.groq.chat.transformation import GroqChatConfig
 
 class TestGroq(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
@@ -10,3 +20,9 @@ class TestGroq(BaseLLMChatTest):
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""
         pass
+
+    @pytest.mark.parametrize("model", ["groq/qwen/qwen3-32b", "groq/openai/gpt-oss-20b", "groq/openai/gpt-oss-120b"])
+    def test_reasoning_effort_in_supported_params(self, model):
+        """Test that reasoning_effort is in the list of supported parameters for Groq"""
+        supported_params = GroqChatConfig().get_supported_openai_params(model=model)
+        assert "reasoning_effort" in supported_params


### PR DESCRIPTION
## Title

Support reasoning_effort in Groq

## Relevant issues

Fix https://github.com/BerriAI/litellm/issues/14163

The original issue title requested support for GPT-OSS and KimiK2, but the gqroq documentation indicated support only for Qwen 3 32B, GPT-OSS 20B, and GPT-OSS 120B. Therefore, only these three are implemented.
https://console.groq.com/docs/reasoning#reasoning-effort

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1039" height="264" alt="image" src="https://github.com/user-attachments/assets/3125d40a-09ca-4c25-a3eb-b3acd159805d" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

- [Support reasoning_effort in groq](https://github.com/BerriAI/litellm/commit/455ea1fb96a766b863b219479fed344273891e72)
- [add test](https://github.com/BerriAI/litellm/pull/14207/commits/f491fda019beb571dfe71b2998d1f46d3d41b2fe)