### PR TITLE
[Fix]: prevent session leaks when recreating aiohttp sessions

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -169,14 +169,17 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                 or session_loop != current_loop
                 or session_loop.is_closed()
             ):
-                # Clean up the old session
+                # Close old session to prevent leaks
+                old_session = self.client
                 try:
-                    # Note: not awaiting close() here as it might be from a different loop
-                    # The session will be garbage collected
-                    pass
+                    if not old_session.closed:
+                        try:
+                            asyncio.create_task(old_session.close())
+                        except RuntimeError:
+                            # Different event loop - can't schedule task, rely on GC
+                            verbose_logger.debug("Old session from different loop, relying on GC")
                 except Exception as e:
                     verbose_logger.debug(f"Error closing old session: {e}")
-                    pass
 
                 # Create a new session in the current event loop
                 if hasattr(self, "_client_factory") and callable(self._client_factory):


### PR DESCRIPTION
## Title

[Fix]: prevent session leaks when recreating aiohttp sessions

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Don't wait for connections to be closed, but don't count that the GC will clean it as well, close the connection on the background.

## Test Results

<img width="1082" height="152" alt="Screenshot 2025-10-10 at 7 34 10 PM" src="https://github.com/user-attachments/assets/46843827-0647-4c97-98e5-2c7bf335a44d" />

- Failures seem unrelated.

