### PR TITLE
fix: cache root cause

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -815,11 +815,9 @@ async def _cache_management_object(
     user_api_key_cache: DualCache,
     proxy_logging_obj: Optional[ProxyLogging],
 ):
-    # Always store as a plain dict for consistent retrieval
+
     await user_api_key_cache.async_set_cache(
-        key=key,
-        value=value,
-        ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+        key=key, value=value, ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
     )
 
 
@@ -1131,7 +1129,6 @@ async def get_key_object(
             return UserAPIKeyAuth(**cached_key_obj)
         elif isinstance(cached_key_obj, UserAPIKeyAuth):
             return cached_key_obj
-
 
     if check_cache_only:
         raise Exception(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -818,7 +818,7 @@ async def _cache_management_object(
     # Always store as a plain dict for consistent retrieval
     await user_api_key_cache.async_set_cache(
         key=key,
-        value=value.model_dump(),
+        value=value,
         ttl=DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
     )
 
@@ -1122,7 +1122,9 @@ async def get_key_object(
     # check if in cache
     key = hashed_token
 
-    cached_key_obj = await user_api_key_cache.async_get_cache(key=key)
+    cached_key_obj: Optional[UserAPIKeyAuth] = await user_api_key_cache.async_get_cache(
+        key=key
+    )
 
     if cached_key_obj is not None:
         if isinstance(cached_key_obj, dict):
@@ -1186,13 +1188,12 @@ async def get_org_object(
         )
 
     # check if in cache
-    cached_org_obj = await user_api_key_cache.async_get_cache(key="org_id:{}".format(org_id))
+    cached_org_obj = user_api_key_cache.async_get_cache(key="org_id:{}".format(org_id))
     if cached_org_obj is not None:
         if isinstance(cached_org_obj, dict):
             return LiteLLM_OrganizationTable(**cached_org_obj)
         elif isinstance(cached_org_obj, LiteLLM_OrganizationTable):
             return cached_org_obj
-        
     # else, check db
     try:
         response = await prisma_client.db.litellm_organizationtable.find_unique(


### PR DESCRIPTION
Ensure values are set and retrieved with the expected type to avoid unnecessary checks and cache misses.

## Title

Fixed Cache Root Cause Issue

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring

## Changes

By enforcing the expected type on set, the get function avoids type checks, preventing cache misses caused by type mismatches.

## Performance Changes
- 8 CPUs & RAM

### Summary

Over a large enough sample, the RPS didn't change all that much, but the median, p95, p99 and average did.

<h3>Baseline</h3>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 50374 | 0 | 900 | 3500 | 4600 | 1247.86 | 26 | 7375 | 398 | 407.7 | 0
Custom | LiteLLM Overhead Duration (ms) | 50374 | 0 | 92 | 420 | 1500 | 151.73 | 1 | 3467 | 0 | 407.7 | 0
  | Aggregated | 100748 | 0 | 240 | 2900 | 4200 | 699.8 | 1 | 7375 | 199 | 815.4 | 0


<!-- notionvc: 63cc2a3b-ad78-4fe8-ad68-627c95f53d17 -->

<h3>After Changes</h3>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 66782 | 0 | 720 | 2600 | 4200 | 962.85 | 26 | 5762 | 398 | 651.4 | 0
Custom | LiteLLM Overhead Duration (ms) | 66782 | 0 | 77 | 340 | 900 | 125.2 | 2 | 4351 | 0 | 651.4 | 0
  | Aggregated | 133564 | 0 | 210 | 2100 | 3200 | 544.03 | 2 | 5762 | 199 | 1302.8 | 0


<!-- notionvc: 31a6ba51-2f00-4c6f-b9d2-e9238ff2ccf9 -->

