### PR TITLE
feat(langfuse): add prompt caching for Langfuse

### DIFF
--- a/tests/test_langfuse_prompt_cache.py
+++ b/tests/test_langfuse_prompt_cache.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_langfuse_get_prompt_caching(monkeypatch):
+    """Ensure get_prompt uses cache to avoid repeated API calls."""
+
+    call_count = {"count": 0}
+
+    class DummyClientProjects:
+        def get(self):
+            return types.SimpleNamespace(data=[types.SimpleNamespace(id="proj")])
+
+    class DummyLangfuse:
+        def __init__(self, *args, **kwargs):
+            self.client = types.SimpleNamespace(projects=DummyClientProjects())
+
+        def get_prompt(self, name, variables=None):
+            call_count["count"] += 1
+            return {"name": name, "prompt": "hello"}
+
+    dummy_module = types.SimpleNamespace(
+        Langfuse=DummyLangfuse, version=types.SimpleNamespace(__version__="2.7.3")
+    )
+    monkeypatch.setitem(sys.modules, "langfuse", dummy_module)
+
+    from litellm.integrations.langfuse import LangFuseLogger
+
+    logger = LangFuseLogger()
+
+    first = logger.get_prompt("test-prompt")
+    second = logger.get_prompt("test-prompt")
+
+    assert first == second
+    assert call_count["count"] == 1
+

--- a/tests/test_litellm/test_langfuse_prompt_cache.py
+++ b/tests/test_litellm/test_langfuse_prompt_cache.py
@@ -2,7 +2,7 @@ import os
 import sys
 import types
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 
 def test_langfuse_get_prompt_caching(monkeypatch):


### PR DESCRIPTION
## Title

Other integrations have caching via Dual Cache, this adds caching to Langfuse Prompt Management integration

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


