### PR TITLE
fix(proxy): Correctly parse multi-part MCP server aliases from URL paths

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -578,7 +578,7 @@ if MCP_AVAILABLE:
         """
         import re
         mcp_servers_from_path: Optional[List[str]] = None
-        mcp_path_match = re.match(r"^/mcp/([^/]+)(/.*)?$", path)
+        mcp_path_match = re.match(r"^/mcp/([^/]+/[^/]+|[^/]+)(/.*)?$", path)
         if mcp_path_match:
             mcp_servers_str = mcp_path_match.group(1)
             if mcp_servers_str:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -342,3 +342,82 @@ async def test_concurrent_initialize_session_managers():
         mcp_server._SESSION_MANAGERS_INITIALIZED = original_initialized
         mcp_server._session_manager_cm = original_session_cm
         mcp_server._sse_session_manager_cm = original_sse_session_cm
+
+
+@pytest.mark.asyncio
+async def test_mcp_routing_with_conflicting_alias_and_group_name():
+    """
+    Tests (GH #14536) where an MCP server alias (e.g., "group/id")
+    conflicts with an access group name (e.g., "group").
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_mcp_servers_in_path,
+            _get_tools_from_mcp_servers,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+        from litellm.proxy._types import MCPTransport, MCPSpecVersion
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    global_mcp_server_manager.registry.clear()
+
+    # Create two in-memory servers
+    specific_server = MCPServer(
+        server_id="specific_server_id",
+        name="custom_solutions/user_123",
+        alias="custom_solutions/user_123",
+        transport=MCPTransport.http,
+        spec_version=MCPSpecVersion.jun_2025,
+    )
+    other_server = MCPServer(
+        server_id="other_server_in_group_id",
+        name="custom_solutions/another_user_456",
+        alias="custom_solutions/another_user_456",
+        transport=MCPTransport.http,
+        spec_version=MCPSpecVersion.jun_2025,
+    )
+    global_mcp_server_manager.registry[specific_server.server_id] = specific_server
+    global_mcp_server_manager.registry[other_server.server_id] = other_server
+
+    user_key = UserAPIKeyAuth(api_key="sk-test", team_id="team_custom_solutions")
+
+    # Define the request path that triggers the bug
+    test_path = "/mcp/custom_solutions/user_123/chat/completions"
+
+    # This mock will be our "spy" to see which servers are ultimately contacted
+    mock_get_tools_spy = AsyncMock(return_value=[])
+
+    # Mock the function that checks DB for an access group named "custom_solutions"
+    mock_db_lookup = AsyncMock(return_value=[specific_server.server_id, other_server.server_id])
+
+    mock_get_allowed = AsyncMock(return_value=[specific_server.server_id, other_server.server_id])
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_allowed_mcp_servers",
+        mock_get_allowed,
+    ), patch(
+        "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler._get_mcp_servers_from_access_groups",
+        mock_db_lookup,
+    ), patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager._get_tools_from_server",
+        mock_get_tools_spy,
+    ):
+        mcp_servers_from_path = _get_mcp_servers_in_path(test_path)
+
+        await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_key,
+            mcp_servers=mcp_servers_from_path,
+            mcp_auth_header=None,
+        )
+
+    # Get the list of actual server objects that the orchestrator tried to contact
+    called_servers = [call.kwargs["server"] for call in mock_get_tools_spy.call_args_list]
+
+    assert len(called_servers) == 1, "Should have resolved to exactly one server."
+    assert (
+        called_servers[0].server_id == specific_server.server_id
+    ), "Should have contacted the specific server alias, not the group."


### PR DESCRIPTION
## Relevant issues

Fixes #14536  

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

**Problem:**
A request to an MCP server with an alias like `custom_solutions/user_123` was being incorrectly routed to the `custom_solutions` access group. This was caused by the regular expression in the `_get_mcp_servers_in_path` function, which only captured the part of the URL path before the first slash.

**Solution:**
The regex in `_get_m_servers_in_path` has been updated to prioritize matching a two-part alias (e.g., `group/id`) before falling back to a single-part alias. This ensures the full, specific server alias is correctly parsed from the URL.

**Testing:**
- Added a new holistic test, `test_mcp_routing_with_conflicting_alias_and_group_name`, to the MCP server test suite.
- This test creates the specific conflicting scenario in-memory and asserts that only the single, correct server is contacted.

## Screenshot
<img width="1488" height="186" alt="image" src="https://github.com/user-attachments/assets/f77abbea-2234-4241-bd90-690105a827c1" />
