### PR TITLE
Bug fix for openai.gpt-oss when using reasoning_effort parameter

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -467,7 +467,7 @@ print(f"\nResponse: {resp}")
 
 ## Usage - 'thinking' / 'reasoning content'
 
-This is currently only supported for Anthropic's Claude 3.7 Sonnet + Deepseek R1.
+This is currently only supported for Anthropic's Claude 3.7 Sonnet + Deepseek R1 + GPT-OSS models.
 
 Works on v1.61.20+.
 

--- a/docs/my-website/docs/reasoning_content.md
+++ b/docs/my-website/docs/reasoning_content.md
@@ -12,7 +12,7 @@ Requires LiteLLM v1.63.0+
 Supported Providers:
 - Deepseek (`deepseek/`)
 - Anthropic API (`anthropic/`)
-- Bedrock (Anthropic + Deepseek) (`bedrock/`)
+- Bedrock (Anthropic + Deepseek + GPT-OSS) (`bedrock/`)
 - Vertex AI (Anthropic) (`vertexai/`)
 - OpenRouter (`openrouter/`)
 - XAI (`xai/`)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -474,7 +474,7 @@ class AmazonConverseConfig(BaseConfig):
                 )
 
         # Only update thinking tokens for non-GPT-OSS models
-        if not ("gpt-oss" in model):
+        if "gpt-oss" not in model:
             self.update_optional_params_with_thinking_tokens(
                 non_default_params=non_default_params, optional_params=optional_params
             )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -466,13 +466,12 @@ class AmazonConverseConfig(BaseConfig):
                 if "gpt-oss" in model:
                     # GPT-OSS models: keep reasoning_effort as-is
                     # It will be passed through to additionalModelRequestFields
-                    optional_params["reasoning_effort"] = value
                     continue
-                else:
-                    # Anthropic and other models: convert to thinking parameter
-                    optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
-                        value
-                    )
+
+                # Anthropic and other models: convert to thinking parameter
+                optional_params["thinking"] = AnthropicConfig._map_reasoning_effort(
+                    value
+                )
 
         # Only update thinking tokens for non-GPT-OSS models
         if not ("gpt-oss" in model):

--- a/tests/llm_translation/test_bedrock_gpt_oss.py
+++ b/tests/llm_translation/test_bedrock_gpt_oss.py
@@ -2,11 +2,13 @@ from base_llm_unit_tests import BaseLLMChatTest
 import pytest
 import sys
 import os
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import litellm
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 
 
 class TestBedrockGPTOSS(BaseLLMChatTest):
@@ -25,3 +27,27 @@ class TestBedrockGPTOSS(BaseLLMChatTest):
         Remove override once we have access to Bedrock prompt caching
         """
         pass
+
+    @pytest.mark.parametrize("model", [
+        "bedrock/openai.gpt-oss-20b-1:0",
+        "bedrock/openai.gpt-oss-120b-1:0",
+    ])
+    def test_reasoning_effort_transformation_gpt_oss(self, model):
+        """Test that reasoning_effort is handled correctly for GPT-OSS models."""
+        config = AmazonConverseConfig()
+
+        # Test GPT-OSS model - should keep reasoning_effort as-is
+        non_default_params = {"reasoning_effort": "low"}
+        optional_params = {}
+
+        result = config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=False,
+        )
+        
+        # GPT-OSS should have reasoning_effort in result, not thinking
+        assert "reasoning_effort" in result
+        assert result["reasoning_effort"] == "low"
+        assert "thinking" not in result


### PR DESCRIPTION
## Bug fix for openai.gpt-oss when using reasoning_effort parameter 

<!-- e.g. "Implement user authentication feature" -->
I have modified the mapping to enable setting the reasoning effort in GPT-OSS.

To be precise, the Bedrock documentation does not mention the reasoning_effort argument, but it works the same as the OpenAI API, so we need to avoid converting it for other Bedrock models.
https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/model-parameters-openai.html

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fix https://github.com/BerriAI/litellm/issues/14225

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="2416" height="426" alt="image" src="https://github.com/user-attachments/assets/67f0afc8-cc42-4075-93c7-593f9bfbf6f3" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


