### PR TITLE
Fix document of quick start in proxy deploy

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -13,6 +13,7 @@ To start using Litellm, run the following commands in a shell:
 ```bash
 # Get the code
 curl -O https://raw.githubusercontent.com/BerriAI/litellm/main/docker-compose.yml
+curl -O https://raw.githubusercontent.com/BerriAI/litellm/main/prometheus.yml
 
 # Add the master key - you can change this after setup
 echo 'LITELLM_MASTER_KEY="sk-1234"' > .env


### PR DESCRIPTION
## Title

Fix document of quick start in proxy deploy document 

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
   -> This PR is document only
- [X] I have added a screenshot of my new test passing locally
   -> This PR is document only
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
   -> Test results are no changes before/after this PR.
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes
Add download prometheus.yml to avoid error.

### Before
I encountered an error when executing `docker-compose up`.

Screenshot:
<img width="1276" height="380" alt="image" src="https://github.com/user-attachments/assets/2608132a-9195-475b-8f19-79cd7293b172" />

Text:
```
 ✔ db Pulled                                                                                                                                                                                                33.1s 
   ✔ b2feff975e6d Pull complete                                                                                                                                                                             15.8s 
   ✔ f269318ebda2 Pull complete                                                                                                                                                                             15.8s 
   ✔ 14f1e2461ce8 Pull complete                                                                                                                                                                             16.1s 
   ✔ b80f8a2d9349 Pull complete                                                                                                                                                                             16.1s 
   ✔ 75e312077dc0 Pull complete                                                                                                                                                                             16.6s 
   ✔ bd013743ffe5 Pull complete                                                                                                                                                                             16.7s 
   ✔ a1fbf4ab6e3f Pull complete                                                                                                                                                                             17.0s 
   ✔ 5e4a55fb874f Pull complete                                                                                                                                                                             17.3s 
   ✔ 0884a384ff19 Pull complete                                                                                                                                                                             25.9s 
   ✔ ed406be7fd81 Pull complete                                                                                                                                                                             25.9s 
   ✔ 7020209115d0 Pull complete                                                                                                                                                                             25.9s 
   ✔ 7dd8ee8c703f Pull complete                                                                                                                                                                             26.0s 
   ✔ 29af474288c3 Pull complete                                                                                                                                                                             26.0s 
   ✔ d02226a5ed3d Pull complete                                                                                                                                                                             26.0s 
[+] Running 6/6
 ✔ Network test_default            Created                                                                                                                                                                   0.2s 
 ✔ Volume "test_prometheus_data"   Created                                                                                                                                                                   0.0s 
 ✔ Volume "litellm_postgres_data"  Created                                                                                                                                                                   0.0s 
 ✔ Container litellm_db            Created                                                                                                                                                                   0.3s 
 ✔ Container test-prometheus-1     Created                                                                                                                                                                   0.3s 
 ✔ Container test-litellm-1        Created                                                                                                                                                                   0.2s 
Attaching to litellm_db, litellm-1, prometheus-1
Gracefully stopping... (press Ctrl+C again to force)
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/host_mnt/Users/tosi/test/prometheus.yml" to rootfs at "/etc/prometheus/prometheus.yml": mount /host_mnt/Users/tosi/test/prometheus.yml:/etc/prometheus/prometheus.yml (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

### After
It looks working fine.
<img width="1276" height="115" alt="image" src="https://github.com/user-attachments/assets/ba7ed772-5c17-42ec-9fd9-2f0659817139" />
