### PR TITLE
Added railtracks to projects that are using litellm

### DIFF
--- a/docs/my-website/docs/projects/Railtracks.md
+++ b/docs/my-website/docs/projects/Railtracks.md
@@ -1,0 +1,7 @@
+# Railtracks
+
+`Railtracks` is an open-source agentic framework that helps developers build resilient agentic systems offering local and remote monitoring tools.
+
+- [Github](https://github.com/RailtownAI/railtracks)
+- [Docs](https://railtownai.github.io/railtracks/)
+- [Railtracks](https://railtracks.org/)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -699,7 +699,8 @@ const sidebars = {
             "projects/llm_cord",
             "projects/pgai",
             "projects/GPTLocalhost",
-            "projects/HolmesGPT"
+            "projects/HolmesGPT",
+            "projects/Railtracks",
           ],
         },
         "extras/code_quality",


### PR DESCRIPTION
## Title

In this PR I am updating the documentation to include `Railtracks` as a project using LiteLLM.

## Relevant issues

No specific issues were addressed and this change is an addition to the documentation.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation


## Changes

- Added `docs/my-website/docs/projects/Railtracks.md` that includes the information about the Railtracks framework.
- Changed `docs/my-website/sidebars.js` to include the tab for Railtracks
