### PR TITLE
GPT-3.5-Turbo price updated.

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11261,13 +11261,13 @@
         ]
     },
     "gpt-3.5-turbo": {
-        "input_cost_per_token": 1.5e-06,
+        "input_cost_per_token": 0.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
         "max_output_tokens": 4096,
         "max_tokens": 4097,
         "mode": "chat",
-        "output_cost_per_token": 2e-06,
+        "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_system_messages": true,


### PR DESCRIPTION
## Title

Update the price for GPT-3.5-Turbo in cost map.

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Updates the outdated input_cost_per_token and output_cost_per_token prices for GPT-3.5-Turbo in cost map according to https://platform.openai.com/docs/pricing.

<img width="783" height="36" alt="image" src="https://github.com/user-attachments/assets/18f55d74-d748-4d20-b5c8-2fe01e961fb8" />

