### PR TITLE
Pass extra_body params in the request-body to vertexAI

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -468,6 +468,12 @@ def _transform_request_body(
             data["generationConfig"] = generation_config
         if cached_content is not None:
             data["cachedContent"] = cached_content
+            
+         # Add any extra body params passed to the request body
+        extra_body = optional_params.get("extra_body", {})
+        if extra_body is not None:
+            data = {**extra_body, **data}
+            
     except Exception as e:
         raise e
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -9182,4 +9182,4 @@ utils = ["numpydoc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<4.0, !=3.9.7"
-content-hash = "8ebdb444c0ff253857f90d3ec9926a58d23d4482c644fd158a047f0c0f892bb9"
+content-hash = "54374b906931afe92861b6b9b226751579c0d342f650bc8f7ebaf4c5882d6249"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -1503,3 +1503,32 @@ def test_system_prompt_only_adds_blank_user_message():
     #########################################################
     assert len(data["system_instruction"]) == 1
     assert data["system_instruction"]["parts"][0]["text"] == SYSTEM_INSTRUCTION
+
+def test_extra_body_labels_added_and_existing_fields_not_overridden():
+    """
+    Test that list of parameters sent as "extra_body" are added to the request body and existing fields are not overridden.
+
+    Relevant Issue - https://github.com/BerriAI/litellm/issues/13692
+    """
+    data = _transform_request_body(
+        messages=[{"role": "system", "content": "System instructions for the model"}],
+        model="gemini-2.5-flash",
+        optional_params={
+            "extra_body": {
+                "labels": {"team": "ml"},
+                "cachedContent": "should_not_override"
+            }
+        },
+        custom_llm_provider="vertex_ai",
+        litellm_params={},
+        cached_content="pre_set",
+    )
+
+    print("Final data with extra_body: ", data)
+
+    # validate that extra_body fields are added
+    assert "labels" in data
+    assert data["labels"] == {"team": "ml"}
+
+    # validate that existing fields are not overridden
+    assert data["cachedContent"] == "pre_set"


### PR DESCRIPTION
## Title

Support for passing extra_body (eg:- labels ) parameters to Vertex AI models

## Relevant issues

https://github.com/BerriAI/litellm/issues/13692

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**


- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="1743" height="375" alt="image" src="https://github.com/user-attachments/assets/b22841f1-d63a-4fb2-8b89-c69d4c6e7955" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

`litellm/llms/vertex_ai/gemini/transformation.py:` Logic to pass along _extra_body_ params
`tests/test_litellm/llms/vertex_ai/test_vertex.py:` Added Test case


