### PR TITLE
[Fix] /model/metrics - 500 error due to indefinite DB hang

### DIFF
--- a/tests/proxy_unit_tests/test_model_metrics_validation.py
+++ b/tests/proxy_unit_tests/test_model_metrics_validation.py
@@ -1,0 +1,55 @@
+"""
+Tests for model metrics validation functionality.
+
+Tests the validate_and_normalize_model_group helper and ensures
+validation doesn't break existing endpoints.
+"""
+import os
+import sys
+import pytest
+from unittest.mock import Mock
+from fastapi import status
+
+# Add parent directory to path to import from local code
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+# Import from local litellm module
+import litellm.proxy.proxy_server as proxy_server
+from litellm.proxy.utils import ProxyException
+from litellm.router import Router, Deployment
+
+# Get the function from the module
+validate_and_normalize_model_group = proxy_server.validate_and_normalize_model_group
+
+
+def test_validate_and_normalize_model_group():
+    """Test validate_and_normalize_model_group helper function with various inputs."""
+    # Test 1: Valid model_group passes through
+    mock_router = Mock(spec=Router)
+    mock_router.model_names = ["gpt-4", "gpt-3.5-turbo"]
+    mock_router.has_model_id.return_value = False
+    
+    result = validate_and_normalize_model_group(mock_router, "gpt-4")
+    assert result == "gpt-4"
+    
+    # Test 2: Converts model_id to model_group name
+    mock_router.has_model_id.return_value = True
+    mock_deployment = Mock(spec=Deployment)
+    mock_deployment.model_name = "gpt-4"
+    mock_router.get_deployment.return_value = mock_deployment
+    
+    model_id = "model_name_65cc21c4-8797-45ef-b450-a5f1fca107a2"
+    result = validate_and_normalize_model_group(mock_router, model_id)
+    assert result == "gpt-4"
+    
+    # Test 3: Invalid model_group raises 404
+    mock_router.has_model_id.return_value = False
+    mock_router.model_names = ["gpt-4"]
+    
+    with pytest.raises(ProxyException) as exc_info:
+        validate_and_normalize_model_group(mock_router, "invalid-model")
+    assert str(exc_info.value.code) == str(status.HTTP_404_NOT_FOUND)
+    
+    # Test 4: Graceful fallback when router unavailable
+    result = validate_and_normalize_model_group(None, "any-model")
+    assert result == "any-model"


### PR DESCRIPTION
## Closing PR

The issue ended up being querying a big table which was timing out since prisma has a default of 60 seconds.


## Title

[Fix] /model/metrics - 500 error due to indefinite DB hang

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Validate model_group before DB queries (404 on invalid)
- Convert model_id → model_group for consistent queries
- Update 4 metrics endpoints: streaming, latency, slow responses, exceptions

## Test Results

<img width="1416" height="191" alt="Screenshot 2025-10-11 at 12 14 48 PM" src="https://github.com/user-attachments/assets/8691ab12-20b6-4e9a-bf8e-a14e04bbaa00" />

- Failures seem unrelated.
