### PR TITLE
fixed OpenAI API causing 'Unknown parameter' error

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -432,6 +432,8 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         """
         start_time = time.time()
         try:
+            data.pop("extra_body", None)
+            data.pop("litellm_params", None)
             raw_response = (
                 await openai_aclient.chat.completions.with_raw_response.create(
                     **data, timeout=timeout


### PR DESCRIPTION
## Title

Fix OpenAI API call by removing internal parameters before request

## Relevant issues

Fixes #14901

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Code Change:**
- Added `data.pop("extra_body", None)` and `data.pop("litellm_params", None)` in `make_openai_chat_completion_request` function before making the OpenAI API call
- This prevents internal LiteLLM parameters from being passed to the OpenAI API, which was causing "unknown parameter" errors

**Tests:**
- I attempted to add tests but couldn't find clear patterns or appropriate locations for testing this specific fix in the current test structure
- Would appreciate guidance from maintainers on where and how to add proper tests for this change

**PR Description:**
This PR fixes issue #14901 where internal LiteLLM parameters (`extra_body` and `litellm_params`) were being passed to the OpenAI API, causing "unknown parameter" errors. The solution removes these internal parameters from the request data before making the actual OpenAI API call, ensuring only valid OpenAI parameters are sent.

The fix is minimal and isolated - it only removes the problematic parameters at the point where the OpenAI API call is made, without affecting any other functionality.