### PR TITLE
Added Indochina Time timezone support for budget resets

### DIFF
--- a/docs/my-website/docs/proxy/budget_reset_and_tz.md
+++ b/docs/my-website/docs/proxy/budget_reset_and_tz.md
@@ -29,5 +29,6 @@ Common timezone values:
 - `US/Pacific` - Pacific Time
 - `Europe/London` - UK Time
 - `Asia/Kolkata` - Indian Standard Time (IST)
+- `Asia/Bangkok` - Indochina Time (ICT)
 - `Asia/Tokyo` - Japan Standard Time
 - `Australia/Sydney` - Australian Eastern Time

--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -158,6 +158,7 @@ def _setup_timezone(
                 "US/Eastern": timezone(timedelta(hours=-4)),  # EDT
                 "US/Pacific": timezone(timedelta(hours=-7)),  # PDT
                 "Asia/Kolkata": timezone(timedelta(hours=5, minutes=30)),  # IST
+                "Asia/Bangkok": timezone(timedelta(hours=7)),  # ICT (Indochina Time)
                 "Europe/London": timezone(timedelta(hours=1)),  # BST
                 "UTC": timezone.utc,
             }

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -88,6 +88,12 @@ class TestStandardizedResetTime(unittest.TestCase):
         )
         self.assertEqual(london_result, london_expected)
 
+        # Test Bangkok timezone (UTC+7): 5:30 AM next day, so next reset is midnight the day after
+        bangkok = ZoneInfo("Asia/Bangkok")
+        bangkok_expected = datetime(2023, 5, 17, 0, 0, 0, tzinfo=bangkok)
+        bangkok_result = get_next_standardized_reset_time("1d", base_time, "Asia/Bangkok")
+        self.assertEqual(bangkok_result, bangkok_expected)
+
     def test_edge_cases(self):
         """Test edge cases and boundary conditions"""
         # Exactly on hour boundary


### PR DESCRIPTION
## Title

Add Asia/Bangkok timezone support for budget resets

## Relevant issues

The timezones supported at the moment does not include ICT (Indochina Time). With this change, ICT would be supported.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Add Asia/Bangkok (UTC+7) to timezone_map in duration_parser.py
- Update documentation to include Bangkok in common timezone values
- Add test case to verify Bangkok timezone functionality

<img width="1393" height="223" alt="image" src="https://github.com/user-attachments/assets/9ed1ae24-473e-4f8d-a2d4-fe9742891e61" />
<img width="1502" height="323" alt="image" src="https://github.com/user-attachments/assets/9d60c2a2-2caf-4f88-835e-8551c623f8ca" />

