### PR TITLE
Update gpt_5_transformation.py

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -20,7 +20,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         Accepts both explicit gpt-5 model names and the ``gpt5_series/`` prefix
         used for manual routing.
         """
-        return "gpt-5" in model or "gpt5_series" in model
+        return "gpt-5" in model or "gpt5_series" in model or "GPT5" in model
 
     def get_supported_openai_params(self, model: str) -> List[str]:
         return OpenAIGPT5Config.get_supported_openai_params(self, model=model)


### PR DESCRIPTION
Azure uses "GPT5"  for the model name on my instance. Current `main` branch of litellm looks for `gpt-5` in model name and errors otherwise. 

I need some help around testing. I'm not sure how to test this beside just trying it to see if it works [it did]. But this is a blocker for me so I wanted to start the conversation ...


## Title

Azure uses GPT5 as model name internally. 

## Relevant issues

This fixes #14456

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
<img width="801" height="629" alt="Screenshot 2025-09-11 at 9 32 58 PM" src="https://github.com/user-attachments/assets/8ef92482-4491-4dbc-ae3f-3f8c3450582c" />
- [] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
    tests unrelated to my change are failing, sorry
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🐛 Bug Fix

## Changes

I added 
```python
or "GPT5" in model
```
to the gpt-5 model checker
