### PR TITLE
Update best practices for num_workers

### DIFF
--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -62,7 +62,34 @@ These specifications provide:
 - Adequate memory for request processing and caching
 
 
-## 3. On Kubernetes - Use 1 Uvicorn worker [Suggested CMD]
+## 3. Set `num_workers` to match CPU count for optimal performance
+
+For maximum performance, set the number of workers to match your CPU count. LiteLLM can achieve +400 RPS when using the correct number of CPU cores.
+
+**By default**, LiteLLM now uses `num_workers = os.cpu_count()` for optimal performance.
+
+### Override Options
+
+**Set environment variable:**
+```bash
+export NUM_WORKERS=4  # Set to your CPU count
+# or
+export DEFAULT_NUM_WORKERS_LITELLM_PROXY=4
+```
+
+**Or start LiteLLM Proxy with:**
+```bash
+litellm --num_workers 4 --config ./proxy_server_config.yaml
+```
+
+**Performance Impact:**
+- **+400 RPS** performance boost when using correct number of workers
+- Optimal resource utilization
+- Better handling of concurrent requests
+
+> **Note:** This applies to non-Kubernetes deployments. For Kubernetes deployments, see section 4 below.
+
+## 4. On Kubernetes - Use 1 Uvicorn worker [Suggested CMD]
 
 Use this Docker `CMD`. This will start the proxy with 1 Uvicorn Async Worker
 
@@ -72,7 +99,7 @@ CMD ["--port", "4000", "--config", "./proxy_server_config.yaml"]
 ```
 
 
-## 4. Use Redis 'port','host', 'password'. NOT 'redis_url'
+## 5. Use Redis 'port','host', 'password'. NOT 'redis_url'
 
 If you decide to use Redis, DO NOT use 'redis_url'. We recommend using redis port, host, and password params. 
 
@@ -108,13 +135,13 @@ litellm_settings:
 > **WARNING**
 **Usage-based routing is not recommended for production due to performance impacts.** Use `simple-shuffle` (default) for optimal performance in high-traffic scenarios.
 
-## 5. Disable 'load_dotenv'
+## 6. Disable 'load_dotenv'
 
 Set `export LITELLM_MODE="PRODUCTION"`
 
 This disables the load_dotenv() functionality, which will automatically load your environment credentials from the local `.env`. 
 
-## 6. If running LiteLLM on VPC, gracefully handle DB unavailability
+## 7. If running LiteLLM on VPC, gracefully handle DB unavailability
 
 When running LiteLLM on a VPC (and inaccessible from the public internet), you can enable graceful degradation so that request processing continues even if the database is temporarily unavailable.
 
@@ -143,7 +170,7 @@ When `allow_requests_on_db_unavailable` is set to `true`, LiteLLM will handle er
 
 [More information about what the Database is used for here](db_info)
 
-## 7. Use Helm PreSync Hook for Database Migrations [BETA]
+## 8. Use Helm PreSync Hook for Database Migrations [BETA]
 
 To ensure only one service manages database migrations, use our [Helm PreSync hook for Database Migrations](https://github.com/BerriAI/litellm/blob/main/deploy/charts/litellm-helm/templates/migrations-job.yaml). This ensures migrations are handled during `helm upgrade` or `helm install`, while LiteLLM pods explicitly disable migrations.
 
@@ -171,7 +198,7 @@ To ensure only one service manages database migrations, use our [Helm PreSync ho
    ```
 
 
-## 8. Set LiteLLM Salt Key 
+## 9. Set LiteLLM Salt Key 
 
 If you plan on using the DB, set a salt key for encrypting/decrypting variables in the DB. 
 
@@ -186,7 +213,7 @@ export LITELLM_SALT_KEY="sk-1234"
 [**See Code**](https://github.com/BerriAI/litellm/blob/036a6821d588bd36d170713dcf5a72791a694178/litellm/proxy/common_utils/encrypt_decrypt_utils.py#L15)
 
 
-## 9. Use `prisma migrate deploy`
+## 10. Use `prisma migrate deploy`
 
 Use this to handle db migrations across LiteLLM versions in production
 
@@ -235,7 +262,7 @@ To fix this, just set `LITELLM_MIGRATION_DIR="/path/to/writeable/directory"` in 
 
 LiteLLM will use this directory to write migration files.
 
-## 10. Use a Separate Health Check App
+## 11. Use a Separate Health Check App
 :::info
 The Separate Health Check App only runs when running via the the LiteLLM Docker Image and using Docker and setting the SEPARATE_HEALTH_APP env var to "1"
 :::


### PR DESCRIPTION
## Title

Add `num_workers` CPU matching best practice to production documentation

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

This PR addresses a gap in the production best practices documentation by adding crucial guidance on `num_workers` optimization.

-   **Why:** The documentation was missing a key best practice: matching `num_workers` to the CPU count for LiteLLM Proxy can significantly boost performance (up to +400 RPS). This change ensures users are aware of this optimization and how to implement it.
-   **What:** A new section "3. Set `num_workers` to match CPU count for optimal performance" has been added to `docs/my-website/docs/proxy/prod.md`. This section details the performance benefits, default behavior, and configuration options. Subsequent sections were renumbered to maintain proper order.

---
[Slack Thread](https://berriaillm.slack.com/archives/D09H1V0HE3V/p1758837465146189?thread_ts=1758837465.146189&cid=D09H1V0HE3V)

<a href="https://cursor.com/background-agent?bcId=bc-bdedfb99-89f5-4942-bba3-4b279dd81762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bdedfb99-89f5-4942-bba3-4b279dd81762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

