### PR TITLE
Fix load credentials in token counter proxy

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -35,6 +35,7 @@ from litellm.constants import (
     LITELLM_SETTINGS_SAFE_DB_OVERRIDES,
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.utils import load_credentials_from_list
 from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
@@ -5894,6 +5895,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             pass
     if deployment is not None:
         litellm_model_name = deployment.get("litellm_params", {}).get("model")
+        load_credentials_from_list(deployment.get("litellm_params", {}))
         # remove the custom_llm_provider_prefix in the litellm_model_name
         if "/" in litellm_model_name:
             litellm_model_name = litellm_model_name.split("/", 1)[1]


### PR DESCRIPTION
## Fix load credentials in token counter proxy

<!-- e.g. "Implement user authentication feature" -->

I fixed a bug where calling token_count from a proxy like Gemini CLI after setting credentials via the UI caused an error because the credentials information wasn't loaded.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/14588

<!-- e.g. "Fixes #000" -->

The image above shows the error before correction, but after correction, it functions normally as shown below.

<img width="716" height="255" alt="image" src="https://github.com/user-attachments/assets/672b1dba-c8ca-4454-8c0f-530eb499a9d1" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Since this is a very minor fix, no tests have been added.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


