### PR TITLE
[Fix] DD LLM Observability - Ensure `apm_id` is set on traces 

### DIFF
--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -46,6 +46,7 @@ class LLMMetrics(TypedDict, total=False):
 class LLMObsPayload(TypedDict, total=False):
     parent_id: str
     trace_id: str
+    apm_id: str
     span_id: str
     name: str
     meta: Meta


### PR DESCRIPTION
## [Fix] DD LLM Observability - Ensure `apm_id` is set on traces 

- apm_id is a field that can be set for DD LLM Observability 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


