### PR TITLE
Add Cohere Embed v4 support for AWS Bedrock

### DIFF
--- a/docs/my-website/docs/providers/bedrock_embedding.md
+++ b/docs/my-website/docs/providers/bedrock_embedding.md
@@ -265,6 +265,7 @@ print(response)
 | TwelveLabs Marengo Embed 2.7 | `embedding(model="bedrock/us.twelvelabs.marengo-embed-2-7-v1:0", input=input)` | Supports multimodal input (text, video, audio, image) |
 | Cohere Embeddings - English | `embedding(model="bedrock/cohere.embed-english-v3", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/cohere_transformation.py#L18)
 | Cohere Embeddings - Multilingual | `embedding(model="bedrock/cohere.embed-multilingual-v3", input=input)` | [here](https://github.com/BerriAI/litellm/blob/f5905e100068e7a4d61441d7453d7cf5609c2121/litellm/llms/bedrock/embed/cohere_transformation.py#L18)
+| Cohere Embed v4 | `embedding(model="bedrock/cohere.embed-v4:0", input=input)` | Supports text and image input, configurable dimensions (256, 512, 1024, 1536), 128k context length |
 
 ### Advanced - [Drop Unsupported Params](https://docs.litellm.ai/docs/completion/drop_params#openai-proxy-usage)
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -871,6 +871,7 @@ bedrock_embedding_models: set = set(
         "amazon.titan-embed-text-v1",
         "cohere.embed-english-v3",
         "cohere.embed-multilingual-v3",
+        "cohere.embed-v4:0",
         "twelvelabs.marengo-embed-2-7-v1:0",
     ]
 )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5294,6 +5294,16 @@
         "output_cost_per_token": 0.0,
         "supports_embedding_image_input": true
     },
+    "cohere.embed-v4:0": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1536,
+        "supports_embedding_image_input": true
+    },
     "cohere.rerank-v3-5:0": {
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5294,6 +5294,16 @@
         "output_cost_per_token": 0.0,
         "supports_embedding_image_input": true
     },
+    "cohere.embed-v4:0": {
+        "input_cost_per_token": 1.2e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_vector_size": 1536,
+        "supports_embedding_image_input": true
+    },
     "cohere.rerank-v3-5:0": {
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,


### PR DESCRIPTION
## Title
Add Cohere Embed v4 support for AWS Bedrock

## Relevant issues
Fixes #15272

## Type
🆕 New Feature

## Changes
- Add `cohere.embed-v4:0` to model pricing configurations (model_prices_and_context_window.json and backup)
- Update `bedrock_embedding_models` constant in litellm/constants.py
- Add documentation entry for Cohere Embed v4 in bedrock_embedding.md

Model specifications:
- Max tokens: 128,000
- Input cost: $0.00012 per 1K tokens
- Default output dimensions: 1536 (configurable: 256, 512, 1024, 1536)
- Supports text and image input