### PR TITLE
Fixed a bug when disable_spend_updates setting is enabled

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -188,10 +188,6 @@ class _ProxyDBLogger(CustomLogger):
                         response_cost=response_cost,
                         max_budget=end_user_max_budget,
                     )
-                else:
-                    raise Exception(
-                        "User API key and team id and user id missing from custom callback."
-                    )
             else:
                 if kwargs["stream"] is not True or (
                     kwargs["stream"] is True and "complete_streaming_response" in kwargs
@@ -267,4 +263,8 @@ def _should_track_cost_callback(
         or end_user_id is not None
     ):
         return True
-    return False
+    else:
+        raise Exception(
+            "User API key and team id and user id missing from custom callback."
+        )
+

--- a/tests/test_litellm/proxy/hooks/test_should_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_should_track_cost_callback.py
@@ -1,0 +1,15 @@
+import pytest
+from litellm.proxy.hooks.proxy_track_cost_callback import _should_track_cost_callback
+
+# Test: should track cost when any key is present
+def test_should_track_cost_callback_valid():
+    assert _should_track_cost_callback(user_api_key="key", user_id=None, team_id=None, end_user_id=None) is True
+    assert _should_track_cost_callback(user_api_key=None, user_id="uid", team_id=None, end_user_id=None) is True
+    assert _should_track_cost_callback(user_api_key=None, user_id=None, team_id="tid", end_user_id=None) is True
+    assert _should_track_cost_callback(user_api_key=None, user_id=None, team_id=None, end_user_id="eid") is True
+    assert _should_track_cost_callback(user_api_key="key", user_id="uid", team_id="tid", end_user_id="eid") is True
+
+# Test: should raise Exception when all are None
+def test_should_track_cost_callback_invalid():
+    with pytest.raises(Exception, match="User API key and team id and user id missing from custom callback."):
+        _should_track_cost_callback(user_api_key=None, user_id=None, team_id=None, end_user_id=None)


### PR DESCRIPTION
## Title

Fixed a bug when disable_spend_updates setting is enabled

## Relevant issues

Change to fix bug when enabling a legitimate setting 'disable_spend_updates' causes an invalid exception to be raised.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] I have added a screenshot of my new test passing locally 
<img width="1243" height="279" alt="Screenshot 2025-10-11 at 12 53 27 PM" src="https://github.com/user-attachments/assets/c7ef737b-88f1-44c2-870d-f269535f2b5d" />
- [x ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


