### PR TITLE
Removing git merge artifacts from poetry lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2722,17 +2722,8 @@ python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6
 groups = ["main"]
 markers = "extra == \"proxy\""
 files = [
-<<<<<<< HEAD
     {file = "litellm_proxy_extras-0.2.20-py3-none-any.whl", hash = "sha256:80ebe03be210eed99ddab0bf8e1a14169f24a502ecdaa98f4bb5032ebe65a944"},
     {file = "litellm_proxy_extras-0.2.20.tar.gz", hash = "sha256:8dea657f965122490be480327995ce534e75dc96778cb3e05c562c7996f85cce"},
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    {file = "litellm_proxy_extras-0.2.19-py3-none-any.whl", hash = "sha256:cd4cc5fc639ac24bc99af70b8b56b7cc0480b0e72a2a53638f557beb7e9f64fd"},
-    {file = "litellm_proxy_extras-0.2.19.tar.gz", hash = "sha256:e53592e39eb0b9c3b6cd32f29e6a0a53be51d7ad31dedfb69b58c24073b5b3ec"},
->>>>>>> parent of ded823a3a3 ([Feat] Initial support for scheduled key rotations  (#14877))
-=======
->>>>>>> parent of c4838e730c (bump v extras)
 ]
 
 [[package]]


### PR DESCRIPTION
## Removing git merge artifacts from poetry lock

poetry.lock had git merge artifacts which caused errors when using poetry. This removes those merge artifacts.

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Removed git merge changes from poetry.lock
