### PR TITLE
fix (opentelemetry): use generation_name for span naming in logging method

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -575,9 +575,16 @@ class OpenTelemetry(CustomLogger):
         if litellm.turn_off_message_logging or not self.message_logging:
             return
 
+        litellm_params = kwargs.get("litellm_params", {})
+        metadata = litellm_params.get("metadata", {})
+        generation_name = metadata.get("generation_name")
+
+        raw_span_name = generation_name if generation_name else RAW_REQUEST_SPAN_NAME
+
+
         otel_tracer: Tracer = self.get_tracer_to_use_for_request(kwargs)
         raw_span = otel_tracer.start_span(
-            name=RAW_REQUEST_SPAN_NAME,
+            name=raw_span_name,
             start_time=self._to_ns(start_time),
             context=trace.set_span_in_context(parent_span),
         )
@@ -1165,6 +1172,13 @@ class OpenTelemetry(CustomLogger):
         return int(dt.timestamp() * 1e9)
 
     def _get_span_name(self, kwargs):
+        litellm_params = kwargs.get("litellm_params", {})
+        metadata = litellm_params.get("metadata", {})
+        generation_name = metadata.get("generation_name")
+
+        if generation_name:
+            return generation_name
+
         return LITELLM_REQUEST_SPAN_NAME
 
     def get_traceparent_from_header(self, headers):


### PR DESCRIPTION
## Title

Fix OpenTelemetry span naming to use dynamic generation_name from metadata

## Relevant issues

> Before
<img width="490" height="551" alt="image" src="https://github.com/user-attachments/assets/6f659bc8-a089-4c27-8078-40b8322711d6" />

> After
<img width="491" height="506" alt="image" src="https://github.com/user-attachments/assets/50d6c0a8-1e97-4ab8-ab7c-b36cfdaa8332" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="2160" height="515" alt="image" src="https://github.com/user-attachments/assets/b91c1b61-d36c-446f-8d73-092d71e7f395" />


## Type
🐛 Bug Fix

## Changes
Problem

When using Langfuse sdk v3 for logging with OpenTelemetry integration, span names were hardcoded instead of using the dynamic generation_name provided in the request metadata. This prevented proper trace organization and made it difficult
to identify specific operations in observability tools.

Solution

- Updated _get_span_name() function to properly extract and use generation_name from litellm_params.metadata
- Updated _maybe_log_raw_request() function to use the same dynamic span naming for raw request spans
- Added comprehensive unit tests for both functions to ensure proper behavior

Technical Details

- The generation_name is now extracted from kwargs["litellm_params"]["metadata"]["generation_name"]
- Falls back to default span names (LITELLM_REQUEST_SPAN_NAME and RAW_REQUEST_SPAN_NAME) when generation_name is not provided
- Maintains backward compatibility with existing implementations

Tests Added

- test_get_span_name_with_generation_name: Verifies custom generation names are used
- test_get_span_name_without_generation_name: Verifies fallback to default names
- test_maybe_log_raw_request_creates_span: Verifies raw request span creation
- test_maybe_log_raw_request_skips_when_logging_disabled: Verifies proper logging control

This fix enables proper span naming when using Langfuse v3 and other observability tools that rely on dynamic generation names for trace organization.

