### PR TITLE
fix(azure): forward api_version and auth params to async embedding calls in azure

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -744,6 +744,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     client=client,
                     litellm_params=litellm_params,
                     api_base=api_base,
+                    api_version=api_version,
+                    max_retries=max_retries,
+                    azure_ad_token=azure_ad_token,
+                    azure_ad_token_provider=azure_ad_token_provider,
                 )
             azure_client = self.get_azure_openai_client(
                 api_version=api_version,

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -19,7 +19,7 @@ from litellm.types.router import GenericLiteLLMParams
 from litellm.types.secret_managers.get_azure_ad_token_provider import (
     AzureCredentialType,
 )
-from litellm.types.utils import CallTypes
+from litellm.types.utils import CallTypes, EmbeddingResponse
 
 
 # Mock the necessary dependencies
@@ -915,6 +915,82 @@ async def test_azure_client_cache_separates_sync_and_async():
         assert (
             mock_init_azure.call_count == 2
         ), "initialize_azure_sdk_client should be called twice"
+
+
+@pytest.mark.asyncio
+async def test_aembedding_path_forwards_azure_parameters(monkeypatch):
+    from unittest.mock import Mock
+    from litellm.llms.azure.azure import AzureChatCompletion
+
+    captured_params = {}
+
+    async def fake_aembedding(
+        self,
+        *,
+        data,
+        input,
+        model,
+        logging_obj,
+        api_key,
+        model_response,
+        timeout,
+        client,
+        litellm_params,
+        api_base,
+        api_version=None,
+        max_retries=None,
+        azure_ad_token=None,
+        azure_ad_token_provider=None,
+    ):
+        captured_params.update(
+            {
+                "api_version": api_version,
+                "max_retries": max_retries,
+                "azure_ad_token": azure_ad_token,
+                "azure_ad_token_provider": azure_ad_token_provider,
+                "litellm_params": litellm_params,
+            }
+        )
+        return "ok"
+
+    monkeypatch.setattr(AzureChatCompletion, "aembedding", fake_aembedding)
+    monkeypatch.setattr(
+        AzureChatCompletion, "create_client_session", lambda self: "client"
+    )
+
+    azure_completion = AzureChatCompletion()
+    logging_obj = Mock()
+    api_version = "2023-05-15"
+    max_retries = 4
+    azure_ad_token = "oidc/mock-token"
+
+    def token_provider():
+        return "token"
+
+    coroutine = azure_completion.embedding(
+        model="azure/text-embedding-3-large",
+        input=["hello"],
+        api_base="https://example.azure.com/",
+        api_version=api_version,
+        timeout=30,
+        logging_obj=logging_obj,
+        model_response=EmbeddingResponse(),
+        optional_params={},
+        api_key="test-key",
+        azure_ad_token=azure_ad_token,
+        azure_ad_token_provider=token_provider,
+        max_retries=max_retries,
+        litellm_params={"foo": "bar"},
+        aembedding=True,
+    )
+
+    result = await coroutine
+    assert result == "ok"
+    assert captured_params["api_version"] == api_version
+    assert captured_params["max_retries"] == max_retries
+    assert captured_params["azure_ad_token"] == azure_ad_token
+    assert captured_params["azure_ad_token_provider"] is token_provider
+    assert captured_params["litellm_params"] == {"foo": "bar"}
 
 
 def test_scope_always_string_in_initialize_azure_sdk_client(setup_mocks, monkeypatch):


### PR DESCRIPTION
## Title

fix(azure): forward api_version and auth params to async embedding calls in azure

## Relevant issues

Fixes #9406

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory,
**Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

Bug Fix

## Changes

### The Bug
When `aembedding=True` (which is always the case for proxy requests using the async path), the `embedding` method in `litellm/llms/azure/azure.py` was not forwarding critical Azure parameters to `self.aembedding()`:
- `api_version` (most critical - causes the regression)
- `azure_ad_token`
- `azure_ad_token_provider`
- `max_retries`

Without `api_version`, the client falls back to `litellm.AZURE_DEFAULT_API_VERSION` (currently `2025-02-01-preview`), causing 404 "Resource not found" errors for Azure endpoints that only support older API versions like `2023-05-15`.

### The Fix
This PR ensures these parameters are properly forwarded when calling `self.aembedding()` at lines 747-750.

### Impact
This fix resolves embedding failures for Azure OpenAI resources that haven't been upgraded to support the preview API version  (`2025-02-01-preview`) and still require older stable API versions.

### Testing
Added regression test `test_aembedding_path_forwards_azure_parameters` in `tests/test_litellm/llms/azure/test_azure_common_utils.py` that verifies all Azure-specific parameters are correctly forwarded through the async embedding path.

<img width="958" height="206" alt="image" src="https://github.com/user-attachments/assets/a3381112-67f3-46ec-af1f-ac4530a329bd" />
