### PR TITLE
[Fix] - shared session parsing and usage issue

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1125,6 +1125,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         api_base: Optional[str] = None,
         client: Optional[AsyncOpenAI] = None,
         max_retries=None,
+        shared_session: Optional["ClientSession"] = None,
     ):
         try:
             openai_aclient: AsyncOpenAI = self._get_openai_client(  # type: ignore
@@ -1134,6 +1135,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 timeout=timeout,
                 max_retries=max_retries,
                 client=client,
+                shared_session=shared_session,
             )
             headers, response = await self.make_openai_embedding_request(
                 openai_aclient=openai_aclient,
@@ -1197,6 +1199,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client=None,
         aembedding=None,
         max_retries: Optional[int] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> EmbeddingResponse:
         super().embedding()
         try:
@@ -1223,6 +1226,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     timeout=timeout,
                     client=client,
                     max_retries=max_retries,
+                    shared_session=shared_session,
                 )
 
             openai_client: OpenAI = self._get_openai_client(  # type: ignore

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3996,6 +3996,7 @@ def embedding(  # noqa: PLR0915
     """
     azure = kwargs.get("azure", None)
     client = kwargs.pop("client", None)
+    shared_session = kwargs.get("shared_session", None)
     max_retries = kwargs.get("max_retries", None)
     litellm_logging_obj: LiteLLMLoggingObj = kwargs.get("litellm_logging_obj")  # type: ignore
     mock_response: Optional[List[float]] = kwargs.get("mock_response", None)  # type: ignore
@@ -4185,6 +4186,7 @@ def embedding(  # noqa: PLR0915
                 client=client,
                 aembedding=aembedding,
                 max_retries=max_retries,
+                shared_session=shared_session,
             )
         elif custom_llm_provider == "databricks":
             api_base = api_base or litellm.api_base or get_secret("DATABRICKS_API_BASE")  # type: ignore

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2382,6 +2382,7 @@ all_litellm_params = [
     "litellm_session_id",
     "use_litellm_proxy",
     "prompt_label",
+    "shared_session",
 ] + list(StandardCallbackDynamicParams.__annotations__.keys()) + list(CustomPricingLiteLLMParams.model_fields.keys())
 
 

--- a/tests/test_litellm/test_aembedding_session_reuse_e2e.py
+++ b/tests/test_litellm/test_aembedding_session_reuse_e2e.py
@@ -1,0 +1,61 @@
+"""
+Regression test for commit 819a6b5f18
+
+Ensures shared_session is in all_litellm_params to prevent
+"Object of type ClientSession is not JSON serializable" errors.
+"""
+import os
+import sys
+import inspect
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.types.utils import all_litellm_params
+
+
+def test_shared_session_in_all_litellm_params():
+    """
+    CRITICAL: shared_session must be in all_litellm_params.
+    
+    If missing, it gets passed to provider APIs causing JSON serialization errors.
+    Regression test for commit 819a6b5f18.
+    """
+    assert "shared_session" in all_litellm_params
+
+
+def test_openai_embedding_passes_shared_session():
+    """
+    Verify shared_session flows through the complete call chain.
+    
+    Full chain: litellm.embedding() -> OpenAI.embedding() -> _get_openai_client() 
+                -> AsyncHTTPHandler -> _create_async_transport() -> _create_aiohttp_transport()
+    """
+    import litellm
+    from litellm.llms.openai.openai import OpenAIChatCompletion
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    
+    # Step 1: litellm.embedding() extracts and passes shared_session
+    main_source = inspect.getsource(litellm.embedding)
+    assert 'shared_session' in main_source
+    
+    # Step 2: OpenAI handlers pass it forward
+    aembedding_source = inspect.getsource(OpenAIChatCompletion.aembedding)
+    embedding_source = inspect.getsource(OpenAIChatCompletion.embedding)
+    assert 'shared_session=shared_session' in aembedding_source
+    assert 'shared_session=shared_session' in embedding_source
+    
+    # Step 3: _get_openai_client passes it to AsyncHTTPHandler
+    client_source = inspect.getsource(OpenAIChatCompletion._get_openai_client)
+    assert 'shared_session' in client_source
+    
+    # Step 4: AsyncHTTPHandler.create_client passes it to _create_async_transport
+    create_client_source = inspect.getsource(AsyncHTTPHandler.create_client)
+    assert 'shared_session=shared_session' in create_client_source
+    
+    # Step 5: _create_async_transport passes it to _create_aiohttp_transport
+    async_transport_source = inspect.getsource(AsyncHTTPHandler._create_async_transport)
+    assert 'shared_session=shared_session' in async_transport_source
+    
+    # Step 6: _create_aiohttp_transport uses it
+    aiohttp_transport_source = inspect.getsource(AsyncHTTPHandler._create_aiohttp_transport)
+    assert 'shared_session' in aiohttp_transport_source


### PR DESCRIPTION
## Title

[Fix] - shared session parsing and usage issue

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes

* Fixed JSON serialization error when using `shared_session` with embedding calls by adding it to all_litellm_params
* Enabled connection pooling for embeddings by passing shared_session through the OpenAI embedding call chain
* Added regression test to verify shared_session flows correctly through all layers of the embedding stack


## Test Results

<img width="1428" height="160" alt="Screenshot 2025-10-10 at 6 13 54 PM" src="https://github.com/user-attachments/assets/6bf17f20-1674-4069-bf56-52f2b104ca09" />

- Failures seem unrelated.
