### PR TITLE
[Fix] Priority Reservation: keys without priority metadata receive higher priority than keys with explicit priority configurations.

### DIFF
--- a/docs/my-website/docs/proxy/dynamic_rate_limit.md
+++ b/docs/my-website/docs/proxy/dynamic_rate_limit.md
@@ -139,6 +139,8 @@ litellm_settings:
   priority_reservation: 
     "prod": 0.9  # 90% reserved for production (9 RPM)
     "dev": 0.1   # 10% reserved for development (1 RPM)
+  priority_reservation_settings:
+    default_priority: 0  # Weight (0%) assigned to keys without explicit priority metadata
 
 general_settings:
   master_key: sk-1234 # OR set `LITELLM_MASTER_KEY=".."` in your .env
@@ -151,6 +153,9 @@ general_settings:
 - **Key (str)**: Priority level name (can be any string like "prod", "dev", "critical", etc.)
 - **Value (float)**: Percentage of total TPM/RPM to reserve (0.0 to 1.0)
 - **Note**: Values should sum to 1.0 or less
+
+`priority_reservation_settings`: Object (Optional)
+- **default_priority (float)**: Weight/percentage (0.0 to 1.0) assigned to API keys that have no priority metadata set (defaults to 0.5)
 
 **Start Proxy**
 
@@ -178,6 +183,14 @@ curl -X POST 'http://0.0.0.0:4000/key/generate' \
 -d '{
   "metadata": {"priority": "dev"}
 }'
+```
+
+**Key Without Priority (uses default_priority weight):**
+```bash
+curl -X POST 'http://0.0.0.0:4000/key/generate' \
+-H 'Authorization: Bearer sk-1234' \
+-H 'Content-Type: application/json' \
+-d '{}'
 ```
 
 **Expected Response for both:**
@@ -217,9 +230,10 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 With the configuration above:
 
-1. **Production keys** can make up to 9 requests per minute
-2. **Development keys** can make up to 1 request per minute  
-3. Production requests are never blocked by development usage
+1. **Production keys** can make up to 9 requests per minute (90% of 10 RPM)
+2. **Development keys** can make up to 1 request per minute (10% of 10 RPM)
+3. **Keys without explicit priority** get the default_priority weight (0 = 0%), which allocates 0 requests per minute (0% of 10 RPM)
+4. Named priorities in `priority_reservation` and keys with `default_priority` operate independently
 
 **Rate Limit Error Example:**
 ```json

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -89,6 +89,7 @@ from litellm.types.proxy.management_endpoints.ui_sso import (
     LiteLLM_UpperboundKeyGenerateParams,
 )
 from litellm.types.utils import StandardKeyGenerationConfig, LlmProviders
+from litellm.types.utils import PriorityReservationSettings
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.logging_callback_manager import LoggingCallbackManager
 import httpx
@@ -373,6 +374,7 @@ public_model_groups: Optional[List[str]] = None
 public_model_groups_links: Dict[str, str] = {}
 #### REQUEST PRIORITIZATION ######
 priority_reservation: Optional[Dict[str, float]] = None
+priority_reservation_settings: "PriorityReservationSettings" = PriorityReservationSettings()
 
 
 ######## Networking Settings ########

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -40,7 +40,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
 
     def _get_priority_weight(self, priority: Optional[str]) -> float:
         """Get the weight for a given priority from litellm.priority_reservation"""
-        weight: float = 1.0
+        weight: float = litellm.priority_reservation_settings.default_priority
         if (
             litellm.priority_reservation is None
             or priority not in litellm.priority_reservation

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2633,3 +2633,18 @@ CostResponseTypes = Union[
     ImageResponse,
     TranscriptionResponse,
 ]
+
+
+class PriorityReservationSettings(BaseModel):
+    """
+    Settings for priority-based rate limiting reservation.
+    
+    Defines what priority to assign to keys without explicit priority metadata.
+    The priority_reservation mapping is configured separately via litellm.priority_reservation.
+    """
+    default_priority: float = Field(
+        default=0.5,
+        description="Priority level to assign to API keys without explicit priority metadata. Should match a key in litellm.priority_reservation."
+    )
+
+    model_config = ConfigDict(protected_namespaces=())


### PR DESCRIPTION
## [Fix] Priority Reservation: keys without priority metadata receive higher priority than keys with explicit priority configurations.

Fixes LIT-1080

Adds support for configurable default priority weight assignment to API keys that don't have explicit priority metadata set in the dynamic rate limiter v3.

```yaml
litellm_settings:
  callbacks: ["dynamic_rate_limiter_v3"]
  priority_reservation: 
    "prod": 0.9  # 90% reserved for production
    "dev": 0.1   # 10% reserved for development  
  priority_reservation_settings:
    default_priority: 0  # Keys without priority get 0% (blocked)
```

Before: Keys without priority got hardcoded 0.5 weight
After: Configurable via default_priority (defaults to 0.5)


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


