### PR TITLE
feat: read from custom-llm-provider header

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -18,6 +18,7 @@ from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessin
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_query,
+    get_custom_llm_provider_from_request_headers,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
@@ -282,6 +283,7 @@ async def retrieve_batch(
         else:
             custom_llm_provider = (
                 provider
+                or get_custom_llm_provider_from_request_headers(request=request)
                 or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )
@@ -392,6 +394,7 @@ async def list_batches(
         else:
             custom_llm_provider = (
                 provider
+                or get_custom_llm_provider_from_request_headers(request=request)
                 or get_custom_llm_provider_from_request_query(request=request)
                 or "openai"
             )

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -54,3 +54,11 @@ def get_custom_llm_provider_from_request_query(request: Request) -> Optional[str
     if "custom_llm_provider" in request.query_params:
         return request.query_params["custom_llm_provider"]
     return None
+
+def get_custom_llm_provider_from_request_headers(request: Request) -> Optional[str]:
+    """
+    Get the `custom_llm_provider` from the request header `custom-llm-provider`
+    """
+    if "custom-llm-provider" in request.headers:
+        return request.headers["custom-llm-provider"]
+    return None

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -32,6 +32,7 @@ from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessin
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_body,
     get_custom_llm_provider_from_request_query,
+    get_custom_llm_provider_from_request_headers,
 )
 from litellm.proxy.utils import ProxyLogging, is_known_model
 from litellm.router import Router
@@ -238,6 +239,7 @@ async def create_file(
         file_content = await file.read()
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_headers(request=request)
             or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
@@ -427,6 +429,7 @@ async def get_file_content(
 
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_headers(request=request)
             or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
@@ -594,6 +597,7 @@ async def get_file(
     try:
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_headers(request=request)
             or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
@@ -737,6 +741,7 @@ async def delete_file(
     try:
         custom_llm_provider = (
             provider
+            or get_custom_llm_provider_from_request_headers(request=request)
             or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
@@ -922,6 +927,7 @@ async def list_files(
         else:
             custom_llm_provider = (
                 provider
+                or get_custom_llm_provider_from_request_headers(request=request)
                 or get_custom_llm_provider_from_request_query(request=request)
                 or await get_custom_llm_provider_from_request_body(request=request)
                 or "openai"

--- a/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
+++ b/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
@@ -72,7 +72,7 @@ def create_batch_oai_sdk(filepath: str, custom_llm_provider: str) -> str:
     batch_input_file = client.files.create(
         file=open(filepath, "rb"),
         purpose="batch",
-        extra_body={"custom_llm_provider": custom_llm_provider},
+        extra_headers={"custom-llm-provider": custom_llm_provider},
     )
     batch_input_file_id = batch_input_file.id
 
@@ -85,7 +85,7 @@ def create_batch_oai_sdk(filepath: str, custom_llm_provider: str) -> str:
         metadata={
             "description": filepath,
         },
-        extra_body={"custom_llm_provider": custom_llm_provider},
+        extra_headers={"custom-llm-provider": custom_llm_provider},
     )
 
     print(f"Batch submitted. ID: {rq.id}")
@@ -98,7 +98,7 @@ def await_batch_completion(batch_id: str, custom_llm_provider: str):
 
     while tries < max_tries:
         batch = client.batches.retrieve(
-            batch_id, extra_body={"custom_llm_provider": custom_llm_provider}
+            batch_id, extra_headers={"custom-llm-provider": custom_llm_provider}
         )
         if batch.status == "completed":
             print(f"Batch {batch_id} completed.")
@@ -117,11 +117,11 @@ def write_content_to_file(
     batch_id: str, output_path: str, custom_llm_provider: str
 ) -> str:
     batch = client.batches.retrieve(
-        batch_id=batch_id, extra_body={"custom_llm_provider": custom_llm_provider}
+        batch_id=batch_id, extra_headers={"custom-llm-provider": custom_llm_provider}
     )
     content = client.files.content(
         file_id=batch.output_file_id,
-        extra_body={"custom_llm_provider": custom_llm_provider},
+        extra_headers={"custom-llm-provider": custom_llm_provider},
     )
     print("content from files.content", content.content)
     content.write_to_file(output_path)
@@ -144,7 +144,7 @@ def read_jsonl(filepath: str):
 
 def get_any_completed_batch_id_azure():
     print("AZURE getting any completed batch id")
-    list_of_batches = client.batches.list(extra_body={"custom_llm_provider": "azure"})
+    list_of_batches = client.batches.list(extra_headers={"custom-llm-provider": "azure"})
     print("list of batches", list_of_batches)
     for batch in list_of_batches:
         if batch.status == "completed":
@@ -202,7 +202,7 @@ def test_vertex_batches_endpoint():
     file_obj = oai_client.files.create(
         file=open(file_path, "rb"),
         purpose="batch",
-        extra_body={"custom_llm_provider": "vertex_ai"},
+        extra_headers={"custom-llm-provider": "vertex_ai"},
     )
     print("Response from creating file=", file_obj)
 
@@ -215,7 +215,7 @@ def test_vertex_batches_endpoint():
         completion_window="24h",
         endpoint="/v1/chat/completions",
         input_file_id=batch_input_file_id,
-        extra_body={"custom_llm_provider": "vertex_ai"},
+        extra_headers={"custom-llm-provider": "vertex_ai"},
         metadata={"key1": "value1", "key2": "value2"},
     )
     print("response from create batch", create_batch_response)

--- a/tests/openai_endpoints_tests/test_openai_fine_tuning.py
+++ b/tests/openai_endpoints_tests/test_openai_fine_tuning.py
@@ -18,7 +18,7 @@ async def test_openai_fine_tuning():
         file_path = os.path.join(_current_dir, file_name)
 
         response = await client.files.create(
-            extra_body={"custom_llm_provider": "openai"},
+            extra_headers={"custom-llm-provider": "openai"},
             file=open(file_path, "rb"),
             purpose="fine-tune",
         )
@@ -32,7 +32,7 @@ async def test_openai_fine_tuning():
         ft_job = await client.fine_tuning.jobs.create(
             model="gpt-4o-mini-2024-07-18",
             training_file=response.id,
-            extra_body={"custom_llm_provider": "openai"},
+            extra_headers={"custom-llm-provider": "openai"},
         )
 
         print("response from ft job={}".format(ft_job))
@@ -42,7 +42,7 @@ async def test_openai_fine_tuning():
 
         # list all fine tuning jobs
         list_ft_jobs = await client.fine_tuning.jobs.list(
-            extra_query={"custom_llm_provider": "openai"}
+            extra_headers={"custom-llm-provider": "openai"}
         )
 
         print("list of ft jobs={}".format(list_ft_jobs))
@@ -50,7 +50,7 @@ async def test_openai_fine_tuning():
         # cancel specific fine tuning job
         cancel_ft_job = await client.fine_tuning.jobs.cancel(
             fine_tuning_job_id=ft_job.id,
-            extra_body={"custom_llm_provider": "openai"},
+            extra_headers={"custom-llm-provider": "openai"},
         )
 
         print("response from cancel ft job={}".format(cancel_ft_job))
@@ -60,7 +60,7 @@ async def test_openai_fine_tuning():
         # delete OG file
         await client.files.delete(
             file_id=response.id,
-            extra_body={"custom_llm_provider": "openai"},
+            extra_headers={"custom-llm-provider": "openai"},
         )
     except openai.InternalServerError:
         pass


### PR DESCRIPTION
## Title

Read the custom llm provider option from the request header "custom-llm-provider".

## Relevant issues

Fixes #15522

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Several LiteLLM operations require passing a custom_llm_provider entry in the request. Some requests need this parameter in the request body, others in a query string. Here we add the ability to pass this parameter in a http header instead.

Passing this parameter in a header is easier compared to passing it in the request body or as a query parameter:
1. It would be consistent across all request types
2. The Python and the .NET client for OpenAI both allow to add headers easily
3. Headers are easy to manipulate in a proxy