### PR TITLE
Fix key update premium error on budget change

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1099,6 +1099,10 @@ def prepare_metadata_fields(
                     casted_metadata[k] = v
             if k in LiteLLM_ManagementEndpoint_MetadataFields_Premium:
                 from litellm.proxy.utils import _premium_user_check
+                # Address issues where the frontend incorrectly sends 
+                # an empty list value for .prompts or .guardrails
+                if not v:
+                    continue
 
                 _premium_user_check(k)
                 casted_metadata[k] = v

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -814,6 +814,12 @@ def test_personal_key_generation_check():
             {"tags": ["old_tag"]},
             {"metadata": {"tags": ["old_tag"], "enforced_params": ["metadata.tags"]}},
         ),
+        (
+            {"enforced_params": ["metadata.tags"], "prompts": []},
+            {},
+            {"tags": ["old_tag"]},
+            {"metadata": {"tags": ["old_tag"], "enforced_params": ["metadata.tags"]}},
+        ),
     ],
 )
 def test_prepare_metadata_fields(


### PR DESCRIPTION
## Title

I'm currently, on version 1.77.1.rc1, but the error below has been happening since 1.76.1-stable.

When I try to change any field on an existing key, I get an error "This feature is only available for LiteLLM Enterprise users." 

I've traced it to the fact that the front-end is sending empty lists for the .prompts and .guardrails arrays. 

If I copy the request from Chrome Dev Tools, remove these two arguments from the payload , and reissue - the change works. 

The proposed change will not apply the premium check if the fields are False-y, so None or empty list.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


