### PR TITLE
Fix: Authorization header to use correct "Bearer" capitalization

### DIFF
--- a/litellm/llms/cohere/common_utils.py
+++ b/litellm/llms/cohere/common_utils.py
@@ -31,7 +31,7 @@ def validate_environment(
         "Request-Source": "unspecified:litellm",
         "accept": "application/json",
         "content-type": "application/json",
-        "Authorization": "bearer $CO_API_KEY"
+        "Authorization": "Bearer $CO_API_KEY"
     }
     """
     headers.update(
@@ -42,7 +42,7 @@ def validate_environment(
         }
     )
     if api_key:
-        headers["Authorization"] = f"bearer {api_key}"
+        headers["Authorization"] = f"Bearer {api_key}"
     return headers
 
 

--- a/litellm/llms/cohere/rerank/transformation.py
+++ b/litellm/llms/cohere/rerank/transformation.py
@@ -86,7 +86,7 @@ class CohereRerankConfig(BaseRerankConfig):
             )
 
         default_headers = {
-            "Authorization": f"bearer {api_key}",
+            "Authorization": f"Bearer {api_key}",
             "accept": "application/json",
             "content-type": "application/json",
         }

--- a/litellm/llms/infinity/rerank/transformation.py
+++ b/litellm/llms/infinity/rerank/transformation.py
@@ -49,7 +49,7 @@ class InfinityRerankConfig(CohereRerankConfig):
             )
 
         default_headers = {
-            "Authorization": f"bearer {api_key}",
+            "Authorization": f"Bearer {api_key}",
             "accept": "application/json",
             "content-type": "application/json",
         }

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -76,7 +76,7 @@ async def set_env_variables_in_header(custom_headers: Optional[dict]) -> Optiona
 
     example header can be
 
-    {"Authorization": "bearer os.environ/COHERE_API_KEY"}
+    {"Authorization": "Bearer os.environ/COHERE_API_KEY"}
     """
     if custom_headers is None:
         return None

--- a/tests/local_testing/test_pass_through_endpoints.py
+++ b/tests/local_testing/test_pass_through_endpoints.py
@@ -117,7 +117,7 @@ async def test_pass_through_endpoint_rerank(client):
         {
             "path": "/v1/rerank",
             "target": "https://api.cohere.com/v1/rerank",
-            "headers": {"Authorization": f"bearer {_cohere_api_key}"},
+            "headers": {"Authorization": f"Bearer {_cohere_api_key}"},
         }
     ]
 
@@ -193,7 +193,7 @@ async def test_pass_through_endpoint_rpm_limit(
             "path": "/v1/rerank",
             "target": "https://api.cohere.com/v1/rerank",
             "auth": auth,
-            "headers": {"Authorization": f"bearer {_cohere_api_key}"},
+            "headers": {"Authorization": f"Bearer {_cohere_api_key}"},
         }
     ]
 
@@ -293,7 +293,7 @@ async def test_pass_through_endpoint_sequential_rpm_limit(
             "path": "/v1/rerank",
             "target": "https://api.cohere.com/v1/rerank",
             "auth": auth,
-            "headers": {"Authorization": f"bearer {_cohere_api_key}"},
+            "headers": {"Authorization": f"Bearer {_cohere_api_key}"},
         }
     ]
 

--- a/tests/test_passthrough_endpoints.py
+++ b/tests/test_passthrough_endpoints.py
@@ -17,7 +17,7 @@ dotenv.load_dotenv()
 async def cohere_rerank(session):
     url = "http://localhost:4000/v1/rerank"
     headers = {
-        "Authorization": f"bearer {os.getenv('COHERE_API_KEY')}",
+        "Authorization": f"Bearer {os.getenv('COHERE_API_KEY')}",
         "Content-Type": "application/json",
         "Accept": "application/json",
     }


### PR DESCRIPTION
## Title

Fix: Authorization header to use correct "Bearer" capitalization

## Relevant issues

[[Bug]: Authorization header lowercase in reranker endpoint #14001](https://github.com/BerriAI/litellm/issues/14001)
## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Normalize the `Authorization` header to use `"Bearer"` (capital B, rest lowercase).
- Based on [RFC 6750, Section 2.1](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1), the correct format is: "Authorization: Bearer <token>"
- Although [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235) states that auth scheme names are case-insensitive, many OAuth 2.0 servers/libraries reject `"bearer"`.  
- This change ensures interoperability with OAuth 2.0 endpoints.


## Comment

The problem was that the Authorization header for the reranker endpoint was being sent as bearer (lowercase) instead of the standard Bearer (capitalized).

While many servers might be lenient, the RFC 6750 standard explicitly requires a capital 'B'. Some backends, like the one we're using, enforce this strictly, which was causing our requests to fail.

I'm not sure why this issue specifically arose only with Cohere's rerank endpoint, but I suspect their initial API documentation might have used a lowercase "bearer."

However, their current documentation now consistently uses the capitalized "Bearer" across the board: https://docs.cohere.com/reference/chat

Therefore, I believe it's reasonable to update the prefix in the test cases and the code to align with the standard.