### PR TITLE
fix: Handle NoneType error in dynamic callback controls

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
@@ -69,10 +69,11 @@ class EnterpriseCallbackControls:
         # check if disabled via headers
         #########################################################
         request_headers = get_proxy_server_request_headers(litellm_params)
-        disabled_callbacks = request_headers.get(X_LITELLM_DISABLE_CALLBACKS, None)
-        if disabled_callbacks is not None:
-            disabled_callbacks = set([cb.strip().lower() for cb in disabled_callbacks.split(",")])
-            return list(disabled_callbacks)
+        if request_headers is not None:
+            disabled_callbacks = request_headers.get(X_LITELLM_DISABLE_CALLBACKS, None)
+            if disabled_callbacks is not None:
+                disabled_callbacks = set([cb.strip().lower() for cb in disabled_callbacks.split(",")])
+                return list(disabled_callbacks)
         
 
         #########################################################

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py
@@ -1,0 +1,171 @@
+import os
+import sys
+from unittest.mock import patch
+
+# Add the project root to the path so we can import the modules
+sys.path.insert(0, os.path.abspath("../.."))
+
+import pytest
+from litellm.types.utils import StandardCallbackDynamicParams
+from enterprise.litellm_enterprise.enterprise_callbacks.callback_controls import EnterpriseCallbackControls
+
+
+class TestEnterpriseCallbackControls:
+    """Test suite for EnterpriseCallbackControls class."""
+
+    def test_get_disabled_callbacks_with_none_request_headers(self):
+        """
+        Test that get_disabled_callbacks handles None request headers gracefully.
+
+        This test reproduces the issue where get_proxy_server_request_headers
+        could return None, causing a "'NoneType' object has no attribute 'get'" error.
+        """
+        # Mock the get_proxy_server_request_headers function to return None
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = None
+
+            # Test data
+            litellm_params = {"some": "data"}
+            standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+            # This should not raise an exception
+            result = EnterpriseCallbackControls.get_disabled_callbacks(litellm_params, standard_callback_dynamic_params)
+
+            # Should return None when no disabled callbacks are found
+            assert result is None
+
+    def test_get_disabled_callbacks_with_empty_request_headers(self):
+        """
+        Test that get_disabled_callbacks works with empty request headers.
+        """
+        # Mock the get_proxy_server_request_headers function to return an empty dict
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = {}
+
+            # Test data
+            litellm_params = {"some": "data"}
+            standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+            # This should not raise an exception
+            result = EnterpriseCallbackControls.get_disabled_callbacks(litellm_params, standard_callback_dynamic_params)
+
+            # Should return None when no disabled callbacks are found
+            assert result is None
+
+    def test_get_disabled_callbacks_with_disabled_header(self):
+        """
+        Test that get_disabled_callbacks correctly parses disabled callbacks from headers.
+        """
+        # Mock the get_proxy_server_request_headers function to return headers with disabled callbacks
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = {"x-litellm-disable-callbacks": "prometheus,slack"}
+
+            # Test data
+            litellm_params = {"some": "data"}
+            standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+            # This should not raise an exception
+            result = EnterpriseCallbackControls.get_disabled_callbacks(litellm_params, standard_callback_dynamic_params)
+
+            # Should return the list of disabled callbacks
+            assert result is not None
+            assert isinstance(result, list)
+            assert "prometheus" in [cb.lower() for cb in result]
+            assert "slack" in [cb.lower() for cb in result]
+
+    def test_is_callback_disabled_dynamically_with_none_headers(self):
+        """
+        Test that is_callback_disabled_dynamically handles None request headers gracefully.
+        """
+        # Mock the get_proxy_server_request_headers function to return None
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = None
+
+            # Mock the premium user check to return True
+            with patch(
+                "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.EnterpriseCallbackControls._premium_user_check"
+            ) as mock_premium_check:
+                mock_premium_check.return_value = True
+
+                # Test data
+                callback = "prometheus"
+                litellm_params = {"some": "data"}
+                standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+                # This should not raise an exception
+                result = EnterpriseCallbackControls.is_callback_disabled_dynamically(
+                    callback, litellm_params, standard_callback_dynamic_params
+                )
+
+                # Should return False when no headers are present
+                assert result is False
+
+    def test_is_callback_disabled_dynamically_with_disabled_callback(self):
+        """
+        Test that is_callback_disabled_dynamically correctly identifies disabled callbacks.
+        """
+        # Mock the get_proxy_server_request_headers function to return headers with disabled callbacks
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = {"x-litellm-disable-callbacks": "prometheus,slack"}
+
+            # Mock the premium user check to return True
+            with patch(
+                "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.EnterpriseCallbackControls._premium_user_check"
+            ) as mock_premium_check:
+                mock_premium_check.return_value = True
+
+                # Test data
+                callback = "prometheus"
+                litellm_params = {"some": "data"}
+                standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+                # This should not raise an exception
+                result = EnterpriseCallbackControls.is_callback_disabled_dynamically(
+                    callback, litellm_params, standard_callback_dynamic_params
+                )
+
+                # Should return True for a disabled callback
+                assert result is True
+
+    def test_is_callback_disabled_dynamically_with_enabled_callback(self):
+        """
+        Test that is_callback_disabled_dynamically correctly identifies enabled callbacks.
+        """
+        # Mock the get_proxy_server_request_headers function to return headers with disabled callbacks
+        with patch(
+            "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.get_proxy_server_request_headers"
+        ) as mock_get_headers:
+            mock_get_headers.return_value = {"x-litellm-disable-callbacks": "prometheus,slack"}
+
+            # Mock the premium user check to return True
+            with patch(
+                "enterprise.litellm_enterprise.enterprise_callbacks.callback_controls.EnterpriseCallbackControls._premium_user_check"
+            ) as mock_premium_check:
+                mock_premium_check.return_value = True
+
+                # Test data
+                callback = "langfuse"
+                litellm_params = {"some": "data"}
+                standard_callback_dynamic_params = StandardCallbackDynamicParams()
+
+                # This should not raise an exception
+                result = EnterpriseCallbackControls.is_callback_disabled_dynamically(
+                    callback, litellm_params, standard_callback_dynamic_params
+                )
+
+                # Should return False for an enabled callback
+                assert result is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Title

Fix: Handle NoneType error in dynamic callback controls

## Relevant issues

*N/A*

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/`](https://github.com/BerriAI/litellm/tree/main/tests) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

```txt
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_get_disabled_callbacks_with_disabled_header PASSED [ 16%]
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_get_disabled_callbacks_with_empty_request_headers PASSED [ 33%]
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_get_disabled_callbacks_with_none_request_headers PASSED [ 50%]
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_is_callback_disabled_dynamically_with_disabled_callback PASSED [ 66%]
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_is_callback_disabled_dynamically_with_enabled_callback PASSED [ 83%]
tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py::TestEnterpriseCallbackControls::test_is_callback_disabled_dynamically_with_none_headers PASSED [100%]

```

## Type

🐛 Bug Fix
✅ Test

## Changes

This PR addresses a `NoneType` error that occurs in the enterprise callback controls when `request_headers` are `None`.

1.  **Bug Fix**: Added a null check in `enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py` to safely handle cases where `get_proxy_server_request_headers()` returns `None`. This prevents the `AttributeError: 'NoneType' object has no attribute 'get'` and ensures the function gracefully continues to check the request body for disabled callbacks.

2.  **Added Tests**: Introduced a new test file `tests/enterprise/litellm_enterprise/enterprise_callbacks/test_callback_controls.py` to verify the fix and ensure the dynamic callback control logic is robust. The new tests cover:
    *   The specific scenario where `request_headers` are `None`.
    *   Cases with empty headers and valid headers containing disabled callback keys.
    *   Both `get_disabled_callbacks` and `is_callback_disabled_dynamically` functions.


