### PR TITLE
[Performance] Reduce complexity of `InMemoryCache.evict_cache` from O(n*log(n)) to O(log(n))

### DIFF
--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -26,12 +26,12 @@ from .base_cache import BaseCache
 
 class InMemoryCache(BaseCache):
     def __init__(
-            self,
-            max_size_in_memory: Optional[int] = 200,
-            default_ttl: Optional[
-                int
-            ] = 600,  # default ttl is 10 minutes. At maximum litellm rate limiting logic requires objects to be in memory for 1 minute
-            max_size_per_item: Optional[int] = 1024,  # 1MB = 1024KB
+        self,
+        max_size_in_memory: Optional[int] = 200,
+        default_ttl: Optional[
+            int
+        ] = 600,  # default ttl is 10 minutes. At maximum litellm rate limiting logic requires objects to be in memory for 1 minute
+        max_size_per_item: Optional[int] = 1024,  # 1MB = 1024KB
     ):
         """
         max_size_in_memory [int]: Maximum number of items in cache. done to prevent memory leaks. Use 200 items as a default
@@ -41,7 +41,7 @@ class InMemoryCache(BaseCache):
         )  # set an upper bound of 200 items in-memory
         self.default_ttl = default_ttl or 600
         self.max_size_per_item = (
-                max_size_per_item or MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB
+            max_size_per_item or MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB
         )  # 1MB = 1024KB
 
         # in-memory cache

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -47,7 +47,7 @@ class InMemoryCache(BaseCache):
         # in-memory cache
         self.cache_dict: dict = {}
         self.ttl_dict: dict = {}
-        self.expiration_heap = []
+        self.expiration_heap: list[tuple[float, str]] = []
 
     def check_value_size(self, value: Any):
         """

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -57,9 +57,9 @@ class InMemoryCache(BaseCache):
         try:
             # Fast path for common primitive types that are typically small
             if (
-                    isinstance(value, (bool, int, float, str))
-                    and len(str(value))
-                    < self.max_size_per_item * MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB
+                isinstance(value, (bool, int, float, str))
+                and len(str(value))
+                < self.max_size_per_item * MAX_SIZE_PER_ITEM_IN_MEMORY_CACHE_IN_KB
             ):  # Conservative estimate
                 return True
 
@@ -74,7 +74,7 @@ class InMemoryCache(BaseCache):
 
             # Fallback for complex types
             if isinstance(value, BaseModel) and hasattr(
-                    value, "model_dump"
+                value, "model_dump"
             ):  # Pydantic v2
                 value = value.model_dump()
             elif hasattr(value, "isoformat"):  # datetime objects
@@ -252,7 +252,7 @@ class InMemoryCache(BaseCache):
         return value
 
     async def async_increment_pipeline(
-            self, increment_list: List["RedisPipelineIncrementOperation"], **kwargs
+        self, increment_list: List["RedisPipelineIncrementOperation"], **kwargs
     ) -> Optional[List[float]]:
         results = []
         for increment in increment_list:

--- a/tests/test_litellm/caching/test_in_memory_cache.py
+++ b/tests/test_litellm/caching/test_in_memory_cache.py
@@ -186,3 +186,16 @@ def test_in_memory_cache_eviction_order():
     # Items with later expiration should remain
     assert "late_expire" in in_memory_cache.cache_dict
     assert "new_item" in in_memory_cache.cache_dict
+
+
+def test_in_memory_cache_heap_size_staus_bounded():
+    """
+    Test that the expiration_heap does not grow unbounded when the same key is updated repeaatedly.
+    """
+    in_memory_cache = InMemoryCache(max_size_in_memory=10)
+
+    for i in range(1_000):
+        in_memory_cache.set_cache(key="hot_key", value=f"value_{i}", ttl=60)
+
+    # Expiration heap should only have 1 entry
+    assert len(in_memory_cache.expiration_heap) == 1

--- a/tests/test_litellm/litellm_core_utils/specialty_caches/test_dynamic_logging_cache.py
+++ b/tests/test_litellm/litellm_core_utils/specialty_caches/test_dynamic_logging_cache.py
@@ -41,8 +41,10 @@ class TestLangfuseInMemoryCache:
             "litellm.integrations.langfuse.langfuse.LangFuseLogger", MockLangFuseLogger
         ):
             # Add the mock logger to cache with expired TTL
+            expired_time = time.time() - 1  # Already expired
             self.cache.cache_dict["test_key"] = mock_logger
-            self.cache.ttl_dict["test_key"] = time.time() - 1  # Already expired
+            self.cache.ttl_dict["test_key"] = expired_time
+            self.cache.expiration_heap = [(expired_time, "test_key")]
 
             initial_count = litellm.initialized_langfuse_clients
 


### PR DESCRIPTION
## Title

The implementation of evict_cache in InMemoryCache which is performed on every set_cache once the cache is full originally had a complexity of `O(n*log(n))`, this PR reduces said complexity to `O(log(n))` providing a performance improvement once the cache is full.

A speed comparison done locally on a Ryzen 7950X shows
<img width="280" height="44" alt="image" src="https://github.com/user-attachments/assets/99a07e21-8230-41e0-8fa3-be5554b3dae4" />
<img width="281" height="43" alt="image" src="https://github.com/user-attachments/assets/b8570f2e-bd25-4be6-86bd-3987fd30f1ae" />

with the code
<img width="451" height="415" alt="image" src="https://github.com/user-attachments/assets/09766b58-5d31-4a42-9062-279e67f32956" />


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="1599" height="124" alt="image" src="https://github.com/user-attachments/assets/b4a78099-8de6-4262-abdf-88153fb1e65d" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 Performance

## Changes


