### PR TITLE
Make UI theme settings publicly accessible for custom branding

### DIFF
--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -539,13 +539,15 @@ async def update_sso_settings(sso_config: SSOConfig):
 @router.get(
     "/get/ui_theme_settings",
     tags=["UI Theme Settings"],
-    dependencies=[Depends(user_api_key_auth)],
     response_model=UIThemeSettingsResponse,
 )
 async def get_ui_theme_settings():
     """
     Get UI theme configuration from the litellm_settings.
     Returns current logo settings for UI customization.
+
+    Note: This endpoint is public (no authentication required) so all users can see custom branding.
+    Only the /update/ui_theme_settings endpoint requires authentication for admins to change settings.
     """
     from litellm.proxy.proxy_server import proxy_config
 

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -25,34 +25,33 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
 
   // Load logo URL from backend on mount
+  // Note: /get/ui_theme_settings is now a public endpoint (no auth required)
+  // so all users can see custom branding set by admins
   useEffect(() => {
     const loadLogoSettings = async () => {
-      if (accessToken) {
-        try {
-          const proxyBaseUrl = getProxyBaseUrl();
-          const url = proxyBaseUrl ? `${proxyBaseUrl}/get/ui_theme_settings` : '/get/ui_theme_settings';
-          const response = await fetch(url, {
-            method: 'GET',
-            headers: {
-              'Authorization': `Bearer ${accessToken}`,
-              'Content-Type': 'application/json',
-            },
-          });
-          
-          if (response.ok) {
-            const data = await response.json();
-            if (data.values?.logo_url) {
-              setLogoUrl(data.values.logo_url);
-            }
+      try {
+        const proxyBaseUrl = getProxyBaseUrl();
+        const url = proxyBaseUrl ? `${proxyBaseUrl}/get/ui_theme_settings` : '/get/ui_theme_settings';
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.values?.logo_url) {
+            setLogoUrl(data.values.logo_url);
           }
-        } catch (error) {
-          console.warn('Failed to load logo settings from backend:', error);
         }
+      } catch (error) {
+        console.warn('Failed to load logo settings from backend:', error);
       }
     };
-    
+
     loadLogoSettings();
-  }, [accessToken]);
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ logoUrl, setLogoUrl }}>


### PR DESCRIPTION
## Title

Fix: Make UI theme settings publicly accessible for custom branding

## Relevant issues

Fixes #15073 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
<img width="838" height="346" alt="image" src="https://github.com/user-attachments/assets/f9322fef-02b8-4408-9da7-3f014af67bb6" />

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🐛 Bug Fix

## Changes

  Backend:
  - Removed authentication requirement from /get/ui_theme_settings endpoint to allow public access
  - /update/ui_theme_settings and /upload/logo remain protected (admin-only)

  Frontend:
  - Removed access token check from ThemeContext to load logos for all users
  - Removed Authorization header from theme settings fetch request

