### PR TITLE
Fix: Vertex AI Gemini labels field provider-aware filtering

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -405,18 +405,6 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
         raise e
 
 
-def _is_google_genai_endpoint(api_base: Optional[str]) -> bool:
-    """
-    Check if API base is Google GenAI (not Vertex AI).
-
-    Google GenAI endpoints use generativelanguage.googleapis.com
-    Vertex AI endpoints use aiplatform.googleapis.com
-    """
-    if not api_base:
-        return False
-    return "generativelanguage.googleapis.com" in api_base
-
-
 def _transform_request_body(
     messages: List[AllMessageValues],
     model: str,
@@ -424,7 +412,6 @@ def _transform_request_body(
     custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
     litellm_params: dict,
     cached_content: Optional[str],
-    api_base: Optional[str] = None,
 ) -> RequestBody:
     """
     Common transformation logic across sync + async Gemini /generateContent calls.
@@ -505,8 +492,8 @@ def _transform_request_body(
             data["generationConfig"] = generation_config
         if cached_content is not None:
             data["cachedContent"] = cached_content
-        # Only add labels for Vertex AI endpoints (not Google GenAI) and only if non-empty
-        if labels and not _is_google_genai_endpoint(api_base):
+        # Only add labels for Vertex AI endpoints (not Google GenAI/AI Studio) and only if non-empty
+        if labels and custom_llm_provider != "gemini":
             data["labels"] = labels
     except Exception as e:
         raise e
@@ -558,7 +545,6 @@ def sync_transform_request_body(
         litellm_params=litellm_params,
         cached_content=cached_content,
         optional_params=optional_params,
-        api_base=api_base,
     )
 
 
@@ -606,7 +592,6 @@ async def async_transform_request_body(
         litellm_params=litellm_params,
         cached_content=cached_content,
         optional_params=optional_params,
-        api_base=api_base,
     )
 
 

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -28,6 +28,7 @@ from litellm.types.files import (
     get_file_type_from_extension,
     is_gemini_1_5_accepted_file_type,
 )
+from litellm.types.utils import LlmProviders
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantMessage,
@@ -493,7 +494,7 @@ def _transform_request_body(
         if cached_content is not None:
             data["cachedContent"] = cached_content
         # Only add labels for Vertex AI endpoints (not Google GenAI/AI Studio) and only if non-empty
-        if labels and custom_llm_provider != "gemini":
+        if labels and custom_llm_provider != LlmProviders.GEMINI:
             data["labels"] = labels
     except Exception as e:
         raise e

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -405,6 +405,18 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
         raise e
 
 
+def _is_google_genai_endpoint(api_base: Optional[str]) -> bool:
+    """
+    Check if API base is Google GenAI (not Vertex AI).
+
+    Google GenAI endpoints use generativelanguage.googleapis.com
+    Vertex AI endpoints use aiplatform.googleapis.com
+    """
+    if not api_base:
+        return False
+    return "generativelanguage.googleapis.com" in api_base
+
+
 def _transform_request_body(
     messages: List[AllMessageValues],
     model: str,
@@ -412,6 +424,7 @@ def _transform_request_body(
     custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
     litellm_params: dict,
     cached_content: Optional[str],
+    api_base: Optional[str] = None,
 ) -> RequestBody:
     """
     Common transformation logic across sync + async Gemini /generateContent calls.
@@ -492,7 +505,8 @@ def _transform_request_body(
             data["generationConfig"] = generation_config
         if cached_content is not None:
             data["cachedContent"] = cached_content
-        if labels is not None:
+        # Only add labels for Vertex AI endpoints (not Google GenAI) and only if non-empty
+        if labels and not _is_google_genai_endpoint(api_base):
             data["labels"] = labels
     except Exception as e:
         raise e
@@ -544,6 +558,7 @@ def sync_transform_request_body(
         litellm_params=litellm_params,
         cached_content=cached_content,
         optional_params=optional_params,
+        api_base=api_base,
     )
 
 
@@ -591,6 +606,7 @@ async def async_transform_request_body(
         litellm_params=litellm_params,
         cached_content=cached_content,
         optional_params=optional_params,
+        api_base=api_base,
     )
 
 
@@ -647,3 +663,5 @@ def _transform_system_message(
         return SystemInstructions(parts=system_content_blocks), messages
 
     return None, messages
+
+


### PR DESCRIPTION
## Title

Fix: Vertex AI Gemini labels field provider-aware filtering

## Relevant issues

Fixes #14556

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### What this PR does

This PR fixes a critical issue where Google GenAI endpoints (generativelanguage.googleapis.com) failed when receiving requests with the `labels` field, which is only supported by Vertex AI endpoints (aiplatform.googleapis.com). The fix implements provider-aware filtering to include labels only for Vertex AI endpoints while excluding them for Google GenAI endpoints.

### Problem being solved

Issue #14556 reported that when using LiteLLM with Google GenAI endpoints, requests would fail because the `labels` field was being included in the request payload. Google GenAI's API doesn't support the `labels` field (which is a Vertex AI specific feature), causing API errors and request failures.

### Core Implementation Changes

- **`litellm/llms/vertex_ai/gemini/transformation.py:408-420`**: Added `_is_google_genai_endpoint()` helper function to detect Google GenAI vs Vertex AI endpoints based on the API base URL
- **`litellm/llms/vertex_ai/gemini/transformation.py:427`**: Updated `_transform_request_body()` to accept `api_base` parameter for provider detection
- **`litellm/llms/vertex_ai/gemini/transformation.py:508-509`**: Modified labels inclusion logic to only add labels for Vertex AI endpoints (not Google GenAI)
- **`litellm/llms/vertex_ai/gemini/transformation.py:561,609`**: Updated sync and async transform functions to pass `api_base` parameter through the transformation chain

### Testing Changes

Added comprehensive test coverage in `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py`:

- **`test_google_genai_excludes_labels()`**: Verifies Google GenAI endpoints exclude labels even when explicitly provided
- **`test_vertex_ai_includes_labels()`**: Confirms Vertex AI endpoints include labels when provided
- **`test_provider_detection()`**: Tests the endpoint detection logic for various URL patterns
- **`test_metadata_to_labels_vertex_only()`**: Ensures metadata-to-labels conversion only happens for Vertex AI

### How to verify it

#### Automated Verification
- [ ] Tests pass: `poetry run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py -v`
- [ ] Linting passes: `ruff check litellm/llms/vertex_ai/gemini/transformation.py`
- [ ] Type checking passes: `mypy litellm/llms/vertex_ai/gemini/transformation.py`
- [ ] Integration tests pass: `poetry run pytest tests/test_litellm/test_completion.py -k vertex_ai -v`

#### Manual Verification
- [ ] Google GenAI requests with labels succeed (labels are filtered out)
- [ ] Vertex AI requests with labels continue to work (labels are included)
- [ ] No regression in existing Vertex AI functionality
- [ ] Endpoint detection correctly identifies provider type

### Breaking changes

None - this is a backward-compatible bug fix that maintains existing functionality while fixing the Google GenAI compatibility issue.

### Migration required

None - existing code will continue to work without changes.

### Related issues/PRs

- Fixes #14556 - Labels field causes Google GenAI requests to fail