### PR TITLE
Respect max_end_user_budget as the default budget for end user

### DIFF
--- a/docs/my-website/docs/proxy/customers.md
+++ b/docs/my-website/docs/proxy/customers.md
@@ -215,14 +215,20 @@ curl -X POST 'http://localhost:4000/customer/new' \
 <Tabs>
 <TabItem value="curl" label="curl">
 
-```bash
-curl -X POST 'http://localhost:4000/customer/new' \
--H 'Content-Type: application/json' \
--H 'Authorization: Bearer sk-1234' \
--D '{
-    "user_id": "my-customer-id",
-    "budget_id": "my-free-tier" # 👈 KEY CHANGE
-}
+```shell
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+        --header 'Content-Type: application/json' \
+        --header 'Authorization: Bearer sk-zi5onDRdHGD24v0Zdn7VBA' \
+        --data ' {
+        "model": "azure-gpt-3.5",
+        "user": "my-customer-id",
+        "messages": [
+            {
+            "role": "user",
+            "content": "what time is it"
+            }
+        ]
+        }'
 ```
 
 </TabItem>

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -163,6 +163,21 @@ async def common_checks(
                 max_budget=end_user_budget,
                 message=f"ExceededBudget: End User={end_user_object.user_id} over budget. Spend={end_user_object.spend}, Budget={end_user_budget}",
             )
+    # 5.1 Fallback to global default end-user budget if no per-customer budget exists
+    elif (
+        end_user_object is not None
+        and end_user_object.litellm_budget_table is None
+        and litellm.max_end_user_budget is not None
+    ):
+        if (
+            end_user_object.spend is not None
+            and end_user_object.spend > litellm.max_end_user_budget
+        ):
+            raise litellm.BudgetExceededError(
+                current_cost=end_user_object.spend,
+                max_budget=litellm.max_end_user_budget,
+                message=f"ExceededBudget: End User={end_user_object.user_id} over budget. Spend={end_user_object.spend}, Budget={litellm.max_end_user_budget}",
+            )
 
     # 6. [OPTIONAL] If 'enforce_user_param' enabled - did developer pass in 'user' param for openai endpoints
     if (
@@ -458,6 +473,16 @@ async def get_end_user_object(
         if route in LiteLLMRoutes.info_routes.value:  # allow calling info routes
             return
         if end_user_obj.litellm_budget_table is None:
+            # Fallback to global default if configured
+            if litellm.max_end_user_budget is not None:
+                if (
+                    end_user_obj.spend is not None
+                    and end_user_obj.spend > litellm.max_end_user_budget
+                ):
+                    raise litellm.BudgetExceededError(
+                        current_cost=end_user_obj.spend,
+                        max_budget=litellm.max_end_user_budget,
+                    )
             return
         end_user_budget = end_user_obj.litellm_budget_table.max_budget
         if end_user_budget is not None and end_user_obj.spend > end_user_budget:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -640,6 +640,11 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                             end_user_params["end_user_max_budget"] = (
                                 budget_info.max_budget
                             )
+                        elif litellm.max_end_user_budget is not None:
+                            # propagate default end-user budget into token for alerts/limits
+                            end_user_params["end_user_max_budget"] = (
+                                litellm.max_end_user_budget
+                            )
             except Exception as e:
                 if isinstance(e, litellm.BudgetExceededError):
                     raise e


### PR DESCRIPTION
…l customers.

## Title

Respect max_end_user_budget as the default budget for the end user

## Relevant issues

https://github.com/BerriAI/litellm/discussions/10447

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


