### PR TITLE
Enable LLM API keys to see models.

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -374,6 +374,9 @@ class LiteLLMRoutes(enum.Enum):
         + passthrough_routes_wildcard
         + apply_guardrail_routes
         + mcp_routes
+        + ["/model/info", "/model/info"]
+        + ["/model/info", "/v1/model/info"]
+        + ["/model/info", "/v2/model/info"]
     )
     info_routes = [
         "/key/info",

--- a/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
+++ b/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
@@ -94,7 +94,11 @@ def test_is_llm_api_route():
     assert RouteChecks.is_llm_api_route("/mcp/tools") is True
     assert RouteChecks.is_llm_api_route("/mcp/tools/call") is True
     assert RouteChecks.is_llm_api_route("/mcp/tools/list") is True
-
+    
+    
+    # model info routes (added to llm_api_routes)
+    assert RouteChecks.is_llm_api_route("/model/info") is True
+    assert RouteChecks.is_llm_api_route("/v1/model/info") is True
     
     # check non-matching routes
     assert RouteChecks.is_llm_api_route("/some/random/route") is False

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -135,6 +135,8 @@ def test_virtual_key_allowed_routes_with_litellm_routes_member_name_denied():
     "/anthropic/v1/count_tokens",
     "/gemini/v1/models",
     "/gemini/countTokens",
+    "/model/info",
+    "/v1/model/info",
 ])
 def test_virtual_key_llm_api_route_includes_passthrough_prefix(route):
     """


### PR DESCRIPTION
## Title

Added to enable LLM API keys to see models. For example when using a LLM API key in an application such as Kilo Code or OpenWebUI, it should be able to populate the list of models and get some basic info about them.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

<img width="1409" height="576" alt="image" src="https://github.com/user-attachments/assets/7d4189d3-39c4-414a-9312-b19cc5b0ab44" />

