### PR TITLE
Litellm create team model reset

### DIFF
--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -214,7 +214,6 @@ const Teams: React.FC<TeamProps> = ({
     const models = getOrganizationModels(currentOrgForCreateTeam, userModels);
     console.log(`models: ${models}`);
     setModelsToPick(models);
-    form.setFieldValue("models", []);
   }, [currentOrgForCreateTeam, userModels]);
 
   // Add this useEffect to fetch guardrails


### PR DESCRIPTION
## Title
## Create team models reset bug fix

https://www.loom.com/share/a0056f963ea946d8861e0cfb710d59be?sid=550aa1f8-4835-4318-962e-34f2eb8b2529
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

Refactored useEffect logic for handling model selection section auto reset, and added comprehensive testing to test_teams.py and redid some prior bug issues in test suite.
