### PR TITLE
fix vertex ai file upload

### DIFF
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -69,6 +69,29 @@ def get_files_provider_config(
 ):
     global files_config
     if custom_llm_provider == "vertex_ai":
+        # For Vertex AI, extract config from model_list instead of files_config
+        from litellm.proxy.proxy_server import proxy_config
+
+        if hasattr(proxy_config, "config") and "model_list" in proxy_config.config:
+            for model in proxy_config.config["model_list"]:
+                if isinstance(model, dict) and "litellm_params" in model:
+                    litellm_params = model["litellm_params"]
+                    if litellm_params.get("model", "").startswith("vertex_ai/"):
+                        # Extract vertex_ai specific parameters
+                        vertex_config = {}
+                        if "vertex_project" in litellm_params:
+                            vertex_config["vertex_project"] = litellm_params[
+                                "vertex_project"
+                            ]
+                        if "vertex_location" in litellm_params:
+                            vertex_config["vertex_location"] = litellm_params[
+                                "vertex_location"
+                            ]
+                        if "vertex_credentials" in litellm_params:
+                            vertex_config["vertex_credentials"] = litellm_params[
+                                "vertex_credentials"
+                            ]
+                        return vertex_config
         return None
     if files_config is None:
         raise ValueError("files_settings is not set, set it on your config.yaml file.")

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_vertex_ai_files_regression.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_vertex_ai_files_regression.py
@@ -1,0 +1,271 @@
+"""
+Regression tests for Vertex AI file upload functionality in the proxy.
+
+This module contains tests to ensure that the fix for Vertex AI file uploads
+in the proxy server continues to work and prevents regression of the issue
+where get_files_provider_config returned None for vertex_ai provider.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from litellm.proxy.openai_files_endpoints.files_endpoints import get_files_provider_config
+
+
+def test_vertex_ai_files_provider_config_never_returns_none_when_configured():
+    """
+    Regression test: Ensure that get_files_provider_config never returns None
+    for vertex_ai when properly configured in model_list.
+    
+    This test prevents regression of the bug where vertex_ai provider
+    always returned None, causing "Could not resolve project_id" errors.
+    """
+    from litellm.proxy.proxy_server import proxy_config
+    
+    # Mock the proxy_config with a proper Vertex AI configuration
+    mock_config = {
+        'model_list': [
+            {
+                'model_name': 'gemini-2.5-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-2.5-flash',
+                    'vertex_project': 'test-project-123',
+                    'vertex_location': 'us-central1',
+                    'vertex_credentials': '/path/to/service_account.json'
+                }
+            }
+        ]
+    }
+    
+    # Mock proxy_config.config
+    original_config = getattr(proxy_config, 'config', None)
+    proxy_config.config = mock_config
+    
+    try:
+        result = get_files_provider_config('vertex_ai')
+        
+        # This should NEVER be None when vertex_ai is properly configured
+        assert result is not None, (
+            "CRITICAL REGRESSION: get_files_provider_config returned None for vertex_ai "
+            "when it should return configuration. This would cause 'Could not resolve project_id' errors."
+        )
+        
+        # Verify all expected parameters are present
+        assert 'vertex_project' in result
+        assert 'vertex_location' in result
+        assert 'vertex_credentials' in result
+        
+    finally:
+        # Restore original config
+        if original_config is not None:
+            proxy_config.config = original_config
+        else:
+            delattr(proxy_config, 'config')
+
+
+def test_vertex_ai_files_provider_config_handles_multiple_vertex_models():
+    """
+    Test that get_files_provider_config correctly handles multiple Vertex AI models
+    in the model_list and returns configuration from the first one found.
+    """
+    from litellm.proxy.proxy_server import proxy_config
+    
+    # Mock the proxy_config with multiple Vertex AI models
+    mock_config = {
+        'model_list': [
+            {
+                'model_name': 'gemini-1.5-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-1.5-flash',
+                    'vertex_project': 'project-1',
+                    'vertex_location': 'us-east1',
+                    'vertex_credentials': '/path/to/creds1.json'
+                }
+            },
+            {
+                'model_name': 'gemini-2.5-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-2.5-flash',
+                    'vertex_project': 'project-2',
+                    'vertex_location': 'us-central1',
+                    'vertex_credentials': '/path/to/creds2.json'
+                }
+            }
+        ]
+    }
+    
+    # Mock proxy_config.config
+    original_config = getattr(proxy_config, 'config', None)
+    proxy_config.config = mock_config
+    
+    try:
+        result = get_files_provider_config('vertex_ai')
+        
+        assert result is not None, "Should return config when multiple vertex_ai models are present"
+        
+        # Should return config from the first vertex_ai model found
+        assert result['vertex_project'] == 'project-1'
+        assert result['vertex_location'] == 'us-east1'
+        assert result['vertex_credentials'] == '/path/to/creds1.json'
+        
+    finally:
+        # Restore original config
+        if original_config is not None:
+            proxy_config.config = original_config
+        else:
+            delattr(proxy_config, 'config')
+
+
+def test_vertex_ai_files_provider_config_ignores_non_vertex_models():
+    """
+    Test that get_files_provider_config correctly identifies vertex_ai models
+    and ignores other model types when searching for configuration.
+    """
+    from litellm.proxy.proxy_server import proxy_config
+    
+    # Mock the proxy_config with mixed model types
+    mock_config = {
+        'model_list': [
+            {
+                'model_name': 'gpt-3.5-turbo',
+                'litellm_params': {
+                    'model': 'openai/gpt-3.5-turbo',
+                    'api_key': 'test-key'
+                }
+            },
+            {
+                'model_name': 'gemini-2.5-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-2.5-flash',
+                    'vertex_project': 'test-project',
+                    'vertex_location': 'us-central1',
+                    'vertex_credentials': '/path/to/creds.json'
+                }
+            },
+            {
+                'model_name': 'claude-3',
+                'litellm_params': {
+                    'model': 'anthropic/claude-3',
+                    'api_key': 'test-key'
+                }
+            }
+        ]
+    }
+    
+    # Mock proxy_config.config
+    original_config = getattr(proxy_config, 'config', None)
+    proxy_config.config = mock_config
+    
+    try:
+        result = get_files_provider_config('vertex_ai')
+        
+        assert result is not None, "Should find vertex_ai config even with mixed model types"
+        assert result['vertex_project'] == 'test-project'
+        
+    finally:
+        # Restore original config
+        if original_config is not None:
+            proxy_config.config = original_config
+        else:
+            delattr(proxy_config, 'config')
+
+
+def test_vertex_ai_files_provider_config_handles_malformed_model_list():
+    """
+    Test that get_files_provider_config gracefully handles malformed model_list entries
+    without crashing.
+    """
+    from litellm.proxy.proxy_server import proxy_config
+    
+    # Mock the proxy_config with malformed entries
+    mock_config = {
+        'model_list': [
+            # Missing litellm_params
+            {
+                'model_name': 'gemini-2.5-flash'
+            },
+            # Missing model field
+            {
+                'model_name': 'gemini-1.5-flash',
+                'litellm_params': {
+                    'vertex_project': 'test-project'
+                }
+            },
+            # Valid vertex_ai model
+            {
+                'model_name': 'gemini-2.0-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-2.0-flash',
+                    'vertex_project': 'test-project',
+                    'vertex_location': 'us-central1',
+                    'vertex_credentials': '/path/to/creds.json'
+                }
+            }
+        ]
+    }
+    
+    # Mock proxy_config.config
+    original_config = getattr(proxy_config, 'config', None)
+    proxy_config.config = mock_config
+    
+    try:
+        result = get_files_provider_config('vertex_ai')
+        
+        # Should still work and find the valid vertex_ai model
+        assert result is not None, "Should handle malformed entries and find valid vertex_ai model"
+        assert result['vertex_project'] == 'test-project'
+        
+    finally:
+        # Restore original config
+        if original_config is not None:
+            proxy_config.config = original_config
+        else:
+            delattr(proxy_config, 'config')
+
+
+def test_vertex_ai_files_provider_config_old_behavior_regression():
+    """
+    Regression test: Ensure that the old behavior of always returning None
+    for vertex_ai provider is completely eliminated.
+    
+    This test specifically checks that the function no longer has the old
+    hardcoded return None for vertex_ai.
+    """
+    from litellm.proxy.proxy_server import proxy_config
+    
+    # Mock the proxy_config with a minimal but valid Vertex AI configuration
+    mock_config = {
+        'model_list': [
+            {
+                'model_name': 'gemini-2.5-flash',
+                'litellm_params': {
+                    'model': 'vertex_ai/gemini-2.5-flash',
+                    'vertex_project': 'minimal-project'
+                }
+            }
+        ]
+    }
+    
+    # Mock proxy_config.config
+    original_config = getattr(proxy_config, 'config', None)
+    proxy_config.config = mock_config
+    
+    try:
+        result = get_files_provider_config('vertex_ai')
+        
+        # The old behavior would always return None here
+        # The new behavior should return the configuration
+        assert result is not None, (
+            "REGRESSION DETECTED: The old behavior of returning None for vertex_ai "
+            "has returned. This indicates the fix has been reverted."
+        )
+        
+        # Verify we get the expected configuration
+        assert isinstance(result, dict), "Result should be a dictionary"
+        assert 'vertex_project' in result, "Should contain vertex_project"
+        
+    finally:
+        # Restore original config
+        if original_config is not None:
+            proxy_config.config = original_config
+        else:
+            delattr(proxy_config, 'config')


### PR DESCRIPTION
## Title

Fix Vertex AI file upload in proxy server by extracting configuration from model_list

Fixes #12682

## Relevant issues

Fixes issue where Vertex AI file uploads through the proxy server failed with "Could not resolve project_id" error due to `get_files_provider_config` returning `None` for `vertex_ai` provider.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
The `get_files_provider_config` function in `litellm/proxy/openai_files_endpoints/files_endpoints.py` was hardcoded to return `None` for `vertex_ai` provider, causing file uploads to fail with "Could not resolve project_id" error. This happened because the function only looked in `files_config` but Vertex AI configuration was stored in the `model_list` section of `config.yaml`.

### Solution
Modified `get_files_provider_config` to extract Vertex AI configuration from `model_list` when the provider is `vertex_ai`:

```python
if custom_llm_provider == "vertex_ai":
    # For Vertex AI, extract config from model_list instead of files_config
    from litellm.proxy.proxy_server import proxy_config
    if hasattr(proxy_config, 'config') and 'model_list' in proxy_config.config:
        for model in proxy_config.config['model_list']:
            if isinstance(model, dict) and 'litellm_params' in model:
                litellm_params = model['litellm_params']
                if litellm_params.get('model', '').startswith('vertex_ai/'):
                    # Extract vertex_ai specific parameters
                    vertex_config = {}
                    if 'vertex_project' in litellm_params:
                        vertex_config['vertex_project'] = litellm_params['vertex_project']
                    if 'vertex_location' in litellm_params:
                        vertex_config['vertex_location'] = litellm_params['vertex_location']
                    if 'vertex_credentials' in litellm_params:
                        vertex_config['vertex_credentials'] = litellm_params['vertex_credentials']
                    return vertex_config
    return None
```

### Testing
Local Test
<img width="968" height="574" alt="Screenshot 2025-09-11 at 10 28 06 PM" src="https://github.com/user-attachments/assets/3d2d7fca-5683-43e2-98c7-6a4665062454" />

Added comprehensive test coverage:

1. **4 functional tests** in `test_files_endpoint.py`:
   - `test_get_files_provider_config_vertex_ai_with_model_list()` - Verifies fix works
   - `test_get_files_provider_config_vertex_ai_no_model_list()` - Handles missing config
   - `test_get_files_provider_config_vertex_ai_no_vertex_models()` - Handles non-Vertex models
   - `test_get_files_provider_config_vertex_ai_partial_config()` - Handles partial config

2. **5 regression tests** in `test_vertex_ai_files_regression.py`:
   - `test_vertex_ai_files_provider_config_never_returns_none_when_configured()` - **CRITICAL** regression test
   - `test_vertex_ai_files_provider_config_handles_multiple_vertex_models()` - Multiple models
   - `test_vertex_ai_files_provider_config_ignores_non_vertex_models()` - Mixed providers
   - `test_vertex_ai_files_provider_config_handles_malformed_model_list()` - Robustness
   - `test_vertex_ai_files_provider_config_old_behavior_regression()` - Detects old behavior
 

### Impact
- ✅ Fixes Vertex AI file uploads through proxy server
- ✅ Maintains backward compatibility
- ✅ Handles edge cases gracefully
- ✅ Prevents regression with comprehensive test coverage
- ✅ No breaking changes to existing functionality

### Files Modified
- `litellm/proxy/openai_files_endpoints/files_endpoints.py` - Fixed `get_files_provider_config` function
- `tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py` - Added 4 functional tests
- `tests/test_litellm/proxy/openai_files_endpoint/test_vertex_ai_files_regression.py` - Added 5 regression tests