### PR TITLE
clarity on how to update max_tokens default runtime value 

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -44,7 +44,7 @@ Check this in code, [here](../completion/input.md#translated-openai-params)
 
 :::info
 
-Anthropic API fails requests when `max_tokens` are not passed. Due to this litellm passes `max_tokens=4096` when no `max_tokens` are passed.
+Anthropic API fails requests when `max_tokens` are not passed. Due to this litellm passes `max_tokens=4096` when no `max_tokens` are passed. To set run time defaults to a different value, use `litellm_params.max_tokens`
 
 :::
 


### PR DESCRIPTION
Context: Users were trying to update the `max_tokens` value using `model_info.max_tokens`  which is just for metadata.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation


## Changes
Added more context in the first info note about `max_tokens`

