### PR TITLE
Fix parallel tool calls in the Anthropic passthrough adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -7,7 +7,7 @@ from collections import deque
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal, Optional
 
 from litellm import verbose_logger
-from litellm.types.llms.anthropic import UsageDelta
+from litellm.types.llms.anthropic import UsageDelta, ToolUseBlock
 from litellm.types.utils import AdapterCompletionStreamWrapper
 
 if TYPE_CHECKING:
@@ -270,7 +270,6 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                             processed_chunk.get("delta", {}).get("stop_reason")
                             is not None
                         ):
-
                             self.holding_stop_reason_chunk = processed_chunk
                         else:
                             self.chunk_queue.append(processed_chunk)
@@ -376,6 +375,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         )
 
         if block_type != self.current_content_block_type:
+            self.current_content_block_type = block_type
+            self.current_content_block_start = content_block_start
+            return True
+
+        # For parallel tool calls, we'll necessarily have a new content block
+        # if we get a function name since it signals a new tool call
+        if block_type == "tool_use" and content_block_start.get("name"):
             self.current_content_block_type = block_type
             self.current_content_block_start = content_block_start
             return True

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -7,7 +7,7 @@ from collections import deque
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal, Optional
 
 from litellm import verbose_logger
-from litellm.types.llms.anthropic import UsageDelta, ToolUseBlock
+from litellm.types.llms.anthropic import UsageDelta
 from litellm.types.utils import AdapterCompletionStreamWrapper
 
 if TYPE_CHECKING:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -1,0 +1,315 @@
+import os
+import sys
+from typing import List
+
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+    AnthropicStreamWrapper,
+)
+from litellm.types.utils import (
+    Delta,
+    ModelResponse,
+    StreamingChoices,
+    Usage,
+    ChatCompletionDeltaToolCall,
+    Function,
+)
+
+
+class MockCompletionStream:
+    def __init__(self, responses: List[ModelResponse]):
+        self.responses = responses
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.responses):
+            raise StopIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.index >= len(self.responses):
+            raise StopAsyncIteration
+        response = self.responses[self.index]
+        self.index += 1
+        return response
+
+
+def construct_text_chunk(text: str) -> ModelResponse:
+    return ModelResponse(
+        stream=True,
+        choices=[
+            StreamingChoices(
+                delta=Delta(content=text),
+                index=0,
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def construct_split_tool_call(
+    id: str, function_name: str, function_arg_parts: List[str]
+) -> List[ModelResponse]:
+    return [
+        # https://platform.openai.com/docs/guides/function-calling#streaming
+        ModelResponse(
+            stream=True,
+            choices=[
+                StreamingChoices(
+                    delta=Delta(
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id=id,
+                                function=Function(arguments="", name=function_name),
+                                index=0,
+                                type="function",
+                            )
+                        ]
+                    ),
+                    index=0,
+                    finish_reason=None,
+                )
+            ],
+        ),
+        *[
+            ModelResponse(
+                stream=True,
+                choices=[
+                    StreamingChoices(
+                        delta=Delta(
+                            tool_calls=[
+                                ChatCompletionDeltaToolCall(
+                                    id=None,
+                                    function=Function(arguments=part, name=None),
+                                    index=0,
+                                    type=None,
+                                )
+                            ]
+                        ),
+                        index=0,
+                        finish_reason=None,
+                    )
+                ],
+            )
+            for part in function_arg_parts
+        ],
+    ]
+
+
+def test_anthropic_stream_wrapper_single_tool_call():
+    responses = [
+        *construct_split_tool_call("tooluse_foo", "get_weather", ['{"city":', '"NY"}']),
+        ModelResponse(
+            stream=True,
+            choices=[
+                StreamingChoices(
+                    delta=Delta(content="", stop_reason="tool_calls"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=230, completion_tokens=65, total_tokens=295),
+        ),
+    ]
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockCompletionStream(responses),
+        model="sonnet-4-5",
+    )
+
+    chunks = []
+    chunk_types = []
+
+    # Collect all chunks
+    for chunk in wrapper:
+        chunks.append(chunk)
+        chunk_types.append(chunk.get("type"))
+
+    # Verify the expected sequence of chunk types
+    expected_types = [
+        "message_start",  # Initial message start
+        # TODO: for future contributors: if the initial content_block_start
+        # respects the upstream's starting chunk, the initial empty text block
+        # should be removed (and this test should be updated accordingly)
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Initial empty text block start
+        "content_block_stop",  # End of empty text block
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # "NY"}
+        "content_block_stop",  # End of first tool_use content block
+        "message_delta",  # Stop reason with merged usage
+        "message_stop",  # Final message stop
+    ]
+
+    assert expected_types == chunk_types
+
+    get_weather_calls = 0
+
+    for chunk in chunks:
+        if (
+            chunk.get("type") == "content_block_start"
+            and chunk["content_block"]["type"] == "tool_use"
+        ):
+            if chunk["content_block"]["name"] == "get_weather":
+                get_weather_calls += 1
+
+    assert get_weather_calls == 1
+
+
+def test_anthropic_stream_wrapper_back_to_back_tool_calls():
+    responses = [
+        *construct_split_tool_call("tooluse_foo", "get_weather", ['{"city":', '"NY"}']),
+        *construct_split_tool_call("tooluse_bar", "get_weather", ['{"city":', '"SF"}']),
+        ModelResponse(
+            stream=True,
+            choices=[
+                StreamingChoices(
+                    delta=Delta(content="", stop_reason="tool_calls"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=230, completion_tokens=65, total_tokens=295),
+        ),
+    ]
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockCompletionStream(responses),
+        model="sonnet-4-5",
+    )
+
+    chunks = []
+    chunk_types = []
+
+    # Collect all chunks
+    for chunk in wrapper:
+        chunks.append(chunk)
+        chunk_types.append(chunk.get("type"))
+
+    # Verify the expected sequence of chunk types
+    expected_types = [
+        "message_start",  # Initial message start
+        # TODO: for future contributors: if the initial content_block_start
+        # respects the upstream's starting chunk, the initial empty text block
+        # should be removed (and this test should be updated accordingly)
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Initial empty text block start
+        "content_block_stop",  # End of empty text block
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # "NY"}
+        "content_block_stop",  # End of first tool_use content block
+        "content_block_start",  # Start of second tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # " SF"}
+        "content_block_stop",  # End of second tool_use content block
+        "message_delta",  # Stop reason with merged usage
+        "message_stop",  # Final message stop
+    ]
+
+    assert expected_types == chunk_types
+
+    get_weather_calls = 0
+
+    for chunk in chunks:
+        if (
+            chunk.get("type") == "content_block_start"
+            and chunk["content_block"]["type"] == "tool_use"
+        ):
+            if chunk["content_block"]["name"] == "get_weather":
+                get_weather_calls += 1
+
+    assert get_weather_calls == 2
+
+
+def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
+    responses = [
+        *construct_split_tool_call("tooluse_foo", "get_weather", ['{"city":', '"NY"}']),
+        construct_text_chunk("The weather is nice today."),
+        *construct_split_tool_call("tooluse_bar", "get_weather", ['{"city":', '"SF"}']),
+        *construct_split_tool_call(
+            "tooluse_bar", "get_weather", ['{"city":', '"CHI"}']
+        ),
+        construct_text_chunk("The weather is not so nice today."),
+        ModelResponse(
+            stream=True,
+            choices=[
+                StreamingChoices(
+                    delta=Delta(content="", stop_reason="tool_calls"),
+                    index=0,
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=230, completion_tokens=65, total_tokens=295),
+        ),
+    ]
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=MockCompletionStream(responses),
+        model="sonnet-4-5",
+    )
+
+    chunks = []
+    chunk_types = []
+
+    # Collect all chunks
+    for chunk in wrapper:
+        chunks.append(chunk)
+        chunk_types.append(chunk.get("type"))
+
+    # Verify the expected sequence of chunk types
+    expected_types = [
+        "message_start",  # Initial message start
+        # TODO: for future contributors: if the initial content_block_start
+        # respects the upstream's starting chunk, the initial empty text block
+        # should be removed (and this test should be updated accordingly)
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Initial empty text block start
+        "content_block_stop",  # End of empty text block
+        # ---------------------------------------------------------------------
+        "content_block_start",  # Start of first tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # "NY"}
+        "content_block_stop",  # End of first tool_use content block
+        "content_block_start",  # "The weather is nice today"
+        "content_block_stop",
+        "content_block_start",  # Start of second tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # " SF"}
+        "content_block_stop",  # End of second tool_use content block
+        "content_block_start",  # Start of third tool_use content block
+        "content_block_delta",  # {"city":
+        "content_block_delta",  # " CHI"}
+        "content_block_stop",  # End of third tool_use content block
+        "content_block_start",  # "The weather is not so nice today"
+        "content_block_stop",
+        "message_delta",  # Stop reason with merged usage
+        "message_stop",  # Final message stop
+    ]
+
+    assert expected_types == chunk_types
+
+    get_weather_calls = 0
+
+    for chunk in chunks:
+        if (
+            chunk.get("type") == "content_block_start"
+            and chunk["content_block"]["type"] == "tool_use"
+        ):
+            if chunk["content_block"]["name"] == "get_weather":
+                get_weather_calls += 1
+
+    assert get_weather_calls == 3


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Fix parallel tool calls in the Anthropic passthrough adapter

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes https://github.com/BerriAI/litellm/issues/15307

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 

<img width="2956" height="356" alt="CleanShot 2025-10-07 at 21 02 44@2x" src="https://github.com/user-attachments/assets/dec0acbc-cde1-43ac-800a-254008ca7486" />

- [ ] ~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~ will rely on CI
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

This PR adds support for parallel tool calling for models that can stream multiple back-to-back tool calls. We do this by adding an additional fall-through behaviour to the `_should_start_new_content_block` check: if the current block type is a `tool_use` block, _and_ we have a name, this is necessarily a new tool call.

This matches the behaviour of what OpenAI and Anthropic return.

[OpenAI's example](https://platform.openai.com/docs/guides/function-calling#streaming):

```
[{"index": 0, "id": "call_DdmO9pD3xa9XTPNJ32zg2hcA", "function": {"arguments": "", "name": "get_weather"}, "type": "function"}]
[{"index": 0, "id": null, "function": {"arguments": "{\"", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": "location", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": "\":\"", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": "Paris", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": ",", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": " France", "name": null}, "type": null}]
[{"index": 0, "id": null, "function": {"arguments": "\"}", "name": null}, "type": null}]
```
> Many of these fields are only set for the first delta of each tool call, like id, function.name, and type.

[Anthropic's example](https://docs.claude.com/en/docs/build-with-claude/streaming#streaming-request-with-tool-use):

```
event: content_block_start
data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}

event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
```

So as long as we get a `name`, this block should necessarily be a new tool call. 

## Test plan

See the [repro script](https://gist.github.com/lcfyi/a3845a61248a59f48ee8c9a60ff658ff) and full configuration in the [original issue](https://github.com/BerriAI/litellm/issues/15307). With the changes, we now get:

```
Starting streaming conversation with tool calls...

RawMessageStartEvent(message=Message(id='msg_eaa56e78-d5bd-40db-8f9a-32ca1274025d', content=[], model='converse/us.anthropic.claude-sonnet-4-20250514-v1:0', role='assistant', stop_reason=None, stop_sequence=None, type='message', usage=Usage(cache_creation=None, cache_creation_input_tokens=None, cache_read_input_tokens=None, input_tokens=0, output_tokens=0, server_tool_use=None, service_tier=None)), type='message_start')
RawContentBlockStartEvent(content_block=TextBlock(citations=None, text='', type='text'), index=0, type='content_block_start')

💬 Assistant response:
ContentBlockStopEvent(index=0, type='content_block_stop', content_block=TextBlock(citations=None, text='', type='text'))
RawContentBlockStartEvent(content_block=ToolUseBlock(id='tooluse_-ltZL7ykRqaZWM8m4_nZvA', input={}, name='get_weather', type='tool_use'), index=1, type='content_block_start')

🔧 Starting tool call: get_weather
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='{"location', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='{"location', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='":', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='":', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json=' "San Franci', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json=' "San Franci', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='sco, CA', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='sco, CA', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='"}', type='input_json_delta'), index=1, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='"}', snapshot={'location': 'San Francisco, CA'})
ContentBlockStopEvent(index=1, type='content_block_stop', content_block=ToolUseBlock(id='tooluse_-ltZL7ykRqaZWM8m4_nZvA', input={'location': 'San Francisco, CA'}, name='get_weather', type='tool_use'))

  Input: {'location': 'San Francisco, CA'}
RawContentBlockStartEvent(content_block=ToolUseBlock(id='tooluse_E6hoCX6yR4GqYJjRr4v0zw', input={}, name='get_weather', type='tool_use'), index=2, type='content_block_start')

🔧 Starting tool call: get_weather
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='{"locat', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='{"locat', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='ion"', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='ion"', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json=': "Ne', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json=': "Ne', snapshot={})
RawContentBlockDeltaEvent(delta=InputJSONDelta(partial_json='w York, NY"}', type='input_json_delta'), index=2, type='content_block_delta')
InputJsonEvent(type='input_json', partial_json='w York, NY"}', snapshot={'location': 'New York, NY'})
ContentBlockStopEvent(index=2, type='content_block_stop', content_block=ToolUseBlock(id='tooluse_E6hoCX6yR4GqYJjRr4v0zw', input={'location': 'New York, NY'}, name='get_weather', type='tool_use'))

  Input: {'location': 'New York, NY'}
RawMessageDeltaEvent(delta=Delta(stop_reason='tool_use', stop_sequence=None), type='message_delta', usage=MessageDeltaUsage(cache_creation_input_tokens=None, cache_read_input_tokens=None, input_tokens=426, output_tokens=95, server_tool_use=None))
MessageStopEvent(type='message_stop', message=Message(id='msg_eaa56e78-d5bd-40db-8f9a-32ca1274025d', content=[TextBlock(citations=None, text='', type='text'), ToolUseBlock(id='tooluse_-ltZL7ykRqaZWM8m4_nZvA', input={'location': 'San Francisco, CA'}, name='get_weather', type='tool_use'), ToolUseBlock(id='tooluse_E6hoCX6yR4GqYJjRr4v0zw', input={'location': 'New York, NY'}, name='get_weather', type='tool_use')], model='converse/us.anthropic.claude-sonnet-4-20250514-v1:0', role='assistant', stop_reason='tool_use', stop_sequence=None, type='message', usage=Usage(cache_creation=None, cache_creation_input_tokens=None, cache_read_input_tokens=None, input_tokens=426, output_tokens=95, server_tool_use=None, service_tier=None)))
```

So we're now parsing multiple back-to-back tool calls properly.