### PR TITLE
fix(lm_studio): resolve illegal Bearer header value issue

### DIFF
--- a/litellm/llms/lm_studio/chat/transformation.py
+++ b/litellm/llms/lm_studio/chat/transformation.py
@@ -15,8 +15,8 @@ class LMStudioChatConfig(OpenAIGPTConfig):
     ) -> Tuple[Optional[str], Optional[str]]:
         api_base = api_base or get_secret_str("LM_STUDIO_API_BASE")  # type: ignore
         dynamic_api_key = (
-            api_key or get_secret_str("LM_STUDIO_API_KEY") or " "
-        )  # vllm does not require an api key
+            api_key or get_secret_str("LM_STUDIO_API_KEY") or "fake-api-key"
+        )  # LM Studio does not require an api key, but OpenAI client requires non-None value
         return api_base, dynamic_api_key
     
     def map_openai_params(

--- a/tests/test_litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
+++ b/tests/test_litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from unittest.mock import patch
 
 from pydantic import BaseModel
 
@@ -53,3 +54,32 @@ class TestLMStudioChatConfigResponseFormat:
         assert mapped_schema["properties"] == schema["properties"]
         opt_schema = optional_params["response_format"]["json_schema"]["schema"]
         assert opt_schema["properties"] == schema["properties"]
+
+
+def test_lm_studio_get_openai_compatible_provider_info():
+    """Test provider info retrieval"""
+    config = LMStudioChatConfig()
+    
+    # Test default behavior (no API key provided)
+    _, api_key = config._get_openai_compatible_provider_info(None, None)
+    assert api_key == "fake-api-key"
+    
+    # Test explicit API key
+    _, api_key = config._get_openai_compatible_provider_info(None, "test-key")
+    assert api_key == "test-key"
+
+
+def test_lm_studio_get_openai_compatible_provider_info_with_env():
+    """Test provider info retrieval with environment variables."""
+    config = LMStudioChatConfig()
+    
+    with patch.dict(
+        "os.environ",
+        {
+            "LM_STUDIO_API_BASE": "http://localhost:1234/v1",
+            "LM_STUDIO_API_KEY": "env_api_key",
+        },
+    ):
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+        assert api_base == "http://localhost:1234/v1"
+        assert api_key == "env_api_key"


### PR DESCRIPTION
## Title

fix(lm_studio): resolve illegal Bearer header value issue

## Relevant issues

Fixes #14502

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
Users couldn't use LMStudio locally due to `httpcore.LocalProtocolError: Illegal header value b'Bearer  '` when no API key was set. The issue was caused by the default API key being a single space `" "`, which created an illegal HTTP Authorization header `Bearer  ` (Bearer followed by two spaces).

### Root Cause
In `litellm/llms/lm_studio/chat/transformation.py`, the default API key was set to `" "` (space) to satisfy OpenAI client requirements, but this created malformed HTTP headers.

### Solution
- Changed default API key from `" "` to `"fake-api-key"`
- This follows the pattern used by other similar providers in the codebase (e.g., `hosted_vllm`)
- Creates valid HTTP headers: `Authorization: Bearer fake-api-key`
- Maintains full backward compatibility for users with explicit API keys

### Testing
- Added comprehensive tests for provider info retrieval
- Tests cover default behavior, explicit API keys, and environment variables
- All existing tests continue to pass

### Impact
- Fixes the exact user scenario described in issue #14502
- No breaking changes - existing configurations continue to work
- LMStudio now works out-of-the-box without requiring API key setup