### PR TITLE
Fix markdown formatting issues in Docker quick start documentation

### DIFF
--- a/docs/my-website/docs/proxy/docker_quick_start.md
+++ b/docs/my-website/docs/proxy/docker_quick_start.md
@@ -13,7 +13,7 @@ End-to-End tutorial for LiteLLM Proxy to:
 
 ## Pre-Requisites 
 
-- Install LiteLLM Docker Image ** OR ** LiteLLM CLI (pip package)
+- Install LiteLLM Docker Image **OR** LiteLLM CLI (pip package)
 
 <Tabs>
 
@@ -278,15 +278,15 @@ See All General Settings [here](http://localhost:3000/docs/proxy/configs#all-set
    - **Description**: 
      - Set a `master key`, this is your Proxy Admin key - you can use this to create other keys (🚨 must start with `sk-`).
    - **Usage**: 
-     - ** Set on config.yaml** set your master key under `general_settings:master_key`, example - 
+     - **Set on config.yaml** set your master key under `general_settings:master_key`, example - 
         `master_key: sk-1234`
-     - ** Set env variable** set `LITELLM_MASTER_KEY`
+     - **Set env variable** set `LITELLM_MASTER_KEY`
 
 2. **`database_url`** (str)
    - **Description**: 
      - Set a `database_url`, this is the connection to your Postgres DB, which is used by litellm for generating keys, users, teams.
    - **Usage**: 
-     - ** Set on config.yaml** set your `database_url` under `general_settings:database_url`, example - 
+     - **Set on config.yaml** set your `database_url` under `general_settings:database_url`, example - 
         `database_url: "postgresql://..."`
      - Set `DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<dbname>` in your env 
 


### PR DESCRIPTION
## Title
Fix markdown formatting issues in Docker quick start documentation

## Relevant issues
<!-- No specific issue referenced -->

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [ ] I have Added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
📖 Documentation

## Changes
- Fixed spacing issues around "OR" in pre-requisites section (removed extra spaces around bold formatting)
- Corrected markdown formatting for `master_key` configuration examples (removed extra spaces in `** Set` → `**Set`)
- Corrected markdown formatting for `database_url` configuration examples (removed extra spaces in `** Set` → `**Set`)
- Improved overall consistency and readability of the Docker quick start documentation

These changes are purely cosmetic formatting fixes that improve the professional appearance and readability of the documentation without changing any functionality or content.