### PR TITLE
[Refactor] Utils: extract inner function from client

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6249,6 +6249,20 @@ class Router:
                         returned_models.append(alias_model)
                     else:
                         returned_models.append(model)
+        elif team_id is not None:
+            # Fallback: if team_id is provided and model_name not in index,
+            # check if model_name matches any team_public_model_name
+            # O(n) scan but only when team_id lookup fails
+            for idx, model in enumerate(self.model_list):
+                if self.should_include_deployment(
+                    model_name=model_name, model=model, team_id=team_id
+                ):
+                    if model_alias is not None:
+                        alias_model = copy.deepcopy(model)
+                        alias_model["model_name"] = model_alias
+                        returned_models.append(alias_model)
+                    else:
+                        returned_models.append(model)
 
         return returned_models
 


### PR DESCRIPTION
## Title

[Refactor] Utils: extract inner function from client

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

- Removed function definitions from inside the utils::client function.
- Fixed test_arouter_test_team_model failure by adding a fallback to the index look up.

## Test Results
<img width="1427" height="122" alt="Screenshot 2025-10-06 at 9 35 55 AM" src="https://github.com/user-attachments/assets/f02bfd63-157b-457d-8459-26609f0c9fae" />

- The failure seems unrelated.