### PR TITLE
Add codeowners for model prices file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,5 @@
 
 # Model prices and context window configuration
 # This file contains sensitive pricing and model information that should be reviewed by the team
+# Requires 2 approvals from @berriai/litellm-team (configured in repository settings)
 /model_prices_and_context_window.json @berriai/litellm-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for LiteLLM
+# This file defines who can review and approve changes to specific files
+
+# Model prices and context window configuration
+# This file contains sensitive pricing and model information that should be reviewed by the team
+/model_prices_and_context_window.json @berriai/litellm-team


### PR DESCRIPTION
## Title

Add CODEOWNERS file for `model_prices_and_context_window.json`

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

This PR introduces a `CODEOWNERS` file to the repository root.
The file specifies that changes to `/model_prices_and_context_window.json` must be reviewed by the `@berriai/litellm-team`. This ensures that modifications to sensitive model pricing and context window configurations are always reviewed by the designated team, providing better control and oversight.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4750d97-d1ed-4e58-b7e7-3be3a28e9581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4750d97-d1ed-4e58-b7e7-3be3a28e9581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

