### PR TITLE
[Performance] Use _PROXY_MaxParallelRequestsHandler_v3 by default again

### DIFF
--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -17,13 +17,13 @@ except ImportError:
 # List of all available hooks that can be enabled
 PROXY_HOOKS = {
     "max_budget_limiter": _PROXY_MaxBudgetLimiter,
-    "parallel_request_limiter": _PROXY_MaxParallelRequestsHandler,
+    "parallel_request_limiter": _PROXY_MaxParallelRequestsHandler_v3,
     "cache_control_check": _PROXY_CacheControlCheck,
 }
 
 ## FEATURE FLAG HOOKS ##
-if os.getenv("EXPERIMENTAL_MULTI_INSTANCE_RATE_LIMITING", "false").lower() == "true":
-    PROXY_HOOKS["parallel_request_limiter"] = _PROXY_MaxParallelRequestsHandler_v3
+if os.getenv("LEGACY_MULTI_INSTANCE_RATE_LIMITING", "false").lower() == "true":
+    PROXY_HOOKS["parallel_request_limiter"] = _PROXY_MaxParallelRequestsHandler
 
 
 ### update PROXY_HOOKS with ENTERPRISE_PROXY_HOOKS ###

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -266,7 +266,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             if current_limit is None or rate_limit_type is None:
                 continue
 
-            if counter_value is not None and int(counter_value) + 1 > current_limit:
+            if counter_value is not None and int(counter_value) > current_limit:
                 overall_code = "OVER_LIMIT"
                 item_code = "OVER_LIMIT"
 

--- a/tests/local_testing/test_pass_through_endpoints.py
+++ b/tests/local_testing/test_pass_through_endpoints.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import uuid
 from typing import Optional
 
 import pytest
@@ -157,7 +158,7 @@ async def test_pass_through_endpoint_rpm_limit(
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.proxy_server import ProxyLogging, hash_token, user_api_key_cache
 
-    mock_api_key = "sk-my-test-key"
+    mock_api_key = f"sk-test-{uuid.uuid4().hex}"
     cache_value = UserAPIKeyAuth(token=hash_token(mock_api_key), rpm_limit=rpm_limit)
 
     _cohere_api_key = os.environ.get("COHERE_API_KEY")

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -67,9 +67,10 @@ async def generate_key(
     user_id: Optional[str] = None,
     team_id: Optional[str] = None,
     metadata: Optional[dict] = None,
-    calling_key="sk-1234",
+    calling_key: Optional[str] = None,
 ):
     url = "http://0.0.0.0:4000/key/generate"
+    calling_key = calling_key or f"sk-test-{uuid.uuid4().hex}"
     headers = {
         "Authorization": f"Bearer {calling_key}",
         "Content-Type": "application/json",

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -67,10 +67,9 @@ async def generate_key(
     user_id: Optional[str] = None,
     team_id: Optional[str] = None,
     metadata: Optional[dict] = None,
-    calling_key: Optional[str] = None,
+    calling_key="sk-1234",
 ):
     url = "http://0.0.0.0:4000/key/generate"
-    calling_key = calling_key or f"sk-test-{uuid.uuid4().hex}"
     headers = {
         "Authorization": f"Bearer {calling_key}",
         "Content-Type": "application/json",


### PR DESCRIPTION
Follow up on https://github.com/BerriAI/litellm/pull/14420 and https://github.com/BerriAI/litellm/pull/14352

The rate limiter was incorrectly rejecting requests when the limit was met, but not exceeded. The check in `is_cache_list_over_limit` was `int(counter_value) + 1 > current_limit`, which caused the first request to be rejected if the limit was 1.

This PR removes the `+ 1`, changing the logic to `int(counter_value) > current_limit`. The check now correctly allows requests up to the specified parallel limit.

It also adds several tests to ensure correct behavior when handling parallel/sequential requests from multiple users.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/`](https://github.com/BerriAI/litellm/tree/main/tests/) directory
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<details><summary>pytest tests/test_end_users.py::test_aaaend_user_specific_region  tests/local_testing/test_pass_through_endpoints.py -k 'rpm or specific_region' -n 6 -vv</summary>


<img width="869" height="628" alt="image" src="https://github.com/user-attachments/assets/0d34e733-e146-4d63-a89a-574de8c475e7" /></details>


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure
✅ Test

## Changes


