### PR TITLE
[Fix] x-litellm-cache-key header not being returned on cache hit

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -14,10 +14,10 @@ It utilizes the (RedisCache, s3Cache, RedisSemanticCache, QdrantSemanticCache, I
 In each method it will call the appropriate method from caching.py
 """
 
-import time
 import asyncio
 import datetime
 import inspect
+import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -62,12 +62,10 @@ else:
     LiteLLMLoggingObj = Any
 
 
-from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-
-
 from litellm.litellm_core_utils.core_helpers import (
-_get_parent_otel_span_from_kwargs,
+    _get_parent_otel_span_from_kwargs,
 )
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 
 
 class CachingHandlerResponse(BaseModel):
@@ -214,9 +212,7 @@ class LLMCachingHandler:
                             end_time=end_time,
                             cache_hit=cache_hit,
                         )
-                    cache_key = litellm.cache._get_preset_cache_key_from_kwargs(
-                        **kwargs
-                    )
+                    cache_key = litellm.cache.get_cache_key(**kwargs)
                     if (
                         isinstance(cached_result, BaseModel)
                         or isinstance(cached_result, CustomStreamWrapper)
@@ -330,9 +326,7 @@ class LLMCachingHandler:
                         end_time=end_time,
                         cache_hit=cache_hit
                     )
-                    cache_key = litellm.cache._get_preset_cache_key_from_kwargs(
-                        **kwargs
-                    )
+                    cache_key = litellm.cache.get_cache_key(**kwargs)
                     if (
                         isinstance(cached_result, BaseModel)
                         or isinstance(cached_result, CustomStreamWrapper)

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -397,13 +397,13 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         )
         from litellm.types.llms.openai import ChatCompletionToolParam
 
-        for message in messages:
-            message = cast(
+        for i, message in enumerate(messages):
+            messages[i] = cast(
                 AllMessageValues, filter_value_from_dict(message, "cache_control")  # type: ignore
             )
         if tools is not None:
-            for tool in tools:
-                tool = cast(
+            for i, tool in enumerate(tools):
+                tools[i] = cast(
                     ChatCompletionToolParam,
                     filter_value_from_dict(tool, "cache_control"),  # type: ignore
                 )


### PR DESCRIPTION
## [Fix] x-litellm-cache-key header not being returned on cache hit

Fix `x-litellm-cache-key` header not being returned on cache hit

<img width="1723" height="619" alt="Screenshot 2025-10-08 at 5 52 25 PM" src="https://github.com/user-attachments/assets/a704415d-555a-4b9b-9379-1f24da90d7a4" />


<img width="1723" height="619" alt="Screenshot 2025-10-08 at 5 52 25 PM" src="https://github.com/user-attachments/assets/3833e9d2-89fd-4d7d-8ab4-3cff70b012df" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


