### PR TITLE
Fix #15323: populate contents for Anthropic count_tokens when routed to Vertex Claude

### DIFF
--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -278,10 +278,24 @@ async def count_tokens(
         
         # Create TokenCountRequest for the internal endpoint
         from litellm.proxy._types import TokenCountRequest
-        
+
+        contents = None
+        if messages:
+            try:
+                from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+                    VertexGeminiConfig,
+                )
+
+                contents = VertexGeminiConfig()._transform_messages(
+                    messages=messages
+                )
+            except Exception:
+                contents = None
+
         token_request = TokenCountRequest(
             model=model_name,
-            messages=messages
+            messages=messages,
+            contents=contents,
         )
         
         # Call the internal token counter function with direct request flag set to False


### PR DESCRIPTION
- ensure the Anthropic `/v1/messages/count_tokens` proxy populates `TokenCountRequest.contents`
- reuse `VertexGeminiConfig()._transform_messages(...)` to convert Anthropic messages when the router targets Vertex Claude
- prevents the Gemini token counter from receiving `None` and throwing `TypeError` in issue #15323 