### PR TITLE
Fix OCI Generative AI  Integration when using Proxy

### DIFF
--- a/docs/my-website/docs/providers/oci.md
+++ b/docs/my-website/docs/providers/oci.md
@@ -44,6 +44,7 @@ response = completion(
     oci_user=<your_oci_user>,
     oci_fingerprint=<your_oci_fingerprint>,
     oci_tenancy=<your_oci_tenancy>,
+    oci_serving_mode="ON_DEMAND",  # Optional, default is "ON_DEMAND". Other option is "DEDICATED"
     # Provide either the private key string OR the path to the key file:
     # Option 1: pass the private key as a string
     oci_key=<string_with_content_of_oci_key>,
@@ -71,6 +72,7 @@ response = completion(
     oci_user=<your_oci_user>,
     oci_fingerprint=<your_oci_fingerprint>,
     oci_tenancy=<your_oci_tenancy>,
+    oci_serving_mode="ON_DEMAND",  # Optional, default is "ON_DEMAND". Other option is "DEDICATED"
     # Provide either the private key string OR the path to the key file:
     # Option 1: pass the private key as a string
     oci_key=<string_with_content_of_oci_key>,

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -615,11 +615,6 @@ class OCIChatConfig(BaseConfig):
         if "stream" in data:
             del data["stream"]
 
-        stops = data.get("chatRequest", {}).get("stop")
-        if stops and len(stops) > 8:
-            # mantém apenas os 8 primeiros
-            data["chatRequest"]["stop"] = stops[:8]
-
         if client is None or isinstance(client, HTTPHandler):
             client = get_async_httpx_client(llm_provider=LlmProviders.BYTEZ, params={})
 

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -208,8 +208,8 @@ class OCIChatConfig(BaseConfig):
 
             if alias is False:
                 # Workaround for mypy issue
-                #if drop_params:
-                continue
+                if drop_params or litellm.drop_params:
+                    continue
                 raise Exception(f"param `{key}` is not supported on OCI")
 
             if alias is None:

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -207,9 +207,9 @@ class OCIChatConfig(BaseConfig):
             alias = open_ai_to_oci_param_map.get(key)
 
             if alias is False:
-                if drop_params:
-                    continue
-
+                # Workaround for mypy issue
+                #if drop_params:
+                continue
                 raise Exception(f"param `{key}` is not supported on OCI")
 
             if alias is None:
@@ -450,12 +450,26 @@ class OCIChatConfig(BaseConfig):
                 "Cohere models are not yet supported in the litellm OCI chat completion endpoint. Use the Cohere API directly."
             )
         else:
-            data = OCICompletionPayload(
-                compartmentId=oci_compartment_id,
-                servingMode=OCIServingMode(
+            oci_serving_mode = optional_params.get("oci_serving_mode", "ON_DEMAND")
+            if oci_serving_mode not in ["ON_DEMAND", "DEDICATED"]:
+                raise Exception(
+                    "kwarg `oci_serving_mode` must be either 'ON_DEMAND' or 'DEDICATED'"
+                )
+
+            if oci_serving_mode == "DEDICATED":
+                servingMode = OCIServingMode(
+                    servingType="DEDICATED",
+                    endpointId=model,
+                )
+            else:
+                servingMode = OCIServingMode(
                     servingType="ON_DEMAND",
                     modelId=model,
-                ),
+                )
+
+            data = OCICompletionPayload(
+                compartmentId=oci_compartment_id,
+                servingMode=servingMode,
                 chatRequest=OCIChatRequestPayload(
                     apiFormat=vendor.value,
                     messages=adapt_messages_to_generic_oci_standard(messages),
@@ -600,6 +614,11 @@ class OCIChatConfig(BaseConfig):
     ) -> "OCIStreamWrapper":
         if "stream" in data:
             del data["stream"]
+
+        stops = data.get("chatRequest", {}).get("stop")
+        if stops and len(stops) > 8:
+            # mantém apenas os 8 primeiros
+            data["chatRequest"]["stop"] = stops[:8]
 
         if client is None or isinstance(client, HTTPHandler):
             client = get_async_httpx_client(llm_provider=LlmProviders.BYTEZ, params={})

--- a/litellm/types/llms/oci.py
+++ b/litellm/types/llms/oci.py
@@ -100,8 +100,8 @@ class OCIServingMode(BaseModel):
     """Defines the serving mode and the model to be used."""
 
     servingType: str
-    modelId: str
-
+    endpointId: Optional[str] = None
+    modelId: Optional[str] = None
 
 class OCICompletionPayload(BaseModel):
     """Pydantic model for the complete OCI chat request body."""
@@ -129,7 +129,7 @@ class OCIPromptTokensDetails(BaseModel):
 
 class OCIResponseUsage(BaseModel):
     """Token usage in the OCI response."""
-    
+
     promptTokens: int
     completionTokens: int
     totalTokens: int


### PR DESCRIPTION
## Fix OCI Generative AI Integration when using Proxy

## Relevant issues

* OCI Generative AI provides two serving options: Dedicated and On-Demand. This PR adds support for the Dedicated option.
* The drop parameter is currently not working (at least in this version). I removed its validation for now, but I can reintroduce it once the LiteLLM team resolves the issue.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


