### PR TITLE
Fix Anthropic streaming IDs (#14962)

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -51,6 +51,7 @@ from litellm.types.utils import (
     ModelResponseStream,
     StreamingChoices,
     Usage,
+    _generate_id,
 )
 
 from ...base import BaseLLM
@@ -490,6 +491,8 @@ class ModelResponseIterator:
         self.content_blocks: List[ContentBlockDelta] = []
         self.tool_index = -1
         self.json_mode = json_mode
+        # Generate response ID once per stream to match OpenAI-compatible behavior
+        self.response_id = _generate_id()
 
         # Track if we're currently streaming a response_format tool
         self.is_response_format_tool: bool = False
@@ -765,6 +768,7 @@ class ModelResponseIterator:
                     )
                 ],
                 usage=usage,
+                id=self.response_id,
             )
 
             return returned_chunk
@@ -936,4 +940,4 @@ class ModelResponseIterator:
             data_json = json.loads(str_line[5:])
             return self.chunk_parser(chunk=data_json)
         else:
-            return ModelResponseStream()
+            return ModelResponseStream(id=self.response_id)

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -439,3 +439,24 @@ def test_multiple_tools_streaming_has_index_zero():
             assert (
                 parsed.choices[0].index == 0
             ), f"Expected index=0, got {parsed.choices[0].index}"
+
+
+def test_streaming_chunks_have_stable_ids():
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=False, json_mode=False
+    )
+    first_chunk = {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "Hello"},
+    }
+    second_chunk = {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": " world"},
+    }
+
+    response_one = iterator.chunk_parser(chunk=first_chunk)
+    response_two = iterator.chunk_parser(chunk=second_chunk)
+
+    assert response_one.id == response_two.id == iterator.response_id


### PR DESCRIPTION
## Title

Fix: Maintain stable response IDs for Anthropic streaming chunks

## Relevant issues

Fixes #14962

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem**
Anthropic streaming responses emitted a new `chatcmpl-` ID for every chunk, which broke OpenAI-compatible clients that expect a single identifier per stream.

**Solution**
Cache a single OpenAI-style response ID when the stream starts and reuse it for every chunk generated by `ModelResponseIterator`. Added a regression test that ensures consecutive chunks reuse the iterator's ID.

**Tests Added**
- `test_streaming_chunks_have_stable_ids` in `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py`
<img width="1134" height="255" alt="Screenshot 2025-09-26 at 6 25 39 PM" src="https://github.com/user-attachments/assets/083f7b0b-e75d-469b-a48f-ef0acd6dd362" />

**Test Results**
All targeted tests pass locally:
- `pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py`
- `PIP_INDEX_URL=https://pypi.org/simple/ poetry run pytest tests/test_litellm/llms/anthropic/ -v`
<img width="1781" height="1002" alt="Screenshot 2025-09-26 at 6 29 01 PM" src="https://github.com/user-attachments/assets/5da5967b-d220-4c14-9fbe-759d6283ca2a" />

