### PR TITLE
Fix: handle empty arguments in Bedrock tool call invocation

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2680,7 +2680,10 @@ def _convert_to_bedrock_tool_call_invoke(
                 id = tool["id"]
                 name = tool["function"].get("name", "")
                 arguments = tool["function"].get("arguments", "")
-                arguments_dict = json.loads(arguments) if arguments else {}
+                if not arguments or not arguments.strip():
+                    arguments_dict = {}
+                else:
+                    arguments_dict = json.loads(arguments)
                 bedrock_tool = BedrockToolUseBlock(
                     input=arguments_dict, name=name, toolUseId=id
                 )


### PR DESCRIPTION
## Title

Fix Bedrock Empty arguments tool call when tool call arguments is empty string with spaces " "

When converting OpenAI-style tool calls to Bedrock tool calls, the field tool["function"]["arguments"] may be an empty string (" ").
Currently, the code always attempts json.loads(arguments), which fails with:

``json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)``


This error prevents Bedrock requests from being created, even when the tool call is otherwise valid.

## Changes

- Updated _convert_to_bedrock_tool_call_invoke to handle empty or invalid arguments safely.

If arguments is "", we now default to {} instead of calling json.loads.

This prevents crashes and ensures Bedrock tool call conversion works as expected.

Verified fix against failing logs such as:

``Unable to convert openai tool calls=... Received error=Expecting value: line 1 column 1 (char 0)``


## Type


🐛 Bug Fix


## Changes


