### PR TITLE
Fix  - OpenRouter cache_control to only apply to last content block

### DIFF
--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -18,6 +18,7 @@ from litellm import get_secret_str
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.azure.files.handler import AzureOpenAIFilesAPI
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.openai.openai import FileDeleted, FileObject, OpenAIFilesAPI
 from litellm.llms.vertex_ai.files.handler import VertexAIFilesHandler

--- a/litellm/proxy/guardrails/guardrail_hooks/enkryptai/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/enkryptai/__init__.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
-from .enkryptai import EnkryptAIGuardrails
-
 if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2254,7 +2254,6 @@ class CustomPricingLiteLLMParams(BaseModel):
     input_cost_per_token_cache_hit: Optional[float] = None
     input_cost_per_token_above_128k_tokens: Optional[float] = None
     input_cost_per_token_above_200k_tokens: Optional[float] = None
-    input_cost_per_character_above_128k_tokens: Optional[float] = None
     input_cost_per_query: Optional[float] = None
     input_cost_per_image: Optional[float] = None
     input_cost_per_image_above_128k_tokens: Optional[float] = None


### PR DESCRIPTION
# Fix OpenRouter cache_control to only apply to last content block

## Problem

When moving `cache_control` from message level to content blocks for OpenRouter's Anthropic models, the current implementation was adding `cache_control` to **all** content blocks. This could easily exceed Anthropic's limit of 4 cache breakpoints per prompt.

For example, a system message with 5 content blocks would create 5 cache breakpoints, breaking inference:

```json
{
  "role": "system",
  "content": [
    {"type": "text", "text": "Block 1", "cache_control": {"type": "ephemeral"}},
    {"type": "text", "text": "Block 2", "cache_control": {"type": "ephemeral"}},
    {"type": "text", "text": "Block 3", "cache_control": {"type": "ephemeral"}},
    {"type": "text", "text": "Block 4", "cache_control": {"type": "ephemeral"}},
    {"type": "text", "text": "Block 5", "cache_control": {"type": "ephemeral"}}
  ]
}
```

## Solution

Modified `_move_cache_control_to_content()` to only add `cache_control` to the **last** content block in each message, matching OpenRouter's documentation:

```json
{
  "role": "system",
  "content": [
    {"type": "text", "text": "You are a historian studying the fall of the Roman Empire..."},
    {"type": "text", "text": "HUGE TEXT BODY", "cache_control": {"type": "ephemeral"}}
  ]
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


