### PR TITLE
fix: reduced computation on hot path

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -494,14 +494,17 @@ def get_applied_guardrails(kwargs: Dict[str, Any]) -> List[str]:
         _last_callbacks_count = len(litellm.callbacks)
 
     request_guardrails = get_request_guardrails(kwargs)
-    applied_guardrails = _default_guardrails.copy()
 
-    # Append request-specific guardrails if not already included
+    # Start with default guardrails
+    applied_guardrails = list(_default_guardrails)
+
+    # Append request-specific guardrails, avoiding duplicates
     for cb in litellm.callbacks:
         if (
             isinstance(cb, CustomGuardrail)
             and cb.guardrail_name
             and cb.guardrail_name in request_guardrails
+            and cb.guardrail_name not in _default_guardrails
         ):
             applied_guardrails.append(cb.guardrail_name)
 


### PR DESCRIPTION
## Title

Optimized `get_applied_guardrails`

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

* [ ] I have Added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
* [ ] I have added a screenshot of my new test passing locally
* [x] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
* [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

✅ Refactoring
🧹 Performance Improvement

## Changes

* Refactored `get_applied_guardrails` to **cache default-on guardrails** across calls, avoiding recomputation.

<h2>Performance Comparison</h2>
<p>Wasn't as much as I expected</p>

Metric | Previous | Changes
-- | -- | --
Total requests | 33k | 33k
Failures | 0 | 0
Throughput (RPS) | 136 | 140
Median latency (p50) | 38 ms | 34 ms
P95 latency | 180 ms | 175 ms
P99 latency | 375 ms | 361 ms
Max latency | 0.9 s | 0.9 s
Average latency | 55 ms | 49 ms


<!-- notionvc: cbc60101-3898-4e08-86b1-d58e10da1817 -->

