### PR TITLE
[Performance] Use orjson for cache loads

### DIFF
--- a/litellm/caching/gcs_cache.py
+++ b/litellm/caching/gcs_cache.py
@@ -5,6 +5,8 @@ import json
 import asyncio
 from typing import Optional
 
+import orjson
+
 from litellm._logging import print_verbose, verbose_logger
 from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
 from litellm.llms.custom_httpx.http_handler import (
@@ -62,7 +64,7 @@ class GCSCache(BaseCache):
             url = f"https://storage.googleapis.com/storage/v1/b/{bucket_name}/o/{object_name}?alt=media"
             response = self.sync_client.get(url=url, headers=headers)
             if response.status_code == 200:
-                cached_response = json.loads(response.text)
+                cached_response = orjson.loads(response.text)
                 verbose_logger.debug(
                     f"Got GCS Cache: key: {key}, cached_response {cached_response}. Type Response {type(cached_response)}"
                 )
@@ -79,7 +81,7 @@ class GCSCache(BaseCache):
             url = f"https://storage.googleapis.com/storage/v1/b/{bucket_name}/o/{object_name}?alt=media"
             response = await self.async_client.get(url=url, headers=headers)
             if response.status_code == 200:
-                return json.loads(response.text)
+                return orjson.loads(response.text)
             return None
         except Exception as e:
             verbose_logger.error(f"GCS Caching: async_get_cache() - Got exception from GCS: {e}")

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -13,6 +13,9 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any, List, Optional
 
+import orjson
+
+
 if TYPE_CHECKING:
     from litellm.types.caching import RedisPipelineIncrementOperation
 
@@ -186,7 +189,7 @@ class InMemoryCache(BaseCache):
                 return None
             original_cached_response = self.cache_dict[key]
             try:
-                cached_response = json.loads(original_cached_response)
+                cached_response = orjson.loads(original_cached_response)
             except Exception:
                 cached_response = original_cached_response
             return cached_response

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -16,6 +16,8 @@ import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast
 
+import orjson
+
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
@@ -153,6 +155,7 @@ class RedisCache(BaseCache):
                     "Ignoring async redis ping. No running event loop."
                 )
             else:
+                # FIXME: this won't work really, create_task won't throw error inside a coroutine
                 verbose_logger.error(
                     "Error connecting to Async Redis client - {}".format(str(e)),
                     extra={"error": str(e)},
@@ -704,7 +707,7 @@ class RedisCache(BaseCache):
         # cached_response is in `b{} convert it to ModelResponse
         cached_response = cached_response.decode("utf-8")  # Convert bytes to string
         try:
-            cached_response = json.loads(
+            cached_response = orjson.loads(
                 cached_response
             )  # Convert string to dictionary
         except Exception:

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -15,6 +15,8 @@ import json
 import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 
+import orjson
+
 import litellm
 from litellm._logging import print_verbose
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -173,7 +175,7 @@ class RedisSemanticCache(BaseCache):
 
         # Convert string representation to Python object
         try:
-            cached_response = json.loads(cached_response)
+            cached_response = orjson.loads(cached_response)
         except json.JSONDecodeError:
             try:
                 cached_response = ast.literal_eval(cached_response)

--- a/litellm/caching/s3_cache.py
+++ b/litellm/caching/s3_cache.py
@@ -15,6 +15,8 @@ from functools import partial
 from typing import Optional
 from datetime import datetime, timezone, timedelta
 
+import orjson
+
 from litellm._logging import print_verbose, verbose_logger
 
 from .base_cache import BaseCache
@@ -137,7 +139,7 @@ class S3Cache(BaseCache):
                     cached_response["Body"].read().decode("utf-8")
                 )  # Convert bytes to string
                 try:
-                    cached_response = json.loads(
+                    cached_response = orjson.loads(
                         cached_response
                     )  # Convert string to dictionary
                 except Exception:


### PR DESCRIPTION
orjson.dumps has different semantics, not touching for now

Thinking about this now, probably better way to do this would be to define json module which would attempt to use orjson if it's installed and fallback to json otherwise, as well as have a wrapper mimicking builtin json semantics. This way we could replace json usage throughout the project just by importing.

## Pre-Submission checklist

These changes are not meant to change any behavior, on the contrary. So I can't think of a relevant additional test here — these paths are already covered.

- ~~[ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~
- ~~[ ] I have added a screenshot of my new test passing locally~~
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring
🧭 Performance

## Impact


### Tests
<img width="1366" height="32" alt="image" src="https://github.com/user-attachments/assets/7b1e1476-2ab9-4c9f-b97d-03e86c129729" />


