### PR TITLE
added an optional nodePort setting in order to be able to force the n…

### DIFF
--- a/deploy/charts/litellm-helm/templates/service.yaml
+++ b/deploy/charts/litellm-helm/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -62,6 +62,9 @@ service:
   # If service type is `LoadBalancer` you can
   # optionally specify loadBalancerClass
   # loadBalancerClass: tailscale
+  # If service type is 'NodePort' you can
+  # optionally specify nodePort
+  # nodePort: 30000
 
 # Separate health app configuration
 # When enabled, health checks will use a separate port and the application

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -1,4 +1,5 @@
 # Default values for litellm.
+#
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -62,7 +63,7 @@ service:
   # If service type is `LoadBalancer` you can
   # optionally specify loadBalancerClass
   # loadBalancerClass: tailscale
-  # If service type is 'NodePort' you can
+  # If service type is 'NodePort' you can 
   # optionally specify nodePort
   # nodePort: 30000
 


### PR DESCRIPTION
## Title

Added a nodePort setting to the Helm Chart service template,
in order to be able to force the nodePort when the service type is NodePort

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

I'm sorry I'm no Helm expert and I don't know how to unit-test this simple change.
I've tested it locally with and without a specified port number
I've also tested it by setting the service type to ClusterIP

- [x ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes

Added a nodePort setting to the Helm Chart service template, and associated doc in the default values.yaml file
