### PR TITLE
Add opnerouter/x-ai/grok-4-fast:free model to price and context window json file

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21268,6 +21268,16 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "x-ai/grok-4-fast:free": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "litellm_provider": "xai",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "max_tokens": 2000000,
+    "mode": "chat",
+    "source": "https://openrouter.ai/x-ai/grok-4-fast:free"
+    },
     "xai/grok-beta": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21268,6 +21268,16 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "x-ai/grok-4-fast:free": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "litellm_provider": "xai",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "max_tokens": 2000000,
+    "mode": "chat",
+    "source": "https://openrouter.ai/x-ai/grok-4-fast:free"
+    },
     "xai/grok-beta": {
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",


### PR DESCRIPTION
## Added "opnerouter/x-ai/grok-4-fast:free" to model_prices_and_context_window.json

### Description

This PR adds support for the "opnerouter/x-ai/grok-4-fast:free" model to `model_prices_and_context_window.json` and the backup file.  
Model details were referenced from [OpenRouter](https://openrouter.ai/x-ai/grok-4-fast:free) and added to ensure accurate model metadata is available for LiteLLM.

---

## Relevant issues

Fixes #14745

---

## Pre-Submission Checklist

- [ ] I have added at least one test in [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) as required ([contributing guide](https://docs.litellm.ai/docs/extras/contributing_code))
- [ ] I have included a screenshot of my new test passing locally
- [ ] My PR passes all unit tests (`make test-unit`)
- [x] My PR only solves one specific problem and is as isolated as possible

---

## Type

<!-- Select all that apply by keeping the relevant lines (remove the rest) -->

🆕 New Feature

---

## Changes

- Added entry for `"opnerouter/x-ai/grok-4-fast:free"` in `model_prices_and_context_window.json` and its backup
- Populated entry with input/output cost, token limits, and source URL per official documentation

---

## Screenshots/test evidence

I have not added or run tests for this PR. This change only updates JSON configuration and does not alter code logic. If a test is required, please guide me on what needs to be added or how to run the relevant tests, as I am a beginner.

## Additional Notes

This is my first contribution to this repository. I have added the new model entry as described in the issue but am not familiar with the test setup or running tests for configuration files. Any feedback or guidance on this process would be greatly appreciated!