### PR TITLE
Add /user/list to management routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -422,6 +422,7 @@ class LiteLLMRoutes(enum.Enum):
         "/user/update",
         "/user/delete",
         "/user/info",
+        "/user/list",
         # team
         "/team/new",
         "/team/update",


### PR DESCRIPTION
## Title

Add `/user/list` to `management_routes`

## Relevant issues

Addresses an issue where virtual keys with `management_routes` permissions could not access the `/user/list` endpoint, resulting in a "Virtual key is not allowed to call this route" error. (Context from Slack thread)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

This change adds `/user/list` to the `management_routes` list in `litellm/proxy/_types.py`. This ensures that virtual keys granted access to `management_routes` can properly call the `/user/list` endpoint, aligning its permissions with other user management routes like `/user/new`, `/user/update`, `/user/delete`, and `/user/info`. This resolves the error where such keys were explicitly denied access to `/user/list`.

---
[Slack Thread](https://berriaillm.slack.com/archives/C09D01MKYE9/p1758658822137729?thread_ts=1758658822.137729&cid=C09D01MKYE9)

<a href="https://cursor.com/background-agent?bcId=bc-8fbf64e6-6b96-46c4-9ee0-24fa0de3574b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fbf64e6-6b96-46c4-9ee0-24fa0de3574b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

