### PR TITLE
Remove useful links from admin settings

### DIFF
--- a/ui/litellm-dashboard/src/components/admins.tsx
+++ b/ui/litellm-dashboard/src/components/admins.tsx
@@ -45,7 +45,6 @@ import SSOModals from "./SSOModals";
 import { ssoProviderConfigs } from './SSOModals';
 import SCIMConfig from "./SCIM";
 import UIAccessControlForm from "./UIAccessControlForm";
-import UsefulLinksManagement from "./useful_links_management";
 import NotificationsManager from "./molecules/notifications_manager";
 
 interface AdminPanelProps {
@@ -555,7 +554,6 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
         <TabList>
           <Tab>Security Settings</Tab>
           <Tab>SCIM</Tab>
-          <Tab>Useful Links</Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -708,12 +706,6 @@ const AdminPanel: React.FC<AdminPanelProps> = ({
               accessToken={accessToken} 
               userID={userID}
               proxySettings={proxySettings}
-            />
-          </TabPanel>
-          <TabPanel>
-            <UsefulLinksManagement 
-              accessToken={accessToken}
-              userRole={userRole || null}
             />
           </TabPanel>
         </TabPanels>


### PR DESCRIPTION
## Title

Remove "Useful Links" from Admin Settings UI

## Relevant issues

Fixes UI issue where "Useful Links" under admin settings was blank (as reported in Slack thread).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

This PR removes the "Useful Links" section from the admin settings UI. This section was consistently blank and not serving any purpose, leading to a confusing user experience.

The changes include:
- Removing the "Useful Links" tab from the `TabList`.
- Deleting the corresponding `TabPanel` that previously contained the `UsefulLinksManagement` component.
- Removing the unused import statement for `UsefulLinksManagement`.

---
[Slack Thread](https://berriaillm.slack.com/archives/C04HP96S19D/p1758835401962049?thread_ts=1758835401.962049&cid=C04HP96S19D)

<a href="https://cursor.com/background-agent?bcId=bc-725f8849-4d29-4d26-8255-21784dc1829b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-725f8849-4d29-4d26-8255-21784dc1829b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

