### PR TITLE
fix: set usage_details.total in langfuse integration

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -690,6 +690,7 @@ class LangFuseLogger:
                     }
                     usage_details = LangfuseUsageDetails(input=_usage_obj.prompt_tokens,
                                                         output=_usage_obj.completion_tokens,
+                                                        total=_usage_obj.total_tokens,
                                                         cache_creation_input_tokens=_usage_obj.get('cache_creation_input_tokens', 0),
                                                         cache_read_input_tokens=_usage_obj.get('cache_read_input_tokens', 0))
 

--- a/litellm/types/integrations/langfuse.py
+++ b/litellm/types/integrations/langfuse.py
@@ -12,5 +12,6 @@ class LangfuseLoggingConfig(TypedDict):
 class LangfuseUsageDetails(TypedDict):
     input: Optional[int]
     output: Optional[int]
+    total: Optional[int]
     cache_creation_input_tokens: Optional[int]
     cache_read_input_tokens: Optional[int]

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -109,6 +109,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         usage_details: LangfuseUsageDetails = {
             "input": 10,
             "output": 20,
+            "total": 30,
             "cache_creation_input_tokens": 5,
             "cache_read_input_tokens": 3
         }
@@ -116,6 +117,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         # Verify all fields are present
         self.assertEqual(usage_details["input"], 10)
         self.assertEqual(usage_details["output"], 20)
+        self.assertEqual(usage_details["total"], 30)
         self.assertEqual(usage_details["cache_creation_input_tokens"], 5)
         self.assertEqual(usage_details["cache_read_input_tokens"], 3)
 
@@ -123,12 +125,14 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         minimal_usage_details: LangfuseUsageDetails = {
             "input": 10,
             "output": 20,
+            "total": 30,
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0
         }
 
         self.assertEqual(minimal_usage_details["input"], 10)
         self.assertEqual(minimal_usage_details["output"], 20)
+        self.assertEqual(minimal_usage_details["total"], 30)
 
     def test_log_langfuse_v2_usage_details(self):
         """Test that usage_details in _log_langfuse_v2 is correctly typed and assigned"""
@@ -183,6 +187,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         usage_details: LangfuseUsageDetails = {
             "input": 10,
             "output": 20,
+            "total": 30,
             "cache_creation_input_tokens": None,
             "cache_read_input_tokens": None
         }
@@ -190,6 +195,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         # Verify fields can be None
         self.assertEqual(usage_details["input"], 10)
         self.assertEqual(usage_details["output"], 20)
+        self.assertEqual(usage_details["total"], 30)
         self.assertIsNone(usage_details["cache_creation_input_tokens"])
         self.assertIsNone(usage_details["cache_read_input_tokens"])
 
@@ -202,6 +208,7 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         usage_details = {
             "input": 15,
             "output": 25,
+            "total": 40,
             "cache_creation_input_tokens": 7,
             "cache_read_input_tokens": 4
         }
@@ -209,12 +216,14 @@ class TestLangfuseUsageDetails(unittest.TestCase):
         # Verify the structure matches what we expect
         self.assertIn("input", usage_details)
         self.assertIn("output", usage_details)
+        self.assertIn("total", usage_details)
         self.assertIn("cache_creation_input_tokens", usage_details)
         self.assertIn("cache_read_input_tokens", usage_details)
 
         # Verify the values
         self.assertEqual(usage_details["input"], 15)
         self.assertEqual(usage_details["output"], 25)
+        self.assertEqual(usage_details["total"], 40)
         self.assertEqual(usage_details["cache_creation_input_tokens"], 7)
         self.assertEqual(usage_details["cache_read_input_tokens"], 4)
 


### PR DESCRIPTION
## Title
Add `total` field to langfuse usage details for proper langfuse integration of total_tokens

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

I've modified the existing `tests/test_litellm/integrations/test_langfuse.py` to test the newly added total field and confirmed it passing. The failed tests are unrelated to this PR and seem to be due to uninstalled dependencies.
<img width="457" height="195" alt="Screenshot 2025-09-29 at 4 43 23 PM" src="https://github.com/user-attachments/assets/9c83f945-b630-4f9c-bdac-18e54bd432ee" />



## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
## Changes
Thanks to #10955, cached tokens are added to langfuse usage_details.

But as mentioned in the [langfuse docs](https://langfuse.com/docs/observability/features/token-and-cost-tracking), langfuse sums all values in usage_details if there is no `total` field which leads to double counting of cached tokens.

> If no total usage type is ingested, Langfuse sums up all usage type units to a total.

This PR fixes the issue by explicitly passing the total_tokens value to usage_details.total
|Before|After|
|-|-|
|cached tokens are double counted in total|cached tokens are counted once in total|
|<img width="256" height="301" alt="Screenshot 2025-09-29 at 4 31 15 PM" src="https://github.com/user-attachments/assets/3e23c64b-d369-4a11-87aa-8835c09517c4" />|<img width="257" height="324" alt="Screenshot 2025-09-29 at 4 37 03 PM" src="https://github.com/user-attachments/assets/8ef7dd0c-c445-4eb9-aedb-048543a0fce8" />|