### PR TITLE
fix: remove keys alias filter to prevent excessive /key/list fetching…

### DIFF
--- a/ui/litellm-dashboard/src/components/all_keys_table.tsx
+++ b/ui/litellm-dashboard/src/components/all_keys_table.tsx
@@ -152,7 +152,7 @@ export function AllKeysTable({
 
   // Use the filter logic hook
 
-  const { filters, filteredKeys, allKeyAliases, allTeams, allOrganizations, handleFilterChange, handleFilterReset } =
+  const { filters, filteredKeys, allTeams, allOrganizations, handleFilterChange, handleFilterReset } =
     useFilterLogic({
       keys,
       teams,
@@ -503,19 +503,7 @@ export function AllKeysTable({
     {
       name: "Key Alias",
       label: "Key Alias",
-      isSearchable: true,
-      searchFn: async (searchText) => {
-        const filteredKeyAliases = allKeyAliases.filter((key) => {
-          return key.toLowerCase().includes(searchText.toLowerCase());
-        });
-
-        return filteredKeyAliases.map((key) => {
-          return {
-            label: key,
-            value: key,
-          };
-        });
-      },
+      isSearchable: false,
     },
     {
       name: "User ID",

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
@@ -3,53 +3,6 @@ import { Team } from "./key_list";
 import { Organization } from "../networking";
 
 /**
- * Fetches all key aliases across all pages
- * @param accessToken The access token for API authentication
- * @returns Array of all unique key aliases
- */
-export const fetchAllKeyAliases = async (accessToken: string | null): Promise<string[]> => {
-  if (!accessToken) return [];
-
-  try {
-    // Fetch all pages of keys to extract aliases
-    let allAliases: string[] = [];
-    let currentPage = 1;
-    let hasMorePages = true;
-
-    while (hasMorePages) {
-      const response = await keyListCall(
-        accessToken,
-        null, // organization_id
-        "", // team_id
-        null, // selectedKeyAlias
-        null, // user_id
-        null, // key_hash
-        currentPage,
-        100, // larger page size to reduce number of requests
-      );
-
-      // Extract aliases from this page
-      const pageAliases = response.keys.map((key: any) => key.key_alias).filter(Boolean) as string[];
-
-      allAliases = [...allAliases, ...pageAliases];
-
-      // Check if there are more pages
-      if (currentPage < response.total_pages) {
-        currentPage++;
-      } else {
-        hasMorePages = false;
-      }
-    }
-
-    // Remove duplicates
-    return Array.from(new Set(allAliases));
-  } catch (error) {
-    console.error("Error fetching all key aliases:", error);
-    return [];
-  }
-};
-
-/**
  * Fetches all teams across all pages
  * @param accessToken The access token for API authentication
  * @param organizationId Optional organization ID to filter teams

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_logic.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useState, useRef } from "react";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import { keyListCall, Organization } from "../networking";
 import { Team } from "../key_team_helpers/key_list";
-import { useQuery } from "@tanstack/react-query";
-import { fetchAllKeyAliases, fetchAllOrganizations, fetchAllTeams } from "./filter_helpers";
+import { fetchAllOrganizations, fetchAllTeams } from "./filter_helpers";
 import { Setter } from "@/types";
 import { debounce } from "lodash";
 import { defaultPageSize } from "../constants";
@@ -123,16 +122,6 @@ export function useFilterLogic({
     }
   }, [accessToken]);
 
-  const queryAllKeysQuery = useQuery({
-    queryKey: ["allKeys"],
-    queryFn: async () => {
-      if (!accessToken) throw new Error("Access token required");
-      return await fetchAllKeyAliases(accessToken);
-    },
-    enabled: !!accessToken,
-  });
-  const allKeyAliases = queryAllKeysQuery.data || [];
-
   // Update teams and organizations when props change
   useEffect(() => {
     if (teams && teams.length > 0) {
@@ -182,7 +171,6 @@ export function useFilterLogic({
   return {
     filters,
     filteredKeys,
-    allKeyAliases,
     allTeams,
     allOrganizations,
     handleFilterChange,

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -21,7 +21,6 @@ import GuardrailViewer from "@/components/view_logs/GuardrailViewer/GuardrailVie
 import FilterComponent from "../molecules/filter";
 import { FilterOption } from "../molecules/filter";
 import { useLogFilterLogic } from "./log_filter_logic";
-import { fetchAllKeyAliases } from "../key_team_helpers/filter_helpers";
 import { Tab, TabGroup, TabList, TabPanels, TabPanel, Text, Switch } from "@tremor/react";
 import AuditLogs from "./audit_logs";
 import { getTimeRangeDisplay } from "./logs_utils";
@@ -237,7 +236,6 @@ export default function SpendLogsTable({
     filters,
     filteredLogs,
     allTeams: hookAllTeams,
-    allKeyAliases,
     handleFilterChange,
     handleFilterReset,
   } = useLogFilterLogic({
@@ -401,16 +399,7 @@ export default function SpendLogsTable({
     {
       name: "Key Alias",
       label: "Key Alias",
-      isSearchable: true,
-      searchFn: async (searchText: string) => {
-        if (!accessToken) return [];
-        const keyAliases = await fetchAllKeyAliases(accessToken);
-        const filtered = keyAliases.filter((alias) => alias.toLowerCase().includes(searchText.toLowerCase()));
-        return filtered.map((alias) => ({
-          label: alias,
-          value: alias,
-        }));
-      },
+      isSearchable: false,
     },
     {
       name: "End User",

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { modelAvailableCall, uiSpendLogsCall } from "../networking";
 import { Team } from "../key_team_helpers/key_list";
 import { useQuery } from "@tanstack/react-query";
-import { fetchAllKeyAliases, fetchAllTeams } from "../../components/key_team_helpers/filter_helpers";
+import { fetchAllTeams } from "../../components/key_team_helpers/filter_helpers";
 import { debounce } from "lodash";
 import { defaultPageSize } from "../constants";
 import { PaginatedResponse } from ".";
@@ -114,16 +114,6 @@ export function useLogFilterLogic({
   useEffect(() => {
     return () => debouncedSearch.cancel();
   }, [debouncedSearch]);
-
-  const queryAllKeysQuery = useQuery({
-    queryKey: ["allKeys"],
-    queryFn: async () => {
-      if (!accessToken) throw new Error("Access token required");
-      return await fetchAllKeyAliases(accessToken);
-    },
-    enabled: !!accessToken,
-  });
-  const allKeyAliases = queryAllKeysQuery.data || [];
 
   // Determine when backend filters are active (server-side filtering)
   const hasBackendFilters = useMemo(
@@ -266,7 +256,6 @@ export function useLogFilterLogic({
   return {
     filters,
     filteredLogs,
-    allKeyAliases,
     allTeams,
     handleFilterChange,
     handleFilterReset,

--- a/ui/litellm-dashboard/tests/view_logs/useLogFilterLogic.min.test.tsx
+++ b/ui/litellm-dashboard/tests/view_logs/useLogFilterLogic.min.test.tsx
@@ -6,7 +6,6 @@ import { useLogFilterLogic } from "../../src/components/view_logs/log_filter_log
 
 // Minimal mocks to avoid real network during hook init
 vi.mock("../../src/components/key_team_helpers/filter_helpers", () => ({
-  fetchAllKeyAliases: vi.fn().mockResolvedValue([]),
   fetchAllTeams: vi.fn().mockResolvedValue([]),
 }));
 


### PR DESCRIPTION
## Title

Remove keys alias filter to prevent excessive /key/list fetching

## Relevant issues

Fixes #14881

Originally, the Key Alias filter allowed users to select from a dropdown list.
However, since fetching the full list of aliases caused performance issues,
I updated it to work like the User ID and Key Hash filters — users now filter by typing input instead of selecting from a list.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

