### PR TITLE
fix: reduced __inits__ overhead in 7%

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1458,6 +1458,7 @@ jobs:
       # - run: python ./tests/documentation_tests/test_general_setting_keys.py
       - run: python ./tests/code_coverage_tests/check_licenses.py
       - run: python ./tests/code_coverage_tests/router_code_coverage.py
+      - run: python ./tests/code_coverage_tests/test_chat_completion_imports.py
       - run: python ./tests/code_coverage_tests/info_log_check.py
       - run: python ./tests/code_coverage_tests/test_ban_set_verbose.py
       - run: python ./tests/code_coverage_tests/code_qa_check_tests.py

--- a/litellm/litellm_core_utils/cached_imports.py
+++ b/litellm/litellm_core_utils/cached_imports.py
@@ -1,0 +1,56 @@
+"""
+Cached imports module for LiteLLM.
+
+This module provides cached import functionality to avoid repeated imports
+inside functions that are critical to performance.
+"""
+
+from typing import TYPE_CHECKING, Callable, Optional, Type
+
+# Type annotations for cached imports
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.litellm_core_utils.coroutine_checker import CoroutineChecker
+
+# Global cache variables
+_LiteLLMLogging: Optional[Type["Logging"]] = None
+_coroutine_checker: Optional["CoroutineChecker"] = None
+_set_callbacks: Optional[Callable] = None
+
+
+def get_litellm_logging_class() -> Type["Logging"]:
+    """Get the cached LiteLLM Logging class, initializing if needed."""
+    global _LiteLLMLogging
+    if _LiteLLMLogging is not None:
+        return _LiteLLMLogging
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    _LiteLLMLogging = Logging
+    return _LiteLLMLogging
+
+
+def get_coroutine_checker() -> "CoroutineChecker":
+    """Get the cached coroutine checker instance, initializing if needed."""
+    global _coroutine_checker
+    if _coroutine_checker is not None:
+        return _coroutine_checker
+    from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
+    _coroutine_checker = coroutine_checker
+    return _coroutine_checker
+
+
+def get_set_callbacks() -> Callable:
+    """Get the cached set_callbacks function, initializing if needed."""
+    global _set_callbacks
+    if _set_callbacks is not None:
+        return _set_callbacks
+    from litellm.litellm_core_utils.litellm_logging import set_callbacks
+    _set_callbacks = set_callbacks
+    return _set_callbacks
+
+
+def clear_cached_imports() -> None:
+    """Clear all cached imports. Useful for testing or memory management."""
+    global _LiteLLMLogging, _coroutine_checker, _set_callbacks
+    _LiteLLMLogging = None
+    _coroutine_checker = None
+    _set_callbacks = None

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any, Dict, List, Optional
 
 import orjson
@@ -51,8 +52,6 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
                     body_str = body.decode("utf-8") if isinstance(body, bytes) else body
 
                     # Replace invalid surrogate pairs
-                    import re
-
                     # This regex finds incomplete surrogate pairs
                     body_str = re.sub(
                         r"[\uD800-\uDBFF](?![\uDC00-\uDFFF])", "", body_str

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -567,11 +567,6 @@ def function_setup(  # noqa: PLR0915
     original_function: str, rules_obj, start_time, *args, **kwargs
 ):  # just run once to check if user wants to send their data anywhere - PostHog/Sentry/Slack/etc.
     ### NOTICES ###
-    # Ensure cached instances are initialized
-    _get_litellm_logging_class()
-    _get_coroutine_checker()
-    _get_set_callbacks()
-
     if litellm.set_verbose is True:
         verbose_logger.warning(
             "`litellm.set_verbose` is deprecated. Please set `os.environ['LITELLM_LOG'] = 'DEBUG'` for debug logs."
@@ -831,7 +826,7 @@ def function_setup(  # noqa: PLR0915
             call_type=call_type,
         ):
             stream = True
-        logging_obj = _LiteLLMLogging(
+        logging_obj = _get_litellm_logging_class()(
             model=model,  # type: ignore
             messages=messages,
             stream=stream,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -59,10 +59,12 @@ import litellm.litellm_core_utils.audio_utils.utils
 import litellm.litellm_core_utils.json_validation_rule
 import litellm.llms
 import litellm.llms.gemini
-# Cache class to avoid repeated imports
-_LiteLLMLogging = None
-_coroutine_checker = None
-_set_callbacks = None
+# Import cached imports utilities
+from litellm.litellm_core_utils.cached_imports import (
+    get_coroutine_checker,
+    get_litellm_logging_class,
+    get_set_callbacks,
+)
 from litellm.caching._internal_lru_cache import lru_cache_wrapper
 from litellm.caching.caching import DualCache
 from litellm.caching.caching_handler import CachingHandlerResponse, LLMCachingHandler
@@ -226,41 +228,6 @@ from typing import (
     get_args,
 )
 
-# Type annotations for cached imports (after typing imports)
-if TYPE_CHECKING:
-    from litellm.litellm_core_utils.litellm_logging import Logging
-    from litellm.litellm_core_utils.coroutine_checker import CoroutineChecker
-
-_LiteLLMLogging: Optional[Type["Logging"]] = _LiteLLMLogging  # type: ignore
-_coroutine_checker: Optional["CoroutineChecker"] = _coroutine_checker  # type: ignore
-_set_callbacks: Optional[Callable] = _set_callbacks  # type: ignore
-
-def _get_litellm_logging_class() -> Type["Logging"]:
-    """Get the cached LiteLLM Logging class, initializing if needed."""
-    global _LiteLLMLogging
-    if _LiteLLMLogging is not None:
-        return _LiteLLMLogging
-    from litellm.litellm_core_utils.litellm_logging import Logging
-    _LiteLLMLogging = Logging
-    return _LiteLLMLogging
-
-def _get_coroutine_checker() -> "CoroutineChecker":
-    """Get the cached coroutine checker instance, initializing if needed."""
-    global _coroutine_checker
-    if _coroutine_checker is not None:
-        return _coroutine_checker
-    from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
-    _coroutine_checker = coroutine_checker
-    return _coroutine_checker
-
-def _get_set_callbacks() -> Callable:
-    """Get the cached set_callbacks function, initializing if needed."""
-    global _set_callbacks
-    if _set_callbacks is not None:
-        return _set_callbacks
-    from litellm.litellm_core_utils.litellm_logging import set_callbacks
-    _set_callbacks = set_callbacks
-    return _set_callbacks
 
 from openai import OpenAIError as OriginalError
 
@@ -629,12 +596,12 @@ def function_setup(  # noqa: PLR0915
                     + litellm.failure_callback
                 )
             )
-            _get_set_callbacks()(callback_list=callback_list, function_id=function_id)
+            get_set_callbacks()(callback_list=callback_list, function_id=function_id)
         ## ASYNC CALLBACKS
         if len(litellm.input_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.input_callback):  # type: ignore
-                if _get_coroutine_checker().is_async_callable(callback):
+                if get_coroutine_checker().is_async_callable(callback):
                     litellm._async_input_callback.append(callback)
                     removed_async_items.append(index)
 
@@ -644,7 +611,7 @@ def function_setup(  # noqa: PLR0915
         if len(litellm.success_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.success_callback):  # type: ignore
-                if _get_coroutine_checker().is_async_callable(callback):
+                if get_coroutine_checker().is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_success_callback(
                         callback
                     )
@@ -669,7 +636,7 @@ def function_setup(  # noqa: PLR0915
         if len(litellm.failure_callback) > 0:
             removed_async_items = []
             for index, callback in enumerate(litellm.failure_callback):  # type: ignore
-                if _get_coroutine_checker().is_async_callable(callback):
+                if get_coroutine_checker().is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_failure_callback(
                         callback
                     )
@@ -702,7 +669,7 @@ def function_setup(  # noqa: PLR0915
             removed_async_items = []
             for index, callback in enumerate(kwargs["success_callback"]):
                 if (
-                    _get_coroutine_checker().is_async_callable(callback)
+                    get_coroutine_checker().is_async_callable(callback)
                     or callback == "dynamodb"
                     or callback == "s3"
                 ):
@@ -826,7 +793,7 @@ def function_setup(  # noqa: PLR0915
             call_type=call_type,
         ):
             stream = True
-        logging_obj = _get_litellm_logging_class()(
+        logging_obj = get_litellm_logging_class()( # Victim for object pool
             model=model,  # type: ignore
             messages=messages,
             stream=stream,
@@ -939,7 +906,7 @@ def client(original_function):  # noqa: PLR0915
     rules_obj = Rules()
 
     def check_coroutine(value) -> bool:
-        return _get_coroutine_checker().is_async_callable(value)
+        return get_coroutine_checker().is_async_callable(value)
 
     async def async_pre_call_deployment_hook(kwargs: Dict[str, Any], call_type: str):
         """
@@ -1633,7 +1600,7 @@ def client(original_function):  # noqa: PLR0915
             setattr(e, "timeout", timeout)
             raise e
 
-    is_coroutine = _get_coroutine_checker().is_async_callable(original_function)
+    is_coroutine = get_coroutine_checker().is_async_callable(original_function)
 
     # Return the appropriate wrapper based on the original function type
     if is_coroutine:

--- a/tests/code_coverage_tests/test_chat_completion_imports.py
+++ b/tests/code_coverage_tests/test_chat_completion_imports.py
@@ -1,0 +1,43 @@
+## Tests that chat_completion endpoint has no imports inside function bodies
+## This is critical for performance optimization in the hot path
+
+import ast
+from pathlib import Path
+
+
+def test_chat_completion_no_imports():
+    """Test that chat_completion endpoint has no imports in function bodies."""
+    # Path to the proxy server file
+    proxy_server_path = Path(__file__).parent.parent.parent / "litellm" / "proxy" / "proxy_server.py"
+    
+    with open(proxy_server_path, 'r') as f:
+        content = f.read()
+    
+    # Parse the AST
+    tree = ast.parse(content)
+    
+    # Find the chat_completion function
+    chat_completion_func = None
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.AsyncFunctionDef) and node.name == "chat_completion"):
+            chat_completion_func = node
+            break
+    
+    assert chat_completion_func is not None, "chat_completion function not found"
+    
+    # Check for imports inside the function body
+    import_violations = []
+    
+    for node in ast.walk(chat_completion_func):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            # Get line number
+            line_num = node.lineno
+            import_violations.append(line_num)
+    
+    # Assert no import violations found
+    if import_violations:
+        print(f"Found {len(import_violations)} import violations in chat_completion endpoint:")
+        for line_num in import_violations:
+            print(f"  - Line {line_num}: Import statement found")
+        print("\nchat_completion endpoint should not contain imports for optimal performance.")
+        raise Exception("Import violations found in chat_completion endpoint")


### PR DESCRIPTION
## Title

No imports inside the hot path

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring
✅ Performance

## Changes
Importing inside the function caused performance penalties, while removing it led to circular import issues. Caching the import after a single load resolves both issues efficiently.

## Performance Changes

* `__init__` functions previously consumed **33%** of `function_setup` time per call.
* Removed imports from inside `function_setup`.
* **Result:** reduced to **25.6%**, cutting **per-call** overhead.


