### PR TITLE
feat: Add DD_AGENT_HOST support for Datadog integration

### DIFF
--- a/docs/my-website/docs/observability/datadog.md
+++ b/docs/my-website/docs/observability/datadog.md
@@ -56,9 +56,16 @@ litellm_settings:
 
 **Step 2**: Set Required env variables for datadog
 
+**Option 1 - Direct API Access:**
 ```shell
 DD_API_KEY="5f2d0f310***********" # your datadog API Key
 DD_SITE="us5.datadoghq.com"       # your datadog base url
+DD_SOURCE="litellm_dev"       # [OPTIONAL] your datadog source. use to differentiate dev vs. prod deployments
+```
+
+**Option 2 - Agent-based Access (for security):**
+```shell
+DD_AGENT_HOST="datadog-agent:8126" # your datadog agent host and port
 DD_SOURCE="litellm_dev"       # [OPTIONAL] your datadog source. use to differentiate dev vs. prod deployments
 ```
 
@@ -169,12 +176,15 @@ LiteLLM supports customizing the following Datadog environment variables
 
 | Environment Variable | Description | Default Value | Required |
 |---------------------|-------------|---------------|----------|
-| `DD_API_KEY` | Your Datadog API key for authentication | None | ✅ Yes |
-| `DD_SITE` | Your Datadog site (e.g., "us5.datadoghq.com") | None | ✅ Yes |
+| `DD_API_KEY` | Your Datadog API key for authentication (Option 1) | None | ✅ Yes* |
+| `DD_SITE` | Your Datadog site (e.g., "us5.datadoghq.com") (Option 1) | None | ✅ Yes* |
+| `DD_AGENT_HOST` | Your Datadog agent host and port (Option 2) | None | ✅ Yes* |
 | `DD_ENV` | Environment tag for your logs (e.g., "production", "staging") | "unknown" | ❌ No |
 | `DD_SERVICE` | Service name for your logs | "litellm-server" | ❌ No |
 | `DD_SOURCE` | Source name for your logs | "litellm" | ❌ No |
 | `DD_VERSION` | Version tag for your logs | "unknown" | ❌ No |
 | `HOSTNAME` | Hostname tag for your logs | "" | ❌ No |
 | `POD_NAME` | Pod name tag (useful for Kubernetes deployments) | "unknown" | ❌ No |
+
+*Choose either Option 1 (DD_API_KEY + DD_SITE) OR Option 2 (DD_AGENT_HOST)
 

--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -438,8 +438,9 @@ router_settings:
 | DD_BASE_URL | Base URL for Datadog integration
 | DATADOG_BASE_URL | (Alternative to DD_BASE_URL) Base URL for Datadog integration
 | _DATADOG_BASE_URL | (Alternative to DD_BASE_URL) Base URL for Datadog integration
-| DD_API_KEY | API key for Datadog integration
-| DD_SITE | Site URL for Datadog (e.g., datadoghq.com)
+| DD_API_KEY | API key for Datadog integration (Option 1)
+| DD_SITE | Site URL for Datadog (e.g., datadoghq.com) (Option 1)
+| DD_AGENT_HOST | Datadog agent host and port (Option 2)
 | DD_SOURCE | Source identifier for Datadog logs
 | DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE | Resource name for Datadog tracing of streaming chunk yields. Default is "streaming.chunk.yield"
 | DD_ENV | Environment identifier for Datadog logs. Only supported for `datadog_llm_observability` callback

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1,6 +1,6 @@
 import enum
 import json
-from litellm._uuid import uuid
+import uuid
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -422,7 +422,6 @@ class LiteLLMRoutes(enum.Enum):
         "/user/update",
         "/user/delete",
         "/user/info",
-        "/user/list",
         # team
         "/team/new",
         "/team/update",
@@ -1916,7 +1915,7 @@ class UserAPIKeyAuth(
             key_alias=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
             team_alias=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
         )
-    
+
     @classmethod
     def get_litellm_cli_user_api_key_auth(cls) -> "UserAPIKeyAuth":
         """
@@ -2318,7 +2317,7 @@ class AllCallbacks(LiteLLMPydanticObjectBase):
 
     datadog: CallbackOnUI = CallbackOnUI(
         litellm_callback_name="datadog",
-        litellm_callback_params=["DD_API_KEY", "DD_SITE"],
+        litellm_callback_params=["DD_API_KEY", "DD_SITE", "DD_AGENT_HOST"],
         ui_callback_name="Datadog",
     )
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_agent_host.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_agent_host.py
@@ -4,8 +4,7 @@ Test DD_AGENT_HOST configuration for Datadog integrations
 
 import os
 import pytest
-import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 
@@ -13,35 +12,25 @@ from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 class TestDataDogAgentHost:
     """Test DD_AGENT_HOST configuration for DataDogLogger"""
 
-    def test_datadog_logger_agent_mode_configuration(self):
+    def test_datadog_logger_agent_mode(self):
         """Test DataDogLogger with DD_AGENT_HOST configuration"""
         with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
             with patch("asyncio.create_task"):
                 logger = DataDogLogger()
-
+                
                 # Verify agent mode is enabled
                 assert logger.use_agent_mode is True
                 assert logger.DD_API_KEY is None
                 assert logger.intake_url == "http://datadog-agent:8126/v1/input"
 
-    def test_datadog_logger_agent_mode_without_port(self):
-        """Test DataDogLogger with DD_AGENT_HOST without port (should add default port)"""
-        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}):
-            with patch("asyncio.create_task"):
-                logger = DataDogLogger()
-
-                # Verify agent mode is enabled and port is added
-                assert logger.use_agent_mode is True
-                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
-
-    def test_datadog_logger_direct_api_mode_configuration(self):
+    def test_datadog_logger_direct_api_mode(self):
         """Test DataDogLogger with direct API configuration (backward compatibility)"""
         with patch.dict(
             os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
         ):
             with patch("asyncio.create_task"):
                 logger = DataDogLogger()
-
+                
                 # Verify direct API mode is enabled
                 assert logger.use_agent_mode is False
                 assert logger.DD_API_KEY == "test-key"
@@ -55,99 +44,32 @@ class TestDataDogAgentHost:
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(Exception) as exc_info:
                 DataDogLogger()
-
-            assert (
-                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
-                in str(exc_info.value)
-            )
-
-    def test_datadog_logger_partial_configuration_raises_exception(self):
-        """Test DataDogLogger raises exception when only DD_AGENT_HOST is set but DD_API_KEY/DD_SITE are missing"""
-        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}, clear=True):
-            with patch("asyncio.create_task"):
-                # This should work since DD_AGENT_HOST is sufficient for agent mode
-                logger = DataDogLogger()
-                assert logger.use_agent_mode is True
-
-    def test_datadog_logger_agent_mode_headers(self):
-        """Test that agent mode doesn't include DD-API-KEY header"""
-        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
-            with patch("asyncio.create_task"):
-                logger = DataDogLogger()
-
-                # Mock the sync client to capture headers
-                mock_client = MagicMock()
-                logger.sync_client = mock_client
-
-                # Create a test payload
-                test_payload = {"test": "data"}
-
-                # Call log_success_event to test headers
-                logger.log_success_event(
-                    kwargs={"standard_logging_object": test_payload},
-                    response_obj=None,
-                    start_time=None,
-                    end_time=None,
-                )
-
-                # Verify the post was called with empty headers (no DD-API-KEY)
-                mock_client.post.assert_called_once()
-                call_args = mock_client.post.call_args
-                headers = call_args[1]["headers"]
-                assert "DD-API-KEY" not in headers
-
-    def test_datadog_logger_direct_mode_headers(self):
-        """Test that direct mode includes DD-API-KEY header"""
-        with patch.dict(
-            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
-        ):
-            with patch("asyncio.create_task"):
-                logger = DataDogLogger()
-
-                # Mock the sync client to capture headers
-                mock_client = MagicMock()
-                logger.sync_client = mock_client
-
-                # Create a test payload
-                test_payload = {"test": "data"}
-
-                # Call log_success_event to test headers
-                logger.log_success_event(
-                    kwargs={"standard_logging_object": test_payload},
-                    response_obj=None,
-                    start_time=None,
-                    end_time=None,
-                )
-
-                # Verify the post was called with DD-API-KEY header
-                mock_client.post.assert_called_once()
-                call_args = mock_client.post.call_args
-                headers = call_args[1]["headers"]
-                assert headers["DD-API-KEY"] == "test-key"
+            
+            assert "DD_API_KEY is not set" in str(exc_info.value)
 
 
 class TestDataDogLLMObsAgentHost:
     """Test DD_AGENT_HOST configuration for DataDogLLMObsLogger"""
 
-    def test_datadog_llm_obs_logger_agent_mode_configuration(self):
+    def test_datadog_llm_obs_logger_agent_mode(self):
         """Test DataDogLLMObsLogger with DD_AGENT_HOST configuration"""
         with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
             with patch("asyncio.create_task"):
                 logger = DataDogLLMObsLogger()
-
+                
                 # Verify agent mode is enabled
                 assert logger.use_agent_mode is True
                 assert logger.DD_API_KEY is None
                 assert logger.intake_url == "http://datadog-agent:8126/v1/input"
 
-    def test_datadog_llm_obs_logger_direct_api_mode_configuration(self):
+    def test_datadog_llm_obs_logger_direct_api_mode(self):
         """Test DataDogLLMObsLogger with direct API configuration (backward compatibility)"""
         with patch.dict(
             os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
         ):
             with patch("asyncio.create_task"):
                 logger = DataDogLLMObsLogger()
-
+                
                 # Verify direct API mode is enabled
                 assert logger.use_agent_mode is False
                 assert logger.DD_API_KEY == "test-key"
@@ -161,58 +83,5 @@ class TestDataDogLLMObsAgentHost:
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(Exception) as exc_info:
                 DataDogLLMObsLogger()
-
-            assert (
-                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
-                in str(exc_info.value)
-            )
-
-    def test_datadog_llm_obs_logger_agent_mode_headers(self):
-        """Test that agent mode doesn't include DD-API-KEY header for LLM Obs"""
-        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
-            with patch("asyncio.create_task"):
-                logger = DataDogLLMObsLogger()
-
-                # Mock the async client to capture headers
-                mock_client = MagicMock()
-                logger.async_client = mock_client
-
-                # Create a test payload
-                test_payload = {"test": "data"}
-
-                # Call async_send_batch to test headers
-                logger.log_queue = [test_payload]
-                asyncio.run(logger.async_send_batch())
-
-                # Verify the post was called with headers that don't include DD-API-KEY
-                mock_client.post.assert_called_once()
-                call_args = mock_client.post.call_args
-                headers = call_args[1]["headers"]
-                assert "DD-API-KEY" not in headers
-                assert "Content-Type" in headers
-
-    def test_datadog_llm_obs_logger_direct_mode_headers(self):
-        """Test that direct mode includes DD-API-KEY header for LLM Obs"""
-        with patch.dict(
-            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
-        ):
-            with patch("asyncio.create_task"):
-                logger = DataDogLLMObsLogger()
-
-                # Mock the async client to capture headers
-                mock_client = MagicMock()
-                logger.async_client = mock_client
-
-                # Create a test payload
-                test_payload = {"test": "data"}
-
-                # Call async_send_batch to test headers
-                logger.log_queue = [test_payload]
-                asyncio.run(logger.async_send_batch())
-
-                # Verify the post was called with DD-API-KEY header
-                mock_client.post.assert_called_once()
-                call_args = mock_client.post.call_args
-                headers = call_args[1]["headers"]
-                assert headers["DD-API-KEY"] == "test-key"
-                assert "Content-Type" in headers
+            
+            assert "DD_API_KEY is not set" in str(exc_info.value)

--- a/tests/test_litellm/integrations/datadog/test_datadog_agent_host.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_agent_host.py
@@ -1,0 +1,218 @@
+"""
+Test DD_AGENT_HOST configuration for Datadog integrations
+"""
+
+import os
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+
+
+class TestDataDogAgentHost:
+    """Test DD_AGENT_HOST configuration for DataDogLogger"""
+
+    def test_datadog_logger_agent_mode_configuration(self):
+        """Test DataDogLogger with DD_AGENT_HOST configuration"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify agent mode is enabled
+                assert logger.use_agent_mode is True
+                assert logger.DD_API_KEY is None
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_logger_agent_mode_without_port(self):
+        """Test DataDogLogger with DD_AGENT_HOST without port (should add default port)"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify agent mode is enabled and port is added
+                assert logger.use_agent_mode is True
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_logger_direct_api_mode_configuration(self):
+        """Test DataDogLogger with direct API configuration (backward compatibility)"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify direct API mode is enabled
+                assert logger.use_agent_mode is False
+                assert logger.DD_API_KEY == "test-key"
+                assert (
+                    logger.intake_url
+                    == "https://http-intake.logs.us5.datadoghq.com/api/v2/logs"
+                )
+
+    def test_datadog_logger_no_configuration_raises_exception(self):
+        """Test DataDogLogger raises exception when no configuration is provided"""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception) as exc_info:
+                DataDogLogger()
+
+            assert (
+                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
+                in str(exc_info.value)
+            )
+
+    def test_datadog_logger_partial_configuration_raises_exception(self):
+        """Test DataDogLogger raises exception when only DD_AGENT_HOST is set but DD_API_KEY/DD_SITE are missing"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}, clear=True):
+            with patch("asyncio.create_task"):
+                # This should work since DD_AGENT_HOST is sufficient for agent mode
+                logger = DataDogLogger()
+                assert logger.use_agent_mode is True
+
+    def test_datadog_logger_agent_mode_headers(self):
+        """Test that agent mode doesn't include DD-API-KEY header"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Mock the sync client to capture headers
+                mock_client = MagicMock()
+                logger.sync_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call log_success_event to test headers
+                logger.log_success_event(
+                    kwargs={"standard_logging_object": test_payload},
+                    response_obj=None,
+                    start_time=None,
+                    end_time=None,
+                )
+
+                # Verify the post was called with empty headers (no DD-API-KEY)
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert "DD-API-KEY" not in headers
+
+    def test_datadog_logger_direct_mode_headers(self):
+        """Test that direct mode includes DD-API-KEY header"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Mock the sync client to capture headers
+                mock_client = MagicMock()
+                logger.sync_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call log_success_event to test headers
+                logger.log_success_event(
+                    kwargs={"standard_logging_object": test_payload},
+                    response_obj=None,
+                    start_time=None,
+                    end_time=None,
+                )
+
+                # Verify the post was called with DD-API-KEY header
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert headers["DD-API-KEY"] == "test-key"
+
+
+class TestDataDogLLMObsAgentHost:
+    """Test DD_AGENT_HOST configuration for DataDogLLMObsLogger"""
+
+    def test_datadog_llm_obs_logger_agent_mode_configuration(self):
+        """Test DataDogLLMObsLogger with DD_AGENT_HOST configuration"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Verify agent mode is enabled
+                assert logger.use_agent_mode is True
+                assert logger.DD_API_KEY is None
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_llm_obs_logger_direct_api_mode_configuration(self):
+        """Test DataDogLLMObsLogger with direct API configuration (backward compatibility)"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Verify direct API mode is enabled
+                assert logger.use_agent_mode is False
+                assert logger.DD_API_KEY == "test-key"
+                assert (
+                    logger.intake_url
+                    == "https://api.us5.datadoghq.com/api/intake/llm-obs/v1/trace/spans"
+                )
+
+    def test_datadog_llm_obs_logger_no_configuration_raises_exception(self):
+        """Test DataDogLLMObsLogger raises exception when no configuration is provided"""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception) as exc_info:
+                DataDogLLMObsLogger()
+
+            assert (
+                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
+                in str(exc_info.value)
+            )
+
+    def test_datadog_llm_obs_logger_agent_mode_headers(self):
+        """Test that agent mode doesn't include DD-API-KEY header for LLM Obs"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Mock the async client to capture headers
+                mock_client = MagicMock()
+                logger.async_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call async_send_batch to test headers
+                logger.log_queue = [test_payload]
+                asyncio.run(logger.async_send_batch())
+
+                # Verify the post was called with headers that don't include DD-API-KEY
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert "DD-API-KEY" not in headers
+                assert "Content-Type" in headers
+
+    def test_datadog_llm_obs_logger_direct_mode_headers(self):
+        """Test that direct mode includes DD-API-KEY header for LLM Obs"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Mock the async client to capture headers
+                mock_client = MagicMock()
+                logger.async_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call async_send_batch to test headers
+                logger.log_queue = [test_payload]
+                asyncio.run(logger.async_send_batch())
+
+                # Verify the post was called with DD-API-KEY header
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert headers["DD-API-KEY"] == "test-key"
+                assert "Content-Type" in headers

--- a/tests/test_litellm/integrations/datadog/test_datadog_agent_host_old.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_agent_host_old.py
@@ -1,0 +1,218 @@
+"""
+Test DD_AGENT_HOST configuration for Datadog integrations
+"""
+
+import os
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+
+
+class TestDataDogAgentHost:
+    """Test DD_AGENT_HOST configuration for DataDogLogger"""
+
+    def test_datadog_logger_agent_mode_configuration(self):
+        """Test DataDogLogger with DD_AGENT_HOST configuration"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify agent mode is enabled
+                assert logger.use_agent_mode is True
+                assert logger.DD_API_KEY is None
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_logger_agent_mode_without_port(self):
+        """Test DataDogLogger with DD_AGENT_HOST without port (should add default port)"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify agent mode is enabled and port is added
+                assert logger.use_agent_mode is True
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_logger_direct_api_mode_configuration(self):
+        """Test DataDogLogger with direct API configuration (backward compatibility)"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Verify direct API mode is enabled
+                assert logger.use_agent_mode is False
+                assert logger.DD_API_KEY == "test-key"
+                assert (
+                    logger.intake_url
+                    == "https://http-intake.logs.us5.datadoghq.com/api/v2/logs"
+                )
+
+    def test_datadog_logger_no_configuration_raises_exception(self):
+        """Test DataDogLogger raises exception when no configuration is provided"""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception) as exc_info:
+                DataDogLogger()
+
+            assert (
+                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
+                in str(exc_info.value)
+            )
+
+    def test_datadog_logger_partial_configuration_raises_exception(self):
+        """Test DataDogLogger raises exception when only DD_AGENT_HOST is set but DD_API_KEY/DD_SITE are missing"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent"}, clear=True):
+            with patch("asyncio.create_task"):
+                # This should work since DD_AGENT_HOST is sufficient for agent mode
+                logger = DataDogLogger()
+                assert logger.use_agent_mode is True
+
+    def test_datadog_logger_agent_mode_headers(self):
+        """Test that agent mode doesn't include DD-API-KEY header"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Mock the sync client to capture headers
+                mock_client = MagicMock()
+                logger.sync_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call log_success_event to test headers
+                logger.log_success_event(
+                    kwargs={"standard_logging_object": test_payload},
+                    response_obj=None,
+                    start_time=None,
+                    end_time=None,
+                )
+
+                # Verify the post was called with empty headers (no DD-API-KEY)
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert "DD-API-KEY" not in headers
+
+    def test_datadog_logger_direct_mode_headers(self):
+        """Test that direct mode includes DD-API-KEY header"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLogger()
+
+                # Mock the sync client to capture headers
+                mock_client = MagicMock()
+                logger.sync_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call log_success_event to test headers
+                logger.log_success_event(
+                    kwargs={"standard_logging_object": test_payload},
+                    response_obj=None,
+                    start_time=None,
+                    end_time=None,
+                )
+
+                # Verify the post was called with DD-API-KEY header
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert headers["DD-API-KEY"] == "test-key"
+
+
+class TestDataDogLLMObsAgentHost:
+    """Test DD_AGENT_HOST configuration for DataDogLLMObsLogger"""
+
+    def test_datadog_llm_obs_logger_agent_mode_configuration(self):
+        """Test DataDogLLMObsLogger with DD_AGENT_HOST configuration"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Verify agent mode is enabled
+                assert logger.use_agent_mode is True
+                assert logger.DD_API_KEY is None
+                assert logger.intake_url == "http://datadog-agent:8126/v1/input"
+
+    def test_datadog_llm_obs_logger_direct_api_mode_configuration(self):
+        """Test DataDogLLMObsLogger with direct API configuration (backward compatibility)"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Verify direct API mode is enabled
+                assert logger.use_agent_mode is False
+                assert logger.DD_API_KEY == "test-key"
+                assert (
+                    logger.intake_url
+                    == "https://api.us5.datadoghq.com/api/intake/llm-obs/v1/trace/spans"
+                )
+
+    def test_datadog_llm_obs_logger_no_configuration_raises_exception(self):
+        """Test DataDogLLMObsLogger raises exception when no configuration is provided"""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception) as exc_info:
+                DataDogLLMObsLogger()
+
+            assert (
+                "DD_API_KEY and DD_SITE are not set, and DD_AGENT_HOST is not set"
+                in str(exc_info.value)
+            )
+
+    def test_datadog_llm_obs_logger_agent_mode_headers(self):
+        """Test that agent mode doesn't include DD-API-KEY header for LLM Obs"""
+        with patch.dict(os.environ, {"DD_AGENT_HOST": "datadog-agent:8126"}):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Mock the async client to capture headers
+                mock_client = MagicMock()
+                logger.async_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call async_send_batch to test headers
+                logger.log_queue = [test_payload]
+                asyncio.run(logger.async_send_batch())
+
+                # Verify the post was called with headers that don't include DD-API-KEY
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert "DD-API-KEY" not in headers
+                assert "Content-Type" in headers
+
+    def test_datadog_llm_obs_logger_direct_mode_headers(self):
+        """Test that direct mode includes DD-API-KEY header for LLM Obs"""
+        with patch.dict(
+            os.environ, {"DD_API_KEY": "test-key", "DD_SITE": "us5.datadoghq.com"}
+        ):
+            with patch("asyncio.create_task"):
+                logger = DataDogLLMObsLogger()
+
+                # Mock the async client to capture headers
+                mock_client = MagicMock()
+                logger.async_client = mock_client
+
+                # Create a test payload
+                test_payload = {"test": "data"}
+
+                # Call async_send_batch to test headers
+                logger.log_queue = [test_payload]
+                asyncio.run(logger.async_send_batch())
+
+                # Verify the post was called with DD-API-KEY header
+                mock_client.post.assert_called_once()
+                call_args = mock_client.post.call_args
+                headers = call_args[1]["headers"]
+                assert headers["DD-API-KEY"] == "test-key"
+                assert "Content-Type" in headers


### PR DESCRIPTION
- Add support for DD_AGENT_HOST environment variable as alternative to DD_API_KEY/DD_SITE
- Enable secure agent-based configuration for Datadog integrations
- Maintain full backward compatibility with existing DD_API_KEY/DD_SITE configuration
- Add comprehensive unit tests for both agent and direct API modes
- Update documentation with new configuration options

This allows users to configure Datadog integration using their fleet of Datadog agents instead of requiring direct API access, improving security for enterprise deployments.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


