### PR TITLE
[Feature]: More control on store_prompts_in_spend_logs

### DIFF
--- a/docs/my-website/docs/proxy/request_headers.md
+++ b/docs/my-website/docs/proxy/request_headers.md
@@ -14,6 +14,8 @@ By default, LiteLLM does not forward client headers to LLM provider APIs. Howeve
 
 `x-litellm-enable-message-redaction`: Optional[bool]: Don't log the message content to logging integrations. Just track spend. [Learn More](./logging#redact-messages-response-content)
 
+`x-litellm-disable-prompts-in-spend-logs`: Optional[bool]: Disable storing prompts and responses in the database spend logs. Useful for embeddings or other large requests where you want to track spend but not store the actual content.
+
 `x-litellm-tags`: Optional[str]: A comma separated list (e.g. `tag1,tag2,tag3`) of tags to use for [tag-based routing](./tag_routing) **OR** [spend-tracking](./enterprise.md#tracking-spend-for-custom-tags).
 
 `x-litellm-num-retries`: Optional[int]: The number of retries for the request.

--- a/docs/my-website/docs/proxy/ui_logs.md
+++ b/docs/my-website/docs/proxy/ui_logs.md
@@ -35,6 +35,65 @@ general_settings:
 <Image img={require('../../img/ui_request_logs_content.png')}/>
 
 
+### [Opt Out] Disable Prompts/Responses in Spend Logs Per Request
+
+In certain use cases, you may want to disable prompts and responses in spend logs for a specific request even if the global setting is enabled.
+
+For use cases like embeddings where you want to track spend but not store large prompts/responses in the database, you can disable database logging using the `x-litellm-disable-prompts-in-spend-logs` header.
+
+This is especially useful for:
+- Embedding requests with large text inputs  
+- Requests where you want spend tracking but not content storage
+- Compliance scenarios where content shouldn't be persisted
+
+<Tabs>
+<TabItem value="Curl" label="Curl Request">
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/v1/embeddings' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer <litellm-api-key>' \
+-H 'x-litellm-disable-prompts-in-spend-logs: true' \
+-d '{
+    "model": "text-embedding-ada-002",
+    "input": "Your large text content here..."
+}'
+```
+
+</TabItem>
+<TabItem value="OpenAI" label="OpenAI Python SDK">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="<litellm-api-key>",
+    base_url="http://0.0.0.0:4000"
+)
+
+response = client.embeddings.create(
+    model="text-embedding-ada-002",
+    input="Your large text content here...",
+    extra_headers={
+        "x-litellm-disable-prompts-in-spend-logs": "true"
+    }
+)
+```
+
+</TabItem>
+</Tabs>
+
+**What gets disabled:**
+- Messages field in `LiteLLM_SpendLogs` table will be empty (`{}`)
+- Response field in `LiteLLM_SpendLogs` table will be empty (`{}`) 
+
+**What remains enabled:**
+- All callback logging (Langfuse, DataDog, etc.) continues to work
+- Spend tracking, token counts, and other metadata are still logged normally
+- Token counting and usage metrics
+- Request metadata and headers
+
+
 ## Stop storing Error Logs in DB
 
 If you do not want to store error logs in DB, you can opt out with this setting

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -909,7 +909,6 @@ MAXIMUM_TRACEBACK_LINES_TO_LOG = int(os.getenv("MAXIMUM_TRACEBACK_LINES_TO_LOG",
 
 # Headers to control callbacks
 X_LITELLM_DISABLE_CALLBACKS = "x-litellm-disable-callbacks"
-X_LITELLM_DISABLE_PROMPTS_IN_SPEND_LOGS = "x-litellm-disable-prompts-in-spend-logs"
 LITELLM_METADATA_FIELD = "litellm_metadata"
 OLD_LITELLM_METADATA_FIELD = "metadata"
 LITELLM_TRUNCATED_PAYLOAD_FIELD = "litellm_truncated"

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -909,6 +909,7 @@ MAXIMUM_TRACEBACK_LINES_TO_LOG = int(os.getenv("MAXIMUM_TRACEBACK_LINES_TO_LOG",
 
 # Headers to control callbacks
 X_LITELLM_DISABLE_CALLBACKS = "x-litellm-disable-callbacks"
+X_LITELLM_DISABLE_PROMPTS_IN_SPEND_LOGS = "x-litellm-disable-prompts-in-spend-logs"
 LITELLM_METADATA_FIELD = "litellm_metadata"
 OLD_LITELLM_METADATA_FIELD = "metadata"
 LITELLM_TRUNCATED_PAYLOAD_FIELD = "litellm_truncated"

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,13 +1,21 @@
 model_list:
-  - model_name: bedrock/batch-anthropic.claude-3-5-sonnet-20240620-v1:0
+  - model_name: db-openai-endpoint
     litellm_params:
-      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
-      #########################################################
-      ########## batch specific params ########################
-      s3_bucket_name: litellm-proxy
-      s3_region_name: us-west-2
-      s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
-      s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
-      aws_batch_role_arn: arn:aws:iam::888602223428:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
-    model_info: 
-      mode: batch
+      model: openai/fake
+      api_key: fake-key
+      api_base: https://exampleopenaiendpoint-production.up.railway.app/
+      rpm: 100
+  - model_name: openai/*
+    litellm_params:
+      model: openai/*
+
+
+
+# Litellm settings
+litellm_settings:
+  callbacks: ["prometheus", "dynamic_rate_limiter_v3"]
+  priority_reservation: {"dev": 0.1, "prod": 0.9}
+  set_verbose: true  # Enable debug logging to see priority allocation
+
+general_settings:
+  store_prompts_in_spend_logs: true


### PR DESCRIPTION
## [Feature]: More control on store_prompts_in_spend_logs

Use a header to disable logging prompt/response in spend logs per request 

```
"headers": {
                "x-litellm-disable-prompts-in-spend-logs": "true"
            }
        }
```

Fixes: https://github.com/BerriAI/litellm/issues/14603

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


