### PR TITLE
feature/add max requests env var

### DIFF
--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -715,6 +715,25 @@ docker run ghcr.io/berriai/litellm:main-stable
 ```
 
 
+### Restart Workers After N Requests
+
+Use this to mitigate memory growth by recycling workers after a fixed number of requests. When set, each worker restarts after completing the specified number of requests. Defaults to disabled when unset.
+
+Usage Examples:
+
+```shell showLineNumbers title="docker run (CLI flag)"
+docker run ghcr.io/berriai/litellm:main-stable \
+    --max_requests_before_restart 10000
+```
+
+Or set via environment variable:
+
+```shell showLineNumbers title="Environment Variable"
+export MAX_REQUESTS_BEFORE_RESTART=10000
+docker run ghcr.io/berriai/litellm:main-stable
+```
+
+
 ### 5. config.yaml file on s3, GCS Bucket Object/url
 
 Use this if you cannot mount a config file on your deployment service (example - AWS Fargate, Railway etc)

--- a/docs/my-website/docs/proxy/prod.md
+++ b/docs/my-website/docs/proxy/prod.md
@@ -71,6 +71,16 @@ Use this Docker `CMD`. This will start the proxy with 1 Uvicorn Async Worker
 CMD ["--port", "4000", "--config", "./proxy_server_config.yaml"]
 ```
 
+> Optional: If you observe gradual memory growth under sustained load, consider recycling workers after a fixed number of requests to mitigate leaks. Set this via CLI or environment variable:
+
+```shell
+# CLI
+CMD ["--port", "4000", "--config", "./proxy_server_config.yaml", "--max_requests_before_restart", "10000"]
+
+# or ENV (for deployment manifests / containers)
+export MAX_REQUESTS_BEFORE_RESTART=10000
+```
+
 
 ## 4. Use Redis 'port','host', 'password'. NOT 'redis_url'
 


### PR DESCRIPTION
## Title

Add proxy CLI option to recycle workers after N requests.

Have been observing potential memory leaks which are causing OOMs:
<img width="1220" height="672" alt="image" src="https://github.com/user-attachments/assets/4e40fc27-69c4-4458-902f-d85c4a5c4b98" />
Note that the memory is increasing for every worker until they OOM and restart (a few might be new deployments in this screenshot)

Have tried to look at the profiler but haven't found a definitive root cause.
To prevent OOMs interrupting requests, I would like to restart my workers gracefully until the memory issue is identified and solved.

Note: It's also possible that the leak occurs in my custom callback or other dependencies I added in my proxy (eg ddtrace).

## Relevant issues

Not directly related but could at least mitigate other OOM issues:
- https://github.com/BerriAI/litellm/issues/14540
- https://github.com/BerriAI/litellm/issues/13891
- https://github.com/BerriAI/litellm/issues/12685

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally:
<img width="1067" height="74" alt="image" src="https://github.com/user-attachments/assets/dfbcf5cc-d99e-4fa6-b75b-09e73e2f57a0" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - One failure, but unrelated test
<img width="875" height="345" alt="image" src="https://github.com/user-attachments/assets/bd597db5-5ea9-426a-bb76-07544befd176" />

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Added `--max_requests_before_restart` (env `MAX_REQUESTS_BEFORE_RESTART`) to proxy CLI.
- Uvicorn path sets `limit_max_requests`; Gunicorn path sets `max_requests`.
- Default is disabled (unset).