### PR TITLE
fix: In Memory Guardrail fails to update

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -487,7 +487,8 @@ class CustomGuardrail(CustomLogger):
         """
         Update the guardrails litellm params in memory
         """
-        pass
+        for key, value in vars(litellm_params).items():
+            setattr(self, key, value)
 
 
 def log_guardrail_information(func):

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -675,5 +675,6 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         """
         Update the guardrails litellm params in memory
         """
+        super().update_in_memory_litellm_params(litellm_params)
         if litellm_params.pii_entities_config:
             self.pii_entities_config = litellm_params.pii_entities_config

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -1,6 +1,9 @@
+from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy.guardrails.guardrail_registry import (
     get_guardrail_initializer_from_hooks,
+    InMemoryGuardrailHandler,
 )
+from litellm.types.guardrails import GuardrailEventHooks, Guardrail, LitellmParams
 
 
 def test_get_guardrail_initializer_from_hooks():
@@ -15,3 +18,33 @@ def test_guardrail_class_registry():
     print(f"guardrail_class_registry: {guardrail_class_registry}")
     assert "aim" in guardrail_class_registry
     assert "aporia" in guardrail_class_registry
+
+
+def test_update_in_memory_guardrail():
+    handler = InMemoryGuardrailHandler()
+    handler.guardrail_id_to_custom_guardrail["123"] = CustomGuardrail(
+        guardrail_name="test-guardrail",
+        default_on=False,
+        event_hook=GuardrailEventHooks.pre_call,
+    )
+
+    handler.update_in_memory_guardrail(
+        "123",
+        Guardrail(
+            guardrail_name="test-guardrail",
+            litellm_params=LitellmParams(
+                guardrail="test-guardrail", mode="pre_call", default_on=True
+            ),
+        ),
+    )
+
+    assert (
+        handler.guardrail_id_to_custom_guardrail["123"].should_run_guardrail(
+            data={}, event_type=GuardrailEventHooks.pre_call
+        )
+        is True
+    )
+    assert (
+        handler.guardrail_id_to_custom_guardrail["123"].event_hook
+        is GuardrailEventHooks.pre_call
+    )


### PR DESCRIPTION
## fix: In Memory Guardrail fails to update

## Relevant issues
N/A

## Pre-Submission checklist

<img width="3336" height="880" alt="image" src="https://github.com/user-attachments/assets/376293a7-a46f-4eca-a756-bbb4c4b1f57b" />


**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes
- update in memory custom guardrail objects properly
- added corresponding test for in memory guardrail handler

