### PR TITLE
fix: pass speechConfig in gemini tts request

### DIFF
--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -206,6 +206,7 @@ class GenerationConfig(TypedDict, total=False):
     responseLogprobs: bool
     logprobs: int
     responseModalities: List[GeminiResponseModalities]
+    speechConfig: SpeechConfig
     thinkingConfig: GeminiThinkingConfig
 
 


### PR DESCRIPTION
## Summary
- Add `speechConfig` field to `GenerationConfig` TypedDict for Gemini TTS requests

## Changes
- Added `speechConfig: SpeechConfig` to the `GenerationConfig` in `litellm/types/llms/vertex_ai.py`

This fix ensures that the `speechConfig` parameter can be properly passed in Gemini text-to-speech API requests.

## Test plan
**Request before applying the fix:**
```
litellm-dev-litellm-855cf484f4-fkkwc litellm POST Request Sent from LiteLLM:
litellm-dev-litellm-855cf484f4-fkkwc litellm curl -X POST \
litellm-dev-litellm-855cf484f4-fkkwc litellm https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro-preview-tts:generateContent?key=*****\
litellm-dev-litellm-855cf484f4-fkkwc litellm -H 'Content-Type: application/json' \
litellm-dev-litellm-855cf484f4-fkkwc litellm -d '{'contents': [{'role': 'user', 'parts': [{'text': 'Pronounce the word ***'}]}], 'generationConfig': {'responseModalities': ['AUDIO']}}'
```


**Request after applying the fix:**
```
litellm-dev-litellm-7768489884-p69tz litellm POST Request Sent from LiteLLM:
litellm-dev-litellm-7768489884-p69tz litellm curl -X POST \
litellm-dev-litellm-7768489884-p69tz litellm https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro-preview-tts:generateContent?key=*****\
litellm-dev-litellm-7768489884-p69tz litellm -H 'Content-Type: application/json' \
litellm-dev-litellm-7768489884-p69tz litellm -d '{'contents': [{'role': 'user', 'parts': [{'text': 'Pronounce the word ***'}]}], 'generationConfig': {'responseModalities': ['AUDIO'], 'speechConfig': {'voiceConfig': {'prebuiltVoiceConfig': {'voiceName': 'algenib'}}}}}'
```