### PR TITLE
feat: New model - Add support for Qwen models family & Deepseek 3.1 to Amazon Bedrock

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -812,6 +812,10 @@ BEDROCK_EMBEDDING_PROVIDERS_LITERAL = Literal[
 ]
 
 BEDROCK_CONVERSE_MODELS = [
+    "qwen.qwen3-coder-480b-a35b-v1:0",
+    "qwen.qwen3-235b-a22b-2507-v1:0",
+    "qwen.qwen3-coder-30b-a3b-v1:0",
+    "qwen.qwen3-32b-v1:0",
     "deepseek.v3-v1:0",
     "openai.gpt-oss-20b-1:0",
     "openai.gpt-oss-120b-1:0",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -812,6 +812,7 @@ BEDROCK_EMBEDDING_PROVIDERS_LITERAL = Literal[
 ]
 
 BEDROCK_CONVERSE_MODELS = [
+    "deepseek.v3-v1:0",
     "openai.gpt-oss-20b-1:0",
     "openai.gpt-oss-120b-1:0",
     "anthropic.claude-opus-4-1-20250805-v1:0",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17500,6 +17500,54 @@
         "mode": "chat",
         "output_cost_per_token": 2.8e-07
     },
+    "qwen.qwen3-coder-480b-a35b-v1:0": {
+        "input_cost_per_token": 2.2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 65536,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen.qwen3-235b-a22b-2507-v1:0": {
+        "input_cost_per_token": 2.2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen.qwen3-coder-30b-a3b-v1:0": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6.0e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    }, 
+    "qwen.qwen3-32b-v1:0": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.0e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },      
     "recraft/recraftv2": {
         "litellm_provider": "recraft",
         "mode": "image_generation",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7191,6 +7191,18 @@
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
+    "deepseek.v3-v1:0": {
+        "input_cost_per_token": 5.8e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 81920,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },     
     "dolphin": {
         "input_cost_per_token": 5e-07,
         "litellm_provider": "nlp_cloud",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7191,6 +7191,18 @@
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
+    "deepseek.v3-v1:0": {
+        "input_cost_per_token": 5.8e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 81920,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.68e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },    
     "dolphin": {
         "input_cost_per_token": 5e-07,
         "litellm_provider": "nlp_cloud",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17514,6 +17514,54 @@
         "mode": "chat",
         "output_cost_per_token": 2.8e-07
     },
+    "qwen.qwen3-coder-480b-a35b-v1:0": {
+        "input_cost_per_token": 2.2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262000,
+        "max_output_tokens": 65536,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen.qwen3-235b-a22b-2507-v1:0": {
+        "input_cost_per_token": 2.2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "qwen.qwen3-coder-30b-a3b-v1:0": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6.0e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    }, 
+    "qwen.qwen3-32b-v1:0": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.0e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },           
     "recraft/recraftv2": {
         "litellm_provider": "recraft",
         "mode": "image_generation",


### PR DESCRIPTION
## Title

New model - Add support for Qwen models family & Deepseek 3.1 to Amazon Bedrock - "qwen.qwen3-coder-480b-a35b-v1:0", "qwen.qwen3-235b-a22b-2507-v1:0", "qwen.qwen3-coder-30b-a3b-v1:0", "qwen.qwen3-32b-v1:0", "deepseek.v3-v1:0"

Reference:
https://aws.amazon.com/blogs/aws/qwen-models-are-now-available-in-amazon-bedrock/
https://aws.amazon.com/blogs/aws/deepseek-v3-1-now-available-in-amazon-bedrock/

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [*] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes


