### PR TITLE
feature: warm-up cache

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -44,7 +44,7 @@ DEFAULT_IMAGE_HEIGHT = int(os.getenv("DEFAULT_IMAGE_HEIGHT", 300))
 MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
     os.getenv("MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB", 1024)
 )  # 1MB = 1024KB
-_DEFAULT_CACHE_WARMUP_USERS = 100
+DEFAULT_CACHE_WARMUP_USERS = 100
 SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD = int(
     os.getenv("SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD", 1000)
 )  # Minimum number of requests to consider "reasonable traffic". Used for single-deployment cooldown logic.

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -44,6 +44,7 @@ DEFAULT_IMAGE_HEIGHT = int(os.getenv("DEFAULT_IMAGE_HEIGHT", 300))
 MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB = int(
     os.getenv("MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB", 1024)
 )  # 1MB = 1024KB
+_DEFAULT_CACHE_WARMUP_USERS = 100
 SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD = int(
     os.getenv("SINGLE_DEPLOYMENT_TRAFFIC_FAILURE_THRESHOLD", 1000)
 )  # Minimum number of requests to consider "reasonable traffic". Used for single-deployment cooldown logic.

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1743,7 +1743,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     user_header_mappings: Optional[List[UserHeaderMapping]] = None
     preload_users_limit: Optional[int] = Field(
         default=100,
-        description="Maximum number of users to pre-load into cache on startup. Set to 0 to disable preloading. Defaults to 0."
+        description="Maximum number of users to pre-load into cache on startup. Set to 0 to disable preloading. Defaults to 100."
     )
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1741,6 +1741,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         description="[DEPRECATED] Use 'user_header_mappings' instead. When set, the header value is treated as the end user id unless overridden by user_header_mappings.",
     )
     user_header_mappings: Optional[List[UserHeaderMapping]] = None
+    preload_users_limit: Optional[int] = Field(
+        default=100,
+        description="Maximum number of users to pre-load into cache on startup. Set to 0 to disable preloading. Defaults to 0."
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1741,10 +1741,6 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         description="[DEPRECATED] Use 'user_header_mappings' instead. When set, the header value is treated as the end user id unless overridden by user_header_mappings.",
     )
     user_header_mappings: Optional[List[UserHeaderMapping]] = None
-    preload_users_limit: Optional[int] = Field(
-        default=100,
-        description="Maximum number of users to pre-load into cache on startup. Set to 0 to disable preloading. Defaults to 100."
-    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,7 +12,7 @@ import traceback
 import uuid
 import warnings
 from datetime import datetime, timedelta
-from litellm.constants import _DEFAULT_CACHE_WARMUP_USERS
+from litellm.constants import DEFAULT_CACHE_WARMUP_USERS
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -655,7 +655,7 @@ async def proxy_startup_event(app: FastAPI):
 
     ### PRELOAD USERS INTO CACHE ###
     if prisma_client is not None:
-        preload_limit = _DEFAULT_CACHE_WARMUP_USERS
+        preload_limit = DEFAULT_CACHE_WARMUP_USERS
         if preload_limit > 0:
             from litellm.proxy.utils import preload_users_into_cache        
             verbose_proxy_logger.info(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -655,12 +655,7 @@ async def proxy_startup_event(app: FastAPI):
 
     ### PRELOAD USERS INTO CACHE ###
     if prisma_client is not None:
-        default_preload_limit = _DEFAULT_CACHE_WARMUP_USERS
-        preload_limit = (
-            general_settings.get("preload_users_limit", default_preload_limit)
-            if general_settings is not None
-            else default_preload_limit
-        )
+        preload_limit = _DEFAULT_CACHE_WARMUP_USERS
         if preload_limit > 0:
             from litellm.proxy.utils import preload_users_into_cache        
             verbose_proxy_logger.info(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,7 +12,7 @@ import traceback
 import uuid
 import warnings
 from datetime import datetime, timedelta
-from constants import _DEFAULT_CACHE_WARMUP_USERS
+from litellm.constants import _DEFAULT_CACHE_WARMUP_USERS
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,6 +12,7 @@ import traceback
 import uuid
 import warnings
 from datetime import datetime, timedelta
+from constants import _DEFAULT_CACHE_WARMUP_USERS
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -653,8 +654,13 @@ async def proxy_startup_event(app: FastAPI):
         )
 
     ### PRELOAD USERS INTO CACHE ###
-    if prisma_client is not None and general_settings is not None:
-        preload_limit = general_settings.get("preload_users_limit", 0)
+    if prisma_client is not None:
+        default_preload_limit = _DEFAULT_CACHE_WARMUP_USERS
+        preload_limit = (
+            general_settings.get("preload_users_limit", default_preload_limit)
+            if general_settings is not None
+            else default_preload_limit
+        )
         if preload_limit > 0:
             from litellm.proxy.utils import preload_users_into_cache        
             verbose_proxy_logger.info(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2075,8 +2075,6 @@ class PrismaClient:
                 if query_type == "find_all":
                     response = await self.db.litellm_endusertable.find_many(
                         where={"budget_id": {"in": budget_id_list}},
-                        order={"litellm_budget_table": {"created_at": "desc"}},
-                        include={"litellm_budget_table": True}
                     )
                     return response
             elif table_name == "team":


### PR DESCRIPTION
## Title

Pre-load Users

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

If a user already has a database and starts or restarts the proxy server, they can now choose to load the most recent users into memory.

## Observations

This feature has space to be expended upon, maybe loading the most active users instead of the most recent 

## Performance Improvements

- When this configuration is enabled, it prevents the initial latency spikes seen in load balancing tests, where all concurrent users would otherwise hit the database directly.
- It was observed that latency is way more stable, and recovers quickly from spikes.

#### With Cache Warmup
<img width="2048" height="1280" alt="cache_warmup copy" src="https://github.com/user-attachments/assets/f5efe947-cb5b-4cb7-8b69-f599d7533db6" />

#### Without Cache Warmup
<img width="2048" height="1280" alt="no_warmup copy" src="https://github.com/user-attachments/assets/622318c7-5679-4072-b55a-afec9ac4e86b" />


