### PR TITLE
fix(prometheus): Fix Prometheus metric collection in a multi-workers …

### DIFF
--- a/enterprise/litellm_enterprise/integrations/prometheus.py
+++ b/enterprise/litellm_enterprise/integrations/prometheus.py
@@ -2197,7 +2197,13 @@ class PrometheusLogger(CustomLogger):
             )
 
         # Create metrics ASGI app
-        metrics_app = make_asgi_app()
+        if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            from prometheus_client import CollectorRegistry, multiprocess
+            registry = CollectorRegistry()
+            multiprocess.MultiProcessCollector(registry)
+            metrics_app = make_asgi_app(registry)
+        else:
+            metrics_app = make_asgi_app()
 
         # Mount the metrics app to the app
         app.mount("/metrics", metrics_app)


### PR DESCRIPTION
## Changes

In multi-worker instances, metrics between Prometheus clients are calculated independently.
For example:
worker0: metric.counter=1
worker1: metric.counter=2

When requesting /metrics api, what is returned metirc.counter=1 or 2, not 3(1+2)

When the PROMETHEUS_MULTIPROC_DIR environment variable was specified at that time, the prometheus client would store data in the specified directory. 
After correct initialization, requesting the /metrics api of any worker could return the full amount of data from disk

## Type

🐛 Bug Fix



