### PR TITLE
Minimal fix: gpt5 models should not go on cooldown when called with temperature!=1

### DIFF
--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -62,6 +62,8 @@ def _is_cooldown_required(
                     return False
 
         if isinstance(exception_status, str):
+            if len(exception_status) == 0:
+                return False
             exception_status = int(exception_status)
 
         if exception_status >= 400 and exception_status < 500:

--- a/tests/router_unit_tests/test_router_cooldown_utils.py
+++ b/tests/router_unit_tests/test_router_cooldown_utils.py
@@ -32,6 +32,7 @@ from litellm.router_utils.cooldown_handlers import _should_cooldown_deployment
 
 load_dotenv()
 
+
 @pytest.mark.asyncio
 async def test_router_cooldown_event_callback_no_deployment():
     """
@@ -410,4 +411,6 @@ def test_is_cooldown_required_empty_string_exception_status(testing_litellm_rout
         exception_status="",
     )
 
-    assert result is False, "Should not require cooldown when exception_status is empty string"
+    assert (
+        result is False
+    ), "Should not require cooldown when exception_status is empty string"

--- a/tests/router_unit_tests/test_router_cooldown_utils.py
+++ b/tests/router_unit_tests/test_router_cooldown_utils.py
@@ -18,6 +18,7 @@ from litellm.router_utils.cooldown_handlers import (
     _should_run_cooldown_logic,
     _should_cooldown_deployment,
     cast_exception_status_to_int,
+    _is_cooldown_required,
 )
 from litellm.router_utils.router_callbacks.track_deployment_metrics import (
     increment_deployment_failures_for_current_minute,
@@ -397,3 +398,16 @@ def test_mixed_success_failure(mock_failures, mock_successes, router):
     assert (
         should_cooldown is False
     ), "Should not cooldown when failure rate is below threshold"
+
+
+def test_is_cooldown_required_empty_string_exception_status(testing_litellm_router):
+    """
+    Test that _is_cooldown_required returns False when exception_status is an empty string
+    """
+    result = _is_cooldown_required(
+        litellm_router_instance=testing_litellm_router,
+        model_id="test_deployment",
+        exception_status="",
+    )
+
+    assert result is False, "Should not require cooldown when exception_status is empty string"


### PR DESCRIPTION
## The issue

When the newer gpt5 models are called with a temperature!=1, they cause the following error: 

```
litellm.UnsupportedParamsError: gpt-5 models (including gpt-5-codex) don't support temperature=0. Only temperature=1 is supported. To drop unsupported params set `litellm.drop_params = True`
```

This is obviously expected and it’s feedback you’d want to provide to your users (i.e. you’d ideally not want to set `litellm.drop_params=True`). There is a bug, however, that causes this error to trigger cooldowns on gpt5 model deployments (which is not the intended behavior for this type of error) under certain conditions.

The error arises when gpt5 models are called through the `v1/messages` endpoint with an incorrect temperature and `stream=True`. In a real-world scenario this is a problem since e.g. Claude Code uses this endpoint, so anyone using gpt5 models through Claude Code will inevitably trigger cooldown logic. For us, this has caused the gpt5 models to be borderline unusable during fairly long time periods.

We haven't seen the issue in production with any other models, but I imagine that due to the nature of the bug it could cause similar issues in other scenarios. 

## The cause

My understanding is that the bug arises from the following sequence: 

1. The`v1/messages` endpoint is called with `temperature!=1`
2. `anthropic_messages()` at *litellm/llms/anthropic/experimental_pass_through/messages/handler.py:37* is called. This is wrapped by the `wrapper_async()` function at *utils.py:1368*
3. `acompletion()` at *main.py:341* is called: (`anthropic_messages()`->`async_anthropic_messages_handler()` *handler.py:157*->`acompletion()`. This is also wrapped by the same function as `anthropic_messages()`, `wrapper_async()` 
4. The relevant error is raised inside `acompletion()` with `status_code=400`.
5. This error raised in `acompletions()` is then handled by the exception handler in `wrapper_async()` (*utils.py:1563*). The `logging_obj.failure_handler()` eventually hits  the `_is_cooldown_required()` function in *router_utils/cooldown_handlers.py:39*. Since the `status_code=400`, the **error does not trigger cooldown logic**. 
6.  The `litellm.acompletions()` call has now already internally raised and handled the actual error correctly via its wrapper. But this error propagates up to the `async_anthropic_messages_handler()` function that catches the error and wraps it in a ValueError (*litellm/llms/anthropic/experimental_pass_through/adapters/handler.py:179*). **This error does not have a status_code**.
7. This ValueError is in turn handled by the `anthropic_messages` wrapper. It goes through the same path as the previous errors. Here (in `failure_handler()`) is where paths for `stream=True` and `stream=False` diverge: 
     - When `stream=False`, `self.should_run_logging()` is `False`, since `has_run_logging()` is `True`. For this reason, the error is not handled at all and no cooldown logic is triggered
     - When `stream=True`, `self.should_run_logging()` is `True`, since `has_run_logging()` never sets `has_logged_{event_type}` to `True` (see logic on *litellm_logging.py:1354*)
 8. During error handling, the `stream=False` case eventually hits the `_is_cooldown_required()` function **again**. At this point, the `exception_status` is just an empty string (since it was completely missing on the error currently being handled). At *cooldown_handlers.py:65*, there is an attempt to cast this empty string to an integer, which is not allowed and raises a ValueError. This error is then caught which makes `_is_cooldown_required()` return `True`, and cooldown logic is triggered. 
 
## Solutions

This PR is a minimal fix for the acute issue of gpt5 going on cooldown which makes sure that `_is_cooldown_required()` returns `False` when the `exception_status` is an empty string. 

Some better, more comprehensive solutions could be: 

- Make sure that errors that "propagate upwards" always preserve their status codes. This would also have the added benefit of actually returning the correct status code to the user (right now, any requests to `v1/messages` with `temperature!=1` and gpt5 models return a 500 instead of the original 400). 
- Never wrap caught errors, at least not in new, generic ones (such as this case, where we wrap a `litellm.UnsupportedParamsError` in a `ValueError`).
- Make sure to keep better track of the logging of streaming requests (`has_run_logging()` in *litellm_core_utils/litellm_logging.py*) to prevent them from being logged twice. 

...or something else I haven't thought about. But I'll leave any such solution to someone who knows the codebase better than I do :)  

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<s>- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)</s>
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

*Notes* `make test-unit` insists on running the integration tests under *tests/test_litellm/llms/volcengine/test_volcengine_embedding.py*, which fail. But even when I exclude that file I get multiple errors, among other: 

`FAILED tests/test_litellm/test_utils.py::test_aaamodel_prices_and_context_window_json_is_valid`
`FAILED tests/test_litellm/llms/gemini/test_gemini_common_utils.py::TestGoogleAIStudioTokenCounter`

which can't possibly have been affected by my change. 

Additionally, `make format-check` tells me that 383 files would be changed, none of which I have touched. So I haven't run that either

## Type

🐛 Bug Fix




