### PR TITLE
Fix unsupported stop param for grok-code models

### DIFF
--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -80,6 +80,8 @@ class XAIChatConfig(OpenAIGPTConfig):
             return False
         elif "grok-4" in model:
             return False
+        elif "grok-code-fast" in model:
+            return False
         return True
     
     def _supports_frequency_penalty(self, model: str) -> bool:


### PR DESCRIPTION
## Title

Fix xAI stop parameter filtering for grok-code-fast models

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Local Testing
<img width="976" height="723" alt="image" src="https://github.com/user-attachments/assets/a5fcf2a7-e3c3-4e3e-a928-1d96204a2368" />

## Type

🐛 Bug Fix

## Changes

Updated the `_supports_stop_reason()` method in `litellm/litellm/llms/xai/chat/transformation.py` to include `grok-code-fast` models in the list of models that don't support the `stop` parameter:

```python
def _supports_stop_reason(self, model: str) -> bool:
    if "grok-3-mini" in model:
        return False
    elif "grok-4" in model:
        return False
    elif "grok-code-fast" in model:  # Added this line
        return False
    return True
```

### Models Affected
- `grok-code-fast`
- `grok-code-fast-1` 
- `grok-code-fast-1-0825`
