### PR TITLE
DataDog shows spend metrics

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -185,7 +185,6 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
 
         messages = standard_logging_payload["messages"]
         messages = self._ensure_string_content(messages=messages)
-        response_obj = standard_logging_payload.get("response")
 
         metadata = kwargs.get("litellm_params", {}).get("metadata", {})
 
@@ -495,6 +494,12 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         latency_metrics = self._get_latency_metrics(standard_logging_payload)
         _metadata.update({"latency_metrics": dict(latency_metrics)})
 
+        #########################################################
+        # Add spend metrics to metadata
+        #########################################################
+        spend_metrics = self._get_spend_metrics(standard_logging_payload)
+        _metadata.update({"spend_metrics": dict(spend_metrics)})
+
         ## extract tool calls and add to metadata
         tool_call_metadata = self._extract_tool_call_metadata(standard_logging_payload)
         _metadata.update(tool_call_metadata)
@@ -543,6 +548,47 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
                 )
 
         return latency_metrics
+    
+    def _get_spend_metrics(
+            self, standard_logging_payload: StandardLoggingPayload
+    ) -> DDLLMObsSpendMetrics:
+        """
+        Get the spend metrics from the standard logging payload
+        """
+        spend_metrics: DDLLMObsSpendMetrics = DDLLMObsSpendMetrics()
+        
+        # Get response cost for litellm_spend_metric
+        response_cost = standard_logging_payload.get("response_cost", 0.0)
+        if response_cost > 0:
+            spend_metrics["litellm_spend_metric"] = response_cost
+
+        # Get budget information from metadata
+        metadata = standard_logging_payload.get("metadata", {})
+        
+        # API key max budget
+        user_api_key_max_budget = metadata.get("user_api_key_max_budget")
+        if user_api_key_max_budget is not None:
+            spend_metrics["litellm_api_key_max_budget_metric"] = user_api_key_max_budget
+
+        # API key budget remaining hours
+        user_api_key_budget_reset_at = metadata.get("user_api_key_budget_reset_at")
+        if user_api_key_budget_reset_at is not None:
+            try:
+                from datetime import datetime
+                if isinstance(user_api_key_budget_reset_at, str):
+                    # Parse ISO string if it's a string
+                    budget_reset_at = datetime.fromisoformat(user_api_key_budget_reset_at.replace('Z', '+00:00'))
+                else:
+                    budget_reset_at = user_api_key_budget_reset_at
+                
+                remaining_hours = (
+                    budget_reset_at - datetime.now(budget_reset_at.tzinfo)
+                ).total_seconds() / 3600
+                spend_metrics["litellm_api_key_budget_remaining_hours_metric"] = max(0, remaining_hours)
+            except Exception as e:
+                verbose_logger.debug(f"Error calculating remaining hours for budget reset: {e}")
+
+        return spend_metrics
 
     def _process_input_messages_preserving_tool_calls(
         self, messages: List[Any]

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -585,18 +585,29 @@ class DataDogLLMObsLogger(DataDogLogger, CustomBatchLogger):
         # API key max budget
         user_api_key_max_budget = metadata.get("user_api_key_max_budget")
         if user_api_key_max_budget is not None:
-            spend_metrics["litellm_api_key_max_budget_metric"] = user_api_key_max_budget
+            # type casting to make sure its a float value
+            try:
+                if isinstance(user_api_key_max_budget, (int, float)):
+                    spend_metrics["litellm_api_key_max_budget_metric"] = float(user_api_key_max_budget)
+                elif isinstance(user_api_key_max_budget, str):
+                    spend_metrics["litellm_api_key_max_budget_metric"] = float(user_api_key_max_budget)
+            except (ValueError, TypeError):
+                verbose_logger.debug(f"Invalid user_api_key_max_budget value: {user_api_key_max_budget}")
 
         # API key budget remaining hours
         user_api_key_budget_reset_at = metadata.get("user_api_key_budget_reset_at")
         if user_api_key_budget_reset_at is not None:
             try:
                 from datetime import datetime
+                budget_reset_at: datetime
                 if isinstance(user_api_key_budget_reset_at, str):
                     # Parse ISO string if it's a string
                     budget_reset_at = datetime.fromisoformat(user_api_key_budget_reset_at.replace('Z', '+00:00'))
-                else:
+                elif isinstance(user_api_key_budget_reset_at, datetime):
                     budget_reset_at = user_api_key_budget_reset_at
+                else:
+                    verbose_logger.debug(f"Invalid user_api_key_budget_reset_at type: {type(user_api_key_budget_reset_at)}")
+                    return spend_metrics
                 
                 remaining_hours = (
                     budget_reset_at - datetime.now(budget_reset_at.tzinfo)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -299,9 +299,9 @@ class Logging(LiteLLMLoggingBaseClass):
         self.litellm_trace_id: str = litellm_trace_id or str(uuid.uuid4())
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
-        self.sync_streaming_chunks: List[Any] = (
-            []
-        )  # for generating complete stream response
+        self.sync_streaming_chunks: List[
+            Any
+        ] = []  # for generating complete stream response
         self.log_raw_request_response = log_raw_request_response
 
         # Initialize dynamic callbacks
@@ -670,24 +670,23 @@ class Logging(LiteLLMLoggingBaseClass):
         if anthropic_cache_control_logger := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(
             non_default_params
         ):
-            self.model_call_details["prompt_integration"] = (
-                anthropic_cache_control_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = anthropic_cache_control_logger.__class__.__name__
             return anthropic_cache_control_logger
 
         #########################################################
         # Vector Store / Knowledge Base hooks
         #########################################################
         if litellm.vector_store_registry is not None:
-
             vector_store_custom_logger = _init_custom_logger_compatible_class(
                 logging_integration="vector_store_pre_call_hook",
                 internal_usage_cache=None,
                 llm_router=None,
             )
-            self.model_call_details["prompt_integration"] = (
-                vector_store_custom_logger.__class__.__name__
-            )
+            self.model_call_details[
+                "prompt_integration"
+            ] = vector_store_custom_logger.__class__.__name__
             return vector_store_custom_logger
 
         return None
@@ -739,9 +738,9 @@ class Logging(LiteLLMLoggingBaseClass):
             model
         ):  # if model name was changes pre-call, overwrite the initial model call name with the new one
             self.model_call_details["model"] = model
-        self.model_call_details["litellm_params"]["api_base"] = (
-            self._get_masked_api_base(additional_args.get("api_base", ""))
-        )
+        self.model_call_details["litellm_params"][
+            "api_base"
+        ] = self._get_masked_api_base(additional_args.get("api_base", ""))
 
     def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
         # Log the exact input to the LLM API
@@ -770,10 +769,10 @@ class Logging(LiteLLMLoggingBaseClass):
                 try:
                     # [Non-blocking Extra Debug Information in metadata]
                     if turn_off_message_logging is True:
-                        _metadata["raw_request"] = (
-                            "redacted by litellm. \
+                        _metadata[
+                            "raw_request"
+                        ] = "redacted by litellm. \
                             'litellm.turn_off_message_logging=True'"
-                        )
                     else:
                         curl_command = self._get_request_curl_command(
                             api_base=additional_args.get("api_base", ""),
@@ -784,32 +783,32 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         _metadata["raw_request"] = str(curl_command)
                         # split up, so it's easier to parse in the UI
-                        self.model_call_details["raw_request_typed_dict"] = (
-                            RawRequestTypedDict(
-                                raw_request_api_base=str(
-                                    additional_args.get("api_base") or ""
-                                ),
-                                raw_request_body=self._get_raw_request_body(
-                                    additional_args.get("complete_input_dict", {})
-                                ),
-                                raw_request_headers=self._get_masked_headers(
-                                    additional_args.get("headers", {}) or {},
-                                    ignore_sensitive_headers=True,
-                                ),
-                                error=None,
-                            )
+                        self.model_call_details[
+                            "raw_request_typed_dict"
+                        ] = RawRequestTypedDict(
+                            raw_request_api_base=str(
+                                additional_args.get("api_base") or ""
+                            ),
+                            raw_request_body=self._get_raw_request_body(
+                                additional_args.get("complete_input_dict", {})
+                            ),
+                            raw_request_headers=self._get_masked_headers(
+                                additional_args.get("headers", {}) or {},
+                                ignore_sensitive_headers=True,
+                            ),
+                            error=None,
                         )
                 except Exception as e:
-                    self.model_call_details["raw_request_typed_dict"] = (
-                        RawRequestTypedDict(
-                            error=str(e),
-                        )
+                    self.model_call_details[
+                        "raw_request_typed_dict"
+                    ] = RawRequestTypedDict(
+                        error=str(e),
                     )
-                    _metadata["raw_request"] = (
-                        "Unable to Log \
+                    _metadata[
+                        "raw_request"
+                    ] = "Unable to Log \
                         raw request: {}".format(
-                            str(e)
-                        )
+                        str(e)
                     )
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
@@ -1092,13 +1091,13 @@ class Logging(LiteLLMLoggingBaseClass):
         for callback in callbacks:
             try:
                 if isinstance(callback, CustomLogger):
-                    response: Optional[MCPPostCallResponseObject] = (
-                        await callback.async_post_mcp_tool_call_hook(
-                            kwargs=kwargs,
-                            response_obj=post_mcp_tool_call_response_obj,
-                            start_time=start_time,
-                            end_time=end_time,
-                        )
+                    response: Optional[
+                        MCPPostCallResponseObject
+                    ] = await callback.async_post_mcp_tool_call_hook(
+                        kwargs=kwargs,
+                        response_obj=post_mcp_tool_call_response_obj,
+                        start_time=start_time,
+                        end_time=end_time,
                     )
                     ######################################################################
                     # if any of the callbacks modify the response, use the modified response
@@ -1218,9 +1217,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
             return None
 
         try:
@@ -1245,9 +1244,9 @@ class Logging(LiteLLMLoggingBaseClass):
             verbose_logger.debug(
                 f"response_cost_failure_debug_information: {debug_info}"
             )
-            self.model_call_details["response_cost_failure_debug_information"] = (
-                debug_info
-            )
+            self.model_call_details[
+                "response_cost_failure_debug_information"
+            ] = debug_info
 
         return None
 
@@ -1391,9 +1390,9 @@ class Logging(LiteLLMLoggingBaseClass):
                 end_time = datetime.datetime.now()
             if self.completion_start_time is None:
                 self.completion_start_time = end_time
-                self.model_call_details["completion_start_time"] = (
-                    self.completion_start_time
-                )
+                self.model_call_details[
+                    "completion_start_time"
+                ] = self.completion_start_time
             self.model_call_details["log_event_type"] = "successful_api_call"
             self.model_call_details["end_time"] = end_time
             self.model_call_details["cache_hit"] = cache_hit
@@ -1446,39 +1445,39 @@ class Logging(LiteLLMLoggingBaseClass):
                             "response_cost"
                         ]
                     else:
-                        self.model_call_details["response_cost"] = (
-                            self._response_cost_calculator(result=logging_result)
-                        )
+                        self.model_call_details[
+                            "response_cost"
+                        ] = self._response_cost_calculator(result=logging_result)
                     ## STANDARDIZED LOGGING PAYLOAD
 
-                    self.model_call_details["standard_logging_object"] = (
-                        get_standard_logging_object_payload(
-                            kwargs=self.model_call_details,
-                            init_response_obj=logging_result,
-                            start_time=start_time,
-                            end_time=end_time,
-                            logging_obj=self,
-                            status="success",
-                            standard_built_in_tools_params=self.standard_built_in_tools_params,
-                        )
+                    self.model_call_details[
+                        "standard_logging_object"
+                    ] = get_standard_logging_object_payload(
+                        kwargs=self.model_call_details,
+                        init_response_obj=logging_result,
+                        start_time=start_time,
+                        end_time=end_time,
+                        logging_obj=self,
+                        status="success",
+                        standard_built_in_tools_params=self.standard_built_in_tools_params,
                     )
                 elif isinstance(result, dict) or isinstance(result, list):
                     ## STANDARDIZED LOGGING PAYLOAD
-                    self.model_call_details["standard_logging_object"] = (
-                        get_standard_logging_object_payload(
-                            kwargs=self.model_call_details,
-                            init_response_obj=result,
-                            start_time=start_time,
-                            end_time=end_time,
-                            logging_obj=self,
-                            status="success",
-                            standard_built_in_tools_params=self.standard_built_in_tools_params,
-                        )
+                    self.model_call_details[
+                        "standard_logging_object"
+                    ] = get_standard_logging_object_payload(
+                        kwargs=self.model_call_details,
+                        init_response_obj=result,
+                        start_time=start_time,
+                        end_time=end_time,
+                        logging_obj=self,
+                        status="success",
+                        standard_built_in_tools_params=self.standard_built_in_tools_params,
                     )
             elif standard_logging_object is not None:
-                self.model_call_details["standard_logging_object"] = (
-                    standard_logging_object
-                )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = standard_logging_object
             else:  # streaming chunks + image gen.
                 self.model_call_details["response_cost"] = None
 
@@ -1577,7 +1576,6 @@ class Logging(LiteLLMLoggingBaseClass):
         )
 
         if complete_streaming_response is not None:
-
             self.success_handler(result=complete_streaming_response)
         return
 
@@ -1630,23 +1628,23 @@ class Logging(LiteLLMLoggingBaseClass):
                 verbose_logger.debug(
                     "Logging Details LiteLLM-Success Call streaming complete"
                 )
-                self.model_call_details["complete_streaming_response"] = (
-                    complete_streaming_response
-                )
-                self.model_call_details["response_cost"] = (
-                    self._response_cost_calculator(result=complete_streaming_response)
-                )
+                self.model_call_details[
+                    "complete_streaming_response"
+                ] = complete_streaming_response
+                self.model_call_details[
+                    "response_cost"
+                ] = self._response_cost_calculator(result=complete_streaming_response)
                 ## STANDARDIZED LOGGING PAYLOAD
-                self.model_call_details["standard_logging_object"] = (
-                    get_standard_logging_object_payload(
-                        kwargs=self.model_call_details,
-                        init_response_obj=complete_streaming_response,
-                        start_time=start_time,
-                        end_time=end_time,
-                        logging_obj=self,
-                        status="success",
-                        standard_built_in_tools_params=self.standard_built_in_tools_params,
-                    )
+                self.model_call_details[
+                    "standard_logging_object"
+                ] = get_standard_logging_object_payload(
+                    kwargs=self.model_call_details,
+                    init_response_obj=complete_streaming_response,
+                    start_time=start_time,
+                    end_time=end_time,
+                    logging_obj=self,
+                    status="success",
+                    standard_built_in_tools_params=self.standard_built_in_tools_params,
                 )
             callbacks = self.get_combined_callback_list(
                 dynamic_success_callbacks=self.dynamic_success_callbacks,
@@ -1970,10 +1968,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
                             openMeterLogger.log_success_event(
@@ -2012,10 +2010,10 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                         else:
                             if self.stream and complete_streaming_response:
-                                self.model_call_details["complete_response"] = (
-                                    self.model_call_details.get(
-                                        "complete_streaming_response", {}
-                                    )
+                                self.model_call_details[
+                                    "complete_response"
+                                ] = self.model_call_details.get(
+                                    "complete_streaming_response", {}
                                 )
                                 result = self.model_call_details["complete_response"]
 
@@ -2117,10 +2115,12 @@ class Logging(LiteLLMLoggingBaseClass):
                 result.usage = batch_usage
 
             elif not is_base64_unified_file_id:  # only run for non-unified file ids
-                response_cost, batch_usage, batch_models = (
-                    await _handle_completed_batch(
-                        batch=result, custom_llm_provider=self.custom_llm_provider
-                    )
+                (
+                    response_cost,
+                    batch_usage,
+                    batch_models,
+                ) = await _handle_completed_batch(
+                    batch=result, custom_llm_provider=self.custom_llm_provider
                 )
 
                 result._hidden_params["response_cost"] = response_cost
@@ -2151,9 +2151,9 @@ class Logging(LiteLLMLoggingBaseClass):
         if complete_streaming_response is not None:
             print_verbose("Async success callbacks: Got a complete streaming response")
 
-            self.model_call_details["async_complete_streaming_response"] = (
-                complete_streaming_response
-            )
+            self.model_call_details[
+                "async_complete_streaming_response"
+            ] = complete_streaming_response
 
             try:
                 if self.model_call_details.get("cache_hit", False) is True:
@@ -2164,10 +2164,10 @@ class Logging(LiteLLMLoggingBaseClass):
                         model_call_details=self.model_call_details
                     )
                     # base_model defaults to None if not set on model_info
-                    self.model_call_details["response_cost"] = (
-                        self._response_cost_calculator(
-                            result=complete_streaming_response
-                        )
+                    self.model_call_details[
+                        "response_cost"
+                    ] = self._response_cost_calculator(
+                        result=complete_streaming_response
                     )
 
                 verbose_logger.debug(
@@ -2180,16 +2180,16 @@ class Logging(LiteLLMLoggingBaseClass):
                 self.model_call_details["response_cost"] = None
 
             ## STANDARDIZED LOGGING PAYLOAD
-            self.model_call_details["standard_logging_object"] = (
-                get_standard_logging_object_payload(
-                    kwargs=self.model_call_details,
-                    init_response_obj=complete_streaming_response,
-                    start_time=start_time,
-                    end_time=end_time,
-                    logging_obj=self,
-                    status="success",
-                    standard_built_in_tools_params=self.standard_built_in_tools_params,
-                )
+            self.model_call_details[
+                "standard_logging_object"
+            ] = get_standard_logging_object_payload(
+                kwargs=self.model_call_details,
+                init_response_obj=complete_streaming_response,
+                start_time=start_time,
+                end_time=end_time,
+                logging_obj=self,
+                status="success",
+                standard_built_in_tools_params=self.standard_built_in_tools_params,
             )
         callbacks = self.get_combined_callback_list(
             dynamic_success_callbacks=self.dynamic_async_success_callbacks,
@@ -2402,18 +2402,18 @@ class Logging(LiteLLMLoggingBaseClass):
 
         ## STANDARDIZED LOGGING PAYLOAD
 
-        self.model_call_details["standard_logging_object"] = (
-            get_standard_logging_object_payload(
-                kwargs=self.model_call_details,
-                init_response_obj={},
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=self,
-                status="failure",
-                error_str=str(exception),
-                original_exception=exception,
-                standard_built_in_tools_params=self.standard_built_in_tools_params,
-            )
+        self.model_call_details[
+            "standard_logging_object"
+        ] = get_standard_logging_object_payload(
+            kwargs=self.model_call_details,
+            init_response_obj={},
+            start_time=start_time,
+            end_time=end_time,
+            logging_obj=self,
+            status="failure",
+            error_str=str(exception),
+            original_exception=exception,
+            standard_built_in_tools_params=self.standard_built_in_tools_params,
         )
         return start_time, end_time
 
@@ -3302,9 +3302,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 endpoint=arize_config.endpoint,
             )
 
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"space_id={arize_config.space_key},api_key={arize_config.api_key}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"space_id={arize_config.space_key},api_key={arize_config.api_key}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, ArizeLogger)
@@ -3328,9 +3328,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
 
             # auth can be disabled on local deployments of arize phoenix
             if arize_phoenix_config.otlp_auth_headers is not None:
-                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                    arize_phoenix_config.otlp_auth_headers
-                )
+                os.environ[
+                    "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+                ] = arize_phoenix_config.otlp_auth_headers
 
             for callback in _in_memory_loggers:
                 if (
@@ -3367,6 +3367,7 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             return galileo_logger  # type: ignore
         elif logging_integration == "cloudzero":
             from litellm.integrations.cloudzero.cloudzero import CloudZeroLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, CloudZeroLogger):
                     return callback  # type: ignore
@@ -3437,9 +3438,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                 exporter="otlp_http",
                 endpoint="https://langtrace.ai/api/trace",
             )
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = (
-                f"api_key={os.getenv('LANGTRACE_API_KEY')}"
-            )
+            os.environ[
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+            ] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if (
                     isinstance(callback, OpenTelemetry)
@@ -3594,6 +3595,7 @@ def get_custom_logger_compatible_class(  # noqa: PLR0915
                     return callback
         elif logging_integration == "cloudzero":
             from litellm.integrations.cloudzero.cloudzero import CloudZeroLogger
+
             for callback in _in_memory_loggers:
                 if isinstance(callback, CloudZeroLogger):
                     return callback
@@ -4088,10 +4090,10 @@ class StandardLoggingPayloadSetup:
             for key in StandardLoggingHiddenParams.__annotations__.keys():
                 if key in hidden_params:
                     if key == "additional_headers":
-                        clean_hidden_params["additional_headers"] = (
-                            StandardLoggingPayloadSetup.get_additional_headers(
-                                hidden_params[key]
-                            )
+                        clean_hidden_params[
+                            "additional_headers"
+                        ] = StandardLoggingPayloadSetup.get_additional_headers(
+                            hidden_params[key]
                         )
                     else:
                         clean_hidden_params[key] = hidden_params[key]  # type: ignore
@@ -4504,7 +4506,7 @@ def get_standard_logging_object_payload(
 
 def emit_standard_logging_payload(payload: StandardLoggingPayload):
     if os.getenv("LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD"):
-        print(json.dumps(payload, indent=4)) # noqa
+        print(json.dumps(payload, indent=4))  # noqa
 
 
 def get_standard_logging_metadata(
@@ -4527,6 +4529,9 @@ def get_standard_logging_metadata(
     clean_metadata = StandardLoggingMetadata(
         user_api_key_hash=None,
         user_api_key_alias=None,
+        user_api_key_spend=None,
+        user_api_key_max_budget=None,
+        user_api_key_budget_reset_at=None,
         user_api_key_team_id=None,
         user_api_key_org_id=None,
         user_api_key_user_id=None,
@@ -4576,9 +4581,9 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
     ):
         for k, v in metadata["user_api_key_metadata"].items():
             if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[k] = (
-                    "scrubbed_by_litellm_for_sensitive_keys"
-                )
+                cleaned_user_api_key_metadata[
+                    k
+                ] = "scrubbed_by_litellm_for_sensitive_keys"
             else:
                 cleaned_user_api_key_metadata[k] = v
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -546,6 +546,7 @@ class LiteLLMProxyRequestSetup:
             user_api_key_end_user_id=user_api_key_dict.end_user_id,
             user_api_key_user_email=user_api_key_dict.user_email,
             user_api_key_request_route=user_api_key_dict.request_route,
+            user_api_key_budget_reset_at=user_api_key_dict.budget_reset_at,
         )
         return user_api_key_logged_metadata
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -474,6 +474,9 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                 user_api_key_team_alias=user_api_key_dict.team_alias,
                 user_api_key_end_user_id=user_api_key_dict.end_user_id,
                 user_api_key_request_route=user_api_key_dict.request_route,
+                user_api_key_spend=user_api_key_dict.spend,
+                user_api_key_max_budget=user_api_key_dict.max_budget,
+                user_api_key_budget_reset_at=user_api_key_dict.budget_reset_at,
             )
         )
 
@@ -1003,7 +1006,7 @@ class InitPassThroughEndpointHelpers:
     ):
         """Add exact path route for pass-through endpoint"""
         route_key = f"{endpoint_id}:exact:{path}"
-        
+
         # Check if this exact route is already registered
         if route_key in _registered_pass_through_routes:
             verbose_proxy_logger.debug(
@@ -1011,7 +1014,7 @@ class InitPassThroughEndpointHelpers:
                 path,
             )
             return
-            
+
         verbose_proxy_logger.debug(
             "adding exact pass through endpoint: %s, dependencies: %s",
             path,
@@ -1032,12 +1035,12 @@ class InitPassThroughEndpointHelpers:
             methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
             dependencies=dependencies,
         )
-        
+
         # Register the route to prevent duplicates
         _registered_pass_through_routes[route_key] = {
             "endpoint_id": endpoint_id,
             "path": path,
-            "type": "exact"
+            "type": "exact",
         }
 
     @staticmethod
@@ -1055,7 +1058,7 @@ class InitPassThroughEndpointHelpers:
         """Add wildcard route for sub-paths"""
         wildcard_path = f"{path}/{{subpath:path}}"
         route_key = f"{endpoint_id}:subpath:{path}"
-        
+
         # Check if this subpath route is already registered
         if route_key in _registered_pass_through_routes:
             verbose_proxy_logger.debug(
@@ -1063,7 +1066,7 @@ class InitPassThroughEndpointHelpers:
                 wildcard_path,
             )
             return
-            
+
         verbose_proxy_logger.debug(
             "adding wildcard pass through endpoint: %s, dependencies: %s",
             wildcard_path,
@@ -1085,19 +1088,20 @@ class InitPassThroughEndpointHelpers:
             methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
             dependencies=dependencies,
         )
-        
+
         # Register the route to prevent duplicates
         _registered_pass_through_routes[route_key] = {
             "endpoint_id": endpoint_id,
             "path": path,
-            "type": "subpath"
+            "type": "subpath",
         }
 
     @staticmethod
     def remove_endpoint_routes(endpoint_id: str):
         """Remove all routes for a specific endpoint ID from the registry"""
         keys_to_remove = [
-            key for key, value in _registered_pass_through_routes.items()
+            key
+            for key, value in _registered_pass_through_routes.items()
             if value["endpoint_id"] == endpoint_id
         ]
         for key in keys_to_remove:
@@ -1480,7 +1484,7 @@ async def delete_pass_through_endpoints(
     pass_through_endpoint_data.pop(endpoint_index)
     response_obj = found_endpoint
 
-    # Remove routes from registry  
+    # Remove routes from registry
     InitPassThroughEndpointHelpers.remove_endpoint_routes(endpoint_id)
 
     ## Update db

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -82,6 +82,7 @@ class DDLLMObsLatencyMetrics(TypedDict, total=False):
     litellm_overhead_time_ms: float
     guardrail_overhead_time_ms: float
 
+
 class DDLLMObsSpendMetrics(TypedDict, total=False):
     response_cost: float
     user_api_key_spend: float

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -83,6 +83,7 @@ class DDLLMObsLatencyMetrics(TypedDict, total=False):
     guardrail_overhead_time_ms: float
 
 class DDLLMObsSpendMetrics(TypedDict, total=False):
-    litellm_spend_metric: float
-    litellm_api_key_max_budget_metric: float
-    litellm_api_key_budget_remaining_hours_metric: float
+    response_cost: float
+    user_api_key_spend: float
+    user_api_key_max_budget: float
+    user_api_key_budget_reset_at: str

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -85,5 +85,4 @@ class DDLLMObsLatencyMetrics(TypedDict, total=False):
 class DDLLMObsSpendMetrics(TypedDict, total=False):
     litellm_spend_metric: float
     litellm_api_key_max_budget_metric: float
-    litellm_remaining_api_key_budget_metric: float
     litellm_api_key_budget_remaining_hours_metric: float

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -81,3 +81,9 @@ class DDLLMObsLatencyMetrics(TypedDict, total=False):
     time_to_first_token_ms: float
     litellm_overhead_time_ms: float
     guardrail_overhead_time_ms: float
+
+class DDLLMObsSpendMetrics(TypedDict, total=False):
+    litellm_spend_metric: float
+    litellm_api_key_max_budget_metric: float
+    litellm_remaining_api_key_budget_metric: float
+    litellm_api_key_budget_remaining_hours_metric: float

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -162,7 +162,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
         SearchContextCostPerQuery
     ]  # Cost for using web search tool
     citation_cost_per_token: Optional[float]  # Cost per citation token for Perplexity
-    tiered_pricing: Optional[List[Dict[str, Any]]]  # Tiered pricing structure for models like Dashscope
+    tiered_pricing: Optional[
+        List[Dict[str, Any]]
+    ]  # Tiered pricing structure for models like Dashscope
     litellm_provider: Required[str]
     mode: Required[
         Literal[
@@ -1808,8 +1810,8 @@ class StandardLoggingUserAPIKeyMetadata(TypedDict):
     user_api_key_hash: Optional[str]  # hash of the litellm virtual key used
     user_api_key_alias: Optional[str]
     user_api_key_spend: Optional[float]
-    user_api_key_max_budget: Optional[float] = None
-    user_api_key_budget_reset_at: Optional[str] = None
+    user_api_key_max_budget: Optional[float]
+    user_api_key_budget_reset_at: Optional[str]
     user_api_key_org_id: Optional[str]
     user_api_key_team_id: Optional[str]
     user_api_key_user_id: Optional[str]
@@ -1999,7 +2001,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     ]
     guardrail_request: Optional[dict]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
-    guardrail_status: Literal["success", "failure","blocked"]
+    guardrail_status: Literal["success", "failure", "blocked"]
     start_time: Optional[float]
     end_time: Optional[float]
     duration: Optional[float]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1807,6 +1807,9 @@ class AdapterCompletionStreamWrapper:
 class StandardLoggingUserAPIKeyMetadata(TypedDict):
     user_api_key_hash: Optional[str]  # hash of the litellm virtual key used
     user_api_key_alias: Optional[str]
+    user_api_key_spend: Optional[float]
+    user_api_key_max_budget: Optional[float] = None
+    user_api_key_budget_reset_at: Optional[str] = None
     user_api_key_org_id: Optional[str]
     user_api_key_team_id: Optional[str]
     user_api_key_user_id: Optional[str]

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -657,87 +657,6 @@ def test_guardrail_information_in_metadata(mock_env_vars):
         assert guardrail_info["guardrail_response"]["score"] == 0.1
 
 
-def create_standard_logging_payload_with_spend_metrics() -> StandardLoggingPayload:
-    """Create a StandardLoggingPayload object with spend metrics for testing"""
-    from datetime import datetime, timezone
-    
-    # Create a budget reset time 24 hours from now
-    budget_reset_at = datetime.now(timezone.utc) + timedelta(hours=24)
-    
-    return {
-        "id": "test-request-id-spend",
-        "trace_id": "test-trace-id-spend",
-        "call_type": "completion",
-        "stream": None,
-        "response_cost": 0.15,
-        "response_cost_failure_debug_info": None,
-        "status": "success",
-        "custom_llm_provider": "openai",
-        "total_tokens": 30,
-        "prompt_tokens": 10,
-        "completion_tokens": 20,
-        "startTime": 1234567890.0,
-        "endTime": 1234567891.0,
-        "completionStartTime": 1234567890.5,
-        "response_time": 1.0,
-        "model_map_information": {
-            "model_map_key": "gpt-4",
-            "model_map_value": None
-        },
-        "model": "gpt-4",
-        "model_id": "model-123",
-        "model_group": "openai-gpt",
-        "api_base": "https://api.openai.com",
-        "metadata": {
-            "user_api_key_hash": "test_hash",
-            "user_api_key_org_id": None,
-            "user_api_key_alias": "test_alias",
-            "user_api_key_team_id": "test_team",
-            "user_api_key_user_id": "test_user",
-            "user_api_key_team_alias": "test_team_alias",
-            "user_api_key_user_email": None,
-            "user_api_key_end_user_id": None,
-            "user_api_key_request_route": None,
-            "user_api_key_max_budget": 10.0,  # $10 max budget
-            "user_api_key_budget_reset_at": budget_reset_at.isoformat(),
-            "spend_logs_metadata": None,
-            "requester_ip_address": "127.0.0.1",
-            "requester_metadata": None,
-            "requester_custom_headers": None,
-            "prompt_management_metadata": None,
-            "mcp_tool_call_metadata": None,
-            "vector_store_request_metadata": None,
-            "applied_guardrails": None,
-            "usage_object": None,
-            "cold_storage_object_key": None,
-        },
-        "cache_hit": False,
-        "cache_key": None,
-        "saved_cache_cost": 0.0,
-        "request_tags": [],
-        "end_user": None,
-        "requester_ip_address": "127.0.0.1",
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-        "response": {"choices": [{"message": {"content": "Hi there!"}}]},
-        "error_str": None,
-        "error_information": None,
-        "model_parameters": {"stream": False},
-        "hidden_params": {
-            "model_id": "model-123",
-            "cache_key": None,
-            "api_base": "https://api.openai.com",
-            "response_cost": "0.15",
-            "litellm_overhead_time_ms": None,
-            "additional_headers": None,
-            "batch_models": None,
-            "litellm_model_name": None,
-            "usage_object": None,
-        },
-        "guardrail_information": None,
-        "standard_built_in_tools_params": None,
-    }  # type: ignore
-
-
 def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
     """Create a StandardLoggingPayload object with tool calls for testing"""
     return {
@@ -983,49 +902,253 @@ class TestDataDogLLMObsLoggerToolCalls:
             assert output_function_info.get("name") == "format_response"
 
 
-def test_spend_metrics_in_datadog_payload(mock_env_vars):
+def create_standard_logging_payload() -> StandardLoggingPayload:
+    """Create a standard logging payload for testing"""
+    return {
+        "id": "test_id",
+        "trace_id": "test_trace_id",
+        "call_type": "completion",
+        "stream": False,
+        "response_cost": 0.1,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "custom_llm_provider": None,
+        "total_tokens": 30,
+        "prompt_tokens": 20,
+        "completion_tokens": 10,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "response_time": 1.0,
+        "model_map_information": {
+            "model_map_key": "gpt-3.5-turbo",
+            "model_map_value": None
+        },
+        "model": "gpt-3.5-turbo",
+        "model_id": "model-123",
+        "model_group": "openai-gpt",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "test_hash",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": "test_alias",
+            "user_api_key_team_id": "test_team",
+            "user_api_key_user_id": "test_user",
+            "user_api_key_team_alias": "test_team_alias",
+            "user_api_key_end_user_id": None,
+            "user_api_key_request_route": None,
+            "user_api_key_max_budget": None,
+            "user_api_key_budget_reset_at": None,
+            "user_api_key_user_email": None,
+            "spend_logs_metadata": None,
+            "requester_ip_address": "127.0.0.1",
+            "requester_metadata": None,
+            "requester_custom_headers": None,
+            "prompt_management_metadata": None,
+            "mcp_tool_call_metadata": None,
+            "vector_store_request_metadata": None,
+            "applied_guardrails": None,
+            "usage_object": None,
+            "cold_storage_object_key": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": "127.0.0.1",
+        "messages": [{"role": "user", "content": "Hello, world!"}],
+        "response": {"choices": [{"message": {"content": "Hi there!"}}]},
+        "error_str": None,
+        "model_parameters": {"stream": True},
+        "hidden_params": {
+            "model_id": "model-123",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.1",
+            "additional_headers": None,
+            "litellm_overhead_time_ms": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "error_information": None,
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+    }  # type: ignore
+
+
+def create_standard_logging_payload_with_spend_metrics() -> StandardLoggingPayload:
+    """Create a StandardLoggingPayload object with spend metrics for testing"""
+    from datetime import datetime, timezone
+
+    # Create a budget reset time 24 hours from now
+    budget_reset_at = datetime.now(timezone.utc) + timedelta(hours=24)
+
+    return {
+        "id": "test-request-id-spend",
+        "trace_id": "test-trace-id-spend",
+        "call_type": "completion",
+        "stream": None,
+        "response_cost": 0.15,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "custom_llm_provider": "openai",
+        "total_tokens": 30,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "response_time": 1.0,
+        "model_map_information": {
+            "model_map_key": "gpt-4",
+            "model_map_value": None
+        },
+        "model": "gpt-4",
+        "model_id": "model-123",
+        "model_group": "openai-gpt",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "test_hash",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": "test_alias",
+            "user_api_key_team_id": "test_team",
+            "user_api_key_user_id": "test_user",
+            "user_api_key_team_alias": "test_team_alias",
+            "user_api_key_user_email": None,
+            "user_api_key_end_user_id": None,
+            "user_api_key_request_route": None,
+            "user_api_key_max_budget": 10.0,  # $10 max budget
+            "user_api_key_budget_reset_at": budget_reset_at.isoformat(),
+            "spend_logs_metadata": None,
+            "requester_ip_address": "127.0.0.1",
+            "requester_metadata": None,
+            "requester_custom_headers": None,
+            "prompt_management_metadata": None,
+            "mcp_tool_call_metadata": None,
+            "vector_store_request_metadata": None,
+            "applied_guardrails": None,
+            "usage_object": None,
+            "cold_storage_object_key": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": "127.0.0.1",
+        "messages": [{"role": "user", "content": "Hello, world!"}],
+        "response": {"choices": [{"message": {"content": "Hi there!"}}]},
+        "error_str": None,
+        "error_information": None,
+        "model_parameters": {"stream": False},
+        "hidden_params": {
+            "model_id": "model-123",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.15",
+            "litellm_overhead_time_ms": None,
+            "additional_headers": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+    }  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_datadog_llm_obs_spend_metrics():
+    """Test that budget metrics are properly extracted and logged"""
+    datadog_llm_obs_logger = DataDogLLMObsLogger()
+
+    # Create a standard logging payload with budget metadata
+    payload = create_standard_logging_payload()
+
+    # Add budget information to metadata
+    payload["metadata"]["user_api_key_max_budget"] = 10.0
+    payload["metadata"]["user_api_key_budget_reset_at"] = "2025-09-15T00:00:00+00:00"
+
+    # Test the _get_spend_metrics method
+    spend_metrics = datadog_llm_obs_logger._get_spend_metrics(payload)
+
+    # Verify budget metrics are present
+    assert "litellm_api_key_max_budget_metric" in spend_metrics
+    assert spend_metrics["litellm_api_key_max_budget_metric"] == 10.0
+
+    assert "litellm_api_key_budget_remaining_hours_metric" in spend_metrics
+    # The remaining hours should be calculated based on the reset time
+    assert spend_metrics["litellm_api_key_budget_remaining_hours_metric"] >= 0
+
+    print(f"Spend metrics: {spend_metrics}")
+
+
+@pytest.mark.asyncio
+async def test_datadog_llm_obs_spend_metrics_no_budget():
+    """Test that spend metrics work when no budget is set"""
+    datadog_llm_obs_logger = DataDogLLMObsLogger()
+
+    # Create a standard logging payload without budget metadata
+    payload = create_standard_logging_payload()
+
+    # Test the _get_spend_metrics method
+    spend_metrics = datadog_llm_obs_logger._get_spend_metrics(payload)
+
+    # Verify only response cost is present
+    assert "litellm_spend_metric" in spend_metrics
+    assert spend_metrics["litellm_spend_metric"] == 0.1
+
+    # Budget metrics should not be present
+    assert "litellm_api_key_max_budget_metric" not in spend_metrics
+    assert "litellm_api_key_budget_remaining_hours_metric" not in spend_metrics
+
+    print(f"Spend metrics (no budget): {spend_metrics}")
+
+
+@pytest.mark.asyncio
+async def test_spend_metrics_in_datadog_payload():
     """Test that spend metrics are correctly included in DataDog LLM Observability payloads"""
-    with patch(
-        "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-    ), patch("asyncio.create_task"):
-        logger = DataDogLLMObsLogger()
+    datadog_llm_obs_logger = DataDogLLMObsLogger()
 
-        standard_payload = create_standard_logging_payload_with_spend_metrics()
+    standard_payload = create_standard_logging_payload_with_spend_metrics()
 
-        kwargs = {
-            "standard_logging_object": standard_payload,
-            "litellm_params": {"metadata": {}},
-        }
+    kwargs = {
+        "standard_logging_object": standard_payload,
+        "litellm_params": {"metadata": {}},
+    }
 
-        start_time = datetime.now()
-        end_time = datetime.now()
+    start_time = datetime.now()
+    end_time = datetime.now()
 
-        payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+    payload = datadog_llm_obs_logger.create_llm_obs_payload(kwargs, start_time, end_time)
 
-        # Verify basic payload structure
-        assert payload.get("name") == "litellm_llm_call"
-        assert payload.get("status") == "ok"
+    # Verify basic payload structure
+    assert payload.get("name") == "litellm_llm_call"
+    assert payload.get("status") == "ok"
 
-        # Verify spend metrics are included in metadata
-        meta = payload.get("meta", {})
-        assert meta is not None, "Meta section should exist in payload"
-        
-        metadata = meta.get("metadata", {})
-        assert metadata is not None, "Metadata section should exist in meta"
-        
-        spend_metrics = metadata.get("spend_metrics", {})
-        assert spend_metrics, "Spend metrics should exist in metadata"
+    # Verify spend metrics are included in metadata
+    meta = payload.get("meta", {})
+    assert meta is not None, "Meta section should exist in payload"
 
-        # Check that all three spend metrics are present
-        assert "litellm_spend_metric" in spend_metrics
-        assert "litellm_api_key_max_budget_metric" in spend_metrics
-        assert "litellm_api_key_budget_remaining_hours_metric" in spend_metrics
+    metadata = meta.get("metadata", {})
+    assert metadata is not None, "Metadata section should exist in meta"
 
-        # Verify the values are correct
-        assert spend_metrics["litellm_spend_metric"] == 0.15  # response_cost
-        assert spend_metrics["litellm_api_key_max_budget_metric"] == 10.0  # max budget
+    spend_metrics = metadata.get("spend_metrics", {})
+    assert spend_metrics, "Spend metrics should exist in metadata"
 
-        # Verify remaining hours is a reasonable value (should be close to 24 since we set it to 24 hours from now)
-        remaining_hours = spend_metrics["litellm_api_key_budget_remaining_hours_metric"]
-        assert isinstance(remaining_hours, (int, float))
-        assert 20 <= remaining_hours <= 25  # Should be close to 24 hours
+    # Check that all three spend metrics are present
+    assert "litellm_spend_metric" in spend_metrics
+    assert "litellm_api_key_max_budget_metric" in spend_metrics
+    assert "litellm_api_key_budget_remaining_hours_metric" in spend_metrics
+
+    # Verify the values are correct
+    assert spend_metrics["litellm_spend_metric"] == 0.15  # response_cost
+    assert spend_metrics["litellm_api_key_max_budget_metric"] == 10.0  # max budget
+
+    # Verify remaining hours is a reasonable value (should be close to 24 since we set it to 24 hours from now)
+    remaining_hours = spend_metrics["litellm_api_key_budget_remaining_hours_metric"]
+    assert isinstance(remaining_hours, (int, float))
+    assert 20 <= remaining_hours <= 25  # Should be close to 24 hours
+

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -657,21 +657,109 @@ def test_guardrail_information_in_metadata(mock_env_vars):
         assert guardrail_info["guardrail_response"]["score"] == 0.1
 
 
+def create_standard_logging_payload_with_spend_metrics() -> StandardLoggingPayload:
+    """Create a StandardLoggingPayload object with spend metrics for testing"""
+    from datetime import datetime, timezone
+    
+    # Create a budget reset time 24 hours from now
+    budget_reset_at = datetime.now(timezone.utc) + timedelta(hours=24)
+    
+    return {
+        "id": "test-request-id-spend",
+        "trace_id": "test-trace-id-spend",
+        "call_type": "completion",
+        "stream": None,
+        "response_cost": 0.15,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "custom_llm_provider": "openai",
+        "total_tokens": 30,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "response_time": 1.0,
+        "model_map_information": {
+            "model_map_key": "gpt-4",
+            "model_map_value": None
+        },
+        "model": "gpt-4",
+        "model_id": "model-123",
+        "model_group": "openai-gpt",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "test_hash",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": "test_alias",
+            "user_api_key_team_id": "test_team",
+            "user_api_key_user_id": "test_user",
+            "user_api_key_team_alias": "test_team_alias",
+            "user_api_key_user_email": None,
+            "user_api_key_end_user_id": None,
+            "user_api_key_request_route": None,
+            "user_api_key_max_budget": 10.0,  # $10 max budget
+            "user_api_key_budget_reset_at": budget_reset_at.isoformat(),
+            "spend_logs_metadata": None,
+            "requester_ip_address": "127.0.0.1",
+            "requester_metadata": None,
+            "requester_custom_headers": None,
+            "prompt_management_metadata": None,
+            "mcp_tool_call_metadata": None,
+            "vector_store_request_metadata": None,
+            "applied_guardrails": None,
+            "usage_object": None,
+            "cold_storage_object_key": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": "127.0.0.1",
+        "messages": [{"role": "user", "content": "Hello, world!"}],
+        "response": {"choices": [{"message": {"content": "Hi there!"}}]},
+        "error_str": None,
+        "error_information": None,
+        "model_parameters": {"stream": False},
+        "hidden_params": {
+            "model_id": "model-123",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.15",
+            "litellm_overhead_time_ms": None,
+            "additional_headers": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+    }  # type: ignore
+
+
 def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
     """Create a StandardLoggingPayload object with tool calls for testing"""
     return {
         "id": "test-request-id-tool-calls",
+        "trace_id": "test-trace-id-tool-calls",
         "call_type": "completion",
+        "stream": None,
         "response_cost": 0.05,
         "response_cost_failure_debug_info": None,
         "status": "success",
+        "custom_llm_provider": "openai",
         "total_tokens": 50,
         "prompt_tokens": 20,
         "completion_tokens": 30,
         "startTime": 1234567890.0,
         "endTime": 1234567891.0,
         "completionStartTime": 1234567890.5,
-        "model_map_information": {"model_map_key": "gpt-4", "model_map_value": None},
+        "response_time": 1.0,
+        "model_map_information": {
+            "model_map_key": "gpt-4",
+            "model_map_value": None
+        },
         "model": "gpt-4",
         "model_id": "model-123",
         "model_group": "openai-gpt",
@@ -746,6 +834,7 @@ def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
             ]
         },
         "error_str": None,
+        "error_information": None,
         "model_parameters": {"temperature": 0.7},
         "hidden_params": {
             "model_id": "model-123",
@@ -758,14 +847,9 @@ def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
             "litellm_model_name": None,
             "usage_object": None,
         },
-        "stream": None,
-        "response_time": 1.0,
-        "error_information": None,
         "guardrail_information": None,
         "standard_built_in_tools_params": None,
-        "trace_id": "test-trace-id-tool-calls",
-        "custom_llm_provider": "openai",
-    }
+    }  # type: ignore
 
 
 class TestDataDogLLMObsLoggerToolCalls:
@@ -897,3 +981,51 @@ class TestDataDogLLMObsLoggerToolCalls:
             assert len(output_tool_calls) == 1
             output_function_info = output_tool_calls[0].get("function", {})
             assert output_function_info.get("name") == "format_response"
+
+
+def test_spend_metrics_in_datadog_payload(mock_env_vars):
+    """Test that spend metrics are correctly included in DataDog LLM Observability payloads"""
+    with patch(
+        "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
+    ), patch("asyncio.create_task"):
+        logger = DataDogLLMObsLogger()
+
+        standard_payload = create_standard_logging_payload_with_spend_metrics()
+
+        kwargs = {
+            "standard_logging_object": standard_payload,
+            "litellm_params": {"metadata": {}},
+        }
+
+        start_time = datetime.now()
+        end_time = datetime.now()
+
+        payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+        # Verify basic payload structure
+        assert payload.get("name") == "litellm_llm_call"
+        assert payload.get("status") == "ok"
+
+        # Verify spend metrics are included in metadata
+        meta = payload.get("meta", {})
+        assert meta is not None, "Meta section should exist in payload"
+        
+        metadata = meta.get("metadata", {})
+        assert metadata is not None, "Metadata section should exist in meta"
+        
+        spend_metrics = metadata.get("spend_metrics", {})
+        assert spend_metrics, "Spend metrics should exist in metadata"
+
+        # Check that all three spend metrics are present
+        assert "litellm_spend_metric" in spend_metrics
+        assert "litellm_api_key_max_budget_metric" in spend_metrics
+        assert "litellm_api_key_budget_remaining_hours_metric" in spend_metrics
+
+        # Verify the values are correct
+        assert spend_metrics["litellm_spend_metric"] == 0.15  # response_cost
+        assert spend_metrics["litellm_api_key_max_budget_metric"] == 10.0  # max budget
+
+        # Verify remaining hours is a reasonable value (should be close to 24 since we set it to 24 hours from now)
+        remaining_hours = spend_metrics["litellm_api_key_budget_remaining_hours_metric"]
+        assert isinstance(remaining_hours, (int, float))
+        assert 20 <= remaining_hours <= 25  # Should be close to 24 hours

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -1060,7 +1060,7 @@ def create_standard_logging_payload_with_spend_metrics() -> StandardLoggingPaylo
 
 
 @pytest.mark.asyncio
-async def test_datadog_llm_obs_spend_metrics():
+async def test_datadog_llm_obs_spend_metrics(mock_env_vars):
     """Test that budget metrics are properly extracted and logged"""
     datadog_llm_obs_logger = DataDogLLMObsLogger()
 
@@ -1086,7 +1086,7 @@ async def test_datadog_llm_obs_spend_metrics():
 
 
 @pytest.mark.asyncio
-async def test_datadog_llm_obs_spend_metrics_no_budget():
+async def test_datadog_llm_obs_spend_metrics_no_budget(mock_env_vars):
     """Test that spend metrics work when no budget is set"""
     datadog_llm_obs_logger = DataDogLLMObsLogger()
 
@@ -1108,7 +1108,7 @@ async def test_datadog_llm_obs_spend_metrics_no_budget():
 
 
 @pytest.mark.asyncio
-async def test_spend_metrics_in_datadog_payload():
+async def test_spend_metrics_in_datadog_payload(mock_env_vars):
     """Test that spend metrics are correctly included in DataDog LLM Observability payloads"""
     datadog_llm_obs_logger = DataDogLLMObsLogger()
 


### PR DESCRIPTION
## Title

Added these metrics in datadog logging
- litellm_spend_metric
- litellm_api_key_max_budget_value
- litellm_api_key_budget_reset_at

<img width="648" height="704" alt="Screenshot 2025-09-14 at 1 45 51 PM" src="https://github.com/user-attachments/assets/0b3e4ac3-b92a-46d0-b2b7-5797418c62df" />
<img width="1119" height="275" alt="Screenshot 2025-09-14 at 2 38 40 PM" src="https://github.com/user-attachments/assets/7d955183-dffc-4cd3-8ef0-911a92c78a44" />
<img width="725" height="77" alt="Screenshot 2025-09-14 at 2 49 45 PM" src="https://github.com/user-attachments/assets/c0630445-3f78-4ff7-8e67-ad6d33d5464b" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
