### PR TITLE
(perf) mitigation: removes SOME duplicate network calls from model_dashboard

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/templates/model_dashboard.tsx
@@ -661,18 +661,15 @@ const ModelDashboard: React.FC<ModelDashboardProps> = ({
     if (accessToken && token && userRole && userID) {
       fetchData();
     }
+  }, [accessToken, token, userRole, userID, selectedTeam]);
 
-    const fetchModelMap = async () => {
+  useEffect(() => {
+    if (!accessToken || modelMap) return;
+    (async () => {
       const data = await modelCostMap(accessToken);
-      console.log(`received model cost map data: ${Object.keys(data)}`);
       setModelMap(data);
-    };
-    if (modelMap == null) {
-      fetchModelMap();
-    }
-
-    handleRefreshClick();
-  }, [accessToken, token, userRole, userID, modelMap, lastRefreshed, selectedTeam]);
+    })();
+  }, [accessToken, modelMap]);
 
   if (!modelData) {
     return <div>Loading...</div>;


### PR DESCRIPTION
## mitigation: removes SOME duplicate network calls from model_dashboard

## Relevant issues

Mitigates LIT-1198, but does not completely solve.

Fix requires complete refactor. No way around it.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->

🐛 Bug Fix

## Changes
- removes circular dependency from useEffect
- separates modelMap updating to its own useEffect

