### PR TITLE
fix: usage page >> Model Activity >> spend per day graph: y-axis clipping on large spend values

### DIFF
--- a/ui/litellm-dashboard/src/components/activity_metrics.tsx
+++ b/ui/litellm-dashboard/src/components/activity_metrics.tsx
@@ -113,7 +113,8 @@ const ModelSection = ({ modelName, metrics }: { modelName: string; metrics: Mode
             index="date"
             categories={["metrics.spend"]}
             colors={["green"]}
-            valueFormatter={(value: number) => `$${formatNumberWithCommas(value, 2)}`}
+            valueFormatter={(value: number) => `$${formatNumberWithCommas(value, 2, true)}`}
+            yAxisWidth={72}
           />
         </Card>
 

--- a/ui/litellm-dashboard/src/utils/dataUtils.ts
+++ b/ui/litellm-dashboard/src/utils/dataUtils.ts
@@ -13,14 +13,38 @@ export function updateExistingKeys<Source extends Object>(target: Source, source
   return clonedTarget;
 }
 
-export const formatNumberWithCommas = (value: number | null | undefined, decimals: number = 0): string => {
-  if (value === null || value === undefined) {
+export const formatNumberWithCommas = (
+  value: number | null | undefined,
+  decimals: number = 0,
+  abbreviate: boolean = false,
+): string => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
     return "-";
   }
-  return value.toLocaleString("en-US", {
+
+  const opts: Intl.NumberFormatOptions = {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
-  });
+  };
+
+  if (!abbreviate) {
+    return value.toLocaleString("en-US", opts);
+  }
+
+  const sign = value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+  let scaled = abs;
+  let suffix = "";
+
+  if (abs >= 1_000_000) {
+    scaled = abs / 1_000_000;
+    suffix = "M";
+  } else if (abs >= 1_000) {
+    scaled = abs / 1_000;
+    suffix = "K";
+  }
+
+  return `${sign}${scaled.toLocaleString("en-US", opts)}${suffix}`;
 };
 
 export const copyToClipboard = async (


### PR DESCRIPTION
## fix: usage page >> Model Activity >> spend per day graph: y-axis clipping on large spend values

These changes fix the y-axis clipping on the spend per day graph.

**Before**:
<img width="1486" height="858" alt="image" src="https://github.com/user-attachments/assets/b3192d2c-ad78-4615-bdf5-c58b7721dd44" />

**After**:
<img width="1478" height="854" alt="image" src="https://github.com/user-attachments/assets/3019e15c-abfb-48fa-958a-8ce0801a8ab5" />


## Relevant issues
N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
- adds the option to abbreviate large numbers using K and M
- increases the width of the y-axis labels

