### PR TITLE
fix: spend tags endpoint returns 500

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -149,13 +149,6 @@ async def view_spend_tags(
     ```
     """
 
-    try:
-        from enterprise.utils import get_spend_by_tags
-    except ImportError:
-        raise Exception(
-            "Trying to use Spend by Tags"
-            + CommonProxyErrors.missing_enterprise_package_docker.value
-        )
     from litellm.proxy.proxy_server import prisma_client
 
     try:


### PR DESCRIPTION
## Title

/spend/tags endpoint returned 500 error

`"/Users/mubashirosmani/litellm/litellm/proxy/spend_tracking/spend_management_endpoints.py", line 155, in view_spend_tags
    |     raise Exception(
    | Exception: Trying to use Spend by TagsThis uses the enterprise folder - only available on the Docker image.`

<img width="832" height="160" alt="Screenshot 2025-09-07 at 10 08 57 AM" src="https://github.com/user-attachments/assets/85bf36b2-bab2-4a7e-9a29-80682cef924b" />
<img width="903" height="218" alt="Screenshot 2025-09-07 at 10 16 55 AM" src="https://github.com/user-attachments/assets/ca48a73e-47ff-4d14-ae29-85e173b36c1a" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

