### PR TITLE
[Feat] Proxy CLI Auth - Allow re-using cli auth token

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -947,6 +947,7 @@ HEALTH_CHECK_TIMEOUT_SECONDS = int(
     os.getenv("HEALTH_CHECK_TIMEOUT_SECONDS", 60)
 )  # 60 seconds
 LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME = "litellm-internal-health-check"
+LITTELM_CLI_SERVICE_ACCOUNT_NAME = "litellm-cli"
 
 UI_SESSION_TOKEN_TEAM_ID = "litellm-dashboard"
 LITELLM_PROXY_ADMIN_NAME = "default_user_id"

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1915,6 +1915,22 @@ class UserAPIKeyAuth(
             key_alias=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
             team_alias=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
         )
+    
+    @classmethod
+    def get_litellm_cli_user_api_key_auth(cls) -> "UserAPIKeyAuth":
+        """
+        Returns a `UserAPIKeyAuth` object for the litellm internal health check service account.
+
+        This is used to track number of requests/spend for health check calls.
+        """
+        from litellm.constants import LITTELM_CLI_SERVICE_ACCOUNT_NAME
+
+        return cls(
+            api_key=LITTELM_CLI_SERVICE_ACCOUNT_NAME,
+            team_id=LITTELM_CLI_SERVICE_ACCOUNT_NAME,
+            key_alias=LITTELM_CLI_SERVICE_ACCOUNT_NAME,
+            team_alias=LITTELM_CLI_SERVICE_ACCOUNT_NAME,
+        )
 
 
 class UserInfoResponse(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/client/cli/commands/auth.py
+++ b/litellm/proxy/client/cli/commands/auth.py
@@ -64,12 +64,19 @@ def login(ctx: click.Context):
     
     base_url = ctx.obj["base_url"]
     
+    # Check if we have an existing key to regenerate
+    existing_key = get_stored_api_key()
+    
     # Generate unique key ID for this login session
     key_id = f"sk-{str(uuid.uuid4())}"
     
     try:
         # Construct SSO login URL with CLI source and pre-generated key
         sso_url = f"{base_url}/sso/key/generate?source={LITELLM_CLI_SOURCE_IDENTIFIER}&key={key_id}"
+        
+        # If we have an existing key, include it so the server can regenerate it
+        if existing_key:
+            sso_url += f"&existing_key={existing_key}"
         
         click.echo(f"Opening browser to: {sso_url}")
         click.echo("Please complete the SSO authentication in your browser...")

--- a/tests/test_litellm/proxy/client/cli/test_auth_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_auth_commands.py
@@ -435,3 +435,105 @@ class TestWhoamiCommand:
             assert "✅ Authenticated" in result.output
             # Should calculate age based on timestamp=0
             assert "Token age:" in result.output
+
+
+class TestCLIKeyRegenerationFlow:
+    """Test the end-to-end CLI key regeneration flow from CLI perspective"""
+
+    def setup_method(self):
+        """Setup for each test"""
+        self.runner = CliRunner()
+
+    def test_login_with_existing_key_regeneration_flow(self):
+        """Test complete login flow when user has existing key - should regenerate it"""
+        mock_context = Mock()
+        mock_context.obj = {"base_url": "https://test.example.com"}
+        
+        # Mock existing stored key
+        existing_key = "sk-existing-key-123"
+        
+        # Mock successful regeneration response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "ready",
+            "key": "sk-regenerated-key-456"  # New regenerated key
+        }
+        
+        with patch('webbrowser.open') as mock_browser, \
+             patch('requests.get', return_value=mock_response) as mock_get, \
+             patch('litellm.proxy.client.cli.commands.auth.get_stored_api_key', return_value=existing_key) as mock_get_stored, \
+             patch('litellm.proxy.client.cli.commands.auth.save_token') as mock_save, \
+             patch('litellm.proxy.client.cli.interface.show_commands') as mock_show_commands, \
+             patch('uuid.uuid4', return_value='new-session-uuid-789'):
+            
+            result = self.runner.invoke(login, obj=mock_context.obj)
+            
+            assert result.exit_code == 0
+            assert "✅ Login successful!" in result.output
+            assert "API Key: sk-regenerated-key-456" in result.output
+            
+            # Verify existing key was retrieved
+            mock_get_stored.assert_called_once()
+            
+            # Verify browser was opened with correct URL including existing key
+            mock_browser.assert_called_once()
+            call_args = mock_browser.call_args[0][0]
+            assert "https://test.example.com/sso/key/generate" in call_args
+            assert "source=litellm-cli" in call_args
+            assert "key=sk-new-session-uuid-789" in call_args
+            assert f"existing_key={existing_key}" in call_args
+            
+            # Verify polling was done with correct session key
+            mock_get.assert_called()
+            poll_url = mock_get.call_args[0][0]
+            assert "sk-new-session-uuid-789" in poll_url
+            
+            # Verify regenerated key was saved
+            mock_save.assert_called_once()
+            saved_data = mock_save.call_args[0][0]
+            assert saved_data['key'] == 'sk-regenerated-key-456'
+            assert saved_data['user_id'] == 'cli-user'
+            
+            mock_show_commands.assert_called_once()
+
+    def test_login_without_existing_key_creation_flow(self):
+        """Test complete login flow when user has no existing key - should create new one"""
+        mock_context = Mock()
+        mock_context.obj = {"base_url": "https://test.example.com"}
+        
+        # Mock no existing key
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "ready",
+            "key": "sk-new-created-key-789"
+        }
+        
+        with patch('webbrowser.open') as mock_browser, \
+             patch('requests.get', return_value=mock_response), \
+             patch('litellm.proxy.client.cli.commands.auth.get_stored_api_key', return_value=None) as mock_get_stored, \
+             patch('litellm.proxy.client.cli.commands.auth.save_token') as mock_save, \
+             patch('litellm.proxy.client.cli.interface.show_commands'), \
+             patch('uuid.uuid4', return_value='new-session-uuid-999'):
+            
+            result = self.runner.invoke(login, obj=mock_context.obj)
+            
+            assert result.exit_code == 0
+            assert "✅ Login successful!" in result.output
+            
+            # Verify existing key check was done
+            mock_get_stored.assert_called_once()
+            
+            # Verify browser was opened with correct URL WITHOUT existing key
+            mock_browser.assert_called_once()
+            call_args = mock_browser.call_args[0][0]
+            assert "https://test.example.com/sso/key/generate" in call_args
+            assert "source=litellm-cli" in call_args
+            assert "key=sk-new-session-uuid-999" in call_args
+            assert "existing_key=" not in call_args  # Should not include existing_key param
+            
+            # Verify new key was saved
+            mock_save.assert_called_once()
+            saved_data = mock_save.call_args[0][0]
+            assert saved_data['key'] == 'sk-new-created-key-789'


### PR DESCRIPTION
## [Feat] Proxy CLI Auth - Allow re-using cli auth token

Fixes LIT-912

When rolling this out to 1K to 5K employees we will have a new key per employee this can explode in the DB. This feature allows re-using the token. 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


