### PR TITLE
Fix: make `pondpond` as optional dependency for `proxy` extras, disable object pooling gracefully

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2730,9 +2730,10 @@ files = [
 name = "madoka"
 version = "0.7.1"
 description = "Memory-efficient CountMin Sketch key-value structure (based on Madoka C++ library)"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"proxy\""
 files = [
     {file = "madoka-0.7.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:7521eee9ace30b376bb54fdcb2cb42bf6b7a0346b0d0b612f25f3299aa4a95af"},
     {file = "madoka-0.7.1.tar.gz", hash = "sha256:e258baa84fc0a3764365993b8bf5e1b065383a6ca8c9f862fb3e3e709843fae7"},
@@ -4044,9 +4045,10 @@ xlsxwriter = ["xlsxwriter"]
 name = "pondpond"
 version = "1.4.1"
 description = "Pond is a high performance object-pooling library for Python."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"proxy\""
 files = [
     {file = "pondpond-1.4.1-py3-none-any.whl", hash = "sha256:641028ead4e8018ca6de1220c660ddd6d6fbf62a60e72f410655dd0451d82880"},
     {file = "pondpond-1.4.1.tar.gz", hash = "sha256:8afa34b869d1434d21dd2ec12644abc3b1733fcda8fcf355300338a13a79bb7b"},
@@ -6747,11 +6749,11 @@ type = ["pytest-mypy"]
 caching = ["diskcache"]
 extra-proxy = ["azure-identity", "azure-keyvault-secrets", "google-cloud-iam", "google-cloud-kms", "prisma", "redisvl", "resend"]
 mlflow = ["mlflow"]
-proxy = ["PyJWT", "apscheduler", "azure-identity", "azure-storage-blob", "backoff", "boto3", "cryptography", "fastapi", "fastapi-sso", "fastuuid", "gunicorn", "litellm-enterprise", "litellm-proxy-extras", "mcp", "orjson", "polars", "pynacl", "python-multipart", "pyyaml", "rich", "rq", "uvicorn", "uvloop", "websockets"]
+proxy = ["PyJWT", "apscheduler", "azure-identity", "azure-storage-blob", "backoff", "boto3", "cryptography", "fastapi", "fastapi-sso", "fastuuid", "gunicorn", "litellm-enterprise", "litellm-proxy-extras", "mcp", "orjson", "polars", "pondpond", "pynacl", "python-multipart", "pyyaml", "rich", "rq", "uvicorn", "uvloop", "websockets"]
 semantic-router = ["semantic-router"]
 utils = ["numpydoc"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<4.0, !=3.9.7"
-content-hash = "75004c6a23b70be86622fa417fd0d62fa3843e6e61c8dff8507ae5c967b7205d"
+content-hash = "16fdc1044b4bb316803cbf1825bc970895526949a8bef93eab741777b7210ca8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ jinja2 = "^3.1.2"
 aiohttp = ">=3.10"
 pydantic = "^2.5.0"
 jsonschema = "^4.22.0"
-pondpond = "^1.4.1"
+pondpond = {version = "^1.4.1", optional = true}
 numpydoc = {version = "*", optional = true} # used in utils.py
 fastuuid = {version = ">=0.12.0", optional = true}
 
@@ -94,6 +94,7 @@ proxy = [
     "rich",
     "polars",
     "fastuuid",
+    "pondpond",
 ]
 
 extra_proxy = [

--- a/tests/litellm_utils_tests/test_object_pooling.py
+++ b/tests/litellm_utils_tests/test_object_pooling.py
@@ -3,6 +3,7 @@ Simplified tests for object pooling utilities in litellm.
 """
 
 import pytest
+pytest.importorskip("pond")
 
 from litellm.litellm_core_utils.object_pooling import (
     get_object_pool,


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Make `pondpond` as optional dependency for `proxy` instead of hard runtime requirement.

Following related PRs added object pooling implementation and `pondpond` as new dependency:
- https://github.com/BerriAI/litellm/pull/14702
- https://github.com/BerriAI/litellm/pull/14706

`pondpond` has `madoka` dependency which itself does not have available wheels for some platform environments. This blocks users from upgrading to latest litellm version. Resolving this by marking `pondpond` as optional dependency, moving it to `proxy` extras (assuming object pooling support is meant for litellm proxy purposes), and gracefully disabling object pooling when `pondpond` is not installed. Note that currently looks like `get_object_pool` is not used in any litellm functional code. Did my best to keep original implementation code as much as possible.

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes https://github.com/BerriAI/litellm/issues/14762

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
- Move `pondpond` from the core dependency list in `pyproject.toml` to optional extra for `proxy`
- Update `litellm/litellm_core_utils/object_pooling.py` with optional import and conditional logic when pondpond is not installed
- Skip `tests/litellm_utils_tests/test_object_pooling.py` test module when pondpond is not installed
- Update poetry lock


## Screenshots
With `pondpond` installed:
<img width="543" height="195" alt="image" src="https://github.com/user-attachments/assets/cbb4924a-9737-4c10-9788-ca53baf15915" />

With `pondpond` not installed:
<img width="538" height="160" alt="image" src="https://github.com/user-attachments/assets/26a47191-7141-4f14-b1f8-fe071ddf256d" />

