### PR TITLE
Fix: Auto-router PreRoutingHookResponse validation with tool calls (#14633)

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -56,12 +56,11 @@ else:
 class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callback#callback-class
     # Class variables or attributes
     def __init__(
-        self, 
+        self,
         turn_off_message_logging: bool = False,
-
         # deprecated param, use `turn_off_message_logging` instead
         message_logging: bool = True,
-        **kwargs
+        **kwargs,
     ) -> None:
         """
         Args:
@@ -152,7 +151,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         self,
         model: str,
         request_kwargs: Dict,
-        messages: Optional[List[Dict[str, str]]] = None,
+        messages: Optional[List[Union[Dict[str, Any], Any]]] = None,
         input: Optional[Union[str, List]] = None,
         specific_deployment: Optional[bool] = False,
     ) -> Optional[PreRoutingHookResponse]:
@@ -185,9 +184,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         pass
 
-    async def async_pre_call_check(
-        self, deployment: dict, parent_otel_span: Optional[Span]
-    ) -> Optional[dict]:
+    async def async_pre_call_check(self, deployment: dict, parent_otel_span: Optional[Span]) -> Optional[dict]:
         pass
 
     def pre_call_check(self, deployment: dict) -> Optional[dict]:
@@ -210,29 +207,21 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     ):
         pass
 
-    async def log_success_fallback_event(
-        self, original_model_group: str, kwargs: dict, original_exception: Exception
-    ):
+    async def log_success_fallback_event(self, original_model_group: str, kwargs: dict, original_exception: Exception):
         pass
 
-    async def log_failure_fallback_event(
-        self, original_model_group: str, kwargs: dict, original_exception: Exception
-    ):
+    async def log_failure_fallback_event(self, original_model_group: str, kwargs: dict, original_exception: Exception):
         pass
 
     #### ADAPTERS #### Allow calling 100+ LLMs in custom format - https://github.com/BerriAI/litellm/pulls
 
-    def translate_completion_input_params(
-        self, kwargs
-    ) -> Optional[ChatCompletionRequest]:
+    def translate_completion_input_params(self, kwargs) -> Optional[ChatCompletionRequest]:
         """
         Translates the input params, from the provider's native format to the litellm.completion() format.
         """
         pass
 
-    def translate_completion_output_params(
-        self, response: ModelResponse
-    ) -> Optional[BaseModel]:
+    def translate_completion_output_params(self, response: ModelResponse) -> Optional[BaseModel]:
         """
         Translates the output params, from the OpenAI format to the custom format.
         """
@@ -303,15 +292,11 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     ) -> Any:
         pass
 
-    async def async_logging_hook(
-        self, kwargs: dict, result: Any, call_type: str
-    ) -> Tuple[dict, Any]:
+    async def async_logging_hook(self, kwargs: dict, result: Any, call_type: str) -> Tuple[dict, Any]:
         """For masking logged request/response. Return a modified version of the request/result."""
         return kwargs, result
 
-    def logging_hook(
-        self, kwargs: dict, result: Any, call_type: str
-    ) -> Tuple[dict, Any]:
+    def logging_hook(self, kwargs: dict, result: Any, call_type: str) -> Tuple[dict, Any]:
         """For masking logged request/response. Return a modified version of the request/result."""
         return kwargs, result
 
@@ -361,9 +346,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         except Exception:
             print_verbose(f"Custom Logger Error - {traceback.format_exc()}")
 
-    async def async_log_input_event(
-        self, model, messages, kwargs, print_verbose, callback_func
-    ):
+    async def async_log_input_event(self, model, messages, kwargs, print_verbose, callback_func):
         try:
             kwargs["model"] = model
             kwargs["messages"] = messages
@@ -375,9 +358,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         except Exception:
             print_verbose(f"Custom Logger Error - {traceback.format_exc()}")
 
-    def log_event(
-        self, kwargs, response_obj, start_time, end_time, print_verbose, callback_func
-    ):
+    def log_event(self, kwargs, response_obj, start_time, end_time, print_verbose, callback_func):
         # Method definition
         try:
             kwargs["log_event_type"] = "post_api_call"
@@ -391,9 +372,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             print_verbose(f"Custom Logger Error - {traceback.format_exc()}")
             pass
 
-    async def async_log_event(
-        self, kwargs, response_obj, start_time, end_time, print_verbose, callback_func
-    ):
+    async def async_log_event(self, kwargs, response_obj, start_time, end_time, print_verbose, callback_func):
         # Method definition
         try:
             kwargs["log_event_type"] = "post_api_call"
@@ -410,7 +389,6 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     #########################################################
     # MCP TOOL CALL HOOKS
     #########################################################
-
 
     async def async_post_mcp_tool_call_hook(
         self, kwargs, response_obj: MCPPostCallResponseObject, start_time, end_time
@@ -473,15 +451,12 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     def _truncate_text(self, text: str, max_length: int) -> str:
         """Truncate text if it exceeds max_length"""
         return (
-            text[:max_length]
-            + "...truncated by litellm, this logger does not support large content"
+            text[:max_length] + "...truncated by litellm, this logger does not support large content"
             if len(text) > max_length
             else text
         )
 
-    def _select_metadata_field(
-        self, request_kwargs: Optional[Dict] = None
-    ) -> Optional[str]:
+    def _select_metadata_field(self, request_kwargs: Optional[Dict] = None) -> Optional[str]:
         """
         Select the metadata field to use for logging
 
@@ -495,29 +470,28 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         if LITELLM_METADATA_FIELD in request_kwargs:
             return LITELLM_METADATA_FIELD
         return OLD_LITELLM_METADATA_FIELD
-    
-    def redact_standard_logging_payload_from_model_call_details(
-        self, model_call_details: Dict
-    ) -> Dict:
+
+    def redact_standard_logging_payload_from_model_call_details(self, model_call_details: Dict) -> Dict:
         """
         Only redacts messages and responses when self.turn_off_message_logging is True
-        
+
 
         By default, self.turn_off_message_logging is False and this does nothing.
-        
+
         Return a redacted deepcopy of the provided logging payload.
-        
+
         This is useful for logging payloads that contain sensitive information.
         """
         from copy import copy
 
         from litellm import Choices, Message, ModelResponse
         from litellm.types.utils import LiteLLMCommonStrings
+
         turn_off_message_logging: bool = getattr(self, "turn_off_message_logging", False)
-        
+
         if turn_off_message_logging is False:
             return model_call_details
-        
+
         # Only make a shallow copy of the top-level dict to avoid deepcopy issues
         # with complex objects like AuthenticationError that may be present
         model_call_details_copy = copy(model_call_details)
@@ -533,17 +507,13 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             standard_logging_object_copy["messages"] = [Message(content=redacted_str).model_dump()]
 
         if standard_logging_object_copy.get("response") is not None:
-            model_response = ModelResponse(
-                choices=[Choices(message=Message(content=redacted_str))]
-            )
+            model_response = ModelResponse(choices=[Choices(message=Message(content=redacted_str))])
             model_response_dict = model_response.model_dump()
             standard_logging_object_copy["response"] = model_response_dict
 
         model_call_details_copy["standard_logging_object"] = standard_logging_object_copy
         return model_call_details_copy
-    
 
-    
     async def get_proxy_server_request_from_cold_storage_with_object_key(
         self,
         object_key: str,

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -122,7 +122,7 @@ class AutoRouter(CustomLogger):
             )
 
         user_message = messages[-1]
-        message_content = user_message.get("content", "")  # type: ignore
+        message_content = user_message.get("content", "")
         route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(text=message_content)  # type: ignore
         verbose_router_logger.debug(f"route_choice: {route_choice}")
         if isinstance(route_choice, RouteChoice):

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -133,8 +133,8 @@ class AutoRouter(CustomLogger):
         verbose_router_logger.debug(f"route_choice: {route_choice}")
         if isinstance(route_choice, RouteChoice):
             model = route_choice.name or self.default_model  # type: ignore
-        elif isinstance(route_choice, list) and len(route_choice) > 0:
-            model = getattr(route_choice[0], 'name', None) or self.default_model
+        elif isinstance(route_choice, list):
+            model = route_choice[0].name or self.default_model  # type: ignore
 
         return PreRoutingHookResponse(
             model=model,

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -11,14 +11,17 @@ if TYPE_CHECKING:
 
     from litellm.router import Router
     from litellm.types.router import PreRoutingHookResponse
+    from litellm.types.utils import Message
 else:
     Router = Any
     PreRoutingHookResponse = Any
     Route = Any
+    Message = Any
 
 
 class AutoRouter(CustomLogger):
     DEFAULT_AUTO_SYNC_VALUE = "local"
+
     def __init__(
         self,
         model_name: str,
@@ -27,7 +30,7 @@ class AutoRouter(CustomLogger):
         litellm_router_instance: "Router",
         auto_router_config_path: Optional[str] = None,
         auto_router_config: Optional[str] = None,
-    ):  
+    ):
         """
         Auto-Router class that uses a semantic router to route requests to the appropriate model.
 
@@ -49,22 +52,22 @@ class AutoRouter(CustomLogger):
         self.default_model = default_model
         self.embedding_model: str = embedding_model
         self.litellm_router_instance: "Router" = litellm_router_instance
-    
+
     def _load_semantic_routing_routes(self) -> List[Route]:
         from semantic_router.routers import SemanticRouter
+
         if self.auto_router_config_path:
             return SemanticRouter.from_json(self.auto_router_config_path).routes
         elif self.auto_router_config:
             return self._load_auto_router_routes_from_config_json()
         else:
             raise ValueError("No router config provided")
-    
 
     def _load_auto_router_routes_from_config_json(self) -> List[Route]:
         import json
 
         from semantic_router.routers.base import Route
-        
+
         if self.auto_router_config is None:
             raise ValueError("No auto router config provided")
         auto_router_routes: List[Route] = []
@@ -75,17 +78,16 @@ class AutoRouter(CustomLogger):
                     name=route.get("name"),
                     description=route.get("description"),
                     utterances=route.get("utterances", []),
-                    score_threshold=route.get("score_threshold")
+                    score_threshold=route.get("score_threshold"),
                 )
             )
         return auto_router_routes
-
 
     async def async_pre_routing_hook(
         self,
         model: str,
         request_kwargs: Dict,
-        messages: Optional[List[Dict[str, str]]] = None,
+        messages: Optional[List[Union["Message", Dict[str, Any]]]] = None,
         input: Optional[Union[str, List]] = None,
         specific_deployment: Optional[bool] = False,
     ) -> Optional["PreRoutingHookResponse"]:
@@ -101,34 +103,40 @@ class AutoRouter(CustomLogger):
             LiteLLMRouterEncoder,
         )
         from litellm.types.router import PreRoutingHookResponse
+
         if messages is None:
             # do nothing, return same inputs
             return None
-        
+
         if self.routelayer is None:
             #######################
             # Create the route layer
             #######################
             self.routelayer = SemanticRouter(
-                    routes=self.loaded_routes,
-                    encoder=LiteLLMRouterEncoder(
-                        litellm_router_instance=self.litellm_router_instance,
-                        model_name=self.embedding_model,
-                    ),
-                    auto_sync=self.auto_sync_value,
+                routes=self.loaded_routes,
+                encoder=LiteLLMRouterEncoder(
+                    litellm_router_instance=self.litellm_router_instance,
+                    model_name=self.embedding_model,
+                ),
+                auto_sync=self.auto_sync_value,
             )
-        
-        user_message: Dict[str, str] = messages[-1]
-        message_content: str = user_message.get("content", "")
-        route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(text=message_content)
+
+        user_message = messages[-1]
+        # Handle both Message objects and Dict formats
+        if hasattr(user_message, "content"):
+            # It's a Message object
+            message_content = user_message.content or ""  # type: ignore
+        else:
+            # It's a Dict
+            message_content = user_message.get("content", "")  # type: ignore
+        route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(text=message_content)  # type: ignore
         verbose_router_logger.debug(f"route_choice: {route_choice}")
         if isinstance(route_choice, RouteChoice):
-            model = route_choice.name or self.default_model
-        elif isinstance(route_choice, list):
-            model = route_choice[0].name or self.default_model
-        
+            model = route_choice.name or self.default_model  # type: ignore
+        elif isinstance(route_choice, list) and len(route_choice) > 0:
+            model = getattr(route_choice[0], 'name', None) or self.default_model
+
         return PreRoutingHookResponse(
             model=model,
             messages=messages,
         )
-

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -122,13 +122,7 @@ class AutoRouter(CustomLogger):
             )
 
         user_message = messages[-1]
-        # Handle both Message objects and Dict formats
-        if hasattr(user_message, "content"):
-            # It's a Message object
-            message_content = user_message.content or ""  # type: ignore
-        else:
-            # It's a Dict
-            message_content = user_message.get("content", "")  # type: ignore
+        message_content = user_message.get("content", "")  # type: ignore
         route_choice: Optional[Union[RouteChoice, List[RouteChoice]]] = self.routelayer(text=message_content)  # type: ignore
         verbose_router_logger.debug(f"route_choice: {route_choice}")
         if isinstance(route_choice, RouteChoice):


### PR DESCRIPTION
## Title

Fix: Auto-router PreRoutingHookResponse validation with tool calls (#14633)

## Relevant issues

Fixes #14633

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Auto-router was failing with Pydantic validation errors when processing OpenAI messages containing tool calls.

**Root cause:** `PreRoutingHookResponse.messages` was typed as `List[Dict[str, str]]` but OpenAI tool call messages contain complex structures with None values and nested objects.

**Fix:**
- Updated `PreRoutingHookResponse.messages` type to `List[Union[Message, Dict[str, Any]]]` in `litellm/types/router.py`
- Updated related method signatures in `CustomLogger` base class
- Added type ignores for optional `semantic_router` dependency
- Added test case reproducing the issue

Maintains backward compatibility and OpenAI API compatibility.