### PR TITLE
fix: improve response api handling and cold storage configuration

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4161,10 +4161,14 @@ class StandardLoggingPayloadSetup:
             # Get the actual s3_path from the configured cold storage logger instance
             s3_path = ""  # default value
             
-            # Get the actual logger instance from the logger name
-            custom_logger = litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(configured_cold_storage_logger)
-            if custom_logger and hasattr(custom_logger, 's3_path') and custom_logger.s3_path:
-                s3_path = custom_logger.s3_path
+            # Try to get the actual logger instance from the logger name
+            try:
+                custom_logger = litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(configured_cold_storage_logger)
+                if custom_logger and hasattr(custom_logger, 's3_path') and custom_logger.s3_path:
+                    s3_path = custom_logger.s3_path
+            except Exception:
+                # If any error occurs in getting the logger instance, use default empty s3_path
+                pass
             
             s3_object_key = get_s3_object_key(
                 s3_path=s3_path,  # Use actual s3_path from logger configuration

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4150,15 +4150,24 @@ class StandardLoggingPayloadSetup:
         from litellm.integrations.s3 import get_s3_object_key
 
         # Only generate object key if cold storage is configured
-        if litellm.configured_cold_storage_logger is None:
+        configured_cold_storage_logger = litellm.configured_cold_storage_logger
+        if configured_cold_storage_logger is None:
             return None
 
         try:
             # Generate file name in same format as litellm.utils.get_logging_id
             s3_file_name = f"time-{start_time.strftime('%H-%M-%S-%f')}_{response_id}"
 
+            # Get the actual s3_path from the configured cold storage logger instance
+            s3_path = ""  # default value
+            
+            # Get the actual logger instance from the logger name
+            custom_logger = litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(configured_cold_storage_logger)
+            if custom_logger and hasattr(custom_logger, 's3_path') and custom_logger.s3_path:
+                s3_path = custom_logger.s3_path
+            
             s3_object_key = get_s3_object_key(
-                s3_path="",  # Use empty path as default
+                s3_path=s3_path,  # Use actual s3_path from logger configuration
                 team_alias_prefix="",  # Don't split by team alias for cold storage
                 start_time=start_time,
                 s3_file_name=s3_file_name,

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -141,7 +141,7 @@ class ResponsesSessionHandler:
         # Add Output messages for this Spend Log
         ############################################################
         _response_output = spend_log.get("response", "{}")
-        if isinstance(_response_output, dict):
+        if isinstance(_response_output, dict) and _response_output and _response_output != {}:
             # transform `ChatCompletion Response` to `ResponsesAPIResponse`
             model_response = ModelResponse(**_response_output)
             for choice in model_response.choices:


### PR DESCRIPTION
## Title

fix: improve response api handling and cold storage configuration

## Relevant issues
https://github.com/BerriAI/litellm/issues/14533

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### 1. **Fixed S3 Cold Storage Object Key Path Consistency**

**Problem**: `_generate_cold_storage_object_key()` was using empty `s3_path=""` instead of the actual configured S3 path from logger instance, causing retrieval failures.

**Solution**: 
- Modified `StandardLoggingPayloadSetup._generate_cold_storage_object_key()` to retrieve actual `s3_path` from the configured cold storage logger instance
- Added fallback to empty string when `s3_path` is not available

**Files changed**:
- `litellm/litellm_core_utils/litellm_logging.py`

**Code changes**:
```python
# Get the actual logger instance from the logger name
custom_logger = litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(configured_cold_storage_logger)
if custom_logger and hasattr(custom_logger, 's3_path') and custom_logger.s3_path:
    s3_path = custom_logger.s3_path
```

### 2. **Enhanced Empty Response Handling**

**Problem**: When `response` field is empty dict (`{}`), invalid chat completion history was generated, causing 500 errors.

**Solution**:
- Enhanced validation in `session_handler.py` to check for non-empty dict responses
- Added check: `isinstance(_response_output, dict) and _response_output and _response_output != {}`

**Files changed**:
- `litellm/responses/litellm_completion_transformation/session_handler.py`

### 3. **Added Comprehensive Test Coverage**

**New tests added**:
- `test_e2e_generate_cold_storage_object_key_with_custom_logger_s3_path`: Tests s3_path retrieval from logger instance
- `test_e2e_generate_cold_storage_object_key_with_logger_no_s3_path`: Tests fallback when s3_path is not available  
- `test_get_chat_completion_message_history_empty_response_dict`: Tests empty response dict handling
