### PR TITLE
fix: model + endpoints page crash when config file contains router_settings.model_group_alias

### DIFF
--- a/ui/litellm-dashboard/src/components/model_group_alias_settings.tsx
+++ b/ui/litellm-dashboard/src/components/model_group_alias_settings.tsx
@@ -5,9 +5,11 @@ import { setCallbacksCall } from "./networking";
 import { Card, Title, Text, Table, TableHead, TableHeaderCell, TableBody, TableRow, TableCell } from "@tremor/react";
 import NotificationsManager from "./molecules/notifications_manager";
 
+type ModelGroupAliasValue = string | { model: string; hidden?: boolean };
+
 interface ModelGroupAliasSettingsProps {
   accessToken: string;
-  initialModelGroupAlias?: { [key: string]: string };
+  initialModelGroupAlias?: Record<string, ModelGroupAliasValue>;
   onAliasUpdate?: (updatedAlias: { [key: string]: string }) => void;
 }
 
@@ -28,11 +30,11 @@ const ModelGroupAliasSettings: React.FC<ModelGroupAliasSettingsProps> = ({
   const [isExpanded, setIsExpanded] = useState(true);
 
   useEffect(() => {
-    // Convert object to array for display
-    const aliasArray = Object.entries(initialModelGroupAlias).map(([aliasName, targetModelGroup], index) => ({
+    const aliasArray = Object.entries(initialModelGroupAlias).map(([aliasName, value], index) => ({
       id: `${index}-${aliasName}`,
       aliasName,
-      targetModelGroup,
+      // if object, use its model field; otherwise use the string
+      targetModelGroup: typeof value === "string" ? value : value?.model ?? "",
     }));
     setAliases(aliasArray);
   }, [initialModelGroupAlias]);


### PR DESCRIPTION
## fix: model + endpoints page crash when config file contains router_settings.model_group_alias

## Relevant issues
closes LIT-1198

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
- adds a more accurate type for initialModelGroupAlias and checks for whether the response is an object

