### PR TITLE
Fix embeddings using azure_ad_token_provider.

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3854,7 +3854,7 @@ def embedding(  # noqa: PLR0915
     max_retries = kwargs.get("max_retries", None)
     litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
     mock_response: Optional[List[float]] = kwargs.get("mock_response", None)  # type: ignore
-    azure_ad_token_provider = kwargs.pop("azure_ad_token_provider", None)
+    azure_ad_token_provider = kwargs.get("azure_ad_token_provider", None)
     aembedding = kwargs.get("aembedding", None)
     extra_headers = kwargs.get("extra_headers", None)
     headers = kwargs.get("headers", None)


### PR DESCRIPTION
## Fix embeddings using azure_ad_token_provider

## Relevant issues

Fixes #13984

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

I have not added any tests for the 1-line change. The tests fail for me locally when running from a clean slate off of main. I am also not sure what and where to add a test for this 1-line change. I am happy to add a test to the PR with some guidance.

## Type

🐛 Bug Fix

## Changes

Update `main.py embedding` to use `get` instead of `pop` for getting the `azure_ad_token_provider` from the `kwargs`. This fixes the issue as other areas of the code and methods attempt to re-retrieve the `azure_ad_token_provider` from `kwargs`. This is also in line with how `completion` retrieves `azure_ad_token_provider`.
