### PR TITLE
[Fix] Cache - Avoiding expensive operations when cache isn't available

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -58,10 +58,15 @@ from litellm.types.utils import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.litellm_core_utils.streaming_handler import (
+        CustomStreamWrapper as CustomStreamWrapperType,
+    )
 else:
     LiteLLMLoggingObj = Any
-    CustomStreamWrapper = Any
+    CustomStreamWrapperType = Any
+
+# Import CustomStreamWrapper at runtime for isinstance checks
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 
 
 from litellm.litellm_core_utils.core_helpers import (

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -14,6 +14,7 @@ It utilizes the (RedisCache, s3Cache, RedisSemanticCache, QdrantSemanticCache, I
 In each method it will call the appropriate method from caching.py
 """
 
+import time
 import asyncio
 import datetime
 import inspect
@@ -57,10 +58,16 @@ from litellm.types.utils import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-    from litellm.utils import CustomStreamWrapper
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 else:
     LiteLLMLoggingObj = Any
     CustomStreamWrapper = Any
+
+
+from litellm.litellm_core_utils.core_helpers import (
+_get_parent_otel_span_from_kwargs,
+)
+
 
 
 class CachingHandlerResponse(BaseModel):
@@ -140,26 +147,19 @@ class LLMCachingHandler:
         ) and (
             kwargs.get("cache", {}).get("no-cache", False) is not True
         ):  # allow users to control returning cached responses from the completion function
-            from litellm.litellm_core_utils.core_helpers import (
-                _get_parent_otel_span_from_kwargs,
-            )
-            from litellm.utils import CustomStreamWrapper
-
-            kwargs = kwargs.copy()
             args = args or ()
-            #########################################################
-            # Init cache timing metrics
-            #########################################################
-            cache_check_start_time = datetime.datetime.now()
-            cache_check_end_time = None
-            #########################################################
-
-
-            parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
-            kwargs["parent_otel_span"] = parent_otel_span
             final_embedding_cached_response: Optional[EmbeddingResponse] = None
             embedding_all_elements_cache_hit: bool = False
             cached_result: Optional[Any] = None
+            kwargs = kwargs.copy()
+            #########################################################
+            # Init cache timing metrics
+            #########################################################
+            cache_check_start_time = time.perf_counter()
+            cache_check_end_time: Optional[float] = None
+            #########################################################
+            parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
+            kwargs["parent_otel_span"] = parent_otel_span
             
             if litellm.cache is not None and self._is_call_type_supported_by_cache(
                 original_function=original_function
@@ -170,7 +170,7 @@ class LLMCachingHandler:
                     kwargs=kwargs,
                     args=args,
                 )
-                cache_check_end_time = datetime.datetime.now()
+                cache_check_end_time = time.perf_counter()
 
                 if cached_result is not None and not isinstance(cached_result, list):
                     verbose_logger.debug("Cache Hit!")
@@ -182,7 +182,7 @@ class LLMCachingHandler:
                         api_base=kwargs.get("api_base", None),
                         api_key=kwargs.get("api_key", None),
                     )
-                    cache_duration_ms = (cache_check_end_time - cache_check_start_time).total_seconds() * 1000
+                    cache_duration_ms = (cache_check_end_time - cache_check_start_time) * 1000
                     self._update_litellm_logging_obj_environment(
                         logging_obj=logging_obj,
                         model=model,

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -58,21 +58,16 @@ from litellm.types.utils import (
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-    from litellm.litellm_core_utils.streaming_handler import (
-        CustomStreamWrapper as CustomStreamWrapperType,
-    )
 else:
     LiteLLMLoggingObj = Any
-    CustomStreamWrapperType = Any
 
-# Import CustomStreamWrapper at runtime for isinstance checks
+
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 
 
 from litellm.litellm_core_utils.core_helpers import (
 _get_parent_otel_span_from_kwargs,
 )
-
 
 
 class CachingHandlerResponse(BaseModel):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1401,7 +1401,7 @@ def client(original_function):  # noqa: PLR0915
             print_verbose(
                 f"ASYNC kwargs[caching]: {kwargs.get('caching', False)}; litellm.cache: {litellm.cache}; kwargs.get('cache'): {kwargs.get('cache', None)}"
             )
-            _caching_handler_response: CachingHandlerResponse = (
+            _caching_handler_response: Optional[CachingHandlerResponse] = (
                 await _llm_caching_handler._async_get_cache(
                     model=model or "",
                     original_function=original_function,
@@ -1413,14 +1413,15 @@ def client(original_function):  # noqa: PLR0915
                 )
             )
 
-            if (
-                _caching_handler_response.cached_result is not None
-                and _caching_handler_response.final_embedding_cached_response is None
-            ):
-                return _caching_handler_response.cached_result
+            if _caching_handler_response is not None:
+                if (
+                    _caching_handler_response.cached_result is not None
+                    and _caching_handler_response.final_embedding_cached_response is None
+                ):
+                    return _caching_handler_response.cached_result
 
-            elif _caching_handler_response.embedding_all_elements_cache_hit is True:
-                return _caching_handler_response.final_embedding_cached_response
+                elif _caching_handler_response.embedding_all_elements_cache_hit is True:
+                    return _caching_handler_response.final_embedding_cached_response
 
             # CHECK MAX TOKENS
             if (
@@ -1523,6 +1524,7 @@ def client(original_function):  # noqa: PLR0915
             # REBUILD EMBEDDING CACHING
             if (
                 isinstance(result, EmbeddingResponse)
+                and _caching_handler_response is not None
                 and _caching_handler_response.final_embedding_cached_response
                 is not None
             ):


### PR DESCRIPTION
## Title

[Fix] Cache - Avoiding expensive operations when cache isn't available

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

- Only do expensive work when necessary, avoid it otherwise.

### Performance Gains

### With DB
<p><strong>Before</strong></p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 102040 | 2 | 500 | 830 | 1200 | 532.05 | 67 | 2527 | 398 | 778.4 | 0
Custom | LiteLLM Overhead Duration (ms) | 102038 | 0 | 47 | 71 | 97 | 50.42 | 4 | 1438 | 0 | 778.4 | 0
  | Aggregated | 204078 | 2 | 290 | 700 | 1100 | 291.24 | 4 | 2527 | 199 | 1556.8 | 0


<!-- notionvc: f70db98a-3c36-4248-a312-497fac9c4f48 -->

<p><strong>After</strong></p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 101891 | 2 | 280 | 520 | 1000 | 310.07 | 105 | 53491 | 398 | 939.1 | 0.1
Custom | LiteLLM Overhead Duration (ms) | 101889 | 0 | 25 | 45 | 60 | 27.27 | 1 | 851 | 0 | 939 | 0
  | Aggregated | 203780 | 2 | 130 | 420 | 870 | 168.67 | 1 | 53491 | 199 | 1878.1 | 0.1


<!-- notionvc: 6565b509-fa02-4852-9ad8-cef2602bf00a -->

### With DB + Redis
<p><strong>Before</strong></p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 35569 | 0 | 1900 | 3500 | 4400 | 2052.36 | 254 | 8315 | 398 | 330.2 | 0
Custom | LiteLLM Overhead Duration (ms) | 35569 | 0 | 300 | 770 | 1200 | 356.51 | 27 | 2156 | 0 | 330.2 | 0
  | Aggregated | 71138 | 0 | 920 | 3100 | 4000 | 1204.44 | 27 | 8315 | 199 | 660.4 | 0


<!-- notionvc: 5d389c47-8a6a-4a35-bbb3-f4f5fdca3dcc -->

<p><strong>After</strong></p>

Type | Name | # Requests | # Fails | Median (ms) | 95%ile (ms) | 99%ile (ms) | Average (ms) | Min (ms) | Max (ms) | Average size (bytes) | Current RPS | Current Failures/s
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
POST | /chat/completions | 21000 | 0 | 1700 | 2800 | 3400 | 1744.71 | 84 | 5383 | 398 | 424.1 | 0
Custom | LiteLLM Overhead Duration (ms) | 21000 | 0 | 270 | 650 | 1100 | 311.15 | 7 | 1413 | 0 | 424.1 | 0
  | Aggregated | 42000 | 0 | 820 | 2600 | 3100 | 1027.93 | 7 | 5383 | 199 | 848.2 | 0


<!-- notionvc: 138d98fa-f73f-4f60-a993-90ff61752778 -->


