### PR TITLE
feat: pass-through of custom headers to MCP servers

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -1167,6 +1167,39 @@ curl --location '<your-litellm-proxy-base-url>/v1/responses' \
 ```
 
 
+### Forwarding Custom Headers to MCP
+
+By default, LiteLLM does not forward arbitrary client-supplied headers to MCP servers. To allow pass-through of custom headers (in addition to any server-specific auth headers you set), enable it in your config:
+
+```yaml title="config.yaml" showLineNumbers
+general_settings:
+  forward_client_headers_to_mcp: true
+```
+
+When enabled, headers you provide under the MCP tool's `headers` field in your request are forwarded to the target MCP server. Headers used by LiteLLM for its own routing and authentication (for example, `x-litellm-api-key`) are not forwarded.
+
+```bash title="cURL example: forward a custom header" showLineNumbers
+curl --location '<your-litellm-proxy-base-url>/v1/responses' \
+  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $LITELLM_API_KEY" \
+  --data '{
+    "model": "gpt-4o",
+    "tools": [
+      {
+        "type": "mcp",
+        "server_label": "litellm",
+        "server_url": "litellm_proxy",
+        "require_approval": "never",
+        "headers": {
+          "x-custom-request-id": "abc-123"
+        }
+      }
+    ],
+    "input": "Run available tools",
+    "tool_choice": "required"
+  }'
+```
+
 
 ## MCP Cost Tracking
 

--- a/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/litellm_auth_handler.py
@@ -8,7 +8,7 @@ from litellm.proxy._types import UserAPIKeyAuth
 class MCPAuthenticatedUser(AuthenticatedUser):
     """
     Wrapper class to make LiteLLM's authentication and configuration compatible with MCP's AuthenticatedUser.
-    
+
     This class handles:
     1. User API key authentication information
     2. MCP authentication header (deprecated)
@@ -16,9 +16,18 @@ class MCPAuthenticatedUser(AuthenticatedUser):
     4. Server-specific authentication headers
     """
 
-    def __init__(self, user_api_key_auth: UserAPIKeyAuth, mcp_auth_header: Optional[str] = None, mcp_servers: Optional[List[str]] = None, mcp_server_auth_headers: Optional[Dict[str, str]] = None, mcp_protocol_version: Optional[str] = None):
+    def __init__(
+        self,
+        user_api_key_auth: UserAPIKeyAuth,
+        mcp_auth_header: Optional[str] = None,
+        mcp_servers: Optional[List[str]] = None,
+        mcp_server_auth_headers: Optional[Dict[str, str]] = None,
+        mcp_protocol_version: Optional[str] = None,
+        forwarded_headers: Optional[Dict[str, str]] = None,
+    ):
         self.user_api_key_auth = user_api_key_auth
         self.mcp_auth_header = mcp_auth_header
         self.mcp_servers = mcp_servers
         self.mcp_server_auth_headers = mcp_server_auth_headers or {}
         self.mcp_protocol_version = mcp_protocol_version
+        self.forwarded_headers = forwarded_headers or {}

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -374,6 +374,7 @@ class MCPServerManager:
         self,
         server: MCPServer,
         mcp_auth_header: Optional[str] = None,
+        forwarded_headers: Optional[Dict[str, str]] = None,
     ) -> MCPClient:
         """
         Create an MCPClient instance for the given server.
@@ -403,6 +404,7 @@ class MCPServerManager:
                 auth_value=mcp_auth_header or server.authentication_token,
                 timeout=60.0,
                 stdio_config=stdio_config,
+                extra_headers=forwarded_headers,
             )
         else:
             # For HTTP/SSE transports
@@ -413,6 +415,7 @@ class MCPServerManager:
                 auth_type=server.auth_type,
                 auth_value=mcp_auth_header or server.authentication_token,
                 timeout=60.0,
+                extra_headers=forwarded_headers,
             )
 
     async def _get_tools_from_server(
@@ -556,6 +559,7 @@ class MCPServerManager:
         mcp_auth_header: Optional[str] = None,
         mcp_server_auth_headers: Optional[Dict[str, str]] = None,
         proxy_logging_obj: Optional[ProxyLogging] = None,
+        forwarded_headers: Optional[Dict[str, str]] = None,
     ) -> CallToolResult:
         """
         Call a tool with the given name and arguments (handles prefixed tool names)
@@ -673,6 +677,7 @@ class MCPServerManager:
         client = self._create_mcp_client(
             server=mcp_server,
             mcp_auth_header=server_auth_header,
+            forwarded_headers=forwarded_headers,
         )
 
         async with client:


### PR DESCRIPTION
## Title

pass-through of custom headers to MCP servers

## Relevant issues

Fixes #14141

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

Here is the result from my local test:
```
$ curl -v -X POST http://localhost:4000/mcp/echo -H "Content-Type: application/json" -H "Accept: application/json,text/event-stream" -d @tools_call.json -H "x-litellm-api-key: Bearer sk-xxxxxxxxxxx" -H "mcp-protocol-version: 2025-06-18" -H "x-test: 1234" -H "x-aaaaaaa: aaaa" -H "Authentication: Bearer 1234"

{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\n  \"host\": \"localhost:3000\",\n  \"accept-encoding\": \"gzip, deflate\",\n  \"connection\": \"keep-alive\",\n  \"user-agent\": \"python-httpx/0.28.1\",\n  \"accept\": \"application/json, text/event-stream\",\n  \"content-type\": \"application/json\",\n  \"x-test\": \"1234\",\n  \"x-aaaaaaa\": \"aaaa\",\n  \"mcp-protocol-version\": \"2025-06-18\",\n  \"content-length\": \"86\"\n}"}],"isError":false}}
```
