### PR TITLE
fix: Prevent AttributeError for _get_tags_from_request_kwargs

### DIFF
--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -136,10 +136,10 @@ def _get_tags_from_request_kwargs(
     if request_kwargs is None:
         return []
     if metadata_variable_name in request_kwargs:
-        metadata = request_kwargs[metadata_variable_name]
+        metadata = request_kwargs[metadata_variable_name] or {}
         return metadata.get("tags", [])
     elif "litellm_params" in request_kwargs:
-        litellm_params = request_kwargs["litellm_params"]
-        _metadata = litellm_params.get(metadata_variable_name, {})
+        litellm_params = request_kwargs["litellm_params"] or {}
+        _metadata = litellm_params.get(metadata_variable_name, {}) or {}
         return _metadata.get("tags", [])
     return []


### PR DESCRIPTION
## Title

Prevent AttributeError for _get_tags_from_request_kwargs which can prevent budget limiter callback from working correctly if tags cannot be parsed.

It's possible that metadata is None. The current code does not protect against this.

Example error I've run into that this fixes:
```
21:47:08 - LiteLLM:ERROR: litellm_logging.py:2396 - LiteLLM.LoggingError: [Non-Blocking] Exception occurred while success logging Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/litellm/litellm_core_utils/litellm_logging.py", line 2312, in async_success_handler
    await callback.async_log_success_event(
    ...<6 lines>...
    )
  File "/usr/lib/python3.13/site-packages/litellm/router_strategy/budget_limiter.py", line 396, in async_log_success_event
    request_tags = _get_tags_from_request_kwargs(kwargs)
  File "/usr/lib/python3.13/site-packages/litellm/router_strategy/tag_based_routing.py", line 144, in _get_tags_from_request_kwargs
    return _metadata.get("tags", [])
           ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get' 
```

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Safeguard against AttributeError
