### PR TITLE
Add streamGenerateContent cost tracking in passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -301,6 +301,9 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
             or ("rawPredict") in url
             or ("streamRawPredict") in url
         ):
+            # Check if it's Gemini (Google AI Studio) or Vertex AI
+            if parsed_url.hostname and parsed_url.hostname.endswith("generativelanguage.googleapis.com"):
+                return EndpointType.GEMINI
             return EndpointType.VERTEX_AI
         elif parsed_url.hostname == "api.anthropic.com":
             return EndpointType.ANTHROPIC

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -105,6 +105,28 @@ class PassThroughStreamingHandler:
                 anthropic_passthrough_logging_handler_result["result"]
             )
             kwargs = anthropic_passthrough_logging_handler_result["kwargs"]
+        elif endpoint_type == EndpointType.GEMINI:
+            from litellm.proxy.pass_through_endpoints.llm_provider_handlers.gemini_passthrough_logging_handler import (
+                GeminiPassthroughLoggingHandler,
+            )
+
+            gemini_passthrough_logging_handler_result = (
+                GeminiPassthroughLoggingHandler._handle_logging_gemini_collected_chunks(
+                    litellm_logging_obj=litellm_logging_obj,
+                    passthrough_success_handler_obj=passthrough_success_handler_obj,
+                    url_route=url_route,
+                    request_body=request_body,
+                    endpoint_type=endpoint_type,
+                    start_time=start_time,
+                    all_chunks=all_chunks,
+                    end_time=end_time,
+                    model=model,
+                )
+            )
+            standard_logging_response_object = (
+                gemini_passthrough_logging_handler_result["result"]
+            )
+            kwargs = gemini_passthrough_logging_handler_result["kwargs"]
         elif endpoint_type == EndpointType.VERTEX_AI:
             vertex_passthrough_logging_handler_result = (
                 VertexPassthroughLoggingHandler._handle_logging_vertex_collected_chunks(

--- a/litellm/types/passthrough_endpoints/pass_through_endpoints.py
+++ b/litellm/types/passthrough_endpoints/pass_through_endpoints.py
@@ -6,6 +6,7 @@ from typing_extensions import TypedDict
 
 class EndpointType(str, Enum):
     VERTEX_AI = "vertex-ai"
+    GEMINI = "gemini"
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
     GENERIC = "generic"


### PR DESCRIPTION
## Title

Add streamGenerateContent cost tracking in passthrough

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes

### Problem
Passthrough streaming requests for Gemini endpoints were not calculating costs correctly. The streaming cost calculation was missing the `logging_obj` parameter needed for cost injection, and Gemini's unique fragmented JSON streaming format was not being parsed correctly.

https://www.loom.com/share/f2b38813059b4ea3ab5259f3fae31ea5?sid=9a6b6978-553b-4d0c-a658-1a39c8c61bdb