### PR TITLE
[Performance] Avoid deepcopy calls on model instantiation

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -720,22 +720,20 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
 
     key_alias: Optional[str] = None
     duration: Optional[str] = None
-    models: Optional[list] = []
+    models: Optional[list] = Field(default_factory=list)
     spend: Optional[float] = 0
     max_budget: Optional[float] = None
     user_id: Optional[str] = None
     team_id: Optional[str] = None
     max_parallel_requests: Optional[int] = None
-    metadata: Optional[dict] = {}
+    metadata: Optional[dict] = Field(default_factory=dict)
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
-    allowed_cache_controls: Optional[list] = []
-    config: Optional[dict] = {}
-    permissions: Optional[dict] = {}
-    model_max_budget: Optional[dict] = (
-        {}
-    )  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
+    allowed_cache_controls: Optional[list] = Field(default_factory=list)
+    config: Optional[dict] = Field(default_factory=dict)
+    permissions: Optional[dict] = Field(default_factory=dict)
+    model_max_budget: Optional[dict] = Field(default_factory=dict)  # {"gpt-4": 5.0, "gpt-3.5-turbo": 5.0}, defaults to {}
 
     model_config = ConfigDict(protected_namespaces=())
     model_rpm_limit: Optional[dict] = None
@@ -743,7 +741,7 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     guardrails: Optional[List[str]] = None
     prompts: Optional[List[str]] = None
     blocked: Optional[bool] = None
-    aliases: Optional[dict] = {}
+    aliases: Optional[dict] = Field(default_factory=dict)
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
 
 
@@ -752,7 +750,7 @@ class KeyRequestBase(GenerateRequestBase):
     budget_id: Optional[str] = None
     tags: Optional[List[str]] = None
     enforced_params: Optional[List[str]] = None
-    allowed_routes: Optional[list] = []
+    allowed_routes: Optional[list] = Field(default_factory=list)
 
 
 class LiteLLMKeyType(str, enum.Enum):
@@ -1220,9 +1218,9 @@ class TeamBase(LiteLLMPydanticObjectBase):
     team_alias: Optional[str] = None
     team_id: Optional[str] = None
     organization_id: Optional[str] = None
-    admins: list = []
-    members: list = []
-    members_with_roles: List[Member] = []
+    admins: list = Field(default_factory=list)
+    members: list = Field(default_factory=list)
+    members_with_roles: List[Member] = Field(default_factory=list)
     team_member_permissions: Optional[List[str]] = None
     metadata: Optional[dict] = None
     tpm_limit: Optional[int] = None
@@ -1232,7 +1230,7 @@ class TeamBase(LiteLLMPydanticObjectBase):
     max_budget: Optional[float] = None
     budget_duration: Optional[str] = None
 
-    models: list = []
+    models: list = Field(default_factory=list)
     blocked: bool = False
 
 
@@ -1350,11 +1348,11 @@ class AddTeamCallback(LiteLLMPydanticObjectBase):
 
 
 class TeamCallbackMetadata(LiteLLMPydanticObjectBase):
-    success_callback: Optional[List[str]] = []
-    failure_callback: Optional[List[str]] = []
-    callbacks: Optional[List[str]] = []
+    success_callback: Optional[List[str]] = Field(default_factory=list)
+    failure_callback: Optional[List[str]] = Field(default_factory=list)
+    callbacks: Optional[List[str]] = Field(default_factory=list)
     # for now - only supported for langfuse
-    callback_vars: Optional[Dict[str, str]] = {}
+    callback_vars: Optional[Dict[str, str]] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
@@ -1393,9 +1391,9 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     """Represents a LiteLLM_ObjectPermissionTable record"""
 
     object_permission_id: str
-    mcp_servers: Optional[List[str]] = []
-    mcp_access_groups: Optional[List[str]] = []
-    vector_stores: Optional[List[str]] = []
+    mcp_servers: Optional[List[str]] = Field(default_factory=list)
+    mcp_access_groups: Optional[List[str]] = Field(default_factory=list)
+    vector_stores: Optional[List[str]] = Field(default_factory=list)
 
 
 class LiteLLM_TeamTable(TeamBase):
@@ -1495,7 +1493,7 @@ class LiteLLM_TeamMemberTable(LiteLLM_BudgetTable):
 class NewOrganizationRequest(LiteLLM_BudgetTable):
     organization_id: Optional[str] = None
     organization_alias: str
-    models: List = []
+    models: List = Field(default_factory=list)
     budget_id: Optional[str] = None
     metadata: Optional[dict] = None
 
@@ -1552,7 +1550,7 @@ class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
         description="The URL to which requests for this path should be forwarded."
     )
     headers: dict = Field(
-        default={},
+        default_factory=dict,
         description="Key-value pairs of headers to be forwarded with the request. You can set any key value pair here and it will be forwarded to your target endpoint",
     )
     include_subpath: bool = Field(
@@ -1744,22 +1742,22 @@ class LiteLLM_VerificationToken(LiteLLMPydanticObjectBase):
     spend: float = 0.0
     max_budget: Optional[float] = None
     expires: Optional[Union[str, datetime]] = None
-    models: List = []
-    aliases: Dict = {}
-    config: Dict = {}
+    models: List = Field(default_factory=list)
+    aliases: Dict = Field(default_factory=dict)
+    config: Dict = Field(default_factory=dict)
     user_id: Optional[str] = None
     team_id: Optional[str] = None
     max_parallel_requests: Optional[int] = None
-    metadata: Dict = {}
+    metadata: Dict = Field(default_factory=dict)
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
     budget_reset_at: Optional[datetime] = None
-    allowed_cache_controls: Optional[list] = []
-    allowed_routes: Optional[list] = []
-    permissions: Dict = {}
-    model_spend: Dict = {}
-    model_max_budget: Dict = {}
+    allowed_cache_controls: Optional[list] = Field(default_factory=list)
+    allowed_routes: Optional[list] = Field(default_factory=list)
+    permissions: Dict = Field(default_factory=dict)
+    model_spend: Dict = Field(default_factory=dict)
+    model_max_budget: Dict = Field(default_factory=dict)
     soft_budget_cooldown: bool = False
     blocked: Optional[bool] = None
     litellm_budget_table: Optional[dict] = None
@@ -1784,7 +1782,7 @@ class LiteLLM_VerificationTokenView(LiteLLM_VerificationToken):
     team_tpm_limit: Optional[int] = None
     team_rpm_limit: Optional[int] = None
     team_max_budget: Optional[float] = None
-    team_models: List = []
+    team_models: List = Field(default_factory=list)
     team_blocked: bool = False
     soft_budget: Optional[float] = None
     team_model_aliases: Optional[Dict] = None
@@ -1935,16 +1933,16 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     user_id: str
     max_budget: Optional[float] = None
     spend: float = 0.0
-    model_max_budget: Optional[Dict] = {}
-    model_spend: Optional[Dict] = {}
+    model_max_budget: Optional[Dict] = Field(default_factory=dict)
+    model_spend: Optional[Dict] = Field(default_factory=dict)
     user_email: Optional[str] = None
     user_alias: Optional[str] = None
-    models: list = []
+    models: list = Field(default_factory=list)
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     user_role: Optional[str] = None
     organization_memberships: Optional[List[LiteLLM_OrganizationMembershipTable]] = None
-    teams: List[str] = []
+    teams: List[str] = Field(default_factory=list)
     sso_user_id: Optional[str] = None
     budget_duration: Optional[str] = None
     budget_reset_at: Optional[datetime] = None
@@ -1991,8 +1989,8 @@ class LiteLLM_OrganizationTable(LiteLLMPydanticObjectBase):
 class LiteLLM_OrganizationTableWithMembers(LiteLLM_OrganizationTable):
     """Returned by the /organization/info endpoint and /organization/list endpoint"""
 
-    members: List[LiteLLM_OrganizationMembershipTable] = []
-    teams: List[LiteLLM_TeamTable] = []
+    members: List[LiteLLM_OrganizationMembershipTable] = Field(default_factory=list)
+    teams: List[LiteLLM_TeamTable] = Field(default_factory=list)
     litellm_budget_table: Optional[LiteLLM_BudgetTable] = None
     created_at: datetime
     updated_at: datetime
@@ -2045,7 +2043,7 @@ class LiteLLM_SpendLogs(LiteLLMPydanticObjectBase):
     startTime: Union[str, datetime, None]
     endTime: Union[str, datetime, None]
     user: Optional[str] = ""
-    metadata: Optional[Json] = {}
+    metadata: Optional[Json] = Field(default_factory=dict)
     cache_hit: Optional[str] = "False"
     cache_key: Optional[str] = None
     request_tags: Optional[Json] = None
@@ -2060,7 +2058,7 @@ class LiteLLM_ErrorLogs(LiteLLMPydanticObjectBase):
     model_group: Optional[str] = ""
     litellm_model_name: Optional[str] = ""
     model_id: Optional[str] = ""
-    request_kwargs: Optional[dict] = {}
+    request_kwargs: Optional[dict] = Field(default_factory=dict)
     exception_type: Optional[str] = ""
     status_code: Optional[str] = ""
     exception_string: Optional[str] = ""
@@ -2223,82 +2221,76 @@ class CallbackOnUI(LiteLLMPydanticObjectBase):
 
 
 class AllCallbacks(LiteLLMPydanticObjectBase):
-    langfuse: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="langfuse",
-        ui_callback_name="Langfuse",
-        litellm_callback_params=[
-            "LANGFUSE_PUBLIC_KEY",
-            "LANGFUSE_SECRET_KEY",
-            "LANGFUSE_HOST",
-        ],
+    langfuse: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="langfuse",
+            litellm_callback_params=["LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"],
+            ui_callback_name="Langfuse",
+        )
     )
 
-    otel: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="otel",
-        ui_callback_name="OpenTelemetry",
-        litellm_callback_params=[
-            "OTEL_EXPORTER",
-            "OTEL_ENDPOINT",
-            "OTEL_HEADERS",
-        ],
+    otel: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="otel",
+            litellm_callback_params=["OTEL_EXPORTER", "OTEL_ENDPOINT", "OTEL_HEADERS"],
+            ui_callback_name="OpenTelemetry",
+        )
     )
 
-    s3: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="s3",
-        ui_callback_name="s3 Bucket (AWS)",
-        litellm_callback_params=[
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_REGION_NAME",
-        ],
+    s3: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="s3",
+            litellm_callback_params=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"],
+            ui_callback_name="s3 Bucket (AWS)",
+        )
     )
 
-    openmeter: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="openmeter",
-        ui_callback_name="OpenMeter",
-        litellm_callback_params=[
-            "OPENMETER_API_ENDPOINT",
-            "OPENMETER_API_KEY",
-        ],
+    openmeter: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="openmeter",
+            litellm_callback_params=["OPENMETER_API_ENDPOINT", "OPENMETER_API_KEY"],
+            ui_callback_name="OpenMeter",
+        )
     )
 
-    custom_callback_api: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="custom_callback_api",
-        litellm_callback_params=["GENERIC_LOGGER_ENDPOINT"],
-        ui_callback_name="Custom Callback API",
+    custom_callback_api: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="custom_callback_api",
+            litellm_callback_params=["GENERIC_LOGGER_ENDPOINT"],
+            ui_callback_name="Custom Callback API",
+        )
     )
 
-    datadog: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="datadog",
-        litellm_callback_params=["DD_API_KEY", "DD_SITE"],
-        ui_callback_name="Datadog",
+    datadog: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="datadog",
+            litellm_callback_params=["DD_API_KEY", "DD_SITE"],
+            ui_callback_name="Datadog",
+        )
     )
 
-    braintrust: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="braintrust",
-        litellm_callback_params=["BRAINTRUST_API_KEY", "BRAINTRUST_API_BASE"],
-        ui_callback_name="Braintrust",
+    braintrust: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="braintrust",
+            litellm_callback_params=["BRAINTRUST_API_KEY", "BRAINTRUST_API_BASE"],
+            ui_callback_name="Braintrust",
+        )
     )
 
-    langsmith: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="langsmith",
-        litellm_callback_params=[
-            "LANGSMITH_API_KEY",
-            "LANGSMITH_PROJECT",
-            "LANGSMITH_DEFAULT_RUN_NAME",
-        ],
-        ui_callback_name="Langsmith",
+    langsmith: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="langsmith",
+            litellm_callback_params=["LANGSMITH_API_KEY", "LANGSMITH_PROJECT", "LANGSMITH_DEFAULT_RUN_NAME"],
+            ui_callback_name="Langsmith",
+        )
     )
 
-    lago: CallbackOnUI = CallbackOnUI(
-        litellm_callback_name="lago",
-        litellm_callback_params=[
-            "LAGO_API_BASE",
-            "LAGO_API_KEY",
-            "LAGO_API_EVENT_CODE",
-            "LAGO_API_CHARGE_BY",
-        ],
-        ui_callback_name="Lago Billing",
+    lago: CallbackOnUI = Field(
+        default_factory=lambda: CallbackOnUI(
+            litellm_callback_name="lago",
+            litellm_callback_params=["LAGO_API_BASE", "LAGO_API_KEY", "LAGO_API_EVENT_CODE", "LAGO_API_CHARGE_BY"],
+            ui_callback_name="Lago Billing",
+        )
     )
 
 
@@ -3011,9 +3003,7 @@ class ProviderBudgetResponse(LiteLLMPydanticObjectBase):
     Maps provider names to their budget configs.
     """
 
-    providers: Dict[str, ProviderBudgetResponseObject] = (
-        {}
-    )  # Dictionary mapping provider names to their budget configurations
+    providers: Dict[str, ProviderBudgetResponseObject] = Field(default_factory=dict)  # Dictionary mapping provider names to their budget configurations
 
 
 class ProxyStateVariables(TypedDict):
@@ -3114,19 +3104,19 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     """
 
     admin_jwt_scope: str = "litellm_proxy_admin"
-    admin_allowed_routes: List[str] = [
+    admin_allowed_routes: List[str] = Field(default_factory=lambda: [
         "management_routes",
         "spend_tracking_routes",
         "global_spend_tracking_routes",
         "info_routes",
-    ]
+    ])
     team_id_jwt_field: Optional[str] = None
     team_id_upsert: bool = False
     team_ids_jwt_field: Optional[str] = None
     upsert_sso_user_to_team: bool = False
     team_allowed_routes: List[
         Literal["openai_routes", "info_routes", "management_routes"]
-    ] = ["openai_routes", "info_routes"]
+    ] = Field(default_factory=lambda: ["openai_routes", "info_routes"])
     team_id_default: Optional[str] = Field(
         default=None,
         description="If no team_id given, default permissions/spend-tracking to this team.s",
@@ -3143,7 +3133,7 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     )
     end_user_id_jwt_field: Optional[str] = None
     public_key_ttl: float = 600
-    public_allowed_routes: List[str] = ["public_routes"]
+    public_allowed_routes: List[str] = Field(default_factory=lambda: ["public_routes"])
     enforce_rbac: bool = False
     roles_jwt_field: Optional[str] = None  # v2 on role mappings
     role_mappings: Optional[List[RoleMapping]] = None

--- a/litellm/types/completion.py
+++ b/litellm/types/completion.py
@@ -1,6 +1,6 @@
 from typing import Iterable, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Literal, Required, TypedDict
 
 
@@ -164,7 +164,7 @@ ChatCompletionMessageParam = Union[
 
 class CompletionRequest(BaseModel):
     model: str
-    messages: List[ChatCompletionMessageParam] = []
+    messages: List[ChatCompletionMessageParam] = Field(default_factory=list)
     timeout: Optional[Union[float, int]] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None

--- a/litellm/types/embedding.py
+++ b/litellm/types/embedding.py
@@ -1,11 +1,11 @@
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class EmbeddingRequest(BaseModel):
     model: str
-    input: List[str] = []
+    input: List[str] = Field(default_factory=list)
     timeout: int = 600
     api_base: Optional[str] = None
     api_version: Optional[str] = None

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -495,8 +495,8 @@ class UserAPIKeyLabelValues(BaseModel):
         Optional[str],
         Field(..., alias=UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME.value),
     ] = None
-    tags: List[str] = []
-    custom_metadata_labels: Dict[str, str] = {}
+    tags: List[str] = Field(default_factory=list)
+    custom_metadata_labels: Dict[str, str] = Field(default_factory=dict)
     model_id: Annotated[
         Optional[str], Field(..., alias=UserAPIKeyLabelNames.MODEL_ID.value)
     ] = None

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -1,7 +1,7 @@
 import enum
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from litellm.types.llms.base import HiddenParams
@@ -79,7 +79,7 @@ class MCPPreCallRequestObject(BaseModel):
     arguments: Dict[str, Any]
     server_name: Optional[str] = None
     user_api_key_auth: Optional[Dict[str, Any]] = None
-    hidden_params: HiddenParams = HiddenParams()
+    hidden_params: HiddenParams = Field(default_factory=HiddenParams)
 
 
 class MCPPreCallResponseObject(BaseModel):
@@ -89,7 +89,7 @@ class MCPPreCallResponseObject(BaseModel):
     should_proceed: bool = True
     modified_arguments: Optional[Dict[str, Any]] = None
     error_message: Optional[str] = None
-    hidden_params: HiddenParams = HiddenParams()
+    hidden_params: HiddenParams = Field(default_factory=HiddenParams)
 
 
 class MCPDuringCallRequestObject(BaseModel):
@@ -100,7 +100,7 @@ class MCPDuringCallRequestObject(BaseModel):
     arguments: Dict[str, Any]
     server_name: Optional[str] = None
     start_time: Optional[float] = None
-    hidden_params: HiddenParams = HiddenParams()
+    hidden_params: HiddenParams = Field(default_factory=HiddenParams)
 
 
 class MCPDuringCallResponseObject(BaseModel):
@@ -109,7 +109,7 @@ class MCPDuringCallResponseObject(BaseModel):
     """
     should_continue: bool = True
     error_message: Optional[str] = None
-    hidden_params: HiddenParams = HiddenParams()
+    hidden_params: HiddenParams = Field(default_factory=HiddenParams)
 
 
 class MCPPostCallResponseObject(BaseModel):

--- a/litellm/types/proxy/management_endpoints/scim_v2.py
+++ b/litellm/types/proxy/management_endpoints/scim_v2.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from fastapi import HTTPException
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, field_validator, Field
 
 
 class LiteLLM_UserScimMetadata(BaseModel):
@@ -63,7 +63,7 @@ class SCIMGroup(SCIMResource):
 
 # SCIM List Response Models
 class SCIMListResponse(BaseModel):
-    schemas: List[str] = ["urn:ietf:params:scim:api:messages:2.0:ListResponse"]
+    schemas: List[str] = Field(default_factory=lambda: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"])
     totalResults: int
     startIndex: Optional[int] = 1
     itemsPerPage: Optional[int] = 10
@@ -88,7 +88,7 @@ class SCIMPatchOperation(BaseModel):
 
 
 class SCIMPatchOp(BaseModel):
-    schemas: List[str] = ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+    schemas: List[str] = Field(default_factory=lambda: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"])
     Operations: List[SCIMPatchOperation]
 
 
@@ -101,14 +101,14 @@ class SCIMFeature(BaseModel):
 
 
 class SCIMServiceProviderConfig(BaseModel):
-    schemas: List[str] = [
+    schemas: List[str] = Field(default_factory=lambda: [
         "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
-    ]
-    patch: SCIMFeature = SCIMFeature(supported=True)
-    bulk: SCIMFeature = SCIMFeature(supported=False)
-    filter: SCIMFeature = SCIMFeature(supported=False)
-    changePassword: SCIMFeature = SCIMFeature(supported=False)
-    sort: SCIMFeature = SCIMFeature(supported=False)
-    etag: SCIMFeature = SCIMFeature(supported=False)
+    ])
+    patch: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=True))
+    bulk: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=False))
+    filter: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=False))
+    changePassword: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=False))
+    sort: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=False))
+    etag: SCIMFeature = Field(default_factory=lambda: SCIMFeature(supported=False))
     authenticationSchemes: Optional[List[Dict[str, Any]]] = None
     meta: Optional[Dict[str, Any]] = None

--- a/litellm/types/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/team_endpoints.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from litellm.proxy._types import (
     LiteLLM_TeamMembership,
@@ -24,7 +24,7 @@ class GetTeamMemberPermissionsResponse(BaseModel):
     The team id that the permissions are for
     """
 
-    team_member_permissions: Optional[List[str]] = []
+    team_member_permissions: Optional[List[str]] = Field(default_factory=list)
     """
     The team member permissions currently set for the team
     """

--- a/litellm/types/proxy/management_endpoints/ui_sso.py
+++ b/litellm/types/proxy/management_endpoints/ui_sso.py
@@ -133,7 +133,7 @@ class DefaultTeamSSOParams(LiteLLMPydanticObjectBase):
     """
 
     models: List[str] = Field(
-        default=[],
+        default_factory=list,
         description="Default list of models that new automatically created teams can access",
     )
     max_budget: Optional[float] = Field(

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -51,17 +51,17 @@ class RouterConfig(BaseModel):
     redis_password: Optional[str] = None
 
     cache_responses: Optional[bool] = False
-    cache_kwargs: Optional[Dict] = {}
+    cache_kwargs: Optional[Dict] = Field(default_factory=dict)
     caching_groups: Optional[List[Tuple[str, List[str]]]] = None
     client_ttl: Optional[int] = 3600
     num_retries: Optional[int] = 0
     timeout: Optional[float] = None
-    default_litellm_params: Optional[Dict[str, str]] = {}
+    default_litellm_params: Optional[Dict[str, str]] = Field(default_factory=dict)
     set_verbose: Optional[bool] = False
-    fallbacks: Optional[List] = []
+    fallbacks: Optional[List] = Field(default_factory=list)
     allowed_fails: Optional[int] = None
-    context_window_fallbacks: Optional[List] = []
-    model_group_alias: Optional[Dict[str, List[str]]] = {}
+    context_window_fallbacks: Optional[List] = Field(default_factory=list)
+    model_group_alias: Optional[Dict[str, List[str]]] = Field(default_factory=dict)
     retry_after: Optional[int] = 0
     routing_strategy: Literal[
         "simple-shuffle",
@@ -89,7 +89,7 @@ class UpdateRouterConfig(BaseModel):
     retry_after: Optional[float] = None
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
-    model_group_alias: Optional[Dict[str, Union[str, Dict]]] = {}
+    model_group_alias: Optional[Dict[str, Union[str, Dict]]] = Field(default_factory=dict)
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -590,7 +590,7 @@ class ModelGroupInfo(BaseModel):
     supports_url_context: bool = Field(default=False)
     supports_reasoning: bool = Field(default=False)
     supports_function_calling: bool = Field(default=False)
-    supported_openai_params: Optional[List[str]] = Field(default=[])
+    supported_openai_params: Optional[List[str]] = Field(default_factory=list)
     configurable_clientside_auth_params: CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS = None
 
     def __init__(self, **data):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1312,7 +1312,7 @@ class ModelResponse(ModelResponseBase):
 
 
 class Embedding(OpenAIObject):
-    embedding: Union[list, str] = []
+    embedding: Union[list, str] = Field(default_factory=list)
     index: int
     object: Literal["embedding"]
 


### PR DESCRIPTION
When using mutable defaults, pyndantic has to call copy.deepcopy for each of them, which results in slower model instantiation.

## Pre-Submission checklist

These changes are not meant to change any behavior, on the contrary. So I can't think of a relevant additional test here — these paths are already covered.

- ~~[ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~
- ~~[ ] I have added a screenshot of my new test passing locally~~
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🧹 Refactoring
🧭 Performance

## Impact
### Before

<img width="1087" height="253" alt="image" src="https://github.com/user-attachments/assets/abdc647b-fecb-403e-9bfe-ee9ac61c899f" />

### After
with #14350
<img width="1006" height="408" alt="image" src="https://github.com/user-attachments/assets/3303aba4-907b-407d-9d2d-c0bc23717a7e" />

<details><summary>Benchmark code</summary>

```py
import time
import statistics
from typing import List, Dict
from pydantic import BaseModel, Field


class DirectDefaultModel(BaseModel):
    items: List[str] = []
    metadata: Dict[str, int] = {}
    tags: List[int] = [1, 2, 3]


class FactoryDefaultModel(BaseModel):
    items: List[str] = Field(default_factory=list)
    metadata: Dict[str, int] = Field(default_factory=dict)
    tags: List[int] = Field(default_factory=lambda: [1, 2, 3])


def benchmark_instantiation(model_class, iterations=100000):
    times = []

    for _ in range(10):
        start = time.perf_counter()
        for _ in range(iterations // 10):
            model_class()
        end = time.perf_counter()
        times.append((end - start) * 1000)

    return {
        "mean": statistics.mean(times),
        "median": statistics.median(times),
        "stdev": statistics.stdev(times),
        "min": min(times),
        "max": max(times),
    }


def main():
    print("Pydantic Mutable Defaults Benchmark")
    print("=" * 40)

    iterations = 100000
    print(f"Benchmarking {iterations:,} instantiations\n")

    direct_stats = benchmark_instantiation(DirectDefaultModel, iterations)
    factory_stats = benchmark_instantiation(FactoryDefaultModel, iterations)

    print("Results (ms per 10,000 instantiations):")
    print("-" * 40)
    print(f"Direct defaults:  {direct_stats['mean']:.2f} ± {direct_stats['stdev']:.2f}")
    print(
        f"Factory defaults: {factory_stats['mean']:.2f} ± {factory_stats['stdev']:.2f}"
    )

    difference = direct_stats["mean"] - factory_stats["mean"]
    ratio = direct_stats["mean"] / factory_stats["mean"]

    print(f"\nDifference: {difference:.2f} ms ({ratio:.1f}x slower for direct)")
    print(f"Direct defaults use copy.deepcopy() - factory functions don't")


if __name__ == "__main__":
    main()

```

</details>

Benchmarking 100,000 instantiations

Results (ms per 10,000 instantiations):

- Direct defaults:  38.01 ± 1.68 ms
- Factory defaults: 7.79 ± 0.16 ms

Difference: 30.22 ms (4.9x slower for direct)
Direct defaults use copy.deepcopy() - factory functions don't

### Tests
<img width="1366" height="32" alt="image" src="https://github.com/user-attachments/assets/7b1e1476-2ab9-4c9f-b97d-03e86c129729" />


