### PR TITLE
[Feat]Add last message as default in gaurdrail

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -102,6 +102,69 @@ class AmazonConverseConfig(BaseConfig):
             "performanceConfig": PerformanceConfigBlock,
         }
 
+    @staticmethod
+    def _convert_last_user_message_to_guarded_text(
+        messages: List[AllMessageValues], optional_params: dict
+    ) -> List[AllMessageValues]:
+        """
+        Convert the last user message to guarded_text type if guardrailConfig is present
+        and no guarded_text is already present in the last user message.
+        """
+        # Check if guardrailConfig is present
+        if "guardrailConfig" not in optional_params:
+            return messages
+
+        # Find the last user message
+        last_user_message = None
+        last_user_message_index = -1
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") == "user":
+                last_user_message = messages[i]
+                last_user_message_index = i
+                break
+
+        if last_user_message is None:
+            return messages
+
+        # Check if the last user message already has guarded_text
+        content = last_user_message.get("content", [])
+        if isinstance(content, list):
+            has_guarded_text = any(
+                isinstance(item, dict) and item.get("type") == "guarded_text"
+                for item in content
+            )
+            if has_guarded_text:
+                return messages
+
+            # Convert text elements to guarded_text
+            new_content = []
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    new_item = {
+                        "type": "guarded_text",
+                        "text": item["text"]
+                    }
+                    new_content.append(new_item)
+                else:
+                    new_content.append(item)
+            
+            # Create a copy of messages and update the last user message
+            messages_copy = copy.deepcopy(messages)
+            messages_copy[last_user_message_index]["content"] = new_content
+            return messages_copy
+        elif isinstance(content, str):
+            # If content is a string, convert it to guarded_text
+            messages_copy = copy.deepcopy(messages)
+            messages_copy[last_user_message_index]["content"] = [
+                {
+                    "type": "guarded_text",
+                    "text": content
+                }
+            ]
+            return messages_copy
+
+        return messages
+
     @classmethod
     def get_config(cls):
         return {
@@ -769,6 +832,9 @@ class AmazonConverseConfig(BaseConfig):
         headers: Optional[dict] = None,
     ) -> RequestObject:
         messages, system_content_blocks = self._transform_system_message(messages)
+        
+        # Convert last user message to guarded_text if guardrailConfig is present
+        messages = self._convert_last_user_message_to_guarded_text(messages, optional_params)
         ## TRANSFORMATION ##
 
         _data: CommonRequestObject = self._transform_request_helper(
@@ -820,6 +886,9 @@ class AmazonConverseConfig(BaseConfig):
         headers: Optional[dict] = None,
     ) -> RequestObject:
         messages, system_content_blocks = self._transform_system_message(messages)
+
+        # Convert last user message to guarded_text if guardrailConfig is present
+        messages = self._convert_last_user_message_to_guarded_text(messages, optional_params)
 
         _data: CommonRequestObject = self._transform_request_helper(
             model=model,


### PR DESCRIPTION
## Title

Implement automatic conversion of last user message to guarded_text when guardrailConfig is present

## Relevant issues

#12676

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Testing 
<img width="848" height="682" alt="image" src="https://github.com/user-attachments/assets/87ca2918-c682-4af9-a10b-06fbf0cafd3d" />

## Changes

### Summary
This PR implements automatic conversion of the last user message to `guarded_text` type when `guardrailConfig` is present in Bedrock Converse requests but no `guarded_text` is explicitly provided. This provides a better default behavior for users who want to use guardrails without manually specifying which content should be guarded.