### PR TITLE
Update litellm docs from latest release

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -149,6 +149,16 @@ mcp_servers:
     auth_type: "api_key"
     auth_value: "abc123"        # headers={"X-API-Key": "abc123"}
 
+  # NEW – OAuth 2.0 Client Credentials (v1.77.5)
+  oauth2_example:
+    url: "https://my-mcp-server.com/mcp"
+    auth_type: "oauth2"         # 👈 KEY CHANGE
+    authorization_url: "https://my-mcp-server.com/oauth/authorize" # optional for client-credentials
+    token_url: "https://my-mcp-server.com/oauth/token"             # required
+    client_id: os.environ/OAUTH_CLIENT_ID
+    client_secret: os.environ/OAUTH_CLIENT_SECRET
+    scopes: ["tool.read", "tool.write"] # optional
+
   bearer_example:
     url: "https://my-mcp-server.com/mcp"
     auth_type: "bearer_token"


### PR DESCRIPTION
## Title

Update documentation for v1.77.5 features (MCP OAuth2 & Virtual Key Rotation)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

This PR updates the documentation to reflect new features introduced in LiteLLM v1.77.5-stable:

*   **MCP Gateway**: Added an example and explanation for OAuth 2.0 client-credentials authentication.
*   **Virtual Keys**: Introduced a new section on "Scheduled Key Rotations", covering its functionality, setup, and webhook payload.

---
[Slack Thread](https://berriaillm.slack.com/archives/D09H1V0HE3V/p1759077093196949?thread_ts=1759077093.196949&cid=D09H1V0HE3V)

<a href="https://cursor.com/background-agent?bcId=bc-f7ed2329-9657-4051-b80f-a4a73ceabd60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7ed2329-9657-4051-b80f-a4a73ceabd60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

