### PR TITLE
NEW Amazon Bedrock Guardrail Info View in Logs

### DIFF
--- a/ui/litellm-dashboard/build_ui.sh
+++ b/ui/litellm-dashboard/build_ui.sh
@@ -11,11 +11,11 @@ if ! command -v nvm &> /dev/null; then
 fi
 
 # Use nvm to set the required Node.js version
-nvm use v18.17.0
+nvm use v20
 
 # Check if nvm use was successful
 if [ $? -ne 0 ]; then
-  echo "Error: Failed to switch to Node.js v18.17.0. Deployment aborted."
+  echo "Error: Failed to switch to Node.js v20. Deployment aborted."
   exit 1
 fi
 

--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -42,6 +42,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/babel__traverse": "^7.28.0",
         "@types/lodash": "^4.17.15",
         "@types/node": "^20",
         "@types/react": "18.2.48",
@@ -5408,6 +5409,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -45,6 +45,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/babel__traverse": "^7.28.0",
     "@types/lodash": "^4.17.15",
     "@types/node": "^20",
     "@types/react": "18.2.48",


### PR DESCRIPTION
## NEW Amazon Bedrock Guardrail Info View in Logs
<img width="3000" height="1384" alt="image" src="https://github.com/user-attachments/assets/e0d661e3-a70a-4476-a1c5-1ccc51603d25" />
<img width="2934" height="1736" alt="image" src="https://github.com/user-attachments/assets/1f64bf0f-bd70-46b8-b5ab-767c56dec656" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->

🆕 New Feature
🧹 Refactoring
📖 Documentation
✅ Test

## Changes
- extracted PresidioDetectedEntities.tsx into its own component
- new component: BedrockGuardrailDetails.tsx
- added new field on `metadata.guardrail_information` for `guardrail_provider`

