### PR TITLE
[Fix] Proxy Auth - Ensure LLM_API_KEYs can access pass through routes

### DIFF
--- a/docs/my-website/docs/providers/lemonade.md
+++ b/docs/my-website/docs/providers/lemonade.md
@@ -186,3 +186,6 @@ print("Available models:", [model['id'] for model in models.get('data', [])])
 ## Support
 
 For more information regarding Lemonade please go to to the [Lemonade website](https://lemonade-server.ai/) or [Lemonade repository](https://github.com/lemonade-sdk/lemonade).
+
+</TabItem>
+</Tabs>

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -62,12 +62,22 @@ class RouteChecks:
             for allowed_route in valid_token.allowed_routes
         ):
             for allowed_route in valid_token.allowed_routes:
-                if allowed_route in LiteLLMRoutes._member_names_:
+                if allowed_route in LiteLLMRoutes._member_names_:                    
                     if RouteChecks.check_route_access(
                         route=route,
                         allowed_routes=LiteLLMRoutes._member_map_[allowed_route].value,
                     ):
                         return True
+                    
+                    ################################################
+                    #  For llm_api_routes, also check registered pass-through endpoints
+                    ################################################
+                    if allowed_route == "llm_api_routes":
+                        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+                            InitPassThroughEndpointHelpers,
+                        )
+                        if InitPassThroughEndpointHelpers.is_registered_pass_through_route(route=route):
+                            return True
 
         # check if wildcard pattern is allowed
         for allowed_route in valid_token.allowed_routes:


### PR DESCRIPTION
## [Fix] Proxy Auth - Ensure LLM_API_KEYs can access pass through routes

Fixes LIT-1099

Users have keys created for LLM API routes - they use the same key for passthroughs like assistants API, Image Gen Passthrough, Video Gen Passthrough 

Virtual keys with llm_api_routes permission were blocked from accessing pass-through endpoints registered in the DB (e.g., /azure-assistant/openai/assistants).

Solution:
Added is_registered_pass_through_route() static method to InitPassThroughEndpointHelpers class in pass_through_endpoints.py - checks in-memory _registered_pass_through_routes registry (no DB queries)



<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


