### PR TITLE
[Fix] GEMINI - CLI -  add google_routes to llm_api_routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -377,6 +377,7 @@ class LiteLLMRoutes(enum.Enum):
     llm_api_routes = (
         openai_routes
         + anthropic_routes
+        + google_routes
         + mapped_pass_through_routes
         + passthrough_routes_wildcard
         + apply_guardrail_routes

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -156,6 +156,31 @@ def test_virtual_key_llm_api_route_includes_passthrough_prefix(route):
     assert result is True
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/v1beta/models/gemini-2.5-flash:countTokens",
+        "/v1beta/models/gemini-2.0-flash:generateContent",
+        "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
+        "/models/gemini-2.5-flash:countTokens",
+        "/models/gemini-2.0-flash:generateContent",
+        "/models/gemini-1.5-pro:streamGenerateContent",
+    ],
+)
+def test_virtual_key_llm_api_routes_allows_google_routes(route):
+    """
+    Test that virtual keys with llm_api_routes permission can access Google AI Studio routes.
+    """
+
+    valid_token = UserAPIKeyAuth(user_id="test_user", allowed_routes=["llm_api_routes"])
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route=route, valid_token=valid_token
+    )
+
+    assert result is True
+
+
 def test_virtual_key_allowed_routes_with_multiple_litellm_routes_member_names():
     """Test that virtual key works with multiple LiteLLMRoutes member names in allowed_routes"""
 


### PR DESCRIPTION
## [Fix] GEMINI - CLI -  add google_routes to llm_api_routes

Fixes LIT-1262

Virtual keys with allowed_routes: ["llm_api_routes"] were unable to access Google AI Studio endpoints (e.g., /v1beta/models/gemini-2.5-flash:countTokens), resulting in 401 errors


The google_routes list was defined in LiteLLMRoutes but wasn't included in the llm_api_routes tuple, causing authorization checks to fail for all Google AI Studio endpoints.


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


