### PR TITLE
[Fix] Use the `extra_query` parameter for GET requests in Azure Batch

### DIFF
--- a/docs/my-website/docs/providers/azure/azure.md
+++ b/docs/my-website/docs/providers/azure/azure.md
@@ -931,7 +931,7 @@ curl http://localhost:4000/v1/batches \
 ```python
 retrieved_batch = client.batches.retrieve(
     batch.id,
-    extra_body={"custom_llm_provider": "azure"}
+    extra_query={"custom_llm_provider": "azure"}
 )
 ```
 
@@ -978,7 +978,7 @@ curl http://localhost:4000/v1/batches/batch_abc123/cancel \
 <TabItem value="sdk" label="OpenAI Python SDK">
 
 ```python
-client.batches.list(extra_body={"custom_llm_provider": "azure"})
+client.batches.list(extra_query={"custom_llm_provider": "azure"})
 ```
 
 </TabItem>

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -17,7 +17,6 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.common_utils.openai_endpoint_utils import (
-    get_custom_llm_provider_from_request_body,
     get_custom_llm_provider_from_request_query,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -18,6 +18,7 @@ from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessin
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_body,
+    get_custom_llm_provider_from_request_query,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
@@ -282,7 +283,7 @@ async def retrieve_batch(
         else:
             custom_llm_provider = (
                 provider
-                or await get_custom_llm_provider_from_request_body(request=request)
+                or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )
             response = await litellm.aretrieve_batch(
@@ -392,7 +393,7 @@ async def list_batches(
         else:
             custom_llm_provider = (
                 provider
-                or await get_custom_llm_provider_from_request_body(request=request)
+                or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )
             response = await litellm.alist_batches(

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -38,3 +38,14 @@ async def get_custom_llm_provider_from_request_body(request: Request) -> Optiona
     if "custom_llm_provider" in request_body:
         return request_body["custom_llm_provider"]
     return None
+
+
+def get_custom_llm_provider_from_request_query(request: Request) -> Optional[str]:
+    """
+    Get the `custom_llm_provider` from the request query parameters
+
+    Safely reads the request query parameters
+    """
+    if "custom_llm_provider" in request.query_params:
+        return request.query_params["custom_llm_provider"]
+    return None


### PR DESCRIPTION
## Use the `extra_query` parameter for GET requests in Azure Batch

<!-- e.g. "Implement user authentication feature" -->

The `client.batches.retrieve` method in the Azure Batches API is a GET request. Therefore, even when specifying `custom_llm_provider` in the `extra_body`, that information was not passed to the proxy server request and was interpreted as a request to OpenAI.
To address this, I modified the approach to specify it as `extra_query`. By parsing the `query_params` at the proxy server, I ensured the `custom_llm_provider` information is now used correctly.

<img width="604" height="672" alt="Screenshot 2025-09-28 at 18 06 02" src="https://github.com/user-attachments/assets/96b7652a-7a5c-49a7-a9b6-3918158858ab" />

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/14940

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

This is a minor change, so I don't add tests.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


