### PR TITLE
fix: use fastuuid helper

### DIFF
--- a/cookbook/litellm_router_load_test/memory_usage/router_endpoint.py
+++ b/cookbook/litellm_router_load_test/memory_usage/router_endpoint.py
@@ -5,7 +5,7 @@ import os
 import litellm
 from litellm import Router
 from dotenv import load_dotenv
-import uuid
+from litellm._uuid import uuid
 
 load_dotenv()
 

--- a/cookbook/litellm_router_load_test/memory_usage/router_memory_usage copy.py
+++ b/cookbook/litellm_router_load_test/memory_usage/router_memory_usage copy.py
@@ -12,7 +12,7 @@ sys.path.insert(
 import litellm
 from litellm import Router
 from dotenv import load_dotenv
-import uuid
+from litellm._uuid import uuid
 
 load_dotenv()
 

--- a/cookbook/litellm_router_load_test/memory_usage/router_memory_usage.py
+++ b/cookbook/litellm_router_load_test/memory_usage/router_memory_usage.py
@@ -12,7 +12,7 @@ sys.path.insert(
 import litellm
 from litellm import Router
 from dotenv import load_dotenv
-import uuid
+from litellm._uuid import uuid
 
 load_dotenv()
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/generic_api_callback.py
@@ -9,7 +9,7 @@ Callback to log events to a Generic API Endpoint
 import asyncio
 import os
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import Dict, List, Optional, Union
 
 import litellm

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -2,7 +2,7 @@
 Polls LiteLLM_ManagedObjectTable to check if the batch job is complete, and if the cost has been tracked.
 """
 
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, cast
 

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -4,7 +4,7 @@
 import asyncio
 import base64
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union, cast
 
 from fastapi import HTTPException

--- a/litellm/_uuid.py
+++ b/litellm/_uuid.py
@@ -11,7 +11,7 @@ try:
 
     FASTUUID_AVAILABLE = True
 except Exception:  # pragma: no cover - fallback path
-    import uuid as _uuid  # type: ignore
+    from litellm._uuid import uuid as _uuid  # type: ignore
 
 
 # Expose a module-like alias so callers can use: uuid.uuid4()

--- a/litellm/_uuid.py
+++ b/litellm/_uuid.py
@@ -11,7 +11,7 @@ try:
 
     FASTUUID_AVAILABLE = True
 except Exception:  # pragma: no cover - fallback path
-    from litellm._uuid import uuid as _uuid  # type: ignore
+    import uuid as _uuid  # type: ignore
 
 
 # Expose a module-like alias so callers can use: uuid.uuid4()

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -168,7 +168,7 @@ class QdrantSemanticCache(BaseCache):
 
     def set_cache(self, key, value, **kwargs):
         print_verbose(f"qdrant semantic-cache set_cache, kwargs: {kwargs}")
-        import uuid
+        from litellm._uuid import uuid
 
         # get the prompt
         messages = kwargs["messages"]
@@ -279,7 +279,7 @@ class QdrantSemanticCache(BaseCache):
         pass
 
     async def async_set_cache(self, key, value, **kwargs):
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm.proxy.proxy_server import llm_model_list, llm_router
 

--- a/litellm/integrations/azure_storage/azure_storage.py
+++ b/litellm/integrations/azure_storage/azure_storage.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import time
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta
 from typing import List, Optional
 

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -17,7 +17,7 @@ import asyncio
 import datetime
 import os
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime as datetimeObj
 from typing import Any, List, Optional, Union
 

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -9,7 +9,7 @@ API Reference: https://docs.datadoghq.com/llm_observability/setup/api/?tab=examp
 import asyncio
 import json
 import os
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 

--- a/litellm/integrations/deepeval/deepeval.py
+++ b/litellm/integrations/deepeval/deepeval.py
@@ -1,5 +1,5 @@
 import os
-import uuid
+from litellm._uuid import uuid
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.deepeval.api import Api, Endpoints, HttpMethods
 from litellm.integrations.deepeval.types import (

--- a/litellm/integrations/dynamodb.py
+++ b/litellm/integrations/dynamodb.py
@@ -3,7 +3,7 @@
 
 import os
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import Any
 
 import litellm

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import quote

--- a/litellm/integrations/lago.py
+++ b/litellm/integrations/lago.py
@@ -3,7 +3,7 @@
 
 import json
 import os
-import uuid
+from litellm._uuid import uuid
 from typing import Literal, Optional
 
 import httpx

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -5,7 +5,7 @@ import os
 import random
 import traceback
 import types
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 

--- a/litellm/integrations/literal_ai.py
+++ b/litellm/integrations/literal_ai.py
@@ -2,7 +2,7 @@
 # This file contains the LiteralAILogger class which is used to log steps to the LiteralAI observability platform.
 import asyncio
 import os
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional
 
 import httpx

--- a/litellm/integrations/logfire_logger.py
+++ b/litellm/integrations/logfire_logger.py
@@ -3,7 +3,7 @@
 
 import os
 import traceback
-import uuid
+from litellm._uuid import uuid
 from enum import Enum
 from typing import Any, Dict, NamedTuple
 

--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -11,7 +11,7 @@ For batching specific details see CustomBatchLogger class
 
 import asyncio
 import os
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, Optional
 
 

--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -1,4 +1,4 @@
-import uuid
+from litellm._uuid import uuid
 from typing import Optional
 
 import litellm

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 import litellm

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2,7 +2,7 @@ import copy
 import json
 import mimetypes
 import re
-import uuid
+from litellm._uuid import uuid
 import xml.etree.ElementTree as ET
 from enum import Enum
 from typing import Any, List, Optional, Tuple, cast, overload

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -5,7 +5,7 @@ import json
 import threading
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import httpx

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -2,7 +2,7 @@
 ## Translates OpenAI call to Anthropic `/v1/messages` format
 import json
 import traceback
-import uuid
+from litellm._uuid import uuid
 from collections import deque
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal, Optional
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -458,7 +458,7 @@ class LiteLLMAnthropicMessagesAdapter:
         Literal["text", "tool_use"],
         "ContentBlockContentBlockDict",
     ]:
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm.types.llms.anthropic import TextBlock, ToolUseBlock
 

--- a/litellm/llms/azure/audio_transcriptions.py
+++ b/litellm/llms/azure/audio_transcriptions.py
@@ -1,4 +1,4 @@
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Coroutine, Optional, Union
 
 from openai import AsyncAzureOpenAI, AzureOpenAI

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -5,7 +5,7 @@ https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Invoke
 """
 import base64
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -7,7 +7,7 @@ import json
 import time
 import types
 import urllib.parse
-import uuid
+from litellm._uuid import uuid
 from functools import partial
 from typing import (
     Any,

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -802,7 +802,7 @@ class CommonBatchFilesUtils:
             Tuple of (bucket_name, object_key)
         """
         import time
-        import uuid
+        from litellm._uuid import uuid
 
         # Get bucket name
         bucket_name = (

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from httpx import Headers, Response

--- a/litellm/llms/bedrock/rerank/transformation.py
+++ b/litellm/llms/bedrock/rerank/transformation.py
@@ -4,7 +4,7 @@ Translates from Cohere's `/v1/rerank` input format to Bedrock's `/rerank` input 
 Why separate file? Make it easy to see how transformation works
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional, Union
 
 from litellm.types.llms.bedrock import (

--- a/litellm/llms/deepinfra/rerank/transformation.py
+++ b/litellm/llms/deepinfra/rerank/transformation.py
@@ -2,7 +2,7 @@
 Translate between Cohere's `/rerank` format and Deepinfra's `/rerank` format. 
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Union
 
 import httpx

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import Any, List, Literal, Optional, Tuple, Union, cast
 
 import httpx

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -3,7 +3,7 @@ This file contains the transformation logic for the Gemini realtime API.
 """
 
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Union, cast
 
 from litellm import verbose_logger

--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -2,7 +2,7 @@
 Transformation logic for Hosted VLLM rerank
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from litellm.types.rerank import (

--- a/litellm/llms/huggingface/rerank/transformation.py
+++ b/litellm/llms/huggingface/rerank/transformation.py
@@ -1,5 +1,5 @@
 import os
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import httpx

--- a/litellm/llms/infinity/rerank/transformation.py
+++ b/litellm/llms/infinity/rerank/transformation.py
@@ -4,7 +4,7 @@ Transformation logic from Cohere's /v1/rerank format to Infinity's  `/v1/rerank`
 Why separate file? Make it easy to see how transformation works
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional
 
 import httpx

--- a/litellm/llms/jina_ai/rerank/transformation.py
+++ b/litellm/llms/jina_ai/rerank/transformation.py
@@ -6,7 +6,7 @@ Why separate file? Make it easy to see how transformation works
 Docs - https://jina.ai/reranker
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from httpx import URL, Response

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -1,6 +1,6 @@
 import json
 import time
-import uuid
+from litellm._uuid import uuid
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -1,6 +1,6 @@
 import json
 import time
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, List, Optional, Union
 
 from httpx._models import Headers, Response

--- a/litellm/llms/ollama_chat.py
+++ b/litellm/llms/ollama_chat.py
@@ -1,6 +1,6 @@
 import json
 import time
-import uuid
+from litellm._uuid import uuid
 from typing import Any, List, Optional, Union
 
 import aiohttp

--- a/litellm/llms/together_ai/rerank/transformation.py
+++ b/litellm/llms/together_ai/rerank/transformation.py
@@ -4,7 +4,7 @@ Transformation logic from Cohere's /v1/rerank format to Together AI's  `/v1/rera
 Why separate file? Make it easy to see how transformation works
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional
 
 from litellm.types.rerank import (

--- a/litellm/llms/vertex_ai/batches/transformation.py
+++ b/litellm/llms/vertex_ai/batches/transformation.py
@@ -1,4 +1,4 @@
-import uuid
+from litellm._uuid import uuid
 from typing import Dict
 
 from litellm.llms.vertex_ai.common_utils import (

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from httpx import Headers, Response

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3,7 +3,7 @@
 ## Initial implementation - covers gemini + image gen calls
 import json
 import time
-import uuid
+from litellm._uuid import uuid
 from copy import deepcopy
 from functools import partial
 from typing import (

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -17,7 +17,7 @@ import random
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from concurrent import futures
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from copy import deepcopy

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -1,4 +1,4 @@
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1,6 +1,6 @@
 import enum
 import json
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,

--- a/litellm/proxy/client/cli/commands/auth.py
+++ b/litellm/proxy/client/cli/commands/auth.py
@@ -336,7 +336,7 @@ def _handle_team_assignment(base_url: str, api_key: str, user_id: str) -> None:
 @click.pass_context
 def login(ctx: click.Context):
     """Login to LiteLLM proxy using SSO authentication"""
-    import uuid
+    from litellm._uuid import uuid
 
     from litellm.constants import LITELLM_CLI_SOURCE_IDENTIFIER
     from litellm.proxy.client.cli.interface import show_commands

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Optional
 
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -5,7 +5,7 @@ PANW Prisma AIRS Built-in Guardrail for LiteLLM
 """
 
 import os
-import uuid
+from litellm._uuid import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, cast
 
 from fastapi import HTTPException

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -10,7 +10,7 @@
 
 import asyncio
 import json
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import (
     Any,

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -2,7 +2,7 @@
 
 import importlib
 import os
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Type, cast
 

--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 

--- a/litellm/proxy/hooks/user_management_event_hooks.py
+++ b/litellm/proxy/hooks/user_management_event_hooks.py
@@ -3,7 +3,7 @@ Hooks that are triggered when a litellm user event occurs
 """
 
 import asyncio
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Optional
 

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -14,7 +14,7 @@ These are members of a Team on LiteLLM
 import asyncio
 import json
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union, cast
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -14,7 +14,7 @@ import copy
 import json
 import secrets
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta, timezone
 from typing import List, Literal, Optional, Tuple, cast
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -13,7 +13,7 @@ model/{model_id}/update - PATCH endpoint for model update.
 import asyncio
 import datetime
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -11,7 +11,7 @@ Endpoints for /organization operations
 
 #### ORGANIZATION MANAGEMENT ####
 
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -4,7 +4,7 @@
 This is an enterprise feature and requires a premium license.
 """
 
-import uuid
+from litellm._uuid import uuid
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from fastapi import (

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -12,7 +12,7 @@ All /team management endpoints
 import asyncio
 import json
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -10,7 +10,7 @@ Has all /sso/* routes
 
 import asyncio
 import os
-import uuid
+from litellm._uuid import uuid
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -3,7 +3,7 @@ Functions to create audit logs for LiteLLM Proxy
 """
 
 import json
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 
 import litellm

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -4,7 +4,7 @@ organizations, teams, and keys.
 """
 
 import json
-import uuid
+from litellm._uuid import uuid
 from typing import Dict, Optional, Union
 
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Helper utils for the management endpoints (keys/users/teams)
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from functools import wraps
 from typing import Optional, Tuple

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -3,7 +3,7 @@ import asyncio
 import copy
 import json
 import traceback
-import uuid
+from litellm._uuid import uuid
 from base64 import b64encode
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Union

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -922,7 +922,7 @@ def create_pass_through_route(
     cost_per_request: Optional[float] = None,
 ):
     # check if target is an adapter.py or a url
-    import uuid
+    from litellm._uuid import uuid
 
     from litellm.proxy.types_utils.utils import get_instance_fn
 
@@ -1123,7 +1123,7 @@ async def initialize_pass_through_endpoints(
     Returns:
         None
     """
-    import uuid
+    from litellm._uuid import uuid
 
     verbose_proxy_logger.debug("initializing pass through endpoints")
     from litellm.proxy._types import CommonProxyErrors, LiteLLMRoutes
@@ -1366,7 +1366,7 @@ async def create_pass_through_endpoints(
     """
     Create new pass-through endpoint
     """
-    import uuid
+    from litellm._uuid import uuid
 
     from litellm.proxy.proxy_server import (
         get_config_general_settings,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 import warnings
 from datetime import datetime, timedelta
 from typing import (

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -370,7 +370,7 @@ def _get_session_id_for_spend_log(
     This ensures each spend log is associated with a unique session id.
 
     """
-    import uuid
+    from litellm._uuid import uuid
 
     if (
         standard_logging_payload is not None

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -671,7 +671,7 @@ async def upload_logo(file: UploadFile = File(...)):
     os.makedirs(upload_dir, exist_ok=True)
     
     # Generate unique filename
-    import uuid
+    from litellm._uuid import uuid
     unique_filename = f"logo_{uuid.uuid4().hex}{file_extension}"
     file_path = os.path.join(upload_dir, unique_filename)
     

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -1308,7 +1308,7 @@ class ProxyLogging:
             "litellm_logging_obj", None
         )
         if litellm_logging_obj is None:
-            import uuid
+            from litellm._uuid import uuid
 
             request_data["litellm_call_id"] = str(uuid.uuid4())
             user_api_key_logged_metadata = (

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -211,7 +211,7 @@ async def aresponses_api_with_mcp(
     # Handle MCP streaming if requested
     if stream and mcp_tools_with_litellm_proxy:
         # Generate MCP discovery events using the already processed tools
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm.responses.mcp.mcp_streaming_iterator import (
             create_mcp_list_tools_events,

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -630,7 +630,7 @@ class LiteLLM_Proxy_MCP_Handler:
         Returns:
             List of MCP tool execution events for streaming
         """
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm.responses.mcp.mcp_streaming_iterator import create_mcp_call_events
 
@@ -714,7 +714,7 @@ class LiteLLM_Proxy_MCP_Handler:
         """Add custom output elements to the final response for MCP tool execution."""
         # Import the required classes for creating output items
         import json
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm.types.responses.main import GenericResponseOutputItem, OutputText
 

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -1,4 +1,4 @@
-import uuid
+from litellm._uuid import uuid
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -444,9 +444,6 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         """Generate tool execution events and execute tools"""
         if not self.collected_response:
             return
-            
-        import uuid
-
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -17,7 +17,7 @@ import logging
 import threading
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from collections import defaultdict
 from functools import lru_cache
 from typing import (

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -215,7 +215,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
             optional_params: Additional AWS parameters
             timeout: Request timeout
         """
-        import uuid
+        from litellm._uuid import uuid
 
         # Prepare the request data
         data = {"Name": secret_name, "SecretString": secret_value}

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -4,7 +4,7 @@ litellm.Router Types - includes RouterConfig, UpdateRouterConfig, ModelInfo etc
 
 import datetime
 import enum
-import uuid
+from litellm._uuid import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, get_type_hints
 

--- a/litellm/types/services.py
+++ b/litellm/types/services.py
@@ -1,5 +1,5 @@
 import enum
-import uuid
+from litellm._uuid import uuid
 from typing import List, Optional
 
 from pydantic import BaseModel, Field

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
 import logging
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 

--- a/tests/guardrails_tests/test_guardrails_config.py
+++ b/tests/guardrails_tests/test_guardrails_config.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 import pytest

--- a/tests/litellm_utils_tests/test_aws_secret_manager.py
+++ b/tests/litellm_utils_tests/test_aws_secret_manager.py
@@ -28,7 +28,7 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
-import uuid
+from litellm._uuid import uuid
 import json
 from litellm.secret_managers.aws_secret_manager_v2 import AWSSecretsManagerV2
 

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -13,7 +13,7 @@ sys.path.insert(
 from unittest.mock import patch, MagicMock
 import logging
 from litellm._logging import verbose_logger
-import uuid
+from litellm._uuid import uuid
 
 verbose_logger.setLevel(logging.DEBUG)
 

--- a/tests/litellm_utils_tests/test_secret_manager.py
+++ b/tests/litellm_utils_tests/test_secret_manager.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 import json

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 import os
-import uuid
+from litellm._uuid import uuid
 import time
 import base64
 

--- a/tests/llm_translation/base_audio_transcription_unit_tests.py
+++ b/tests/llm_translation/base_audio_transcription_unit_tests.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 import os
-import uuid
+from litellm._uuid import uuid
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/llm_translation/base_llm_unit_tests.py
+++ b/tests/llm_translation/base_llm_unit_tests.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 import os
-import uuid
+from litellm._uuid import uuid
 import time
 import base64
 import inspect

--- a/tests/local_testing/cache_unit_tests.py
+++ b/tests/local_testing/cache_unit_tests.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 

--- a/tests/local_testing/test_add_update_models.py
+++ b/tests/local_testing/test_add_update_models.py
@@ -1,7 +1,7 @@
 import sys, os
 import traceback
 import json
-import uuid
+from litellm._uuid import uuid
 from dotenv import load_dotenv
 from fastapi import Request
 from datetime import datetime
@@ -72,7 +72,7 @@ async def test_add_new_model(prisma_client):
 
     await litellm.proxy.proxy_server.prisma_client.connect()
     from litellm.proxy.proxy_server import user_api_key_cache
-    import uuid
+    from litellm._uuid import uuid
 
     _new_model_id = f"local-test-{uuid.uuid4().hex}"
 
@@ -121,7 +121,7 @@ async def test_add_update_model(prisma_client):
 
     await litellm.proxy.proxy_server.prisma_client.connect()
     from litellm.proxy.proxy_server import user_api_key_cache
-    import uuid
+    from litellm._uuid import uuid
 
     _new_model_id = f"local-test-{uuid.uuid4().hex}"
 
@@ -230,7 +230,7 @@ async def test_add_team_model_to_db(prisma_client):
     from litellm.proxy.management_endpoints.model_management_endpoints import (
         _add_team_model_to_db,
     )
-    import uuid
+    from litellm._uuid import uuid
 
     new_team = await _create_new_team(prisma_client)
     team_id = new_team.team_id

--- a/tests/local_testing/test_alangfuse.py
+++ b/tests/local_testing/test_alangfuse.py
@@ -212,7 +212,7 @@ def create_async_task(**completion_kwargs):
 @pytest.mark.flaky(retries=12, delay=2)
 async def test_langfuse_logging_without_request_response(stream, langfuse_client):
     try:
-        import uuid
+        from litellm._uuid import uuid
 
         _unique_trace_name = f"litellm-test-{str(uuid.uuid4())}"
         litellm.set_verbose = True
@@ -276,7 +276,7 @@ async def test_langfuse_logging_audio_transcriptions(langfuse_client):
     """
     Test that creates a trace with masked input and output
     """
-    import uuid
+    from litellm._uuid import uuid
 
     _unique_trace_name = f"litellm-test-{str(uuid.uuid4())}"
     litellm.set_verbose = True
@@ -314,7 +314,7 @@ async def test_langfuse_masked_input_output(langfuse_client):
     """
     Test that creates a trace with masked input and output
     """
-    import uuid
+    from litellm._uuid import uuid
 
     for mask_value in [True, False]:
         _unique_trace_name = f"litellm-test-{str(uuid.uuid4())}"
@@ -364,7 +364,7 @@ async def test_aaalangfuse_logging_metadata(langfuse_client):
     Release is just set for the trace
     Tags is just set for the trace
     """
-    import uuid
+    from litellm._uuid import uuid
 
     litellm.set_verbose = True
     litellm.success_callback = ["langfuse"]
@@ -939,7 +939,7 @@ def test_aaalangfuse_dynamic_logging():
 
     Covers the team-logging scenario.
     """
-    import uuid
+    from litellm._uuid import uuid
 
     import langfuse
 

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -2489,7 +2489,7 @@ def mock_gemini_list_request(*args, **kwargs):
     return mock_response
 
 
-import uuid
+from litellm._uuid import uuid
 
 
 @pytest.mark.parametrize(

--- a/tests/local_testing/test_audio_speech.py
+++ b/tests/local_testing/test_audio_speech.py
@@ -7,7 +7,7 @@ import random
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 

--- a/tests/local_testing/test_caching.py
+++ b/tests/local_testing/test_caching.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 
@@ -659,7 +659,7 @@ async def test_embedding_caching_base_64():
         host=os.environ["REDIS_HOST"],
         port=os.environ["REDIS_PORT"],
     )
-    import uuid
+    from litellm._uuid import uuid
 
     inputs = [
         f"{uuid.uuid4()} hello this is ishaan",
@@ -788,7 +788,7 @@ async def test_redis_batch_cache_write():
     - read from client
     """
     litellm.set_verbose = True
-    import uuid
+    from litellm._uuid import uuid
 
     messages = [
         {"role": "user", "content": f"write a one sentence poem about: {uuid.uuid4()}"},
@@ -1479,7 +1479,7 @@ async def test_cache_control_overrides():
     )
     print("Testing cache override")
     litellm.set_verbose = True
-    import uuid
+    from litellm._uuid import uuid
 
     unique_num = str(uuid.uuid4())
 
@@ -1527,7 +1527,7 @@ def test_sync_cache_control_overrides():
     )
     print("Testing cache override")
     litellm.set_verbose = True
-    import uuid
+    from litellm._uuid import uuid
 
     unique_num = str(uuid.uuid4())
 
@@ -2050,7 +2050,7 @@ async def test_redis_proxy_batch_redis_get_cache():
 
     user_api_key_cache = DualCache()
 
-    import uuid
+    from litellm._uuid import uuid
 
     batch_redis_get_obj.in_memory_cache = user_api_key_cache.in_memory_cache
 
@@ -2493,7 +2493,7 @@ def test_redis_caching_multiple_namespaces():
 
     The same request with different namespaces should not be cached under the same key
     """
-    import uuid
+    from litellm._uuid import uuid
     from unittest.mock import patch, MagicMock
     import litellm
     from litellm.caching import Cache
@@ -2639,7 +2639,7 @@ def test_caching_with_reasoning_content():
     Test that reasoning content is cached
     """
 
-    import uuid
+    from litellm._uuid import uuid
 
     messages = [{"role": "user", "content": f"what is litellm? {uuid.uuid4()}"}]
     litellm.cache = Cache()

--- a/tests/local_testing/test_caching_handler.py
+++ b/tests/local_testing/test_caching_handler.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 

--- a/tests/local_testing/test_custom_callback_input.py
+++ b/tests/local_testing/test_custom_callback_input.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 import pytest

--- a/tests/local_testing/test_dual_cache.py
+++ b/tests/local_testing/test_dual_cache.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 

--- a/tests/local_testing/test_dynamic_rate_limit_handler.py
+++ b/tests/local_testing/test_dynamic_rate_limit_handler.py
@@ -6,7 +6,7 @@ import random
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import Optional, Tuple
 

--- a/tests/local_testing/test_gcs_bucket.py
+++ b/tests/local_testing/test_gcs_bucket.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import logging
 import tempfile
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 import pytest

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -97,7 +97,7 @@ def create_async_task(**completion_kwargs):
     reason="Authentication missing for openai",
 )
 async def test_helicone_logging_metadata():
-    import uuid
+    from litellm._uuid import uuid
 
     litellm.success_callback = ["helicone"]
 

--- a/tests/local_testing/test_langsmith.py
+++ b/tests/local_testing/test_langsmith.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 
 import asyncio
 import logging
-import uuid
+from litellm._uuid import uuid
 
 import pytest
 

--- a/tests/local_testing/test_mem_usage.py
+++ b/tests/local_testing/test_mem_usage.py
@@ -13,7 +13,7 @@
 # from concurrent.futures import ThreadPoolExecutor
 # from collections import defaultdict
 # from dotenv import load_dotenv
-# import uuid
+# from litellm._uuid import uuid
 # import tracemalloc
 # import objgraph
 

--- a/tests/local_testing/test_pass_through_endpoints.py
+++ b/tests/local_testing/test_pass_through_endpoints.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from functools import partial
 from typing import Optional
 

--- a/tests/local_testing/test_router_timeout.py
+++ b/tests/local_testing/test_router_timeout.py
@@ -96,7 +96,7 @@ def test_router_timeouts():
 
 @pytest.mark.asyncio
 async def test_router_timeouts_bedrock():
-    import uuid
+    from litellm._uuid import uuid
 
     import openai
 

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import Tuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2784,7 +2784,7 @@ def test_azure_streaming_and_function_calling():
 
 @pytest.mark.asyncio
 async def test_azure_astreaming_and_function_calling():
-    import uuid
+    from litellm._uuid import uuid
 
     tools = [
         {

--- a/tests/local_testing/test_timeout.py
+++ b/tests/local_testing/test_timeout.py
@@ -9,7 +9,7 @@ sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 import time
-import uuid
+from litellm._uuid import uuid
 
 import httpx
 import openai

--- a/tests/local_testing/test_unit_test_caching.py
+++ b/tests/local_testing/test_unit_test_caching.py
@@ -2,7 +2,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 

--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -8,7 +8,7 @@ import os
 import random
 import sys
 import time
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 

--- a/tests/logging_callback_tests/test_built_in_tools_cost_tracking.py
+++ b/tests/logging_callback_tests/test_built_in_tools_cost_tracking.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 import pytest
 from dotenv import load_dotenv
 from fastapi import Request
@@ -98,7 +98,7 @@ async def test_openai_web_search_logging_cost_tracking(
 ):
     """Test web search cost tracking with different search context sizes"""
     test_custom_logger = await _setup_web_search_test()
-    import uuid
+    from litellm._uuid import uuid
 
     
 

--- a/tests/logging_callback_tests/test_langfuse_e2e_test.py
+++ b/tests/logging_callback_tests/test_langfuse_e2e_test.py
@@ -119,7 +119,7 @@ class TestLangfuseLogging:
     @pytest.fixture
     async def mock_setup(self):
         """Common setup for Langfuse logging tests"""
-        import uuid
+        from litellm._uuid import uuid
         from unittest.mock import AsyncMock, patch
         import httpx
 

--- a/tests/logging_callback_tests/test_moderations_api_logging.py
+++ b/tests/logging_callback_tests/test_moderations_api_logging.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 import pytest
 from dotenv import load_dotenv
 from fastapi import Request

--- a/tests/logging_callback_tests/test_spend_logs.py
+++ b/tests/logging_callback_tests/test_spend_logs.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 from fastapi import Request

--- a/tests/logging_callback_tests/test_token_counting.py
+++ b/tests/logging_callback_tests/test_token_counting.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 import pytest
 from dotenv import load_dotenv
 from fastapi import Request

--- a/tests/logging_callback_tests/test_view_request_resp_logs.py
+++ b/tests/logging_callback_tests/test_view_request_resp_logs.py
@@ -8,7 +8,7 @@ import asyncio
 import json
 import logging
 import tempfile
-import uuid
+from litellm._uuid import uuid
 
 import json
 from datetime import datetime, timedelta, timezone

--- a/tests/multi_instance_e2e_tests/test_update_team_e2e.py
+++ b/tests/multi_instance_e2e_tests/test_update_team_e2e.py
@@ -52,7 +52,7 @@ async def chat_completion_on_port(
     Accepts an optional prompt string.
     """
     from openai import AsyncOpenAI
-    import uuid
+    from litellm._uuid import uuid
 
     if prompt is None:
         prompt = f"Say hello! {uuid.uuid4()}" * 100

--- a/tests/old_proxy_tests/tests/bursty_load_test_completion.py
+++ b/tests/old_proxy_tests/tests/bursty_load_test_completion.py
@@ -1,6 +1,6 @@
 import time, asyncio
 from openai import AsyncOpenAI
-import uuid
+from litellm._uuid import uuid
 import traceback
 
 

--- a/tests/old_proxy_tests/tests/load_test_completion.py
+++ b/tests/old_proxy_tests/tests/load_test_completion.py
@@ -2,7 +2,7 @@ import time
 import asyncio
 import os
 from openai import AsyncOpenAI, AsyncAzureOpenAI
-import uuid
+from litellm._uuid import uuid
 import traceback
 from large_text import text
 from dotenv import load_dotenv

--- a/tests/old_proxy_tests/tests/load_test_embedding_100.py
+++ b/tests/old_proxy_tests/tests/load_test_embedding_100.py
@@ -1,6 +1,6 @@
 import time, asyncio
 from openai import AsyncOpenAI
-import uuid
+from litellm._uuid import uuid
 import traceback
 
 

--- a/tests/old_proxy_tests/tests/test_simple_traceparent_openai.py
+++ b/tests/old_proxy_tests/tests/test_simple_traceparent_openai.py
@@ -1,5 +1,5 @@
 # mypy: ignore-errors
-import uuid
+from litellm._uuid import uuid
 
 import openai
 

--- a/tests/otel_tests/test_e2e_budgeting.py
+++ b/tests/otel_tests/test_e2e_budgeting.py
@@ -61,7 +61,7 @@ async def generate_key(
 async def chat_completion(session, key: str, model: str):
     """Make a chat completion request using OpenAI SDK"""
     from openai import AsyncOpenAI
-    import uuid
+    from litellm._uuid import uuid
 
     client = AsyncOpenAI(
         api_key=key, base_url="http://0.0.0.0:4000/v1"  # Point to our local proxy

--- a/tests/otel_tests/test_e2e_model_access.py
+++ b/tests/otel_tests/test_e2e_model_access.py
@@ -35,7 +35,7 @@ async def generate_team(session, models: Optional[List[str]] = None):
 async def mock_chat_completion(session, key: str, model: str):
     """Make a chat completion request using OpenAI SDK"""
     from openai import AsyncOpenAI
-    import uuid
+    from litellm._uuid import uuid
 
     client = AsyncOpenAI(api_key=key, base_url="http://0.0.0.0:4000/v1")
 

--- a/tests/otel_tests/test_guardrails.py
+++ b/tests/otel_tests/test_guardrails.py
@@ -4,7 +4,7 @@ import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI
 from typing import Optional, List, Union
 import json
-import uuid
+from litellm._uuid import uuid
 
 
 async def chat_completion(

--- a/tests/otel_tests/test_moderations.py
+++ b/tests/otel_tests/test_moderations.py
@@ -3,7 +3,7 @@ import asyncio
 import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI
 from typing import Optional, List, Union
-import uuid
+from litellm._uuid import uuid
 
 
 async def make_moderations_curl_request(

--- a/tests/otel_tests/test_otel.py
+++ b/tests/otel_tests/test_otel.py
@@ -5,7 +5,7 @@ import asyncio
 import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI
 from typing import Optional, List, Union
-import uuid
+from litellm._uuid import uuid
 
 
 async def generate_key(

--- a/tests/otel_tests/test_prometheus.py
+++ b/tests/otel_tests/test_prometheus.py
@@ -5,7 +5,7 @@ Unit tests for prometheus metrics
 import pytest
 import aiohttp
 import asyncio
-import uuid
+from litellm._uuid import uuid
 import os
 import sys
 from openai import AsyncOpenAI

--- a/tests/otel_tests/test_rerank.py
+++ b/tests/otel_tests/test_rerank.py
@@ -3,7 +3,7 @@ import asyncio
 import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI
 from typing import Optional, List, Union
-import uuid
+from litellm._uuid import uuid
 
 
 async def make_rerank_curl_request(

--- a/tests/otel_tests/test_team_member_permissions.py
+++ b/tests/otel_tests/test_team_member_permissions.py
@@ -45,7 +45,7 @@
 import pytest
 import asyncio
 import aiohttp, openai
-import uuid
+from litellm._uuid import uuid
 import json
 from litellm.proxy._types import ProxyErrorTypes
 from typing import Optional

--- a/tests/otel_tests/test_team_tag_routing.py
+++ b/tests/otel_tests/test_team_tag_routing.py
@@ -5,7 +5,7 @@ import asyncio
 import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI
 from typing import Optional, List, Union
-import uuid
+from litellm._uuid import uuid
 
 LITELLM_MASTER_KEY = "sk-1234"
 

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 import datetime as dt
 from datetime import datetime
 
@@ -228,7 +228,7 @@ async def test_regenerate_api_key_with_new_alias_and_expiration(prisma_client):
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
     await litellm.proxy.proxy_server.prisma_client.connect()
-    import uuid
+    from litellm._uuid import uuid
 
     # generate new key
     key_alias = f"test_alias_regenerate_key-{uuid.uuid4()}"
@@ -279,7 +279,7 @@ async def test_regenerate_key_ui(prisma_client):
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
     await litellm.proxy.proxy_server.prisma_client.connect()
-    import uuid
+    from litellm._uuid import uuid
 
     # generate new key
     key_alias = f"test_alias_regenerate_key-{uuid.uuid4()}"
@@ -1076,7 +1076,7 @@ async def test_list_key_helper_team_filtering(prisma_client):
     from litellm.proxy.management_endpoints.key_management_endpoints import (
         _list_key_helper,
     )
-    import uuid
+    from litellm._uuid import uuid
 
     # Setup
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -5,7 +5,7 @@ RBAC tests
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 from dotenv import load_dotenv

--- a/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
+++ b/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 import datetime as dt
 from datetime import datetime
 

--- a/tests/proxy_admin_ui_tests/test_sso_sign_in.py
+++ b/tests/proxy_admin_ui_tests/test_sso_sign_in.py
@@ -60,7 +60,7 @@ async def test_auth_callback_new_user(mock_google_sso, mock_env_vars, prisma_cli
     """
     Tests that a new SSO Sign In user is by default given an 'INTERNAL_USER_VIEW_ONLY' role
     """
-    import uuid
+    from litellm._uuid import uuid
     import litellm
 
     litellm._turn_on_debug()
@@ -133,7 +133,7 @@ async def test_auth_callback_new_user_with_sso_default(
 
     Tests that a new SSO Sign In user is by default given an 'INTERNAL_USER' role
     """
-    import uuid
+    from litellm._uuid import uuid
 
     # Generate a unique user ID
     unique_user_id = str(uuid.uuid4())

--- a/tests/proxy_admin_ui_tests/test_usage_endpoints.py
+++ b/tests/proxy_admin_ui_tests/test_usage_endpoints.py
@@ -16,7 +16,7 @@ For all tests - test the following:
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 from dotenv import load_dotenv

--- a/tests/proxy_unit_tests/test_audit_logs_proxy.py
+++ b/tests/proxy_unit_tests/test_audit_logs_proxy.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 from dotenv import load_dotenv
@@ -24,7 +24,7 @@ import logging
 load_dotenv()
 
 import pytest
-import uuid
+from litellm._uuid import uuid
 import litellm
 from litellm._logging import verbose_proxy_logger
 

--- a/tests/proxy_unit_tests/test_custom_callback_input.py
+++ b/tests/proxy_unit_tests/test_custom_callback_input.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 
 import pytest

--- a/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
+++ b/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 from typing import List
 from datetime import datetime, timezone, timedelta
 
@@ -379,7 +379,7 @@ async def test_e2e_size_of_redis_buffer():
     from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
     from litellm.proxy.db.db_transaction_queue.base_update_queue import BaseUpdateQueue
     from litellm.caching import RedisCache
-    import uuid
+    from litellm._uuid import uuid
 
 
     redis_cache = RedisCache(host=os.getenv("REDIS_HOST"), port=os.getenv("REDIS_PORT"), password=os.getenv("REDIS_PASSWORD"))

--- a/tests/proxy_unit_tests/test_jwt.py
+++ b/tests/proxy_unit_tests/test_jwt.py
@@ -7,7 +7,7 @@ import random
 import sys
 import time
 import traceback
-import uuid
+from litellm._uuid import uuid
 
 from dotenv import load_dotenv
 
@@ -240,7 +240,7 @@ def prisma_client():
 @pytest.fixture
 def team_token_tuple():
     import json
-    import uuid
+    from litellm._uuid import uuid
 
     import jwt
     from cryptography.hazmat.backends import default_backend
@@ -305,7 +305,7 @@ def team_token_tuple():
 @pytest.mark.asyncio
 async def test_team_token_output(prisma_client, audience, monkeypatch):
     import json
-    import uuid
+    from litellm._uuid import uuid
 
     import jwt
     from cryptography.hazmat.backends import default_backend
@@ -478,7 +478,7 @@ async def test_team_token_output(prisma_client, audience, monkeypatch):
 async def aaaatest_user_token_output(
     prisma_client, audience, team_id_set, default_team_id, user_id_upsert, monkeypatch
 ):
-    import uuid
+    from litellm._uuid import uuid
 
     args = locals()
     print(f"received args - {args}")
@@ -491,7 +491,7 @@ async def aaaatest_user_token_output(
     - retry -> it should pass now
     """
     import json
-    import uuid
+    from litellm._uuid import uuid
 
     import jwt
     from cryptography.hazmat.backends import default_backend
@@ -726,7 +726,7 @@ async def test_allowed_routes_admin(
     - check if admin passes user_api_key_auth for them
     """
     import json
-    import uuid
+    from litellm._uuid import uuid
 
     import jwt
     from cryptography.hazmat.backends import default_backend

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -22,7 +22,7 @@
 import os
 import sys
 import traceback
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 
 from dotenv import load_dotenv
@@ -1236,7 +1236,7 @@ def test_generate_and_update_key(prisma_client):
     # 11. Generate a Key, cal key/info, call key/update, call key/info
     # Check if data gets updated
     # Check if untouched data does not get updated
-    import uuid
+    from litellm._uuid import uuid
 
     print("prisma client=", prisma_client)
 
@@ -1554,7 +1554,7 @@ def test_call_with_key_over_budget(prisma_client):
 
             litellm.cache = Cache()
             import time
-            import uuid
+            from litellm._uuid import uuid
 
             request_id = f"chatcmpl-e41836bb-bb8b-4df2-8e70-8f3e160155ac{uuid.uuid4()}"
 
@@ -1676,7 +1676,7 @@ def test_call_with_key_over_budget_no_cache(prisma_client):
 
             litellm.cache = Cache()
             import time
-            import uuid
+            from litellm._uuid import uuid
 
             request_id = f"chatcmpl-e41836bb-bb8b-4df2-8e70-8f3e160155ac{uuid.uuid4()}"
 
@@ -1900,7 +1900,7 @@ async def test_call_with_key_never_over_budget(prisma_client):
 
         # update spend using track_cost callback, make 2nd request, it should fail
         import time
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm import Choices, Message, ModelResponse, Usage
         from litellm.proxy.proxy_server import _ProxyDBLogger
@@ -1991,7 +1991,7 @@ async def test_call_with_key_over_budget_stream(prisma_client):
 
         # update spend using track_cost callback, make 2nd request, it should fail
         import time
-        import uuid
+        from litellm._uuid import uuid
 
         from litellm import Choices, Message, ModelResponse, Usage
         from litellm.proxy.proxy_server import _ProxyDBLogger
@@ -2440,7 +2440,7 @@ async def test_key_with_no_permissions(prisma_client):
 
 
 async def track_cost_callback_helper_fn(generated_key: str, user_id: str):
-    import uuid
+    from litellm._uuid import uuid
 
     from litellm import Choices, Message, ModelResponse, Usage
     from litellm.proxy.proxy_server import _ProxyDBLogger
@@ -2549,7 +2549,7 @@ async def test_proxy_load_test_db(prisma_client):
 @pytest.mark.asyncio()
 async def test_master_key_hashing(prisma_client):
     try:
-        import uuid
+        from litellm._uuid import uuid
 
         print("prisma client=", prisma_client)
 

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -928,7 +928,7 @@ async def test_get_team_redis(client_no_auth):
 
 
 import random
-import uuid
+from litellm._uuid import uuid
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from litellm.proxy._types import (

--- a/tests/spend_tracking_tests/test_spend_accuracy_tests.py
+++ b/tests/spend_tracking_tests/test_spend_accuracy_tests.py
@@ -4,7 +4,7 @@ import aiohttp
 import json
 from httpx import AsyncClient
 from typing import Any, Optional
-import uuid
+from litellm._uuid import uuid
 
 """
 Tests to run
@@ -89,7 +89,7 @@ async def generate_key(session, user_id: str, team_id: str):
 async def chat_completion(session, key: str):
     """Make a chat completion request"""
     from openai import AsyncOpenAI
-    import uuid
+    from litellm._uuid import uuid
 
     client = AsyncOpenAI(api_key=key, base_url="http://0.0.0.0:4000/v1")
 

--- a/tests/store_model_in_db_tests/test_mcp_servers.py
+++ b/tests/store_model_in_db_tests/test_mcp_servers.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 import pytest
-import uuid
+from litellm._uuid import uuid
 import os
 import asyncio
 from unittest import mock

--- a/tests/store_model_in_db_tests/test_team_models.py
+++ b/tests/store_model_in_db_tests/test_team_models.py
@@ -3,9 +3,9 @@ import asyncio
 import aiohttp
 import json
 from openai import AsyncOpenAI
-import uuid
+from litellm._uuid import uuid
 from httpx import AsyncClient
-import uuid
+from litellm._uuid import uuid
 import os
 
 TEST_MASTER_KEY = "sk-1234"

--- a/tests/test_budget_management.py
+++ b/tests/test_budget_management.py
@@ -1,6 +1,6 @@
 # What is this?
 ## Unit tests for the /budget/* endpoints
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timedelta
 
 import aiohttp

--- a/tests/test_callbacks_on_proxy.py
+++ b/tests/test_callbacks_on_proxy.py
@@ -108,7 +108,7 @@ async def test_check_num_callbacks():
     -> sleep for 30 seconds
     -> check current callbacks
     """
-    import uuid
+    from litellm._uuid import uuid
 
     async with aiohttp.ClientSession() as session:
         await asyncio.sleep(30)
@@ -158,7 +158,7 @@ async def test_check_num_callbacks_on_lowest_latency():
     -> check current callbacks
     -> update back to original routing-strategy
     """
-    import uuid
+    from litellm._uuid import uuid
 
     async with aiohttp.ClientSession() as session:
         await asyncio.sleep(30)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,7 +83,7 @@ async def test_team_logging():
             await config_update(session)
 
             # 2. Call /chat/completions with a specific trace id
-            import uuid
+            from litellm._uuid import uuid
 
             _trace_id = f"trace-{uuid.uuid4()}"
             _request_metadata = {

--- a/tests/test_end_users.py
+++ b/tests/test_end_users.py
@@ -4,7 +4,7 @@ import pytest
 import asyncio
 import aiohttp
 import time
-import uuid
+from litellm._uuid import uuid
 from openai import AsyncOpenAI
 from typing import Optional
 

--- a/tests/test_litellm/integrations/test_deepeval.py
+++ b/tests/test_litellm/integrations/test_deepeval.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_litellm/llms/bedrock/invoke_agent/test_bedrock_agent_transformation.py
+++ b/tests/test_litellm/llms/bedrock/invoke_agent/test_bedrock_agent_transformation.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from datetime import datetime
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from typing import Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-import uuid
+from litellm._uuid import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,5 +1,5 @@
 import copy
-import uuid
+from litellm._uuid import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -280,7 +280,7 @@ async def test_add_and_delete_models():
     - Delete model
     - Call model -> expect to fail
     """
-    import uuid
+    from litellm._uuid import uuid
 
     async with aiohttp.ClientSession() as session:
         key_gen = await generate_key(session=session)
@@ -404,7 +404,7 @@ async def test_add_model_run_health():
     Call /health
     -> Ensure the health check for the endpoint is working as expected
     """
-    import uuid
+    from litellm._uuid import uuid
 
     async with aiohttp.ClientSession() as session:
         key_gen = await generate_key(session=session)
@@ -528,7 +528,7 @@ async def test_team_model_e2e():
     """
     from tests.test_users import new_user
     from tests.test_team import new_team
-    import uuid
+    from litellm._uuid import uuid
 
     async with aiohttp.ClientSession() as session:
         # Creat a user

--- a/tests/test_openai_endpoints.py
+++ b/tests/test_openai_endpoints.py
@@ -5,7 +5,7 @@ import asyncio
 import aiohttp, openai
 from openai import OpenAI, AsyncOpenAI, AzureOpenAI, AsyncAzureOpenAI
 from typing import Optional, List, Union
-import uuid
+from litellm._uuid import uuid
 
 LITELLM_MASTER_KEY = "sk-1234"
 

--- a/tests/test_team_logging.py
+++ b/tests/test_team_logging.py
@@ -78,7 +78,7 @@ async def test_aaateam_logging():
                 session, models=["fake-openai-endpoint"], team_id="team-1"
             )  # team-1 logs to project 1
 
-            import uuid
+            from litellm._uuid import uuid
 
             _trace_id = f"trace-{uuid.uuid4()}"
             _request_metadata = {
@@ -144,7 +144,7 @@ async def test_team_2logging():
                 session, models=["fake-openai-endpoint"], team_id="team-2"
             )  # team-1 logs to project 1
 
-            import uuid
+            from litellm._uuid import uuid
 
             _trace_id = f"trace-{uuid.uuid4()}"
             _request_metadata = {

--- a/tests/test_team_members.py
+++ b/tests/test_team_members.py
@@ -3,7 +3,7 @@ import requests
 import time
 from typing import Dict, List
 import logging
-import uuid
+from litellm._uuid import uuid
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -318,7 +318,7 @@ async def test_user_model_access():
 
 
 import json
-import uuid
+from litellm._uuid import uuid
 import pytest
 import aiohttp
 from typing import Dict, Tuple

--- a/tests/vector_store_tests/base_vector_store_test.py
+++ b/tests/vector_store_tests/base_vector_store_test.py
@@ -5,7 +5,7 @@ import sys
 from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 import os
-import uuid
+from litellm._uuid import uuid
 import time
 import base64
 


### PR DESCRIPTION
## Title

Replaced uuid imports with helper

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

The codebase already had a helper that uses fastuuid when available; I just needed to run a script to replace all UUID occurrences with the helper.

## Performance Impact Summary
- Profiling showed UUID generation took 6.4µs per call on LiteLLM's endpoints. With the new version, it’s reduced to 1.8µs per call.
- FastUUID is ~72% faster per call compared to Python’s uuid.uuid4.
