### PR TITLE
[Bug Fix] Passthrough API Endpoints - Ensure query params are forwarded from origin url to downstream request

### DIFF
--- a/litellm/proxy/example_config_yaml/pass_through_config.yaml
+++ b/litellm/proxy/example_config_yaml/pass_through_config.yaml
@@ -27,3 +27,8 @@ model_list:
 general_settings: 
   master_key: sk-1234 
   custom_auth: custom_auth_basic.user_api_key_auth
+  pass_through_endpoints:
+    - path: "/azure-config-passthrough"
+      target: os.environ/AZURE_API_BASE
+      headers:
+        Authorization: os.environ/AZURE_API_KEY

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -688,10 +688,8 @@ async def pass_through_request(  # noqa: PLR0915
 
         # combine url with query params for logging
         requested_query_params: Optional[dict] = (
-            query_params or request.query_params.__dict__
+            query_params or dict(request.query_params)
         )
-        if requested_query_params == request.query_params.__dict__:
-            requested_query_params = None
 
         requested_query_params_str = None
         if requested_query_params:

--- a/tests/pass_through_tests/test_openai_assistants_passthrough.py
+++ b/tests/pass_through_tests/test_openai_assistants_passthrough.py
@@ -96,3 +96,37 @@ def test_openai_assistants_e2e_operations_stream():
         event_handler=EventHandler(),
     ) as stream:
         stream.until_done()
+
+
+
+def test_azure_openai_assistants_e2e_operations_stream():
+    client = openai.OpenAI(base_url="http://0.0.0.0:4000/azure-config-passthrough", api_key="sk-1234")
+    assistant = client.beta.assistants.create(
+        name="Math Tutor",
+        instructions="You are a personal math tutor. Write and run code to answer math questions.",
+        tools=[{"type": "code_interpreter"}],
+        model="gpt-4o",
+    )
+    print("assistant created", assistant)
+
+    thread = client.beta.threads.create()
+    print("thread created", thread)
+
+    message = client.beta.threads.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content="I need to solve the equation `3x + 11 = 14`. Can you help me?",
+    )
+    print("message created", message)
+
+    # Then, we use the `stream` SDK helper
+    # with the `EventHandler` class to create the Run
+    # and stream the response.
+
+    with client.beta.threads.runs.stream(
+        thread_id=thread.id,
+        assistant_id=assistant.id,
+        instructions="Please address the user as Jane Doe. The user has a premium account.",
+        event_handler=EventHandler(),
+    ) as stream:
+        stream.until_done()


### PR DESCRIPTION
## [Bug Fix] Passthrough API Endpoints - Ensure query params are forwarded from origin url to downstream request

Problem: Query parameters (like api-version=2025-01-01-preview) were being dropped when forwarding requests through LiteLLM proxy pass-through endpoints to Azure OpenAI and other providers.

Buggy logic in pass_through_request() function that incorrectly nullified query parameters:

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


