### PR TITLE
[Fix Security] Ensure OCI secret fields not shared on /models and /v1/models endpoints

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -21,6 +21,8 @@ class SensitiveDataMasker:
             "access",
             "private",
             "certificate",
+            "fingerprint",
+            "tenancy",
         }
 
         self.visible_prefix = visible_prefix

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -6,7 +6,10 @@ from typing import Optional
 
 from fastapi import Request
 
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
+
+SENSITIVE_DATA_MASKER = SensitiveDataMasker()
 
 
 def remove_sensitive_info_from_deployment(deployment_dict: dict) -> dict:
@@ -24,6 +27,8 @@ def remove_sensitive_info_from_deployment(deployment_dict: dict) -> dict:
     deployment_dict["litellm_params"].pop("vertex_credentials", None)
     deployment_dict["litellm_params"].pop("aws_access_key_id", None)
     deployment_dict["litellm_params"].pop("aws_secret_access_key", None)
+
+    deployment_dict["litellm_params"] = SENSITIVE_DATA_MASKER.mask_dict(deployment_dict["litellm_params"])
 
     return deployment_dict
 


### PR DESCRIPTION
## [Fix Security] Ensure OCI secret fields not shared on /models and /v1/models endpoints

<img width="1021" height="551" alt="Screenshot 2025-09-30 at 1 47 58 PM" src="https://github.com/user-attachments/assets/6401b9d8-2070-4f39-a057-edc7c93868c6" />

The following oci secret fields were leaked on /models - this is now fixed 


Below is an example config.yaml 
```yaml
  - model_name: "grok-4"
    model_info:
      mode: completion
    litellm_params:
      model: oci/xai.grok-4
      oci_key: ocid1.api_key.oc1..aaaaaaaa7kbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbk
      oci_region: us-phoenix-1
      oci_user: ocid1.user.oc1..aaaaaaaa7kbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbk
      oci_fingerprint: aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99:00
      oci_tenancy: ocid1.tenancy.oc1..aaaaaaaa7kbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbk
      oci_key_file: /path/to/oci_api_key.pem
      oci_compartment_id: ocid1.compartment.oc1..aaaaaaaa7kbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbkbk
      drop_params: True
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


