### PR TITLE
fix volcengine thinking parameters missing when it set disable

### DIFF
--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -97,9 +97,9 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
                 and isinstance(thinking_value, dict)
                 and thinking_value.get("type", None) in ["enabled", "disabled", "auto"],  # legal values, see docs
             ):
-                # Add thinking parameter to extra_body for all other cases
+                # Add thinking parameter to extra_body for all legal cases
                 optional_params.setdefault("extra_body", {})["thinking"] = thinking_value
             else:
-                # Skip adding thinking parameter when it's not set
+                # Skip adding thinking parameter when it's not set or has invalid value
                 pass
         return optional_params

--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -95,7 +95,7 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
             if (
                 thinking_value is not None
                 and isinstance(thinking_value, dict)
-                and thinking_value.get("type", None) in ["enabled", "disabled", "auto"],  # legal values, see docs
+                and thinking_value.get("type", None) in ["enabled", "disabled", "auto"]  # legal values, see docs
             ):
                 # Add thinking parameter to extra_body for all legal cases
                 optional_params.setdefault("extra_body", {})["thinking"] = thinking_value

--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -4,6 +4,9 @@ from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
 
 
 class VolcEngineChatConfig(OpenAILikeChatConfig):
+    """
+    Reference: https://www.volcengine.com/docs/82379/1494384
+    """
     frequency_penalty: Optional[int] = None
     function_call: Optional[Union[str, dict]] = None
     functions: Optional[list] = None
@@ -81,20 +84,22 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
         )
 
         if "thinking" in optional_params:
+            """
+            The `thinking` parameters of VolcEngine model has different default values.
+            See the docs for details.
+            Refrence: https://www.volcengine.com/docs/82379/1449737#0002
+            """
             thinking_value = optional_params.pop("thinking")
 
-            # Handle disabled thinking case - don't add to extra_body if disabled
+            # Handle using thinking params case - add to extra_body if value is legal
             if (
                 thinking_value is not None
                 and isinstance(thinking_value, dict)
-                and thinking_value.get("type") == "disabled"
+                and thinking_value.get("type", None) in ["enabled", "disabled", "auto"],  # legal values, see docs
             ):
-                # Skip adding thinking parameter when it's disabled
-                pass
-            else:
                 # Add thinking parameter to extra_body for all other cases
-                optional_params.setdefault("extra_body", {})[
-                    "thinking"
-                ] = thinking_value
-
+                optional_params.setdefault("extra_body", {})["thinking"] = thinking_value
+            else:
+                # Skip adding thinking parameter when it's not set
+                pass
         return optional_params

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -14,7 +14,7 @@ class TestVolcEngineConfig:
         supported_params = config.get_supported_openai_params(model="doubao-seed-1.6")
         assert "thinking" in supported_params
 
-        # Test thinking disabled - should NOT appear in extra_body
+        # Test thinking disabled - should appear in extra_body
         mapped_params = config.map_openai_params(
             non_default_params={
                 "thinking": {"type": "disabled"},
@@ -25,7 +25,9 @@ class TestVolcEngineConfig:
         )
 
         # Fixed: thinking disabled should be omitted from extra_body
-        assert mapped_params == {}
+        assert mapped_params == {
+            "extra_body": {"thinking": {"type": "disabled"}}
+        }
 
         e2e_mapped_params = get_optional_params(
             model="doubao-seed-1.6",
@@ -43,7 +45,7 @@ class TestVolcEngineConfig:
     def test_thinking_parameter_handling(self):
         """Test comprehensive thinking parameter handling scenarios"""
         config = VolcEngineConfig()
-        
+
         # Test 1: thinking enabled - should appear in extra_body
         result_enabled = config.map_openai_params(
             non_default_params={"thinking": {"type": "enabled"}},
@@ -54,38 +56,36 @@ class TestVolcEngineConfig:
         assert result_enabled == {
             "extra_body": {"thinking": {"type": "enabled"}}
         }
-        
-        # Test 2: thinking None - should appear in extra_body as None
+
+        # Test 2: thinking None - should NOT appear in extra_body
         result_none = config.map_openai_params(
             non_default_params={"thinking": None},
             optional_params={},
-            model="doubao-seed-1.6", 
+            model="doubao-seed-1.6",
             drop_params=False,
         )
-        assert result_none == {
-            "extra_body": {"thinking": None}
-        }
-        
-        # Test 3: thinking with custom value - should appear in extra_body
+        assert result_none == {}
+
+        # Test 3: thinking with custom value - should NOT appear in extra_body (invalid value)
         result_custom = config.map_openai_params(
             non_default_params={"thinking": "custom_mode"},
             optional_params={},
             model="doubao-seed-1.6",
             drop_params=False,
         )
-        assert result_custom == {
-            "extra_body": {"thinking": "custom_mode"}
-        }
-        
-        # Test 4: thinking disabled - should NOT appear in extra_body
+        assert result_custom == {}
+
+        # Test 4: thinking disabled - should appear in extra_body with original structure
         result_disabled = config.map_openai_params(
             non_default_params={"thinking": {"type": "disabled"}},
             optional_params={},
             model="doubao-seed-1.6",
             drop_params=False,
         )
-        assert result_disabled == {}
-        
+        assert result_disabled == {
+            "extra_body": {"thinking": {"type": "disabled"}}
+        }
+
         # Test 5: No thinking parameter - should return empty dict
         result_no_thinking = config.map_openai_params(
             non_default_params={},
@@ -131,5 +131,5 @@ class TestVolcEngineConfig:
 
             mock_create.assert_called_once()
             print(mock_create.call_args.kwargs)
-            # Fixed: thinking disabled should NOT appear in extra_body
-            assert "extra_body" not in mock_create.call_args.kwargs or "thinking" not in mock_create.call_args.kwargs.get("extra_body", {})
+            # Fixed: thinking disabled should appear in extra_body with original structure
+            assert "extra_body" in mock_create.call_args.kwargs and "thinking" in mock_create.call_args.kwargs.get("extra_body", {}) and mock_create.call_args.kwargs.get("extra_body", {})["thinking"] == {"type": "disabled"}

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -95,6 +95,15 @@ class TestVolcEngineConfig:
         )
         assert result_no_thinking == {}
 
+        # Test 6: invalid thinking type - should NOT appear in extra_body (invalid type)
+        result_no_thinking = config.map_openai_params(
+            non_default_params={"thinking": {"type": "invalid_type"}},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert result_no_thinking == {}
+
     def test_e2e_completion(self):
         from openai import OpenAI
 

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -24,7 +24,7 @@ class TestVolcEngineConfig:
             drop_params=False,
         )
 
-        # Fixed: thinking disabled should be omitted from extra_body
+        # Fixed: thinking disabled should appear in extra_body
         assert mapped_params == {
             "extra_body": {"thinking": {"type": "disabled"}}
         }

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -104,6 +104,15 @@ class TestVolcEngineConfig:
         )
         assert result_no_thinking == {}
 
+        # Test 7: invalid thinking type - should NOT appear in extra_body (value is None)
+        result_no_thinking = config.map_openai_params(
+            non_default_params={"thinking": {"type": None}},
+            optional_params={},
+            model="doubao-seed-1.6",
+            drop_params=False,
+        )
+        assert result_no_thinking == {}
+
     def test_e2e_completion(self):
         from openai import OpenAI
 


### PR DESCRIPTION
## Title

fix volcengine thinking parameters missing when it set disable

## Relevant issues

Fixes [#14568](https://github.com/BerriAI/litellm/issues/14568)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix
✅ Test

## Changes

Modified the thinking parameter handling logic to ensure all valid values ("enabled", "disabled", "auto") are properly passed to the volcengine API.
