### PR TITLE
fix: reduce get_deployment cost to O(1)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -637,11 +637,6 @@ async def proxy_startup_event(app: FastAPI):
         user_api_key_cache=user_api_key_cache,
     )
 
-    if use_background_health_checks:
-        asyncio.create_task(
-            _run_background_health_check()
-        )  # start the background health check coroutine.
-
     if prompt_injection_detection_obj is not None:  # [TODO] - REFACTOR THIS
         prompt_injection_detection_obj.update_environment(router=llm_router)
 
@@ -663,6 +658,12 @@ async def proxy_startup_event(app: FastAPI):
         )
 
         await ProxyStartupEvent._update_default_team_member_budget()
+
+    # Start background health checks AFTER models are loaded and index is built
+    if use_background_health_checks:
+        asyncio.create_task(
+            _run_background_health_check()
+        )  # start the background health check coroutine.
 
     ## [Optional] Initialize dd tracer
     ProxyStartupEvent._init_dd_tracer()

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4979,7 +4979,7 @@ class Router:
 
             model = deployment.to_json(exclude_none=True)
 
-            self._add_model_to_list_and_index_map(model, deployment.model_info.id)
+            self._add_model_to_list_and_index_map(model=model, model_id=deployment.model_info.id)
             return deployment
         except Exception as e:
             if self.ignore_invalid_deployments:
@@ -5329,7 +5329,7 @@ class Router:
         self._add_deployment(deployment=deployment)
 
         # add to model names
-        self._add_model_to_list_and_index_map(_deployment, deployment.model_info.id)
+        self._add_model_to_list_and_index_map(model=_deployment, model_id=deployment.model_info.id)
         self.model_names.append(deployment.model_name)
         return deployment
 
@@ -5342,9 +5342,9 @@ class Router:
         - removal_idx: int - the index where the deployment was removed from model_list
         """
         # Update indices for all models after the removed one
-        for model_id, idx in self.model_id_to_deployment_index_map.items():
+        for deployment_id, idx in self.model_id_to_deployment_index_map.items():
             if idx > removal_idx:
-                self.model_id_to_deployment_index_map[model_id] = idx - 1
+                self.model_id_to_deployment_index_map[deployment_id] = idx - 1
         # Remove the deleted model from index
         if model_id in self.model_id_to_deployment_index_map:
             del self.model_id_to_deployment_index_map[model_id]
@@ -5398,7 +5398,7 @@ class Router:
 
                     if removal_idx is not None:
                         self.model_list.pop(removal_idx)
-                        self._update_deployment_indices_after_removal(deployment_id, removal_idx)
+                        self._update_deployment_indices_after_removal(model_id=deployment_id, removal_idx=removal_idx)
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)
@@ -5429,7 +5429,7 @@ class Router:
             if deployment_idx is not None:
                 # Pop the item from the list first
                 item = self.model_list.pop(deployment_idx)
-                self._update_deployment_indices_after_removal(id, deployment_idx)
+                self._update_deployment_indices_after_removal(model_id=id, removal_idx=deployment_idx)
                 return item
             else:
                 return None
@@ -6093,7 +6093,7 @@ class Router:
                     model["model_info"] = {}
                 model["model_info"]["id"] = model_id
             
-            self._add_model_to_list_and_index_map(model, model_id)
+            self._add_model_to_list_and_index_map(model=model, model_id=model_id)
 
     def get_model_ids(
         self, model_name: Optional[str] = None, exclude_team_models: bool = False

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -16,24 +16,28 @@ class TestRouterIndexManagement:
         """Create a router instance for testing"""
         return Router(model_list=[])
 
-    def test_remove_deployment_from_index(self, router):
-        """Test _remove_deployment_from_index function"""
-        # Setup: Add models to router
-        router.model_list = [{"model": "test1"}, {"model": "test2"}, {"model": "test3"}]
-        router.model_index = {"model-1": 0, "model-2": 1, "model-3": 2}
+    def test_update_deployment_indices_after_removal(self, router):
+        """Test _update_deployment_indices_after_removal function"""
+        # Setup: Add models to router with proper structure
+        router.model_list = [
+            {"model": "test1", "model_info": {"id": "model-1"}}, 
+            {"model": "test2", "model_info": {"id": "model-2"}}, 
+            {"model": "test3", "model_info": {"id": "model-3"}}
+        ]
+        router.model_id_to_deployment_index_map = {"model-1": 0, "model-2": 1, "model-3": 2}
 
         # Test: Remove model-2 (index 1)
-        router._remove_deployment_from_index("model-2", 1)
+        router._update_deployment_indices_after_removal(model_id="model-2", removal_idx=1)
 
         # Verify: model-2 is removed from index
-        assert "model-2" not in router.model_index
+        assert "model-2" not in router.model_id_to_deployment_index_map
         # Verify: model-3 index is updated (2 -> 1)
-        assert router.model_index["model-3"] == 1
+        assert router.model_id_to_deployment_index_map["model-3"] == 1
         # Verify: model-1 index remains unchanged
-        assert router.model_index["model-1"] == 0
+        assert router.model_id_to_deployment_index_map["model-1"] == 0
 
-    def test_build_model_index_from_list(self, router):
-        """Test _build_model_index_from_list function"""
+    def test_build_model_id_to_deployment_index_map(self, router):
+        """Test _build_model_id_to_deployment_index_map function"""
         model_list = [
             {
                 "model_name": "gpt-3.5-turbo",
@@ -48,10 +52,10 @@ class TestRouterIndexManagement:
         ]
 
         # Test: Build index from model list
-        router._build_model_index_from_list(model_list)
+        router._build_model_id_to_deployment_index_map(model_list)
 
         # Verify: model_list is populated
         assert len(router.model_list) == 2
-        # Verify: model_index is correctly built
-        assert router.model_index["model-1"] == 0
-        assert router.model_index["model-2"] == 1
+        # Verify: model_id_to_deployment_index_map is correctly built
+        assert router.model_id_to_deployment_index_map["model-1"] == 0
+        assert router.model_id_to_deployment_index_map["model-2"] == 1

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -59,3 +59,47 @@ class TestRouterIndexManagement:
         # Verify: model_id_to_deployment_index_map is correctly built
         assert router.model_id_to_deployment_index_map["model-1"] == 0
         assert router.model_id_to_deployment_index_map["model-2"] == 1
+
+    def test_add_model_to_list_and_index_map_from_model_info(self, router):
+        """Test _add_model_to_list_and_index_map extracting model_id from model_info"""
+        # Setup: Empty router
+        router.model_list = []
+        router.model_id_to_deployment_index_map = {}
+        
+        # Test: Add model without explicit model_id
+        model = {"model": "test-model", "model_info": {"id": "model-info-id"}}
+        router._add_model_to_list_and_index_map(model=model)
+        
+        # Verify: Model added to list
+        assert len(router.model_list) == 1
+        assert router.model_list[0] == model
+        
+        # Verify: Index map uses model_info.id
+        assert router.model_id_to_deployment_index_map["model-info-id"] == 0
+
+
+    def test_add_model_to_list_and_index_map_multiple_models(self, router):
+        """Test _add_model_to_list_and_index_map with multiple models to verify indexing"""
+        # Setup: Empty router
+        router.model_list = []
+        router.model_id_to_deployment_index_map = {}
+        
+        # Test: Add multiple models
+        model1 = {"model": "model1", "model_info": {"id": "id-1"}}
+        model2 = {"model": "model2", "model_info": {"id": "id-2"}}
+        model3 = {"model": "model3", "model_info": {"id": "id-3"}}
+        
+        router._add_model_to_list_and_index_map(model=model1, model_id="id-1")
+        router._add_model_to_list_and_index_map(model=model2, model_id="id-2")
+        router._add_model_to_list_and_index_map(model=model3, model_id="id-3")
+        
+        # Verify: All models added to list
+        assert len(router.model_list) == 3
+        assert router.model_list[0] == model1
+        assert router.model_list[1] == model2
+        assert router.model_list[2] == model3
+        
+        # Verify: Correct indices in map
+        assert router.model_id_to_deployment_index_map["id-1"] == 0
+        assert router.model_id_to_deployment_index_map["id-2"] == 1
+        assert router.model_id_to_deployment_index_map["id-3"] == 2

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -1,0 +1,57 @@
+import sys
+import os
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
+from litellm import Router
+
+
+class TestRouterIndexManagement:
+    """Test cases for router index management functions"""
+
+    @pytest.fixture
+    def router(self):
+        """Create a router instance for testing"""
+        return Router(model_list=[])
+
+    def test_remove_deployment_from_index(self, router):
+        """Test _remove_deployment_from_index function"""
+        # Setup: Add models to router
+        router.model_list = [{"model": "test1"}, {"model": "test2"}, {"model": "test3"}]
+        router.model_index = {"model-1": 0, "model-2": 1, "model-3": 2}
+
+        # Test: Remove model-2 (index 1)
+        router._remove_deployment_from_index("model-2", 1)
+
+        # Verify: model-2 is removed from index
+        assert "model-2" not in router.model_index
+        # Verify: model-3 index is updated (2 -> 1)
+        assert router.model_index["model-3"] == 1
+        # Verify: model-1 index remains unchanged
+        assert router.model_index["model-1"] == 0
+
+    def test_build_model_index_from_list(self, router):
+        """Test _build_model_index_from_list function"""
+        model_list = [
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo"},
+                "model_info": {"id": "model-1"},
+            },
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4"},
+                "model_info": {"id": "model-2"},
+            },
+        ]
+
+        # Test: Build index from model list
+        router._build_model_index_from_list(model_list)
+
+        # Verify: model_list is populated
+        assert len(router.model_list) == 2
+        # Verify: model_index is correctly built
+        assert router.model_index["model-1"] == 0
+        assert router.model_index["model-2"] == 1


### PR DESCRIPTION
## Title

Fail fast, succeded fast on get_deployment

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Performance

## Changes

- Created a hashmap, mapping model id to index.
- Removed linear look ups.


## Performance Improvement

`get_deployment` used to account for **0.186s out of 0.710s (26.2%)** of callee time.

After this change, it takes **0.133s out of 1.05s (12.7%)**.

That’s a **28.5% reduction in its raw runtime** and a **~52% drop in its share of total time**.