### PR TITLE
 The 'last 24 hours' button shows up above the end user dropdown on Logs page

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -550,7 +550,7 @@ export default function SpendLogsTable({
                         </div>
 
                         <div className="flex items-center gap-2 min-w-0 flex-shrink">
-                          <div className="relative z-[9999]" ref={quickSelectRef}>
+                          <div className="relative z-50" ref={quickSelectRef}>
                             <button
                               onClick={() => setQuickSelectOpen(!quickSelectOpen)}
                               className="px-3 py-2 text-sm border rounded-md hover:bg-gray-50 flex items-center gap-2"
@@ -567,7 +567,7 @@ export default function SpendLogsTable({
                             </button>
 
                             {quickSelectOpen && (
-                              <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border p-2 z-[9999]">
+                              <div className="absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border p-2 z-50">
                                 <div className="space-y-1">
                                   {quickSelectOptions.map((option) => (
                                     <button


### PR DESCRIPTION
## Title
 The 'last 24 hours' button shows up above the end user dropdown on Logs page
<!-- e.g. "Implement user authentication feature" -->

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Fixed the z-index of "Last 24 hours" button on logs page.
<img width="1496" height="812" alt="Screenshot 2025-09-14 at 13 29 41" src="https://github.com/user-attachments/assets/a240ddde-eb28-478f-8b4d-e060ffa1331a" />

