### PR TITLE
Resolve cache key collision issue where all soft budget alerts use identical cache keys

### DIFF
--- a/litellm/integrations/SlackAlerting/budget_alert_types.py
+++ b/litellm/integrations/SlackAlerting/budget_alert_types.py
@@ -31,7 +31,7 @@ class SoftBudgetAlert(BaseBudgetAlertType):
         return "Soft Budget Crossed: "
 
     def get_id(self, user_info: CallInfo) -> str:
-        return "default_id"
+        return user_info.token or "default_id"
 
 
 class UserBudgetAlert(BaseBudgetAlertType):

--- a/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_budget_alert_types.py
@@ -1,0 +1,41 @@
+from litellm.integrations.SlackAlerting.budget_alert_types import SoftBudgetAlert
+from litellm.proxy._types import CallInfo, Litellm_EntityType
+
+
+class TestSoftBudgetAlert:
+    def test_get_id_with_token(self):
+        """Test that get_id returns user_info.token when token is provided"""
+        token_value = "test_token_123"
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=120.0,
+            token=token_value,
+            event_group=Litellm_EntityType.KEY,
+        )
+        
+        result = alert.get_id(user_info)
+        assert result == token_value
+
+    def test_get_id_without_token(self):
+        """Test that get_id returns 'default_id' when token is None"""
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=100.0,
+            token=None,
+            event_group=Litellm_EntityType.KEY,
+        )
+        
+        result = alert.get_id(user_info)
+        assert result == "default_id"
+
+    def test_get_id_with_empty_token(self):
+        """Test that get_id returns 'default_id' when token is empty string"""
+        alert = SoftBudgetAlert()
+        user_info = CallInfo(
+            spend=100.0,
+            token="",
+            event_group=Litellm_EntityType.KEY,
+        )
+        
+        result = alert.get_id(user_info)
+        assert result == "default_id"


### PR DESCRIPTION
## Title

SoftBudgetAlerts always gets the key:

`default_id_soft_budget_crossed`

for `cache_key` in cache meaning that its always a race condition determining what key is triggering an event once the ttl expires. 

Instead, this implementation now sets it to token value if exists or defaults to `default_id` for the id of the alert. 

## Relevant issues

No issue

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


<img width="3217" height="434" alt="image" src="https://github.com/user-attachments/assets/e68215a5-f5f8-416e-8845-dfd32963eddc" />

Note, the test failing works when run isolated. Has nothing to do with these changes:

<img width="3217" height="333" alt="image" src="https://github.com/user-attachments/assets/31441ea6-6cbb-4e3f-bffe-8c306a28436f" />


## Type


🐛 Bug Fix
✅ Test

## Changes

`get_id` of `SoftBudgetAlert` type returns token from CallInfo if its there
