### PR TITLE
[Feature]: Support "Token" MCPAuth 

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -113,6 +113,7 @@ mcp_servers:
     transport: "http"
     description: "My custom MCP server"
     auth_type: "api_key"
+    auth_value: "abc123"
     spec_version: "2025-03-26"
 ```
 
@@ -128,8 +129,42 @@ mcp_servers:
 - **Args**: Array of arguments to pass to the command (optional for stdio)
 - **Env**: Environment variables to set for the stdio process (optional for stdio)
 - **Description**: Optional description for the server
-- **Auth Type**: Optional authentication type
-- **Spec Version**: Optional MCP specification version (defaults to `2025-03-26`)
+- **Auth Type**: Optional authentication type. Supported values:
+
+  | Value | Header sent |
+  |-------|-------------|
+  | `api_key` | `X-API-Key: <auth_value>` |
+  | `bearer_token` | `Authorization: Bearer <auth_value>` |
+  | `basic` | `Authorization: Basic <auth_value>` |
+  | `authorization` | `Authorization: <auth_value>` |
+
+- **Spec Version**: Optional MCP specification version (defaults to `2025-06-18`)
+
+Examples for each auth type:
+
+```yaml title="MCP auth examples (config.yaml)" showLineNumbers
+mcp_servers:
+  api_key_example:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: "api_key"
+    auth_value: "abc123"        # headers={"X-API-Key": "abc123"}
+
+  bearer_example:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: "bearer_token"
+    auth_value: "abc123"        # headers={"Authorization": "Bearer abc123"}
+
+  basic_example:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: "basic"
+    auth_value: "dXNlcjpwYXNz"  # headers={"Authorization": "Basic dXNlcjpwYXNz"}
+
+  custom_auth_example:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: "authorization"
+    auth_value: "Token example123"  # headers={"Authorization": "Token example123"}
+```
+
 
 ### MCP Aliases
 

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -193,6 +193,8 @@ class MCPClient:
                 headers["Authorization"] = f"Basic {self._mcp_auth_value}"
             elif self.auth_type == MCPAuth.api_key:
                 headers["X-API-Key"] = self._mcp_auth_value
+            elif self.auth_type == MCPAuth.authorization:
+                headers["Authorization"] = self._mcp_auth_value
 
         # Handle protocol version - it might be a string or enum
         if hasattr(self.protocol_version, 'value'):

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -31,13 +31,20 @@ class MCPAuth(str, enum.Enum):
     api_key = "api_key"
     bearer_token = "bearer_token"
     basic = "basic"
+    authorization = "authorization"
 
 
 # MCP Literals
 MCPTransportType = Literal[MCPTransport.sse, MCPTransport.http, MCPTransport.stdio]
 MCPSpecVersionType = Literal[MCPSpecVersion.nov_2024, MCPSpecVersion.mar_2025, MCPSpecVersion.jun_2025]
 MCPAuthType = Optional[
-    Literal[MCPAuth.none, MCPAuth.api_key, MCPAuth.bearer_token, MCPAuth.basic]
+    Literal[
+        MCPAuth.none,
+        MCPAuth.api_key,
+        MCPAuth.bearer_token,
+        MCPAuth.basic,
+        MCPAuth.authorization,
+    ]
 ]
 
 

--- a/tests/mcp_tests/test_mcp_auth_priority.py
+++ b/tests/mcp_tests/test_mcp_auth_priority.py
@@ -1,0 +1,44 @@
+"""
+Simple test to validate MCP auth header priority behavior.
+
+Validates that:
+1. auth_value is not required in config.yaml
+2. Server-specific headers (x-mcp-server-name-authorization) take precedence over config auth_value
+"""
+
+import pytest
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+from litellm.types.mcp import MCPAuth, MCPTransport, MCPSpecVersion
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+
+def test_mcp_server_works_without_config_auth_value():
+    """
+    Test that MCP servers work without auth_value in config when headers are provided.
+    This validates that auth_value is truly optional in config.yaml.
+    """
+    # Create a server WITHOUT config auth_value
+    server_without_config_auth = MCPServer(
+        server_id="test-server-no-config",
+        name="Test MCP Server No Config Auth",
+        server_name="test_server_no_config",
+        alias="test_no_config",
+        url="https://api.example.com/mcp", 
+        transport=MCPTransport.http,
+        spec_version=MCPSpecVersion.jun_2025,
+        auth_type=MCPAuth.authorization,
+        authentication_token=None  # No config auth
+    )
+    
+    manager = MCPServerManager()
+    
+    # Test that it works with only header auth
+    client = manager._create_mcp_client(
+        server=server_without_config_auth,
+        mcp_auth_header="Bearer token_from_header_only",
+        protocol_version="2025-06-18"
+    )
+    
+    # Verify header token is used
+    assert client._mcp_auth_value == "Bearer token_from_header_only"
+    assert client.auth_type == MCPAuth.authorization

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -62,6 +62,18 @@ class TestMCPClientUnitTests:
         )
         headers = client._get_auth_headers()
         assert headers == {"X-API-Key": "api_key_123", "MCP-Protocol-Version": "2025-06-18"}
+
+        # Custom authorization header
+        client = MCPClient(
+            "http://example.com",
+            auth_type=MCPAuth.authorization,
+            auth_value="Token custom_token",
+        )
+        headers = client._get_auth_headers()
+        assert headers == {
+            "Authorization": "Token custom_token",
+            "MCP-Protocol-Version": "2025-06-18",
+        }
         
         # No auth
         client = MCPClient("http://example.com")


### PR DESCRIPTION
## [Feature]: Support "Token" MCPAuth 

- Allow setting auth_type: "authorization", this forwards `Authorization` value as `auth_value` defined on the config.yaml 

```yaml title="MCP auth examples (config.yaml)" showLineNumbers
mcp_servers:
  custom_auth_example:
    url: "https://my-mcp-server.com/mcp"
    auth_type: "authorization"
    auth_value: "Token example123"  # headers={"Authorization": "Token example123"}
```

Fixes https://github.com/BerriAI/litellm/issues/14355

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


