### PR TITLE
Feature/add gpt 5 pro clean

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -166,6 +166,7 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 | gpt-5 | `response = completion(model="gpt-5", messages=messages)` |
 | gpt-5-mini | `response = completion(model="gpt-5-mini", messages=messages)` |
 | gpt-5-nano | `response = completion(model="gpt-5-nano", messages=messages)` |
+| gpt-5-pro | `response = completion(model="gpt-5-pro", messages=messages)` |
 | gpt-5-chat | `response = completion(model="gpt-5-chat", messages=messages)` |
 | gpt-5-chat-latest | `response = completion(model="gpt-5-chat-latest", messages=messages)` |
 | gpt-5-2025-08-07 | `response = completion(model="gpt-5-2025-08-07", messages=messages)` |
@@ -203,6 +204,26 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 
 
 These also support the `OPENAI_BASE_URL` environment variable, which can be used to specify a custom API endpoint.
+
+### GPT-5 Pro Special Notes
+
+GPT-5 Pro is OpenAI's most advanced reasoning model with unique characteristics:
+
+- **Responses API Only**: GPT-5 Pro is only available through the `/v1/responses` endpoint, not `/v1/chat/completions`
+- **No Streaming**: Does not support streaming responses
+- **High Reasoning**: Designed for complex reasoning tasks with highest effort reasoning
+- **Context Window**: 400,000 tokens input, 272,000 tokens output
+- **Pricing**: $15.00 input / $120.00 output per 1M tokens (Standard), $7.50 input / $60.00 output (Batch)
+- **Tools**: Supports Web Search, File Search, Image Generation, MCP (but not Code Interpreter or Computer Use)
+- **Modalities**: Text and Image input, Text output only
+
+```python
+# GPT-5 Pro usage example
+response = completion(
+    model="gpt-5-pro", 
+    messages=[{"role": "user", "content": "Solve this complex reasoning problem..."}]
+)
+```
 
 ## OpenAI Vision Models 
 | Model Name            | Function Call                                                   |

--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -209,7 +209,7 @@ These also support the `OPENAI_BASE_URL` environment variable, which can be used
 
 GPT-5 Pro is OpenAI's most advanced reasoning model with unique characteristics:
 
-- **Responses API Only**: GPT-5 Pro is only available through the `/v1/responses` endpoint, not `/v1/chat/completions`
+- **Responses API Only**: GPT-5 Pro is only available through the `/v1/responses` endpoint
 - **No Streaming**: Does not support streaming responses
 - **High Reasoning**: Designed for complex reasoning tasks with highest effort reasoning
 - **Context Window**: 400,000 tokens input, 272,000 tokens output

--- a/docs/my-website/src/pages/completion/supported.md
+++ b/docs/my-website/src/pages/completion/supported.md
@@ -8,6 +8,7 @@
 | gpt-3.5-turbo-16k    | `completion('gpt-3.5-turbo-16k', messages)` | `os.environ['OPENAI_API_KEY']`       |
 | gpt-3.5-turbo-16k-0613    | `completion('gpt-3.5-turbo-16k-0613', messages)` | `os.environ['OPENAI_API_KEY']`       |
 | gpt-4            | `completion('gpt-4', messages)`         | `os.environ['OPENAI_API_KEY']`       |
+| gpt-5-pro        | `completion('gpt-5-pro', messages)`    | `os.environ['OPENAI_API_KEY']`       |
 
 ## Azure OpenAI Chat Completion Models
 For Azure calls add the `azure/` prefix to `model`. If your azure deployment name is `gpt-v-2` set `model` = `azure/gpt-v-2`

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12879,7 +12879,7 @@
         "max_input_tokens": 400000,
         "max_output_tokens": 272000,
         "max_tokens": 272000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 1.2e-04,
         "output_cost_per_token_batches": 6e-05,
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12872,6 +12872,45 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-5-pro": {
+        "input_cost_per_token": 1.5e-05,
+        "input_cost_per_token_batches": 7.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-04,
+        "output_cost_per_token_batches": 6e-05,
+        "supported_endpoints": [
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": false,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_file_search": true,
+        "supports_image_generation": true,
+        "supports_mcp": true,
+        "supports_fine_tuning": false,
+        "supports_code_interpreter": false,
+        "supports_computer_use": false
+    },
     "gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,


### PR DESCRIPTION
This PR adds support for OpenAI's GPT-5 Pro model to LiteLLM, including complete model configuration and comprehensive documentation updates.

Changes

Model Configuration (model_prices_and_context_window.json):
Added gpt-5-pro entry with complete specifications
Mode: responses (Responses API only, not Chat Completions)
Pricing: $15.00 input / $120.00 output (Standard), $7.50 input / $60.00 output (Batch)
Context Window: 400,000 tokens input, 272,000 tokens output
Endpoints: /v1/batch, /v1/responses only
Features: Web Search, File Search, Image Generation, MCP support
Limitations: No streaming, no Code Interpreter, no Computer Use