### PR TITLE
[Fix] - SensitiveDataMasker converts lists to string

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -75,7 +75,7 @@ class SensitiveDataMasker:
                     masked_data[k] = self._mask_value(str_value)
                 else:
                     masked_data[k] = (
-                        v if isinstance(v, (int, float, bool, str)) else str(v)
+                        v if isinstance(v, (int, float, bool, str, list)) else str(v)
                     )
             except Exception:
                 masked_data[k] = "<unable to serialize>"
@@ -89,12 +89,14 @@ masker = SensitiveDataMasker()
 data = {
     "api_key": "sk-1234567890abcdef",
     "redis_password": "very_secret_pass",
-    "port": 6379
+    "port": 6379,
+    "tags": ["East US 2", "production", "test"]
 }
 masked = masker.mask_dict(data)
 # Result: {
 #    "api_key": "sk-1****cdef",
 #    "redis_password": "very****pass",
-#    "port": 6379
+#    "port": 6379,
+#    "tags": ["East US 2", "production", "test"]
 # }
 """

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for SensitiveDataMasker - List Preservation
+"""
+
+import os
+import sys
+
+import pytest
+
+# Add the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
+
+
+def test_lists_are_preserved_not_converted_to_strings():
+    """
+    Regression test: Ensure lists are preserved as JSON arrays, not converted to strings.
+    Previously, tags field in /model/info was returned as "['tag1', 'tag2']" instead of ["tag1", "tag2"]
+    """
+    masker = SensitiveDataMasker()
+    
+    data = {
+        "tags": ["East US 2", "production", "test"],
+    }
+    
+    masked = masker.mask_dict(data)
+    
+    # Must be a list, not a string
+    assert isinstance(masked["tags"], list)
+    assert masked["tags"] == ["East US 2", "production", "test"]


### PR DESCRIPTION
## Title

[Fix] - SensitiveDataMasker converts lists to string

## Relevant issues

Fixes #15275

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x]  I have Added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [[see details](https://docs.litellm.ai/docs/extras/contributing_code)](https://docs.litellm.ai/docs/extras/contributing_code)
- [x]  I have added a screenshot of my new test passing locally
- [x]  My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x]  My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Added `list` to the allowed primitive types in `SensitiveDataMasker.mask_dict()`
- Updated usage example documentation to demonstrate list preservation

## Test Results

<img width="1416" height="146" alt="Screenshot 2025-10-10 at 11 27 30 AM" src="https://github.com/user-attachments/assets/fd01ba36-d91a-4d9b-8e7a-f3232876cb61" />

- Failures appear unrelated.

## API Call

<img width="1415" height="340" alt="Screenshot 2025-10-10 at 1 04 48 PM" src="https://github.com/user-attachments/assets/454286d6-4c0e-4ce4-b053-fe86b534d99b" />

