### PR TITLE
[Security] fix memory_usage_in_mem_cache cache endpoint vulnerability

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -388,7 +388,11 @@ class LiteLLMRoutes(enum.Enum):
     ]
 
     # NOTE: ROUTES ONLY FOR MASTER KEY - only the Master Key should be able to Reset Spend
-    master_key_only_routes = ["/global/spend/reset"]
+    master_key_only_routes = [
+        "/global/spend/reset",
+        "/memory-usage-in-mem-cache",
+        "/memory-usage-in-mem-cache-items",
+    ]
 
     key_management_routes = [
         KeyManagementRoutes.KEY_GENERATE,

--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -5,10 +5,12 @@ import os
 import tracemalloc
 from collections import Counter
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from litellm import get_secret_str
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 router = APIRouter()
 
@@ -84,7 +86,9 @@ if os.environ.get("LITELLM_PROFILE", "false").lower() == "true":
 
 
 @router.get("/memory-usage-in-mem-cache", include_in_schema=False)
-async def memory_usage_in_mem_cache():
+async def memory_usage_in_mem_cache(
+    _: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     # returns the size of all in-memory caches on the proxy server
     """
     1. user_api_key_cache
@@ -121,7 +125,9 @@ async def memory_usage_in_mem_cache():
 
 
 @router.get("/memory-usage-in-mem-cache-items", include_in_schema=False)
-async def memory_usage_in_mem_cache_items():
+async def memory_usage_in_mem_cache_items(
+    _: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     # returns the size of all in-memory caches on the proxy server
     """
     1. user_api_key_cache


### PR DESCRIPTION
## [Security] fix memory_usage_in_mem_cache cache endpoint vulnerability

- Secured memory debug routes by adding authentication dependencies for in-memory cache endpoints, ensuring only authorized requests can inspect cache contents
- Restricted sensitive memory inspection endpoints to master-key use by listing them in the master-key-only routes configuration
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
✅ Test

## Changes


