### PR TITLE
fix: avoid deepcopy crash with non-pickleables in Gemini/Vertex

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -116,6 +116,7 @@ from litellm.utils import (
 
 from ._logging import verbose_logger
 from .caching.caching import disable_cache, enable_cache, update_cache
+from .litellm_core_utils.core_helpers import safe_deep_copy
 from .litellm_core_utils.fallback_utils import (
     async_completion_with_fallbacks,
     completion_with_fallbacks,
@@ -2772,8 +2773,7 @@ def completion(  # type: ignore # noqa: PLR0915
             )
 
             api_base = api_base or litellm.api_base or get_secret("GEMINI_API_BASE")
-
-            new_params = deepcopy(optional_params)
+            new_params = safe_deep_copy(optional_params or {})
             response = vertex_chat_completion.completion(  # type: ignore
                 model=model,
                 messages=messages,
@@ -2817,7 +2817,7 @@ def completion(  # type: ignore # noqa: PLR0915
 
             api_base = api_base or litellm.api_base or get_secret("VERTEXAI_API_BASE")
 
-            new_params = deepcopy(optional_params)
+            new_params = safe_deep_copy(optional_params or {})
             if vertex_partner_models_chat_completion.is_vertex_partner_model(model):
                 model_response = vertex_partner_models_chat_completion.completion(
                     model=model,


### PR DESCRIPTION
## Relevant issues

Fixes #14195 - originally surfaced “when calling MCP”, but root cause is the Gemini/Vertex provider path performing a raw `deepcopy(optional_params)`.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

- 🐛 Bug Fix  
- ✅ Test

## Changes

- Harden `safe_deep_copy` in `litellm/utils.py`:
  - Temporarily redact `metadata.litellm_parent_otel_span` and restore it after copying.
  - Perform **per-key** `deepcopy` with fallback to original reference for non-pickleables (e.g., `_thread.RLock`, clients/transports).
  - Preserve structure/keys; only the span is redacted in the returned copy.

- Replace `deepcopy(optional_params)` with `safe_deep_copy(optional_params or {})` in provider paths:
  - `litellm/main.py`: branches for `custom_llm_provider` in `{"gemini", "vertex_ai", "vertex_ai_beta"}`.

- Add tests:
  - `tests/test_litellm/utils/test_safe_deep_copy.py`: verifies structure preservation, span redaction, and tolerance of non-pickleables.

**Before:** Requests could crash with `TypeError: cannot pickle '_thread.RLock' object` when non-pickleables were present in `optional_params` (often surfaced during MCP/streaming flows but not MCP-specific).  
**After:** No crash; request params are safely copied, preserving all fields and isolating mutable payloads without dropping information.
