### PR TITLE
[Fix] Restore forgotten `raise` keyword in front of an `exception_type()` call

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1937,7 +1937,7 @@ class CustomStreamWrapper:
                 )
             ## Map to OpenAI Exception
             try:
-                exception_type(
+                raise exception_type(
                     model=self.model,
                     custom_llm_provider=self.custom_llm_provider,
                     original_exception=e,


### PR DESCRIPTION
## Title

A `raise` keyword was forgotten in front of one of the `exception_type()` calls.

## Relevant issues

https://github.com/teremterem/claude-code-gpt-5/issues/24

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

**NOTE: The failing checks in this PR are not related to my change.** The checks seem to be failing because of something that was merged into the `main` branch earlier.

## Type

🐛 Bug Fix

## Changes

Restored a forgotten `raise` keyword in front of an `exception_type()` call.

**This simple correction makes quite a difference when using LiteLLM as a Proxy.**

Without it the errors that might happen in a user-defined CustomLLM subclass during token streaming get obscured by a generic Exception with no message and no useful traceback (please see an example of such a generic Exception in the description of the issue that I linked above).

There is only one place in the whole code base where `raise` keyword was forgotten in front of an `exception_type()` call in this manner:

<img width="981" height="583" alt="image" src="https://github.com/user-attachments/assets/a520319d-638f-40e3-8d3e-a318f6e4b666" />

This PR simply fills this missing `raise` keyword back in, in that single location.
