### PR TITLE
fix: resolve regression with duplicate Mcp-Protocol-Version header

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -194,7 +194,7 @@ class MCPClient:
 
     def _get_auth_headers(self) -> dict:
         """Generate authentication headers based on auth type."""
-        headers = {"MCP-Protocol-Version": "2025-06-18"}
+        headers = {}
 
         if self._mcp_auth_value:
             if isinstance(self._mcp_auth_value, str):

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -44,7 +44,6 @@ class TestMCPClientUnitTests:
         headers = client._get_auth_headers()
         assert headers == {
             "Authorization": "Bearer test_token",
-            "MCP-Protocol-Version": "2025-06-18",
         }
 
         # Basic auth
@@ -55,7 +54,6 @@ class TestMCPClientUnitTests:
         headers = client._get_auth_headers()
         assert headers == {
             "Authorization": f"Basic {expected_encoded}",
-            "MCP-Protocol-Version": "2025-06-18",
         }
 
         # API key
@@ -65,7 +63,6 @@ class TestMCPClientUnitTests:
         headers = client._get_auth_headers()
         assert headers == {
             "X-API-Key": "api_key_123",
-            "MCP-Protocol-Version": "2025-06-18",
         }
 
         # Custom authorization header
@@ -77,13 +74,12 @@ class TestMCPClientUnitTests:
         headers = client._get_auth_headers()
         assert headers == {
             "Authorization": "Token custom_token",
-            "MCP-Protocol-Version": "2025-06-18",
         }
 
         # No auth
         client = MCPClient("http://example.com")
         headers = client._get_auth_headers()
-        assert headers == {"MCP-Protocol-Version": "2025-06-18"}
+        assert headers == {}
 
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.streamablehttp_client")
@@ -112,7 +108,6 @@ class TestMCPClientUnitTests:
         call_args = mock_transport.call_args
         assert call_args[1]["headers"] == {
             "Authorization": "Bearer test_token",
-            "MCP-Protocol-Version": "2025-06-18",
         }
 
         # Verify session was initialized


### PR DESCRIPTION
## Title

fix: resolve regression with duplicate Mcp-Protocol-Version header

## Relevant issues

#14695

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

It seems that the regression was inadvertently introduced in commit 1e20e56715664cc70f2121cd09bd83a72c5614ee.
