### PR TITLE
Add model to azure error message

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5465,7 +5465,7 @@ class Router:
         ## SET MODEL TO 'model=' - if base_model is None + not azure
         if custom_llm_provider == "azure" and base_model is None:
             verbose_router_logger.error(
-                "Could not identify azure model. Set azure 'base_model' for accurate max tokens, cost tracking, etc.- https://docs.litellm.ai/docs/proxy/cost_tracking#spend-tracking-for-azure-openai-models"
+                f"Could not identify azure model '{_model}'. Set azure 'base_model' for accurate max tokens, cost tracking, etc.- https://docs.litellm.ai/docs/proxy/cost_tracking#spend-tracking-for-azure-openai-models"
             )
         elif custom_llm_provider != "azure":
             model = _model


### PR DESCRIPTION
## Title

Enhance Azure `base_model` error message with model name

## Relevant issues

This change addresses feedback from a Slack conversation where users experienced confusion regarding the "Could not identify azure model" error message. The conversation highlighted the need for clearer error messages to aid in debugging and understanding the impact on cost tracking.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

The existing error message "Could not identify azure model. Set azure 'base_model' for accurate max tokens, cost tracking, etc." was ambiguous as it didn't specify *which* Azure model was causing the issue.

This change modifies the error message to include the specific model name (e.g., `Could not identify azure model 'gpt-4o-2024-08-06'`). This significantly improves diagnostic clarity, allowing users to quickly identify the problematic model and understand the context of the error, especially when troubleshooting cost tracking or token limit issues.

---
[Slack Thread](https://berriaillm.slack.com/archives/C08NCTYSK8U/p1757026557716109?thread_ts=1757026557.716109&cid=C08NCTYSK8U)

<a href="https://cursor.com/background-agent?bcId=bc-9c9d8161-c765-4492-9d7a-2dbbce2bf072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c9d8161-c765-4492-9d7a-2dbbce2bf072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

