### PR TITLE
Fix(critical) : Preserve Whitespace Characters in Model Response Streams

### DIFF
--- a/litellm/litellm_core_utils/model_response_utils.py
+++ b/litellm/litellm_core_utils/model_response_utils.py
@@ -84,7 +84,9 @@ def _has_meaningful_content(value: Any) -> bool:
         return False
 
     if isinstance(value, str):
-        return len(value.strip()) > 0
+        # Don't strip whitespace - preserve all content including newlines, spaces, etc.
+        # Even pure whitespace characters like '\n' or ' ' are meaningful content
+        return len(value) > 0
 
     if isinstance(value, (list, dict)):
         return len(value) > 0


### PR DESCRIPTION
## Fix(critical) : Preserve Whitespace Characters in Model Response Streams

### Problem

The `_has_meaningful_content` function was incorrectly filtering out whitespace-only strings (newlines, spaces, tabs) by using `.strip()` before checking string length. This caused valid content chunks containing only whitespace characters which is meaningful to Markdown format to be incorrectly classified as empty.

Some LLM responses contain excessively short chunks consisting solely of whitespace or newline characters. This bug causes significant content filtering, resulting in incomplete outputs delivered to the client. **The error is critical for LLM applications, as it fundamentally compromises output integrity and reliability**.

### Solution

Modified the string handling logic to preserve all non-empty strings, including those containing only whitespace characters:

**Before:**

```python
if isinstance(value, str):
    return len(value.strip()) > 0
```

**After:**

```python
if isinstance(value, str):
    # Don't strip whitespace - preserve all content including newlines, spaces, etc.
    # Even pure whitespace characters like '\n' or ' ' are meaningful content
    return len(value) > 0
```

### Impact

- **Streaming Responses**: Whitespace characters in streaming responses are now correctly preserved
- **Content Integrity**: Ensures that newlines, spaces, and other whitespace remain part of the response
- **Edge Cases**: Fixes scenarios where whitespace-only chunks were being dropped

### Files Changed

- `litellm/litellm_core_utils/model_response_utils.py` (4 lines changed)

### Testing Screenshot

- Screenshot of incorrectly filtering out whitespace-only strings

<img width="873" height="775" alt="iShot_2025-10-03_14 21 47" src="https://github.com/user-attachments/assets/7b1a0a8c-0b45-4e27-a0ab-660718ac811e" />

- Screenshot after fixed

<img width="856" height="981" alt="iShot_2025-10-03_14 22 26" src="https://github.com/user-attachments/assets/5a9e129a-54b6-44cf-a96f-6bc77b171b0b" />

