### PR TITLE
[MCP Gateway] Backend - Allow storing allowed tools by team/key

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20251006143948_add_mcp_tool_permissions/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20251006143948_add_mcp_tool_permissions/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_ObjectPermissionTable" ADD COLUMN     "mcp_tool_permissions" JSONB;
+

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -156,6 +156,7 @@ model LiteLLM_ObjectPermissionTable {
   object_permission_id  String         @id @default(uuid())
   mcp_servers           String[]       @default([])
   mcp_access_groups     String[]       @default([])
+  mcp_tool_permissions  Json?          // Tool-level permissions for MCP servers. Format: {"server_id": ["tool_name_1", "tool_name_2"]}
   vector_stores         String[]       @default([])
   teams                 LiteLLM_TeamTable[]
   verification_tokens   LiteLLM_VerificationToken[]

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -118,7 +118,7 @@ class MCPClient:
             else:  # http
                 headers = self._get_auth_headers()
                 verbose_logger.debug(
-                    "litellm headers for streamablehttp_client: ", headers
+                    "litellm headers for streamablehttp_client: %s", headers
                 )
                 self._transport_ctx = streamablehttp_client(
                     url=self.server_url,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -602,7 +602,7 @@ class MCPServerManager:
             return tool_name not in server.disallowed_tools
         return True
 
-    def check_tool_permission_for_key_team(
+    async def check_tool_permission_for_key_team(
         self,
         tool_name: str,
         server: MCPServer,
@@ -610,41 +610,36 @@ class MCPServerManager:
     ) -> None:
         """
         Check if a tool is allowed based on key/team object_permission.mcp_tool_permissions.
+        Uses MCPRequestHandler.is_tool_allowed_for_server for consistent inheritance logic.
         Raises HTTPException if tool is not allowed.
 
         Args:
             tool_name: Name of the tool to check
             server: MCPServer object
-            user_api_key_auth: User authentication with potential object_permission
+            user_api_key_auth: User authentication
 
         Raises:
             HTTPException: If tool is not allowed for this key/team
         """
-        if not user_api_key_auth or not user_api_key_auth.object_permission:
-            return
-
-        mcp_tool_permissions = user_api_key_auth.object_permission.mcp_tool_permissions
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import MCPRequestHandler
         
-        if not mcp_tool_permissions or not isinstance(mcp_tool_permissions, dict):
+        if not user_api_key_auth:
             return
         
-        server_id = server.server_id
+        # Check if tool is allowed
+        is_allowed = await MCPRequestHandler.is_tool_allowed_for_server(
+            tool_name=tool_name,
+            server_id=server.server_id,
+            user_api_key_auth=user_api_key_auth,
+        )
         
-        # Check if this server has tool-level restrictions
-        if server_id not in mcp_tool_permissions:
-            return
-        
-        allowed_tools = mcp_tool_permissions[server_id]
-        
-        # If tool list exists and is not empty, enforce it
-        if allowed_tools and isinstance(allowed_tools, list):
-            if tool_name not in allowed_tools:
-                raise HTTPException(
-                    status_code=403,
-                    detail={
-                        "error": f"Tool '{tool_name}' is not allowed for your key/team on server '{server.name}'. Allowed tools: {', '.join(allowed_tools)}. Contact proxy admin for access."
-                    },
-                )
+        if not is_allowed:
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": f"Tool '{tool_name}' is not allowed for your key/team on server '{server.name}'. Contact proxy admin for access."
+                },
+            )
 
     async def pre_call_tool_check(
         self,
@@ -666,7 +661,7 @@ class MCPServerManager:
             )
 
         ## check tool-level permissions from object_permission
-        self.check_tool_permission_for_key_team(
+        await self.check_tool_permission_for_key_team(
             tool_name=name,
             server=server,
             user_api_key_auth=user_api_key_auth,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -499,11 +499,13 @@ if MCP_AVAILABLE:
                 )
                 
                 filtered_tools = filter_tools_by_allowed_tools(tools, server)
-                filtered_tools = filter_tools_by_key_team_permissions(
-                    tools=tools,
-                    server_id=server.server_id,
+                
+                filtered_tools = await filter_tools_by_key_team_permissions(
+                    tools=filtered_tools,
+                    server_id=server_id,
                     user_api_key_auth=user_api_key_auth,
                 )
+                
                 all_tools.extend(filtered_tools)
                 
                 verbose_logger.debug(
@@ -526,23 +528,15 @@ if MCP_AVAILABLE:
         user_api_key_auth: Optional[UserAPIKeyAuth],
     ) -> List[MCPTool]:
         """Filter tools based on key/team mcp_tool_permissions."""
-        if not user_api_key_auth or not user_api_key_auth.object_permission:
-            return tools
+        # Filter by key/team tool-level permissions
+        allowed_tool_names = await MCPRequestHandler.get_allowed_tools_for_server(
+            server_id=server_id,
+            user_api_key_auth=user_api_key_auth,
+        )
+        if allowed_tool_names is not None:
+            filtered_tools = [t for t in tools if t.name in allowed_tool_names]
         
-        mcp_tool_permissions = user_api_key_auth.object_permission.mcp_tool_permissions
-        
-        if not mcp_tool_permissions or not isinstance(mcp_tool_permissions, dict):
-            return tools
-        
-        if server_id not in mcp_tool_permissions:
-            return tools
-        
-        allowed_tools = mcp_tool_permissions[server_id]
-        
-        if not allowed_tools or not isinstance(allowed_tools, list):
-            return tools
-        
-        return [t for t in tools if t.name in allowed_tools]
+        return filtered_tools
 
     async def _list_mcp_tools(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -521,8 +521,8 @@ if MCP_AVAILABLE:
             f"Successfully fetched {len(all_tools)} tools total from all MCP servers"
         )
         return all_tools
-    
-    def filter_tools_by_key_team_permissions(
+
+    async def filter_tools_by_key_team_permissions(
         tools: List[MCPTool],
         server_id: str,
         user_api_key_auth: Optional[UserAPIKeyAuth],
@@ -535,6 +535,9 @@ if MCP_AVAILABLE:
         )
         if allowed_tool_names is not None:
             filtered_tools = [t for t in tools if t.name in allowed_tool_names]
+        else:
+            # No restrictions, return all tools
+            filtered_tools = tools
         
         return filtered_tools
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -712,6 +712,7 @@ class ModelParams(LiteLLMPydanticObjectBase):
 class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
     mcp_servers: Optional[List[str]] = None
     mcp_access_groups: Optional[List[str]] = None
+    mcp_tool_permissions: Optional[Dict[str, List[str]]] = None
     vector_stores: Optional[List[str]] = None
 
 
@@ -1414,6 +1415,16 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     object_permission_id: str
     mcp_servers: Optional[List[str]] = []
     mcp_access_groups: Optional[List[str]] = []
+    mcp_tool_permissions: Optional[Dict[str, List[str]]] = None
+    f"""
+    Mapping - server_id -> list of tools
+
+    Enforces allowed tools for a specific key/team/organization
+    {
+        "1234567890": ["tool_name_1", "tool_name_2"]
+    }
+    """
+    
     vector_stores: Optional[List[str]] = []
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1416,7 +1416,7 @@ class LiteLLM_ObjectPermissionTable(LiteLLMPydanticObjectBase):
     mcp_servers: Optional[List[str]] = []
     mcp_access_groups: Optional[List[str]] = []
     mcp_tool_permissions: Optional[Dict[str, List[str]]] = None
-    f"""
+    """
     Mapping - server_id -> list of tools
 
     Enforces allowed tools for a specific key/team/organization

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -837,7 +837,7 @@ async def generate_key_fn(
     - enforced_params: Optional[List[str]] - List of enforced params for the key (Enterprise only). [Docs](https://docs.litellm.ai/docs/proxy/enterprise#enforce-required-params-for-llm-requests)
     - prompts: Optional[List[str]] - List of prompts that the key is allowed to use.
     - allowed_routes: Optional[list] - List of allowed routes for the key. Store the actual route or store a wildcard pattern for a set of routes. Example - ["/chat/completions", "/embeddings", "/keys/*"]
-    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "mcp_tool_permissions": {"server_id_1": ["tool1", "tool2"]}}. IF null or {} then no object permission.
     - key_type: Optional[str] - Type of key that determines default allowed routes. Options: "llm_api" (can call LLM API routes), "management" (can call management routes), "read_only" (can only call info/read routes), "default" (uses default allowed routes). Defaults to "default".
     - prompts: Optional[List[str]] - List of allowed prompts for the key. If specified, the key will only be able to use these specific prompts.
     - auto_rotate: Optional[bool] - Whether this key should be automatically rotated (regenerated)
@@ -987,7 +987,7 @@ async def generate_service_account_key_fn(
     - tags: Optional[List[str]] - Tags for [tracking spend](https://litellm.vercel.app/docs/proxy/enterprise#tracking-spend-for-custom-tags) and/or doing [tag-based routing](https://litellm.vercel.app/docs/proxy/tag_routing).
     - enforced_params: Optional[List[str]] - List of enforced params for the key (Enterprise only). [Docs](https://docs.litellm.ai/docs/proxy/enterprise#enforce-required-params-for-llm-requests)
     - allowed_routes: Optional[list] - List of allowed routes for the key. Store the actual route or store a wildcard pattern for a set of routes. Example - ["/chat/completions", "/embeddings", "/keys/*"]
-    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "mcp_tool_permissions": {"server_id_1": ["tool1", "tool2"]}}. IF null or {} then no object permission.
     Examples:
 
     1. Allow users to turn on/off pii masking
@@ -1300,7 +1300,7 @@ async def update_key_fn(
     - temp_budget_expiry: Optional[str] - Expiry time for the temporary budget increase (Enterprise only).
     - allowed_routes: Optional[list] - List of allowed routes for the key. Store the actual route or store a wildcard pattern for a set of routes. Example - ["/chat/completions", "/embeddings", "/keys/*"]
     - prompts: Optional[List[str]] - List of allowed prompts for the key. If specified, the key will only be able to use these specific prompts.
-    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - key-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "mcp_tool_permissions": {"server_id_1": ["tool1", "tool2"]}}. IF null or {} then no object permission.
     - auto_rotate: Optional[bool] - Whether this key should be automatically rotated
     - rotation_interval: Optional[str] - How often to rotate this key (e.g., '30d', '90d'). Required if auto_rotate=True
     Example:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -311,7 +311,7 @@ async def new_team(  # noqa: PLR0915
     - model_aliases: Optional[dict] - Model aliases for the team. [Docs](https://docs.litellm.ai/docs/proxy/team_based_routing#create-team-with-model-alias)
     - guardrails: Optional[List[str]] - Guardrails for the team. [Docs](https://docs.litellm.ai/docs/proxy/guardrails)
     - prompts: Optional[List[str]] - List of prompts that the team is allowed to use.
-    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "mcp_tool_permissions": {"server_id_1": ["tool1", "tool2"]}}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
@@ -769,7 +769,7 @@ async def update_team(
     - model_aliases: Optional[dict] - Model aliases for the team. [Docs](https://docs.litellm.ai/docs/proxy/team_based_routing#create-team-with-model-alias)
     - guardrails: Optional[List[str]] - Guardrails for the team. [Docs](https://docs.litellm.ai/docs/proxy/guardrails)
     - prompts: Optional[List[str]] - List of prompts that the team is allowed to use.
-    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"]}. IF null or {} then no object permission.
+    - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "mcp_tool_permissions": {"server_id_1": ["tool1", "tool2"]}}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -9,6 +9,8 @@ from typing import Dict, Optional, Union
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.utils import PrismaClient
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+        
 
 
 async def attach_object_permission_to_dict(
@@ -113,6 +115,15 @@ async def handle_update_object_permission_common(
 
     if isinstance(new_object_permission, dict):
         existing_object_permissions_dict.update(new_object_permission)
+
+    #########################################################
+    # Serialize mcp_tool_permissions JSON field to avoid GraphQL parsing issues
+    # (e.g., server IDs starting with "3e64" being interpreted as floats)
+    #########################################################
+    if "mcp_tool_permissions" in existing_object_permissions_dict:
+        existing_object_permissions_dict["mcp_tool_permissions"] = safe_dumps(
+            existing_object_permissions_dict["mcp_tool_permissions"]
+        )
 
     #########################################################
     # Commit the update to the LiteLLM_ObjectPermissionTable

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -156,6 +156,7 @@ model LiteLLM_ObjectPermissionTable {
   object_permission_id  String         @id @default(uuid())
   mcp_servers           String[]       @default([])
   mcp_access_groups     String[]       @default([])
+  mcp_tool_permissions  Json?          // Tool-level permissions for MCP servers. Format: {"server_id": ["tool_name_1", "tool_name_2"]}
   vector_stores         String[]       @default([])
   teams                 LiteLLM_TeamTable[]
   verification_tokens   LiteLLM_VerificationToken[]

--- a/schema.prisma
+++ b/schema.prisma
@@ -156,6 +156,7 @@ model LiteLLM_ObjectPermissionTable {
   object_permission_id  String         @id @default(uuid())
   mcp_servers           String[]       @default([])
   mcp_access_groups     String[]       @default([])
+  mcp_tool_permissions  Json?          // Tool-level permissions for MCP servers. Format: {"server_id": ["tool_name_1", "tool_name_2"]}
   vector_stores         String[]       @default([])
   teams                 LiteLLM_TeamTable[]
   verification_tokens   LiteLLM_VerificationToken[]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -734,3 +734,88 @@ async def test_call_mcp_tool_user_unauthorized_access():
         # Verify the exception details
         assert exc_info.value.status_code == 403
         assert "User not allowed to call this tool" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_list_tools_filters_by_key_team_permissions():
+    """Test that list_tools filters tools based on key/team mcp_tool_permissions"""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    # Create object permission with tool-level restrictions
+    object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="perm_123",
+        mcp_tool_permissions={
+            "server1": ["tool1", "tool2"],  # Only allow tool1 and tool2
+        },
+    )
+
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test_key",
+        user_id="test_user",
+        object_permission=object_permission,
+    )
+    set_auth_context(user_api_key_auth)
+
+    # Mock server
+    server = MagicMock()
+    server.server_id = "server1"
+    server.name = "Test Server"
+    server.alias = "test"
+    server.allowed_tools = None
+    server.disallowed_tools = None
+
+    # Mock manager
+    mock_manager = MagicMock()
+    mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_by_id = lambda server_id: server
+
+    async def mock_get_tools_from_server(
+        server, mcp_auth_header=None, extra_headers=None, add_prefix=False
+    ):
+        # Return 4 tools, but only 2 should be allowed
+        tool1 = MagicMock()
+        tool1.name = "tool1"
+        tool1.description = "Tool 1"
+        tool1.inputSchema = {}
+
+        tool2 = MagicMock()
+        tool2.name = "tool2"
+        tool2.description = "Tool 2"
+        tool2.inputSchema = {}
+
+        tool3 = MagicMock()
+        tool3.name = "tool3"
+        tool3.description = "Tool 3 - not allowed"
+        tool3.inputSchema = {}
+
+        tool4 = MagicMock()
+        tool4.name = "tool4"
+        tool4.description = "Tool 4 - not allowed"
+        tool4.inputSchema = {}
+
+        return [tool1, tool2, tool3, tool4]
+
+    mock_manager._get_tools_from_server = mock_get_tools_from_server
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        mock_manager,
+    ):
+        tools = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            mcp_servers=None,
+            mcp_server_auth_headers=None,
+        )
+
+    # Should only return tool1 and tool2
+    assert len(tools) == 2
+    tool_names = sorted([t.name for t in tools])
+    assert tool_names == ["tool1", "tool2"]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -819,3 +819,179 @@ async def test_list_tools_filters_by_key_team_permissions():
     assert len(tools) == 2
     tool_names = sorted([t.name for t in tools])
     assert tool_names == ["tool1", "tool2"]
+
+
+@pytest.mark.asyncio
+async def test_list_tools_with_team_tool_permissions_inheritance():
+    """Test that list_tools correctly applies key/team tool permissions inheritance logic"""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+        from litellm.proxy._types import (
+            LiteLLM_ObjectPermissionTable,
+            LiteLLM_TeamTable,
+            UserAPIKeyAuth,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    # Team allows tool1, tool2, tool3
+    team_object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="team_perm_123",
+        mcp_tool_permissions={
+            "server1": ["tool1", "tool2", "tool3"],
+        },
+    )
+
+    # Key allows tool2, tool3, tool4 - intersection should be tool2, tool3
+    key_object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="key_perm_456",
+        mcp_tool_permissions={
+            "server1": ["tool2", "tool3", "tool4"],
+        },
+    )
+
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test_key",
+        user_id="test_user",
+        team_id="team_123",
+        object_permission=key_object_permission,
+    )
+    set_auth_context(user_api_key_auth)
+
+    # Mock server
+    server = MagicMock()
+    server.server_id = "server1"
+    server.name = "Test Server"
+    server.alias = "test"
+    server.allowed_tools = None
+    server.disallowed_tools = None
+
+    # Mock manager
+    mock_manager = MagicMock()
+    mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_by_id = lambda server_id: server
+
+    async def mock_get_tools_from_server(
+        server, mcp_auth_header=None, extra_headers=None, add_prefix=False
+    ):
+        # Return 4 tools
+        tool1 = MagicMock()
+        tool1.name = "tool1"
+        tool1.description = "Tool 1"
+        tool1.inputSchema = {}
+
+        tool2 = MagicMock()
+        tool2.name = "tool2"
+        tool2.description = "Tool 2"
+        tool2.inputSchema = {}
+
+        tool3 = MagicMock()
+        tool3.name = "tool3"
+        tool3.description = "Tool 3"
+        tool3.inputSchema = {}
+
+        tool4 = MagicMock()
+        tool4.name = "tool4"
+        tool4.description = "Tool 4"
+        tool4.inputSchema = {}
+
+        return [tool1, tool2, tool3, tool4]
+
+    mock_manager._get_tools_from_server = mock_get_tools_from_server
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        mock_manager,
+    ):
+        # Mock the team object permission retrieval
+        with patch(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_team_object_permission",
+            AsyncMock(return_value=team_object_permission),
+        ):
+            tools = await _get_tools_from_mcp_servers(
+                user_api_key_auth=user_api_key_auth,
+                mcp_auth_header=None,
+                mcp_servers=None,
+                mcp_server_auth_headers=None,
+            )
+
+    # Should only return tool2 and tool3 (intersection of key and team permissions)
+    assert len(tools) == 2
+    tool_names = sorted([t.name for t in tools])
+    assert tool_names == ["tool2", "tool3"]
+
+
+@pytest.mark.asyncio
+async def test_list_tools_with_no_tool_permissions_shows_all():
+    """Test that list_tools shows all tools when no mcp_tool_permissions are set"""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+            set_auth_context,
+        )
+        from litellm.proxy._types import UserAPIKeyAuth
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    # No tool-level restrictions
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test_key",
+        user_id="test_user",
+        object_permission=None,
+    )
+    set_auth_context(user_api_key_auth)
+
+    # Mock server
+    server = MagicMock()
+    server.server_id = "server1"
+    server.name = "Test Server"
+    server.alias = "test"
+    server.allowed_tools = None
+    server.disallowed_tools = None
+
+    # Mock manager
+    mock_manager = MagicMock()
+    mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_by_id = lambda server_id: server
+
+    async def mock_get_tools_from_server(
+        server, mcp_auth_header=None, extra_headers=None, add_prefix=False
+    ):
+        # Return 3 tools
+        tool1 = MagicMock()
+        tool1.name = "tool1"
+        tool1.description = "Tool 1"
+        tool1.inputSchema = {}
+
+        tool2 = MagicMock()
+        tool2.name = "tool2"
+        tool2.description = "Tool 2"
+        tool2.inputSchema = {}
+
+        tool3 = MagicMock()
+        tool3.name = "tool3"
+        tool3.description = "Tool 3"
+        tool3.inputSchema = {}
+
+        return [tool1, tool2, tool3]
+
+    mock_manager._get_tools_from_server = mock_get_tools_from_server
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        mock_manager,
+    ):
+        tools = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=None,
+            mcp_servers=None,
+            mcp_server_auth_headers=None,
+        )
+
+    # Should return all tools when no restrictions
+    assert len(tools) == 3
+    tool_names = sorted([t.name for t in tools])
+    assert tool_names == ["tool1", "tool2", "tool3"]

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPToolPermissions.tsx
@@ -90,10 +90,11 @@ const MCPToolPermissions: React.FC<MCPToolPermissionsProps> = ({
       ? currentTools.filter(name => name !== toolName)
       : [...currentTools, toolName];
     
-    onChange({
+    const updatedPermissions = {
       ...toolPermissions,
       [serverId]: newTools,
-    });
+    };
+    onChange(updatedPermissions);
   };
 
   const handleSelectAll = (serverId: string) => {

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -383,6 +383,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
         formValues.aliases = JSON.stringify(modelAliases);
       }
 
+
       let response;
       if (keyOwner === "service_account") {
         response = await keyCreateServiceAccountCall(accessToken, formValues);
@@ -994,6 +995,11 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                         />
                       </Form.Item>
 
+                      {/* Hidden field to register mcp_tool_permissions with the form */}
+                      <Form.Item name="mcp_tool_permissions" initialValue={{}} hidden>
+                        <Input type="hidden" />
+                      </Form.Item>
+
                       <Form.Item 
                         noStyle
                         shouldUpdate={(prevValues, currentValues) => 
@@ -1007,7 +1013,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({
                               accessToken={accessToken}
                               selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
                               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                              onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
                             />
                           </div>
                         )}

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -681,6 +681,11 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     />
                   </Form.Item>
 
+                  {/* Hidden field to register mcp_tool_permissions with the form */}
+                  <Form.Item name="mcp_tool_permissions" initialValue={{}} hidden>
+                    <Input type="hidden" />
+                  </Form.Item>
+
                   <Form.Item 
                     noStyle
                     shouldUpdate={(prevValues, currentValues) => 
@@ -694,7 +699,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                           accessToken={accessToken || ""}
                           selectedServers={form.getFieldValue("mcp_servers_and_groups")?.servers || []}
                           toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                          onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                          onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
                         />
                       </div>
                     )}

--- a/ui/litellm-dashboard/src/components/teams.tsx
+++ b/ui/litellm-dashboard/src/components/teams.tsx
@@ -1280,6 +1280,11 @@ const Teams: React.FC<TeamProps> = ({
                         />
                       </Form.Item>
 
+                      {/* Hidden field to register mcp_tool_permissions with the form */}
+                      <Form.Item name="mcp_tool_permissions" initialValue={{}} hidden>
+                        <Input type="hidden" />
+                      </Form.Item>
+
                       <Form.Item 
                         noStyle
                         shouldUpdate={(prevValues, currentValues) => 
@@ -1293,7 +1298,7 @@ const Teams: React.FC<TeamProps> = ({
                               accessToken={accessToken || ""}
                               selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
                               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-                              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+                              onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
                             />
                           </div>
                         )}

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -294,6 +294,11 @@ export function KeyEditView({
         />
       </Form.Item>
 
+      {/* Hidden field to register mcp_tool_permissions with the form */}
+      <Form.Item name="mcp_tool_permissions" initialValue={{}} hidden>
+        <Input type="hidden" />
+      </Form.Item>
+
       <Form.Item 
         noStyle
         shouldUpdate={(prevValues, currentValues) => 
@@ -307,7 +312,7 @@ export function KeyEditView({
               accessToken={accessToken || ""}
               selectedServers={form.getFieldValue("mcp_servers_and_groups")?.servers || []}
               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
-              onChange={(toolPerms) => form.setFieldValue("mcp_tool_permissions", toolPerms)}
+              onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
             />
           </div>
         )}


### PR DESCRIPTION
## [MCP Gateway] Backend - Allow storing allowed tools by team/key

Adds granular tool-level access control for MCP servers. Keys/teams can now specify which tools within an MCP server are accessible, not just all-or-nothing server access. 

Implements Backend + DB level changes 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


