### PR TITLE
Validate store model in db setting

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -987,7 +987,7 @@ async def update_public_model_groups(
     try:
         # Update the public model groups
         import litellm
-        from litellm.proxy.proxy_server import proxy_config
+        from litellm.proxy.proxy_server import proxy_config, store_model_in_db
 
         # Check if user has admin permissions
         if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
@@ -997,6 +997,15 @@ async def update_public_model_groups(
                     "error": "Only proxy admins can update public model groups. Your role={}".format(
                         user_api_key_dict.user_role
                     )
+                },
+            )
+
+        # Check if STORE_MODEL_IN_DB is enabled
+        if store_model_in_db is not True:
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": "Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature."
                 },
             )
 


### PR DESCRIPTION
## Title

Validate `STORE_MODEL_IN_DB` for public model group updates

## Relevant issues

Addresses an issue where public model hub settings were not persisting across restarts if `STORE_MODEL_IN_DB` was not enabled, leading to user confusion (as discussed in Slack).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

This PR adds validation to the `/model_group/make_public` endpoint. Previously, users could attempt to make model groups public without `STORE_MODEL_IN_DB` being enabled, leading to non-persistent settings across proxy restarts and confusion.

Now, if `STORE_MODEL_IN_DB` is not set to `True`, the endpoint will raise an `HTTPException` with a clear message, guiding users to enable the environment variable for proper functionality and persistence. This ensures that the public model hub feature works as expected and provides immediate feedback to the user if the necessary configuration is missing.

---
[Slack Thread](https://berriaillm.slack.com/archives/C094R7U2P43/p1757016042769029?thread_ts=1757016042.769029&cid=C094R7U2P43)

<a href="https://cursor.com/background-agent?bcId=bc-8096308b-6770-4eb4-9257-8ff5bb90d167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8096308b-6770-4eb4-9257-8ff5bb90d167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

