### PR TITLE
Propagate response through InternalServerError

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -546,7 +546,7 @@ class InternalServerError(openai.InternalServerError):  # type: ignore
         self.litellm_debug_info = litellm_debug_info
         self.max_retries = max_retries
         self.num_retries = num_retries
-        self.response = httpx.Response(
+        self.response = response or httpx.Response(
             status_code=self.status_code,
             request=httpx.Request(
                 method="POST",


### PR DESCRIPTION
## Propagate response through InternalServerError

If there's a reason the response is currently ignored then feel free to just close.

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

keep the response passed to the InternalServerError constructor if it is not None
