### PR TITLE
[Performance] Use getattr instead of hasattr in several places

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -202,10 +202,11 @@ class LLMCachingHandler:
                         **kwargs
                     )
                     if (
-                        isinstance(cached_result, BaseModel)
-                        or isinstance(cached_result, CustomStreamWrapper)
-                    ) and hasattr(cached_result, "_hidden_params"):
-                        cached_result._hidden_params["cache_key"] = cache_key  # type: ignore
+                        isinstance(cached_result, (BaseModel, CustomStreamWrapper))
+                        and (_hidden_params := getattr(cached_result, "_hidden_params", None))
+                        is not None
+                    ):
+                        _hidden_params["cache_key"] = cache_key  # type: ignore
                     return CachingHandlerResponse(cached_result=cached_result)
                 elif (
                     call_type == CallTypes.aembedding.value
@@ -309,10 +310,11 @@ class LLMCachingHandler:
                         **kwargs
                     )
                     if (
-                        isinstance(cached_result, BaseModel)
-                        or isinstance(cached_result, CustomStreamWrapper)
-                    ) and hasattr(cached_result, "_hidden_params"):
-                        cached_result._hidden_params["cache_key"] = cache_key  # type: ignore
+                        isinstance(cached_result, (BaseModel, CustomStreamWrapper))
+                    ) and (
+                        _hidden_params := getattr(cached_result, "_hidden_params", None)
+                    ) is not None:
+                        _hidden_params["cache_key"] = cache_key  # type: ignore
                     return CachingHandlerResponse(cached_result=cached_result)
         return CachingHandlerResponse(cached_result=cached_result)
 
@@ -708,9 +710,9 @@ class LLMCachingHandler:
             )
 
         if (
-            hasattr(cached_result, "_hidden_params")
-            and cached_result._hidden_params is not None
-            and isinstance(cached_result._hidden_params, dict)
+            (_hidden_params := getattr(cached_result, "_hidden_params", None))
+            and _hidden_params is not None
+            and isinstance(_hidden_params, dict)
         ):
             cached_result._hidden_params["cache_hit"] = True
         return cached_result

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -94,11 +94,11 @@ def _safe_get_request_parsed_body(request: Optional[Request]) -> Optional[dict]:
     if request is None:
         return None
     if (
-        hasattr(request, "scope")
-        and "parsed_body" in request.scope
-        and isinstance(request.scope["parsed_body"], tuple)
+        (scope := getattr(request, "scope", None))
+        and (raw_parsed_body := scope.get("parsed_body"))
+        and isinstance(raw_parsed_body, tuple)
     ):
-        accepted_keys, parsed_body = request.scope["parsed_body"]
+        accepted_keys, parsed_body = raw_parsed_body
         return {key: parsed_body[key] for key in accepted_keys}
     return None
 


### PR DESCRIPTION
Not an exhaustive change, there are probably lot more of places like this.

This doesn't bring any significant changes, but a good practice overall, as many of such checks add up.

## Pre-Submission checklist

These changes are not meant to change any behavior, on the contrary. So I can't think of a relevant additional test here — these paths are already covered.

- ~~[ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~
- ~~[ ] I have added a screenshot of my new test passing locally~~
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring
🧭 Performance

## Impact


### Tests
<img width="1366" height="32" alt="image" src="https://github.com/user-attachments/assets/7b1e1476-2ab9-4c9f-b97d-03e86c129729" />


