### PR TITLE
fix: remove enterprise restriction from guardrails list endpoint

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/quick_start.md
+++ b/docs/my-website/docs/proxy/guardrails/quick_start.md
@@ -197,13 +197,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 
 Follow this simple workflow to implement and tune guardrails:
 
-### 1. ✨ View Available Guardrails
-
-:::info
-
-✨ This is an Enterprise only feature [Get a free trial](https://www.litellm.ai/enterprise#trial)
-
-:::
+### 1. View Available Guardrails
 
 First, check what guardrails are available and their parameters:
 


### PR DESCRIPTION
## Description
This PR removes the incorrect enterprise-only restriction from the 'View Available Guardrails' section in the guardrails documentation.

Based on this: https://github.com/BerriAI/litellm/discussions/5321
@ishaan-jaff 

## Changes
- Removed enterprise-only label and info box from the 'View Available Guardrails' section
- The  endpoint appears to be available in the OSS version based on the code structure
- Makes the documentation more accurate for open-source users

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature

## Testing
- [x] Verified the endpoint is available in OSS version
- [x] Documentation formatting checked

## Impact
This change makes the documentation more accessible and accurate for OSS users who want to view available guardrails.