### PR TITLE
Remove hardcoded "public" schema in 20250918083359_drop_spec_version_column_from_mcp_table/migration.sql

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20250918083359_drop_spec_version_column_from_mcp_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20250918083359_drop_spec_version_column_from_mcp_table/migration.sql
@@ -5,4 +5,4 @@
 
 */
 -- AlterTable
-ALTER TABLE "public"."LiteLLM_MCPServerTable" DROP COLUMN "spec_version";
+ALTER TABLE "LiteLLM_MCPServerTable" DROP COLUMN "spec_version";


### PR DESCRIPTION
## Title

Fix hardcoded schema in 20250918083359_drop_spec_version_column_from_mcp_table/migration.sql

## The issue

Applying 20250918083359_drop_spec_version_column_from_mcp_table/migration.sql does not currently work when using a non-default schema name, because "public" has been hard-coded as the schema. 

```
2025-10-07 13:01:26.022 UTC [35] STATEMENT:  /*
litellm-db          |     Warnings:
litellm-db          |
litellm-db          |     - You are about to drop the column `spec_version` on the `LiteLLM_MCPServerTable` table. All the data in the column will be lost.
litellm-db          |
litellm-db          |   */
litellm-db          |   -- AlterTable
litellm-db          |   ALTER TABLE "public"."LiteLLM_MCPServerTable" DROP COLUMN "spec_version";
litellm-db          |
api                 | 2025-10-07 13:01:26,163 - litellm_proxy_extras - INFO - prisma db error: prisma:warn Prisma doesn't know which engines to download for the Linux distro "wolfi". Falling back to Prisma engines built "debian".
api                 | Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
api                 | prisma:warn Prisma doesn't know which engines to download for the Linux distro "wolfi". Falling back to Prisma engines built "debian".
api                 | Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
api                 | Error: P3018
api                 |
api                 | A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
api                 |
api                 | Migration name: 20250918083359_drop_spec_version_column_from_mcp_table
api                 |
api                 | Database error code: 42P01
api                 |
api                 | Database error:
api                 | ERROR: relation "public.LiteLLM_MCPServerTable" does not exist
api                 |
api                 | DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42P01), message: "relation \"public.LiteLLM_MCPServerTable\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("namespace.c"), line: Some(427), routine: Some("RangeVarGetRelidExtended") }
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- ~[x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

I don't see how the two failing tests could be related to this:
<img width="1533" height="604" alt="image" src="https://github.com/user-attachments/assets/e13f2b9a-36f6-4f1c-bcf7-d87abcadd53c" />


## Type

🐛 Bug Fix

## Changes

