### PR TITLE
feat: Add imageConfig parameter for  gemini-2.5-flash-image 

### DIFF
--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -178,6 +178,10 @@ class GeminiThinkingConfig(TypedDict, total=False):
 
 GeminiResponseModalities = Literal["TEXT", "IMAGE", "AUDIO", "VIDEO"]
 
+GeminiImageAspectRatio = Literal["1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9"]
+
+class GeminiImageConfig(TypedDict, total=False):
+    aspectRatio: GeminiImageAspectRatio
 
 class PrebuiltVoiceConfig(TypedDict):
     voiceName: str
@@ -206,6 +210,7 @@ class GenerationConfig(TypedDict, total=False):
     responseLogprobs: bool
     logprobs: int
     responseModalities: List[GeminiResponseModalities]
+    imageConfig: GeminiImageConfig
     thinkingConfig: GeminiThinkingConfig
 
 

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -117,3 +117,39 @@ async def test__transform_request_body_labels_and_metadata():
     # Check URL
     assert rb["contents"] == [{'parts': [{'text': 'hi'}], 'role': 'user'}, {'parts': [{'text': 'Hello! How can I assist you today?'}], 'role': 'model'}, {'parts': [{'text': 'hi'}], 'role': 'user'}]
     assert "labels" in rb and rb["labels"] == {"lparam1": "lvalue1", "lparam2": "lvalue2"}
+
+@pytest.mark.asyncio
+async def test__transform_request_body_image_config():
+    """
+    Test that Vertex AI Gemini supports the imageConfig parameter for gemini-2.5-flash-image model.
+    """
+    model = "gemini-2.5-flash-image"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme"
+                }
+            ]
+        }
+    ]
+    optional_params = {
+        "imageConfig": {"aspectRatio": "16:9"},
+        "responseModalities": ["Image"]
+    }
+    litellm_params = {}
+    transform_request_params = {
+        "messages": messages,
+        "model": model,
+        "optional_params": optional_params,
+        "custom_llm_provider": "gemini",
+        "litellm_params": litellm_params,
+        "cached_content": None,
+    }
+
+    rb: RequestBody = transformation._transform_request_body(**transform_request_params)
+
+    assert "imageConfig" in rb
+    assert rb["imageConfig"] == {"aspectRatio": "16:9"}


### PR DESCRIPTION
## Title

Add imageConfig parameter support for Vertex AI to enable gemini-2.5-flash-image model requirements

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
![20251014183641](https://github.com/user-attachments/assets/e458823f-7c15-40f6-9ef6-2668b96bf8ee)


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes

Add imageConfig parameter support for Vertex AI to enable gemini-2.5-flash-image model requirements
https://ai.google.dev/api/generate-content#ImageConfig
