### PR TITLE
Update vertex ai qwen model pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21189,6 +21189,30 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "vertex_ai-qwen_models",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "vertex_ai-qwen_models",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
     "xai/grok-2": {
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",


### PR DESCRIPTION
## Title

Add Vertex AI Qwen3-Next models to cost map

Adds the following models 

vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas
vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Adds two new Qwen3-Next models from Google Cloud Vertex AI to `model_prices_and_context_window.json`:
- `vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas`
- `vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas`

These models were recently released on GCP and include their specified pricing, context window, and capability details. The entries have been tested by the user and confirmed to work.

---
[Slack Thread](https://berriaillm.slack.com/archives/C078HF3T98B/p1758587805841649?thread_ts=1758587805.841649&cid=C078HF3T98B)

<a href="https://cursor.com/background-agent?bcId=bc-b8bb1c5a-e6d5-4856-b6d3-d4fd1655e4e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8bb1c5a-e6d5-4856-b6d3-d4fd1655e4e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

