### PR TITLE
[MCP Gateway] UI - Select allowed tools for Key, Teams 

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -80,6 +80,7 @@ export interface KeyResponse {
     object_permission_id: string;
     mcp_servers: string[];
     mcp_access_groups?: string[];
+    mcp_tool_permissions?: Record<string, string[]>;
     vector_stores: string[];
   };
   auto_rotate?: boolean;

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -4,8 +4,14 @@ import { fetchMCPServers, fetchMCPAccessGroups } from "../networking";
 import { MCPServer } from "../mcp_tools/types";
 
 interface MCPServerSelectorProps {
-  onChange: (selected: { servers: string[]; accessGroups: string[] }) => void;
-  value?: { servers: string[]; accessGroups: string[] };
+  onChange: (selected: { 
+    servers: string[]; 
+    accessGroups: string[];
+  }) => void;
+  value?: { 
+    servers: string[]; 
+    accessGroups: string[];
+  };
   className?: string;
   accessToken: string;
   placeholder?: string;

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MCPToolPermissions from "./MCPToolPermissions";
+import * as networking from "../networking";
+
+vi.mock("../networking");
+
+describe("MCPToolPermissions", () => {
+  const mockAccessToken = "test-token";
+  const mockServerId = "server-123";
+  const mockServerName = "Test MCP Server";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should update tool permissions when user selects a tool", async () => {
+    /**
+     * Tests that clicking a tool checkbox calls onChange with updated permissions.
+     * This is the core functionality of the component.
+     */
+    const mockOnChange = vi.fn();
+    const mockTools = [
+      { name: "read_wiki_structure", description: "Get documentation topics" },
+      { name: "read_wiki_contents", description: "View documentation" },
+      { name: "ask_question", description: "Ask questions" },
+    ];
+
+    // Mock fetchMCPServers to return server details
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue({
+      data: [
+        {
+          server_id: mockServerId,
+          server_name: mockServerName,
+          alias: mockServerName,
+        },
+      ],
+    });
+
+    // Mock listMCPTools to return tools for the server
+    vi.mocked(networking.listMCPTools).mockResolvedValue({
+      tools: mockTools,
+      error: false,
+    });
+
+    render(
+      <MCPToolPermissions
+        accessToken={mockAccessToken}
+        selectedServers={[mockServerId]}
+        toolPermissions={{}}
+        onChange={mockOnChange}
+      />
+    );
+
+    // Wait for server and tools to load
+    await waitFor(() => {
+      expect(screen.getByText(mockServerName)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("read_wiki_structure")).toBeInTheDocument();
+    });
+
+    // Get all checkboxes and click the first one (for read_wiki_structure)
+    const checkboxes = screen.getAllByRole("checkbox");
+    await userEvent.click(checkboxes[0]);
+
+    // Verify onChange was called with correct permissions
+    expect(mockOnChange).toHaveBeenCalledWith({
+      [mockServerId]: ["read_wiki_structure"],
+    });
+
+    // Verify API calls
+    expect(networking.fetchMCPServers).toHaveBeenCalledWith(mockAccessToken);
+    expect(networking.listMCPTools).toHaveBeenCalledWith(mockAccessToken, mockServerId);
+  });
+});
+

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
@@ -85,23 +85,15 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
 
   // Handle tool selection
   const handleToolToggle = (serverId: string, toolName: string) => {
-    console.log("🔧 handleToolToggle called:", { serverId, toolName });
-    console.log("📋 Current toolPermissions:", toolPermissions);
-    
     const currentTools = toolPermissions[serverId] || [];
     const newTools = currentTools.includes(toolName)
       ? currentTools.filter(name => name !== toolName)
       : [...currentTools, toolName];
     
-    console.log("✅ New tools for server:", newTools);
-    
-    const updatedPermissions = {
+    onChange({
       ...toolPermissions,
       [serverId]: newTools,
-    };
-    
-    console.log("📦 Calling onChange with:", updatedPermissions);
-    onChange(updatedPermissions);
+    });
   };
 
   const handleSelectAll = (serverId: string) => {
@@ -193,16 +185,12 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
                 <div className="space-y-2">
                   {tools.map((tool) => {
                     const isSelected = selectedTools.includes(tool.name);
-                    console.log(`🔍 Tool ${tool.name} - isSelected: ${isSelected}, selectedTools:`, selectedTools);
 
                     return (
                       <div key={tool.name} className="flex items-start gap-2">
                         <Checkbox
                           checked={isSelected}
-                          onChange={(e) => {
-                            console.log("📝 Checkbox onChange event:", e);
-                            handleToolToggle(server.server_id, tool.name);
-                          }}
+                          onChange={() => handleToolToggle(server.server_id, tool.name)}
                           disabled={disabled}
                         />
                         <div className="flex-1 min-w-0">

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useState } from "react";
+import { listMCPTools, fetchMCPServers } from "../networking";
+import { MCPTool, MCPServer } from "../mcp_tools/types";
+import { Text } from "@tremor/react";
+import { Spin, Checkbox } from "antd";
+import { XIcon } from "lucide-react";
+
+interface MCPToolPermissionsProps {
+  accessToken: string;
+  selectedServers: string[];
+  toolPermissions: Record<string, string[]>;
+  onChange: (toolPermissions: Record<string, string[]>) => void;
+  disabled?: boolean;
+}
+
+const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
+  accessToken,
+  selectedServers,
+  toolPermissions,
+  onChange,
+  disabled = false,
+}) => {
+  const [servers, setServers] = useState<MCPServer[]>([]);
+  const [serverTools, setServerTools] = useState<Record<string, MCPTool[]>>({});
+  const [loadingTools, setLoadingTools] = useState<Record<string, boolean>>({});
+  const [toolErrors, setToolErrors] = useState<Record<string, string>>({});
+
+  // Fetch server details
+  useEffect(() => {
+    const loadServerDetails = async () => {
+      if (selectedServers.length === 0) {
+        setServers([]);
+        return;
+      }
+
+      try {
+        const response = await fetchMCPServers(accessToken);
+        const allServers = Array.isArray(response) ? response : response.data || [];
+        
+        const filteredServers = allServers.filter((server: MCPServer) => 
+          selectedServers.includes(server.server_id)
+        );
+        
+        setServers(filteredServers);
+      } catch (error) {
+        console.error("Error fetching MCP servers:", error);
+        setServers([]);
+      }
+    };
+
+    loadServerDetails();
+  }, [selectedServers, accessToken]);
+
+  // Fetch tools for a specific server
+  const fetchToolsForServer = async (serverId: string) => {
+    setLoadingTools(prev => ({ ...prev, [serverId]: true }));
+    setToolErrors(prev => ({ ...prev, [serverId]: "" }));
+    
+    try {
+      const response = await listMCPTools(accessToken, serverId);
+      
+      if (response.error) {
+        setToolErrors(prev => ({ ...prev, [serverId]: response.message || "Failed to fetch tools" }));
+        setServerTools(prev => ({ ...prev, [serverId]: [] }));
+      } else {
+        setServerTools(prev => ({ ...prev, [serverId]: response.tools || [] }));
+      }
+    } catch (err) {
+      console.error(`Error fetching tools for server ${serverId}:`, err);
+      setToolErrors(prev => ({ ...prev, [serverId]: "Failed to fetch tools" }));
+      setServerTools(prev => ({ ...prev, [serverId]: [] }));
+    } finally {
+      setLoadingTools(prev => ({ ...prev, [serverId]: false }));
+    }
+  };
+
+  // Auto-fetch tools when servers change
+  useEffect(() => {
+    servers.forEach(server => {
+      if (!serverTools[server.server_id] && !loadingTools[server.server_id]) {
+        fetchToolsForServer(server.server_id);
+      }
+    });
+  }, [servers]);
+
+  // Handle tool selection
+  const handleToolToggle = (serverId: string, toolName: string) => {
+    console.log("🔧 handleToolToggle called:", { serverId, toolName });
+    console.log("📋 Current toolPermissions:", toolPermissions);
+    
+    const currentTools = toolPermissions[serverId] || [];
+    const newTools = currentTools.includes(toolName)
+      ? currentTools.filter(name => name !== toolName)
+      : [...currentTools, toolName];
+    
+    console.log("✅ New tools for server:", newTools);
+    
+    const updatedPermissions = {
+      ...toolPermissions,
+      [serverId]: newTools,
+    };
+    
+    console.log("📦 Calling onChange with:", updatedPermissions);
+    onChange(updatedPermissions);
+  };
+
+  const handleSelectAll = (serverId: string) => {
+    const tools = serverTools[serverId] || [];
+    onChange({
+      ...toolPermissions,
+      [serverId]: tools.map(t => t.name),
+    });
+  };
+
+  const handleDeselectAll = (serverId: string) => {
+    onChange({
+      ...toolPermissions,
+      [serverId]: [],
+    });
+  };
+
+  if (selectedServers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {servers.map((server) => {
+        const serverName = server.server_name || server.alias || server.server_id;
+        const tools = serverTools[server.server_id] || [];
+        const selectedTools = toolPermissions[server.server_id] || [];
+        const isLoading = loadingTools[server.server_id];
+        const error = toolErrors[server.server_id];
+
+        return (
+          <div key={server.server_id} className="border rounded-lg bg-gray-50">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b bg-white rounded-t-lg">
+              <div>
+                <Text className="font-semibold text-gray-900">{serverName}</Text>
+                {server.description && (
+                  <Text className="text-sm text-gray-500">{server.description}</Text>
+                )}
+              </div>
+              <div className="flex items-center gap-3">
+                <button
+                  className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                  onClick={() => handleSelectAll(server.server_id)}
+                  disabled={disabled || isLoading}
+                >
+                  Select All
+                </button>
+                <button
+                  className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                  onClick={() => handleDeselectAll(server.server_id)}
+                  disabled={disabled || isLoading}
+                >
+                  Deselect All
+                </button>
+                <button
+                  className="text-gray-400 hover:text-gray-600"
+                  onClick={() => {
+                    // Handle remove server if needed
+                  }}
+                >
+                  <XIcon className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Tools */}
+            <div className="p-4">
+              <Text className="text-sm font-medium text-gray-700 mb-3">Available Tools</Text>
+
+              {/* Loading */}
+              {isLoading && (
+                <div className="flex items-center justify-center py-8">
+                  <Spin size="large" />
+                  <Text className="ml-3 text-gray-500">Loading tools...</Text>
+                </div>
+              )}
+
+              {/* Error */}
+              {error && !isLoading && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-center">
+                  <Text className="text-red-600 font-medium">Unable to load tools</Text>
+                  <Text className="text-sm text-red-500 mt-1">{error}</Text>
+                </div>
+              )}
+
+              {/* Tool List - Compact */}
+              {!isLoading && !error && tools.length > 0 && (
+                <div className="space-y-2">
+                  {tools.map((tool) => {
+                    const isSelected = selectedTools.includes(tool.name);
+                    console.log(`🔍 Tool ${tool.name} - isSelected: ${isSelected}, selectedTools:`, selectedTools);
+
+                    return (
+                      <div key={tool.name} className="flex items-start gap-2">
+                        <Checkbox
+                          checked={isSelected}
+                          onChange={(e) => {
+                            console.log("📝 Checkbox onChange event:", e);
+                            handleToolToggle(server.server_id, tool.name);
+                          }}
+                          disabled={disabled}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <Text className="font-medium text-gray-900">{tool.name}</Text>
+                            <Text className="text-sm text-gray-500">
+                              - {tool.description || "No description"}
+                            </Text>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Empty State */}
+              {!isLoading && !error && tools.length === 0 && (
+                <div className="text-center py-6">
+                  <Text className="text-gray-500">No tools available</Text>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MCPToolPermissions;

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -926,7 +926,41 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                       placeholder="Select vector stores (optional)"
                     />
                   </Form.Item>
-
+                  <Form.Item
+                    label={
+                      <span>
+                        Metadata{" "}
+                        <Tooltip title="JSON object with additional information about this key. Used for tracking or custom logic">
+                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="metadata"
+                    className="mt-4"
+                  >
+                    <Input.TextArea rows={4} placeholder="Enter metadata as JSON" />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      <span>
+                        Tags{" "}
+                        <Tooltip title="Tags for tracking spend and/or doing tag-based routing. Used for analytics and filtering">
+                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                        </Tooltip>
+                      </span>
+                    }
+                    name="tags"
+                    className="mt-4"
+                    help={`Tags for tracking spend and/or doing tag-based routing.`}
+                  >
+                    <Select
+                      mode="tags"
+                      style={{ width: "100%" }}
+                      placeholder="Enter tags"
+                      tokenSeparators={[","]}
+                      options={predefinedTags}
+                    />
+                  </Form.Item>
                   <Accordion
                     className="mt-4 mb-4"
                     onClick={() => {
@@ -980,42 +1014,6 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                       </Form.Item>
                     </AccordionBody>
                   </Accordion>
-
-                  <Form.Item
-                    label={
-                      <span>
-                        Metadata{" "}
-                        <Tooltip title="JSON object with additional information about this key. Used for tracking or custom logic">
-                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
-                        </Tooltip>
-                      </span>
-                    }
-                    name="metadata"
-                    className="mt-4"
-                  >
-                    <Input.TextArea rows={4} placeholder="Enter metadata as JSON" />
-                  </Form.Item>
-                  <Form.Item
-                    label={
-                      <span>
-                        Tags{" "}
-                        <Tooltip title="Tags for tracking spend and/or doing tag-based routing. Used for analytics and filtering">
-                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
-                        </Tooltip>
-                      </span>
-                    }
-                    name="tags"
-                    className="mt-4"
-                    help={`Tags for tracking spend and/or doing tag-based routing.`}
-                  >
-                    <Select
-                      mode="tags"
-                      style={{ width: "100%" }}
-                      placeholder="Enter tags"
-                      tokenSeparators={[","]}
-                      options={predefinedTags}
-                    />
-                  </Form.Item>
 
                   {premiumUser ? (
                     <Accordion className="mt-4 mb-4">

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -32,6 +32,7 @@ import BudgetDurationDropdown from "../common_components/budget_duration_dropdow
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { callback_map, mapDisplayToInternalNames } from "../callback_info_helpers";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
 import ModelAliasManager from "../common_components/ModelAliasManager";
 import NotificationsManager from "../molecules/notifications_manager";
 import KeyLifecycleSettings from "../common_components/KeyLifecycleSettings";
@@ -356,6 +357,16 @@ const CreateKey: React.FC<CreateKeyProps> = ({
         // Remove the original field as it's now part of object_permission
         delete formValues.allowed_mcp_servers_and_groups;
       }
+
+      // Add MCP tool permissions to object_permission
+      const mcpToolPermissions = formValues.mcp_tool_permissions || {};
+      if (Object.keys(mcpToolPermissions).length > 0) {
+        if (!formValues.object_permission) {
+          formValues.object_permission = {};
+        }
+        formValues.object_permission.mcp_tool_permissions = mcpToolPermissions;
+      }
+      delete formValues.mcp_tool_permissions;
 
       // Transform allowed_mcp_access_groups into object_permission format
       if (formValues.allowed_mcp_access_groups && formValues.allowed_mcp_access_groups.length > 0) {
@@ -715,15 +726,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
           {/* Section 3: Optional Settings */}
           {!isFormDisabled && (
             <div className="mb-8">
-              <Accordion
-                className="mt-4 mb-4"
-                onClick={() => {
-                  if (!mcpAccessGroupsLoaded) {
-                    fetchMcpAccessGroups();
-                    setMcpAccessGroupsLoaded(true);
-                  }
-                }}
-              >
+              <Accordion className="mt-4 mb-4">
                 <AccordionHeader>
                   <Title className="m-0">Optional Settings</Title>
                 </AccordionHeader>
@@ -924,26 +927,59 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                     />
                   </Form.Item>
 
-                  <Form.Item
-                    label={
-                      <span>
-                        Allowed MCP Servers{" "}
-                        <Tooltip title="Select which MCP servers or access groups this key can access. ">
-                          <InfoCircleOutlined style={{ marginLeft: "4px" }} />
-                        </Tooltip>
-                      </span>
-                    }
-                    name="allowed_mcp_servers_and_groups"
-                    className="mt-4"
-                    help="Select MCP servers or access groups this key can access. "
+                  <Accordion
+                    className="mt-4 mb-4"
+                    onClick={() => {
+                      if (!mcpAccessGroupsLoaded) {
+                        fetchMcpAccessGroups();
+                        setMcpAccessGroupsLoaded(true);
+                      }
+                    }}
                   >
-                    <MCPServerSelector
-                      onChange={(val: any) => form.setFieldValue("allowed_mcp_servers_and_groups", val)}
-                      value={form.getFieldValue("allowed_mcp_servers_and_groups")}
-                      accessToken={accessToken}
-                      placeholder="Select MCP servers or access groups (optional)"
-                    />
-                  </Form.Item>
+                    <AccordionHeader>
+                      <b>MCP Settings</b>
+                    </AccordionHeader>
+                    <AccordionBody>
+                      <Form.Item
+                        label={
+                          <span>
+                            Allowed MCP Servers{" "}
+                            <Tooltip title="Select which MCP servers or access groups this key can access">
+                              <InfoCircleOutlined style={{ marginLeft: "4px" }} />
+                            </Tooltip>
+                          </span>
+                        }
+                        name="allowed_mcp_servers_and_groups"
+                        help="Select MCP servers or access groups this key can access"
+                      >
+                        <MCPServerSelector
+                          onChange={(val: any) => form.setFieldValue("allowed_mcp_servers_and_groups", val)}
+                          value={form.getFieldValue("allowed_mcp_servers_and_groups")}
+                          accessToken={accessToken}
+                          placeholder="Select MCP servers or access groups (optional)"
+                        />
+                      </Form.Item>
+
+                      <Form.Item 
+                        noStyle
+                        shouldUpdate={(prevValues, currentValues) => 
+                          prevValues.allowed_mcp_servers_and_groups !== currentValues.allowed_mcp_servers_and_groups ||
+                          prevValues.mcp_tool_permissions !== currentValues.mcp_tool_permissions
+                        }
+                      >
+                        {() => (
+                          <div className="mt-6">
+                            <MCPToolPermissions
+                              accessToken={accessToken}
+                              selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                              toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                            />
+                          </div>
+                        )}
+                      </Form.Item>
+                    </AccordionBody>
+                  </Accordion>
 
                   <Form.Item
                     label={

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -43,6 +43,7 @@ import { isAdminRole } from "@/utils/roles";
 import ObjectPermissionsView from "../object_permissions_view";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import EditLoggingSettings from "./EditLoggingSettings";
 import LoggingSettingsView from "../logging_settings_view";
@@ -96,6 +97,7 @@ export interface TeamData {
       object_permission_id: string;
       mcp_servers: string[];
       mcp_access_groups?: string[];
+      mcp_tool_permissions?: Record<string, string[]>;
       vector_stores: string[];
     };
     team_member_budget_table: {
@@ -348,7 +350,9 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         servers: [],
         accessGroups: [],
       };
-      if ((servers && servers.length > 0) || (accessGroups && accessGroups.length > 0)) {
+      const mcpToolPermissions = values.mcp_tool_permissions || {};
+      
+      if ((servers && servers.length > 0) || (accessGroups && accessGroups.length > 0) || Object.keys(mcpToolPermissions).length > 0) {
         updateData.object_permission = {};
         if (servers && servers.length > 0) {
           updateData.object_permission.mcp_servers = servers;
@@ -356,8 +360,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         if (accessGroups && accessGroups.length > 0) {
           updateData.object_permission.mcp_access_groups = accessGroups;
         }
+        if (Object.keys(mcpToolPermissions).length > 0) {
+          updateData.object_permission.mcp_tool_permissions = mcpToolPermissions;
+        }
       }
       delete values.mcp_servers_and_groups;
+      delete values.mcp_tool_permissions;
 
       const response = await teamUpdateCall(accessToken, updateData);
 
@@ -552,6 +560,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       servers: info.object_permission?.mcp_servers || [],
                       accessGroups: info.object_permission?.mcp_access_groups || [],
                     },
+                    mcp_tool_permissions: info.object_permission?.mcp_tool_permissions || {},
                   }}
                   layout="vertical"
                 >
@@ -671,6 +680,26 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       placeholder="Select MCP servers or access groups (optional)"
                     />
                   </Form.Item>
+
+                  <Form.Item 
+                    noStyle
+                    shouldUpdate={(prevValues, currentValues) => 
+                      prevValues.mcp_servers_and_groups !== currentValues.mcp_servers_and_groups ||
+                      prevValues.mcp_tool_permissions !== currentValues.mcp_tool_permissions
+                    }
+                  >
+                    {() => (
+                      <div className="mb-6">
+                        <MCPToolPermissions
+                          accessToken={accessToken || ""}
+                          selectedServers={form.getFieldValue("mcp_servers_and_groups")?.servers || []}
+                          toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                          onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                        />
+                      </div>
+                    )}
+                  </Form.Item>
+
                   <Form.Item label="Organization ID" name="organization_id">
                     <Input type="" />
                   </Form.Item>

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -1287,23 +1287,16 @@ const Teams: React.FC<TeamProps> = ({
                           prevValues.mcp_tool_permissions !== currentValues.mcp_tool_permissions
                         }
                       >
-                        {() => {
-                          console.log("🔄 Form re-rendering MCPToolPermissions");
-                          console.log("📋 Current mcp_tool_permissions:", form.getFieldValue("mcp_tool_permissions"));
-                          return (
-                            <div className="mt-6">
-                              <MCPToolPermissions
-                                accessToken={accessToken || ""}
-                                selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
-                                toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                                onChange={(toolPerms) => {
-                                  console.log("🎯 Parent onChange called with:", toolPerms);
-                                  form.setFieldValue("mcp_tool_permissions", toolPerms);
-                                }}
-                              />
-                            </div>
-                          );
-                        }}
+                        {() => (
+                          <div className="mt-6">
+                            <MCPToolPermissions
+                              accessToken={accessToken || ""}
+                              selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                              toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                            />
+                          </div>
+                        )}
                       </Form.Item>
                     </AccordionBody>
                   </Accordion>

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -1283,19 +1283,27 @@ const Teams: React.FC<TeamProps> = ({
                       <Form.Item 
                         noStyle
                         shouldUpdate={(prevValues, currentValues) => 
-                          prevValues.allowed_mcp_servers_and_groups !== currentValues.allowed_mcp_servers_and_groups
+                          prevValues.allowed_mcp_servers_and_groups !== currentValues.allowed_mcp_servers_and_groups ||
+                          prevValues.mcp_tool_permissions !== currentValues.mcp_tool_permissions
                         }
                       >
-                        {() => (
-                          <div className="mt-6">
-                            <MCPToolPermissions
-                              accessToken={accessToken || ""}
-                              selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
-                              toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
-                            />
-                          </div>
-                        )}
+                        {() => {
+                          console.log("🔄 Form re-rendering MCPToolPermissions");
+                          console.log("📋 Current mcp_tool_permissions:", form.getFieldValue("mcp_tool_permissions"));
+                          return (
+                            <div className="mt-6">
+                              <MCPToolPermissions
+                                accessToken={accessToken || ""}
+                                selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                                toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                                onChange={(toolPerms) => {
+                                  console.log("🎯 Parent onChange called with:", toolPerms);
+                                  form.setFieldValue("mcp_tool_permissions", toolPerms);
+                                }}
+                              />
+                            </div>
+                          );
+                        }}
                       </Form.Item>
                     </AccordionBody>
                   </Accordion>

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -1281,19 +1281,20 @@ const Teams: React.FC<TeamProps> = ({
                       </Form.Item>
 
                       <Form.Item 
-                        label="Tool Permissions" 
-                        className="mt-6"
+                        noStyle
                         shouldUpdate={(prevValues, currentValues) => 
                           prevValues.allowed_mcp_servers_and_groups !== currentValues.allowed_mcp_servers_and_groups
                         }
                       >
                         {() => (
-                          <MCPToolPermissions
-                            accessToken={accessToken || ""}
-                            selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
-                            toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                            onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
-                          />
+                          <div className="mt-6">
+                            <MCPToolPermissions
+                              accessToken={accessToken || ""}
+                              selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                              toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                            />
+                          </div>
                         )}
                       </Form.Item>
                     </AccordionBody>

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -66,6 +66,7 @@ import type { KeyResponse, Team } from "./key_team_helpers/key_list";
 import { formatNumberWithCommas } from "../utils/dataUtils";
 import { AlertTriangleIcon, XIcon } from "lucide-react";
 import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
+import MCPToolPermissions from "./mcp_server_management/MCPToolPermissions";
 import ModelAliasManager from "./common_components/ModelAliasManager";
 import NotificationsManager from "./molecules/notifications_manager";
 
@@ -378,7 +379,8 @@ const Teams: React.FC<TeamProps> = ({
           (formValues.allowed_vector_store_ids && formValues.allowed_vector_store_ids.length > 0) ||
           (formValues.allowed_mcp_servers_and_groups &&
             (formValues.allowed_mcp_servers_and_groups.servers?.length > 0 ||
-              formValues.allowed_mcp_servers_and_groups.accessGroups?.length > 0))
+              formValues.allowed_mcp_servers_and_groups.accessGroups?.length > 0 ||
+              formValues.allowed_mcp_servers_and_groups.toolPermissions))
         ) {
           formValues.object_permission = {};
           if (formValues.allowed_vector_store_ids && formValues.allowed_vector_store_ids.length > 0) {
@@ -394,6 +396,15 @@ const Teams: React.FC<TeamProps> = ({
               formValues.object_permission.mcp_access_groups = accessGroups;
             }
             delete formValues.allowed_mcp_servers_and_groups;
+          }
+
+          // Add tool permissions separately
+          if (formValues.mcp_tool_permissions && Object.keys(formValues.mcp_tool_permissions).length > 0) {
+            if (!formValues.object_permission) {
+              formValues.object_permission = {};
+            }
+            formValues.object_permission.mcp_tool_permissions = formValues.mcp_tool_permissions;
+            delete formValues.mcp_tool_permissions;
           }
         }
 
@@ -1240,18 +1251,26 @@ const Teams: React.FC<TeamProps> = ({
                           placeholder="Select vector stores (optional)"
                         />
                       </Form.Item>
+                    </AccordionBody>
+                  </Accordion>
+
+                  <Accordion className="mt-8 mb-8">
+                    <AccordionHeader>
+                      <b>MCP Settings</b>
+                    </AccordionHeader>
+                    <AccordionBody>
                       <Form.Item
                         label={
                           <span>
                             Allowed MCP Servers{" "}
-                            <Tooltip title="Select which MCP servers or access groups this team can access by default. ">
+                            <Tooltip title="Select which MCP servers or access groups this team can access">
                               <InfoCircleOutlined style={{ marginLeft: "4px" }} />
                             </Tooltip>
                           </span>
                         }
                         name="allowed_mcp_servers_and_groups"
-                        className="mt-8"
-                        help="Select MCP servers or access groups this team can access. "
+                        className="mt-4"
+                        help="Select MCP servers or access groups this team can access"
                       >
                         <MCPServerSelector
                           onChange={(val: any) => form.setFieldValue("allowed_mcp_servers_and_groups", val)}
@@ -1259,6 +1278,23 @@ const Teams: React.FC<TeamProps> = ({
                           accessToken={accessToken || ""}
                           placeholder="Select MCP servers or access groups (optional)"
                         />
+                      </Form.Item>
+
+                      <Form.Item 
+                        label="Tool Permissions" 
+                        className="mt-6"
+                        shouldUpdate={(prevValues, currentValues) => 
+                          prevValues.allowed_mcp_servers_and_groups !== currentValues.allowed_mcp_servers_and_groups
+                        }
+                      >
+                        {() => (
+                          <MCPToolPermissions
+                            accessToken={accessToken || ""}
+                            selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                            toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+                            onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                          />
+                        )}
                       </Form.Item>
                     </AccordionBody>
                   </Accordion>

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -7,6 +7,7 @@ import { modelAvailableCall, getPromptsList } from "../networking";
 import NumericalInput from "../shared/numerical_input";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
 import EditLoggingSettings from "../team/EditLoggingSettings";
 import { extractLoggingSettings, formatMetadataForDisplay } from "../key_info_utils";
 import { fetchMCPAccessGroups } from "../networking";
@@ -145,6 +146,7 @@ export function KeyEditView({
       servers: keyData.object_permission?.mcp_servers || [],
       accessGroups: keyData.object_permission?.mcp_access_groups || [],
     },
+    mcp_tool_permissions: keyData.object_permission?.mcp_tool_permissions || {},
     logging_settings: extractLoggingSettings(keyData.metadata),
     disabled_callbacks: Array.isArray(keyData.metadata?.litellm_disabled_callbacks)
       ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
@@ -166,6 +168,7 @@ export function KeyEditView({
         servers: keyData.object_permission?.mcp_servers || [],
         accessGroups: keyData.object_permission?.mcp_access_groups || [],
       },
+      mcp_tool_permissions: keyData.object_permission?.mcp_tool_permissions || {},
       logging_settings: extractLoggingSettings(keyData.metadata),
       disabled_callbacks: Array.isArray(keyData.metadata?.litellm_disabled_callbacks)
         ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
@@ -289,6 +292,25 @@ export function KeyEditView({
           accessToken={accessToken || ""}
           placeholder="Select MCP servers or access groups (optional)"
         />
+      </Form.Item>
+
+      <Form.Item 
+        noStyle
+        shouldUpdate={(prevValues, currentValues) => 
+          prevValues.mcp_servers_and_groups !== currentValues.mcp_servers_and_groups ||
+          prevValues.mcp_tool_permissions !== currentValues.mcp_tool_permissions
+        }
+      >
+        {() => (
+          <div className="mb-6">
+            <MCPToolPermissions
+              accessToken={accessToken || ""}
+              selectedServers={form.getFieldValue("mcp_servers_and_groups")?.servers || []}
+              toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
+              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+            />
+          </div>
+        )}
       </Form.Item>
 
       <Form.Item label="Team ID" name="team_id">

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -136,6 +136,18 @@ export default function KeyInfoView({
         delete formValues.mcp_servers_and_groups;
       }
 
+      // Handle MCP tool permissions
+      if (formValues.mcp_tool_permissions !== undefined) {
+        const mcpToolPermissions = formValues.mcp_tool_permissions || {};
+        if (Object.keys(mcpToolPermissions).length > 0) {
+          formValues.object_permission = {
+            ...formValues.object_permission,
+            mcp_tool_permissions: mcpToolPermissions,
+          };
+        }
+        delete formValues.mcp_tool_permissions;
+      }
+
       // Convert metadata back to an object if it exists and is a string
       if (formValues.metadata && typeof formValues.metadata === "string") {
         try {


### PR DESCRIPTION
## [MCP Gateway] Select allowed tools for Key, Teams 

When Adding/Editing Keys, Teams you can now enforce what MCP tools each entity can access 

<img width="879" height="331" alt="Screenshot 2025-10-06 at 2 20 30 PM" src="https://github.com/user-attachments/assets/6c4df82d-2ead-4b44-b65b-29bf221184b5" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


