### PR TITLE
Improve calculate batch cost

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -146,6 +146,7 @@ class CheckBatchCost:
 
                 batch_cost, batch_usage, batch_models = (
                     await calculate_batch_cost_and_usage(
+                        batch=response,
                         file_content_dictionary=file_content_as_dict,
                         custom_llm_provider=llm_provider,  # type: ignore
                     )

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1210,14 +1210,14 @@ def batch_cost_calculator(
     total_prompt_cost = 0.0
     total_completion_cost = 0.0
 
-    input_tokens = getattr(usage, 'input_tokens', None)
+    input_tokens = usage.prompt_tokens
     if input_tokens is None or input_tokens == 0:
-        input_tokens = usage.prompt_tokens
+        input_tokens = getattr(usage, 'input_tokens', 0)
 
-    output_tokens = getattr(usage, 'output_tokens', None)
+    output_tokens = usage.completion_tokens
     if output_tokens is None or output_tokens == 0:
-        output_tokens = usage.completion_tokens
-    
+        output_tokens = getattr(usage, 'output_tokens', None)
+
     if input_cost_per_token_batches:
         total_prompt_cost = input_tokens * input_cost_per_token_batches
     elif input_cost_per_token:

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1210,25 +1210,25 @@ def batch_cost_calculator(
     total_prompt_cost = 0.0
     total_completion_cost = 0.0
 
-    input_tokens = usage.prompt_tokens
-    if input_tokens is None or input_tokens == 0:
-        input_tokens = getattr(usage, 'input_tokens', 0)
+    prompt_tokens = usage.prompt_tokens
+    if prompt_tokens is None or prompt_tokens == 0:
+        prompt_tokens = getattr(usage, 'input_tokens', 0)
 
-    output_tokens = usage.completion_tokens
-    if output_tokens is None or output_tokens == 0:
-        output_tokens = getattr(usage, 'output_tokens', None)
+    completion_tokens = usage.completion_tokens
+    if completion_tokens is None or completion_tokens == 0:
+        completion_tokens = getattr(usage, 'output_tokens', None)
 
     if input_cost_per_token_batches:
-        total_prompt_cost = input_tokens * input_cost_per_token_batches
+        total_prompt_cost = prompt_tokens * input_cost_per_token_batches
     elif input_cost_per_token:
         total_prompt_cost = (
-            input_tokens * (input_cost_per_token) / 2
+            prompt_tokens * (input_cost_per_token) / 2
         )  # batch cost is usually half of the regular token cost
     if output_cost_per_token_batches:
-        total_completion_cost = output_tokens * output_cost_per_token_batches
+        total_completion_cost = completion_tokens * output_cost_per_token_batches
     elif output_cost_per_token:
         total_completion_cost = (
-            output_tokens * (output_cost_per_token) / 2
+            completion_tokens * (output_cost_per_token) / 2
         )  # batch cost is usually half of the regular token cost
 
     return total_prompt_cost, total_completion_cost

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1209,17 +1209,26 @@ def batch_cost_calculator(
     output_cost_per_token = model_info.get("output_cost_per_token")
     total_prompt_cost = 0.0
     total_completion_cost = 0.0
+
+    input_tokens = getattr(usage, 'input_tokens', None)
+    if input_tokens is None or input_tokens == 0:
+        input_tokens = usage.prompt_tokens
+
+    output_tokens = getattr(usage, 'output_tokens', None)
+    if output_tokens is None or output_tokens == 0:
+        output_tokens = usage.completion_tokens
+    
     if input_cost_per_token_batches:
-        total_prompt_cost = usage.prompt_tokens * input_cost_per_token_batches
+        total_prompt_cost = input_tokens * input_cost_per_token_batches
     elif input_cost_per_token:
         total_prompt_cost = (
-            usage.prompt_tokens * (input_cost_per_token) / 2
+            input_tokens * (input_cost_per_token) / 2
         )  # batch cost is usually half of the regular token cost
     if output_cost_per_token_batches:
-        total_completion_cost = usage.completion_tokens * output_cost_per_token_batches
+        total_completion_cost = output_tokens * output_cost_per_token_batches
     elif output_cost_per_token:
         total_completion_cost = (
-            usage.completion_tokens * (output_cost_per_token) / 2
+            output_tokens * (output_cost_per_token) / 2
         )  # batch cost is usually half of the regular token cost
 
     return total_prompt_cost, total_completion_cost

--- a/tests/batches_tests/test_batches_logging_unit_tests.py
+++ b/tests/batches_tests/test_batches_logging_unit_tests.py
@@ -18,6 +18,8 @@ from typing import Optional
 import litellm
 from litellm import create_batch, create_file
 from litellm._logging import verbose_logger
+from litellm.types.llms.openai import Batch
+from litellm.types.utils import Usage
 from litellm.batches.batch_utils import (
     _batch_cost_calculator,
     _get_file_content_as_dictionary,
@@ -26,6 +28,8 @@ from litellm.batches.batch_utils import (
     _get_batch_job_usage_from_response_body,
     _get_response_from_batch_job_output_file,
     _batch_response_was_successful,
+    calculate_batch_cost_and_usage,
+    _handle_completed_batch,
 )
 
 
@@ -169,3 +173,109 @@ def test_get_response_from_batch_job_output_file(sample_file_content_dict):
     assert result["id"] == "chatcmpl-AhjSMl7oZ79yIPHLRYgmgXSixTJr7"
     assert result["object"] == "chat.completion"
     assert result["usage"]["total_tokens"] == 30
+
+
+# Additional fixtures for batch testing
+@pytest.fixture
+def batch_with_usage_and_model():
+    """Create a mock batch object with usage and model attributes."""
+    batch = MagicMock(spec=Batch)
+    batch.usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150
+    )
+    batch.model = "gpt-4o-mini-2024-07-18"
+    return batch
+
+
+@pytest.fixture
+def batch_without_usage_and_model():
+    """Create a mock batch object without usage and model attributes."""
+    batch = MagicMock(spec=Batch)
+    batch.usage = None
+    batch.model = None
+    batch.output_file_id = "file-abc123"
+    return batch
+
+
+# Tests for calculate_batch_cost_and_usage method
+@pytest.mark.asyncio
+async def test_calculate_batch_cost_and_usage_with_batch_usage_and_model(
+    batch_with_usage_and_model, sample_file_content_dict
+):
+    """Test calculate_batch_cost_and_usage when batch has usage and model."""
+    with patch("litellm.cost_calculator.batch_cost_calculator", return_value=(0.001, 0.002)):
+        batch_cost, batch_usage, batch_models = await calculate_batch_cost_and_usage(
+            batch=batch_with_usage_and_model,
+            file_content_dictionary=sample_file_content_dict,
+            custom_llm_provider="openai",
+        )
+        
+        # Should use batch.usage and batch.model, not file content
+        assert batch_cost == 0.003  # 0.001 + 0.002
+        assert batch_usage.prompt_tokens == 100
+        assert batch_usage.completion_tokens == 50
+        assert batch_usage.total_tokens == 150
+        assert batch_models == ["gpt-4o-mini-2024-07-18"]  # Single model from batch.model
+
+
+@pytest.mark.asyncio
+async def test_calculate_batch_cost_and_usage_without_batch_usage_and_model(
+    batch_without_usage_and_model, sample_file_content_dict
+):
+    """Test calculate_batch_cost_and_usage when batch doesn't have usage and model."""
+    with patch("litellm.completion_cost", return_value=0.5):
+        batch_cost, batch_usage, batch_models = await calculate_batch_cost_and_usage(
+            batch=batch_without_usage_and_model,
+            file_content_dictionary=sample_file_content_dict,
+            custom_llm_provider="openai",
+        )
+        
+        # Should calculate from file content
+        assert batch_cost == 1.0  # 0.5 * 2 successful responses
+        assert batch_usage.prompt_tokens == 42  # 20 + 22
+        assert batch_usage.completion_tokens == 20  # 10 + 10
+        assert batch_usage.total_tokens == 62  # 30 + 32
+        assert batch_models == ["gpt-4o-mini-2024-07-18", "gpt-4o-mini-2024-07-18"]  # Models from file content
+
+
+# Tests for _handle_completed_batch method
+@pytest.mark.asyncio
+async def test_handle_completed_batch_with_batch_usage_and_model(batch_with_usage_and_model):
+    """Test _handle_completed_batch when batch has usage and model."""
+    with patch("litellm.cost_calculator.batch_cost_calculator", return_value=(0.001, 0.002)):
+        batch_cost, batch_usage, batch_models = await _handle_completed_batch(
+            batch=batch_with_usage_and_model,
+            custom_llm_provider="openai",
+        )
+        
+        # Should use batch.usage and batch.model, not load file content
+        assert batch_cost == 0.003  # 0.001 + 0.002
+        assert batch_usage.prompt_tokens == 100
+        assert batch_usage.completion_tokens == 50
+        assert batch_usage.total_tokens == 150
+        assert batch_models == ["gpt-4o-mini-2024-07-18"]  # Single model from batch.model
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_batch_without_batch_usage_and_model(
+    batch_without_usage_and_model, sample_file_content_dict
+):
+    """Test _handle_completed_batch when batch doesn't have usage and model."""
+    with patch(
+        "litellm.batches.batch_utils._get_batch_output_file_content_as_dictionary",
+        return_value=sample_file_content_dict
+    ):
+        with patch("litellm.completion_cost", return_value=0.5):
+            batch_cost, batch_usage, batch_models = await _handle_completed_batch(
+                batch=batch_without_usage_and_model,
+                custom_llm_provider="openai",
+            )
+            
+            # Should load file content and calculate from it
+            assert batch_cost == 1.0  # 0.5 * 2 successful responses
+            assert batch_usage.prompt_tokens == 42  # 20 + 22
+            assert batch_usage.completion_tokens == 20  # 10 + 10
+            assert batch_usage.total_tokens == 62  # 30 + 32
+            assert batch_models == ["gpt-4o-mini-2024-07-18", "gpt-4o-mini-2024-07-18"]  # Models from file content

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -1,31 +1,19 @@
-import asyncio
-import json
 import os
 import sys
-import traceback
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from dotenv import load_dotenv
 
 load_dotenv()
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system-path
-import logging
-import time
 
 import pytest
-from typing import Optional
-import litellm
-from litellm import create_batch, create_file
-from litellm._logging import verbose_logger
+from litellm.types.llms.openai import Batch
+from litellm.types.utils import Usage
 from litellm.batches.batch_utils import (
-    _batch_cost_calculator,
-    _get_file_content_as_dictionary,
-    _get_batch_job_cost_from_file_content,
-    _get_batch_job_total_usage_from_file_content,
-    _get_batch_job_usage_from_response_body,
-    _get_response_from_batch_job_output_file,
-    _batch_response_was_successful,
+    calculate_batch_cost_and_usage,
+    _handle_completed_batch,
 )
 
 
@@ -129,43 +117,106 @@ def sample_file_content_dict():
     ]
 
 
-def test_get_file_content_as_dictionary(sample_file_content):
-    result = _get_file_content_as_dictionary(sample_file_content)
-    assert len(result) == 2
-    assert result[0]["id"] == "batch_req_6769ca596b38819093d7ae9f522de924"
-    assert result[0]["custom_id"] == "request-1"
-    assert result[0]["response"]["status_code"] == 200
-    assert result[0]["response"]["body"]["usage"]["total_tokens"] == 30
-
-
-def test_get_batch_job_total_usage_from_file_content(sample_file_content_dict):
-    usage = _get_batch_job_total_usage_from_file_content(
-        sample_file_content_dict, custom_llm_provider="openai"
+@pytest.fixture
+def batch_with_usage_and_model():
+    """Create a mock batch object with usage and model attributes."""
+    batch = MagicMock(spec=Batch)
+    batch.usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150
     )
-    assert usage.total_tokens == 62  # 30 + 32
-    assert usage.prompt_tokens == 42  # 20 + 22
-    assert usage.completion_tokens == 20  # 10 + 10
+    batch.model = "gpt-4o-mini-2024-07-18"
+    return batch
 
 
+@pytest.fixture
+def batch_without_usage_and_model():
+    """Create a mock batch object without usage and model attributes."""
+    batch = MagicMock(spec=Batch)
+    batch.usage = None
+    batch.model = None
+    batch.output_file_id = "file-abc123"
+    return batch
+
+
+# Tests for calculate_batch_cost_and_usage method
 @pytest.mark.asyncio
-async def test_batch_cost_calculator(sample_file_content_dict):
-    """
-    mock litellm.completion_cost to return 0.5
-
-    we know sample_file_content_dict has 2 successful responses
-
-    so we expect the cost to be 0.5 * 2 = 1.0
-    """
-    with patch("litellm.completion_cost", return_value=0.5):
-        cost = _batch_cost_calculator(
+async def test_calculate_batch_cost_and_usage_with_batch_usage_and_model(
+        batch_with_usage_and_model, sample_file_content_dict
+):
+    """Test calculate_batch_cost_and_usage when batch has usage and model."""
+    with patch("litellm.cost_calculator.batch_cost_calculator", return_value=(0.001, 0.002)):
+        batch_cost, batch_usage, batch_models = await calculate_batch_cost_and_usage(
+            batch=batch_with_usage_and_model,
             file_content_dictionary=sample_file_content_dict,
             custom_llm_provider="openai",
         )
-        assert cost == 1.0  # 0.5 * 2 successful responses
+
+        # Should use batch.usage and batch.model, not file content
+        assert batch_cost == 0.003  # 0.001 + 0.002
+        assert batch_usage.prompt_tokens == 100
+        assert batch_usage.completion_tokens == 50
+        assert batch_usage.total_tokens == 150
+        assert batch_models == ["gpt-4o-mini-2024-07-18"]  # Single model from batch.model
 
 
-def test_get_response_from_batch_job_output_file(sample_file_content_dict):
-    result = _get_response_from_batch_job_output_file(sample_file_content_dict[0])
-    assert result["id"] == "chatcmpl-AhjSMl7oZ79yIPHLRYgmgXSixTJr7"
-    assert result["object"] == "chat.completion"
-    assert result["usage"]["total_tokens"] == 30
+@pytest.mark.asyncio
+async def test_calculate_batch_cost_and_usage_without_batch_usage_and_model(
+        batch_without_usage_and_model, sample_file_content_dict
+):
+    """Test calculate_batch_cost_and_usage when batch doesn't have usage and model."""
+    with patch("litellm.completion_cost", return_value=0.5):
+        batch_cost, batch_usage, batch_models = await calculate_batch_cost_and_usage(
+            batch=batch_without_usage_and_model,
+            file_content_dictionary=sample_file_content_dict,
+            custom_llm_provider="openai",
+        )
+
+        # Should calculate from file content
+        assert batch_cost == 1.0  # 0.5 * 2 successful responses
+        assert batch_usage.prompt_tokens == 42  # 20 + 22
+        assert batch_usage.completion_tokens == 20  # 10 + 10
+        assert batch_usage.total_tokens == 62  # 30 + 32
+        assert batch_models == ["gpt-4o-mini-2024-07-18", "gpt-4o-mini-2024-07-18"]  # Models from file content
+
+
+# Tests for _handle_completed_batch method
+@pytest.mark.asyncio
+async def test_handle_completed_batch_with_batch_usage_and_model(batch_with_usage_and_model):
+    """Test _handle_completed_batch when batch has usage and model."""
+    with patch("litellm.cost_calculator.batch_cost_calculator", return_value=(0.001, 0.002)):
+        batch_cost, batch_usage, batch_models = await _handle_completed_batch(
+            batch=batch_with_usage_and_model,
+            custom_llm_provider="openai",
+        )
+
+        # Should use batch.usage and batch.model, not load file content
+        assert batch_cost == 0.003  # 0.001 + 0.002
+        assert batch_usage.prompt_tokens == 100
+        assert batch_usage.completion_tokens == 50
+        assert batch_usage.total_tokens == 150
+        assert batch_models == ["gpt-4o-mini-2024-07-18"]  # Single model from batch.model
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_batch_without_batch_usage_and_model(
+        batch_without_usage_and_model, sample_file_content_dict
+):
+    """Test _handle_completed_batch when batch doesn't have usage and model."""
+    with patch(
+            "litellm.batches.batch_utils._get_batch_output_file_content_as_dictionary",
+            return_value=sample_file_content_dict
+    ):
+        with patch("litellm.completion_cost", return_value=0.5):
+            batch_cost, batch_usage, batch_models = await _handle_completed_batch(
+                batch=batch_without_usage_and_model,
+                custom_llm_provider="openai",
+            )
+
+            # Should load file content and calculate from it
+            assert batch_cost == 1.0  # 0.5 * 2 successful responses
+            assert batch_usage.prompt_tokens == 42  # 20 + 22
+            assert batch_usage.completion_tokens == 20  # 10 + 10
+            assert batch_usage.total_tokens == 62  # 30 + 32
+            assert batch_models == ["gpt-4o-mini-2024-07-18", "gpt-4o-mini-2024-07-18"]  # Models from file content

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -16,6 +16,7 @@ import litellm
 from litellm.cost_calculator import (
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
+    batch_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
@@ -686,3 +687,129 @@ def test_gemini_25_explicit_caching_cost_direct_usage():
     print(f"Expected actual cost: {expected_actual_cost}")
 
     assert expected_actual_cost == total_cost
+
+
+# Tests for batch_cost_calculator function
+def test_batch_cost_calculator_with_input_output_tokens():
+    """Test batch_cost_calculator when usage has input_tokens and output_tokens"""
+    # Create usage object with input_tokens and output_tokens
+    usage = Usage(
+        input_tokens=120,
+        output_tokens=60,
+        total_tokens=180,
+    )
+    
+    # Mock model_info to return specific cost values
+    with patch('litellm.get_model_info') as mock_get_model_info:
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
+        
+        prompt_cost, completion_cost = batch_cost_calculator(
+            usage=usage,
+            model="gpt-3.5-turbo",
+            custom_llm_provider="openai",
+        )
+        
+        # Should use input_tokens and output_tokens
+        # Batch cost is usually half of regular cost
+        expected_prompt_cost = 120 * (0.001 / 2)
+        expected_completion_cost = 60 * (0.002 / 2)
+        
+        assert prompt_cost == expected_prompt_cost
+        assert completion_cost == expected_completion_cost
+
+
+def test_batch_cost_calculator_without_input_output_tokens():
+    """Test batch_cost_calculator when usage doesn't have input_tokens and output_tokens."""
+    # Create usage object without input_tokens and output_tokens
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+    )
+    
+    # Mock model_info to return specific cost values
+    with patch('litellm.get_model_info') as mock_get_model_info:
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
+        
+        prompt_cost, completion_cost = batch_cost_calculator(
+            usage=usage,
+            model="gpt-3.5-turbo",
+            custom_llm_provider="openai",
+        )
+        
+        # Should fall back to prompt_tokens and completion_tokens
+        expected_prompt_cost = 100 * (0.001 / 2)
+        expected_completion_cost = 50 * (0.002 / 2)
+        
+        assert prompt_cost == expected_prompt_cost
+        assert completion_cost == expected_completion_cost
+
+
+def test_batch_cost_calculator_with_zero_input_output_tokens():
+    """Test batch_cost_calculator when input_tokens and output_tokens are zero."""
+    # Create usage object with zero input_tokens and output_tokens
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+        input_tokens=0,  # Zero value
+        output_tokens=0,  # Zero value
+    )
+    
+    # Mock model_info to return specific cost values
+    with patch('litellm.get_model_info') as mock_get_model_info:
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
+        
+        prompt_cost, completion_cost = batch_cost_calculator(
+            usage=usage,
+            model="gpt-3.5-turbo",
+            custom_llm_provider="openai",
+        )
+        
+        # Should fall back to prompt_tokens and completion_tokens
+        expected_prompt_cost = 100 * (0.001 / 2)
+        expected_completion_cost = 50 * (0.002 / 2)
+        
+        assert prompt_cost == expected_prompt_cost
+        assert completion_cost == expected_completion_cost
+
+
+def test_batch_cost_calculator_with_partial_tokens():
+    """Test batch_cost_calculator with both of input_tokens/output_tokens are None."""
+    # Create usage object
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+        input_tokens=None,  # No input_tokens
+        output_tokens=None,  # No output_tokens
+    )
+    
+    # Mock model_info to return specific cost values
+    with patch('litellm.get_model_info') as mock_get_model_info:
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
+        
+        prompt_cost, completion_cost = batch_cost_calculator(
+            usage=usage,
+            model="gpt-3.5-turbo",
+            custom_llm_provider="openai",
+        )
+        
+        # Should use input_tokens for prompt, completion_tokens for output
+        expected_prompt_cost = 100 * (0.001 / 2)
+        expected_completion_cost = 50 * (0.002 / 2)
+        
+        assert prompt_cost == expected_prompt_cost
+        assert completion_cost == expected_completion_cost

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -783,6 +783,38 @@ def test_batch_cost_calculator_with_zero_input_output_tokens():
         assert completion_cost == expected_completion_cost
 
 
+def test_batch_cost_calculator_with_zero_prompt_completion_tokens():
+    """Test batch_cost_calculator when input_tokens and output_tokens are zero."""
+    # Create usage object with zero input_tokens and output_tokens
+    usage = Usage(
+        prompt_tokens=0,  # Zero value
+        completion_tokens=0,  # Zero value
+        total_tokens=150,
+        input_tokens=100,
+        output_tokens=50,
+    )
+
+    # Mock model_info to return specific cost values
+    with patch('litellm.get_model_info') as mock_get_model_info:
+        mock_get_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
+
+        prompt_cost, completion_cost = batch_cost_calculator(
+            usage=usage,
+            model="gpt-3.5-turbo",
+            custom_llm_provider="openai",
+        )
+
+        # Should fall back to prompt_tokens and completion_tokens
+        expected_prompt_cost = 100 * (0.001 / 2)
+        expected_completion_cost = 50 * (0.002 / 2)
+
+        assert prompt_cost == expected_prompt_cost
+        assert completion_cost == expected_completion_cost
+
+
 def test_batch_cost_calculator_with_partial_tokens():
     """Test batch_cost_calculator with both of input_tokens/output_tokens are None."""
     # Create usage object


### PR DESCRIPTION
## Improve calculate Batch cost
- Now, OpenAI returns Usage and Model when call retrieve /batches/{batch_id} API
  - So we don't have to calculate usage from output file row by row (it's very cpu intensive)
- use input_tokens, output_tokens to calculate cost because `retrieve /batch/{batch_id}` returns input_tokens, output_tokens instead of prompt_tokens, completion_tokens like below

```
{
  "id": "abcde",
  "completion_window": "24h",
  "created_at": 1757679709,
  "endpoint": "/v1/responses",
  "input_file_id": "file-abcde",
  "object": "batch",
  "status": "completed",
  "cancelled_at": null,
  "cancelling_at": null,
  "completed_at": 1757711519,
  "error_file_id": "file-abcef",
  "errors": null,
  "expired_at": null,
  "expires_at": 1757766109,
  "failed_at": null,
  "finalizing_at": 1757710454,
  "in_progress_at": 1757679766,
  "metadata": {
    "description": "Creative Batch"
  },
  "output_file_id": "file-abcedef",
  "request_counts": {
    "completed": 9872,
    "failed": 128,
    "total": 10000
  },
  "usage": {
    "completion_tokens": 0,
    "prompt_tokens": 0,
    "total_tokens": 51279835,
    "completion_tokens_details": null,
    "prompt_tokens_details": null,
    "input_tokens": 31493594,
    "output_tokens": 19786241,
    "input_tokens_details": {
      "cached_tokens": 24045184
    },
    "output_tokens_details": {
      "reasoning_tokens": 18373824
    }
  },
  "model": "gpt-5-2025-08-07"
}
```


## Relevant issues
 - Fixes #14884 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


