### PR TITLE
update: DeepInfra model data refresh [2025-09-12]

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15394,8 +15394,8 @@
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
-        "input_cost_per_token": 7.2e-08,
-        "output_cost_per_token": 7.2e-08,
+        "input_cost_per_token": 8e-08,
+        "output_cost_per_token": 9e-08,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15414,8 +15414,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 1e-07,
-        "output_cost_per_token": 2.8e-07,
+        "input_cost_per_token": 1.2e-07,
+        "output_cost_per_token": 3e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": false
@@ -15534,9 +15534,28 @@
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 2.9e-07,
         "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 2.4e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
+    "deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "max_tokens": 4096,
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 1.4e-06,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
+    "deepinfra/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "max_tokens": 4096,
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 1.4e-06,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15647,8 +15666,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 1e-07,
-        "output_cost_per_token": 4e-07,
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": false
@@ -15657,8 +15676,8 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 7.5e-08,
-        "output_cost_per_token": 1.5e-07,
+        "input_cost_per_token": 2.7e-07,
+        "output_cost_per_token": 2.7e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true
@@ -15703,8 +15722,7 @@
         "cache_read_input_token_cost": 2.16e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
-        "supports_tool_choice": true,
-        "supports_reasoning": true
+        "supports_tool_choice": true
     },
     "deepinfra/google/gemini-2.0-flash-001": {
         "max_tokens": 1000000,
@@ -15966,12 +15984,43 @@
         "mode": "chat",
         "supports_tool_choice": true
     },
+    "deepinfra/moonshotai/Kimi-K2-Instruct-0905": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 4e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
     "deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct": {
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "input_cost_per_token": 1.2e-07,
         "output_cost_per_token": 3e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
+    "deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 4e-07,
+        "litellm_provider": "deepinfra",
+        "mode": "chat",
+        "supports_tool_choice": true
+    },
+    "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {
+        "max_tokens": 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 4e-08,
+        "output_cost_per_token": 1.6e-07,
         "litellm_provider": "deepinfra",
         "mode": "chat",
         "supports_tool_choice": true


### PR DESCRIPTION
## Relevant issues

This PR updates DeepInfra model data
Addresses model availability - new models added
Addresses model parameter updates - pricing/metadata changes

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem.


## Type

📖 Documentation

## Changes

Added Models:
deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct
deepinfra/Qwen/Qwen3-Next-80B-A3B-Thinking
deepinfra/moonshotai/Kimi-K2-Instruct-0905
deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5
deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2

Modified Models:
deepinfra/NousResearch/Hermes-3-Llama-3.1-70B:
   - input_cost_per_token: 1e-07 → 1.2e-07
   - output_cost_per_token: 2.8e-07 → 3e-07

deepinfra/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B:
   - input_cost_per_token: 7.5e-08 → 2.7e-07
   - output_cost_per_token: 1.5e-07 → 2.7e-07

deepinfra/Gryphe/MythoMax-L2-13b:
   - input_cost_per_token: 7.2e-08 → 8e-08
   - output_cost_per_token: 7.2e-08 → 9e-08

deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo:
   - cache_read_input_token_cost: 2.4e-07 → None
   - input_cost_per_token: 3e-07 → 2.9e-07

deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B:
   - input_cost_per_token: 1e-07 → 2e-07
   - output_cost_per_token: 4e-07 → 6e-07