### PR TITLE
fix(llms/openai): enable O-model features for GPT-5 family

### DIFF
--- a/litellm/llms/openai/chat/o_series_transformation.py
+++ b/litellm/llms/openai/chat/o_series_transformation.py
@@ -132,7 +132,7 @@ class OpenAIOSeriesConfig(OpenAIGPTConfig):
     def is_model_o_series_model(self, model: str) -> bool:
         model = model.split("/")[-1]  # could be "openai/o3" or "o3"
         return model in litellm.open_ai_chat_completion_models and any(
-            model.startswith(pfx) for pfx in ("o1", "o3", "o4")
+            model.startswith(pfx) for pfx in ("o1", "o3", "o4", "gpt-5")
         )
 
     @overload

--- a/tests/test_litellm/llms/openai/test_o_series_transformation.py
+++ b/tests/test_litellm/llms/openai/test_o_series_transformation.py
@@ -29,6 +29,11 @@ from litellm.llms.openai.chat.o_series_transformation import OpenAIOSeriesConfig
         ("o5", False),  # Not a valid O-series model
         ("o1-", False),  # Invalid suffix
         ("o3_", False),  # Invalid suffix
+        # GPT-5 models which behave like O-series models despite the name
+        ("gpt-5", True),
+        ("gpt-5-chat", True),
+        ("openai/gpt-5", True),
+        ("openai/gpt-5-chat", True),
     ],
 )
 def test_is_model_o_series_model(model_name: str, expected: bool):


### PR DESCRIPTION
## Title

fix(llms/openai): enable O-model features for GPT-5 family

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


