### PR TITLE
Allow cancellation while waiting for coroutine in LoggingWorker

### DIFF
--- a/litellm/litellm_core_utils/logging_worker.py
+++ b/litellm/litellm_core_utils/logging_worker.py
@@ -51,6 +51,8 @@ class LoggingWorker:
                 coroutine = await self._queue.get()
                 try:
                     await asyncio.wait_for(coroutine, timeout=self.timeout)
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
                     verbose_logger.exception(f"LoggingWorker error: {e}")
                     pass


### PR DESCRIPTION
We have an issue where a unit test that uses `litellm.aembedding()` hangs when executed on Python 3.10 or 3.11. It passes on 3.12. The test tries to cancel all tasks (using `asyncio.runner.Runner.__exit__`) but on 3.11 fails to cancel this task:

```
<Task cancelling name='Task-16' coro=<LoggingWorker._worker_loop() running at python3.11/site-packages/litellm/litellm_core_utils/logging_worker.py:53> wait_for=<Future cancelled>>
```

I've tried this change and it doesn't fix the issue. The sequence of events is:
- `queue.get()` returns the `async_success_handler`.
- `wait_for` starts for `async_success_handler`.
- `async_success_handler` runs.
- `Runner.__exit__` runs and calls `task.cancel()`.
- `wait_for` _returns_. No exception!
- The loop continues. `queue.get()` hangs forever.

I'm really puzzled. Why is there no `CancelledError`?

There is precedent for an `asyncio` bug like this (https://bugs.python.org/issue42130) but it should be fixed in 3.11 already.

I see `wait_for` was largely replaced in 3.12 (https://github.com/python/cpython/commit/a5024a261a75dafa4fb6613298dcb64a9603d9c7). Anyway, when running the test on Python 3.12, the sequence of events is different. The loop has already finished with `async_success_handler` and it's waiting in `queue.get()` when the `CancelledError` comes in and everything is fine.

Anyway, I thought this was possibly a useful change even if it didn't help me. If you're interested I can try to make an isolated repro, let me know. And thanks for LiteLLM! ❤️ 