### PR TITLE
[Fix] `AttributeError: NoneType object has no attribute 'get'` in `parallel_request_limiter_v3.py`

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -832,7 +832,8 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             litellm_parent_otel_span: Union[Span, None] = (
                 _get_parent_otel_span_from_kwargs(kwargs)
             )
-            user_api_key = kwargs["litellm_params"]["metadata"].get("user_api_key")
+            litellm_metadata = kwargs["litellm_params"]["metadata"]
+            user_api_key = litellm_metadata.get("user_api_key") if litellm_metadata else None
             pipeline_operations: List[RedisPipelineIncrementOperation] = []
 
             if user_api_key:


### PR DESCRIPTION
## Title

Fix `AttributeError: NoneType object has no attribute 'get'` in `parallel_request_limiter_v3.py`

## Relevant issues

Whenever there is a failure in LiteLLM proxy, along with the actual error causing the failure, I keep getting this error too:

<img width="840" height="402" alt="image" src="https://github.com/user-attachments/assets/a768731c-db37-49c4-9ca3-b5cddb09e98e" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Turns out `kwargs["litellm_params"]["metadata"]` can be None, not necessarily an empty dictionary. I safeguarded against that exactly where it fails:
```
litellm_metadata = kwargs["litellm_params"]["metadata"]
user_api_key = litellm_metadata.get("user_api_key") if litellm_metadata else None
```

I did not go too hard on safeguarding though - could also have safeguarded against `"metadata"` key not being present in `litellm_params` dictionary at all, but I decided against that. I noticed that in other places of the codebase it is assumed that the "metadata" key is present.
