### PR TITLE
fix: Add /global/spend/tags to admin_viewer_routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -563,6 +563,7 @@ class LiteLLMRoutes(enum.Enum):
         "/team/daily/activity",
         "/tag/daily/activity",
         "/tag/list",
+        "/global/spend/tags",
     ] + info_routes
 
     # All routes accesible by an Org Admin


### PR DESCRIPTION
## Title

After the August 12, 2025 upgrade (commit afe159bb8b), the access control logic for \`proxy_admin_viewer\` was changed to use an explicit \`admin_viewer_routes\` list. The \`/global/spend/tags\` route was never added to this list, making it inaccessible to \`proxy_admin_viewer\` users.
proxy_admin_viewer should have access to spending routes



**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


🐛 Bug Fix


## Changes


