### PR TITLE
Improve team creation model selection and validation

### DIFF
--- a/tests/proxy_admin_ui_tests/ui_unit_tests/team_creation_model_preservation_test.tsx
+++ b/tests/proxy_admin_ui_tests/ui_unit_tests/team_creation_model_preservation_test.tsx
@@ -1,0 +1,137 @@
+// Test for the core logic of team creation model preservation
+// This test focuses on the filtering logic without rendering the full component
+
+// Helper function to get organization models (copied from the component)
+const getOrganizationModels = (organization: any, userModels: string[]) => {
+  let tempModelsToPick = [];
+  if (organization) {
+    if (organization.models.length > 0) {
+      tempModelsToPick = organization.models;
+    } else {
+      tempModelsToPick = userModels;
+    }
+  } else {
+    tempModelsToPick = userModels;
+  }
+  return tempModelsToPick;
+};
+
+describe('Team Creation Modal Model Preservation', () => {
+  const defaultProps = {
+    teams: [],
+    searchParams: {},
+    accessToken: 'test-token',
+    setTeams: jest.fn(),
+    userID: 'test-user',
+    userRole: 'Admin',
+    organizations: [
+      {
+        organization_id: 'org1',
+        organization_alias: 'Organization 1',
+        models: ['model1', 'model2']
+      },
+      {
+        organization_id: 'org2', 
+        organization_alias: 'Organization 2',
+        models: ['model2', 'model3', 'model4']
+      }
+    ],
+    premiumUser: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should preserve models when switching to organization that includes them', () => {
+    const userModels = ['model1', 'model2', 'model3', 'model4'];
+    const selectedModels = ['model1', 'model2'];
+    
+    // Organization 1 has models: ['model1', 'model2']
+    const org1 = defaultProps.organizations![0];
+    const availableModels1 = getOrganizationModels(org1, userModels);
+    
+    // Simulate current selected models
+    const stillAvailableModels = selectedModels.filter((selectedModel: string) => 
+      selectedModel === "all-proxy-models" || availableModels1.includes(selectedModel)
+    );
+    
+    // Both selected models should still be available
+    expect(stillAvailableModels).toEqual(['model1', 'model2']);
+    expect(stillAvailableModels.length).toBe(selectedModels.length);
+  });
+
+  it('should remove only unavailable models when switching organization', () => {
+    const userModels = ['model1', 'model2', 'model3', 'model4'];
+    const selectedModels = ['model1', 'model2', 'model3'];
+    
+    // Organization 1 has models: ['model1', 'model2'] 
+    const org1 = defaultProps.organizations![0];
+    const availableModels1 = getOrganizationModels(org1, userModels);
+    
+    const stillAvailableModels = selectedModels.filter((selectedModel: string) => 
+      selectedModel === "all-proxy-models" || availableModels1.includes(selectedModel)
+    );
+    
+    // Only model1 and model2 should remain, model3 should be filtered out
+    expect(stillAvailableModels).toEqual(['model1', 'model2']);
+    expect(stillAvailableModels.length).toBe(2);
+    expect(stillAvailableModels.length).toBeLessThan(selectedModels.length);
+  });
+
+  it('should preserve all-proxy-models selection regardless of organization', () => {
+    const userModels = ['model1', 'model2', 'model3', 'model4'];
+    const selectedModels = ['all-proxy-models', 'model1'];
+    
+    // Organization 1 has models: ['model1', 'model2']
+    const org1 = defaultProps.organizations![0];
+    const availableModels1 = getOrganizationModels(org1, userModels);
+    
+    const stillAvailableModels = selectedModels.filter((selectedModel: string) => 
+      selectedModel === "all-proxy-models" || availableModels1.includes(selectedModel)
+    );
+    
+    // Both all-proxy-models and model1 should be preserved
+    expect(stillAvailableModels).toEqual(['all-proxy-models', 'model1']);
+    expect(stillAvailableModels.length).toBe(selectedModels.length);
+  });
+
+  it('should handle empty model selection without errors', () => {
+    const userModels = ['model1', 'model2', 'model3', 'model4'];
+    const selectedModels: string[] = [];
+    
+    const org1 = defaultProps.organizations![0];
+    const availableModels1 = getOrganizationModels(org1, userModels);
+    
+    const stillAvailableModels = selectedModels.filter((selectedModel: string) => 
+      selectedModel === "all-proxy-models" || availableModels1.includes(selectedModel)
+    );
+    
+    expect(stillAvailableModels).toEqual([]);
+    expect(stillAvailableModels.length).toBe(0);
+    expect(stillAvailableModels.length).toBe(selectedModels.length);
+  });
+
+  it('should handle organization with no models specified (should use all user models)', () => {
+    const userModels = ['model1', 'model2', 'model3', 'model4'];
+    const selectedModels = ['model1', 'model3'];
+    
+    // Organization with empty models array should use all user models
+    const orgWithNoModels = {
+      organization_id: 'org3',
+      organization_alias: 'Organization 3',
+      models: []
+    };
+    
+    const availableModels = getOrganizationModels(orgWithNoModels, userModels);
+    expect(availableModels).toEqual(userModels);
+    
+    const stillAvailableModels = selectedModels.filter((selectedModel: string) => 
+      selectedModel === "all-proxy-models" || availableModels.includes(selectedModel)
+    );
+    
+    // All selected models should be preserved since org uses all user models
+    expect(stillAvailableModels).toEqual(['model1', 'model3']);
+    expect(stillAvailableModels.length).toBe(selectedModels.length);
+  });
+});


### PR DESCRIPTION
Enhances the team creation UI to better handle organization model availability. Now, when switching organizations, only unavailable models are removed from the selection and a warning is shown if any are removed. Organizations with no available models are disabled in the dropdown, and the UI displays a warning and disables model selection and team creation if no models are available. Added unit tests for model preservation logic.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


