### PR TITLE
feat(files): add @client decorator to file operations

### DIFF
--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -268,6 +268,7 @@ def create_file(
         raise e
 
 
+@client
 async def afile_retrieve(
     file_id: str,
     custom_llm_provider: Literal["openai", "azure"] = "openai",
@@ -308,6 +309,7 @@ async def afile_retrieve(
         raise e
 
 
+@client
 def file_retrieve(
     file_id: str,
     custom_llm_provider: Literal["openai", "azure"] = "openai",
@@ -422,6 +424,7 @@ def file_retrieve(
 
 
 # Delete file
+@client
 async def afile_delete(
     file_id: str,
     custom_llm_provider: Literal["openai", "azure"] = "openai",
@@ -462,6 +465,7 @@ async def afile_delete(
         raise e
 
 
+@client
 def file_delete(
     file_id: str,
     custom_llm_provider: Literal["openai", "azure"] = "openai",
@@ -577,6 +581,7 @@ def file_delete(
 
 
 # List files
+@client
 async def afile_list(
     custom_llm_provider: Literal["openai", "azure"] = "openai",
     purpose: Optional[str] = None,
@@ -617,6 +622,7 @@ async def afile_list(
         raise e
 
 
+@client
 def file_list(
     custom_llm_provider: Literal["openai", "azure"] = "openai",
     purpose: Optional[str] = None,
@@ -729,6 +735,7 @@ def file_list(
         raise e
 
 
+@client
 async def afile_content(
     file_id: str,
     custom_llm_provider: Literal["openai", "azure", "vertex_ai"] = "openai",
@@ -771,6 +778,7 @@ async def afile_content(
         raise e
 
 
+@client
 def file_content(
     file_id: str,
     model: Optional[str] = None,


### PR DESCRIPTION
- Decorate sync/async file APIs (retrieve, delete, list, content) with @client
- Ensures calls route through the configured client, honoring provider/client config
- Standardizes behavior across file endpoints and aligns with existing patterns
- No API signature changes; improves consistency and client-bound usage

## Title

Add @client decorator to files handler

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Added @client decorator to /files handler. This change should make the post_call hooks trigger for routes like /files/{id}/content

Kudos: [@LucasSugi](https://github.com/LucasSugi) for finding the issue and the fix (just making the PR for him).