### PR TITLE
feat: add stop parameter to non-supported params for GPT-5

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -35,6 +35,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             "presence_penalty",
             "frequency_penalty",
             "top_logprobs",
+            "stop",
         ]
 
         return [


### PR DESCRIPTION
- Add 'stop' parameter to the non_supported_params list in OpenAIGPT5Config
- This ensures the stop parameter is automatically dropped when calling GPT-5 models
- Resolves issue where stop parameter was not being stripped for GPT-5