### PR TITLE
fix: remove tcp connector limit

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -657,7 +657,7 @@ class AsyncHTTPHandler:
         )
         return LiteLLMAiohttpTransport(
             client=lambda: ClientSession(
-                connector=TCPConnector(**connector_kwargs),
+                connector=TCPConnector(limit=0, **connector_kwargs),
                 trust_env=trust_env,
             ),
         )

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -79,9 +79,12 @@ async def test_ssl_context_transport():
         # Get the client session and verify SSL context is passed through
         client_session = transport._get_valid_client_session()
         assert isinstance(client_session, ClientSession)
-        assert isinstance(client_session.connector, TCPConnector)
+        connector = client_session.connector
+        assert isinstance(connector, TCPConnector)
         # Verify the connector has SSL context set by checking if it's using SSL
-        assert client_session.connector._ssl is not None
+        assert connector._ssl is not None
+        # Verify connector limit is 0 (no limit)
+        assert connector.limit == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Title

Remove TCP connector limit

## Relevant issues

Fixes #14895 

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1201" height="186" alt="Screenshot 2025-10-06 at 8 26 54 PM" src="https://github.com/user-attachments/assets/35316314-766b-4294-bac5-1c8bc0c16644" />

## Type

🐛 Bug Fix

## Changes

- Remove limit on concurrent TCP connections
  - [aiohttp.TCPConnector](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.TCPConnector) has a default `limit` of 100 - this could become a bottleneck in case of high concurrency or long-running requests