### PR TITLE
Fix: 14473: Guardrail view, edit, and delete behavior

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -857,10 +857,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                     className="mt-4"
                     help={premiumUser ? "Select existing guardrails or enter new ones" : "Premium feature - Upgrade to set guardrails by key"}
                   >
-                    <Tooltip 
-                      title={!premiumUser ? "Setting guardrails by key is a premium feature" : ""}
-                      placement="top"
-                    >
                       <Select
                         mode="tags"
                         style={{ width: '100%' }}
@@ -872,7 +868,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                         }
                         options={guardrailsList.map(name => ({ value: name, label: name }))}
                       />
-                    </Tooltip>
                   </Form.Item>
                   <Form.Item 
                     label={
@@ -894,10 +889,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                     className="mt-4"
                     help={premiumUser ? "Select existing prompts or enter new ones" : "Premium feature - Upgrade to set prompts by key"}
                   >
-                    <Tooltip 
-                      title={!premiumUser ? "Setting prompts by key is a premium feature" : ""}
-                      placement="top"
-                    >
                       <Select
                         mode="tags"
                         style={{ width: '100%' }}
@@ -909,7 +900,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                         }
                         options={promptsList.map(name => ({ value: name, label: name }))}
                       />
-                    </Tooltip>
                   </Form.Item>
                   <Form.Item 
                         label={

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -11,6 +11,7 @@ import EditLoggingSettings from "../team/EditLoggingSettings"
 import { extractLoggingSettings, formatMetadataForDisplay } from "../key_info_utils"
 import { fetchMCPAccessGroups } from "../networking"
 import { mapInternalToDisplayNames, mapDisplayToInternalNames } from "../callback_info_helpers"
+import GuardrailSelector from "@/components/guardrails/GuardrailSelector"
 
 interface KeyEditViewProps {
   keyData: KeyResponse
@@ -220,20 +221,9 @@ export function KeyEditView({
       </Form.Item>
 
       <Form.Item label="Guardrails" name="guardrails">
-        <Tooltip title={!premiumUser ? "Setting guardrails by key is a premium feature" : ""} placement="top">
-          <Select
-            mode="tags"
-            style={{ width: "100%" }}
-            disabled={!premiumUser}
-            placeholder={
-              !premiumUser
-                ? "Premium feature - Upgrade to set guardrails by key"
-                : Array.isArray(keyData.metadata?.guardrails) && keyData.metadata.guardrails.length > 0
-                  ? `Current: ${keyData.metadata.guardrails.join(", ")}`
-                  : "Select or enter guardrails"
-            }
-          />
-        </Tooltip>
+        { accessToken &&
+          <GuardrailSelector onChange={(v) => {form.setFieldValue("guardrails", v)}} accessToken={accessToken} />
+        }
       </Form.Item>
 
       <Form.Item label="Prompts" name="prompts">


### PR DESCRIPTION
## Fix: Guardrail view, edit, and delete behavior

These changes fix the inability for the user to view, edit, and delete guardrails attached to keys.

## Relevant issues

Fixes 14473 [https://github.com/BerriAI/litellm/issues/14473]

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [N/A] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [N/A] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
- removed tooltip from guardrail select on forms
- used generic GuardrailSelect component for key edit form

