### PR TITLE
[Feat] Return Cost for Responses API Streaming requests

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -42,6 +42,7 @@ guardrails:
 
 litellm_settings:
   callbacks: ["datadog"]
+  include_cost_in_streaming_usage: true
   datadog_params:
     turn_off_message_logging: true
   datadog_llm_observability_params:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -851,8 +851,15 @@ class LiteLLMCompletionResponsesConfig:
                 output_tokens=0,
                 total_tokens=0,
             )
-        return ResponseAPIUsage(
+        
+        response_usage = ResponseAPIUsage(
             input_tokens=usage.prompt_tokens,
             output_tokens=usage.completion_tokens,
             total_tokens=usage.total_tokens,
         )
+        
+        # Preserve cost field if it exists (for streaming usage with cost calculation)
+        if hasattr(usage, "cost") and usage.cost is not None:
+            setattr(response_usage, "cost", usage.cost)
+        
+        return response_usage

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 import httpx
 
+import litellm
 from litellm.constants import STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -13,6 +14,7 @@ from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfi
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
     OutputTextDeltaEvent,
+    ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
@@ -95,6 +97,20 @@ class BaseResponsesAPIStreamingIterator:
                     == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
                 ):
                     self.completed_response = openai_responses_api_chunk
+                    # Add cost to usage object if include_cost_in_streaming_usage is True
+                    if litellm.include_cost_in_streaming_usage and self.logging_obj is not None:
+                        response_obj: Optional[ResponsesAPIResponse] = getattr(openai_responses_api_chunk, "response", None)
+                        if response_obj:
+                            usage_obj: Optional[ResponseAPIUsage] = getattr(response_obj, "usage", None)
+                            if usage_obj is not None:
+                                try:
+                                    cost: Optional[float] = self.logging_obj._response_cost_calculator(result=response_obj)
+                                    if cost is not None:
+                                        setattr(usage_obj, "cost", cost)
+                                except Exception:
+                                    # If cost calculation fails, continue without cost
+                                    pass
+                    
                     self._handle_logging_completed_response()
 
                 return openai_responses_api_chunk

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -44,7 +44,7 @@ from openai.types.responses.response import (
 # Handle OpenAI SDK version compatibility for Text type
 try:
     # fmt: off
-    from openai.types.responses.response_create_params import ( # type: ignore[attr-defined]
+    from openai.types.responses.response_create_params import (
         Text as ResponseText,  # type: ignore[attr-defined]
     )
 
@@ -1032,6 +1032,9 @@ class ResponseAPIUsage(BaseLiteLLMOpenAIResponseObject):
 
     total_tokens: int
     """The total number of tokens used."""
+
+    cost: Optional[float] = None
+    """The cost of the request."""
 
     model_config = {"extra": "allow"}
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -44,7 +44,7 @@ from openai.types.responses.response import (
 # Handle OpenAI SDK version compatibility for Text type
 try:
     # fmt: off
-    from openai.types.responses.response_create_params import (
+    from openai.types.responses.response_create_params import ( # type: ignore[attr-defined]
         Text as ResponseText,  # type: ignore[attr-defined]
     )
 

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -146,6 +146,8 @@ class BaseResponsesAPITest(ABC):
     @pytest.mark.flaky(retries=3, delay=2)
     async def test_basic_openai_responses_api_streaming(self, sync_mode):
         litellm._turn_on_debug()
+        # Enable cost calculation for streaming usage
+        litellm.include_cost_in_streaming_usage = True
         base_completion_call_args = self.get_base_completion_call_args()
         collected_content_string = ""
         response_completed_event = None
@@ -207,6 +209,14 @@ class BaseResponsesAPITest(ABC):
             == response_completed_event.response.usage.input_tokens
             + response_completed_event.response.usage.output_tokens
         )
+
+        # assert the response completed event includes cost when include_cost_in_streaming_usage is True
+        assert hasattr(response_completed_event.response.usage, "cost"), "Cost should be included in streaming responses API usage object"
+        assert response_completed_event.response.usage.cost > 0, "Cost should be greater than 0"
+        print(f"Cost found in streaming response: {response_completed_event.response.usage.cost}")
+        
+        # Reset the setting
+        litellm.include_cost_in_streaming_usage = False
 
     @pytest.mark.parametrize("sync_mode", [False, True])
     @pytest.mark.asyncio


### PR DESCRIPTION
## [Feat] Return Cost for Responses API Streaming requests

Fixes LIT-1026


- Cost calling anthropic models 
<img width="1639" height="379" alt="Screenshot 2025-09-29 at 7 07 34 PM" src="https://github.com/user-attachments/assets/674dc2e3-6987-4e0f-8d02-792e0ba0cf05" />

- Cost calling openai models 
<img width="1728" height="677" alt="Screenshot 2025-09-29 at 7 08 58 PM" src="https://github.com/user-attachments/assets/18008fb1-0387-4ead-a32d-5e0e3b5dadbe" />



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


