### PR TITLE
Validate api key on generation

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -551,6 +551,15 @@ async def _common_key_generation_helper(  # noqa: PLR0915
         prisma_client=prisma_client,
     )
 
+    # Validate user-provided key format
+    if data.key is not None and not data.key.startswith("sk-"):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"Invalid key format. LiteLLM Virtual Key must start with 'sk-'. Received: {data.key}"
+            }
+        )
+
     response = await generate_key_helper_fn(
         request_type="key", **data_json, table_name="key"
     )


### PR DESCRIPTION
## Title
Validate `sk-` prefix for custom LiteLLM virtual keys on generation

## Relevant issues
Reported as a papercut in Slack (no GH issue #)

## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
This PR resolves a user experience issue where `/key/generate` (and `/key/service-account/generate`) allowed the creation of LiteLLM virtual keys without the required `sk-` prefix. Such keys would then fail during API calls, causing confusion.

The change adds validation within the `_common_key_generation_helper` function to ensure that any user-provided `key` parameter starts with `sk-`. If the prefix is missing, an `HTTPException` (400 Bad Request) is raised, providing immediate and clear feedback to the user and preventing the creation of unusable keys.

---
[Slack Thread](https://berriaillm.slack.com/archives/C097VVAJ8BU/p1757552798116449?thread_ts=1757552798.116449&cid=C097VVAJ8BU)

<a href="https://cursor.com/background-agent?bcId=bc-c108c70b-52f6-4d35-8adc-087eaa3b43b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c108c70b-52f6-4d35-8adc-087eaa3b43b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

