### PR TITLE
fix: share a single _OPTIONAL_PresidioPIIMasking instance to ensure unmasking works when output_parse_pii=true

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/pii_masking_v2.md
+++ b/docs/my-website/docs/proxy/guardrails/pii_masking_v2.md
@@ -543,7 +543,7 @@ guardrails:
       output_parse_pii: True
 ```
 
-**Expected Flow: **
+**Expected Flow:**
 
 1. User Input: "hello world, my name is Jane Doe. My number is: 034453334"
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -77,9 +77,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             kwargs["event_hook"] = GuardrailEventHooks.logging_only
         super().__init__(**kwargs)
         self.guardrail_provider = "presidio"
-        self.pii_tokens: dict = (
-            {}
-        )  # mapping of PII token to original text - only used with Presidio `replace` operation
+        # Per-request token maps keyed by litellm_call_id
+        self._pii_token_maps: Dict[str, Dict[str, str]] = {}
         self.mock_redacted_text = mock_redacted_text
         self.output_parse_pii = output_parse_pii or False
         self.pii_entities_config: Dict[PiiEntityType, PiiAction] = (
@@ -269,6 +268,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         anonymize_items_response: Any,
         output_parse_pii: bool,
         masked_entity_count: Dict[str, int],
+        token_map: Optional[Dict[str, str]],
     ):
         """
         Extract and store items from the Presidio anonymizer output.
@@ -277,13 +277,17 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             start = item["start"]
             end = item["end"]
             replacement = item["text"]  # replacement token
-            if item["operator"] == "replace" and output_parse_pii is True:
+            if (
+                item["operator"] == "replace"
+                and output_parse_pii is True
+                and token_map is not None
+            ):
                 # check if token in dict
                 # if exists, add a uuid to the replacement token for swapping back to the original text in llm response output parsing
-                if replacement in self.pii_tokens:
+                if replacement in token_map:
                     replacement = replacement + str(uuid.uuid4())
 
-                self.pii_tokens[replacement] = original_text[
+                token_map[replacement] = original_text[
                     start:end
                 ]  # get text it'll replace
 
@@ -293,6 +297,40 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 masked_entity_count[entity_type] = (
                     masked_entity_count.get(entity_type, 0) + 1
                 )
+
+    def _get_call_id(self, request_data: dict) -> Optional[str]:
+        try:
+            call_id = request_data.get("litellm_call_id")
+            return str(call_id) if call_id else None
+        except Exception:
+            return None
+
+    def _get_pii_token_map(self, request_data: dict) -> Optional[Dict[str, str]]:
+        """
+        Get or initialize the per-request PII token map keyed by litellm_call_id.
+        Does NOT mutate request_data.
+        """
+        call_id = self._get_call_id(request_data)
+        if call_id is None:
+            return None
+        token_map = self._pii_token_maps.get(call_id)
+        if token_map is None:
+            token_map = {}
+            self._pii_token_maps[call_id] = token_map
+        return token_map
+
+    def _cleanup_pii_token_map(self, request_data: dict) -> None:
+        """
+        Clear and remove the per-request PII token map. Also clear instance map for safety.
+        """
+        try:
+            call_id = self._get_call_id(request_data)
+            if call_id is not None:
+                tokens = self._pii_token_maps.pop(call_id, None)
+                if isinstance(tokens, dict):
+                    tokens.clear()
+        except Exception:
+            pass
 
     def raise_exception_if_blocked_entities_detected(
         self, analyze_results: Union[List[PresidioAnalyzeResponseItem], Dict]
@@ -359,11 +397,13 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 analyze_results=analyze_results,
             )
 
+            token_map = self._get_pii_token_map(request_data)
             self._record_values_from_anonymizer_items(
                 original_text=text,
                 anonymize_items_response=anonymize_response["items"],
                 output_parse_pii=self.output_parse_pii,
                 masked_entity_count=masked_entity_count,
+                token_map=token_map,
             )
 
             return anonymize_response["text"]
@@ -559,13 +599,16 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             response.choices[0], StreamingChoices
         ):  # /chat/completions requests
             if isinstance(response.choices[0].message.content, str):
+                tokens: Dict[str, str] = self._get_pii_token_map(data) or {}
                 verbose_proxy_logger.debug(
-                    f"self.pii_tokens: {self.pii_tokens}; initial response: {response.choices[0].message.content}"
+                    f"pii_tokens(request): {tokens}; initial response: {response.choices[0].message.content}"
                 )
-                for key, value in self.pii_tokens.items():
+                for key, value in tokens.items():
                     response.choices[0].message.content = response.choices[
                         0
                     ].message.content.replace(key, value)
+                # Cleanup after successful unmasking
+                self._cleanup_pii_token_map(data)
         return response
 
     async def async_post_call_streaming_iterator_hook(
@@ -581,7 +624,8 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         and returns a reconstructed stream. Otherwise, it passes through the original stream.
         """
         # If PII unmasking not needed, just pass through the original stream
-        if not (self.output_parse_pii and self.pii_tokens):
+        tokens: Dict[str, str] = self._get_pii_token_map(request_data) or {}
+        if not (self.output_parse_pii and tokens):
             async for chunk in response:
                 yield chunk
             return
@@ -615,7 +659,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 return
 
             # Apply PII unmasking to the complete content
-            for token, original_text in self.pii_tokens.items():
+            for token, original_text in tokens.items():
                 collected_content = collected_content.replace(token, original_text)
 
             # Reconstruct the response with unmasked content
@@ -642,12 +686,31 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # Return the reconstructed stream
             async for chunk in mock_response:
                 yield chunk
+            # Cleanup after streaming completes
+            self._cleanup_pii_token_map(request_data)
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error in PII streaming processing: {str(e)}")
             # Fallback to original stream on error
             async for chunk in response:
                 yield chunk
+
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict,
+        original_exception: Exception,
+        user_api_key_dict: UserAPIKeyAuth,
+        traceback_str: Optional[str] = None,
+    ):
+        """
+        Ensure per-request PII token maps are cleared on failures.
+        """
+        try:
+            self._cleanup_pii_token_map(request_data)
+        except Exception:
+            # Never raise from failure hook
+            pass
+        return
 
     def get_presidio_settings_from_request_data(
         self, data: dict

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -1,20 +1,20 @@
 import sys
 import os
-import io, asyncio
 import pytest
-import time
 from litellm import mock_completion
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import patch
+
 sys.path.insert(0, os.path.abspath("../.."))
 import litellm
-from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking, PresidioPerRequestConfig
+from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+    _OPTIONAL_PresidioPIIMasking,
+    PresidioPerRequestConfig,
+)
 from litellm.types.guardrails import PiiEntityType, PiiAction
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.caching.caching import DualCache
 from litellm.exceptions import BlockedPiiEntityError
-from litellm.types.utils import CallTypes as LitellmCallTypes
-
-
+from litellm._logging import verbose_logger
 
 
 @pytest.mark.asyncio
@@ -26,44 +26,39 @@ async def test_presidio_with_entities_config():
         PiiEntityType.CREDIT_CARD: PiiAction.MASK,
         PiiEntityType.EMAIL_ADDRESS: PiiAction.MASK,
     }
-    
+
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config=pii_entities_config,
         presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
-        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE"),
     )
-    
+
     # Test text with different PII types
     test_text = "My credit card number is 4111-1111-1111-1111, my email is test@example.com, and my phone is 555-123-4567"
-    
+
     # Test the analyze request configuration
     analyze_request = presidio_guardrail._get_presidio_analyze_request_payload(
-        text=test_text,
-        presidio_config=None,
-        request_data={}
+        text=test_text, presidio_config=None, request_data={}
     )
-    
+
     # Verify entities were passed correctly
     assert "entities" in analyze_request
     assert set(analyze_request["entities"]) == set(pii_entities_config.keys())
-    
+
     # Test the check_pii method - this will call the actual Presidio API
     redacted_text = await presidio_guardrail.check_pii(
-        text=test_text,
-        output_parse_pii=True,
-        presidio_config=None,
-        request_data={}
+        text=test_text, output_parse_pii=True, presidio_config=None, request_data={}
     )
-    
+
     # Verify PII has been masked/replaced/redacted in the result
     assert "4111-1111-1111-1111" not in redacted_text
     assert "test@example.com" not in redacted_text
 
     # Since this entity is not in the config, it should not be masked
     assert "555-123-4567" in redacted_text
-    
+
     # The specific replacements will vary based on Presidio's implementation
-    print(f"Redacted text: {redacted_text}")
+    verbose_logger.debug(f"Redacted text: {redacted_text}")
 
 
 @pytest.mark.asyncio
@@ -73,19 +68,19 @@ async def test_presidio_apply_guardrail():
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config={},
         presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
-        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE"),
     )
-
 
     response = await presidio_guardrail.apply_guardrail(
         text="My credit card number is 4111-1111-1111-1111 and my email is test@example.com",
         language="en",
     )
-    print("response from apply guardrail for presidio: ", response)
+    verbose_logger.debug(f"response from apply guardrail for presidio: {response}")
 
     # assert tthe default config masks the credit card and email
     assert "4111-1111-1111-1111" not in response
     assert "test@example.com" not in response
+
 
 @pytest.mark.asyncio
 async def test_presidio_with_blocked_entities():
@@ -96,36 +91,33 @@ async def test_presidio_with_blocked_entities():
         PiiEntityType.CREDIT_CARD: PiiAction.BLOCK,  # This entity should cause a block
         PiiEntityType.EMAIL_ADDRESS: PiiAction.MASK,  # This entity should be masked
     }
-    
+
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config=pii_entities_config,
         presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
-        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE"),
     )
-    
+
     # Test text with blocked PII type
-    test_text = "My credit card number is 4111-1111-1111-1111 and my email is test@example.com"
-    
+    test_text = (
+        "My credit card number is 4111-1111-1111-1111 and my email is test@example.com"
+    )
+
     # Verify the analyze request configuration
     analyze_request = presidio_guardrail._get_presidio_analyze_request_payload(
-        text=test_text,
-        presidio_config=None,
-        request_data={}
+        text=test_text, presidio_config=None, request_data={}
     )
-    
+
     # Verify entities were passed correctly
     assert "entities" in analyze_request
     assert set(analyze_request["entities"]) == set(pii_entities_config.keys())
-    
+
     # Test that BlockedPiiEntityError is raised when check_pii is called
     with pytest.raises(BlockedPiiEntityError) as excinfo:
         await presidio_guardrail.check_pii(
-            text=test_text,
-            output_parse_pii=True,
-            presidio_config=None,
-            request_data={}
+            text=test_text, output_parse_pii=True, presidio_config=None, request_data={}
         )
-    
+
     # Verify the error contains the correct entity type
     assert excinfo.value.entity_type == PiiEntityType.CREDIT_CARD
     assert excinfo.value.guardrail_name == presidio_guardrail.guardrail_name
@@ -139,37 +131,40 @@ async def test_presidio_pre_call_hook_with_blocked_entities():
         PiiEntityType.CREDIT_CARD: PiiAction.BLOCK,  # This entity should cause a block
         PiiEntityType.EMAIL_ADDRESS: PiiAction.MASK,  # This entity should be masked
     }
-    
+
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config=pii_entities_config,
         presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
-        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE"),
     )
-    
+
     # Create a sample chat completion request with PII data
     data = {
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "My credit card is 4111-1111-1111-1111 and my email is test@example.com."}
+            {
+                "role": "user",
+                "content": "My credit card is 4111-1111-1111-1111 and my email is test@example.com.",
+            },
         ],
-        "model": "gpt-3.5-turbo"
+        "model": "gpt-3.5-turbo",
     }
-    
+
     # Mock objects needed for the pre-call hook
     user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
     cache = DualCache()
-    
+
     # Call the pre-call hook and expect BlockedPiiEntityError
     with pytest.raises(BlockedPiiEntityError) as excinfo:
         await presidio_guardrail.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
             data=data,
-            call_type="completion"
+            call_type="completion",
         )
-    
-    print(f"got error: {excinfo}")
-    
+
+    verbose_logger.debug(f"got error: {excinfo}")
+
     # Verify the error contains the correct entity type
     assert excinfo.value.entity_type == PiiEntityType.CREDIT_CARD
     assert excinfo.value.guardrail_name == presidio_guardrail.guardrail_name
@@ -184,45 +179,49 @@ async def test_presidio_pre_call_hook_with_different_call_types(call_type):
         PiiEntityType.CREDIT_CARD: PiiAction.MASK,
         PiiEntityType.EMAIL_ADDRESS: PiiAction.MASK,
     }
-    
+
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config=pii_entities_config,
         presidio_analyzer_api_base=os.environ.get("PRESIDIO_ANALYZER_API_BASE"),
-        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE")
+        presidio_anonymizer_api_base=os.environ.get("PRESIDIO_ANONYMIZER_API_BASE"),
     )
-    
+
     # Create a sample request with PII data
     data = {
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "My credit card is 4111-1111-1111-1111 and my email is test@example.com. My phone number is 555-123-4567"}
+            {
+                "role": "user",
+                "content": "My credit card is 4111-1111-1111-1111 and my email is test@example.com. My phone number is 555-123-4567",
+            },
         ],
-        "model": "gpt-3.5-turbo"
+        "model": "gpt-3.5-turbo",
     }
-    
+
     # Mock objects needed for the pre-call hook
     user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
     cache = DualCache()
-    
+
     # Call the pre-call hook with the specified call type
     modified_data = await presidio_guardrail.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict,
-        cache=cache,
-        data=data,
-        call_type=call_type
+        user_api_key_dict=user_api_key_dict, cache=cache, data=data, call_type=call_type
     )
-    
+
     # Verify the messages have been modified to mask PII
-    assert modified_data["messages"][0]["content"] == "You are a helpful assistant."  # System prompt should be unchanged
-    
+    assert (
+        modified_data["messages"][0]["content"] == "You are a helpful assistant."
+    )  # System prompt should be unchanged
+
     user_message = modified_data["messages"][1]["content"]
     assert "4111-1111-1111-1111" not in user_message
     assert "test@example.com" not in user_message
 
     # Since this entity is not in the config, it should not be masked
     assert "555-123-4567" in user_message
-    
-    print(f"Modified user message for call_type={call_type}: {user_message}")
+
+    verbose_logger.debug(
+        f"Modified user message for call_type={call_type}: {user_message}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -239,7 +238,7 @@ def test_validate_environment_missing_http(base_url):
     # Use patch.dict to temporarily modify environment variables only for this test
     env_vars = {
         "PRESIDIO_ANALYZER_API_BASE": f"{base_url}/analyze",
-        "PRESIDIO_ANONYMIZER_API_BASE": f"{base_url}/anonymize"
+        "PRESIDIO_ANONYMIZER_API_BASE": f"{base_url}/anonymize",
     }
     with patch.dict(os.environ, env_vars):
         pii_masking.validate_environment()
@@ -268,12 +267,12 @@ async def test_output_parsing():
     litellm.output_parse_pii = True
     pii_masking = _OPTIONAL_PresidioPIIMasking(mock_testing=True)
 
-    initial_message = [
-        {
-            "role": "user",
-            "content": "hello world, my name is Jane Doe. My number is: 034453334",
-        }
-    ]
+    # initial_message = [
+    #     {
+    #         "role": "user",
+    #         "content": "hello world, my name is Jane Doe. My number is: 034453334",
+    #     }
+    # ]
 
     filtered_message = [
         {
@@ -313,7 +312,7 @@ input_a_anonymizer_results = {
     "items": [
         {
             "start": 48,
-            "end": 62,
+            "end": 63,
             "entity_type": "PHONE_NUMBER",
             "text": "<PHONE_NUMBER>",
             "operator": "replace",
@@ -349,29 +348,48 @@ async def test_presidio_pii_masking_input_a():
     Tests to see if correct parts of sentence anonymized
     """
     pii_masking = _OPTIONAL_PresidioPIIMasking(
-        mock_testing=True, mock_redacted_text=input_a_anonymizer_results
+        mock_testing=True,
+        mock_redacted_text=input_a_anonymizer_results,
+        output_parse_pii=True,
     )
 
     _api_key = "sk-12345"
     user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
     local_cache = DualCache()
 
+    request_data: dict = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "hello world, my name is Jane Doe. My number is: 23r323r23r2wwkl",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+
     new_data = await pii_masking.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict,
         cache=local_cache,
-        data={
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "hello world, my name is Jane Doe. My number is: 23r323r23r2wwkl",
-                }
-            ]
-        },
+        data=request_data,
         call_type="completion",
     )
 
     assert "<PERSON>" in new_data["messages"][0]["content"]
     assert "<PHONE_NUMBER>" in new_data["messages"][0]["content"]
+    assert (
+        1
+        == request_data["metadata"]["standard_logging_guardrail_information"][
+            "masked_entity_count"
+        ]["PERSON"]
+    )
+    assert (
+        1
+        == request_data["metadata"]["standard_logging_guardrail_information"][
+            "masked_entity_count"
+        ]["PHONE_NUMBER"]
+    )
+    assert "Jane Doe" == pii_masking.pii_tokens["<PERSON>"]
+    assert "23r323r23r2wwkl" == pii_masking.pii_tokens["<PHONE_NUMBER>"]
 
 
 #   Test if PII masking works with input B (also test if the response != A's response)
@@ -381,29 +399,42 @@ async def test_presidio_pii_masking_input_b():
     Tests to see if correct parts of sentence anonymized
     """
     pii_masking = _OPTIONAL_PresidioPIIMasking(
-        mock_testing=True, mock_redacted_text=input_b_anonymizer_results
+        mock_testing=True,
+        mock_redacted_text=input_b_anonymizer_results,
+        output_parse_pii=True,
     )
 
     _api_key = "sk-12345"
     user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
     local_cache = DualCache()
 
+    request_data: dict = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "My name is Jane Doe, who are you? Say my name in your response",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+
     new_data = await pii_masking.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict,
         cache=local_cache,
-        data={
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "My name is Jane Doe, who are you? Say my name in your response",
-                }
-            ]
-        },
+        data=request_data,
         call_type="completion",
     )
 
     assert "<PERSON>" in new_data["messages"][0]["content"]
     assert "<PHONE_NUMBER>" not in new_data["messages"][0]["content"]
+    assert (
+        1
+        == request_data["metadata"]["standard_logging_guardrail_information"][
+            "masked_entity_count"
+        ]["PERSON"]
+    )
+    assert "Jane Doe" == pii_masking.pii_tokens["<PERSON>"]
+    assert "<PHONE_NUMBER>" not in pii_masking.pii_tokens
 
 
 @pytest.mark.asyncio
@@ -415,10 +446,6 @@ async def test_presidio_pii_masking_logging_output_only_no_pre_api_hook():
         mock_testing=True,
         mock_redacted_text=input_b_anonymizer_results,
     )
-
-    _api_key = "sk-12345"
-    user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
-    local_cache = DualCache()
 
     test_messages = [
         {
@@ -437,24 +464,26 @@ async def test_presidio_pii_masking_logging_output_only_no_pre_api_hook():
 
 
 @pytest.mark.asyncio
-@patch.dict(os.environ, {
-    "PRESIDIO_ANALYZER_API_BASE": "http://localhost:5002",
-    "PRESIDIO_ANONYMIZER_API_BASE": "http://localhost:5001"
-})
+@patch.dict(
+    os.environ,
+    {
+        "PRESIDIO_ANALYZER_API_BASE": "http://localhost:5002",
+        "PRESIDIO_ANONYMIZER_API_BASE": "http://localhost:5001",
+    },
+)
 async def test_presidio_pii_masking_logging_output_only_logged_response_guardrails_config():
     from typing import Dict, List, Optional
 
     import litellm
     from litellm.proxy.guardrails.init_guardrails import initialize_guardrails
     from litellm.types.guardrails import (
-        GuardrailItem,
         GuardrailItemSpec,
         GuardrailEventHooks,
     )
 
     litellm.set_verbose = True
     # Environment variables are now patched via the decorator instead of setting them directly
-    
+
     guardrails_config: List[Dict[str, GuardrailItemSpec]] = [
         {
             "pii_masking": {
@@ -478,7 +507,7 @@ async def test_presidio_pii_masking_logging_output_only_logged_response_guardrai
 
     pii_masking_obj: Optional[_OPTIONAL_PresidioPIIMasking] = None
     for callback in litellm.callbacks:
-        print(f"CALLBACK: {callback}")
+        verbose_logger.debug(f"CALLBACK: {callback}")
         if isinstance(callback, _OPTIONAL_PresidioPIIMasking):
             pii_masking_obj = callback
 
@@ -496,60 +525,53 @@ async def test_presidio_pii_masking_logging_output_only_logged_response_guardrai
 async def test_presidio_language_configuration():
     """Test that presidio_language parameter is properly set and used in analyze requests"""
     litellm._turn_on_debug()
-    
+
     # Test with German language using mock testing to avoid API calls
     presidio_guardrail_de = _OPTIONAL_PresidioPIIMasking(
         pii_entities_config={},
         presidio_language="de",
-        mock_testing=True  # This bypasses the API validation
+        mock_testing=True,  # This bypasses the API validation
     )
-    
+
     test_text = "Meine Telefonnummer ist +49 30 12345678"
-    
+
     # Test the analyze request configuration
     analyze_request = presidio_guardrail_de._get_presidio_analyze_request_payload(
-        text=test_text,
-        presidio_config=None,
-        request_data={}
+        text=test_text, presidio_config=None, request_data={}
     )
-    
+
     # Verify the language is set to German
     assert analyze_request["language"] == "de"
     assert analyze_request["text"] == test_text
-    
+
     # Test with Spanish language
     presidio_guardrail_es = _OPTIONAL_PresidioPIIMasking(
-        pii_entities_config={},
-        presidio_language="es",
-        mock_testing=True
+        pii_entities_config={}, presidio_language="es", mock_testing=True
     )
-    
+
     test_text_es = "Mi número de teléfono es +34 912 345 678"
-    
+
     analyze_request_es = presidio_guardrail_es._get_presidio_analyze_request_payload(
-        text=test_text_es,
-        presidio_config=None,
-        request_data={}
+        text=test_text_es, presidio_config=None, request_data={}
     )
-    
+
     # Verify the language is set to Spanish
     assert analyze_request_es["language"] == "es"
     assert analyze_request_es["text"] == test_text_es
-    
+
     # Test default language (English) when not specified
     presidio_guardrail_default = _OPTIONAL_PresidioPIIMasking(
-        pii_entities_config={},
-        mock_testing=True
+        pii_entities_config={}, mock_testing=True
     )
-    
+
     test_text_en = "My phone number is +1 555-123-4567"
-    
-    analyze_request_default = presidio_guardrail_default._get_presidio_analyze_request_payload(
-        text=test_text_en,
-        presidio_config=None,
-        request_data={}
+
+    analyze_request_default = (
+        presidio_guardrail_default._get_presidio_analyze_request_payload(
+            text=test_text_en, presidio_config=None, request_data={}
+        )
     )
-    
+
     # Verify the language defaults to English
     assert analyze_request_default["language"] == "en"
     assert analyze_request_default["text"] == test_text_en
@@ -559,36 +581,30 @@ async def test_presidio_language_configuration():
 async def test_presidio_language_configuration_with_per_request_override():
     """Test that per-request language configuration overrides the default configured language"""
     litellm._turn_on_debug()
-    
+
     # Set up guardrail with German as default language
     presidio_guardrail = _OPTIONAL_PresidioPIIMasking(
-        pii_entities_config={},
-        presidio_language="de",
-        mock_testing=True
+        pii_entities_config={}, presidio_language="de", mock_testing=True
     )
-    
+
     test_text = "Test text with PII"
-    
+
     # Test with per-request config overriding the default language
     presidio_config = PresidioPerRequestConfig(language="fr")
-    
+
     analyze_request = presidio_guardrail._get_presidio_analyze_request_payload(
-        text=test_text,
-        presidio_config=presidio_config,
-        request_data={}
+        text=test_text, presidio_config=presidio_config, request_data={}
     )
-    
+
     # Verify the per-request language (French) overrides the default (German)
     assert analyze_request["language"] == "fr"
     assert analyze_request["text"] == test_text
-    
+
     # Test without per-request config - should use default language
     analyze_request_default = presidio_guardrail._get_presidio_analyze_request_payload(
-        text=test_text,
-        presidio_config=None,
-        request_data={}
+        text=test_text, presidio_config=None, request_data={}
     )
-    
+
     # Verify the default language (German) is used
     assert analyze_request_default["language"] == "de"
     assert analyze_request_default["text"] == test_text

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -281,7 +281,8 @@ async def test_output_parsing():
         }
     ]
 
-    pii_masking.pii_tokens = {"<PERSON>": "Jane Doe", "<PHONE_NUMBER>": "034453334"}
+    call_id = "call-failed"
+    pii_masking._pii_token_maps[call_id] = {"<PERSON>": "Jane Doe", "<PHONE_NUMBER>": "034453334"}
 
     response = mock_completion(
         model="gpt-3.5-turbo",
@@ -291,6 +292,7 @@ async def test_output_parsing():
     new_response = await pii_masking.async_post_call_success_hook(
         user_api_key_dict=UserAPIKeyAuth(),
         data={
+            "litellm_call_id": call_id,
             "messages": [{"role": "system", "content": "You are an helpfull assistant"}]
         },
         response=response,
@@ -357,7 +359,9 @@ async def test_presidio_pii_masking_input_a():
     user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
     local_cache = DualCache()
 
+    call_id = "call-1"
     request_data: dict = {
+        "litellm_call_id": call_id,
         "messages": [
             {
                 "role": "user",
@@ -388,8 +392,8 @@ async def test_presidio_pii_masking_input_a():
             "masked_entity_count"
         ]["PHONE_NUMBER"]
     )
-    assert "Jane Doe" == pii_masking.pii_tokens["<PERSON>"]
-    assert "23r323r23r2wwkl" == pii_masking.pii_tokens["<PHONE_NUMBER>"]
+    assert "Jane Doe" == pii_masking._pii_token_maps[call_id]["<PERSON>"]
+    assert "23r323r23r2wwkl" == pii_masking._pii_token_maps[call_id]["<PHONE_NUMBER>"]
 
 
 #   Test if PII masking works with input B (also test if the response != A's response)
@@ -408,7 +412,9 @@ async def test_presidio_pii_masking_input_b():
     user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
     local_cache = DualCache()
 
+    call_id = "call-1"
     request_data: dict = {
+        "litellm_call_id": call_id,
         "messages": [
             {
                 "role": "user",
@@ -433,8 +439,8 @@ async def test_presidio_pii_masking_input_b():
             "masked_entity_count"
         ]["PERSON"]
     )
-    assert "Jane Doe" == pii_masking.pii_tokens["<PERSON>"]
-    assert "<PHONE_NUMBER>" not in pii_masking.pii_tokens
+    assert "Jane Doe" == pii_masking._pii_token_maps[call_id]["<PERSON>"]
+    assert "<PHONE_NUMBER>" not in pii_masking._pii_token_maps[call_id]["<PERSON>"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -1,0 +1,184 @@
+from typing import Dict
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+    _OPTIONAL_PresidioPIIMasking,
+)
+from litellm.types.utils import Choices, Message, ModelResponse
+
+
+input_anonymizer_results_a = {
+    "text": "hello world, my name is <PERSON>. My number is: <PHONE_NUMBER>",
+    "items": [
+        {
+            "start": 48,
+            "end": 63,
+            "entity_type": "PHONE_NUMBER",
+            "text": "<PHONE_NUMBER>",
+            "operator": "replace",
+        },
+        {
+            "start": 24,
+            "end": 32,
+            "entity_type": "PERSON",
+            "text": "<PERSON>",
+            "operator": "replace",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_token_map_populated_and_success_cleanup():
+    guard = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        mock_redacted_text=input_anonymizer_results_a,
+        output_parse_pii=True,
+    )
+    cache = DualCache()
+    user_key = UserAPIKeyAuth(api_key="sk-test")
+
+    call_id = "call-1"
+    request_data = {
+        "litellm_call_id": call_id,
+        "messages": [
+            {
+                "role": "user",
+                "content": "hello world, my name is Jane Doe. My number is: 23r323r23r2wwkl",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+
+    # pre_call should analyze/anonymize and populate token map
+    new_data = await guard.async_pre_call_hook(
+        user_api_key_dict=user_key,
+        cache=cache,
+        data=request_data,
+        call_type="completion",
+    )
+
+    assert new_data["messages"][0]["content"] == "hello world, my name is <PERSON>. My number is: <PHONE_NUMBER>"
+
+    # tokens are recorded under the instance map keyed by call id
+    tokens: Dict[str, str] = guard._pii_token_maps.get(call_id) or {}
+    assert tokens.get("<PERSON>") == "Jane Doe"
+    assert tokens.get("<PHONE_NUMBER>") == "23r323r23r2wwkl"
+
+    # success hook should unmask in response and cleanup the map
+    response = ModelResponse(
+        model="test-model",
+        choices=[
+            Choices(message=Message(role="assistant", content="Hi <PERSON> (<PHONE_NUMBER>)"))
+        ],
+    )
+
+    updated = await guard.async_post_call_success_hook(
+        data={"litellm_call_id": call_id},
+        user_api_key_dict=user_key,
+        response=response,
+    )
+    assert isinstance(updated, ModelResponse)
+    assert (
+        updated.choices[0].message.content
+        == "Hi Jane Doe (23r323r23r2wwkl)"
+    )
+    # map is cleaned
+    assert guard._pii_token_maps.get(call_id) is None
+
+
+@pytest.mark.asyncio
+async def test_failure_hook_cleans_token_map():
+    guard = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        mock_redacted_text=input_anonymizer_results_a,
+        output_parse_pii=True,
+    )
+    cache = DualCache()
+    user_key = UserAPIKeyAuth(api_key="sk-test")
+
+    call_id = "call-failed"
+    request_data = {
+        "litellm_call_id": call_id,
+        "messages": [
+            {
+                "role": "user",
+                "content": "hello world, my name is Jane Doe. My number is: 23r323r23r2wwkl",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+
+    _ = await guard.async_pre_call_hook(
+        user_api_key_dict=user_key,
+        cache=cache,
+        data=request_data,
+        call_type="completion",
+    )
+    assert guard._pii_token_maps.get(call_id)
+
+    # simulate a failure after pre_call
+    await guard.async_post_call_failure_hook(
+        request_data={"litellm_call_id": call_id},
+        original_exception=Exception("boom"),
+        user_api_key_dict=user_key,
+    )
+    assert guard._pii_token_maps.get(call_id) is None
+
+
+@pytest.mark.asyncio
+async def test_isolation_between_call_ids():
+    guard = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        mock_redacted_text=input_anonymizer_results_a,
+        output_parse_pii=True,
+    )
+    cache = DualCache()
+    user_key = UserAPIKeyAuth(api_key="sk-test")
+
+    # call A
+    call_id_a = "call-a"
+    req_a = {
+        "litellm_call_id": call_id_a,
+        "messages": [
+            {
+                "role": "user",
+                "content": "hello world, my name is Jane Doe. My number is: 1111",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+    # call B
+    call_id_b = "call-b"
+    req_b = {
+        "litellm_call_id": call_id_b,
+        "messages": [
+            {
+                "role": "user",
+                "content": "hello world, my name is Alice. My number is: 2222",
+            }
+        ],
+        "metadata": {"standard_logging_guardrail_information": {}},
+    }
+
+    # Run pre_call for both
+    await guard.async_pre_call_hook(user_api_key_dict=user_key, cache=cache, data=req_a, call_type="completion")
+    await guard.async_pre_call_hook(user_api_key_dict=user_key, cache=cache, data=req_b, call_type="completion")
+
+    # Both maps exist separately
+    assert guard._pii_token_maps.get(call_id_a) is not None
+    assert guard._pii_token_maps.get(call_id_b) is not None
+    assert guard._pii_token_maps.get(call_id_a) is not guard._pii_token_maps.get(call_id_b)
+
+    # Cleanup only A
+    await guard.async_post_call_failure_hook(
+        request_data={"litellm_call_id": call_id_a},
+        original_exception=Exception("fail a"),
+        user_api_key_dict=user_key,
+    )
+    assert guard._pii_token_maps.get(call_id_a) is None
+    assert guard._pii_token_maps.get(call_id_b) is not None
+


### PR DESCRIPTION
## Title

fix: share a single _OPTIONAL_PresidioPIIMasking instance to ensure unmasking works when output_parse_pii=true

## Relevant issues

Fixes #14516

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix
🧹 Refactoring
📖 Documentation
✅ Test

## Changes

 - https://github.com/BerriAI/litellm/commit/93d07027e0c2f6210bc542033552922d0c6b6250
   In `guardrail_initializers.py`, a separate Presidio Guardrail instance was created for the `post_call` hook.  
   Because of this, the `pii_tokens` field set for unmasking was not shared across instances, and unmasking did not work as expected.
  The issue is resolved by sharing the same Presidio Guardrail instance, ensuring that `pii_tokens` values are preserved and unmasking works correctly.

 - https://github.com/BerriAI/litellm/commit/5db16bfa0c07612b1cf3b32a09b69768292a4691
    Additionally, when using `mock_redacted_text` to mock API responses inside Presidio Guardrail, `pii_tokens` values were not being set.  
This PR includes a small refactor to address that as well.

 - https://github.com/BerriAI/litellm/commit/14b983a4686d601a4f442fc26ddb32a0fe63ab1c
    I also fixed incorrect bold formatting in the documentation.
