### PR TITLE
fix: datadog tool calls returned in metadata

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -253,6 +253,7 @@ class DataDogLogger(
         status: DataDogStatus,
     ) -> DatadogPayload:
         from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
         json_payload = safe_dumps(standard_logging_object)
         verbose_logger.debug("Datadog: Logger - Logging payload = %s", json_payload)
         dd_payload = DatadogPayload(
@@ -319,6 +320,7 @@ class DataDogLogger(
         import gzip
 
         from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
         compressed_data = gzip.compress(safe_dumps(data).encode("utf-8"))
         response = await self.async_client.post(
             url=self.intake_url,
@@ -349,6 +351,7 @@ class DataDogLogger(
             _payload_dict = payload.model_dump()
             _payload_dict.update(event_metadata or {})
             from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
             _dd_message_str = safe_dumps(_payload_dict)
             _dd_payload = DatadogPayload(
                 ddsource=self._get_datadog_source(),
@@ -390,6 +393,7 @@ class DataDogLogger(
             _payload_dict.update(event_metadata or {})
 
             from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
             _dd_message_str = safe_dumps(_payload_dict)
             _dd_payload = DatadogPayload(
                 ddsource=self._get_datadog_source(),
@@ -477,6 +481,7 @@ class DataDogLogger(
         }
 
         from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
         json_payload = safe_dumps(payload)
 
         verbose_logger.debug("Datadog: Logger - Logging payload = %s", json_payload)

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -183,7 +183,6 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
 
         messages = standard_logging_payload["messages"]
         messages = self._ensure_string_content(messages=messages)
-        response_obj = standard_logging_payload.get("response")
 
         metadata = kwargs.get("litellm_params", {}).get("metadata", {})
 

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -63,7 +63,7 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             asyncio.create_task(self.periodic_flush())
             self.flush_lock = asyncio.Lock()
             self.log_queue: List[LLMObsPayload] = []
-            
+
             #########################################################
             # Handle datadog_llm_observability_params set as litellm.datadog_llm_observability_params
             #########################################################
@@ -82,22 +82,25 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         """
         dict_datadog_llm_obs_params: Dict = {}
         if litellm.datadog_llm_observability_params is not None:
-            if isinstance(litellm.datadog_llm_observability_params, DatadogLLMObsInitParams):
-                dict_datadog_llm_obs_params = litellm.datadog_llm_observability_params.model_dump()
+            if isinstance(
+                litellm.datadog_llm_observability_params, DatadogLLMObsInitParams
+            ):
+                dict_datadog_llm_obs_params = (
+                    litellm.datadog_llm_observability_params.model_dump()
+                )
             elif isinstance(litellm.datadog_llm_observability_params, Dict):
                 # only allow params that are of DatadogLLMObsInitParams
-                dict_datadog_llm_obs_params = DatadogLLMObsInitParams(**litellm.datadog_llm_observability_params).model_dump()
+                dict_datadog_llm_obs_params = DatadogLLMObsInitParams(
+                    **litellm.datadog_llm_observability_params
+                ).model_dump()
         return dict_datadog_llm_obs_params
-            
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
             verbose_logger.debug(
                 f"DataDogLLMObs: Logging success event for model {kwargs.get('model', 'unknown')}"
             )
-            payload = self.create_llm_obs_payload(
-                kwargs, start_time, end_time
-            )
+            payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
             verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
             self.log_queue.append(payload)
 
@@ -107,15 +110,13 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             verbose_logger.exception(
                 f"DataDogLLMObs: Error logging success event - {str(e)}"
             )
-    
+
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
             verbose_logger.debug(
                 f"DataDogLLMObs: Logging failure event for model {kwargs.get('model', 'unknown')}"
             )
-            payload = self.create_llm_obs_payload(
-                kwargs, start_time, end_time
-            )
+            payload = self.create_llm_obs_payload(kwargs, start_time, end_time)
             verbose_logger.debug(f"DataDogLLMObs: Payload: {payload}")
             self.log_queue.append(payload)
 
@@ -192,7 +193,7 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         output_meta = OutputMeta(
             messages=self._get_response_messages(
                 standard_logging_payload=standard_logging_payload,
-                call_type=standard_logging_payload.get("call_type")
+                call_type=standard_logging_payload.get("call_type"),
             )
         )
 
@@ -212,7 +213,9 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             output_tokens=float(standard_logging_payload.get("completion_tokens", 0)),
             total_tokens=float(standard_logging_payload.get("total_tokens", 0)),
             total_cost=float(standard_logging_payload.get("response_cost", 0)),
-            time_to_first_token=self._get_time_to_first_token_seconds(standard_logging_payload),
+            time_to_first_token=self._get_time_to_first_token_seconds(
+                standard_logging_payload
+            ),
         )
 
         return LLMObsPayload(
@@ -229,27 +232,35 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 self._get_datadog_tags(standard_logging_object=standard_logging_payload)
             ],
         )
-    
-    def _assemble_error_info(self, standard_logging_payload: StandardLoggingPayload) -> Optional[DDLLMObsError]:
+
+    def _assemble_error_info(
+        self, standard_logging_payload: StandardLoggingPayload
+    ) -> Optional[DDLLMObsError]:
         """
         Assemble error information for failure cases according to DD LLM Obs API spec
         """
         # Handle error information for failure cases according to DD LLM Obs API spec
         error_info: Optional[DDLLMObsError] = None
-        
+
         if standard_logging_payload.get("status") == "failure":
             # Try to get structured error information first
-            error_information: Optional[StandardLoggingPayloadErrorInformation] = standard_logging_payload.get("error_information")
-            
+            error_information: Optional[
+                StandardLoggingPayloadErrorInformation
+            ] = standard_logging_payload.get("error_information")
+
             if error_information:
                 error_info = DDLLMObsError(
-                    message=error_information.get("error_message") or standard_logging_payload.get("error_str") or "Unknown error",
+                    message=error_information.get("error_message")
+                    or standard_logging_payload.get("error_str")
+                    or "Unknown error",
                     type=error_information.get("error_class"),
-                    stack=error_information.get("traceback")
+                    stack=error_information.get("traceback"),
                 )
         return error_info
 
-    def _get_time_to_first_token_seconds(self, standard_logging_payload: StandardLoggingPayload) -> float:
+    def _get_time_to_first_token_seconds(
+        self, standard_logging_payload: StandardLoggingPayload
+    ) -> float:
         """
         Get the time to first token in seconds
 
@@ -258,7 +269,9 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         For non streaming calls, CompletionStartTime is time we get the response back
         """
         start_time: Optional[float] = standard_logging_payload.get("startTime")
-        completion_start_time: Optional[float] = standard_logging_payload.get("completionStartTime")
+        completion_start_time: Optional[float] = standard_logging_payload.get(
+            "completionStartTime"
+        )
         end_time: Optional[float] = standard_logging_payload.get("endTime")
 
         if completion_start_time is not None and start_time is not None:
@@ -268,24 +281,24 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         else:
             return 0.0
 
-
     def _get_response_messages(
         self, standard_logging_payload: StandardLoggingPayload, call_type: Optional[str]
     ) -> List[Any]:
         """
         Get the messages from the response object
-        
+
         This now preserves tool_calls in response messages for Datadog observability.
         """
         response_obj = standard_logging_payload.get("response")
-        
+
         if response_obj is None:
             return []
-        
+
         # Handle case where response_obj is a string representation of a dict
         if isinstance(response_obj, str):
             try:
                 import ast
+
                 # Try to safely evaluate the string as a Python literal
                 response_obj = ast.literal_eval(response_obj)
             except (ValueError, SyntaxError):
@@ -294,18 +307,18 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                     response_obj = json.loads(str(response_obj))
                 except json.JSONDecodeError:
                     return []
-        
+
         # Handle all LLM completion call types, not just completion and acompletion
         if call_type in [
-            CallTypes.completion.value, 
+            CallTypes.completion.value,
             CallTypes.acompletion.value,
-            CallTypes.text_completion.value, 
+            CallTypes.text_completion.value,
             CallTypes.atext_completion.value,
-            CallTypes.generate_content.value, 
+            CallTypes.generate_content.value,
             CallTypes.agenerate_content.value,
-            CallTypes.generate_content_stream.value, 
+            CallTypes.generate_content_stream.value,
             CallTypes.agenerate_content_stream.value,
-            CallTypes.anthropic_messages.value
+            CallTypes.anthropic_messages.value,
         ]:
             try:
                 # Safely extract message from response_obj, handle failure cases
@@ -321,102 +334,104 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 return []
         return []
 
-    def _get_datadog_span_kind(self, call_type: Optional[str]) -> Literal["llm", "tool", "task", "embedding", "retrieval"]:
+    def _get_datadog_span_kind(
+        self, call_type: Optional[str]
+    ) -> Literal["llm", "tool", "task", "embedding", "retrieval"]:
         """
         Map liteLLM call_type to appropriate DataDog LLM Observability span kind.
-        
+
         Available DataDog span kinds: "llm", "tool", "task", "embedding", "retrieval"
         """
         if call_type is None:
             return "llm"
-        
+
         # Embedding operations
         if call_type in [CallTypes.embedding.value, CallTypes.aembedding.value]:
             return "embedding"
-        
-        # LLM completion operations  
+
+        # LLM completion operations
         if call_type in [
-            CallTypes.completion.value, 
+            CallTypes.completion.value,
             CallTypes.acompletion.value,
-            CallTypes.text_completion.value, 
+            CallTypes.text_completion.value,
             CallTypes.atext_completion.value,
-            CallTypes.generate_content.value, 
+            CallTypes.generate_content.value,
             CallTypes.agenerate_content.value,
-            CallTypes.generate_content_stream.value, 
+            CallTypes.generate_content_stream.value,
             CallTypes.agenerate_content_stream.value,
-            CallTypes.anthropic_messages.value
+            CallTypes.anthropic_messages.value,
         ]:
             return "llm"
-        
+
         # Tool operations
         if call_type in [CallTypes.call_mcp_tool.value]:
             return "tool"
-            
+
         # Retrieval operations
         if call_type in [
-            CallTypes.get_assistants.value, 
+            CallTypes.get_assistants.value,
             CallTypes.aget_assistants.value,
-            CallTypes.get_thread.value, 
+            CallTypes.get_thread.value,
             CallTypes.aget_thread.value,
-            CallTypes.get_messages.value, 
+            CallTypes.get_messages.value,
             CallTypes.aget_messages.value,
-            CallTypes.afile_retrieve.value, 
+            CallTypes.afile_retrieve.value,
             CallTypes.file_retrieve.value,
-            CallTypes.afile_list.value, 
+            CallTypes.afile_list.value,
             CallTypes.file_list.value,
-            CallTypes.afile_content.value, 
+            CallTypes.afile_content.value,
             CallTypes.file_content.value,
-            CallTypes.retrieve_batch.value, 
+            CallTypes.retrieve_batch.value,
             CallTypes.aretrieve_batch.value,
-            CallTypes.retrieve_fine_tuning_job.value, 
+            CallTypes.retrieve_fine_tuning_job.value,
             CallTypes.aretrieve_fine_tuning_job.value,
-            CallTypes.responses.value, 
+            CallTypes.responses.value,
             CallTypes.aresponses.value,
-            CallTypes.alist_input_items.value
+            CallTypes.alist_input_items.value,
         ]:
             return "retrieval"
-            
+
         # Task operations (batch, fine-tuning, file operations, etc.)
         if call_type in [
-            CallTypes.create_batch.value, 
+            CallTypes.create_batch.value,
             CallTypes.acreate_batch.value,
-            CallTypes.create_fine_tuning_job.value, 
+            CallTypes.create_fine_tuning_job.value,
             CallTypes.acreate_fine_tuning_job.value,
-            CallTypes.cancel_fine_tuning_job.value, 
+            CallTypes.cancel_fine_tuning_job.value,
             CallTypes.acancel_fine_tuning_job.value,
-            CallTypes.list_fine_tuning_jobs.value, 
+            CallTypes.list_fine_tuning_jobs.value,
             CallTypes.alist_fine_tuning_jobs.value,
-            CallTypes.create_assistants.value, 
+            CallTypes.create_assistants.value,
             CallTypes.acreate_assistants.value,
-            CallTypes.delete_assistant.value, 
+            CallTypes.delete_assistant.value,
             CallTypes.adelete_assistant.value,
-            CallTypes.create_thread.value, 
+            CallTypes.create_thread.value,
             CallTypes.acreate_thread.value,
-            CallTypes.add_message.value, 
+            CallTypes.add_message.value,
             CallTypes.a_add_message.value,
-            CallTypes.run_thread.value, 
+            CallTypes.run_thread.value,
             CallTypes.arun_thread.value,
-            CallTypes.run_thread_stream.value, 
+            CallTypes.run_thread_stream.value,
             CallTypes.arun_thread_stream.value,
-            CallTypes.file_delete.value, 
+            CallTypes.file_delete.value,
             CallTypes.afile_delete.value,
-            CallTypes.create_file.value, 
+            CallTypes.create_file.value,
             CallTypes.acreate_file.value,
-            CallTypes.image_generation.value, 
+            CallTypes.image_generation.value,
             CallTypes.aimage_generation.value,
-            CallTypes.image_edit.value, 
+            CallTypes.image_edit.value,
             CallTypes.aimage_edit.value,
-            CallTypes.moderation.value, 
+            CallTypes.moderation.value,
             CallTypes.amoderation.value,
-            CallTypes.transcription.value, 
+            CallTypes.transcription.value,
             CallTypes.atranscription.value,
-            CallTypes.speech.value, 
+            CallTypes.speech.value,
             CallTypes.aspeech.value,
-            CallTypes.rerank.value, 
-            CallTypes.arerank.value
+            CallTypes.rerank.value,
+            CallTypes.arerank.value,
         ]:
             return "task"
-            
+
         # Default fallback for unknown or passthrough operations
         return "llm"
 
@@ -449,7 +464,9 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             "cache_hit": standard_logging_payload.get("cache_hit", "unknown"),
             "cache_key": standard_logging_payload.get("cache_key", "unknown"),
             "saved_cache_cost": standard_logging_payload.get("saved_cache_cost", 0),
-            "guardrail_information": standard_logging_payload.get("guardrail_information", None),
+            "guardrail_information": standard_logging_payload.get(
+                "guardrail_information", None
+            ),
         }
 
         #########################################################
@@ -470,16 +487,22 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         _metadata.update(_standard_logging_metadata)
         return _metadata
 
-    def _get_latency_metrics(self, standard_logging_payload: StandardLoggingPayload) -> DDLLMObsLatencyMetrics:
+    def _get_latency_metrics(
+        self, standard_logging_payload: StandardLoggingPayload
+    ) -> DDLLMObsLatencyMetrics:
         """
         Get the latency metrics from the standard logging payload
         """
         latency_metrics: DDLLMObsLatencyMetrics = DDLLMObsLatencyMetrics()
         # Add latency metrics to metadata
         # Time to first token (convert from seconds to milliseconds for consistency)
-        time_to_first_token_seconds = self._get_time_to_first_token_seconds(standard_logging_payload)
+        time_to_first_token_seconds = self._get_time_to_first_token_seconds(
+            standard_logging_payload
+        )
         if time_to_first_token_seconds > 0:
-            latency_metrics["time_to_first_token_ms"] = time_to_first_token_seconds * 1000
+            latency_metrics["time_to_first_token_ms"] = (
+                time_to_first_token_seconds * 1000
+            )
 
         # LiteLLM overhead time
         hidden_params = standard_logging_payload.get("hidden_params", {})
@@ -488,19 +511,27 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             latency_metrics["litellm_overhead_time_ms"] = litellm_overhead_ms
 
         # Guardrail overhead latency
-        guardrail_info: Optional[StandardLoggingGuardrailInformation] = standard_logging_payload.get("guardrail_information")
+        guardrail_info: Optional[
+            StandardLoggingGuardrailInformation
+        ] = standard_logging_payload.get("guardrail_information")
         if guardrail_info is not None:
-            _guardrail_duration_seconds: Optional[float] = guardrail_info.get("duration")
+            _guardrail_duration_seconds: Optional[float] = guardrail_info.get(
+                "duration"
+            )
             if _guardrail_duration_seconds is not None:
                 # Convert from seconds to milliseconds for consistency
-                latency_metrics["guardrail_overhead_time_ms"] = _guardrail_duration_seconds * 1000
-            
+                latency_metrics["guardrail_overhead_time_ms"] = (
+                    _guardrail_duration_seconds * 1000
+                )
+
         return latency_metrics
 
-    def _process_input_messages_preserving_tool_calls(self, messages: List[Any]) -> List[Dict[str, Any]]:
+    def _process_input_messages_preserving_tool_calls(
+        self, messages: List[Any]
+    ) -> List[Dict[str, Any]]:
         """
         Process input messages while preserving tool_calls and tool message types.
-        
+
         This bypasses the lossy string conversion when tool calls are present,
         allowing complex nested tool_calls objects to be preserved for Datadog.
         """
@@ -512,11 +543,19 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                     processed.append(msg)
                 else:
                     # For regular messages, still apply string conversion
-                    converted = handle_any_messages_to_chat_completion_str_messages_conversion([msg])
+                    converted = (
+                        handle_any_messages_to_chat_completion_str_messages_conversion(
+                            [msg]
+                        )
+                    )
                     processed.extend(converted)
             else:
                 # For non-dict messages, apply string conversion
-                converted = handle_any_messages_to_chat_completion_str_messages_conversion([msg])
+                converted = (
+                    handle_any_messages_to_chat_completion_str_messages_conversion(
+                        [msg]
+                    )
+                )
                 processed.extend(converted)
         return processed
 
@@ -524,7 +563,7 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
     def _tool_calls_kv_pair(tool_calls: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Extract tool call information into key-value pairs for Datadog metadata.
-        
+
         Similar to OpenTelemetry's implementation but adapted for Datadog's format.
         """
         kv_pairs: Dict[str, Any] = {}
@@ -536,7 +575,7 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                     kv_pairs[f"tool_calls.{idx}.id"] = tool_id
 
                 # Extract tool call type
-                tool_type = tool_call.get("type") 
+                tool_type = tool_call.get("type")
                 if tool_type:
                     kv_pairs[f"tool_calls.{idx}.type"] = tool_type
 
@@ -551,17 +590,26 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                     if function_arguments:
                         # Store arguments as JSON string for Datadog
                         if isinstance(function_arguments, str):
-                            kv_pairs[f"tool_calls.{idx}.function.arguments"] = function_arguments
+                            kv_pairs[
+                                f"tool_calls.{idx}.function.arguments"
+                            ] = function_arguments
                         else:
                             import json
-                            kv_pairs[f"tool_calls.{idx}.function.arguments"] = json.dumps(function_arguments)
+
+                            kv_pairs[
+                                f"tool_calls.{idx}.function.arguments"
+                            ] = json.dumps(function_arguments)
             except (KeyError, TypeError, ValueError) as e:
-                verbose_logger.debug(f"DataDogLLMObs: Error processing tool call {idx}: {str(e)}")
+                verbose_logger.debug(
+                    f"DataDogLLMObs: Error processing tool call {idx}: {str(e)}"
+                )
                 continue
-                
+
         return kv_pairs
 
-    def _extract_tool_call_metadata(self, standard_logging_payload: StandardLoggingPayload) -> Dict[str, Any]:
+    def _extract_tool_call_metadata(
+        self, standard_logging_payload: StandardLoggingPayload
+    ) -> Dict[str, Any]:
         """
         Extract tool call information from both input messages and response for Datadog metadata.
         """
@@ -590,12 +638,16 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                         if message and isinstance(message, dict):
                             tool_calls = message.get("tool_calls")
                             if tool_calls:
-                                response_tool_calls_kv = self._tool_calls_kv_pair(tool_calls)
-                                # Prefix with "output_" to distinguish from input tool calls  
+                                response_tool_calls_kv = self._tool_calls_kv_pair(
+                                    tool_calls
+                                )
+                                # Prefix with "output_" to distinguish from input tool calls
                                 for key, value in response_tool_calls_kv.items():
                                     tool_call_metadata[f"output_{key}"] = value
 
         except Exception as e:
-            verbose_logger.debug(f"DataDogLLMObs: Error extracting tool call metadata: {str(e)}")
+            verbose_logger.debug(
+                f"DataDogLLMObs: Error extracting tool call metadata: {str(e)}"
+            )
 
         return tool_call_metadata

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -189,10 +189,12 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         input_meta = InputMeta(
             messages=self._process_input_messages_preserving_tool_calls(messages)
         )
-        output_meta = OutputMeta(messages=self._get_response_messages(
-            standard_logging_payload=standard_logging_payload,
-            call_type=standard_logging_payload.get("call_type")
-        ))
+        output_meta = OutputMeta(
+            messages=self._get_response_messages(
+                standard_logging_payload=standard_logging_payload,
+                call_type=standard_logging_payload.get("call_type")
+            )
+        )
 
         error_info = self._assemble_error_info(standard_logging_payload)
 
@@ -288,8 +290,8 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 response_obj = ast.literal_eval(response_obj)
             except (ValueError, SyntaxError):
                 try:
-                    # Fallback to JSON parsing
-                    response_obj = json.loads(response_obj)
+                    # Fallback to JSON parsing - cast to ensure type safety
+                    response_obj = json.loads(str(response_obj))
                 except json.JSONDecodeError:
                     return []
         

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -262,7 +262,6 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         """
         # Handle error information for failure cases according to DD LLM Obs API spec
         error_info: Optional[DDLLMObsError] = None
-
         if standard_logging_payload.get("status") == "failure":
             # Try to get structured error information first
             error_information: Optional[

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -19,6 +19,7 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_any_messages_to_chat_completion_str_messages_conversion,
 )
@@ -218,7 +219,7 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
             ),
         )
 
-        return LLMObsPayload(
+        payload: LLMObsPayload = LLMObsPayload(
             parent_id=metadata.get("parent_id", "undefined"),
             trace_id=standard_logging_payload.get("trace_id", str(uuid.uuid4())),
             span_id=metadata.get("span_id", str(uuid.uuid4())),
@@ -232,6 +233,26 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 self._get_datadog_tags(standard_logging_object=standard_logging_payload)
             ],
         )
+
+        apm_trace_id = self._get_apm_trace_id()
+        if apm_trace_id is not None:
+            payload["apm_id"] = apm_trace_id
+
+        return payload
+
+    def _get_apm_trace_id(self) -> Optional[str]:
+        """Retrieve the current APM trace ID if available."""
+        try:
+            current_span_fn = getattr(tracer, "current_span", None)
+            if callable(current_span_fn):
+                current_span = current_span_fn()
+                if current_span is not None:
+                    trace_id = getattr(current_span, "trace_id", None)
+                    if trace_id is not None:
+                        return str(trace_id)
+        except Exception:
+            pass
+        return None
 
     def _assemble_error_info(
         self, standard_logging_payload: StandardLoggingPayload

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -46,6 +46,7 @@ class LLMMetrics(TypedDict, total=False):
 class LLMObsPayload(TypedDict, total=False):
     parent_id: str
     trace_id: str
+    apm_id: str
     span_id: str
     name: str
     meta: Meta
@@ -53,7 +54,7 @@ class LLMObsPayload(TypedDict, total=False):
     duration: int
     metrics: LLMMetrics
     tags: List
-    status: Literal["ok", "error"] # Error status ("ok" or "error"). Defaults to "ok".
+    status: Literal["ok", "error"]  # Error status ("ok" or "error"). Defaults to "ok".
 
 
 class DDSpanAttributes(TypedDict):

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -10,8 +10,8 @@ from litellm.types.integrations.custom_logger import StandardCustomLoggerInitPar
 
 class InputMeta(TypedDict):
     messages: List[
-        Dict[str, str]
-    ]  # Relevant Issue: https://github.com/BerriAI/litellm/issues/9494
+        Dict[str, Any]
+    ]  # Updated to support complex messages with tool_calls - Issue: https://github.com/BerriAI/litellm/issues/9494
 
 
 class OutputMeta(TypedDict):

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -191,6 +191,32 @@ class TestDataDogLLMObsLogger:
             assert metadata["cache_hit"] is True
             assert metadata["cache_key"] == "test-cache-key-789"
 
+    def test_apm_id_included(self, mock_env_vars, mock_response_obj):
+        """Test that the current APM trace ID is attached to the payload"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            fake_tracer = MagicMock()
+            fake_span = MagicMock()
+            fake_span.trace_id = 987654321
+            fake_tracer.current_span.return_value = fake_span
+
+            with patch('litellm.integrations.datadog.datadog_llm_obs.tracer', fake_tracer):
+                logger = DataDogLLMObsLogger()
+
+                standard_payload = create_standard_logging_payload_with_cache()
+
+                kwargs = {
+                    "standard_logging_object": standard_payload,
+                    "litellm_params": {"metadata": {}}
+                }
+
+                start_time = datetime.now()
+                end_time = datetime.now()
+
+                payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+                assert payload["apm_id"] == str(fake_span.trace_id)
+
     def test_cache_metadata_fields(self, mock_env_vars, mock_response_obj):
         """Test that cache-related metadata fields are correctly tracked"""
         with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -612,3 +612,239 @@ def test_guardrail_information_in_metadata(mock_env_vars):
         assert guardrail_info["guardrail_response"]["output"] == "filtered output"
         assert guardrail_info["guardrail_response"]["flagged"] == False
         assert guardrail_info["guardrail_response"]["score"] == 0.1
+
+
+def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
+    """Create a StandardLoggingPayload object with tool calls for testing"""
+    return {
+        "id": "test-request-id-tool-calls",
+        "call_type": "completion",
+        "response_cost": 0.05,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "total_tokens": 50,
+        "prompt_tokens": 20,
+        "completion_tokens": 30,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "model_map_information": {
+            "model_map_key": "gpt-4",
+            "model_map_value": None
+        },
+        "model": "gpt-4",
+        "model_id": "model-123",
+        "model_group": "openai-gpt",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "test_hash",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": "test_alias",
+            "user_api_key_team_id": "test_team",
+            "user_api_key_user_id": "test_user",
+            "user_api_key_team_alias": "test_team_alias",
+            "user_api_key_user_email": None,
+            "user_api_key_end_user_id": None,
+            "user_api_key_request_route": None,
+            "spend_logs_metadata": None,
+            "requester_ip_address": "127.0.0.1",
+            "requester_metadata": None,
+            "requester_custom_headers": None,
+            "prompt_management_metadata": None,
+            "mcp_tool_call_metadata": None,
+            "vector_store_request_metadata": None,
+            "applied_guardrails": None,
+            "usage_object": None,
+            "cold_storage_object_key": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": "127.0.0.1",
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "I'll check the weather for you.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "NYC"}'
+                        }
+                    }
+                ]
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": '{"temperature": 72, "condition": "sunny"}'
+            }
+        ],
+        "response": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "It's 72°F and sunny in NYC!",
+                        "tool_calls": [
+                            {
+                                "id": "call_456",
+                                "type": "function",
+                                "function": {
+                                    "name": "format_response",
+                                    "arguments": '{"temp": 72, "condition": "sunny"}'
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "error_str": None,
+        "model_parameters": {"temperature": 0.7},
+        "hidden_params": {
+            "model_id": "model-123",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.05",
+            "litellm_overhead_time_ms": None,
+            "additional_headers": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "stream": None,
+        "response_time": 1.0,
+        "error_information": None,
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+        "trace_id": "test-trace-id-tool-calls",
+        "custom_llm_provider": "openai",
+    }
+
+class TestDataDogLLMObsLoggerToolCalls:
+    """Simple test suite for DataDog LLM Observability Logger tool call handling"""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        """Mock environment variables for DataDog"""
+        with patch.dict(os.environ, {
+            "DD_API_KEY": "test_api_key",
+            "DD_SITE": "us5.datadoghq.com"
+        }):
+            yield
+
+    def test_tool_call_span_kind_mapping(self, mock_env_vars):
+        """Test that tool call operations are correctly mapped to 'tool' span kind"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+
+            # Test MCP tool call mapping
+            from litellm.types.utils import CallTypes
+            assert logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value) == "tool"
+
+    def test_tool_call_payload_creation(self, mock_env_vars):
+        """Test that tool call payloads are created correctly"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}}
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            # Verify basic payload structure
+            assert payload.get("name") == "litellm_llm_call"
+            assert payload.get("status") == "ok"
+            assert payload.get("meta", {}).get("kind") == "llm"  # Regular completion, not tool call
+
+            # Verify metrics
+            metrics = payload.get("metrics", {})
+            assert metrics.get("input_tokens") == 20
+            assert metrics.get("output_tokens") == 30
+            assert metrics.get("total_tokens") == 50
+
+    def test_tool_call_messages_preserved(self, mock_env_vars):
+        """Test that tool call messages are preserved in the payload"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}}
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            # Verify input messages include tool calls
+            meta = payload.get("meta", {})
+            input_meta = meta.get("input", {})
+            input_messages = input_meta.get("messages", [])
+            assert len(input_messages) == 3
+
+            # Check assistant message has tool calls
+            assistant_msg = input_messages[1]
+            assert assistant_msg.get("role") == "assistant"
+            assert "tool_calls" in assistant_msg
+            tool_calls = assistant_msg.get("tool_calls", [])
+            assert len(tool_calls) == 1
+            tool_call = tool_calls[0]
+            function_info = tool_call.get("function", {})
+            assert function_info.get("name") == "get_weather"
+
+            # Check tool message
+            tool_msg = input_messages[2]
+            assert tool_msg.get("role") == "tool"
+            assert tool_msg.get("tool_call_id") == "call_123"
+
+    def test_tool_call_response_handling(self, mock_env_vars):
+        """Test that tool calls in response are handled correctly"""
+        with patch('litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client'), \
+             patch('asyncio.create_task'):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}}
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            # Verify output messages include tool calls
+            meta = payload.get("meta", {})
+            output_meta = meta.get("output", {})
+            output_messages = output_meta.get("messages", [])
+            assert len(output_messages) == 1
+
+            output_msg = output_messages[0]
+            assert output_msg.get("role") == "assistant"
+            assert "tool_calls" in output_msg
+            output_tool_calls = output_msg.get("tool_calls", [])
+            assert len(output_tool_calls) == 1
+            output_function_info = output_tool_calls[0].get("function", {})
+            assert output_function_info.get("name") == "format_response"

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -3,7 +3,7 @@ import os
 import sys
 from datetime import datetime, timedelta
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -1,11 +1,9 @@
 import asyncio
-import json
 import os
 import sys
-import uuid
 from datetime import datetime, timedelta
-from typing import Dict, Optional
-from unittest.mock import MagicMock, Mock, patch
+from typing import Optional
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -16,8 +14,6 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 from litellm.types.integrations.datadog_llm_obs import (
     DatadogLLMObsInitParams,
-    LLMMetrics,
-    LLMObsPayload,
 )
 from litellm.types.utils import (
     StandardLoggingGuardrailInformation,
@@ -192,7 +188,7 @@ class TestDataDogLLMObsLogger:
             # Test 3: Verify saved_cache_cost is in metadata 
             metadata = payload["meta"]["metadata"]
             assert metadata["saved_cache_cost"] == 0.02
-            assert metadata["cache_hit"] == True
+            assert metadata["cache_hit"] is True
             assert metadata["cache_key"] == "test-cache-key-789"
 
     def test_cache_metadata_fields(self, mock_env_vars, mock_response_obj):
@@ -203,21 +199,11 @@ class TestDataDogLLMObsLogger:
             
             standard_payload = create_standard_logging_payload_with_cache()
             
-            kwargs = {
-                "standard_logging_object": standard_payload,
-                "litellm_params": {"metadata": {}}
-            }
-            
-            start_time = datetime.now()
-            end_time = datetime.now()
-            
-            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
-            
             # Test the _get_dd_llm_obs_payload_metadata method directly
             metadata = logger._get_dd_llm_obs_payload_metadata(standard_payload)
             
             # Verify all cache-related fields are present
-            assert metadata["cache_hit"] == True
+            assert metadata["cache_hit"] is True
             assert metadata["cache_key"] == "test-cache-key-789"
             assert metadata["saved_cache_cost"] == 0.02
             assert metadata["id"] == "test-request-id-456"
@@ -381,9 +367,6 @@ async def test_dd_llms_obs_redaction(mock_env_vars):
     assert dd_llms_obs_logger.logged_standard_logging_payload is not None
     assert test_s3_logger.logged_standard_logging_payload is not None
 
-    print("logged DD LLM Obs payload", json.dumps(dd_llms_obs_logger.logged_standard_logging_payload, indent=4, default=str))
-    print("\n\nlogged S3 payload", json.dumps(test_s3_logger.logged_standard_logging_payload, indent=4, default=str))
-
     assert dd_llms_obs_logger.logged_standard_logging_payload["messages"][0]["content"] == LiteLLMCommonStrings.redacted_by_litellm.value
     assert dd_llms_obs_logger.logged_standard_logging_payload["response"]["choices"][0]["message"]["content"] == LiteLLMCommonStrings.redacted_by_litellm.value
 
@@ -413,8 +396,6 @@ async def test_create_llm_obs_payload(mock_env_vars):
         start_time=datetime.now(),
         end_time=datetime.now() + timedelta(seconds=1),
     )
-
-    print("dd created payload", payload)
 
     assert payload["name"] == "litellm_llm_call"
     assert payload["meta"]["kind"] == "llm"
@@ -610,7 +591,7 @@ def test_guardrail_information_in_metadata(mock_env_vars):
         assert guardrail_info["guardrail_request"]["input"] == "test input message"
         assert guardrail_info["guardrail_request"]["user_id"] == "test_user"
         assert guardrail_info["guardrail_response"]["output"] == "filtered output"
-        assert guardrail_info["guardrail_response"]["flagged"] == False
+        assert guardrail_info["guardrail_response"]["flagged"] is False
         assert guardrail_info["guardrail_response"]["score"] == 0.1
 
 


### PR DESCRIPTION
## Title
Datadog tool calls returned in metadata field

## Relevant issues

fixes #13903

<img width="1213" height="241" alt="Screenshot 2025-09-12 at 12 29 46 AM" src="https://github.com/user-attachments/assets/c1d695c5-9720-4c1f-b019-4585da93356d" />
<img width="743" height="738" alt="Screenshot 2025-09-12 at 12 30 48 AM" src="https://github.com/user-attachments/assets/5c63c47e-183d-487a-a0b9-a6d33f0b75eb" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
