### PR TITLE
fix: SSO "Clear" button writes empty values instead of removing SSO config

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -493,21 +493,32 @@ async def update_sso_settings(sso_config: SSOConfig):
         config["general_settings"] = {}
 
     # Update environment variables in config and in memory
-    sso_data = sso_config.model_dump(exclude_none=True)
+    sso_data = sso_config.model_dump()
     for field_name, value in sso_data.items():
-
-        if field_name == "user_email" and value is not None:
-            # Store user_email in general_settings instead of environment variables
-            config["general_settings"]["proxy_admin_email"] = value
-        elif field_name == "ui_access_mode" and value is not None:
-
-            config["general_settings"]["ui_access_mode"] = value
-        elif field_name in env_var_mapping and value is not None:
+        if field_name == "user_email":
+            if value:
+                # Store user_email in general_settings instead of environment variables
+                config["general_settings"]["proxy_admin_email"] = value
+            else:
+                # Clear user_email if null/empty
+                config["general_settings"].pop("proxy_admin_email", None)
+        elif field_name == "ui_access_mode":
+            if value:
+                config["general_settings"]["ui_access_mode"] = value
+            else:
+                # Clear ui_access_mode if null/empty
+                config["general_settings"].pop("ui_access_mode", None)
+        elif field_name in env_var_mapping and value:
             env_var_name = env_var_mapping[field_name]
             # Update in config
             config["environment_variables"][env_var_name] = value
             # Update in runtime environment
             os.environ[env_var_name] = value
+        elif field_name in env_var_mapping:
+            # Clear environment variable if value is null/empty
+            env_var_name = env_var_mapping[field_name]
+            config["environment_variables"].pop(env_var_name, None)
+            os.environ.pop(env_var_name, None)
 
     stored_config = config
     if len(config["environment_variables"]) > 0:

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -186,21 +186,21 @@ const SSOModals: React.FC<SSOModalsProps> = ({
     }
 
     try {
-      // Clear all SSO settings by sending empty values
+      // Clear all SSO settings
       const clearSettings = {
-        google_client_id: '',
-        google_client_secret: '',
-        microsoft_client_id: '',
-        microsoft_client_secret: '',
-        microsoft_tenant: '',
-        generic_client_id: '',
-        generic_client_secret: '',
-        generic_authorization_endpoint: '',
-        generic_token_endpoint: '',
-        generic_userinfo_endpoint: '',
-        proxy_base_url: '',
-        user_email: '',
-        sso_provider: '',
+        google_client_id: null,
+        google_client_secret: null,
+        microsoft_client_id: null,
+        microsoft_client_secret: null,
+        microsoft_tenant: null,
+        generic_client_id: null,
+        generic_client_secret: null,
+        generic_authorization_endpoint: null,
+        generic_token_endpoint: null,
+        generic_userinfo_endpoint: null,
+        proxy_base_url: null,
+        user_email: null,
+        sso_provider: null,
       };
 
       await updateSSOSettings(accessToken, clearSettings);


### PR DESCRIPTION
## Title

Fix: SSO "Clear" button writes empty values instead of removing SSO config

## Relevant issues

Fixes #14825 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
<img width="835" height="208" alt="image" src="https://github.com/user-attachments/assets/06e7d288-d708-41b4-ba5b-9b6935f08c5e" />


## Type
🐛 Bug Fix

## Changes


