### PR TITLE
[Feat] VertexAI Gemma model family streaming support + Added MedGemma 

### DIFF
--- a/docs/my-website/docs/providers/vertex_batch.md
+++ b/docs/my-website/docs/providers/vertex_batch.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## **Batch APIs**
+# Vertex Batch APIs
 
 Just add the following Vertex env vars to your environment. 
 

--- a/docs/my-website/docs/providers/vertex_self_deployed.md
+++ b/docs/my-website/docs/providers/vertex_self_deployed.md
@@ -124,10 +124,7 @@ Deploy Gemma models on custom Vertex AI prediction endpoints with OpenAI-compati
 | Vertex Documentation | [Vertex AI Prediction](https://cloud.google.com/vertex-ai/docs/predictions/get-predictions) |
 | Required Parameter | `api_base` - Full prediction endpoint URL |
 
-### Usage
-
-<Tabs>
-<TabItem value="proxy" label="Proxy">
+**Proxy Usage:**
 
 **1. Add to config.yaml**
 
@@ -160,9 +157,7 @@ curl http://0.0.0.0:4000/v1/chat/completions \
   }'
 ```
 
-</TabItem>
-
-<TabItem value="sdk" label="SDK">
+**SDK Usage:**
 
 ```python
 from litellm import completion
@@ -176,5 +171,59 @@ response = completion(
 )
 ```
 
-</TabItem>
-</Tabs>
+## MedGemma Models (Custom Endpoints)
+
+Deploy MedGemma models on custom Vertex AI prediction endpoints with OpenAI-compatible format. MedGemma models use the same `vertex_ai/gemma/` route.
+
+| Property | Details |
+|----------|---------|
+| Provider Route | `vertex_ai/gemma/{MODEL_NAME}` |
+| Vertex Documentation | [Vertex AI Prediction](https://cloud.google.com/vertex-ai/docs/predictions/get-predictions) |
+| Required Parameter | `api_base` - Full prediction endpoint URL |
+
+**Proxy Usage:**
+
+**1. Add to config.yaml**
+
+```yaml
+model_list:
+  - model_name: medgemma-model
+    litellm_params:
+      model: vertex_ai/gemma/medgemma-2b-v1
+      api_base: https://ENDPOINT.us-central1-PROJECT.prediction.vertexai.goog/v1/projects/PROJECT_ID/locations/us-central1/endpoints/ENDPOINT_ID:predict
+      vertex_project: "my-project-id"
+      vertex_location: "us-central1"
+```
+
+**2. Start proxy**
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+**3. Test it**
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "medgemma-model",
+    "messages": [{"role": "user", "content": "What are the symptoms of hypertension?"}],
+    "max_tokens": 100
+  }'
+```
+
+**SDK Usage:**
+
+```python
+from litellm import completion
+
+response = completion(
+    model="vertex_ai/gemma/medgemma-2b-v1",
+    messages=[{"role": "user", "content": "What are the symptoms of hypertension?"}],
+    api_base="https://ENDPOINT.us-central1-PROJECT.prediction.vertexai.goog/v1/projects/PROJECT_ID/locations/us-central1/endpoints/ENDPOINT_ID:predict",
+    vertex_project="my-project-id",
+    vertex_location="us-central1",
+)
+```

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -423,6 +423,7 @@ const sidebars = {
           items: [
             "providers/vertex",
             "providers/vertex_partner",
+            "providers/vertex_self_deployed",
             "providers/vertex_image",
             "providers/vertex_batch",
           ]

--- a/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
@@ -88,6 +88,7 @@ class VertexGemmaConfig(OpenAIGPTConfig):
         # Remove params not needed/supported by Vertex Gemma
         openai_request.pop("model", None)
         openai_request.pop("stream", None)  # Streaming not supported, will be faked client-side
+        openai_request.pop("stream_options", None)  # Stream options not supported
         
         # Wrap in Vertex Gemma format
         return {

--- a/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_gemma_models/transformation.py
@@ -13,10 +13,9 @@ from typing import Any, Callable, Dict, List, Optional, Union, cast
 import httpx
 
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
-from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.llms.openai import AllMessageValues
-from litellm.types.utils import LlmProviders, ModelResponse
+from litellm.types.utils import ModelResponse
 
 
 class VertexGemmaConfig(OpenAIGPTConfig):


### PR DESCRIPTION
## [Feat] VertexAI Gemma model family streaming support + Added MedGemma 

This PR adds support for MedGemma models on Vertex AI and ensures that unsupported streaming parameters (stream and stream_options) are properly filtered out before sending requests to Vertex AI Gemma/MedGemma endpoints.

Fixes LIT-1161

<img width="1716" height="765" alt="Screenshot 2025-10-10 at 2 06 03 PM" src="https://github.com/user-attachments/assets/f6ade95c-e84f-4b88-affe-697cf6be2eee" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


