### PR TITLE
[Feat] - Cost Tracking - show input, output, tool call cost breakdown in StandardLoggingPayload

### DIFF
--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -11,6 +11,7 @@ Found under `kwargs["standard_logging_object"]`. This is a standard payload, log
 | `trace_id` | `str` | Trace multiple LLM calls belonging to same overall request |
 | `call_type` | `str` | Type of call |
 | `response_cost` | `float` | Cost of the response in USD ($) |
+| `cost_breakdown` | `Optional[CostBreakdown]` | Detailed cost breakdown object |
 | `response_cost_failure_debug_info` | `StandardLoggingModelCostFailureDebugInformation` | Debug information if cost tracking fails |
 | `status` | `StandardLoggingPayloadStatus` | Status of the payload |
 | `total_tokens` | `int` | Total number of tokens |
@@ -38,6 +39,29 @@ Found under `kwargs["standard_logging_object"]`. This is a standard payload, log
 | `error_information` | `Optional[StandardLoggingPayloadErrorInformation]` | Optional error information |
 | `model_parameters` | `dict` | Model parameters |
 | `hidden_params` | `StandardLoggingHiddenParams` | Hidden parameters |
+
+## Cost Breakdown
+
+The `cost_breakdown` field provides detailed cost breakdown for completion requests as a `CostBreakdown` object containing:
+
+- **`input_cost`**: Cost of input/prompt tokens including cache creation tokens
+- **`output_cost`**: Cost of output/completion tokens (including reasoning tokens if applicable)
+- **`tool_usage_cost`**: Cost of built-in tools usage (e.g., web search, code interpreter)
+- **`total_cost`**: Total cost of input + output + tool usage
+
+**Note**: This field is populated for all call types. For non-completion calls, `input_cost` and `output_cost` may be 0.
+
+The total cost relationship is: `response_cost = cost_breakdown.total_cost`
+
+### CostBreakdown Type
+
+```python
+class CostBreakdown(TypedDict, total=False):
+    input_cost: float        # Cost of input/prompt tokens in USD
+    output_cost: float       # Cost of output/completion tokens in USD (includes reasoning)
+    tool_usage_cost: float   # Cost of built-in tools usage in USD
+    total_cost: float        # Total cost in USD
+```
 
 ## StandardLoggingUserAPIKeyMetadata
 

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -36,3 +36,10 @@ guardrails:
       breakdown: true
       payload: true
       dev_info: true
+
+litellm_settings:
+  callbacks: ["datadog"]
+  datadog_params:
+    turn_off_message_logging: true
+  datadog_llm_observability_params:
+    turn_off_message_logging: true

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2060,12 +2060,23 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
 StandardLoggingPayloadStatus = Literal["success", "failure"]
 
 
+class CostBreakdown(TypedDict, total=False):
+    """
+    Detailed cost breakdown for a request
+    """
+    input_cost: float  # Cost of input/prompt tokens
+    output_cost: float  # Cost of output/completion tokens
+    total_cost: float  # Total cost (input + output + reasoning)
+    tool_usage_cost: float  # Cost of usage of built-in tools
+
+
 class StandardLoggingPayload(TypedDict):
     id: str
     trace_id: str  # Trace multiple LLM calls belonging to same overall request (e.g. fallbacks/retries)
     call_type: str
     stream: Optional[bool]
     response_cost: float
+    cost_breakdown: Optional[CostBreakdown]  # Detailed cost breakdown
     response_cost_failure_debug_info: Optional[
         StandardLoggingModelCostFailureDebugInformation
     ]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2060,13 +2060,13 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
 StandardLoggingPayloadStatus = Literal["success", "failure"]
 
 
-class CostBreakdown(TypedDict, total=False):
+class CostBreakdown(TypedDict):
     """
     Detailed cost breakdown for a request
     """
     input_cost: float  # Cost of input/prompt tokens
-    output_cost: float  # Cost of output/completion tokens
-    total_cost: float  # Total cost (input + output + reasoning)
+    output_cost: float  # Cost of output/completion tokens (includes reasoning if applicable)
+    total_cost: float  # Total cost (input + output + tool usage)
     tool_usage_cost: float  # Cost of usage of built-in tools
 
 

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -516,3 +516,143 @@ def test_standard_logging_metadata_requester_metadata(
 ):
     result = StandardLoggingPayloadSetup.get_standard_logging_metadata(metadata)
     assert result["requester_metadata"] == expected_requester_metadata
+
+
+def test_cost_breakdown_in_standard_logging_payload():
+    """
+    Test that cost breakdown fields are properly included in StandardLoggingPayload.
+    Tests input_cost, output_cost, tool_usage_cost, and total_cost fields.
+    """
+    from litellm.litellm_core_utils.litellm_logging import get_standard_logging_object_payload, Logging
+    from litellm.types.utils import Usage
+    from datetime import datetime
+    import time
+    
+    # Create a mock logging object with cost breakdown
+    logging_obj = Logging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-123",
+        function_id="test-function"
+    )
+    
+    # Simulate cost breakdown being stored during cost calculation
+    logging_obj.set_cost_breakdown(
+        input_cost=0.001,
+        output_cost=0.002,
+        total_cost=0.0035,
+        cost_for_built_in_tools_cost_usd_dollar=0.0005
+    )
+    
+    # Mock response object
+    mock_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello! How can I help you today?"
+                },
+                "finish_reason": "stop"
+            }
+        ]
+    }
+    
+    # Create kwargs
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "response_cost": 0.0035,
+        "custom_llm_provider": "openai",
+    }
+    
+    start_time = datetime.now()
+    end_time = datetime.now()
+    
+    # Get the standard logging payload
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj=mock_response,
+        start_time=start_time,
+        end_time=end_time,
+        logging_obj=logging_obj,
+        status="success"
+    )
+    
+    # Verify the cost breakdown field is present
+    assert payload is not None
+    assert payload["cost_breakdown"] is not None
+    assert payload["cost_breakdown"]["input_cost"] == 0.001
+    assert payload["cost_breakdown"]["output_cost"] == 0.002
+    assert payload["cost_breakdown"]["tool_usage_cost"] == 0.0005
+    assert payload["cost_breakdown"]["total_cost"] == 0.0035
+    assert payload["response_cost"] == 0.0035
+    
+    print("✅ Cost breakdown test passed!")
+
+
+def test_cost_breakdown_missing_in_standard_logging_payload():
+    """
+    Test that cost breakdown field is None when not available (e.g., for embedding calls)
+    """
+    from litellm.litellm_core_utils.litellm_logging import get_standard_logging_object_payload, Logging
+    from datetime import datetime
+    
+    # Create a mock logging object without cost breakdown
+    logging_obj = Logging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=False,
+        call_type="embedding",  # Non-completion call type
+        start_time=datetime.now(),
+        litellm_call_id="test-123",
+        function_id="test-function"
+    )
+    
+    # No cost breakdown stored
+    
+    # Mock response object
+    mock_response = {
+        "object": "list",
+        "data": [{"embedding": [0.1, 0.2, 0.3]}],
+        "model": "text-embedding-ada-002",
+        "usage": {"prompt_tokens": 10, "total_tokens": 10}
+    }
+    
+    kwargs = {
+        "model": "text-embedding-ada-002",
+        "input": ["Hello"],
+        "response_cost": 0.0001,
+        "custom_llm_provider": "openai",
+    }
+    
+    start_time = datetime.now()
+    end_time = datetime.now()
+    
+    # Get the standard logging payload
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj=mock_response,
+        start_time=start_time,
+        end_time=end_time,
+        logging_obj=logging_obj,
+        status="success"
+    )
+    
+    # Verify the cost breakdown field is None for non-completion calls
+    assert payload is not None
+    assert payload["cost_breakdown"] is None
+    assert payload["response_cost"] == 0.0001
+    
+    print("✅ Cost breakdown missing test passed!")


### PR DESCRIPTION
## [Feat] - Cost Tracking - show input, output, tool call cost breakdown in StandardLoggingPayload
Now you can see the breakdown of cost per request in StandardLoggingPayload

Fixes LIT-916

<img width="634" height="682" alt="Screenshot 2025-09-25 at 3 30 51 PM" src="https://github.com/user-attachments/assets/58fdd3ee-3aeb-4601-a9cf-2d86519cc3e1" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


