### PR TITLE
Standardize guardrail and status reporting

### DIFF
--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -14,6 +14,7 @@ Found under `kwargs["standard_logging_object"]`. This is a standard payload, log
 | `cost_breakdown` | `Optional[CostBreakdown]` | Detailed cost breakdown object |
 | `response_cost_failure_debug_info` | `StandardLoggingModelCostFailureDebugInformation` | Debug information if cost tracking fails |
 | `status` | `StandardLoggingPayloadStatus` | Status of the payload |
+| `status_fields` | `StandardLoggingPayloadStatusFields` | Boolean status fields for easy filtering and troubleshooting |
 | `total_tokens` | `int` | Total number of tokens |
 | `prompt_tokens` | `int` | Number of prompt tokens |
 | `completion_tokens` | `int` | Number of completion tokens |
@@ -173,6 +174,45 @@ A literal type with two possible values:
 | `end_time` | `Optional[float]` | End time of the guardrail |
 | `duration` | `Optional[float]` | Duration of the guardrail in seconds |
 | `masked_entity_count` | `Optional[Dict[str, int]]` | Count of masked entities |
+
+## StandardLoggingPayloadStatusFields
+
+Boolean status fields for easy filtering and analytics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_guardrail_failed` | `bool` | `true` if any guardrail had a technical failure/error |
+| `is_guardrail_intervened` | `bool` | `true` if any guardrail blocked or modified content due to policy violations |
+| `is_llm_request_successful` | `bool` | `true` if the underlying LLM request completed successfully (regardless of guardrails) |
+
+### Usage Examples
+
+Filter logs for requests where guardrails intervened:
+```json
+{
+  "status_fields": {
+    "is_guardrail_intervened": true
+  }
+}
+```
+
+Find guardrail technical failures:
+```json
+{
+  "status_fields": {
+    "is_guardrail_failed": true
+  }
+}
+```
+
+Get successful LLM requests (ignoring guardrail status):
+```json
+{
+  "status_fields": {
+    "is_llm_request_successful": true
+  }
+}
+```
 
 ## StandardLoggingPromptManagementMetadata
 

--- a/docs/my-website/docs/proxy/logging_spec.md
+++ b/docs/my-website/docs/proxy/logging_spec.md
@@ -168,7 +168,7 @@ A literal type with two possible values:
 | `guardrail_mode` | `Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks]]]` | Guardrail mode |
 | `guardrail_request` | `Optional[dict]` | Guardrail request |
 | `guardrail_response` | `Optional[Union[dict, str, List[dict]]]` | Guardrail response |
-| `guardrail_status` | `Literal["success", "failure"]` | Guardrail status |
+| `guardrail_status` | `Literal["success", "failure", "blocked"]` | Guardrail execution status: `success` = no violations detected, `blocked` = content blocked/modified due to policy violations, `failure` = technical error or API failure |
 | `start_time` | `Optional[float]` | Start time of the guardrail |
 | `end_time` | `Optional[float]` | End time of the guardrail |
 | `duration` | `Optional[float]` | Duration of the guardrail in seconds |

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2082,6 +2082,16 @@ class CostBreakdown(TypedDict):
     tool_usage_cost: float  # Cost of usage of built-in tools
 
 
+class StandardLoggingPayloadStatusFields(TypedDict, total=False):
+    """Boolean status fields for easy filtering and analytics"""
+    is_guardrail_failed: bool
+    """True if any guardrail had a technical failure/error"""
+    is_guardrail_intervened: bool  
+    """True if any guardrail blocked or modified content due to policy violations"""
+    is_llm_request_successful: bool
+    """True if the underlying LLM request completed successfully (regardless of guardrails)"""
+
+
 class StandardLoggingPayload(TypedDict):
     id: str
     trace_id: str  # Trace multiple LLM calls belonging to same overall request (e.g. fallbacks/retries)
@@ -2093,6 +2103,8 @@ class StandardLoggingPayload(TypedDict):
         StandardLoggingModelCostFailureDebugInformation
     ]
     status: StandardLoggingPayloadStatus
+    status_fields: StandardLoggingPayloadStatusFields
+    """Boolean status fields for easy filtering and troubleshooting"""
     custom_llm_provider: Optional[str]
     total_tokens: int
     prompt_tokens: int

--- a/tests/guardrails_tests/test_guardrail_status_consistency.py
+++ b/tests/guardrails_tests/test_guardrail_status_consistency.py
@@ -1,0 +1,263 @@
+"""
+Test guardrail status consistency across NOMA and Bedrock providers.
+
+This test validates that both providers return consistent status values:
+- "success": Guardrail completed successfully with no violations
+- "blocked": Guardrail detected violations and intervened  
+- "failure": Technical error or API failure
+
+Tests cover:
+1. Successful guardrail checks (no violations)
+2. Blocked requests (content violations)
+3. Technical failures (API errors)
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+import json
+from datetime import datetime
+
+from litellm.proxy.guardrails.guardrail_hooks.noma.noma import NomaGuardrail
+from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockGuardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import StandardLoggingGuardrailInformation
+import httpx
+
+
+class TestGuardrailStatusConsistency:
+    """Test guardrail status consistency across providers."""
+
+    @pytest.fixture
+    def mock_user_auth(self):
+        """Mock user authentication."""
+        return UserAPIKeyAuth(
+            user_id="test_user",
+            team_id="test_team",
+            api_key="test_key"
+        )
+
+    @pytest.fixture
+    def mock_request_data(self):
+        """Mock request data."""
+        return {
+            "messages": [
+                {"role": "user", "content": "Hello, how are you?"}
+            ],
+            "metadata": {}
+        }
+
+    def test_noma_success_status(self, mock_user_auth, mock_request_data):
+        """Test NOMA returns 'success' status for allowed content."""
+        # Test the status determination logic directly
+        noma = NomaGuardrail(api_key="test_key")
+        
+        # Mock successful response (verdict: true)
+        response_json = {
+            "verdict": True,
+            "originalResponse": {
+                "prompt": {
+                    "harmfulContent": {"result": False, "confidence": 0.1}
+                }
+            }
+        }
+        
+        status = noma._determine_guardrail_status(response_json)
+        assert status == "success"
+
+    def test_noma_blocked_status(self, mock_user_auth, mock_request_data):
+        """Test NOMA returns 'blocked' status for flagged content."""
+        noma = NomaGuardrail(api_key="test_key")
+        
+        # Mock blocked response (verdict: false)
+        response_json = {
+            "verdict": False,
+            "originalResponse": {
+                "prompt": {
+                    "harmfulContent": {"result": True, "confidence": 0.95}
+                }
+            }
+        }
+        
+        status = noma._determine_guardrail_status(response_json)
+        assert status == "blocked"
+
+    def test_noma_failure_status(self, mock_user_auth, mock_request_data):
+        """Test NOMA returns 'failure' status for invalid responses."""
+        noma = NomaGuardrail(api_key="test_key")
+        
+        # Test various failure scenarios
+        test_cases = [
+            {},  # Empty response
+            {"verdict": None},  # Null verdict
+            "invalid",  # Non-dict response
+            None,  # None response
+        ]
+        
+        for test_case in test_cases:
+            status = noma._determine_guardrail_status(test_case)
+            assert status == "failure"
+
+    def test_bedrock_success_status(self):
+        """Test Bedrock returns 'success' status for allowed content."""
+        bedrock = BedrockGuardrail(
+            guardrailIdentifier="test-id",
+            guardrailVersion="1.0"
+        )
+        
+        # Mock successful HTTP response with no intervention
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "action": "NONE",
+            "assessments": []
+        }
+        
+        status = bedrock._get_bedrock_guardrail_response_status(mock_response)
+        assert status == "success"
+
+    def test_bedrock_blocked_status(self):
+        """Test Bedrock returns 'blocked' status when guardrail intervenes."""
+        bedrock = BedrockGuardrail(
+            guardrailIdentifier="test-id", 
+            guardrailVersion="1.0"
+        )
+        
+        # Mock HTTP response with guardrail intervention
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "action": "GUARDRAIL_INTERVENED",
+            "assessments": [
+                {
+                    "topicPolicy": {
+                        "topics": [
+                            {"action": "BLOCKED", "type": "VIOLENCE"}
+                        ]
+                    }
+                }
+            ]
+        }
+        
+        status = bedrock._get_bedrock_guardrail_response_status(mock_response)
+        assert status == "blocked"
+
+    def test_bedrock_failure_status(self):
+        """Test Bedrock returns 'failure' status for API errors."""
+        bedrock = BedrockGuardrail(
+            guardrailIdentifier="test-id",
+            guardrailVersion="1.0"
+        )
+        
+        # Test various failure scenarios
+        failure_cases = [
+            # HTTP error status codes
+            Mock(status_code=400),
+            Mock(status_code=500),
+            Mock(status_code=403),
+            # Exception during JSON parsing
+            Mock(status_code=200, json=Mock(side_effect=Exception("JSON error"))),
+            # Exception response in payload
+            Mock(status_code=200, json=Mock(return_value={
+                "Output": {"__type": "SomeException"}
+            }))
+        ]
+        
+        for mock_response in failure_cases:
+            status = bedrock._get_bedrock_guardrail_response_status(mock_response)
+            assert status == "failure"
+
+    @pytest.mark.asyncio
+    async def test_noma_logs_guardrail_information(self, mock_user_auth, mock_request_data):
+        """Test NOMA consistently logs guardrail information."""
+        noma = NomaGuardrail(api_key="test_key", monitor_mode=False)
+        
+        # Mock the API call to return a successful response
+        with patch.object(noma, '_call_noma_api', new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {
+                "verdict": True,
+                "originalResponse": {"prompt": {}}
+            }
+            
+            # Mock the verdict check to not raise exceptions
+            with patch.object(noma, '_check_verdict', new_callable=AsyncMock):
+                with patch.object(noma, '_extract_user_message', new_callable=AsyncMock) as mock_extract:
+                    mock_extract.return_value = "Hello, how are you?"
+                    
+                    # Process the message check
+                    result = await noma._process_user_message_check(mock_request_data, mock_user_auth)
+                    
+                    # Verify guardrail information was logged
+                    metadata = mock_request_data.get("metadata", {})
+                    guardrail_info = metadata.get("standard_logging_guardrail_information")
+                    
+                    assert guardrail_info is not None
+                    assert guardrail_info["guardrail_provider"] == "noma"
+                    assert guardrail_info["guardrail_status"] == "success"
+                    assert "start_time" in guardrail_info
+                    assert "end_time" in guardrail_info
+                    assert "duration" in guardrail_info
+
+    def test_status_values_consistency(self):
+        """Test that both providers use the same status value definitions."""
+        from typing import get_args
+        from litellm.types.utils import StandardLoggingGuardrailInformation
+        
+        # Get the allowed status values from the type definition
+        status_field = StandardLoggingGuardrailInformation.__annotations__["guardrail_status"]
+        allowed_statuses = get_args(status_field)
+        
+        # Verify we have exactly three status values
+        assert len(allowed_statuses) == 3
+        assert "success" in allowed_statuses
+        assert "blocked" in allowed_statuses  
+        assert "failure" in allowed_statuses
+
+    @pytest.mark.asyncio
+    async def test_noma_exception_handling_logs_failure(self, mock_user_auth, mock_request_data):
+        """Test NOMA logs 'failure' status when exceptions occur."""
+        noma = NomaGuardrail(api_key="test_key", block_failures=False)
+        
+        # Mock an exception in the pre-call hook
+        with patch.object(noma, '_check_user_message', side_effect=Exception("API error")):
+            # This should not raise due to block_failures=False
+            result = await noma.async_pre_call_hook(mock_user_auth, None, mock_request_data, "completion")
+            
+            # Verify the failure was logged
+            metadata = mock_request_data.get("metadata", {})
+            guardrail_info = metadata.get("standard_logging_guardrail_information")
+            
+            assert guardrail_info is not None
+            assert guardrail_info["guardrail_provider"] == "noma"
+            assert guardrail_info["guardrail_status"] == "failure"
+
+    def test_guardrail_status_troubleshooting_fields(self):
+        """Test that all necessary fields are present for troubleshooting."""
+        # Test data that simulates what should be logged
+        guardrail_info = StandardLoggingGuardrailInformation(
+            guardrail_name="test-guard",
+            guardrail_provider="noma",
+            guardrail_status="blocked",
+            start_time=datetime.now().timestamp(),
+            end_time=datetime.now().timestamp(),
+            duration=0.5,
+            guardrail_response={"verdict": False}
+        )
+        
+        # Verify all troubleshooting fields are present
+        required_fields = [
+            "guardrail_name",      # Which guardrail was triggered
+            "guardrail_provider",  # Which provider (noma/bedrock)
+            "guardrail_status",    # What happened (success/blocked/failure)
+            "start_time",          # When it started
+            "end_time",            # When it ended
+            "duration",            # How long it took
+            "guardrail_response"   # Full response for debugging
+        ]
+        
+        for field in required_fields:
+            assert field in guardrail_info
+            assert guardrail_info[field] is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/local_testing/create_mock_standard_logging_payload.py
+++ b/tests/local_testing/create_mock_standard_logging_payload.py
@@ -30,12 +30,19 @@ verbose_logger.setLevel(logging.DEBUG)
 
 
 def create_standard_logging_payload() -> StandardLoggingPayload:
+    from litellm.types.utils import StandardLoggingPayloadStatusFields
+    
     return StandardLoggingPayload(
         id="test_id",
         call_type="completion",
         response_cost=0.1,
         response_cost_failure_debug_info=None,
         status="success",
+        status_fields=StandardLoggingPayloadStatusFields(
+            is_guardrail_failed=False,
+            is_guardrail_intervened=False,
+            is_llm_request_successful=True
+        ),
         total_tokens=30,
         prompt_tokens=20,
         completion_tokens=10,

--- a/tests/logging_callback_tests/create_mock_standard_logging_payload.py
+++ b/tests/logging_callback_tests/create_mock_standard_logging_payload.py
@@ -30,12 +30,19 @@ verbose_logger.setLevel(logging.DEBUG)
 
 
 def create_standard_logging_payload() -> StandardLoggingPayload:
+    from litellm.types.utils import StandardLoggingPayloadStatusFields
+    
     return StandardLoggingPayload(
         id="test_id",
         call_type="completion",
         response_cost=0.1,
         response_cost_failure_debug_info=None,
         status="success",
+        status_fields=StandardLoggingPayloadStatusFields(
+            is_guardrail_failed=False,
+            is_guardrail_intervened=False,
+            is_llm_request_successful=True
+        ),
         total_tokens=30,
         prompt_tokens=20,
         completion_tokens=10,


### PR DESCRIPTION
## Title

Standardize Guardrail Status Logging Across NOMA and Bedrock

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring

## Changes

This PR standardizes `guardrail_status` and `guardrail_information` logging within the `StandardLoggingPayload` across NOMA and Bedrock guardrails. Previously, inconsistent status definitions and logging frequency hindered effective troubleshooting.

The changes introduce a unified `guardrail_status` with three clear values: `success`, `blocked`, and `failure`. This ensures that `guardrail_information` is consistently logged for all guardrail interactions, providing clear `guardrail_provider`, `guardrail_status`, and timing details. This significantly improves the ability to troubleshoot and monitor guardrail behavior by offering a consistent and comprehensive view of guardrail outcomes.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b5adcb5-8226-4f5d-aabc-a679a2282f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b5adcb5-8226-4f5d-aabc-a679a2282f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

