### PR TITLE
[Feat] Logging - `datadog` callback Log message content w/o sending to datadog

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -17,6 +17,7 @@ from typing import (
     TYPE_CHECKING,
 )
 from litellm.types.integrations.datadog_llm_obs import DatadogLLMObsInitParams
+from litellm.types.integrations.datadog import DatadogInitParams
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.caching.caching import Cache, DualCache, RedisCache, InMemoryCache
 from litellm.caching.llm_caching_handler import LLMClientCache
@@ -343,6 +344,7 @@ suppress_debug_info = False
 dynamodb_table_name: Optional[str] = None
 s3_callback_params: Optional[Dict] = None
 datadog_llm_observability_params: Optional[Union[DatadogLLMObsInitParams, Dict]] = None
+datadog_params: Optional[Union[DatadogInitParams, Dict]] = None
 aws_sqs_callback_params: Optional[Dict] = None
 generic_logger_headers: Optional[Dict] = None
 default_key_generate_params: Optional[Dict] = None

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -19,7 +19,7 @@ import os
 import traceback
 import uuid
 from datetime import datetime as datetimeObj
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from httpx import Response
@@ -71,6 +71,13 @@ class DataDogLogger(
                 raise Exception("DD_API_KEY is not set, set 'DD_API_KEY=<>")
             if os.getenv("DD_SITE", None) is None:
                 raise Exception("DD_SITE is not set in .env, set 'DD_SITE=<>")
+            
+            #########################################################
+            # Handle datadog_params set as litellm.datadog_params
+            #########################################################
+            dict_datadog_params = self._get_datadog_params()
+            kwargs.update(dict_datadog_params)
+            
             self.async_client = get_async_httpx_client(
                 llm_provider=httpxSpecialProvider.LoggingCallback
             )
@@ -100,6 +107,21 @@ class DataDogLogger(
                 f"Datadog: Got exception on init Datadog client {str(e)}"
             )
             raise e
+
+    def _get_datadog_params(self) -> Dict:
+        """
+        Get the datadog_params from litellm.datadog_params
+
+        These are params specific to initializing the DataDogLogger e.g. turn_off_message_logging
+        """
+        dict_datadog_params: Dict = {}
+        if litellm.datadog_params is not None:
+            if isinstance(litellm.datadog_params, DatadogInitParams):
+                dict_datadog_params = litellm.datadog_params.model_dump()
+            elif isinstance(litellm.datadog_params, Dict):
+                # only allow params that are of DatadogInitParams
+                dict_datadog_params = DatadogInitParams(**litellm.datadog_params).model_dump()
+        return dict_datadog_params
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -457,6 +479,7 @@ class DataDogLogger(
                     continue
                 else:
                     clean_metadata[key] = value
+
 
         # Build the initial payload
         payload = {

--- a/litellm/types/integrations/datadog.py
+++ b/litellm/types/integrations/datadog.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from typing_extensions import TypedDict
 
+from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
+
 DD_MAX_BATCH_SIZE = 1000
 
 
@@ -23,6 +25,14 @@ class DatadogPayload(TypedDict, total=False):
 
 class DD_ERRORS(Enum):
     DATADOG_413_ERROR = "Datadog API Error - Payload too large (batch is above 5MB uncompressed). If you want this logged either disable request/response logging or set `DD_BATCH_SIZE=50`"
+
+
+class DatadogInitParams(StandardCustomLoggerInitParams):
+    """
+    Params for initializing a DataDog logger on litellm
+    """
+
+    pass
 
 
 class DatadogProxyFailureHookJsonMessage(TypedDict, total=False):


### PR DESCRIPTION
## [Feat] Logging - `datadog` callback Log message content w/o sending to datadog

<img width="910" height="447" alt="Screenshot 2025-09-25 at 11 20 31 AM" src="https://github.com/user-attachments/assets/c701900c-8020-472e-a41e-f28fa1912c0e" />


Fixes LIT-1050


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


