### PR TITLE
Fix: MDX compilation error in CompactifAI documentation

### DIFF
--- a/docs/my-website/docs/providers/compactifai.md
+++ b/docs/my-website/docs/providers/compactifai.md
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem';
 # CompactifAI
 https://docs.compactif.ai/
 
-CompactifAI offers highly compressed versions of leading language models, delivering up to **70% lower inference costs**, **4x throughput gains**, and **low-latency inference** with minimal quality loss (<5%). CompactifAI's OpenAI-compatible API makes integration straightforward, enabling developers to build ultra-efficient, scalable AI applications with superior concurrency and resource efficiency.
+CompactifAI offers highly compressed versions of leading language models, delivering up to **70% lower inference costs**, **4x throughput gains**, and **low-latency inference** with minimal quality loss (under 5%). CompactifAI's OpenAI-compatible API makes integration straightforward, enabling developers to build ultra-efficient, scalable AI applications with superior concurrency and resource efficiency.
 
 | Property | Details |
 |-------|-------|
@@ -192,7 +192,7 @@ Common model formats:
 ## Benefits
 
 - **Cost Efficient**: Up to 70% lower inference costs compared to standard models
-- **High Performance**: 4x throughput gains with minimal quality loss (<5%)
+- **High Performance**: 4x throughput gains with minimal quality loss (under 5%)
 - **Low Latency**: Optimized for fast response times
 - **Drop-in Replacement**: Full OpenAI API compatibility
 - **Scalable**: Superior concurrency and resource efficiency


### PR DESCRIPTION
## Title

Fix: MDX compilation error in CompactifAI documentation

## Relevant issues

Fixes #14624

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory *(N/A - Documentation fix only)*
- [x] I have added a screenshot of my new test passing locally *(N/A - Documentation fix only)*
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(N/A - Documentation fix only)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

Fixed MDX compilation error by replacing `(<5%)` with `(under 5%)` in CompactifAI documentation. This resolves webpack build failures in Docusaurus.