### PR TITLE
[Performance] Use executors in post-logging hooks

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -301,10 +301,12 @@ class LLMCachingHandler:
                         is_async=False,
                     )
 
-                    threading.Thread(
-                        target=logging_obj.success_handler,
-                        args=(cached_result, start_time, end_time, cache_hit),
-                    ).start()
+                    logging_obj.handle_sync_success_callbacks_for_async_calls(
+                        result=cached_result,
+                        start_time=start_time,
+                        end_time=end_time,
+                        cache_hit=cache_hit
+                    )
                     cache_key = litellm.cache._get_preset_cache_key_from_kwargs(
                         **kwargs
                     )
@@ -530,15 +532,17 @@ class LLMCachingHandler:
             end_time (datetime): The end time of the operation.
             cache_hit (bool): Whether it was a cache hit.
         """
-        asyncio.create_task(
-            logging_obj.async_success_handler(
-                cached_result, start_time, end_time, cache_hit
+        from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+            async_coroutine=logging_obj.async_success_handler(
+                result=cached_result, start_time=start_time, end_time=end_time, cache_hit=cache_hit
             )
         )
-        threading.Thread(
-            target=logging_obj.success_handler,
-            args=(cached_result, start_time, end_time, cache_hit),
-        ).start()
+
+        logging_obj.handle_sync_success_callbacks_for_async_calls(
+            result=cached_result, start_time=start_time, end_time=end_time, cache_hit=cache_hit
+        )
 
     async def _retrieve_from_cache(
         self, call_type: str, kwargs: Dict[str, Any], args: Tuple[Any, ...]

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2775,6 +2775,7 @@ class Logging(LiteLLMLoggingBaseClass):
         result: Any,
         start_time: datetime.datetime,
         end_time: datetime.datetime,
+        cache_hit: Optional[Any] = None,
     ) -> None:
         """
         Handles calling success callbacks for Async calls.
@@ -2789,6 +2790,7 @@ class Logging(LiteLLMLoggingBaseClass):
             result,
             start_time,
             end_time,
+            cache_hit,
         )
 
     def _should_run_sync_callbacks_for_async_calls(self) -> bool:


### PR DESCRIPTION
Utilize `litellm.litellm_core_utils.logging_worker.LoggingWorker.ensure_initialized_and_enqueue`
and `litellm.litellm_core_utils.litellm_logging.Logging.handle_sync_success_callbacks_for_async_calls` for cache logging

It is pretty cheap change that doesn't change current behavior, while giving slight performance boost now.

However there's still big room for improvement here: currently `litellm.litellm_core_utils.litellm_logging.Logging.async_success_handler` does lots of blocking operations which slow down running loop significantly, preventing server to respond quickly, despite the task is running in the background. This doesn't change in scope of this PR.

## Pre-Submission checklist

These changes are not meant to change any behavior, on the contrary. So I can't think of a relevant additional test here — these paths are already covered.

- ~~[ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~
- ~~[ ] I have added a screenshot of my new test passing locally~~
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring
🧭 Performance

## Impact
Halves the time we spend in acompletion, gives + ~28% RPS compared to 359780b on my hardware

`uv run --isolated --with-requirements requirements.txt locust -f all_cache_hits.py -H http://0.0.0.0:4000/ --csv baseline --headless -u 1000 -r 500` (used 4 locust workers to be precise)
[patch_0001_executors_run0_results_stats.csv](https://github.com/user-attachments/files/22211013/patch_0001_executors_run0_results_stats.csv)
[baseline_run0_results_stats.csv](https://github.com/user-attachments/files/22211139/baseline_run0_results_stats.csv)


### Baseline

<img width="812" height="292" alt="image" src="https://github.com/user-attachments/assets/0d9daab2-0364-4e84-b0a1-529eaed5a181" />

### With these changes

<img width="424" height="291" alt="image" src="https://github.com/user-attachments/assets/0dbb33da-57ee-4df8-bd4f-58a7f7172d40" />

### Tests
<img width="1366" height="32" alt="image" src="https://github.com/user-attachments/assets/7b1e1476-2ab9-4c9f-b97d-03e86c129729" />


