### PR TITLE
[Fix] Ensure `team_id` is a required field for generating service account keys

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -788,15 +788,6 @@ class GenerateKeyRequest(KeyRequestBase):
         description="Type of key that determines default allowed routes.",
     )
 
-class GenerateServiceAccountKeyRequest(GenerateKeyRequest):
-    @model_validator(mode="before")
-    @classmethod
-    def validate_team_id_required(cls, values):
-        if isinstance(values, dict):
-            if not values.get("team_id"):
-                raise ValueError("team_id is required for service account keys")
-        return values
-
 class GenerateKeyResponse(KeyRequestBase):
     key: str  # type: ignore
     key_name: Optional[str] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4,7 +4,6 @@ import uuid
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     Callable,
     Dict,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2,7 +2,17 @@ import enum
 import json
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
 
 import httpx
 from pydantic import (
@@ -778,6 +788,14 @@ class GenerateKeyRequest(KeyRequestBase):
         description="Type of key that determines default allowed routes.",
     )
 
+class GenerateServiceAccountKeyRequest(GenerateKeyRequest):
+    @model_validator(mode="before")
+    @classmethod
+    def validate_team_id_required(cls, values):
+        if isinstance(values, dict):
+            if not values.get("team_id"):
+                raise ValueError("team_id is required for service account keys")
+        return values
 
 class GenerateKeyResponse(KeyRequestBase):
     key: str  # type: ignore

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -685,7 +685,7 @@ async def generate_key_fn(
 )
 @management_endpoint_wrapper
 async def generate_service_account_key_fn(
-    data: GenerateKeyRequest,
+    data: GenerateServiceAccountKeyRequest,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     litellm_changed_by: Optional[str] = Header(
         None,


### PR DESCRIPTION
## [Fix] Ensure `team_id` is a required field for generating service account keys

- Add validate_team_id_used_in_service_account_request when using service account endpoints
- Check team_id exists and validate team_id exists in the DB

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


