### PR TITLE
Deletion of docker-compose buggy comment that cause `config.yaml` based startup fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     #########################################
     ## Uncomment these lines to start proxy with a config.yaml file ##
     # volumes:
-    #  - ./config.yaml:/app/config.yaml <<- this is missing in the docker-compose file currently
+    #  - ./config.yaml:/app/config.yaml
     # command:
     #  - "--config=/app/config.yaml"
     ##############################################


### PR DESCRIPTION
## Deletion of docker-compose buggy comment that cause `config.yaml` based startup fail

## Relevant issues
When execute docker-compose startup with a `config.yaml` the original arrow comment indicating the missing mount point interfered with the volume mount process and whole startup process fail

## Pre-Submission checklist
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Deletion of inline arrow comment after the volume mount path

