### PR TITLE
fix: recompute filters after deleting an MCP Server

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.tsx
@@ -40,6 +40,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
     data: mcpServers,
     isLoading: isLoadingServers,
     refetch,
+    dataUpdatedAt,
   } = useQuery({
     queryKey: ["mcpServers"],
     queryFn: () => {
@@ -47,7 +48,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
       return fetchMCPServers(accessToken)
     },
     enabled: !!accessToken,
-  }) as { data: MCPServer[]; isLoading: boolean; refetch: () => void }
+  }) as { data: MCPServer[]; isLoading: boolean; refetch: () => void; dataUpdatedAt: number }
 
   // state
   const [serverIdToDelete, setServerToDelete] = useState<string | null>(null)
@@ -117,11 +118,10 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
     setFilteredServers(filtered)
   }
 
-  // Initial and effect-based filtering
+  // Initial and effect-based filtering (trigger on query data updates)
   useEffect(() => {
     filterServers(selectedTeam, selectedMcpAccessGroup)
-    // eslint-disable-next-line
-  }, [mcpServers])
+  }, [dataUpdatedAt])
 
   const columns = React.useMemo(
     () =>


### PR DESCRIPTION
## Title

Recompute filters after deleting an MCP Server

## Relevant issues

#14509

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

