### PR TITLE
Add twelve labs to bedrock docs

### DIFF
--- a/docs/my-website/docs/embedding/supported_embedding.md
+++ b/docs/my-website/docs/embedding/supported_embedding.md
@@ -266,6 +266,61 @@ print(response)
 | Titan Embeddings - G1 | `embedding(model="amazon.titan-embed-text-v1", input=input)` |
 | Cohere Embeddings - English | `embedding(model="cohere.embed-english-v3", input=input)` |
 | Cohere Embeddings - Multilingual | `embedding(model="cohere.embed-multilingual-v3", input=input)` |
+| TwelveLabs Marengo Embed 2.7 | `embedding(model="bedrock/twelvelabs.marengo-embed-2-7-v1:0", input=input)` |
+
+### TwelveLabs Marengo Embed 2.7
+
+TwelveLabs Marengo Embed 2.7 supports multimodal embeddings for text and images, with plans to support video and audio in future phases.
+
+#### Text Embedding Usage
+```python
+from litellm import embedding
+import os
+
+# Set your AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = ""
+os.environ["AWS_SECRET_ACCESS_KEY"] = "" 
+os.environ["AWS_REGION_NAME"] = ""
+
+response = embedding(
+    model="bedrock/twelvelabs.marengo-embed-2-7-v1:0",
+    input=["good morning from litellm"],
+)
+print(response)
+```
+
+#### Image Embedding Usage
+```python
+from litellm import embedding
+import os
+
+# Set your AWS credentials
+os.environ["AWS_ACCESS_KEY_ID"] = ""
+os.environ["AWS_SECRET_ACCESS_KEY"] = "" 
+os.environ["AWS_REGION_NAME"] = ""
+
+# Base64 encoded image
+image_b64 = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD..."
+
+response = embedding(
+    model="bedrock/twelvelabs.marengo-embed-2-7-v1:0",
+    input=[image_b64],
+    # Optional: specify embedding options
+    embeddingOption=["visual-text", "visual-image"]
+)
+print(response)
+```
+
+#### Advanced Parameters
+```python
+response = embedding(
+    model="bedrock/twelvelabs.marengo-embed-2-7-v1:0",
+    input=["text to embed"],
+    # Optional parameters
+    textTruncate="end",  # "start", "end", or "none"
+    embeddingOption=["visual-text"]  # ["visual-text", "visual-image", "audio"]
+)
+```
 
 
 ## Cohere Embedding Models

--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -1849,6 +1849,7 @@ print(response)
 | Titan Embeddings V2 | `embedding(model="bedrock/amazon.titan-embed-text-v2:0", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/amazon_titan_v2_transformation.py#L59) |
 | Titan Embeddings - V1 | `embedding(model="bedrock/amazon.titan-embed-text-v1", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/amazon_titan_g1_transformation.py#L53)
 | Titan Multimodal Embeddings | `embedding(model="bedrock/amazon.titan-embed-image-v1", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py#L28) |
+| TwelveLabs Marengo Embed 2.7 | `embedding(model="bedrock/twelvelabs.marengo-embed-2-7-v1:0", input=input)` | `textTruncate`, `embeddingOption` |
 | Cohere Embeddings - English | `embedding(model="bedrock/cohere.embed-english-v3", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/cohere_transformation.py#L18)
 | Cohere Embeddings - Multilingual | `embedding(model="bedrock/cohere.embed-multilingual-v3", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/cohere_transformation.py#L18)
 


### PR DESCRIPTION
## Title

Add TwelveLabs Marengo Embed 2.7 to Bedrock Embeddings Documentation

## Relevant issues

Documents #14674

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

This PR adds comprehensive documentation for the newly integrated TwelveLabs Marengo Embed 2.7 model on AWS Bedrock.

-   **`docs/my-website/docs/embedding/supported_embedding.md`**:
    -   Added TwelveLabs to the Bedrock embedding models table.
    -   Included a dedicated section for TwelveLabs Marengo Embed 2.7 with:
        -   Text embedding usage examples.
        -   Image embedding usage examples (Base64 input) with `embeddingOption` parameters.
        -   Documentation for advanced parameters like `textTruncate` and `embeddingOption`.
-   **`docs/my-website/docs/providers/bedrock.md`**:
    -   Added TwelveLabs to the "Supported AWS Bedrock Embedding Models" table.
    -   Listed supported OpenAI parameters: `textTruncate`, `embeddingOption`.

The documentation highlights support for multimodal embeddings (text and images), the model ID (`bedrock/twelvelabs.marengo-embed-2-7-v1:0`), text truncation options, and embedding options.

---
[Slack Thread](https://berriaillm.slack.com/archives/C0997T460P3/p1758201515218179?thread_ts=1758201515.218179&cid=C0997T460P3)

<a href="https://cursor.com/background-agent?bcId=bc-f14e9f8e-7f37-4773-908c-92ffc8c2c83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f14e9f8e-7f37-4773-908c-92ffc8c2c83d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

