### PR TITLE
fix: Exclude null Fields from Image Generation Response

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1632,6 +1632,17 @@ class ImageObject(OpenAIImage):
     def __init__(self, b64_json=None, url=None, revised_prompt=None, **kwargs):
         super().__init__(b64_json=b64_json, url=url, revised_prompt=revised_prompt)  # type: ignore
 
+    def to_dict(self):
+        d = {
+            "b64_json": self.b64_json,
+            # only include url / revised_prompt if not None
+        }
+        if self.url is not None:
+            d["url"] = self.url
+        if self.revised_prompt is not None:
+            d["revised_prompt"] = self.revised_prompt
+        return d
+        
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
         return hasattr(self, key)
@@ -1650,7 +1661,7 @@ class ImageObject(OpenAIImage):
 
     def json(self, **kwargs):  # type: ignore
         try:
-            return self.model_dump()  # noqa
+            return self.model_dump(self.to_dict(), **kwargs)  # noqa
         except Exception:
             # if using pydantic v1
             return self.dict()


### PR DESCRIPTION
fix: image generated

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
Problem: When using the Azure gpt-image-1 model, the image generation response includes revised_prompt: null and url: null fields, leading to unnecessary null values in the API response.

Solution: Modified the ImageObject class's to_dict method to exclude fields with None values, ensuring that revised_prompt and url are omitted from the response when they are None.

