### PR TITLE
fix: use extra_query for download results (Batch API)

### DIFF
--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -31,6 +31,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_body,
+    get_custom_llm_provider_from_request_query,
 )
 from litellm.proxy.utils import ProxyLogging, is_known_model
 from litellm.router import Router
@@ -237,6 +238,7 @@ async def create_file(
         file_content = await file.read()
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
@@ -425,6 +427,7 @@ async def get_file_content(
 
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
@@ -591,6 +594,7 @@ async def get_file(
     try:
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
@@ -733,6 +737,7 @@ async def delete_file(
     try:
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
@@ -917,6 +922,7 @@ async def list_files(
         else:
             custom_llm_provider = (
                 provider
+                or get_custom_llm_provider_from_request_query(request=request)
                 or await get_custom_llm_provider_from_request_body(request=request)
                 or "openai"
             )


### PR DESCRIPTION
## Title
Fix for Batch API download results - use `extra_query` param for GET/DELETE requests in Files endpoints

## Relevant issues

Related to #14940 (applies same approach to Files endpoints as in PR #14997)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- For OpenAI-compatible Files endpoints, GET/DELETE requests ignore request bodies. Passing custom_llm_provider via `extra_body` led the proxy to default to OpenAI, which then required OPENAI_API_KEY even for Azure

- Solution: Mirrors the approach from PR #14997 by parsing `custom_llm_provider` from query params for GET/DELETE endpoints required to download results via `client.files.content(...)`.
