### PR TITLE
[Draft] feat: add Anthropic support for Bedrock Guardrail

### DIFF
--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -351,7 +351,7 @@ def add_guardrail_to_applied_guardrails_header(
 ):
     if guardrail_name is None:
         return
-    _metadata = request_data.get("metadata", None) or {}
+    _metadata = request_data.get("litellm_metadata") or request_data.get("metadata", {})
     if "applied_guardrails" in _metadata:
         _metadata["applied_guardrails"].append(guardrail_name)
     else:

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -375,6 +375,9 @@ class AnthropicResponseContentBlockText(BaseModel):
     type: Literal["text"]
     text: str
 
+class AnthropicResponseContentBlockRole(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
 
 class AnthropicResponseContentBlockToolUse(BaseModel):
     type: Literal["tool_use"]

--- a/litellm/types/llms/anthropic_messages/anthropic_response.py
+++ b/litellm/types/llms/anthropic_messages/anthropic_response.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+from typing import Any, Dict, List, Literal, Mapping, Optional, TypeGuard, TypedDict, Union
 
 from typing_extensions import TypeAlias
 
 from litellm.types.llms.anthropic import (
+    AnthropicResponseContentBlockRole,
     AnthropicResponseContentBlockText,
     AnthropicResponseContentBlockToolUse,
 )
@@ -50,6 +51,8 @@ class AnthropicResponseRedactedThinkingBlock(TypedDict, total=False):
 
 AnthropicResponseContentBlock: TypeAlias = Union[
     AnthropicResponseTextBlock,
+    AnthropicResponseContentBlockRole,
+    AnthropicResponseContentBlockText,
     AnthropicResponseToolUseBlock,
     AnthropicResponseThinkingBlock,
     AnthropicResponseRedactedThinkingBlock,
@@ -94,3 +97,17 @@ class AnthropicMessagesResponse(TypedDict, total=False):
     stop_sequence: Optional[str]
     type: Optional[Literal["message"]]
     usage: Optional[AnthropicUsage]
+
+
+def is_anthropic_messages_response(
+    response: object,
+) -> "TypeGuard[AnthropicMessagesResponse]":
+    if not isinstance(response, Mapping):
+        return False
+    return (
+        response.get("type") == "message"
+        and "id" in response
+        and "model" in response
+        and "role" in response
+        and isinstance(response.get("content"), list)
+    )

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 from typing_extensions import Callable, Dict, Required, TypedDict, override
 
 import litellm
+from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicMessagesResponse
 from litellm.types.llms.base import (
     BaseLiteLLMOpenAIResponseObject,
     LiteLLMPydanticObjectBase,
@@ -2544,6 +2545,7 @@ LLMResponseTypes = Union[
     OpenAIFileObject,
     LiteLLMBatch,
     LiteLLMFineTuningJob,
+    AnthropicMessagesResponse
 ]
 
 


### PR DESCRIPTION
## Questions for Discussion
Is it acceptable to define a dedicated type for Anthropic’s streaming response?
Currently it’s handled as an AsyncIterator with bytes, but this makes the implementation of async_post_call_streaming_iterator_hook in Guardrails quite complicated.

If we were to change it, are there any concerns or potential downsides I should be aware of?

## Title

Add Anthropic support across Guardrails

## Relevant issues

[https://github.com/BerriAI/litellm/issues/13997](https://github.com/BerriAI/litellm/issues/13997)

Related PR for calling Guardrails from Anthropic endpoints:
[https://github.com/BerriAI/litellm/pull/14107](https://github.com/BerriAI/litellm/pull/14107)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
✅ Test

## Changes


