### PR TITLE
[Bug]: Azure OpenAI & AI Foundry Reject Image Generation Payload Due to extra_body Injection in LiteLLM v1.76.3

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2501,6 +2501,23 @@ def get_optional_params_transcription(
     return optional_params
 
 
+def _map_openai_size_to_vertex_ai_aspect_ratio(size: Optional[str]) -> str:
+    """Map OpenAI size parameter to Vertex AI aspectRatio."""
+    if size is None:
+        return "1:1"
+    
+    # Map OpenAI size strings to Vertex AI aspect ratio strings
+    # Vertex AI accepts: "1:1", "9:16", "16:9", "4:3", "3:4"
+    size_to_aspect_ratio = {
+        "256x256": "1:1",  # Square
+        "512x512": "1:1",  # Square
+        "1024x1024": "1:1",  # Square (default)
+        "1792x1024": "16:9",  # Landscape
+        "1024x1792": "9:16",  # Portrait
+    }
+    return size_to_aspect_ratio.get(size, "1:1")  # Default to square if size not recognized
+
+
 def get_optional_params_image_gen(
     model: Optional[str] = None,
     n: Optional[int] = None,
@@ -2614,19 +2631,7 @@ def get_optional_params_image_gen(
 
         # Map OpenAI size parameter to Vertex AI aspectRatio
         if size is not None:
-            # Map OpenAI size strings to Vertex AI aspect ratio strings
-            # Vertex AI accepts: "1:1", "9:16", "16:9", "4:3", "3:4"
-            size_to_aspect_ratio = {
-                "256x256": "1:1",  # Square
-                "512x512": "1:1",  # Square
-                "1024x1024": "1:1",  # Square (default)
-                "1792x1024": "16:9",  # Landscape
-                "1024x1792": "9:16",  # Portrait
-            }
-            aspect_ratio = size_to_aspect_ratio.get(
-                size, "1:1"
-            )  # Default to square if size not recognized
-            optional_params["aspectRatio"] = aspect_ratio
+            optional_params["aspectRatio"] = _map_openai_size_to_vertex_ai_aspect_ratio(size)
 
     openai_params: list[str] = list(default_params.keys())
     if provider_config is not None:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2642,6 +2642,12 @@ def get_optional_params_image_gen(
         openai_params=openai_params,
         additional_drop_params=additional_drop_params,
     )
+    # remove keys with None or empty dict/list values to avoid sending empty payloads
+    optional_params = {
+        k: v
+        for k, v in optional_params.items()
+        if v is not None and (not isinstance(v, (dict, list)) or len(v) > 0)
+    }
     return optional_params
 
 

--- a/tests/image_gen_tests/request_payloads/azure_gpt_image_1.json
+++ b/tests/image_gen_tests/request_payloads/azure_gpt_image_1.json
@@ -1,0 +1,4 @@
+{
+  "model": "gpt-image-1",
+  "prompt": "test prompt"
+}

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -84,6 +84,15 @@ def test_get_optional_params_image_gen_vertex_ai_size():
     assert optional_params["sampleCount"] == 1
 
 
+def test_get_optional_params_image_gen_filters_empty_values():
+    optional_params = get_optional_params_image_gen(
+        model="gpt-image-1",
+        custom_llm_provider="openai",
+        extra_body={},
+    )
+    assert optional_params == {}
+
+
 def test_all_model_configs():
     from litellm.llms.vertex_ai.vertex_ai_partner_models.ai21.transformation import (
         VertexAIAi21Config,


### PR DESCRIPTION
## [Bug]: Azure OpenAI & AI Foundry Reject Image Generation Payload Due to extra_body Injection in LiteLLM v1.76.3

Fixes https://github.com/BerriAI/litellm/issues/14443
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


