### PR TITLE
Fix: Fixed the bug where Groq speech transcription reported an error …

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5293,8 +5293,7 @@ def transcription(
     proxy_server_request = kwargs.get("proxy_server_request", None)
     model_info = kwargs.get("model_info", None)
     metadata = kwargs.get("metadata", None)
-    atranscription = kwargs.get("atranscription", False)
-    atranscription = kwargs.get("atranscription", False)
+    atranscription = kwargs.pop("atranscription", False)
     litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
     extra_headers = kwargs.get("extra_headers", None)
     kwargs.pop("tags", [])

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -253,7 +253,9 @@ def handle_metadata_dict_from_req(parsed_form_data):
                 and isinstance(parsed_form_data["metadata"], str)):
             parsed_form_data["metadata"] = json.loads(parsed_form_data["metadata"])
 
-    except json.JSONDecodeError:
-        pass
+    except json.JSONDecodeError as e:
+        verbose_proxy_logger.error(
+            "Handle error metadata dict from_req : %s", (str(e))
+        )
 
     return parsed_form_data

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -36,6 +36,7 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
 
         if "form" in content_type:
             parsed_body = dict(await request.form())
+            parsed_body = handle_metadata_dict_from_req(parsed_body)
         else:
             # Read the request body
             body = await request.body()
@@ -226,7 +227,7 @@ async def get_form_data(request: Request) -> Dict[str, Any]:
             parsed_form_data.setdefault(clean_key, []).append(value)
         else:
             parsed_form_data[key] = value
-    return parsed_form_data
+    return handle_metadata_dict_from_req(parsed_form_data)
 
 
 async def get_request_body(request: Request) -> Dict[str, Any]:
@@ -244,3 +245,15 @@ async def get_request_body(request: Request) -> Dict[str, Any]:
         raise ValueError(
             f"Unsupported content type: {request.headers.get('content-type')}"
         )
+
+def handle_metadata_dict_from_req(parsed_form_data):
+    try:
+        if ("metadata" in parsed_form_data
+                and parsed_form_data["metadata"] is not None
+                and isinstance(parsed_form_data["metadata"], str)):
+            parsed_form_data["metadata"] = json.loads(parsed_form_data["metadata"])
+
+    except json.JSONDecodeError:
+        pass
+
+    return parsed_form_data

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2481,6 +2481,9 @@ def get_optional_params_transcription(
     elif custom_llm_provider == "groq":
         supported_params = litellm.GroqSTTConfig().get_supported_openai_params_stt()
         _check_valid_arg(supported_params=supported_params)
+        passed_params = {k: v for k, v in passed_params.items() if k != 'supported_params'
+                         and k != 'passed_params'
+                         and k != 'OPENAI_TRANSCRIPTION_PARAMS'}
         optional_params = litellm.GroqSTTConfig().map_openai_params_stt(
             non_default_params=non_default_params,
             optional_params=optional_params,


### PR DESCRIPTION
Fixed the bug where Groq speech transcription reported an error for not supporting OpenAI parameters, and also fixed the issue where form-submitted voice files couldn't be tagged (metadata).

## Title

Fixed: Groq speech transcription error & voice file tagging bug

## Relevant issues

Fixes #11402

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally  
  ![Test screenshot](上传你的测试截图路径或图片)
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Fixed Groq speech transcription bug: now supports OpenAI parameters correctly
- Fixed voice file submitted via form not being tagged with metadata
- Added corresponding tests in `tests/litellm/`