### PR TITLE
[Fix] Error from OpenAI Responses API with web_search

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -640,7 +640,18 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                     finish_reason="",
                     usage=None,
                 )
-            elif output_item.get("type") in ["message", "reasoning", "web_search_call"]:
+            elif output_item.get("type") == "web_search_call":
+                return GenericStreamingChunk(
+                    text="",
+                    tool_use=None,
+                    is_finished=False,
+                    finish_reason="",
+                    usage=None,
+                    provider_specific_fields={
+                        "web_search": output_item
+                    }
+                )
+            elif output_item.get("type") in ["message", "reasoning"]:
                 pass
             else:
                 raise ValueError(f"Chat provider: Invalid output_item  {output_item}")
@@ -688,7 +699,18 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 return GenericStreamingChunk(
                     finish_reason="stop", is_finished=True, usage=None, text=""
                 )
-            elif output_item.get("type") in ["reasoning", "web_search_call"]:
+            elif output_item.get("type") == "web_search_call":
+                return GenericStreamingChunk(
+                    text="",
+                    tool_use=None,
+                    is_finished=False,
+                    finish_reason="",
+                    usage=None,
+                    provider_specific_fields={
+                        "web_search": output_item
+                    }
+                )
+            elif output_item.get("type") == "reasoning":
                 pass
             else:
                 raise ValueError(f"Chat provider: Invalid output_item  {output_item}")

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -640,9 +640,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                     finish_reason="",
                     usage=None,
                 )
-            elif output_item.get("type") == "message":
-                pass
-            elif output_item.get("type") == "reasoning":
+            elif output_item.get("type") in ["message", "reasoning", "web_search_call"]:
                 pass
             else:
                 raise ValueError(f"Chat provider: Invalid output_item  {output_item}")
@@ -690,7 +688,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 return GenericStreamingChunk(
                     finish_reason="stop", is_finished=True, usage=None, text=""
                 )
-            elif output_item.get("type") == "reasoning":
+            elif output_item.get("type") in ["reasoning", "web_search_call"]:
                 pass
             else:
                 raise ValueError(f"Chat provider: Invalid output_item  {output_item}")

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -273,3 +273,64 @@ def test_convert_tools_to_responses_format():
     result = handler._convert_tools_to_responses_format(tools)
 
     assert result[0]["name"] == "test"
+
+
+def test_openai_responses_chunk_parser_web_search_call_added():
+    """Test that web_search_call output items in response.output_item.added are handled without error."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.output_item.added",
+        "output_index": 1,
+        "item": {
+            "id": "ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5",
+            "type": "web_search_call",
+            "status": "in_progress"
+        },
+        "sequence_number": 563
+    }
+
+    result = iterator.chunk_parser(chunk)
+    
+    assert result is not None
+    assert result.get("text") == ""
+    assert result.get("is_finished") is False
+    assert result.get("tool_use") is None
+    print("✓ web_search_call in output_item.added handled successfully")
+
+
+def test_openai_responses_chunk_parser_web_search_call_done():
+    """Test that web_search_call output items in response.output_item.done are handled without error."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.output_item.done",
+        "output_index": 1,
+        "item": {
+            "id": "ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5",
+            "type": "web_search_call",
+            "status": "completed"
+        },
+        "sequence_number": 600
+    }
+
+    result = iterator.chunk_parser(chunk)
+    
+    # Should return an empty GenericStreamingChunk
+    assert result is not None
+    assert result.get("text") == ""
+    assert result.get("is_finished") is False
+    assert result.get("tool_use") is None
+    print("✓ web_search_call in output_item.done handled successfully")

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -302,6 +302,13 @@ def test_openai_responses_chunk_parser_web_search_call_added():
     assert result.get("text") == ""
     assert result.get("is_finished") is False
     assert result.get("tool_use") is None
+    provider_fields = result.get("provider_specific_fields")
+    assert provider_fields is not None
+    assert "web_search" in provider_fields
+    web_search = provider_fields["web_search"]
+    assert web_search["id"] == "ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5"
+    assert web_search["type"] == "web_search_call"
+    assert web_search["status"] == "in_progress"
     print("✓ web_search_call in output_item.added handled successfully")
 
 
@@ -321,16 +328,28 @@ def test_openai_responses_chunk_parser_web_search_call_done():
         "item": {
             "id": "ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5",
             "type": "web_search_call",
-            "status": "completed"
+            "status": "completed",
+            "action": {
+                "type": "search",
+                "query": "search query",
+            }
         },
         "sequence_number": 600
     }
 
     result = iterator.chunk_parser(chunk)
     
-    # Should return an empty GenericStreamingChunk
     assert result is not None
     assert result.get("text") == ""
     assert result.get("is_finished") is False
     assert result.get("tool_use") is None
+    provider_fields = result.get("provider_specific_fields")
+    assert provider_fields is not None
+    assert "web_search" in provider_fields
+    web_search = provider_fields["web_search"]
+    assert web_search["id"] == "ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5"
+    assert web_search["type"] == "web_search_call"
+    assert web_search["status"] == "completed"
+    assert web_search["action"]["type"] == "search"
+    assert web_search["action"]["query"] == "search query"
     print("✓ web_search_call in output_item.done handled successfully")


### PR DESCRIPTION
## Title

[Fix] Error from OpenAI Responses API with web_search

## Relevant issues

When OpenAI Responses API is called with web_search tool, and the response contains those web_search calls, LiteLLM throws an error with 503 status:
```
litellm.ServiceUnavailableError: litellm.MidStreamFallbackError: litellm.APIConnectionError: APIConnectionError: OpenAIException - Error parsing chunk: Chat provider: Invalid output_item  {'id': 'ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5', 'type': 'web_search_call', 'status': 'in_progress'},
Received chunk: type=<ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED: 'response.output_item.added'> output_index=1 item={'id': 'ws_0e5386c91dd50f830068ebe883849081919a0164a2c5f5a7f5', 'type': 'web_search_call', 'status': 'in_progress'} sequence_number=563.
```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes

- when transforming Responses API response to Completion API format, unsupported web_search calls are skipped now.


## Tests
<img width="1576" height="210" alt="image" src="https://github.com/user-attachments/assets/26dfe8b1-b66a-4c61-a06b-55b4a4f39d6a" />


Before change:
<img width="2557" height="775" alt="image" src="https://github.com/user-attachments/assets/fe4313f3-6660-46bd-a77b-409991be73fc" />

After change:
<img width="2555" height="618" alt="image" src="https://github.com/user-attachments/assets/5a742cea-cb98-4385-beae-b3d3e9126d2e" />

