### PR TITLE
feat: enable Redis mTLS support with client certificate authentication

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -75,6 +75,8 @@ def _get_redis_cluster_kwargs(client=None):
     available_args.append("ssl_cert_reqs")
     available_args.append("ssl_check_hostname")
     available_args.append("ssl_ca_certs")
+    available_args.append("ssl_certfile")  # Client certificate file for TLS authentication
+    available_args.append("ssl_keyfile")  # Client certificate key file for TLS authentication
     available_args.append("redis_connect_func")  # Needed for sync clusters and IAM detection
     available_args.append("gcp_service_account")
     available_args.append("gcp_ssl_ca_certs")

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -34,7 +34,7 @@ def _get_redis_kwargs():
         "retry",
     }
 
-    include_args = ["url", "redis_connect_func", "gcp_service_account", "gcp_ssl_ca_certs"]
+    include_args = ["url", "redis_connect_func", "gcp_service_account", "gcp_ssl_ca_certs", "ssl_certfile", "ssl_keyfile", "ssl_ca_certs"]
 
     available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
 

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -92,6 +92,9 @@ class RedisCache(BaseCache):
         host=None,
         port=None,
         password=None,
+        ssl_certfile=None,
+        ssl_keyfile=None,
+        ssl_ca_certs=None,
         redis_flush_size: Optional[int] = 100,
         namespace: Optional[str] = None,
         startup_nodes: Optional[List] = None,  # for redis-cluster
@@ -113,6 +116,12 @@ class RedisCache(BaseCache):
             redis_kwargs["startup_nodes"] = startup_nodes
         if socket_timeout is not None:
             redis_kwargs["socket_timeout"] = socket_timeout
+        if ssl_certfile is not None:
+            redis_kwargs["ssl_certfile"] = ssl_certfile
+        if ssl_keyfile is not None:
+            redis_kwargs["ssl_keyfile"] = ssl_keyfile
+        if ssl_ca_certs is not None:
+            redis_kwargs["ssl_ca_certs"] = ssl_ca_certs
 
         ### HEALTH MONITORING OBJECT ###
         if kwargs.get("service_logger_obj", None) is not None and isinstance(

--- a/litellm/llms/xai/responses/transformation.py
+++ b/litellm/llms/xai/responses/transformation.py
@@ -85,7 +85,7 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
                     # XAI supports code_interpreter but doesn't use the container field
                     # Keep only the type field
                     verbose_logger.debug(
-                        f"XAI: Transforming code_interpreter tool, removing container field"
+                        "XAI: Transforming code_interpreter tool, removing container field"
                     )
                     transformed_tools.append({"type": "code_interpreter"})
                 else:

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -225,3 +225,5 @@ async def test_redis_cache_tls_client_cert_init(monkeypatch, redis_no_ping):
     assert connection_kwargs["ssl_certfile"] == "/path/to/client.crt"
     assert connection_kwargs["ssl_keyfile"] == "/path/to/client.key"
     assert connection_kwargs["ssl_ca_certs"] == "/path/to/ca.crt"
+
+

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -64,3 +64,37 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
     # Verify mget_nonatomic was called instead of mget
     mock_redis.mget_nonatomic.assert_called_once()
     assert not mock_redis.mget.called
+
+
+@patch("litellm._redis.init_redis_cluster")
+def test_redis_cluster_tls_client_cert_init(mock_init_redis_cluster):
+    """Test RedisClusterCache initialization with TLS client certificate parameters"""
+    # Create a mock Redis client
+    mock_redis = MagicMock()
+    mock_init_redis_cluster.return_value = mock_redis
+
+    # Create RedisClusterCache instance with TLS parameters
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "cluster-node1", "port": 6380}, {"host": "cluster-node2", "port": 6380}],
+        ssl_certfile="/path/to/cluster-client.crt",
+        ssl_keyfile="/path/to/cluster-client.key",
+        ssl_ca_certs="/path/to/cluster-ca.crt"
+    )
+
+    # Verify SSL parameters are stored in redis_kwargs
+    assert cache.redis_kwargs["ssl_certfile"] == "/path/to/cluster-client.crt"
+    assert cache.redis_kwargs["ssl_keyfile"] == "/path/to/cluster-client.key"
+    assert cache.redis_kwargs["ssl_ca_certs"] == "/path/to/cluster-ca.crt"
+    assert cache.redis_kwargs["startup_nodes"] == [{"host": "cluster-node1", "port": 6380}, {"host": "cluster-node2", "port": 6380}]
+
+    # Verify that init_redis_cluster was called with the correct TLS arguments
+    mock_init_redis_cluster.assert_called_once()
+
+    # Get the arguments passed to init_redis_cluster
+    call_args = mock_init_redis_cluster.call_args[0][0]  # First positional argument (dict)
+
+    # Check that TLS parameters were passed to the Redis cluster initialization
+    assert call_args["ssl_certfile"] == "/path/to/cluster-client.crt"
+    assert call_args["ssl_keyfile"] == "/path/to/cluster-client.key"
+    assert call_args["ssl_ca_certs"] == "/path/to/cluster-ca.crt"
+    assert call_args["startup_nodes"] == [{"host": "cluster-node1", "port": 6380}, {"host": "cluster-node2", "port": 6380}]


### PR DESCRIPTION
## Title

Redis supports mTLS using a client certificate for authentication. This PR enables `RedisCache` and `RedisClusterCache` to accept three new arguments `ssl_certfile`, `ssl_keyfile`, and `ssl_ca_certs`. These arguments are passed to the redis client if they are set. 

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1308" height="272" alt="Screenshot 2025-09-25 at 9 48 37 AM" src="https://github.com/user-attachments/assets/9230a1da-1de5-4694-bd98-f4c6f8ed72d4" />
<img width="1315" height="210" alt="Screenshot 2025-09-25 at 9 52 41 AM" src="https://github.com/user-attachments/assets/8d512b75-850f-458a-b91e-b3b323df9fd1" />


## Type

🆕 New Feature

## Changes


