### PR TITLE
propagate execution context into logging tasks

### DIFF
--- a/litellm/litellm_core_utils/logging_worker.py
+++ b/litellm/litellm_core_utils/logging_worker.py
@@ -1,8 +1,19 @@
 import asyncio
 import contextlib
-from typing import Coroutine, Optional
+import contextvars
+from typing import Coroutine, Optional, TypedDict
 
 from litellm._logging import verbose_logger
+
+
+class LoggingTask(TypedDict):
+    """
+    A logging task with its associated context to ensure logging is executed in
+    the original task's context.
+    """
+
+    coroutine: Coroutine
+    context: contextvars.Context
 
 
 class LoggingWorker:
@@ -13,77 +24,84 @@ class LoggingWorker:
     This leads to a +200 RPS performance improvement when using LiteLLM Python SDK or Proxy Server.
     - Use this to queue coroutine tasks that are not critical to the main flow of the application. e.g Success/Error callbacks, logging, etc.
     """
+
     LOGGING_WORKER_MAX_QUEUE_SIZE = 50_000
     LOGGING_WORKER_MAX_TIME_PER_COROUTINE = 20.0
 
     MAX_ITERATIONS_TO_CLEAR_QUEUE = 200
     MAX_TIME_TO_CLEAR_QUEUE = 5.0
-    
+
     def __init__(
-        self, 
-        timeout: float = LOGGING_WORKER_MAX_TIME_PER_COROUTINE, 
+        self,
+        timeout: float = LOGGING_WORKER_MAX_TIME_PER_COROUTINE,
         max_queue_size: int = LOGGING_WORKER_MAX_QUEUE_SIZE,
     ):
         self.timeout = timeout
         self.max_queue_size = max_queue_size
-        self._queue: Optional[asyncio.Queue] = None
+        self._queue: Optional[asyncio.Queue[LoggingTask]] = None
         self._worker_task: Optional[asyncio.Task] = None
-    
+
     def _ensure_queue(self) -> None:
         """Initialize the queue if it doesn't exist."""
         if self._queue is None:
             self._queue = asyncio.Queue(maxsize=self.max_queue_size)
-    
+
     def start(self) -> None:
         """Start the logging worker. Idempotent - safe to call multiple times."""
         self._ensure_queue()
         if self._worker_task is None or self._worker_task.done():
             self._worker_task = asyncio.create_task(self._worker_loop())
-    
+
     async def _worker_loop(self) -> None:
         """Main worker loop that processes log coroutines sequentially."""
         try:
             if self._queue is None:
                 return
-            
+
             while True:
                 # Process one coroutine at a time to keep event loop load predictable
-                coroutine = await self._queue.get()
+                task = await self._queue.get()
                 try:
-                    await asyncio.wait_for(coroutine, timeout=self.timeout)
+                    # Run the coroutine in its original context
+                    await asyncio.wait_for(
+                        task["context"].run(asyncio.create_task, task["coroutine"]),
+                        timeout=self.timeout,
+                    )
                 except Exception as e:
                     verbose_logger.exception(f"LoggingWorker error: {e}")
                     pass
                 finally:
                     self._queue.task_done()
-                    
+
         except asyncio.CancelledError:
             verbose_logger.debug("LoggingWorker cancelled during shutdown")
             # Attempt to clear remaining items to prevent "never awaited" warnings
             await self.clear_queue()
-    
+
     def enqueue(self, coroutine: Coroutine) -> None:
         """
-        Add a coroutine to the logging queue. 
+        Add a coroutine to the logging queue.
         Hot path: never blocks, drops logs if queue is full.
         """
         if self._queue is None:
             return
-        
+
         try:
-            self._queue.put_nowait(coroutine)
+            # Capture the current context when enqueueing
+            task = LoggingTask(coroutine=coroutine, context=contextvars.copy_context())
+            self._queue.put_nowait(task)
         except asyncio.QueueFull as e:
             verbose_logger.exception(f"LoggingWorker queue is full: {e}")
             # Drop logs on overload to protect request throughput
             pass
-    
+
     def ensure_initialized_and_enqueue(self, async_coroutine: Coroutine):
         """
         Ensure the logging worker is initialized and enqueue the coroutine.
         """
         self.start()
         self.enqueue(async_coroutine)
-    
+
     async def stop(self) -> None:
         """Stop the logging worker and clean up resources."""
         if self._worker_task:
@@ -91,34 +109,42 @@ class LoggingWorker:
             with contextlib.suppress(Exception):
                 await self._worker_task
             self._worker_task = None
-    
+
     async def flush(self) -> None:
         """Flush the logging queue."""
         if self._queue is None:
             return
         while not self._queue.empty():
             await self._queue.join()
-    
+
     async def clear_queue(self):
         """
         Clear the queue with a maximum time limit.
         """
         if self._queue is None:
             return
-        
+
         start_time = asyncio.get_event_loop().time()
-        
+
         for _ in range(self.MAX_ITERATIONS_TO_CLEAR_QUEUE):
             # Check if we've exceeded the maximum time
-            if asyncio.get_event_loop().time() - start_time >= self.MAX_TIME_TO_CLEAR_QUEUE:
-                verbose_logger.warning(f"clear_queue exceeded max_time of {self.MAX_TIME_TO_CLEAR_QUEUE}s, stopping early")
+            if (
+                asyncio.get_event_loop().time() - start_time
+                >= self.MAX_TIME_TO_CLEAR_QUEUE
+            ):
+                verbose_logger.warning(
+                    f"clear_queue exceeded max_time of {self.MAX_TIME_TO_CLEAR_QUEUE}s, stopping early"
+                )
                 break
-                
+
             try:
-                coroutine = self._queue.get_nowait()
+                task = self._queue.get_nowait()
                 # Await the coroutine to properly execute and avoid "never awaited" warnings
                 try:
-                    await asyncio.wait_for(coroutine, timeout=self.timeout)
+                    await asyncio.wait_for(
+                        task["context"].run(asyncio.create_task, task["coroutine"]),
+                        timeout=self.timeout,
+                    )
                 except Exception:
                     # Suppress errors during cleanup
                     pass
@@ -129,4 +155,3 @@ class LoggingWorker:
 
 # Global instance for backward compatibility
 GLOBAL_LOGGING_WORKER = LoggingWorker()
-


### PR DESCRIPTION
## Title

Propagate async execution context into async logging tasks

## Relevant issues

Fixes #14327

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) <- It does not, but failures are identical to `main`
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


<img width="1785" height="720" alt="Screenshot 2025-09-11 at 15 51 22" src="https://github.com/user-attachments/assets/c2917d9d-f548-4c11-a8ba-5c9944d298e6" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Update `LoggingWorker` to carry not just the coroutines, but also their respective execution contexts