### PR TITLE
Added a demo to showcase request headers exchange b/w litellm and openweb

### DIFF
--- a/docs/my-website/docs/tutorials/openweb_ui.md
+++ b/docs/my-website/docs/tutorials/openweb_ui.md
@@ -109,6 +109,7 @@ To track spend and usage for each Open WebUI user, configure both Open WebUI and
   - Users can modify their own usernames
   - Administrators can modify both usernames and emails of any account
 
+<Image img={require('../../img/litellm_headers_exchange_openweb.gif')} />
 
 
 ## Render `thinking` content on Open WebUI


### PR DESCRIPTION
Some users requested a demo showing how OpenWebUI request headers, such as `user_id`, are displayed in LiteLLM logs
## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation


## Changes
Added a gif in the openweb docs which contains the demo
