### PR TITLE
fix: allow tool call even when server name prefix is missing

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1292,7 +1292,7 @@ class MCPServerManager:
                 return server
         return None
 
-    def get_mcp_server_names_from_ids(self, server_ids: List[str]) -> List[MCPServer]:
+    def get_mcp_servers_from_ids(self, server_ids: List[str]) -> List[MCPServer]:
         servers = []
         registry = self.get_registry()
         for server in registry.values():

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -238,7 +238,7 @@ if MCP_AVAILABLE:
         (
             user_api_key_auth,
             mcp_auth_header,
-            _,
+            mcp_servers,
             mcp_server_auth_headers,
             oauth2_headers,
             raw_headers,
@@ -272,6 +272,7 @@ if MCP_AVAILABLE:
             response = await call_mcp_tool(
                 user_api_key_auth=user_api_key_auth,
                 mcp_auth_header=mcp_auth_header,
+                mcp_servers=mcp_servers,
                 mcp_server_auth_headers=mcp_server_auth_headers,
                 oauth2_headers=oauth2_headers,
                 raw_headers=raw_headers,
@@ -312,31 +313,32 @@ if MCP_AVAILABLE:
 
     async def _get_allowed_mcp_servers_from_mcp_server_names(
         mcp_servers: Optional[List[str]],
-        allowed_mcp_servers: List[str],
-    ) -> List[str]:
+        allowed_mcp_servers: List[MCPServer],
+    ) -> List[MCPServer]:
         """
         Get the filtered MCP servers from the MCP server names
         """
-        from typing import Set
 
-        filtered_server_ids: Set[str] = set()
+        filtered_server: dict[str, MCPServer] = {}
         # Filter servers based on mcp_servers parameter if provided
         if mcp_servers is not None:
             for server_or_group in mcp_servers:
                 server_name_matched = False
 
-                for server_id in allowed_mcp_servers:
-                    server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
-
+                for server in allowed_mcp_servers:
                     if server:
                         match_list = [
                             s.lower()
-                            for s in [server.alias, server.server_name, server_id]
+                            for s in [
+                                server.alias,
+                                server.server_name,
+                                server.server_id,
+                            ]
                             if s is not None
                         ]
 
                         if server_or_group.lower() in match_list:
-                            filtered_server_ids.add(server_id)
+                            filtered_server[server.server_id] = server
                             server_name_matched = True
                             break
 
@@ -349,15 +351,16 @@ if MCP_AVAILABLE:
                         )
                         # Only include servers that the user has access to
                         for server_id in access_group_server_ids:
-                            if server_id in allowed_mcp_servers:
-                                filtered_server_ids.add(server_id)
+                            for server in allowed_mcp_servers:
+                                if server_id == server.server_id:
+                                    filtered_server[server.server_id] = server
                     except Exception as e:
                         verbose_logger.debug(
                             f"Could not resolve '{server_or_group}' as access group: {e}"
                         )
 
-        if filtered_server_ids:
-            allowed_mcp_servers = list(filtered_server_ids)
+        if filtered_server:
+            return list(filtered_server.values())
 
         return allowed_mcp_servers
 
@@ -450,8 +453,11 @@ if MCP_AVAILABLE:
             return []
 
         # Get allowed MCP servers based on user permissions
-        allowed_mcp_servers = await global_mcp_server_manager.get_allowed_mcp_servers(
-            user_api_key_auth
+        allowed_mcp_server_ids = (
+            await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
+        )
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_server_names_from_ids(
+            allowed_mcp_server_ids
         )
 
         if mcp_servers is not None:
@@ -465,8 +471,7 @@ if MCP_AVAILABLE:
 
         # Get tools from each allowed server
         all_tools = []
-        for server_id in allowed_mcp_servers:
-            server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        for server in allowed_mcp_servers:
             if server is None:
                 continue
 
@@ -504,7 +509,7 @@ if MCP_AVAILABLE:
 
                 filtered_tools = await filter_tools_by_key_team_permissions(
                     tools=filtered_tools,
-                    server_id=server_id,
+                    server_id=server.server_id,
                     user_api_key_auth=user_api_key_auth,
                 )
 
@@ -607,6 +612,7 @@ if MCP_AVAILABLE:
         arguments: Optional[Dict[str, Any]] = None,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
         mcp_auth_header: Optional[str] = None,
+        mcp_servers: Optional[List[str]] = None,
         mcp_server_auth_headers: Optional[Dict[str, Dict[str, str]]] = None,
         oauth2_headers: Optional[Dict[str, str]] = None,
         raw_headers: Optional[Dict[str, str]] = None,
@@ -621,11 +627,6 @@ if MCP_AVAILABLE:
                 status_code=400, detail="Request arguments are required"
             )
 
-        # Remove prefix from tool name for logging and processing
-        original_tool_name, server_name_from_prefix = get_server_name_prefix_tool_mcp(
-            name
-        )
-
         ## CHECK IF USER IS ALLOWED TO CALL THIS TOOL
         allowed_mcp_server_ids = await MCPRequestHandler.get_allowed_mcp_servers(
             user_api_key_auth=user_api_key_auth,
@@ -635,11 +636,22 @@ if MCP_AVAILABLE:
             allowed_mcp_server_ids
         )
 
-        if not MCPRequestHandler.is_tool_allowed(
+        allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
+            mcp_servers=mcp_servers,
             allowed_mcp_servers=allowed_mcp_servers,
-            server_name=server_name_from_prefix,
-        ):
+        )
 
+        server_name: Optional[str]
+        if len(allowed_mcp_servers) == 1:
+            original_tool_name, server_name = name, allowed_mcp_servers[0].server_name
+        else:
+            # Remove prefix from tool name for logging and processing
+            original_tool_name, server_name = get_server_name_prefix_tool_mcp(name)
+
+        if not server_name or not MCPRequestHandler.is_tool_allowed(
+            allowed_mcp_servers=[server.name for server in allowed_mcp_servers],
+            server_name=server_name,
+        ):
             raise HTTPException(
                 status_code=403,
                 detail=f"User not allowed to call this tool. Allowed MCP servers: {allowed_mcp_servers}",
@@ -649,16 +661,16 @@ if MCP_AVAILABLE:
             _get_standard_logging_mcp_tool_call(
                 name=original_tool_name,  # Use original name for logging
                 arguments=arguments,
-                server_name=server_name_from_prefix,
+                server_name=server_name,
             )
         )
         litellm_logging_obj: Optional[LiteLLMLoggingObj] = kwargs.get(
             "litellm_logging_obj", None
         )
         if litellm_logging_obj:
-            litellm_logging_obj.model_call_details["mcp_tool_call_metadata"] = (
-                standard_logging_mcp_tool_call
-            )
+            litellm_logging_obj.model_call_details[
+                "mcp_tool_call_metadata"
+            ] = standard_logging_mcp_tool_call
             litellm_logging_obj.model = f"MCP: {name}"
         # Check if tool exists in local registry first (for OpenAPI-based tools)
         # These tools are registered with their prefixed names
@@ -667,20 +679,21 @@ if MCP_AVAILABLE:
         if local_tool:
             verbose_logger.debug(f"Executing local registry tool: {name}")
             response = await _handle_local_mcp_tool(name, arguments)
-
+        
         # Try managed MCP server tool (pass the full prefixed name)
         # Primary and recommended way to use external MCP servers
         #########################################################
         else:
-            mcp_server: Optional[MCPServer] = (
-                global_mcp_server_manager._get_mcp_server_from_tool_name(name)
-            )
+            mcp_server: Optional[
+                MCPServer
+            ] = global_mcp_server_manager._get_mcp_server_from_tool_name(name)
             if mcp_server:
                 standard_logging_mcp_tool_call["mcp_server_cost_info"] = (
                     mcp_server.mcp_info or {}
                 ).get("mcp_server_cost_info")
                 response = await _handle_managed_mcp_tool(
-                    name=name,  # Pass the full name (potentially prefixed)
+                    server_name=server_name,
+                    name=original_tool_name,  # Pass the full name (potentially prefixed)
                     arguments=arguments,
                     user_api_key_auth=user_api_key_auth,
                     mcp_auth_header=mcp_auth_header,
@@ -734,6 +747,7 @@ if MCP_AVAILABLE:
             )
 
     async def _handle_managed_mcp_tool(
+        server_name: str,
         name: str,
         arguments: Dict[str, Any],
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
@@ -748,6 +762,7 @@ if MCP_AVAILABLE:
         from litellm.proxy.proxy_server import proxy_logging_obj
 
         call_tool_result = await global_mcp_server_manager.call_tool(
+            server_name=server_name,
             name=name,
             arguments=arguments,
             user_api_key_auth=user_api_key_auth,
@@ -1030,14 +1045,16 @@ if MCP_AVAILABLE:
         )
         auth_context_var.set(auth_user)
 
-    def get_auth_context() -> Tuple[
-        Optional[UserAPIKeyAuth],
-        Optional[str],
-        Optional[List[str]],
-        Optional[Dict[str, Dict[str, str]]],
-        Optional[Dict[str, str]],
-        Optional[Dict[str, str]],
-    ]:
+    def get_auth_context() -> (
+        Tuple[
+            Optional[UserAPIKeyAuth],
+            Optional[str],
+            Optional[List[str]],
+            Optional[Dict[str, Dict[str, str]]],
+            Optional[Dict[str, str]],
+            Optional[Dict[str, str]],
+        ]
+    ):
         """
         Get the UserAPIKeyAuth from the auth context variable.
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -456,7 +456,7 @@ if MCP_AVAILABLE:
         allowed_mcp_server_ids = (
             await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
         )
-        allowed_mcp_servers = global_mcp_server_manager.get_mcp_server_names_from_ids(
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(
             allowed_mcp_server_ids
         )
 
@@ -632,7 +632,7 @@ if MCP_AVAILABLE:
             user_api_key_auth=user_api_key_auth,
         )
 
-        allowed_mcp_servers = global_mcp_server_manager.get_mcp_server_names_from_ids(
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(
             allowed_mcp_server_ids
         )
 
@@ -679,7 +679,7 @@ if MCP_AVAILABLE:
         if local_tool:
             verbose_logger.debug(f"Executing local registry tool: {name}")
             response = await _handle_local_mcp_tool(name, arguments)
-        
+
         # Try managed MCP server tool (pass the full prefixed name)
         # Primary and recommended way to use external MCP servers
         #########################################################

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -169,11 +169,12 @@ async def aresponses_api_with_mcp(
     user_api_key_auth = kwargs.get("user_api_key_auth")
 
     # Get original MCP tools (for events) and OpenAI tools (for LLM) by reusing existing methods
-    original_mcp_tools = (
-        await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
-            user_api_key_auth=user_api_key_auth,
-            mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
-        )
+    (
+        original_mcp_tools,
+        tool_server_map,
+    ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
+        user_api_key_auth=user_api_key_auth,
+        mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
     )
     openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(
         original_mcp_tools
@@ -233,6 +234,7 @@ async def aresponses_api_with_mcp(
             mcp_discovery_events=mcp_discovery_events,
             call_params=call_params,
             previous_response_id=previous_response_id,
+            tool_server_map=tool_server_map,
             **kwargs,
         )
 
@@ -277,7 +279,9 @@ async def aresponses_api_with_mcp(
                 "user_api_key_auth"
             )
             tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
-                tool_calls=tool_calls, user_api_key_auth=user_api_key_auth
+                tool_server_map=tool_server_map,
+                tool_calls=tool_calls,
+                user_api_key_auth=user_api_key_auth,
             )
 
             if tool_results:
@@ -323,13 +327,18 @@ async def aresponses_api_with_mcp(
                     )
 
                     final_response = MCPEnhancedStreamingIterator(
-                        base_iterator=final_response, mcp_events=tool_execution_events
+                        tool_server_map=tool_server_map,
+                        base_iterator=final_response,
+                        mcp_events=tool_execution_events,
                     )
 
                 # Add custom output elements to the final response (for non-streaming)
                 elif isinstance(final_response, ResponsesAPIResponse):
                     # Fetch MCP tools again for output elements (without OpenAI transformation)
-                    mcp_tools_for_output = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
+                    (
+                        mcp_tools_for_output,
+                        _,
+                    ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
                         user_api_key_auth=user_api_key_auth,
                         mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
                     )

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from litellm._logging import verbose_logger
+from litellm.proxy._experimental.mcp_server.utils import get_server_name_prefix_tool_mcp
 from litellm.responses.main import aresponses
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse, ToolParam
@@ -68,16 +69,24 @@ class LiteLLM_Proxy_MCP_Handler:
     async def _get_mcp_tools_from_manager(
         user_api_key_auth: Any,
         mcp_tools_with_litellm_proxy: Optional[Iterable[ToolParam]],
-    ) -> List[MCPTool]:
+    ) -> tuple[List[MCPTool], List[str]]:
         """
         Get available tools from the MCP server manager.
 
         Args:
             user_api_key_auth: User authentication info for access control
             mcp_tools_with_litellm_proxy: ToolParam objects with server_url starting with "litellm_proxy"
+
+        Returns:
+            List of MCP tools
+            List names of allowed MCP servers
         """
         from litellm.proxy._experimental.mcp_server.server import (
             _get_tools_from_mcp_servers,
+            _get_allowed_mcp_servers_from_mcp_server_names,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
         )
 
         mcp_servers: List[str] = []
@@ -92,15 +101,40 @@ class LiteLLM_Proxy_MCP_Handler:
                 ):
                     mcp_servers.append(server_url.split("/")[-1])
 
-        return await _get_tools_from_mcp_servers(
+        tools = await _get_tools_from_mcp_servers(
             user_api_key_auth=user_api_key_auth,
             mcp_auth_header=None,
             mcp_servers=mcp_servers,
             mcp_server_auth_headers=None,
         )
+        allowed_mcp_server_ids = (
+            await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
+        )
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_server_names_from_ids(
+            allowed_mcp_server_ids
+        )
+
+        allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
+            mcp_servers=mcp_servers,
+            allowed_mcp_servers=allowed_mcp_servers,
+        )
+
+        server_names: List[str] = []
+        for server in allowed_mcp_servers:
+            if server is None:
+                continue
+            server_name = getattr(server, "server_name", None) or getattr(
+                server, "alias", None
+            ) or getattr(server, "name", None)
+            if isinstance(server_name, str):
+                server_names.append(server_name)
+
+        return tools, server_names
 
     @staticmethod
-    def _deduplicate_mcp_tools(mcp_tools: List[Any]) -> List[Any]:
+    def _deduplicate_mcp_tools(
+        mcp_tools: List[MCPTool], allowed_mcp_servers: List[str]
+    ) -> tuple[List[MCPTool], dict[str, str]]:
         """
         Deduplicate MCP tools by name, keeping the first occurrence of each tool.
 
@@ -109,28 +143,34 @@ class LiteLLM_Proxy_MCP_Handler:
 
         Returns:
             List of deduplicated MCP tools
+            The returned dictionary maps each tool_name to the server_name
         """
         seen_names = set()
         deduplicated_tools = []
+        tool_server_map: dict[str, str] = {}
 
         for tool in mcp_tools:
-            tool_name = (
-                getattr(tool, "name", None)
-                if hasattr(tool, "name")
-                else tool.get("name")
-                if isinstance(tool, dict)
-                else None
-            )
+            if isinstance(tool, dict):
+                tool_name = tool.get("name")
+            else:
+                tool_name = getattr(tool, "name", None)
+
             if tool_name and tool_name not in seen_names:
                 seen_names.add(tool_name)
                 deduplicated_tools.append(tool)
+                if len(allowed_mcp_servers) == 1:
+                    tool_server_map[tool_name] = allowed_mcp_servers[0]
+                else:
+                    tool_server_map[tool_name], _ = get_server_name_prefix_tool_mcp(
+                        tool_name
+                    )
 
-        return deduplicated_tools
+        return deduplicated_tools, tool_server_map
 
     @staticmethod
     def _filter_mcp_tools_by_allowed_tools(
-        mcp_tools: List[Any], mcp_tools_with_litellm_proxy: List[ToolParam]
-    ) -> List[Any]:
+        mcp_tools: List[MCPTool], mcp_tools_with_litellm_proxy: List[ToolParam]
+    ) -> List[MCPTool]:
         """Filter MCP tools based on allowed_tools parameter from the original tool configs."""
         # Collect all allowed tool names from all MCP tool configs
         allowed_tool_names = set()
@@ -147,13 +187,11 @@ class LiteLLM_Proxy_MCP_Handler:
         # Filter tools based on allowed names
         filtered_tools = []
         for mcp_tool in mcp_tools:
-            tool_name = (
-                getattr(mcp_tool, "name", None)
-                if hasattr(mcp_tool, "name")
-                else mcp_tool.get("name")
-                if isinstance(mcp_tool, dict)
-                else None
-            )
+            if isinstance(mcp_tool, dict):
+                tool_name = mcp_tool.get("name")
+            else:
+                tool_name = getattr(mcp_tool, "name", None)
+
             if tool_name and tool_name in allowed_tool_names:
                 filtered_tools.append(mcp_tool)
 
@@ -162,13 +200,9 @@ class LiteLLM_Proxy_MCP_Handler:
     @staticmethod
     async def _process_mcp_tools_to_openai_format(
         user_api_key_auth: Any, mcp_tools_with_litellm_proxy: List[ToolParam]
-    ) -> List[Any]:
+    ) -> tuple[List[Any], dict[str, str]]:
         """
-        Centralized method to process MCP tools through the complete pipeline:
-        1. Fetch tools from MCP manager
-        2. Filter based on allowed_tools parameter
-        3. Deduplicate tools by name
-        4. Transform to OpenAI format
+        Centralized method to process MCP tools through the complete pipeline.
 
         Args:
             user_api_key_auth: User authentication info for access control
@@ -176,40 +210,26 @@ class LiteLLM_Proxy_MCP_Handler:
 
         Returns:
             List of tools in OpenAI format ready to be sent to the LLM
+            The returned dictionary maps each tool_name to the server_name
         """
-        if not mcp_tools_with_litellm_proxy:
-            return []
-
-        # Step 1: Fetch MCP tools from manager
-        mcp_tools_fetched = await LiteLLM_Proxy_MCP_Handler._get_mcp_tools_from_manager(
-            user_api_key_auth=user_api_key_auth,
-            mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
+        (
+            deduplicated_mcp_tools,
+            tool_server_map,
+        ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
+            user_api_key_auth,
+            mcp_tools_with_litellm_proxy,
         )
 
-        # Step 2: Filter tools based on allowed_tools parameter
-        filtered_mcp_tools = (
-            LiteLLM_Proxy_MCP_Handler._filter_mcp_tools_by_allowed_tools(
-                mcp_tools=mcp_tools_fetched,
-                mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
-            )
-        )
-
-        # Step 3: Deduplicate tools after filtering
-        deduplicated_mcp_tools = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(
-            filtered_mcp_tools
-        )
-
-        # Step 4: Transform to OpenAI format
         openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(
             deduplicated_mcp_tools
         )
 
-        return openai_tools
+        return openai_tools, tool_server_map
 
     @staticmethod
     async def _process_mcp_tools_without_openai_transform(
         user_api_key_auth: Any, mcp_tools_with_litellm_proxy: List[ToolParam]
-    ) -> List[Any]:
+    ) -> tuple[List[Any], dict[str, str]]:
         """
         Process MCP tools through filtering and deduplication pipeline without OpenAI transformation.
         This is useful for cases where we need the original MCP tool objects (e.g., for events).
@@ -222,10 +242,13 @@ class LiteLLM_Proxy_MCP_Handler:
             List of filtered and deduplicated MCP tools in their original format
         """
         if not mcp_tools_with_litellm_proxy:
-            return []
+            return [], {}
 
         # Step 1: Fetch MCP tools from manager
-        mcp_tools_fetched = await LiteLLM_Proxy_MCP_Handler._get_mcp_tools_from_manager(
+        (
+            mcp_tools_fetched,
+            allowed_mcp_servers,
+        ) = await LiteLLM_Proxy_MCP_Handler._get_mcp_tools_from_manager(
             user_api_key_auth=user_api_key_auth,
             mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
         )
@@ -239,11 +262,14 @@ class LiteLLM_Proxy_MCP_Handler:
         )
 
         # Step 3: Deduplicate tools after filtering
-        deduplicated_mcp_tools = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(
-            filtered_mcp_tools
+        (
+            deduplicated_mcp_tools,
+            tool_server_map,
+        ) = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(
+            filtered_mcp_tools, allowed_mcp_servers
         )
 
-        return deduplicated_mcp_tools
+        return deduplicated_mcp_tools, tool_server_map
 
     @staticmethod
     def _transform_mcp_tools_to_openai(mcp_tools: List[Any]) -> List[Any]:
@@ -371,7 +397,7 @@ class LiteLLM_Proxy_MCP_Handler:
 
     @staticmethod
     async def _execute_tool_calls(
-        tool_calls: List[Any], user_api_key_auth: Any
+        tool_server_map: dict[str, str], tool_calls: List[Any], user_api_key_auth: Any
     ) -> List[Dict[str, Any]]:
         """Execute tool calls and return results."""
         from fastapi import HTTPException
@@ -402,7 +428,10 @@ class LiteLLM_Proxy_MCP_Handler:
                 # Import here to avoid circular import
                 from litellm.proxy.proxy_server import proxy_logging_obj
 
+                server_name = tool_server_map[tool_name]
+
                 result = await global_mcp_server_manager.call_tool(
+                    server_name=server_name,
                     name=tool_name,
                     arguments=parsed_arguments,
                     user_api_key_auth=user_api_key_auth,
@@ -549,6 +578,7 @@ class LiteLLM_Proxy_MCP_Handler:
         mcp_discovery_events: List[Any],
         call_params: Dict[str, Any],
         previous_response_id: Optional[str],
+        tool_server_map: dict[str, str],
         **kwargs,
     ) -> Any:
         """
@@ -577,6 +607,7 @@ class LiteLLM_Proxy_MCP_Handler:
         return MCPEnhancedStreamingIterator(
             base_iterator=None,  # Will be created internally
             mcp_events=mcp_discovery_events,  # Pre-generated MCP discovery events
+            tool_server_map=tool_server_map,
             mcp_tools_with_litellm_proxy=mcp_tools_with_litellm_proxy,
             user_api_key_auth=kwargs.get("user_api_key_auth"),
             original_request_params=request_params,

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -110,7 +110,7 @@ class LiteLLM_Proxy_MCP_Handler:
         allowed_mcp_server_ids = (
             await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
         )
-        allowed_mcp_servers = global_mcp_server_manager.get_mcp_server_names_from_ids(
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(
             allowed_mcp_server_ids
         )
 

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -38,22 +38,24 @@ async def create_mcp_list_tools_events(
     mcp_tools_with_litellm_proxy: List[ToolParam],
     user_api_key_auth: Any,
     base_item_id: str,
-    pre_processed_mcp_tools: List[Any]
+    pre_processed_mcp_tools: List[Any],
 ) -> List[ResponsesAPIStreamingResponse]:
     """Create MCP discovery events using pre-processed tools from the parent"""
-    
+
     events: List[ResponsesAPIStreamingResponse] = []
-    
+
     try:
         # Extract MCP server names
         mcp_servers = []
         for tool in mcp_tools_with_litellm_proxy:
             if isinstance(tool, dict) and "server_url" in tool:
                 server_url = tool.get("server_url")
-                if isinstance(server_url, str) and server_url.startswith("litellm_proxy/mcp/"):
+                if isinstance(server_url, str) and server_url.startswith(
+                    "litellm_proxy/mcp/"
+                ):
                     server_name = server_url.split("/")[-1]
                     mcp_servers.append(server_name)
-        
+
         # Emit list tools in progress event
         in_progress_event = MCPListToolsInProgressEvent(
             type=ResponsesAPIStreamEvents.MCP_LIST_TOOLS_IN_PROGRESS,
@@ -62,21 +64,21 @@ async def create_mcp_list_tools_events(
             item_id=base_item_id,
         )
         events.append(in_progress_event)
-        
+
         # Use the pre-processed MCP tools that were already fetched, filtered, and deduplicated by the parent
         filtered_mcp_tools = pre_processed_mcp_tools
-        
+
         # Convert tools to dict format for the event
         mcp_tools_dict = []
         for tool in filtered_mcp_tools:
-            if hasattr(tool, 'model_dump') and callable(getattr(tool, 'model_dump')):
+            if hasattr(tool, "model_dump") and callable(getattr(tool, "model_dump")):
                 # Type cast to help mypy understand this is safe after hasattr check
                 mcp_tools_dict.append(cast(Any, tool).model_dump())
-            elif hasattr(tool, '__dict__'):
+            elif hasattr(tool, "__dict__"):
                 mcp_tools_dict.append(tool.__dict__)
             else:
-                mcp_tools_dict.append({"name": getattr(tool, 'name', str(tool))})
-        
+                mcp_tools_dict.append({"name": getattr(tool, "name", str(tool))})
+
         # Emit list tools completed event
         completed_event = MCPListToolsCompletedEvent(
             type=ResponsesAPIStreamEvents.MCP_LIST_TOOLS_COMPLETED,
@@ -85,7 +87,7 @@ async def create_mcp_list_tools_events(
             item_id=base_item_id,
         )
         events.append(completed_event)
-        
+
         # Add output_item.done event with the actual tools list (matching OpenAI format)
         from litellm.types.llms.openai import OutputItemDoneEvent
 
@@ -95,25 +97,27 @@ async def create_mcp_list_tools_events(
             first_tool = mcp_tools_with_litellm_proxy[0]
             if isinstance(first_tool, dict):
                 server_label_value = first_tool.get("server_label", "")
-                server_label = str(server_label_value) if server_label_value is not None else ""
-        
+                server_label = (
+                    str(server_label_value) if server_label_value is not None else ""
+                )
+
         # Format tools for OpenAI output_item.done format
         formatted_tools = []
         for tool in filtered_mcp_tools:
             tool_dict = {
-                "name": getattr(tool, 'name', 'unknown'),
-                "description": getattr(tool, 'description', ''),
+                "name": getattr(tool, "name", "unknown"),
+                "description": getattr(tool, "description", ""),
                 "annotations": {"read_only": False},
             }
-            
+
             # Add input_schema if available
-            if hasattr(tool, 'inputSchema'):
-                tool_dict["input_schema"] = getattr(tool, 'inputSchema')
-            elif hasattr(tool, 'input_schema'):
-                tool_dict["input_schema"] = getattr(tool, 'input_schema')
-            
+            if hasattr(tool, "inputSchema"):
+                tool_dict["input_schema"] = getattr(tool, "inputSchema")
+            elif hasattr(tool, "input_schema"):
+                tool_dict["input_schema"] = getattr(tool, "input_schema")
+
             formatted_tools.append(tool_dict)
-        
+
         # Create the output_item.done event with MCP tools list
         output_item_done_event = OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
@@ -122,18 +126,19 @@ async def create_mcp_list_tools_events(
                 "id": base_item_id,
                 "type": "mcp_list_tools",
                 "server_label": server_label,
-                "tools": formatted_tools
-            }
+                "tools": formatted_tools,
+            },
         )
         events.append(output_item_done_event)
-        
+
         verbose_logger.debug(f"Created {len(events)} MCP discovery events")
-        
+
     except Exception as e:
         verbose_logger.error(f"Error creating MCP list tools events: {e}")
         import traceback
+
         traceback.print_exc()
-        
+
         # Emit failed event on error
         failed_event = MCPListToolsFailedEvent(
             type=ResponsesAPIStreamEvents.MCP_LIST_TOOLS_FAILED,
@@ -142,10 +147,10 @@ async def create_mcp_list_tools_events(
             item_id=base_item_id,
         )
         events.append(failed_event)
-        
+
         # Still emit output_item.done event even on failure (with empty tools list)
         from litellm.types.llms.openai import OutputItemDoneEvent
-        
+
         output_item_done_event = OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
             output_index=0,
@@ -153,26 +158,26 @@ async def create_mcp_list_tools_events(
                 "id": base_item_id,
                 "type": "mcp_list_tools",
                 "server_label": "",
-                "tools": []
-            }
+                "tools": [],
+            },
         )
         events.append(output_item_done_event)
-    
+
     return events
 
 
 def create_mcp_call_events(
-    tool_name: str, 
-    tool_call_id: str, 
+    tool_name: str,
+    tool_call_id: str,
     arguments: str,
     result: Optional[str] = None,
     base_item_id: Optional[str] = None,
-    sequence_start: int = 1
+    sequence_start: int = 1,
 ) -> List[ResponsesAPIStreamingResponse]:
     """Create MCP call events following OpenAI's specification"""
     events: List[ResponsesAPIStreamingResponse] = []
     item_id = base_item_id or f"mcp_{uuid.uuid4().hex[:8]}"
-    
+
     # MCP call in progress event
     in_progress_event = MCPCallInProgressEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_IN_PROGRESS,
@@ -181,7 +186,7 @@ def create_mcp_call_events(
         item_id=item_id,
     )
     events.append(in_progress_event)
-    
+
     # MCP call arguments delta event (streaming the arguments)
     arguments_delta_event = MCPCallArgumentsDeltaEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_ARGUMENTS_DELTA,
@@ -191,7 +196,7 @@ def create_mcp_call_events(
         sequence_number=sequence_start + 1,
     )
     events.append(arguments_delta_event)
-    
+
     # MCP call arguments done event
     arguments_done_event = MCPCallArgumentsDoneEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_ARGUMENTS_DONE,
@@ -201,7 +206,7 @@ def create_mcp_call_events(
         sequence_number=sequence_start + 2,
     )
     events.append(arguments_done_event)
-    
+
     # MCP call completed event (or failed if result indicates failure)
     if result is not None:
         completed_event = MCPCallCompletedEvent(
@@ -211,10 +216,10 @@ def create_mcp_call_events(
             output_index=0,
         )
         events.append(completed_event)
-        
+
         # Add output_item.done event with the tool call result
         from litellm.types.llms.openai import OutputItemDoneEvent
-        
+
         output_item_done_event = OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
             output_index=0,
@@ -226,7 +231,7 @@ def create_mcp_call_events(
                 "error": None,
                 "name": tool_name,
                 "output": result,
-                "server_label": "litellm"
+                "server_label": "litellm",
             },
         )
         events.append(output_item_done_event)
@@ -238,7 +243,7 @@ def create_mcp_call_events(
             output_index=0,
         )
         events.append(failed_event)
-    
+
     return events
 
 
@@ -250,51 +255,62 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
     3. Handles tool execution and follow-up calls for auto-execute tools
     4. Emits tool execution events in the stream
     """
-    
+
     def __init__(
         self,
         base_iterator: Any,  # Can be None - will be created internally
         mcp_events: List[ResponsesAPIStreamingResponse],
+        tool_server_map: dict[str, str],
         mcp_tools_with_litellm_proxy: Optional[List[Any]] = None,
         user_api_key_auth: Any = None,
-        original_request_params: Optional[Dict[str, Any]] = None
+        original_request_params: Optional[Dict[str, Any]] = None,
     ):
         # MCP setup
         self.mcp_tools_with_litellm_proxy = mcp_tools_with_litellm_proxy or []
         self.user_api_key_auth = user_api_key_auth
         self.original_request_params = original_request_params or {}
         self.should_auto_execute = self._should_auto_execute_tools()
-        
+
         # Streaming state management
         self.phase = "mcp_discovery"  # mcp_discovery -> initial_response -> tool_execution -> follow_up_response -> finished
         self.finished = False
-        
+
         # Event queues and generation flags
-        self.mcp_discovery_events: List[ResponsesAPIStreamingResponse] = mcp_events  # Pre-generated MCP discovery events
+        self.mcp_discovery_events: List[
+            ResponsesAPIStreamingResponse
+        ] = mcp_events  # Pre-generated MCP discovery events
         self.tool_execution_events: List[ResponsesAPIStreamingResponse] = []
         self.mcp_discovery_generated = True  # Events are already generated
-        self.mcp_events = mcp_events  # Store the initial MCP events for backward compatibility
-        
+        self.mcp_events = (
+            mcp_events  # Store the initial MCP events for backward compatibility
+        )
+        self.tool_server_map = tool_server_map
+
         # Iterator references
-        self.base_iterator: Optional[Union[Any, ResponsesAPIResponse]] = base_iterator  # Will be created when needed
+        self.base_iterator: Optional[
+            Union[Any, ResponsesAPIResponse]
+        ] = base_iterator  # Will be created when needed
         self.follow_up_iterator: Optional[Any] = None
-        
+
         # Response collection for tool execution
         self.collected_response: Optional[ResponsesAPIResponse] = None
-        
+
         # Set up model metadata (will be updated when we get the real iterator)
-        self.model = self.original_request_params.get('model', 'unknown')
+        self.model = self.original_request_params.get("model", "unknown")
         self.litellm_metadata = {}
-        self.custom_llm_provider = self.original_request_params.get('custom_llm_provider', None)
-        
+        self.custom_llm_provider = self.original_request_params.get(
+            "custom_llm_provider", None
+        )
+
         # Mark as async iterator
         self.is_async = True
-        
+
     def _should_auto_execute_tools(self) -> bool:
         """Check if tools should be auto-executed"""
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
         )
+
         return LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(
             self.mcp_tools_with_litellm_proxy
         )
@@ -306,45 +322,49 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         """
         Phase-based streaming:
         1. mcp_discovery - Emit MCP discovery events
-        2. initial_response - Stream the first LLM response  
+        2. initial_response - Stream the first LLM response
         3. tool_execution - Emit tool execution events
         4. follow_up_response - Stream the follow-up response
         5. finished - End iteration
         """
-        
+
         # Phase 1: MCP Discovery Events
         if self.phase == "mcp_discovery":
             # Generate MCP discovery events if not already done
             # MCP discovery events are already generated and available
-            
+
             # Emit MCP discovery events
             if self.mcp_discovery_events:
                 return self.mcp_discovery_events.pop(0)
-            
+
             # All MCP discovery events emitted, move to next phase
-            verbose_logger.debug("MCP discovery phase complete, transitioning to initial_response")
+            verbose_logger.debug(
+                "MCP discovery phase complete, transitioning to initial_response"
+            )
             self.phase = "initial_response"
             await self._create_initial_response_iterator()
             # Fall through to process the initial response immediately
-        
+
         # Phase 2: Initial Response Stream
         if self.phase == "initial_response":
             if self.base_iterator:
                 # Check if base_iterator is actually iterable
-                if hasattr(self.base_iterator, '__anext__'):
+                if hasattr(self.base_iterator, "__anext__"):
                     try:
                         chunk = await cast(Any, self.base_iterator).__anext__()  # type: ignore[attr-defined]
-                        
+
                         # If auto-execution is enabled, check for completed responses
-                        if self.should_auto_execute and self._is_response_completed(chunk):
+                        if self.should_auto_execute and self._is_response_completed(
+                            chunk
+                        ):
                             # Collect the response for tool execution
-                            response_obj = getattr(chunk, 'response', None)
+                            response_obj = getattr(chunk, "response", None)
                             if isinstance(response_obj, ResponsesAPIResponse):
                                 self.collected_response = response_obj
                             # Move to tool execution phase after emitting this chunk
                             self.phase = "tool_execution"
                             await self._generate_tool_execution_events()
-                        
+
                         return chunk
                     except StopAsyncIteration:
                         # Initial response ended, move to next phase
@@ -357,24 +377,26 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 else:
                     # base_iterator is not async iterable (likely a ResponsesAPIResponse)
                     # Collect it for tool execution if needed
-                    if self.should_auto_execute and isinstance(self.base_iterator, ResponsesAPIResponse):
+                    if self.should_auto_execute and isinstance(
+                        self.base_iterator, ResponsesAPIResponse
+                    ):
                         self.collected_response = self.base_iterator
                         self.phase = "tool_execution"
                         await self._generate_tool_execution_events()
                     else:
                         self.phase = "finished"
                         raise StopAsyncIteration
-        
+
         # Phase 3: Tool Execution Events
         if self.phase == "tool_execution":
             # Emit any queued tool execution events
             if self.tool_execution_events:
                 return self.tool_execution_events.pop(0)
-            
+
             # Move to follow-up response phase
             self.phase = "follow_up_response"
             await self._create_follow_up_iterator()
-        
+
         # Phase 4: Follow-up Response Stream
         if self.phase == "follow_up_response":
             if self.follow_up_iterator:
@@ -386,20 +408,22 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
             else:
                 self.phase = "finished"
                 raise StopAsyncIteration
-        
+
         # Phase 5: Finished
         if self.phase == "finished":
             raise StopAsyncIteration
-            
+
         # Should not reach here
         raise StopAsyncIteration
-    
+
     def _is_response_completed(self, chunk: ResponsesAPIStreamingResponse) -> bool:
         """Check if this chunk indicates the response is completed"""
         from litellm.types.llms.openai import ResponsesAPIStreamEvents
-        return getattr(chunk, 'type', None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
-    
-    
+
+        return (
+            getattr(chunk, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+        )
+
     async def _create_initial_response_iterator(self) -> None:
         """Create the initial response iterator by making the first LLM call"""
         try:
@@ -408,38 +432,45 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
             # Make the initial response API call - but avoid the MCP wrapper
             params = self.original_request_params.copy()
-            params['stream'] = True  # Ensure streaming
-            
+            params["stream"] = True  # Ensure streaming
+
             # Use the pre-fetched all_tools from original_request_params (no re-processing needed)
             params_for_llm = {}
             for key, value in params.items():
-                params_for_llm[key] = value  # Copy all params as-is since tools are already processed
-            
-            tools_count = len(params_for_llm.get('tools', []))
+                params_for_llm[
+                    key
+                ] = value  # Copy all params as-is since tools are already processed
+
+            tools_count = len(params_for_llm.get("tools", []))
             verbose_logger.debug(f"Making LLM call with {tools_count} tools")
             response = await aresponses(**params_for_llm)
-            
+
             # Set the base iterator
-            if hasattr(response, '__aiter__') or hasattr(response, '__iter__'):
+            if hasattr(response, "__aiter__") or hasattr(response, "__iter__"):
                 self.base_iterator = response
                 # Copy metadata from the real iterator
-                self.model = getattr(response, 'model', self.model)
-                self.litellm_metadata = getattr(response, 'litellm_metadata', {})
-                self.custom_llm_provider = getattr(response, 'custom_llm_provider', self.custom_llm_provider)
-                verbose_logger.debug(f"Created base iterator: {type(self.base_iterator)}")
+                self.model = getattr(response, "model", self.model)
+                self.litellm_metadata = getattr(response, "litellm_metadata", {})
+                self.custom_llm_provider = getattr(
+                    response, "custom_llm_provider", self.custom_llm_provider
+                )
+                verbose_logger.debug(
+                    f"Created base iterator: {type(self.base_iterator)}"
+                )
             else:
                 # Non-streaming response - this shouldn't happen but handle it
                 verbose_logger.warning(f"Got non-streaming response: {type(response)}")
                 self.base_iterator = None
                 self.phase = "finished"
-                
+
         except Exception as e:
             verbose_logger.error(f"Error creating initial response iterator: {e}")
             import traceback
+
             traceback.print_exc()
             self.base_iterator = None
             self.phase = "finished"
-    
+
     async def _generate_tool_execution_events(self) -> None:
         """Generate tool execution events and execute tools"""
         if not self.collected_response:
@@ -447,7 +478,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
         )
-        
+
         try:
             # Extract tool calls from the response
             if self.collected_response is not None:
@@ -456,9 +487,13 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 tool_calls = []
             if not tool_calls:
                 return
-            
+
             for tool_call in tool_calls:
-                tool_name, tool_arguments, tool_call_id = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_call)
+                (
+                    tool_name,
+                    tool_arguments,
+                    tool_call_id,
+                ) = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_call)
                 if tool_name and tool_call_id:
                     # Create MCP call events for this tool execution
                     call_events = create_mcp_call_events(
@@ -467,34 +502,39 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                         arguments=tool_arguments or "{}",  # JSON string with arguments
                         result=None,  # Will be set after execution
                         base_item_id=f"mcp_{uuid.uuid4().hex[:8]}",
-                        sequence_start=len(self.tool_execution_events) + 1
+                        sequence_start=len(self.tool_execution_events) + 1,
                     )
                     # Add the in_progress and arguments events (not the completed event yet)
                     self.tool_execution_events.extend(call_events[:-1])
-            
+
             # Execute the tools
             tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
+                tool_server_map=self.tool_server_map,
                 tool_calls=tool_calls,
-                user_api_key_auth=self.user_api_key_auth
+                user_api_key_auth=self.user_api_key_auth,
             )
-            
+
             # Create completion events and output_item.done events for tool execution
             for tool_result in tool_results:
                 tool_call_id = tool_result.get("tool_call_id", "unknown")
                 result_text = tool_result.get("result", "")
-                
+
                 # Find matching tool name and arguments
                 tool_name = "unknown"
                 tool_arguments = "{}"
                 for tool_call in tool_calls:
-                    name, args, call_id = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_call)
+                    (
+                        name,
+                        args,
+                        call_id,
+                    ) = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_call)
                     if call_id == tool_call_id:
                         tool_name = name or "unknown"
                         tool_arguments = args or "{}"
                         break
-                
+
                 item_id = f"mcp_{uuid.uuid4().hex[:8]}"
-                
+
                 # Create the completion event
                 completed_event = MCPCallCompletedEvent(
                     type=ResponsesAPIStreamEvents.MCP_CALL_COMPLETED,
@@ -503,10 +543,10 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                     output_index=0,
                 )
                 self.tool_execution_events.append(completed_event)
-                
+
                 # Create output_item.done event with the tool call result
                 from litellm.types.llms.openai import OutputItemDoneEvent
-                
+
                 output_item_done_event = OutputItemDoneEvent(
                     type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
                     output_index=0,
@@ -518,63 +558,66 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                         "error": None,
                         "name": tool_name,
                         "output": result_text,
-                        "server_label": "litellm"  # or extract from tool config
+                        "server_label": "litellm",  # or extract from tool config
                     },
                 )
                 self.tool_execution_events.append(output_item_done_event)
-            
+
             # Store tool results for follow-up call
             self.tool_results = tool_results
-            
+
         except Exception as e:
             verbose_logger.error(f"Error in tool execution: {e}")
             import traceback
+
             traceback.print_exc()
             self.tool_results = []
-    
+
     async def _create_follow_up_iterator(self) -> None:
         """Create the follow-up response iterator with tool results"""
-        if not self.collected_response or not hasattr(self, 'tool_results'):
+        if not self.collected_response or not hasattr(self, "tool_results"):
             return
-            
+
         from litellm.responses.main import aresponses
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
         )
-        
+
         try:
             # Create follow-up input
             if self.collected_response is not None:
                 follow_up_input = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
                     response=self.collected_response,  # type: ignore[arg-type]
                     tool_results=self.tool_results,
-                    original_input=self.original_request_params.get('input')
+                    original_input=self.original_request_params.get("input"),
                 )
-                
+
                 # Make follow-up call with streaming
                 follow_up_params = self.original_request_params.copy()
-                follow_up_params.update({
-                    'input': follow_up_input,
-                    'previous_response_id': self.collected_response.id,  # type: ignore[attr-defined]
-                    'stream': True
-                })
+                follow_up_params.update(
+                    {
+                        "input": follow_up_input,
+                        "previous_response_id": self.collected_response.id,  # type: ignore[attr-defined]
+                        "stream": True,
+                    }
+                )
             else:
                 return
             # Remove tool_choice to avoid forcing more tool calls
-            follow_up_params.pop('tool_choice', None)
-            
+            follow_up_params.pop("tool_choice", None)
+
             follow_up_response = await aresponses(**follow_up_params)
-            
+
             # Set up the follow-up iterator
-            if hasattr(follow_up_response, '__aiter__'):
+            if hasattr(follow_up_response, "__aiter__"):
                 self.follow_up_iterator = follow_up_response
-            
+
         except Exception as e:
             verbose_logger.error(f"Error creating follow-up iterator: {e}")
             import traceback
+
             traceback.print_exc()
             self.follow_up_iterator = None
-
 
     def __iter__(self):
         return self
@@ -583,11 +626,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         # First, emit any queued MCP events
         if self.mcp_events:  # type: ignore[attr-defined]
             return self.mcp_events.pop(0)  # type: ignore[attr-defined]
-        
+
         # Then delegate to the base iterator
         if not self.is_async:
             try:
-                if self.base_iterator and hasattr(self.base_iterator, '__next__'):
+                if self.base_iterator and hasattr(self.base_iterator, "__next__"):
                     return next(cast(Any, self.base_iterator))  # type: ignore[arg-type]
                 else:
                     raise StopIteration

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -286,6 +286,8 @@ async def test_mcp_allowed_tools_filtering():
             'inputSchema': {'type': 'object', 'properties': {}}
         })()
     ]
+
+    allowed_mcp_servers = ["gitmcp"]
     
     # Test Case 1: MCP tool config with allowed_tools specified
     mcp_tool_config_with_allowed_tools = [
@@ -381,8 +383,8 @@ async def test_mcp_allowed_tools_filtering():
     )
     
     # Then deduplicate the filtered tools
-    filtered_tools_deduplicated = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(
-        filtered_tools_with_duplicates
+    filtered_tools_deduplicated, _ = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(
+        filtered_tools_with_duplicates, []
     )
     
     # Should only return 1 tool (the duplicate should be removed)
@@ -395,7 +397,7 @@ async def test_mcp_allowed_tools_filtering():
     print("✓ Test Case 3: duplicate tools are properly deduplicated")
     
     # Test Case 3b: Test standalone deduplication method
-    standalone_deduplicated = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(mock_mcp_tools_with_duplicates)
+    standalone_deduplicated, _ = LiteLLM_Proxy_MCP_Handler._deduplicate_mcp_tools(mock_mcp_tools_with_duplicates, allowed_mcp_servers)
     
     # Should return 2 unique tools (GitMCP-fetch_litellm_documentation and GitMCP-search_litellm_documentation)
     assert len(standalone_deduplicated) == 2, f"Expected 2 unique tools after standalone deduplication, got {len(standalone_deduplicated)}"

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -106,6 +106,7 @@ async def test_mcp_server_manager_https_server():
         ] = expected_prefix
 
         result = await mcp_server_manager.call_tool(
+            server_name="zapier_mcp_server",
             name=f"{expected_prefix}-gmail_send_email",
             arguments={
                 "body": "Test",
@@ -266,6 +267,7 @@ async def test_mcp_http_transport_call_tool_mock():
 
         # Call the tool
         result = await test_manager.call_tool(
+            server_name="test_http_server",
             name="gmail_send_email",
             arguments={
                 "to": "test@example.com",
@@ -332,6 +334,7 @@ async def test_mcp_http_transport_call_tool_error_mock():
 
         # Call the tool with invalid data
         result = await test_manager.call_tool(
+            server_name="test_http_server",
             name="gmail_send_email",
             arguments={"to": "invalid-email", "subject": "Test", "body": "Test"},
             proxy_logging_obj=None,
@@ -370,6 +373,7 @@ async def test_mcp_http_transport_tool_not_found():
     # Try to call a tool that doesn't exist in mapping
     with pytest.raises(ValueError, match="Tool nonexistent_tool not found"):
         await test_manager.call_tool(
+            server_name="test_http_server",
             name="nonexistent_tool",
             arguments={"param": "value"},
             proxy_logging_obj=None,
@@ -774,7 +778,7 @@ async def test_get_tools_from_mcp_servers():
         mock_manager.get_allowed_mcp_servers = AsyncMock(
             return_value=["server1_id", "server2_id"]
         )
-        mock_manager.get_mcp_server_by_id = mock_get_server_by_id
+        mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server_1, mock_server_2])
         mock_manager._get_tools_from_server = AsyncMock(return_value=[mock_tool_1])
 
         with patch(
@@ -796,7 +800,7 @@ async def test_get_tools_from_mcp_servers():
             mock_manager_2.get_allowed_mcp_servers = AsyncMock(
                 return_value=["server1_id", "server2_id"]
             )
-            mock_manager_2.get_mcp_server_by_id = mock_get_server_by_id
+            mock_manager_2.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server_1, mock_server_2])
             mock_manager_2._get_tools_from_server = AsyncMock(
                 side_effect=lambda server, mcp_auth_header=None, extra_headers=None, add_prefix=False: (
                     [mock_tool_1] if server.server_id == "server1_id" else [mock_tool_2]
@@ -824,7 +828,7 @@ async def test_get_tools_from_mcp_servers():
         mock_manager.get_allowed_mcp_servers = AsyncMock(
             return_value=["server1_id", "server2_id", "server3_id"]
         )
-        mock_manager.get_mcp_server_by_id = mock_get_server_by_id
+        mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server_1, mock_server_2, mock_server_3])
         mock_manager._get_tools_from_server = AsyncMock(return_value=[mock_tool_1])
 
         with patch(
@@ -2062,7 +2066,7 @@ async def test_filter_tools_by_allowed_tools_integration():
         mock_manager.get_allowed_mcp_servers = AsyncMock(
             return_value=["test-server-123"]
         )
-        mock_manager.get_mcp_server_by_id = MagicMock(return_value=mock_server)
+        mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server])
 
         # Mock the _get_tools_from_server method to return all tools
         mock_manager._get_tools_from_server = AsyncMock(return_value=mock_tools)
@@ -2100,7 +2104,7 @@ async def test_filter_tools_by_allowed_tools_integration():
 
             # Verify the manager methods were called correctly
             mock_manager.get_allowed_mcp_servers.assert_called_once_with(mock_user_auth)
-            mock_manager.get_mcp_server_by_id.assert_called_once_with("test-server-123")
+            mock_manager.get_mcp_servers_from_ids.assert_called_once_with(["test-server-123"])
             mock_manager._get_tools_from_server.assert_called_once()
 
 
@@ -2170,8 +2174,7 @@ async def test_filter_tools_by_disallowed_tools_integration():
         mock_manager.get_allowed_mcp_servers = AsyncMock(
             return_value=["test-server-456"]
         )
-        mock_manager.get_mcp_server_by_id = MagicMock(return_value=mock_server)
-
+        mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server])
         # Mock the _get_tools_from_server method to return all tools
         mock_manager._get_tools_from_server = AsyncMock(return_value=mock_tools)
 
@@ -2208,7 +2211,7 @@ async def test_filter_tools_by_disallowed_tools_integration():
 
             # Verify the manager methods were called correctly
             mock_manager.get_allowed_mcp_servers.assert_called_once_with(mock_user_auth)
-            mock_manager.get_mcp_server_by_id.assert_called_once_with("test-server-456")
+            mock_manager.get_mcp_servers_from_ids.assert_called_once_with(["test-server-456"])
             mock_manager._get_tools_from_server.assert_called_once()
 
 
@@ -2265,7 +2268,7 @@ async def test_filter_tools_no_restrictions_integration():
         mock_manager.get_allowed_mcp_servers = AsyncMock(
             return_value=["test-server-000"]
         )
-        mock_manager.get_mcp_server_by_id = MagicMock(return_value=mock_server)
+        mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[mock_server])
 
         # Mock the _get_tools_from_server method to return all tools
         mock_manager._get_tools_from_server = AsyncMock(return_value=mock_tools)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -111,7 +111,7 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["working_server", "failing_server"]
     )
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[working_server, failing_server])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[working_server, failing_server])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         working_server if server_id == "working_server" else failing_server
     )
@@ -208,7 +208,7 @@ async def test_get_tools_from_mcp_servers_handles_all_servers_failing():
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["failing_server1", "failing_server2"]
     )
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[failing_server1, failing_server2])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[failing_server1, failing_server2])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         failing_server1 if server_id == "failing_server1" else failing_server2
     )
@@ -622,7 +622,7 @@ async def test_list_tools_single_server_unprefixed_names():
     # Mock manager: allow just one server and return a tool based on add_prefix flag
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server])
 
     async def mock_get_tools_from_server(
         server, mcp_auth_header=None, extra_headers=None, add_prefix=False
@@ -692,7 +692,7 @@ async def test_list_tools_multiple_servers_prefixed_names():
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["server1", "server2"]
     )
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server1, server2])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server1, server2])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         server1 if server_id == "server1" else server2
     )
@@ -741,13 +741,13 @@ async def test_call_mcp_tool_user_unauthorized_access():
         object_permission_id="key-permission-123",
     )
 
-    # Mock global_mcp_server_manager.get_mcp_server_names_from_ids to return
+    # Mock global_mcp_server_manager.get_mcp_servers_from_ids to return
     # a list that doesn't include "restricted_server" (the server the user is trying to access)
     with patch(
         "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.get_allowed_mcp_servers",
         AsyncMock(return_value=["allowed_server", "another_server"]),
     ), patch(
-        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_names_from_ids"
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_servers_from_ids"
     ) as mock_get_server_names:
         allowed_server_obj = MagicMock()
         allowed_server_obj.name = "allowed_server"
@@ -830,7 +830,7 @@ async def test_list_tools_filters_by_key_team_permissions():
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(
@@ -932,7 +932,7 @@ async def test_list_tools_with_team_tool_permissions_inheritance():
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(
@@ -1019,7 +1019,7 @@ async def test_list_tools_with_no_tool_permissions_shows_all():
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
-    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(
@@ -1109,7 +1109,7 @@ async def test_list_tools_strips_prefix_when_matching_permissions():
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["gitmcp_server"])
-    mock_manager.get_mcp_server_by_id = lambda server_id: server
+    mock_manager.get_mcp_servers_from_ids = MagicMock(return_value=[server])
 
     async def mock_get_tools_from_server(
         server, mcp_auth_header=None, extra_headers=None, add_prefix=True

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -90,18 +91,27 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
     working_server.alias = "working"
     working_server.allowed_tools = None
     working_server.disallowed_tools = None
+    working_server.server_id = "working_server"
+    working_server.server_name = "working_server"
+    working_server.auth_type = None
+    working_server.extra_headers = None
 
     failing_server = MagicMock()
     failing_server.name = "failing_server"
     failing_server.alias = "failing"
     failing_server.allowed_tools = None
     failing_server.disallowed_tools = None
+    failing_server.server_id = "failing_server"
+    failing_server.server_name = "failing_server"
+    failing_server.auth_type = None
+    failing_server.extra_headers = None
 
     # Mock global_mcp_server_manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["working_server", "failing_server"]
     )
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[working_server, failing_server])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         working_server if server_id == "working_server" else failing_server
     )
@@ -138,7 +148,7 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
             result = await _get_tools_from_mcp_servers(
                 user_api_key_auth=user_api_key_auth,
                 mcp_auth_header=None,
-                mcp_servers=None,
+                mcp_servers=["working_server", "failing_server"],
                 mcp_server_auth_headers=mcp_server_auth_headers,
             )
 
@@ -176,16 +186,29 @@ async def test_get_tools_from_mcp_servers_handles_all_servers_failing():
     failing_server1 = MagicMock()
     failing_server1.name = "failing_server1"
     failing_server1.alias = "failing1"
+    failing_server1.allowed_tools = None
+    failing_server1.disallowed_tools = None
+    failing_server1.server_id = "failing_server1"
+    failing_server1.server_name = "failing_server1"
+    failing_server1.auth_type = None
+    failing_server1.extra_headers = None
 
     failing_server2 = MagicMock()
     failing_server2.name = "failing_server2"
     failing_server2.alias = "failing2"
+    failing_server2.allowed_tools = None
+    failing_server2.disallowed_tools = None
+    failing_server2.server_id = "failing_server2"
+    failing_server2.server_name = "failing_server2"
+    failing_server2.auth_type = None
+    failing_server2.extra_headers = None
 
     # Mock global_mcp_server_manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["failing_server1", "failing_server2"]
     )
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[failing_server1, failing_server2])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         failing_server1 if server_id == "failing_server1" else failing_server2
     )
@@ -592,13 +615,14 @@ async def test_list_tools_single_server_unprefixed_names():
     server.alias = "zapier"
     server.allowed_tools = None
     server.disallowed_tools = None
+    server.server_name = "server1"
+    server.auth_type = None
+    server.extra_headers = None
 
     # Mock manager: allow just one server and return a tool based on add_prefix flag
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
-    mock_manager.get_mcp_server_by_id = lambda server_id: (
-        server if server_id == "server1" else None
-    )
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
 
     async def mock_get_tools_from_server(
         server, mcp_auth_header=None, extra_headers=None, add_prefix=False
@@ -649,6 +673,9 @@ async def test_list_tools_multiple_servers_prefixed_names():
     server1.alias = "zapier"
     server1.allowed_tools = None
     server1.disallowed_tools = None
+    server1.server_name = "server1"
+    server1.auth_type = None
+    server1.extra_headers = None
 
     server2 = MagicMock()
     server2.server_id = "server2"
@@ -656,12 +683,16 @@ async def test_list_tools_multiple_servers_prefixed_names():
     server2.alias = "jira"
     server2.allowed_tools = None
     server2.disallowed_tools = None
+    server2.server_name = "server2"
+    server2.auth_type = None
+    server2.extra_headers = None
 
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(
         return_value=["server1", "server2"]
     )
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server1, server2])
     mock_manager.get_mcp_server_by_id = lambda server_id: (
         server1 if server_id == "server1" else server2
     )
@@ -713,10 +744,32 @@ async def test_call_mcp_tool_user_unauthorized_access():
     # Mock global_mcp_server_manager.get_mcp_server_names_from_ids to return
     # a list that doesn't include "restricted_server" (the server the user is trying to access)
     with patch(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.get_allowed_mcp_servers",
+        AsyncMock(return_value=["allowed_server", "another_server"]),
+    ), patch(
         "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_names_from_ids"
     ) as mock_get_server_names:
-        # User has access to "allowed_server" but not "restricted_server"
-        mock_get_server_names.return_value = ["allowed_server", "another_server"]
+        allowed_server_obj = MagicMock()
+        allowed_server_obj.name = "allowed_server"
+        allowed_server_obj.server_name = "allowed_server"
+        allowed_server_obj.server_id = "allowed_server"
+        allowed_server_obj.alias = "allowed_server"
+        allowed_server_obj.allowed_tools = None
+        allowed_server_obj.disallowed_tools = None
+        allowed_server_obj.auth_type = None
+        allowed_server_obj.extra_headers = None
+
+        another_server_obj = MagicMock()
+        another_server_obj.name = "another_server"
+        another_server_obj.server_name = "another_server"
+        another_server_obj.server_id = "another_server"
+        another_server_obj.alias = "another_server"
+        another_server_obj.allowed_tools = None
+        another_server_obj.disallowed_tools = None
+        another_server_obj.auth_type = None
+        another_server_obj.extra_headers = None
+
+        mock_get_server_names.return_value = [allowed_server_obj, another_server_obj]
 
         # Try to call a tool from "restricted_server" - should raise HTTPException with 403 status
         with pytest.raises(HTTPException) as exc_info:
@@ -770,10 +823,14 @@ async def test_list_tools_filters_by_key_team_permissions():
     server.alias = "test"
     server.allowed_tools = None
     server.disallowed_tools = None
+    server.server_name = "server1"
+    server.auth_type = None
+    server.extra_headers = None
 
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(
@@ -868,10 +925,14 @@ async def test_list_tools_with_team_tool_permissions_inheritance():
     server.alias = "test"
     server.allowed_tools = None
     server.disallowed_tools = None
+    server.server_name = "server1"
+    server.auth_type = None
+    server.extra_headers = None
 
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(
@@ -951,10 +1012,14 @@ async def test_list_tools_with_no_tool_permissions_shows_all():
     server.alias = "test"
     server.allowed_tools = None
     server.disallowed_tools = None
+    server.server_name = "server1"
+    server.auth_type = None
+    server.extra_headers = None
 
     # Mock manager
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server1"])
+    mock_manager.get_mcp_server_names_from_ids = MagicMock(return_value=[server])
     mock_manager.get_mcp_server_by_id = lambda server_id: server
 
     async def mock_get_tools_from_server(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1186,7 +1186,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="getpetbyid",
             arguments={"petId": "1"},
-            server_name_from_prefix="my_api_mcp",
+            server_name="my_api_mcp",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -1196,7 +1196,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="findpetsbystatus",
             arguments={"status": "available"},
-            server_name_from_prefix="my_api_mcp",
+            server_name="my_api_mcp",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -1207,7 +1207,7 @@ class TestMCPServerManager:
             await manager.pre_call_tool_check(
                 name="deletepet",
                 arguments={"petId": "1"},
-                server_name_from_prefix="my_api_mcp",
+                server_name="my_api_mcp",
                 user_api_key_auth=user_api_key_auth,
                 proxy_logging_obj=proxy_logging_obj,
                 server=server,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -453,7 +453,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="allowed_tool",
             arguments={"param": "value"},
-            server_name_from_prefix="test-server",
+            server_name="test-server",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -482,7 +482,7 @@ class TestMCPServerManager:
             await manager.pre_call_tool_check(
                 name="blocked_tool",
                 arguments={"param": "value"},
-                server_name_from_prefix="test-server",
+                server_name="test-server",
                 user_api_key_auth=user_api_key_auth,
                 proxy_logging_obj=proxy_logging_obj,
                 server=server,
@@ -529,7 +529,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="allowed_tool",
             arguments={"param": "value"},
-            server_name_from_prefix="test-server",
+            server_name="test-server",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -558,7 +558,7 @@ class TestMCPServerManager:
             await manager.pre_call_tool_check(
                 name="banned_tool",
                 arguments={"param": "value"},
-                server_name_from_prefix="test-server",
+                server_name="test-server",
                 user_api_key_auth=user_api_key_auth,
                 proxy_logging_obj=proxy_logging_obj,
                 server=server,
@@ -605,7 +605,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="any_tool",
             arguments={"param": "value"},
-            server_name_from_prefix="test-server",
+            server_name="test-server",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -644,7 +644,7 @@ class TestMCPServerManager:
         await manager.pre_call_tool_check(
             name="tool2",
             arguments={"param": "value"},
-            server_name_from_prefix="test-server",
+            server_name="test-server",
             user_api_key_auth=user_api_key_auth,
             proxy_logging_obj=proxy_logging_obj,
             server=server,
@@ -655,7 +655,7 @@ class TestMCPServerManager:
             await manager.pre_call_tool_check(
                 name="tool3",
                 arguments={"param": "value"},
-                server_name_from_prefix="test-server",
+                server_name="test-server",
                 user_api_key_auth=user_api_key_auth,
                 proxy_logging_obj=proxy_logging_obj,
                 server=server,
@@ -992,9 +992,9 @@ class TestMCPServerManager:
 
         # Should succeed
         await manager.pre_call_tool_check(
+            server_name="Test Server",
             name="read_wiki_structure",
             arguments={"repoName": "facebook/react"},
-            server_name_from_prefix="test",
             user_api_key_auth=user_auth,
             proxy_logging_obj=proxy_logging,
             server=server,
@@ -1038,9 +1038,9 @@ class TestMCPServerManager:
         # Should fail with 403
         with pytest.raises(HTTPException) as exc_info:
             await manager.pre_call_tool_check(
+                server_name="Test Server",
                 name="ask_question",
                 arguments={"question": "test"},
-                server_name_from_prefix="test",
                 user_api_key_auth=user_auth,
                 proxy_logging_obj=proxy_logging,
                 server=server,


### PR DESCRIPTION
## Title

fix: allow tool call even when server name prefix is missing

## Relevant issues

Fixes #14986
Fixes #15364

When there’s only one server, the prefix is no longer added, which caused an error during the MCP tool call since the prefix couldn’t be extracted in this part of the code:
https://github.com/BerriAI/litellm/blob/main/litellm/proxy/_experimental/mcp_server/server.py#L660

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


