### PR TITLE
fix: support documented params

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -252,11 +252,53 @@ const PROVIDER_CREDENTIAL_FIELDS: Record<Providers, ProviderCredentialField[]> =
       tooltip: "You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`)."
     },
     {
+      key: "aws_session_token",
+      label: "AWS Session Token",
+      type: "password",
+      required: false,
+      tooltip: "Temporary credentials session token. You can provide the raw token or the environment variable (e.g. `os.environ/MY_SESSION_TOKEN`)."
+    },
+    {
       key: "aws_region_name",
       label: "AWS Region Name",
       placeholder: "us-east-1",
       required: false,
       tooltip: "You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`)."
+    },
+    {
+      key: "aws_session_name",
+      label: "AWS Session Name",
+      placeholder: "my-session",
+      required: false,
+      tooltip: "Name for the AWS session. You can provide the raw value or the environment variable (e.g. `os.environ/MY_SESSION_NAME`)."
+    },
+    {
+      key: "aws_profile_name",
+      label: "AWS Profile Name",
+      placeholder: "default",
+      required: false,
+      tooltip: "AWS profile name to use for authentication. You can provide the raw value or the environment variable (e.g. `os.environ/MY_PROFILE_NAME`)."
+    },
+    {
+      key: "aws_role_name",
+      label: "AWS Role Name",
+      placeholder: "MyRole",
+      required: false,
+      tooltip: "AWS IAM role name to assume. You can provide the raw value or the environment variable (e.g. `os.environ/MY_ROLE_NAME`)."
+    },
+    {
+      key: "aws_web_identity_token",
+      label: "AWS Web Identity Token",
+      type: "password",
+      required: false,
+      tooltip: "Web identity token for OIDC authentication. You can provide the raw token or the environment variable (e.g. `os.environ/MY_WEB_IDENTITY_TOKEN`)."
+    },
+    {
+      key: "aws_bedrock_runtime_endpoint",
+      label: "AWS Bedrock Runtime Endpoint",
+      placeholder: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      required: false,
+      tooltip: "Custom Bedrock runtime endpoint URL. You can provide the raw value or the environment variable (e.g. `os.environ/MY_BEDROCK_ENDPOINT`)."
     }
   ],
   [Providers.SageMaker]: [


### PR DESCRIPTION
## Title

Support all the params documented when adding an AWS bedrock model 

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Added the missing params to the Providers.Bedrock list.


