### PR TITLE
docs: add documentation for additional cost-related keys in custom pricing

### DIFF
--- a/docs/my-website/docs/proxy/custom_pricing.md
+++ b/docs/my-website/docs/proxy/custom_pricing.md
@@ -83,6 +83,24 @@ model_list:
       cache_read_input_token_cost: 0.0000006
 ```
 
+### Additional Cost Keys
+
+There are other keys you can use to specify costs for different scenarios and modalities:
+
+- `input_cost_per_token_above_200k_tokens` - Cost for input tokens when context exceeds 200k tokens
+- `output_cost_per_token_above_200k_tokens` - Cost for output tokens when context exceeds 200k tokens  
+- `cache_creation_input_token_cost_above_200k_tokens` - Cache creation cost for large contexts
+- `cache_read_input_token_cost_above_200k_token` - Cache read cost for large contexts
+- `input_cost_per_image` - Cost per image in multimodal requests
+- `output_cost_per_reasoning_token` - Cost for reasoning tokens (e.g., OpenAI o1 models)
+- `input_cost_per_audio_token` - Cost for audio input tokens
+- `output_cost_per_audio_token` - Cost for audio output tokens
+- `input_cost_per_video_per_second` - Cost per second of video input
+- `input_cost_per_video_per_second_above_128k_tokens` - Video cost for large contexts
+- `input_cost_per_character` - Character-based pricing for some providers
+
+These keys evolve based on how new models handle multimodality. The latest version can be found at [https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json).
+
 ## Set 'base_model' for Cost Tracking (e.g. Azure deployments)
 
 **Problem**: Azure returns `gpt-4` in the response when `azure/gpt-4-1106-preview` is used. This leads to inaccurate cost tracking


### PR DESCRIPTION
Co-authored-by: aider (openrouter/anthropic/claude-sonnet-4) <aider@aider.chat>

## Title

Add example of extra keys that can be used to specify the costs of a model.
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes


