### PR TITLE
Ignore type param for gemini tools

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3,7 +3,6 @@
 ## Initial implementation - covers gemini + image gen calls
 import json
 import time
-from litellm._uuid import uuid
 from copy import deepcopy
 from functools import partial
 from typing import (
@@ -25,6 +24,7 @@ import litellm
 import litellm.litellm_core_utils
 import litellm.litellm_core_utils.litellm_logging
 from litellm import verbose_logger
+from litellm._uuid import uuid
 from litellm.constants import (
     DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
@@ -32,8 +32,8 @@ from litellm.constants import (
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH,
-    DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_PRO,
     DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH_LITE,
+    DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_PRO,
 )
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.llms.custom_httpx.http_handler import (
@@ -313,9 +313,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 return None
 
         for tool in value:
-            openai_function_object: Optional[ChatCompletionToolParamFunctionChunk] = (
-                None
-            )
+            openai_function_object: Optional[
+                ChatCompletionToolParamFunctionChunk
+            ] = None
             if "function" in tool:  # tools list
                 _openai_function_object = ChatCompletionToolParamFunctionChunk(  # type: ignore
                     **tool["function"]
@@ -334,6 +334,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
             elif "name" in tool:  # functions list
                 openai_function_object = ChatCompletionToolParamFunctionChunk(**tool)  # type: ignore
+
+            # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
+            if "type" in tool:
+                del tool["type"]  # type: ignore
 
             tool_name = list(tool.keys())[0] if len(tool.keys()) == 1 else None
             if tool_name and (
@@ -437,7 +441,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif model and "gemini-2.5-pro" in model.lower():
                 budget = DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_PRO
             elif model and "gemini-2.5-flash" in model.lower():
-                budget = DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH
+                budget = (
+                    DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH
+                )
             else:
                 budget = DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET
 
@@ -621,16 +627,16 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif param == "seed":
                 optional_params["seed"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
-                optional_params["thinkingConfig"] = (
-                    VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
-                        value, model
-                    )
+                optional_params[
+                    "thinkingConfig"
+                ] = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+                    value, model
                 )
             elif param == "thinking":
-                optional_params["thinkingConfig"] = (
-                    VertexGeminiConfig._map_thinking_param(
-                        cast(AnthropicThinkingParam, value)
-                    )
+                optional_params[
+                    "thinkingConfig"
+                ] = VertexGeminiConfig._map_thinking_param(
+                    cast(AnthropicThinkingParam, value)
                 )
             elif param == "modalities" and isinstance(value, list):
                 response_modalities = self.map_response_modalities(value)
@@ -1066,7 +1072,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             GenerateContentResponseBody, BidiGenerateContentServerMessage
         ],
     ) -> Usage:
-
         if (
             completion_response is not None
             and "usageMetadata" not in completion_response
@@ -1502,28 +1507,28 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             ## ADD METADATA TO RESPONSE ##
 
             setattr(model_response, "vertex_ai_grounding_metadata", grounding_metadata)
-            model_response._hidden_params["vertex_ai_grounding_metadata"] = (
-                grounding_metadata
-            )
+            model_response._hidden_params[
+                "vertex_ai_grounding_metadata"
+            ] = grounding_metadata
 
             setattr(
                 model_response, "vertex_ai_url_context_metadata", url_context_metadata
             )
 
-            model_response._hidden_params["vertex_ai_url_context_metadata"] = (
-                url_context_metadata
-            )
+            model_response._hidden_params[
+                "vertex_ai_url_context_metadata"
+            ] = url_context_metadata
 
             setattr(model_response, "vertex_ai_safety_results", safety_ratings)
-            model_response._hidden_params["vertex_ai_safety_results"] = (
-                safety_ratings  # older approach - maintaining to prevent regressions
-            )
+            model_response._hidden_params[
+                "vertex_ai_safety_results"
+            ] = safety_ratings  # older approach - maintaining to prevent regressions
 
             ## ADD CITATION METADATA ##
             setattr(model_response, "vertex_ai_citation_metadata", citation_metadata)
-            model_response._hidden_params["vertex_ai_citation_metadata"] = (
-                citation_metadata  # older approach - maintaining to prevent regressions
-            )
+            model_response._hidden_params[
+                "vertex_ai_citation_metadata"
+            ] = citation_metadata  # older approach - maintaining to prevent regressions
 
         except Exception as e:
             raise VertexAIError(

--- a/tests/test_litellm/llms/vertex_ai/test_vertex.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex.py
@@ -199,6 +199,61 @@ def test_vertex_function_translation(tool, expect_parameters):
         )
 
 
+def test_vertex_tool_type_field_removal():
+    """
+    Test that the 'type' field is removed from tools during processing
+    to avoid issues with Vertex AI API while maintaining functionality.
+    """
+    # Test with Google Search tool that has 'type' field
+    tools_with_type = [{"type": "google_search", "googleSearch": {}}]
+    
+    optional_params = get_optional_params(
+        model="gemini-1.5-pro",
+        custom_llm_provider="vertex_ai",
+        tools=tools_with_type,
+    )
+    
+    # Verify the tool is processed correctly
+    assert "tools" in optional_params
+    assert len(optional_params["tools"]) == 1
+    assert "googleSearch" in optional_params["tools"][0]
+    assert optional_params["tools"][0]["googleSearch"] == {}
+    
+    # Verify the 'type' field is not present in the final result
+    assert "type" not in optional_params["tools"][0]
+    
+    # Test with function tool that has 'type' field
+    function_tools_with_type = [
+        {
+            "type": "function",
+            "function": {
+                "name": "test_function",
+                "description": "A test function",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"param": {"type": "string"}}
+                }
+            }
+        }
+    ]
+    
+    optional_params_function = get_optional_params(
+        model="gemini-1.5-pro",
+        custom_llm_provider="vertex_ai",
+        tools=function_tools_with_type,
+    )
+    
+    # Verify function tool is processed correctly
+    assert "tools" in optional_params_function
+    assert len(optional_params_function["tools"]) == 1
+    assert "function_declarations" in optional_params_function["tools"][0]
+    assert len(optional_params_function["tools"][0]["function_declarations"]) == 1
+    assert optional_params_function["tools"][0]["function_declarations"][0]["name"] == "test_function"
+    
+    # Verify the 'type' field is not present in the final result
+    assert "type" not in optional_params_function["tools"][0]
+
+
 def test_function_calling_with_gemini():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 


### PR DESCRIPTION
## Title

Remove redundant 'type' field handling in Vertex AI Gemini tool processing

## Relevant issues

Fixes #14644

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

### Summary
This PR removes redundant `type` field handling in the Vertex AI Gemini tool processing logic. The `type` field was being used for tool identification but was unnecessary since tools are already identified by their specific keys (e.g., `googleSearch`, `codeExecution`) or by the presence of `function`/`name` fields.

### What Changed
- **File**: `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
- **Method**: `VertexGeminiConfig._map_function()`
- **Change**: Simplified tool processing by removing the `type` field handling logic (lines 339-350) and instead directly removing the `type` field if present

<img width="1465" height="943" alt="image" src="https://github.com/user-attachments/assets/357ad360-ef94-42f7-8550-fd8908d56616" />


This is a safe, non-breaking refactoring that simplifies the codebase while maintaining full functionality.

