### PR TITLE
Fix error message for missing OCI parameters

### DIFF
--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -378,7 +378,7 @@ class OCIChatConfig(BaseConfig):
             or not oci_compartment_id
         ):
             raise Exception(
-                "Missing required parameters: oci_user, oci_fingerprint, oci_tenancy, "
+                "Missing required parameters: oci_user, oci_fingerprint, oci_tenancy, oci_compartment_id "
                 "and at least one of oci_key or oci_key_file."
             )
 


### PR DESCRIPTION
## Fix error message for missing OCI parameters

This pull request makes a minor update to the error message in the `validate_environment` function. The message now explicitly mentions `oci_compartment_id` as a required parameter, improving clarity for users when required OCI parameters are missing.

## Relevant issues

N/A

## Type

🧹 Refactoring


