### PR TITLE
Guardrails - Don't run post_call guardrail if no text returned from Bedrock

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -727,6 +727,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
             return
 
+        outputs: List[BedrockGuardrailOutput] = (
+            response.get("outputs", []) or []
+        )
+        if not any(output.get("text") for output in outputs):
+            verbose_proxy_logger.warning(
+                "Bedrock AI: not running guardrail. No output text in response"
+            )
+            return
+
         #########################################################
         ########## 1. Make parallel Bedrock API requests ##########
         #########################################################

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -1407,11 +1407,16 @@ async def test_bedrock_guardrail_post_call_success_hook_no_output_text():
         "stopReason": "tool_use"
     }
         
-    data = {}  # request data not used by our condition
+    data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Hello"},
+        ],
+    } 
     mock_user_api_key_dict = UserAPIKeyAuth()
 
     return await guardrail.async_post_call_success_hook(
         data=data,
-        response=mock_bedrock_response,  # dict with "outputs"
+        response=mock_bedrock_response, 
         user_api_key_dict=mock_user_api_key_dict,
     )

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -1366,3 +1366,52 @@ async def test_bedrock_guardrail_disable_exception_on_block_streaming():
             
         except Exception as e:
             pytest.fail(f"Should not raise exception when disable_exception_on_block=True in streaming, but got: {e}")
+
+@pytest.mark.asyncio
+async def test_bedrock_guardrail_post_call_success_hook_no_output_text():
+    """Test that async_post_call_success_hook skips when there's no output text"""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import ModelResponseStream
+    import litellm
+    
+    # Create proper mock objects
+    mock_user_api_key_dict = UserAPIKeyAuth()
+    
+    # Create guardrail instance
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT"
+    )
+    
+    # Mock Bedrock API response with PII masking
+    mock_bedrock_response = MagicMock()
+    mock_bedrock_response.status_code = 200
+    mock_bedrock_response.json.return_value = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "tooluse_kZJMlvQmRJ6eAyJE5GIl7Q",
+                            "name": "top_song",
+                            "input": {
+                                "sign": "WZPZ"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "stopReason": "tool_use"
+    }
+        
+    data = {}  # request data not used by our condition
+    mock_user_api_key_dict = UserAPIKeyAuth()
+
+    return await guardrail.async_post_call_success_hook(
+        data=data,
+        response=mock_bedrock_response,  # dict with "outputs"
+        user_api_key_dict=mock_user_api_key_dict,
+    )

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -1384,7 +1384,7 @@ async def test_bedrock_guardrail_post_call_success_hook_no_output_text():
         guardrailVersion="DRAFT"
     )
     
-    # Mock Bedrock API response with PII masking
+    # Mock Bedrock API with no output text
     mock_bedrock_response = MagicMock()
     mock_bedrock_response.status_code = 200
     mock_bedrock_response.json.return_value = {
@@ -1420,3 +1420,5 @@ async def test_bedrock_guardrail_post_call_success_hook_no_output_text():
         response=mock_bedrock_response, 
         user_api_key_dict=mock_user_api_key_dict,
     )
+    # If no error is raised, then the test passes
+    print("✅ No output text in response test passed")


### PR DESCRIPTION
## Guardrails - Don't run post_call guardrail if no text returned from Bedrock

## Relevant issues
Fixes https://github.com/BerriAI/litellm/issues/15105

## Pre-Submission checklist
- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
<img width="834" height="17" alt="Screenshot 2025-10-01 at 12 02 20 PM" src="https://github.com/user-attachments/assets/382ed654-9a61-4afa-9f51-df03ed6282b2" />


- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Checks that Bedrock returned some text before calling post_call Guardrail

