### PR TITLE
[Feat] LiteLLM x DD LLM Obs - Add support for emitting Key and Team Spend and Budget Metrics 

### DIFF
--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -49,6 +49,13 @@ Found under `kwargs["standard_logging_object"]`. This is a standard payload, log
 | `user_api_key_team_id` | `Optional[str]` | Team ID associated with the key |
 | `user_api_key_user_id` | `Optional[str]` | User ID associated with the key |
 | `user_api_key_team_alias` | `Optional[str]` | Team alias associated with the key |
+| `user_api_key_user_email` | `Optional[str]` | User email associated with the key |
+| `user_api_key_end_user_id` | `Optional[str]` | End user ID associated with the key |
+| `user_api_key_request_route` | `Optional[str]` | Request route used by the key |
+| `user_api_key_spend` | `Optional[float]` | Total spend for the API key |
+| `user_api_key_max_budget` | `Optional[float]` | Max budget for the API key |
+| `user_api_key_team_spend` | `Optional[float]` | Current spend for the team |
+| `user_api_key_team_max_budget` | `Optional[float]` | Max budget for the team |
 
 ## StandardLoggingMetadata
 

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -56,6 +56,10 @@ class _ProxyDBLogger(CustomLogger):
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,
+                user_api_key_spend=user_api_key_dict.spend,
+                user_api_key_max_budget=user_api_key_dict.max_budget,
+                user_api_key_team_spend=user_api_key_dict.team_spend,
+                user_api_key_team_max_budget=user_api_key_dict.team_max_budget,
             )
         )
         _metadata["user_api_key"] = user_api_key_dict.api_key

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -509,6 +509,10 @@ class LiteLLMProxyRequestSetup:
             user_api_key_end_user_id=user_api_key_dict.end_user_id,
             user_api_key_user_email=user_api_key_dict.user_email,
             user_api_key_request_route=user_api_key_dict.request_route,
+            user_api_key_spend=user_api_key_dict.spend,
+            user_api_key_max_budget=user_api_key_dict.max_budget,
+            user_api_key_team_spend=user_api_key_dict.team_spend,
+            user_api_key_team_max_budget=user_api_key_dict.team_max_budget
         )
         return user_api_key_logged_metadata
 
@@ -531,9 +535,9 @@ class LiteLLMProxyRequestSetup:
             "user_api_key"
         ] = user_api_key_dict.api_key  # this is just the hashed token
 
-        data[_metadata_variable_name]["user_api_end_user_max_budget"] = getattr(
-            user_api_key_dict, "end_user_max_budget", None
-        )
+        data[_metadata_variable_name][
+            "user_api_end_user_max_budget"
+        ] = user_api_key_dict.end_user_max_budget
         return data
 
     @staticmethod

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -471,6 +471,10 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,
+                user_api_key_spend=user_api_key_dict.spend,
+                user_api_key_max_budget=user_api_key_dict.max_budget,
+                user_api_key_team_spend=user_api_key_dict.team_spend,
+                user_api_key_team_max_budget=user_api_key_dict.team_max_budget
             )
         )
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1814,6 +1814,18 @@ class StandardLoggingUserAPIKeyMetadata(TypedDict):
     user_api_key_end_user_id: Optional[str]
     user_api_key_request_route: Optional[str]
 
+    #####################################
+    # Key level spend and budget
+    #####################################
+    user_api_key_spend: Optional[float]
+    user_api_key_max_budget: Optional[float]
+
+    #####################################
+    # Team level spend and budget
+    #####################################
+    user_api_key_team_spend: Optional[float]
+    user_api_key_team_max_budget: Optional[float]
+
 
 class StandardLoggingMCPToolCall(TypedDict, total=False):
     name: str

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -57,6 +57,10 @@ def create_standard_logging_payload_with_cache() -> StandardLoggingPayload:
             user_api_key_team_id="test_team",
             user_api_key_user_id="test_user",
             user_api_key_team_alias="test_team_alias",
+            user_api_key_spend=1.23,
+            user_api_key_max_budget=10.0,
+            user_api_key_team_spend=2.34,
+            user_api_key_team_max_budget=20.0,
             spend_logs_metadata=None,
             requester_ip_address="127.0.0.1",
             requester_metadata=None,
@@ -451,6 +455,11 @@ async def test_create_llm_obs_payload(mock_env_vars):
     assert payload["metrics"]["input_tokens"] == 10
     assert payload["metrics"]["output_tokens"] == 20
     assert payload["metrics"]["total_tokens"] == 30
+    metadata = payload["meta"]["metadata"]
+    assert metadata["user_api_key_spend"] == 1.23
+    assert metadata["user_api_key_max_budget"] == 10.0
+    assert metadata["user_api_key_team_spend"] == 2.34
+    assert metadata["user_api_key_team_max_budget"] == 20.0
 
 
 def create_standard_logging_payload_with_latency_metrics() -> StandardLoggingPayload:

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -691,6 +691,10 @@ def test_add_user_api_key_auth_to_request_metadata():
         end_user_id="test-end-user-123",
         request_route="/chat/completions",
         end_user_max_budget=500.0,
+        spend=1.0,
+        max_budget=10.0,
+        team_spend=2.0,
+        team_max_budget=20.0,
     )
 
     metadata_variable_name = "litellm_metadata"
@@ -715,6 +719,10 @@ def test_add_user_api_key_auth_to_request_metadata():
     assert metadata["user_api_key_end_user_id"] == "test-end-user-123"
     assert metadata["user_api_key_user_email"] == "test@example.com"
     assert metadata["user_api_key_request_route"] == "/chat/completions"
+    assert metadata["user_api_key_spend"] == 1.0
+    assert metadata["user_api_key_max_budget"] == 10.0
+    assert metadata["user_api_key_team_spend"] == 2.0
+    assert metadata["user_api_key_team_max_budget"] == 20.0
 
     # Check that the hashed API key was added
     assert metadata["user_api_key"] == "hashed-test-key-123"


### PR DESCRIPTION
## [Feat] LiteLLM x DD LLM Obs - Add support for emitting Key and Team Spend and Budget Metrics 

<img width="1100" height="648" alt="Screenshot 2025-09-04 at 8 39 39 PM" src="https://github.com/user-attachments/assets/f4bff316-ccb1-45d8-9c3b-1f98f63b442e" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


