### PR TITLE
Fix API key passing for Gemini token counting endpoints

### DIFF
--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -121,7 +121,8 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
         default_headers = {
             "Content-Type": "application/json",
         }
-        gemini_api_key = self._get_google_ai_studio_api_key(dict(litellm_params or {}))
+        # Use the passed api_key first, then fall back to litellm_params and environment
+        gemini_api_key = api_key or self._get_google_ai_studio_api_key(dict(litellm_params or {}))
         if gemini_api_key is not None:
             default_headers[self.XGOOGLE_API_KEY] = gemini_api_key
         if headers is not None:


### PR DESCRIPTION
## Fix API key passing for Gemini token counting endpoints

<!-- e.g. "Implement user authentication feature" -->

When running the Google AI Studio Gemini model on the litellm proxy server and using it from gemini-cli, before the fix the API key could not be read and an error like the one at the top of the following image would occur. After the fix, it now responds normally, as shown at the bottom of the image.

<img width="764" height="376" alt="image" src="https://github.com/user-attachments/assets/4668497b-80c9-4346-a55f-0f1a27d38ce7" />

To do this, use the following settings:

```config.yml
model_list:
  - model_name: gemini-2.5-pro
    litellm_params:
      model: gemini/gemini-2.5-pro
      api_key: <your_api_key>
```

## Relevant issues

No (Related to https://github.com/BerriAI/litellm/issues/14588)
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

No tests were added because the changes were very minor and there were no existing tests associated with them.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


