### PR TITLE
update: DeepInfra model data refresh [2025-09-08]

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15517,42 +15517,12 @@
         "litellm_provider": "ollama",
         "mode": "completion"
     },
-    "deepinfra/Austism/chronos-hermes-13b-v2": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1.3e-07,
-        "output_cost_per_token": 1.3e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
     "deepinfra/Gryphe/MythoMax-L2-13b": {
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "input_cost_per_token": 7.2e-08,
         "output_cost_per_token": 7.2e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Gryphe/MythoMax-L2-13b-turbo": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1.3e-07,
-        "output_cost_per_token": 1.3e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/KoboldAI/LLaMA2-13B-Tiefighter": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1e-07,
-        "output_cost_per_token": 1e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15575,74 +15545,14 @@
         "output_cost_per_token": 2.8e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/NovaSky-AI/Sky-T1-32B-Preview": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 1.2e-07,
-        "output_cost_per_token": 1.8e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/Phind/Phind-CodeLlama-34B-v2": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 6e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/QVQ-72B-Preview": {
-        "max_tokens": 32000,
-        "max_input_tokens": 32000,
-        "max_output_tokens": 32000,
-        "input_cost_per_token": 2.5e-07,
-        "output_cost_per_token": 5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
         "supports_tool_choice": false
     },
     "deepinfra/Qwen/QwQ-32B": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 7.5e-08,
-        "output_cost_per_token": 1.5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/QwQ-32B-Preview": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 1.2e-07,
-        "output_cost_per_token": 1.8e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/Qwen/Qwen2-72B-Instruct": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 3.5e-07,
+        "input_cost_per_token": 1.5e-07,
         "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/Qwen/Qwen2-7B-Instruct": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15663,26 +15573,6 @@
         "max_output_tokens": 32768,
         "input_cost_per_token": 4e-08,
         "output_cost_per_token": 1e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/Qwen/Qwen2.5-Coder-32B-Instruct": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 6e-08,
-        "output_cost_per_token": 1.5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/Qwen/Qwen2.5-Coder-7B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 2.5e-08,
-        "output_cost_per_token": 5e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": false
@@ -15773,29 +15663,10 @@
         "max_output_tokens": 262144,
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 2.4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
-    },
-    "deepinfra/Sao10K/L3-70B-Euryale-v2.1": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 7e-07,
-        "output_cost_per_token": 8e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/Sao10K/L3-8B-Lunaris-v1": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3e-08,
-        "output_cost_per_token": 6e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
     },
     "deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo": {
         "max_tokens": 8192,
@@ -15843,6 +15714,7 @@
         "max_output_tokens": 200000,
         "input_cost_per_token": 3.3e-06,
         "output_cost_per_token": 1.65e-05,
+        "cache_read_input_token_cost": 3.3e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15867,67 +15739,15 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/bigcode/starcoder2-15b-instruct-v0.1": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1.5e-07,
-        "output_cost_per_token": 1.5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/cognitivecomputations/dolphin-2.6-mixtral-8x7b": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 2.4e-07,
-        "output_cost_per_token": 2.4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/cognitivecomputations/dolphin-2.9.1-llama-3-70b": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3.5e-07,
-        "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/deepinfra/airoboros-70b": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 7e-07,
-        "output_cost_per_token": 9e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/deepseek-ai/DeepSeek-Prover-V2-671B": {
-        "max_tokens": 163840,
-        "max_input_tokens": 163840,
-        "max_output_tokens": 163840,
-        "input_cost_per_token": 5e-07,
-        "output_cost_per_token": 2.18e-06,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false,
-        "supports_reasoning": true
-    },
     "deepinfra/deepseek-ai/DeepSeek-R1": {
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
-        "input_cost_per_token": 4.5e-07,
-        "output_cost_per_token": 2.15e-06,
+        "input_cost_per_token": 7e-07,
+        "output_cost_per_token": 2.4e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528": {
         "max_tokens": 163840,
@@ -15935,10 +15755,10 @@
         "max_output_tokens": 163840,
         "input_cost_per_token": 5e-07,
         "output_cost_per_token": 2.15e-06,
+        "cache_read_input_token_cost": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo": {
         "max_tokens": 32768,
@@ -15948,8 +15768,7 @@
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
         "max_tokens": 131072,
@@ -15959,8 +15778,7 @@
         "output_cost_per_token": 4e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": false,
-        "supports_reasoning": true
+        "supports_tool_choice": false
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
         "max_tokens": 131072,
@@ -15970,19 +15788,17 @@
         "output_cost_per_token": 1.5e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Turbo": {
-        "max_tokens": 163840,
-        "max_input_tokens": 163840,
-        "max_output_tokens": 163840,
+        "max_tokens": 40960,
+        "max_input_tokens": 40960,
+        "max_output_tokens": 40960,
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3": {
         "max_tokens": 163840,
@@ -15992,8 +15808,7 @@
         "output_cost_per_token": 8.9e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324": {
         "max_tokens": 163840,
@@ -16001,59 +15816,18 @@
         "max_output_tokens": 163840,
         "input_cost_per_token": 2.8e-07,
         "output_cost_per_token": 8.8e-07,
+        "cache_read_input_token_cost": 2.24e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
-    },
-    "deepinfra/deepseek-ai/DeepSeek-V3-0324-Turbo": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 1e-06,
-        "output_cost_per_token": 3e-06,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3.1": {
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1e-06,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false,
-        "supports_reasoning": true
-    },
-    "deepinfra/google/codegemma-7b-it": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 7e-08,
-        "output_cost_per_token": 7e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/google/gemini-1.5-flash": {
-        "max_tokens": 1000000,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 1000000,
-        "input_cost_per_token": 7.5e-08,
-        "output_cost_per_token": 3e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/google/gemini-1.5-flash-8b": {
-        "max_tokens": 1000000,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 1000000,
-        "input_cost_per_token": 3.75e-08,
-        "output_cost_per_token": 1.5e-07,
+        "cache_read_input_token_cost": 2.16e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -16088,36 +15862,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/google/gemma-1.1-7b-it": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 7e-08,
-        "output_cost_per_token": 7e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/google/gemma-2-27b-it": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 2.7e-07,
-        "output_cost_per_token": 2.7e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/google/gemma-2-9b-it": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3e-08,
-        "output_cost_per_token": 6e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
     "deepinfra/google/gemma-3-12b-it": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
@@ -16142,48 +15886,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 2e-08,
-        "output_cost_per_token": 4e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/lizpreciatior/lzlv_70b_fp16_hf": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 3.5e-07,
-        "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/mattshumer/Reflection-Llama-3.1-70B": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3.5e-07,
-        "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/meta-llama/Llama-2-13b-chat-hf": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1.3e-07,
-        "output_cost_per_token": 1.3e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/meta-llama/Llama-2-70b-chat-hf": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 6.4e-07,
-        "output_cost_per_token": 8e-07,
+        "input_cost_per_token": 4e-08,
+        "output_cost_per_token": 8e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -16198,16 +15902,6 @@
         "mode": "chat",
         "supports_tool_choice": false
     },
-    "deepinfra/meta-llama/Llama-3.2-1B-Instruct": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 5e-09,
-        "output_cost_per_token": 1e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
     "deepinfra/meta-llama/Llama-3.2-3B-Instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
@@ -16217,16 +15911,6 @@
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
-    },
-    "deepinfra/meta-llama/Llama-3.2-90B-Vision-Instruct": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 3.5e-07,
-        "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
     },
     "deepinfra/meta-llama/Llama-3.3-70B-Instruct": {
         "max_tokens": 131072,
@@ -16258,16 +15942,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-Turbo": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 5e-07,
-        "output_cost_per_token": 5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
     "deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
         "max_tokens": 327680,
         "max_input_tokens": 327680,
@@ -16298,32 +15972,12 @@
         "mode": "chat",
         "supports_tool_choice": false
     },
-    "deepinfra/meta-llama/Meta-Llama-3-70B-Instruct": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
     "deepinfra/meta-llama/Meta-Llama-3-8B-Instruct": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "input_cost_per_token": 3e-08,
         "output_cost_per_token": 6e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/meta-llama/Meta-Llama-3.1-405B-Instruct": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 8e-07,
-        "output_cost_per_token": 8e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -16368,36 +16022,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/microsoft/Phi-3-medium-4k-instruct": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 1.4e-07,
-        "output_cost_per_token": 1.4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/microsoft/Phi-4-multimodal-instruct": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 5e-08,
-        "output_cost_per_token": 1e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/microsoft/WizardLM-2-7B": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
     "deepinfra/microsoft/WizardLM-2-8x22B": {
         "max_tokens": 65536,
         "max_input_tokens": 65536,
@@ -16414,66 +16038,6 @@
         "max_output_tokens": 16384,
         "input_cost_per_token": 7e-08,
         "output_cost_per_token": 1.4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/microsoft/phi-4-reasoning-plus": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 7e-08,
-        "output_cost_per_token": 3.5e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/mistralai/Devstral-Small-2505": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 6e-08,
-        "output_cost_per_token": 1.2e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/mistralai/Devstral-Small-2507": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 7e-08,
-        "output_cost_per_token": 2.8e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/mistralai/Mistral-7B-Instruct-v0.1": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/mistralai/Mistral-7B-Instruct-v0.2": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/mistralai/Mistral-7B-Instruct-v0.3": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "input_cost_per_token": 2.8e-08,
-        "output_cost_per_token": 5.4e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -16498,32 +16062,12 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/mistralai/Mistral-Small-3.1-24B-Instruct-2503": {
-        "max_tokens": 128000,
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "input_cost_per_token": 5e-08,
-        "output_cost_per_token": 1e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
     "deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 5e-08,
         "output_cost_per_token": 1e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/mistralai/Mixtral-8x22B-Instruct-v0.1": {
-        "max_tokens": 65536,
-        "max_input_tokens": 65536,
-        "max_output_tokens": 65536,
-        "input_cost_per_token": 6.5e-07,
-        "output_cost_per_token": 6.5e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -16558,16 +16102,6 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
-    "deepinfra/nvidia/Nemotron-4-340B-Instruct": {
-        "max_tokens": 4096,
-        "max_input_tokens": 4096,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 4.2e-06,
-        "output_cost_per_token": 4.2e-06,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
     "deepinfra/openai/gpt-oss-120b": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
@@ -16584,36 +16118,6 @@
         "max_output_tokens": 131072,
         "input_cost_per_token": 4e-08,
         "output_cost_per_token": 1.6e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": true
-    },
-    "deepinfra/openbmb/MiniCPM-Llama3-V-2_5": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 3.4e-07,
-        "output_cost_per_token": 3.4e-07,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/openchat/openchat-3.6-8b": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
-        "litellm_provider": "deepinfra",
-        "mode": "chat",
-        "supports_tool_choice": false
-    },
-    "deepinfra/openchat/openchat_3.5": {
-        "max_tokens": 8192,
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "input_cost_per_token": 5.5e-08,
-        "output_cost_per_token": 5.5e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true


### PR DESCRIPTION
# Relevant issues

This PR updates DeepInfra model data
Addresses model deprecation - models removed
Addresses model parameter updates - pricing/metadata changes

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.


## Type

📖 Documentation

## Changes

Removed Models:
deepinfra/Qwen/Qwen2.5-Coder-32B-Instruct
deepinfra/deepseek-ai/DeepSeek-V3-0324-Turbo
deepinfra/meta-llama/Llama-3.2-90B-Vision-Instruct
deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-Turbo
deepinfra/meta-llama/Meta-Llama-3-70B-Instruct
deepinfra/mistralai/Devstral-Small-2507
deepinfra/mistralai/Mistral-7B-Instruct-v0.3
deepinfra/mistralai/Mistral-Small-3.1-24B-Instruct-2503

Modified Models:
deepinfra/deepseek-ai/DeepSeek-R1-0528:
   - cache_read_input_token_cost: None → 4e-07

deepinfra/google/gemma-3-4b-it:
   - input_cost_per_token: 2e-08 → 4e-08
   - output_cost_per_token: 4e-08 → 8e-08

deepinfra/Qwen/QwQ-32B:
   - input_cost_per_token: 7.5e-08 → 1.5e-07
   - output_cost_per_token: 1.5e-07 → 4e-07

deepinfra/deepseek-ai/DeepSeek-V3-0324:
   - cache_read_input_token_cost: None → 2.24e-07

deepinfra/deepseek-ai/DeepSeek-V3.1:
   - input_cost_per_token: 3e-07 → 2.7e-07
   - cache_read_input_token_cost: None → 2.16e-07

deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo:
   - cache_read_input_token_cost: 1.5e-07 → 2.4e-07

deepinfra/NousResearch/Hermes-3-Llama-3.1-70B:
   - supports_tool_choice: True → False

deepinfra/deepseek-ai/DeepSeek-R1-Turbo:
   - max_output_tokens: 163840 → 40960
   - max_input_tokens: 163840 → 40960
   - max_tokens: 163840 → 40960