### PR TITLE
Add logging_only parameter support for Bedrock guardrails

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/bedrock.md
+++ b/docs/my-website/docs/proxy/guardrails/bedrock.md
@@ -34,6 +34,8 @@ guardrails:
 - `pre_call` Run **before** LLM call, on **input**
 - `post_call` Run **after** LLM call, on **input & output**
 - `during_call` Run **during** LLM call, on **input** Same as `pre_call` but runs in parallel as LLM call.  Response not returned until guardrail check completes
+- `logging_only` Run **after** LLM call, only apply PII Masking before logging to Langfuse, etc. Not on the actual llm api request / response.
+- `during_call` Run **during** LLM call, on **input** Same as `pre_call` but runs in parallel as LLM call.  Response not returned until guardrail check completes
 
 ### 2. Start LiteLLM Gateway 
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1063,7 +1063,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         )
                         kwargs["messages"] = masked_messages
                         verbose_proxy_logger.debug(
-                            f"Bedrock logging_only: Masked messages for logging"
+                            "Bedrock logging_only: Masked messages for logging"
                         )
                         
                 except Exception as e:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -24,6 +24,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
+    log_guardrail_information,
 )
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.custom_httpx.http_handler import (

--- a/litellm/proxy/guardrails/init_guardrails.py
+++ b/litellm/proxy/guardrails/init_guardrails.py
@@ -73,6 +73,8 @@ def initialize_guardrails(
                     if guardrail.logging_only is True:
                         if callback == "presidio":
                             callback_specific_params["presidio"] = {"logging_only": True}  # type: ignore
+                        elif callback == "bedrock":
+                            callback_specific_params["bedrock"] = {"logging_only": True}  # type: ignore
 
         default_on_callbacks_list = list(default_on_callbacks)
         if len(default_on_callbacks_list) > 0:


### PR DESCRIPTION
## Title
Fix: Add logging_only parameter support for Bedrock guardrails

## Relevant issues
<!-- No specific issue found for this missing feature -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (454 tests pass, 2 unrelated failures due to missing credentials/dependencies)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix (or bug if you consider other guardrails already had this)


## Changes
Adds missing `logging_only` parameter support for Bedrock guardrails to provide feature parity with other guardrail providers.

**Changes made:**
- Add `logging_only` parameter to `BedrockGuardrail.__init__()`
- Add bedrock support in `init_guardrails.py` to pass `logging_only` parameter
- Add `async_logging_hook` method for PII masking in logging_only mode
- Add `GuardrailEventHooks.logging_only` to supported hooks list
- Add comprehensive test `test_bedrock_guardrail_logging_only`

**Testing:**
- Tested with live deployment using `topic-filter-logging-only` guardrail
- Verified requests are processed normally (not blocked)
- Confirmed PII masking functionality works for compliance logging
- 454 existing tests pass, confirming no regressions

This enables compliance logging where PII is masked in logs but requests are not blocked, allowing for audit trails without exposing sensitive data.

