### PR TITLE
[Fix] response_format bug in hosted vllm audio_transcription

### DIFF
--- a/litellm/llms/hosted_vllm/transcriptions/transformation.py
+++ b/litellm/llms/hosted_vllm/transcriptions/transformation.py
@@ -60,13 +60,6 @@ class HostedVLLMAudioTranscriptionConfig(OpenAIWhisperAudioTranscriptionConfig):
 
         data = {"model": model, "file": audio_file, **optional_params}
 
-        if "response_format" not in data or (
-            data["response_format"] == "text" or data["response_format"] == "json"
-        ):
-            data["response_format"] = (
-                "verbose_json"  # ensures 'duration' is received - used for cost calculation
-            )
-
         return AudioTranscriptionRequestData(
             data=data,
         )


### PR DESCRIPTION
## Fix response_format bug in hosted vllm audio_transcription

<!-- e.g. "Implement user authentication feature" -->

In hosted_vllm, verbose_json was passed for response_format, but json and text are supported.

> response_format: Format of the response ("json", "text") (optional)
https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#transcriptions-api_1

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/14944
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

This is a minor change, so I didn't add test.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


