### PR TITLE
docs: use docker compose instead of docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ echo 'LITELLM_SALT_KEY="sk-1234"' >> .env
 source .env
 
 # Start
-docker-compose up
+docker compose up
 ```
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,7 @@ Replace `your-secret-key` with a strong, randomly generated secret.
 Once you have set the `MASTER_KEY`, you can build and run the containers using the following command:
 
 ```bash
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 This command will:
@@ -42,13 +42,13 @@ This command will:
 You can check the status of the running containers with the following command:
 
 ```bash
-docker-compose ps
+docker compose ps
 ```
 
 To view the logs of the `litellm` container, run:
 
 ```bash
-docker-compose logs -f litellm
+docker compose logs -f litellm
 ```
 
 ### 4. Stopping the Application
@@ -56,7 +56,7 @@ docker-compose logs -f litellm
 To stop the running containers, use the following command:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 ## Troubleshooting

--- a/docs/my-website/docs/proxy/deploy.md
+++ b/docs/my-website/docs/proxy/deploy.md
@@ -27,7 +27,7 @@ echo 'LITELLM_SALT_KEY="sk-1234"' >> .env
 source .env
 
 # Start
-docker-compose up
+docker compose up
 ```
 
 

--- a/docs/my-website/docs/proxy/docker_quick_start.md
+++ b/docs/my-website/docs/proxy/docker_quick_start.md
@@ -55,7 +55,7 @@ echo 'LITELLM_SALT_KEY="sk-1234"' >> .env
 source .env
 
 # Start
-docker-compose up
+docker compose up
 ```
 
 </TabItem>


### PR DESCRIPTION
## Title

docs: replace docker-compose with docker compose

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

- Updated documentation references from docker-compose to Compose-v2 flavored `docker compose` syntax. As suggested by docker documentation <https://docs.docker.com/compose/releases/migrate/>
- No code or tests affected.



