### PR TITLE
Return model id on errors

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3839,9 +3839,12 @@ class Router:
 
         if hasattr(original_exception, "message"):
             # add the available fallbacks to the exception
-            original_exception.message += ". Received Model Group={}\nAvailable Model Group Fallbacks={}".format(  # type: ignore
+            model_id = kwargs.get("model_info", {}).get("id")
+            model_id_str = f"\nReceived Model ID={model_id}" if model_id else ""
+            original_exception.message += ". Received Model Group={}\nAvailable Model Group Fallbacks={}{}".format(  # type: ignore
                 model_group,
                 fallback_model_group,
+                model_id_str,
             )
             if len(fallback_failure_exception_str) > 0:
                 original_exception.message += (  # type: ignore


### PR DESCRIPTION
## Title

Include `model_id` in Router Error Messages for Enhanced Debugging

## Relevant issues

<!-- No specific issue number was provided, but this addresses a common debugging pain point. -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  _Note: An existing test (`test_router_fallbacks_with_model_id`) was identified as covering this change, but no new test was explicitly added during the session._
- [ ] I have added a screenshot of my new test passing locally
  _Note: No new test was added, so no screenshot is available._
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  _Note: `make test-unit` was not run during the session._
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🐛 Bug Fix

## Changes

This PR enhances the error messages generated by the LiteLLM Router's fallback mechanism to include the specific `model_id` when a model group fails.

**Why this change?**
Previously, error messages only displayed the `model_group`, making it difficult to pinpoint the exact failing model in scenarios where a model group contains multiple deployments or specific model IDs. By including the `model_id`, debugging becomes significantly easier, allowing developers to quickly identify and address issues with individual model deployments.

**How it works:**
The `model_id` is extracted from `kwargs.get("model_info", {}).get("id")` within the router's exception handling. If available, it is appended to the error message. This change is backward compatible; if no `model_id` is present, the error message format remains unchanged.

**Example Error Message Enhancement:**

**Before:**
```
Received Model Group=gpt-3.5-turbo
Available Model Group Fallbacks=None
```

**After:**
```
Received Model Group=gpt-3.5-turbo
Available Model Group Fallbacks=None
Received Model ID=model-id-12345
```

---
[Slack Thread](https://berriaillm.slack.com/archives/C07Q2CUDA57/p1757628607492499?thread_ts=1757628607.492499&cid=C07Q2CUDA57)

<a href="https://cursor.com/background-agent?bcId=bc-1368e8d0-9cb8-4480-aba7-6ac877fe316a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1368e8d0-9cb8-4480-aba7-6ac877fe316a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

