### PR TITLE
[Performance] RPS Improvement +500 RPS when sending the `user` field

### DIFF
--- a/litellm/proxy/common_utils/performance_utils.py
+++ b/litellm/proxy/common_utils/performance_utils.py
@@ -72,7 +72,7 @@ def _save_stats(profile_file: PathLib) -> None:
             # Make sure profiler is re-enabled even if there's an error
             try:
                 _profiler.enable()
-            except:
+            except Exception:
                 pass
 
 
@@ -101,7 +101,7 @@ def profile_endpoint(sampling_rate: float = 1.0):
                     if is_sampling:
                         _save_stats(file_path_obj)
                     return result
-                except Exception as e:
+                except Exception:
                     if is_sampling:
                         _save_stats(file_path_obj)
                     raise
@@ -117,7 +117,7 @@ def profile_endpoint(sampling_rate: float = 1.0):
                     if is_sampling:
                         _save_stats(file_path_obj)
                     return result
-                except Exception as e:
+                except Exception:
                     if is_sampling:
                         _save_stats(file_path_obj)
                     raise

--- a/litellm/proxy/common_utils/performance_utils.py
+++ b/litellm/proxy/common_utils/performance_utils.py
@@ -1,0 +1,125 @@
+"""
+Performance utilities for LiteLLM proxy server.
+
+This module provides performance monitoring and profiling functionality for endpoint
+performance analysis using cProfile with configurable sampling rates.
+"""
+
+import asyncio
+import cProfile
+import functools
+import threading
+from pathlib import Path as PathLib
+
+from litellm._logging import verbose_proxy_logger
+
+# Global profiling state
+_profile_lock = threading.Lock()
+_profiler = None
+_last_profile_file_path = None
+_sample_counter = 0
+_sample_counter_lock = threading.Lock()
+
+
+def _should_sample(profile_sampling_rate: float) -> bool:
+    """Determine if current request should be sampled based on sampling rate."""
+    if profile_sampling_rate >= 1.0:
+        return True  # Always sample
+    elif profile_sampling_rate <= 0.0:
+        return False  # Never sample
+    
+    # Use deterministic sampling based on counter for consistent rate
+    global _sample_counter
+    with _sample_counter_lock:
+        _sample_counter += 1
+        # Sample based on rate (e.g., 0.1 means sample every 10th request)
+        should_sample = (_sample_counter % int(1.0 / profile_sampling_rate)) == 0
+        return should_sample
+
+
+def _start_profiling(profile_sampling_rate: float) -> None:
+    """Start cProfile profiling once globally."""
+    global _profiler
+    with _profile_lock:
+        if _profiler is None:
+            _profiler = cProfile.Profile()
+            _profiler.enable()
+            verbose_proxy_logger.info(f"Profiling started with sampling rate: {profile_sampling_rate}")
+
+
+def _start_profiling_for_request(profile_sampling_rate: float) -> bool:
+    """Start profiling for a specific request (if sampling allows)."""
+    if _should_sample(profile_sampling_rate):
+        _start_profiling(profile_sampling_rate)
+        return True
+    return False
+
+
+def _save_stats(profile_file: PathLib) -> None:
+    """Save current stats directly to file."""
+    with _profile_lock:
+        if _profiler is None:
+            return
+        try:
+            # Disable profiler temporarily to dump stats
+            _profiler.disable()
+            _profiler.dump_stats(str(profile_file))
+            # Re-enable profiler to continue profiling
+            _profiler.enable()
+            verbose_proxy_logger.debug(f"Profiling stats saved to {profile_file}")
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error saving profiling stats: {e}")
+            # Make sure profiler is re-enabled even if there's an error
+            try:
+                _profiler.enable()
+            except:
+                pass
+
+
+def profile_endpoint(sampling_rate: float = 1.0):
+    """Decorator to sample endpoint hits and save to a profile file.
+    
+    Args:
+        sampling_rate: Rate of requests to profile (0.0 to 1.0)
+                      - 1.0: Profile all requests (100%)
+                      - 0.1: Profile 1 in 10 requests (10%)
+                      - 0.0: Profile no requests (0%)
+    """
+    def decorator(func):
+        def set_last_profile_path(path: PathLib) -> None:
+            global _last_profile_file_path
+            _last_profile_file_path = path
+
+        if asyncio.iscoroutinefunction(func):
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                is_sampling = _start_profiling_for_request(sampling_rate)
+                file_path_obj = PathLib("endpoint_profile.pstat")
+                set_last_profile_path(file_path_obj)
+                try:
+                    result = await func(*args, **kwargs)
+                    if is_sampling:
+                        _save_stats(file_path_obj)
+                    return result
+                except Exception as e:
+                    if is_sampling:
+                        _save_stats(file_path_obj)
+                    raise
+            return async_wrapper
+        else:
+            @functools.wraps(func)
+            def sync_wrapper(*args, **kwargs):
+                is_sampling = _start_profiling_for_request(sampling_rate)
+                file_path_obj = PathLib("endpoint_profile.pstat")
+                set_last_profile_path(file_path_obj)
+                try:
+                    result = func(*args, **kwargs)
+                    if is_sampling:
+                        _save_stats(file_path_obj)
+                    return result
+                except Exception as e:
+                    if is_sampling:
+                        _save_stats(file_path_obj)
+                    raise
+            return sync_wrapper
+    return decorator

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -48,7 +48,7 @@ async def test_get_end_user_object(customer_spend, customer_budget):
     )
     _cache = DualCache()
     _key = "end_user_id:{}".format(end_user_id)
-    _cache.set_cache(key=_key, value=end_user_obj)
+    _cache.set_cache(key=_key, value=end_user_obj.model_dump())
     try:
         await get_end_user_object(
             end_user_id=end_user_id,


### PR DESCRIPTION
## Cache exception handled 


## Changes

### Short Explanation
- Standardized the caching logic to avoid type issues, which was causing 50% cache misses.

### Context
The set_cache function was storing values with unexpected types. As a result, the get_cache function failed to recognize objects that were actually present in the cache about half the time. This caused unnecessary database lookups roughly 50% of the time, leading to the performance regression shown below.

### Performance Change

<p><strong>Before Fix</strong></p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 31423 | 0 | 27 | 6200 | 11000 | 1212.85 | 12 | 26398 | 398 | 558.7 | 0
  | Aggregated | 31423 | 0 | 27 | 6200 | 11000 | 1212.85 | 12 | 26398 | 398 | 558.7 | 0

<p>After the Fix</p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 36496 | 0 | 86 | 840 | 13000 | 488.78 | 15 | 15683 | 398 | 1039.4 | 0
Custom | LiteLLM Overhead Duration (ms) | 36496 | 0 | 4 | 52 | 190 | 14.13 | 0 | 626 | 0 | 1039.4 | 0
  | Aggregated | 72992 | 0 | 31 | 480 | 10000 | 251.46 | 0 | 15683 | 199 | 2078.8 | 0


<!-- notionvc: f891e75d-c376-4a0a-a63c-60f3a3ed8506 -->


## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🧹 Refactoring


