### PR TITLE
Reduce claude-4-sonnet max_output_tokens to 64k

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4811,7 +4811,7 @@
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 1000000,
-        "max_output_tokens": 1000000,
+        "max_output_tokens": 64000,
         "max_tokens": 1000000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,


### PR DESCRIPTION
## Title

Reduce claude-4-sonnet max_output_tokens to 64k

## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Very hard to test without making any API call. Could mock it but that just feels stupid. Take it or leave it.

## Type

🐛 Bug Fix

## Changes

Claude 4 Sonnet doesn't support more than 64k output tokens: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4

This PR reduces the previous faulty value of 1M down to the correct 64k
