### PR TITLE
Remove aiohttp_ prefix from config

### DIFF
--- a/docs/my-website/docs/load_test_advanced.md
+++ b/docs/my-website/docs/load_test_advanced.md
@@ -27,7 +27,7 @@ Tutorial on how to get to 1K+ RPS with LiteLLM Proxy on locust
 
 **Use this config for testing:**
 
-**Note:**  we're currently migrating to aiohttp which has 10x higher throughput. We recommend using the `aiohttp_openai/` provider for load testing.
+**Note:**  we're currently migrating to aiohttp which has 10x higher throughput. We recommend using the `openai/` provider for load testing.
 
 ```yaml
 model_list:
@@ -58,7 +58,7 @@ litellm provides a hosted `fake-openai-endpoint` you can load test against
 model_list:
   - model_name: fake-openai-endpoint
     litellm_params:
-      model: aiohttp_openai/fake
+      model: openai/fake
       api_key: fake-key
       api_base: https://exampleopenaiendpoint-production.up.railway.app/
 

--- a/docs/my-website/docs/load_test_advanced.md
+++ b/docs/my-website/docs/load_test_advanced.md
@@ -33,7 +33,7 @@ Tutorial on how to get to 1K+ RPS with LiteLLM Proxy on locust
 model_list:
   - model_name: "fake-openai-endpoint"
     litellm_params:
-      model: aiohttp_openai/any
+      model: openai/any
       api_base: https://your-fake-openai-endpoint.com/chat/completions
       api_key: "test"
 ```


### PR DESCRIPTION
## Title

Update model name in 1k RPS benchmarking documentation

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

Corrected the model name in the 1k RPS benchmarking documentation (`docs/my-website/docs/load_test_advanced.md`) from `aiohttp_openai/any` to `openai/any` to reflect the accurate configuration.

---
[Slack Thread](https://berriaillm.slack.com/archives/D09H1V0HE3V/p1758838957028119?thread_ts=1758838957.028119&cid=D09H1V0HE3V)

<a href="https://cursor.com/background-agent?bcId=bc-1f1c2051-f77e-47b1-a427-9fc8f5f76ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f1c2051-f77e-47b1-a427-9fc8f5f76ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

