### PR TITLE
bug: disable user agent tags

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1880,7 +1880,7 @@ class ProxyConfig:
                             litellm.default_max_internal_user_budget
                         )
 
-                elif key == "disable_user_agent_tracking":
+                elif key == "disable_add_user_agent_to_request_tags":
                     setattr(litellm, "disable_add_user_agent_to_request_tags", value)
                 elif key == "custom_provider_map":
                     from litellm.utils import custom_llm_setup

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1879,6 +1879,9 @@ class ProxyConfig:
                         litellm.max_internal_user_budget = (
                             litellm.default_max_internal_user_budget
                         )
+
+                elif key == "disable_user_agent_tracking":
+                    setattr(litellm, "disable_add_user_agent_to_request_tags", value)
                 elif key == "custom_provider_map":
                     from litellm.utils import custom_llm_setup
 


### PR DESCRIPTION
## Title

disable user agent tags under litellm_settings
<img width="1112" height="167" alt="Screenshot 2025-09-04 at 11 19 02 AM" src="https://github.com/user-attachments/assets/bd01c6fe-5555-449c-8a6a-bf5bd16633ff" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
