### PR TITLE
fix: remove excessive call of expensive function

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -566,7 +566,11 @@ def function_setup(  # noqa: PLR0915
                 cb_id = id(callback)
                 with _coroutine_cache_lock:
                     if cb_id not in _coroutine_status_cache:
-                        _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
+                        # For bound methods, we need to check the underlying function
+                        if hasattr(callback, '__func__'):
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback.__func__)
+                        else:
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
                     is_coro = _coroutine_status_cache[cb_id]
                 if callback not in litellm.input_callback:
                     litellm.input_callback.append(callback)  # type: ignore
@@ -604,7 +608,11 @@ def function_setup(  # noqa: PLR0915
                 cb_id = id(callback)
                 with _coroutine_cache_lock:
                     if cb_id not in _coroutine_status_cache:
-                        _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
+                        # For bound methods, we need to check the underlying function
+                        if hasattr(callback, '__func__'):
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback.__func__)
+                        else:
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
                     is_coro = _coroutine_status_cache[cb_id]
                 if is_coro:
                     litellm._async_input_callback.append(callback)
@@ -619,7 +627,11 @@ def function_setup(  # noqa: PLR0915
                 cb_id = id(callback)
                 with _coroutine_cache_lock:
                     if cb_id not in _coroutine_status_cache:
-                        _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
+                        # For bound methods, we need to check the underlying function
+                        if hasattr(callback, '__func__'):
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback.__func__)
+                        else:
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
                     is_coro = _coroutine_status_cache[cb_id]
                 if is_coro:
                     litellm.logging_callback_manager.add_litellm_async_success_callback(
@@ -649,7 +661,11 @@ def function_setup(  # noqa: PLR0915
                 cb_id = id(callback)
                 with _coroutine_cache_lock:
                     if cb_id not in _coroutine_status_cache:
-                        _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
+                        # For bound methods, we need to check the underlying function
+                        if hasattr(callback, '__func__'):
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback.__func__)
+                        else:
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
                     is_coro = _coroutine_status_cache[cb_id]
                 if is_coro:
                     litellm.logging_callback_manager.add_litellm_async_failure_callback(
@@ -686,7 +702,11 @@ def function_setup(  # noqa: PLR0915
                 cb_id = id(callback)
                 with _coroutine_cache_lock:
                     if cb_id not in _coroutine_status_cache:
-                        _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
+                        # For bound methods, we need to check the underlying function
+                        if hasattr(callback, '__func__'):
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback.__func__)
+                        else:
+                            _coroutine_status_cache[cb_id] = inspect.iscoroutinefunction(callback)
                     is_coro = _coroutine_status_cache[cb_id]
                 if (
                     is_coro


### PR DESCRIPTION

## Title

 inspect.iscoroutinefunction is too expensive

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

✅ Refactoring
🧹 Performance Improvement

## Changes

I introduced a cache to cut down on repeated calls to inspect.iscoroutinefunction, and it worked, function_setup dropped from consuming nearly 60% of the execution time in common_processing_pre_call_logic to under 30%. Unfortunately, this optimization didn’t have a meaningful impact on higher-level metrics like p99 latency or RPS.

