### PR TITLE
Add Vertex AI Discovery Engine Rerank Support

### DIFF
--- a/docs/my-website/docs/providers/vertex.md
+++ b/docs/my-website/docs/providers/vertex.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 | Provider Route on LiteLLM | `vertex_ai/` |
 | Link to Provider Doc | [Vertex AI ↗](https://cloud.google.com/vertex-ai) |
 | Base URL | 1. Regional endpoints<br/>`https://{vertex_location}-aiplatform.googleapis.com/`<br/>2. Global endpoints (limited availability)<br/>`https://aiplatform.googleapis.com/`|
-| Supported Operations | [`/chat/completions`](#sample-usage), `/completions`, [`/embeddings`](#embedding-models), [`/audio/speech`](#text-to-speech-apis), [`/fine_tuning`](#fine-tuning-apis), [`/batches`](#batch-apis), [`/files`](#batch-apis), [`/images`](#image-generation-models) |
+| Supported Operations | [`/chat/completions`](#sample-usage), `/completions`, [`/embeddings`](#embedding-models), [`/audio/speech`](#text-to-speech-apis), [`/fine_tuning`](#fine-tuning-apis), [`/batches`](#batch-apis), [`/files`](#batch-apis), [`/images`](#image-generation-models), [`/rerank`](#rerank-api) |
 
 
 <br />
@@ -3114,3 +3114,63 @@ Once that's done, when you deploy the new container in the Google Cloud Run serv
 
 
 s/o @[Darien Kindlund](https://www.linkedin.com/in/kindlund/) for this tutorial
+
+## **Rerank API**
+
+Vertex AI supports reranking through the Discovery Engine API, providing semantic ranking capabilities for document retrieval.
+
+### Setup
+
+Set your Google Cloud project ID:
+
+```bash
+export VERTEXAI_PROJECT="your-project-id"
+```
+
+### Usage
+
+```python
+from litellm import rerank
+
+# Using the latest model (recommended)
+response = rerank(
+    model="vertex_ai/semantic-ranker-default@latest",
+    query="What is Google Gemini?",
+    documents=[
+        "Gemini is a cutting edge large language model created by Google.",
+        "The Gemini zodiac symbol often depicts two figures standing side-by-side.",
+        "Gemini is a constellation that can be seen in the night sky."
+    ],
+    top_n=2,
+    return_documents=True  # Set to False for ID-only responses
+)
+
+# Using specific model versions
+response_v003 = rerank(
+    model="vertex_ai/semantic-ranker-default-003",
+    query="What is Google Gemini?",
+    documents=documents,
+    top_n=2
+)
+
+print(response.results)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `model` | string | Model name (e.g., `vertex_ai/semantic-ranker-default@latest`) |
+| `query` | string | Search query |
+| `documents` | list | Documents to rank |
+| `top_n` | int | Number of top results to return |
+| `return_documents` | bool | Return full content (True) or IDs only (False) |
+
+### Supported Models
+
+- `semantic-ranker-default@latest`
+- `semantic-ranker-fast@latest` 
+- `semantic-ranker-default-003`
+- `semantic-ranker-default-002`
+
+For detailed model specifications, see the [Google Cloud ranking API documentation](https://cloud.google.com/generative-ai-app-builder/docs/ranking#rank_or_rerank_a_set_of_records_according_to_a_query).

--- a/docs/my-website/docs/providers/vertex.md
+++ b/docs/my-website/docs/providers/vertex.md
@@ -3174,3 +3174,41 @@ print(response.results)
 - `semantic-ranker-default-002`
 
 For detailed model specifications, see the [Google Cloud ranking API documentation](https://cloud.google.com/generative-ai-app-builder/docs/ranking#rank_or_rerank_a_set_of_records_according_to_a_query).
+
+### Proxy Usage
+
+Add to your `config.yaml`:
+
+```yaml
+model_list:
+  - model_name: semantic-ranker-default@latest
+    litellm_params:
+      model: vertex_ai/semantic-ranker-default@latest
+      vertex_ai_project: "your-project-id"
+      vertex_ai_location: "us-central1"
+      vertex_ai_credentials: "path/to/service-account.json" 
+```
+
+Start the proxy:
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+Test with curl:
+
+```bash
+curl http://0.0.0.0:4000/rerank \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "semantic-ranker-default@latest",
+    "query": "What is Google Gemini?",
+    "documents": [
+      "Gemini is a cutting edge large language model created by Google.",
+      "The Gemini zodiac symbol often depicts two figures standing side-by-side.",
+      "Gemini is a constellation that can be seen in the night sky."
+    ],
+    "top_n": 2
+  }'
+```

--- a/docs/my-website/docs/rerank.md
+++ b/docs/my-website/docs/rerank.md
@@ -121,4 +121,5 @@ curl http://0.0.0.0:4000/rerank \
 | HuggingFace|   [Usage](../docs/providers/huggingface_rerank)                 |  
 | Infinity|   [Usage](../docs/providers/infinity)                 |  
 | vLLM|   [Usage](../docs/providers/vllm#rerank-endpoint)                 |  
-| DeepInfra|   [Usage](../docs/providers/deepinfra#rerank-endpoint)                 |  
+| DeepInfra|   [Usage](../docs/providers/deepinfra#rerank-endpoint)                 |
+| Vertex AI|   [Usage](../docs/providers/vertex#rerank-api)                 |  

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1067,6 +1067,7 @@ from .llms.infinity.rerank.transformation import InfinityRerankConfig
 from .llms.jina_ai.rerank.transformation import JinaAIRerankConfig
 from .llms.deepinfra.rerank.transformation import DeepinfraRerankConfig
 from .llms.nvidia_nim.rerank.transformation import NvidiaNimRerankConfig
+from .llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
 from .llms.clarifai.chat.transformation import ClarifaiConfig
 from .llms.ai21.chat.transformation import AI21ChatConfig, AI21ChatConfig as AI21Config
 from .llms.meta_llama.chat.transformation import LlamaAPIConfig

--- a/litellm/llms/vertex_ai/rerank/handler.py
+++ b/litellm/llms/vertex_ai/rerank/handler.py
@@ -1,0 +1,5 @@
+"""
+Vertex AI Rerank - uses `llm_http_handler.py` to make httpx requests
+
+Request/Response transformation is handled in `transformation.py`
+"""

--- a/litellm/llms/vertex_ai/rerank/transformation.py
+++ b/litellm/llms/vertex_ai/rerank/transformation.py
@@ -1,0 +1,217 @@
+"""
+Translates from Cohere's `/v1/rerank` input format to Vertex AI Discovery Engine's `/rank` input format.
+
+Why separate file? Make it easy to see how transformation works
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.rerank import RerankResponse
+
+
+class VertexAIRerankConfig(BaseRerankConfig, VertexBase):
+    """
+    Configuration for Vertex AI Discovery Engine Rerank API
+    
+    Reference: https://cloud.google.com/generative-ai-app-builder/docs/ranking#rank_or_rerank_a_set_of_records_according_to_a_query
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_complete_url(self, api_base: Optional[str], model: str) -> str:
+        """
+        Get the complete URL for the Vertex AI Discovery Engine ranking API
+        """
+        # Get project ID from environment or litellm config
+        project_id = (
+            get_secret_str("VERTEXAI_PROJECT") 
+            or litellm.vertex_project
+        )
+        
+        if not project_id:
+            raise ValueError(
+                "Vertex AI project ID is required. Please set 'VERTEXAI_PROJECT' or 'litellm.vertex_project'"
+            )
+        
+        return f"https://discoveryengine.googleapis.com/v1/projects/{project_id}/locations/global/rankingConfigs/default_ranking_config:rank"
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+    ) -> dict:
+        """
+        Validate and set up authentication for Vertex AI Discovery Engine API
+        """
+        # Get credentials and project info
+        vertex_credentials = self.get_vertex_ai_credentials({})
+        vertex_project = self.get_vertex_ai_project({})
+        
+        # Get access token using the base class method
+        access_token, project_id = self._ensure_access_token(
+            credentials=vertex_credentials,
+            project_id=vertex_project,
+            custom_llm_provider="vertex_ai",
+        )
+      
+        default_headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "X-Goog-User-Project": project_id,
+        }
+
+        # If 'Authorization' is provided in headers, it overrides the default.
+        if "Authorization" in headers:
+            default_headers["Authorization"] = headers["Authorization"]
+
+        # Merge other headers, overriding any default ones except Authorization
+        return {**default_headers, **headers}
+
+    def transform_rerank_request(
+        self,
+        model: str,
+        optional_rerank_params: Dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Transform the request from Cohere format to Vertex AI Discovery Engine format
+        """
+        if "query" not in optional_rerank_params:
+            raise ValueError("query is required for Vertex AI rerank")
+        if "documents" not in optional_rerank_params:
+            raise ValueError("documents is required for Vertex AI rerank")
+        
+        query = optional_rerank_params["query"]
+        documents = optional_rerank_params["documents"]
+        top_n = optional_rerank_params.get("top_n", None)
+        return_documents = optional_rerank_params.get("return_documents", True)
+        
+        # Convert documents to records format
+        records = []
+        for idx, document in enumerate(documents):
+            if isinstance(document, str):
+                content = document
+                title = " ".join(document.split()[:3])  # First 3 words as title
+            else:
+                # Handle dict format
+                content = document.get("text", str(document))
+                title = document.get("title", " ".join(content.split()[:3]))
+            
+            records.append({
+                "id": str(idx),
+                "title": title,
+                "content": content
+            })
+        
+        request_data = {
+            "model": model,
+            "query": query,
+            "records": records
+        }
+        
+        if top_n is not None:
+            request_data["topN"] = top_n
+        
+        # Map return_documents to ignoreRecordDetailsInResponse
+        # When return_documents is False, we want to ignore record details (return only IDs)
+        request_data["ignoreRecordDetailsInResponse"] = not return_documents
+        
+        return request_data
+
+    def transform_rerank_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: RerankResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str] = None,
+        request_data: dict = {},
+        optional_params: dict = {},
+        litellm_params: dict = {},
+    ) -> RerankResponse:
+        """
+        Transform Vertex AI Discovery Engine response to Cohere format
+        """
+        try:
+            raw_response_json = raw_response.json()
+        except Exception as e:
+            raise ValueError(f"Failed to parse response: {e}")
+
+        # Extract records from response
+        records = raw_response_json.get("records", [])
+        
+        # Convert to Cohere format
+        results = []
+        for record in records:
+            # Handle both cases: with full details and with only IDs
+            if "score" in record:
+                # Full response with score and details
+                results.append({
+                    "index": int(record["id"]), 
+                    "relevance_score": record.get("score", 0.0)
+                })
+            else:
+                # Response with only IDs (when ignoreRecordDetailsInResponse=true)
+                # We can't provide a relevance score, so we'll use a default
+                results.append({
+                    "index": int(record["id"]), 
+                    "relevance_score": 1.0  # Default score when details are ignored
+                })
+        
+        # Sort by relevance score (descending)
+        results.sort(key=lambda x: x["relevance_score"], reverse=True)
+        
+        # Create response in Cohere format
+        response_data = {
+            "id": f"vertex_ai_rerank_{model}",
+            "results": results,
+            "meta": {
+                "billed_units": {
+                    "search_units": len(records)
+                }
+            }
+        }
+        
+        return RerankResponse(**response_data)
+
+    def get_supported_cohere_rerank_params(self, model: str) -> list:
+        return [
+            "query",
+            "documents", 
+            "top_n",
+            "return_documents",
+        ]
+
+    def map_cohere_rerank_params(
+        self,
+        non_default_params: dict,
+        model: str,
+        drop_params: bool,
+        query: str,
+        documents: List[Union[str, Dict[str, Any]]],
+        custom_llm_provider: Optional[str] = None,
+        top_n: Optional[int] = None,
+        rank_fields: Optional[List[str]] = None,
+        return_documents: Optional[bool] = True,
+        max_chunks_per_doc: Optional[int] = None,
+        max_tokens_per_doc: Optional[int] = None,
+    ) -> Dict:
+        """
+        Map Cohere rerank params to Vertex AI format
+        """
+        return {
+            "query": query,
+            "documents": documents,
+            "top_n": top_n,
+            "return_documents": return_documents,
+        }
+

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -1,25 +1,33 @@
 model_list:
-  - model_name: fake-openai-endpoint
+  - model_name: bedrock/batch-anthropic.claude-3-5-sonnet-20240620-v1:0
     litellm_params:
-      model: openai/gm
-      api_key: hi
-      api_base: https://exampleopenaiendpoint-production.up.railway.app/
-  - model_name: db-openai-endpoint
-    litellm_params:
-      model: openai/gm
-      api_key: hi
-      api_base: http://0.0.0.0:8092
+      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
+      #########################################################
+      ########## batch specific params ########################
+      s3_bucket_name: litellm-proxy
+      s3_region_name: us-west-2
+      s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+      s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+      aws_batch_role_arn: arn:aws:iam::888602223428:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
+    model_info: 
+      mode: batch
   - model_name: anthropic/*
     litellm_params:
       model: anthropic/*
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: openai/*
+    litellm_params:
+      model: openai/*
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: gemini/*
+    litellm_params:
+      model: gemini/*
+      api_key: os.environ/GEMINI_API_KEY
+  - model_name: vertex-gemini-2.5-flash
+    litellm_params:
+      model: vertex_ai/gemini-2.5-flash
+      vertex_project: "your-gcp-project-id"
+      vertex_location: "us-central1"
+      vertex_credentials: "path/to/your/service-account-key.json"
 
-
-
-litellm_settings:
-  callbacks: ["dynamic_rate_limiter_v3"]
-  priority_reservation: 
-    "prod": 0.9  # 90% reserved for production (9 RPM)
-    "dev": 0.1   # 10% reserved for development (1 RPM)
-  priority_reservation_settings:
-    default_priority: 0.2  # Weight (0%) assigned to keys without explicit priority metadata
-    saturation_threshold: 0.50 #  A model is saturated if it has hit 50% of its RPM limit
+ 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7243,6 +7243,8 @@ class ProviderConfigManager:
             return litellm.DeepinfraRerankConfig()
         elif litellm.LlmProviders.NVIDIA_NIM == provider:
             return litellm.NvidiaNimRerankConfig()
+        elif litellm.LlmProviders.VERTEX_AI == provider:
+            return litellm.VertexAIRerankConfig()
         return litellm.CohereRerankConfig()
 
     @staticmethod

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
@@ -1,0 +1,218 @@
+"""
+Integration tests for Vertex AI rerank functionality.
+These tests demonstrate end-to-end usage of the Vertex AI rerank feature.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
+
+
+class TestVertexAIRerankIntegration:
+    def setup_method(self):
+        self.config = VertexAIRerankConfig()
+        self.model = "semantic-ranker-default@latest"
+
+    @patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')
+    def test_end_to_end_rerank_flow(self, mock_ensure_access_token):
+        """Test complete rerank flow from request to response."""
+        # Mock authentication
+        mock_ensure_access_token.return_value = ("test-access-token", "test-project-123")
+        
+        # Test documents
+        documents = [
+            "Gemini is a cutting edge large language model created by Google.",
+            "The Gemini zodiac symbol often depicts two figures standing side-by-side.",
+            "Gemini is a constellation that can be seen in the night sky.",
+            "Google's Gemini AI model represents a significant advancement in artificial intelligence technology."
+        ]
+        query = "What is Google Gemini?"
+        
+        # Step 1: Test request transformation
+        with patch.object(self.config, 'get_vertex_ai_credentials', return_value=None), \
+             patch.object(self.config, 'get_vertex_ai_project', return_value="test-project-123"):
+            
+            # Validate environment
+            headers = self.config.validate_environment(
+                headers={},
+                model=self.model,
+                api_key=None
+            )
+            
+            # Transform request
+            request_data = self.config.transform_rerank_request(
+                model=self.model,
+                optional_rerank_params={
+                    "query": query,
+                    "documents": documents,
+                    "top_n": 2,
+                    "return_documents": True
+                },
+                headers=headers
+            )
+            
+            # Verify request structure
+            assert request_data["model"] == self.model
+            assert request_data["query"] == query
+            assert request_data["topN"] == 2
+            assert request_data["ignoreRecordDetailsInResponse"] == False
+            assert len(request_data["records"]) == 4
+            
+            # Verify record structure
+            for i, record in enumerate(request_data["records"]):
+                assert record["id"] == str(i)  # 0-based indexing
+                assert "title" in record
+                assert "content" in record
+                assert record["content"] == documents[i]
+        
+        # Step 2: Test response transformation
+        # Mock Vertex AI Discovery Engine response
+        mock_response_data = {
+            "records": [
+                {
+                    "id": "3",
+                    "score": 0.95,
+                    "title": "Google's Gemini AI model",
+                    "content": "Google's Gemini AI model represents a significant advancement in artificial intelligence technology."
+                },
+                {
+                    "id": "0",
+                    "score": 0.92,
+                    "title": "Gemini is a",
+                    "content": "Gemini is a cutting edge large language model created by Google."
+                }
+            ]
+        }
+        
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = mock_response_data
+        mock_response.text = '{"records": [{"id": "3", "score": 0.95, "title": "Google\'s Gemini AI model", "content": "Google\'s Gemini AI model represents a significant advancement in artificial intelligence technology."}, {"id": "0", "score": 0.92, "title": "Gemini is a", "content": "Gemini is a cutting edge large language model created by Google."}]}'
+        
+        mock_logging = MagicMock()
+        
+        # Transform response
+        from litellm.types.rerank import RerankResponse
+        model_response = RerankResponse()
+        
+        result = self.config.transform_rerank_response(
+            model=self.model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+        )
+        
+        # Verify response structure
+        assert result.id == f"vertex_ai_rerank_{self.model}"
+        assert len(result.results) == 2
+        
+        # Results should be sorted by relevance score (descending)
+        assert result.results[0]["index"] == 3  # Highest score
+        assert result.results[0]["relevance_score"] == 0.95
+        assert result.results[1]["index"] == 0  # Second highest score
+        assert result.results[1]["relevance_score"] == 0.92
+        
+        # Verify metadata
+        assert result.meta["billed_units"]["search_units"] == 2
+
+    def test_return_documents_false_flow(self):
+        """Test rerank flow when return_documents=False (ID-only response)."""
+        documents = ["doc1", "doc2", "doc3"]
+        query = "test query"
+        
+        # Transform request with return_documents=False
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params={
+                "query": query,
+                "documents": documents,
+                "return_documents": False
+            },
+            headers={}
+        )
+        
+        # Verify ignoreRecordDetailsInResponse is True
+        assert request_data["ignoreRecordDetailsInResponse"] == True
+        
+        # Mock response with only IDs
+        mock_response_data = {
+            "records": [
+                {"id": "1"},
+                {"id": "0"},
+                {"id": "2"}
+            ]
+        }
+        
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = mock_response_data
+        mock_response.text = '{"records": [{"id": "1"}, {"id": "0"}, {"id": "2"}]}'
+        
+        mock_logging = MagicMock()
+        
+        # Transform response
+        from litellm.types.rerank import RerankResponse
+        model_response = RerankResponse()
+        
+        result = self.config.transform_rerank_response(
+            model=self.model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+        )
+        
+        # Verify response structure with default scores
+        assert len(result.results) == 3
+        for result_item in result.results:
+            assert result_item["relevance_score"] == 1.0  # Default score when details are ignored
+            assert "index" in result_item
+
+    def test_document_title_generation(self):
+        """Test that document titles are generated correctly from content."""
+        documents = [
+            "This is a very long document with many words that should be truncated to only the first three words for the title",
+            "Short doc",
+            "Another document with multiple words here and more content"
+        ]
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params={
+                "query": "test query",
+                "documents": documents
+            },
+            headers={}
+        )
+        
+        # Verify title generation
+        assert request_data["records"][0]["title"] == "This is a"  # First 3 words
+        assert request_data["records"][1]["title"] == "Short doc"  # Less than 3 words
+        assert request_data["records"][2]["title"] == "Another document with"  # First 3 words
+
+    def test_dictionary_document_handling(self):
+        """Test handling of dictionary-format documents."""
+        documents = [
+            {"text": "Gemini is a cutting edge large language model created by Google.", "title": "Custom Title 1"},
+            {"text": "The Gemini zodiac symbol often depicts two figures standing side-by-side."},
+            {"text": "Gemini is a constellation that can be seen in the night sky.", "title": "Custom Title 3"}
+        ]
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params={
+                "query": "test query",
+                "documents": documents
+            },
+            headers={}
+        )
+        
+        # Verify custom titles are used when provided
+        assert request_data["records"][0]["title"] == "Custom Title 1"
+        assert request_data["records"][1]["title"] == "The Gemini zodiac"  # Generated from first 3 words
+        assert request_data["records"][2]["title"] == "Custom Title 3"
+        
+        # Verify content is extracted correctly
+        assert request_data["records"][0]["content"] == "Gemini is a cutting edge large language model created by Google."
+        assert request_data["records"][1]["content"] == "The Gemini zodiac symbol often depicts two figures standing side-by-side."
+        assert request_data["records"][2]["content"] == "Gemini is a constellation that can be seen in the night sky."

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_transformation.py
@@ -1,0 +1,353 @@
+"""
+Tests for Vertex AI rerank transformation functionality.
+Based on the test patterns from other rerank providers and the current Vertex AI implementation.
+"""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
+from litellm.types.rerank import RerankResponse
+
+
+class TestVertexAIRerankTransform:
+    def setup_method(self):
+        self.config = VertexAIRerankConfig()
+        self.model = "semantic-ranker-default@latest"
+
+    def test_get_complete_url(self):
+        """Test URL generation for Vertex AI Discovery Engine rerank API."""
+        # Test with project ID from environment
+        with patch.dict(os.environ, {"VERTEXAI_PROJECT": "test-project-123"}):
+            url = self.config.get_complete_url(api_base=None, model=self.model)
+            expected_url = "https://discoveryengine.googleapis.com/v1/projects/test-project-123/locations/global/rankingConfigs/default_ranking_config:rank"
+            assert url == expected_url
+
+        # Test with litellm.vertex_project
+        with patch.dict(os.environ, {}, clear=True):
+            import litellm
+            # Set vertex_project attribute if it doesn't exist
+            if not hasattr(litellm, 'vertex_project'):
+                litellm.vertex_project = None
+            original_project = litellm.vertex_project
+            litellm.vertex_project = "litellm-project-456"
+            try:
+                url = self.config.get_complete_url(api_base=None, model=self.model)
+                expected_url = "https://discoveryengine.googleapis.com/v1/projects/litellm-project-456/locations/global/rankingConfigs/default_ranking_config:rank"
+                assert url == expected_url
+            finally:
+                litellm.vertex_project = original_project
+
+        # Test error when no project ID is available
+        with patch.dict(os.environ, {}, clear=True):
+            import litellm
+            # Set vertex_project to None to ensure no project ID is available
+            if not hasattr(litellm, 'vertex_project'):
+                litellm.vertex_project = None
+            original_project = litellm.vertex_project
+            litellm.vertex_project = None
+            try:
+                with pytest.raises(ValueError, match="Vertex AI project ID is required"):
+                    self.config.get_complete_url(api_base=None, model=self.model)
+            finally:
+                litellm.vertex_project = original_project
+
+    @patch('litellm.llms.vertex_ai.rerank.transformation.VertexAIRerankConfig._ensure_access_token')
+    def test_validate_environment(self, mock_ensure_access_token):
+        """Test environment validation and header setup."""
+        # Mock the authentication
+        mock_ensure_access_token.return_value = ("test-access-token", "test-project-123")
+        
+        # Mock the credential and project methods
+        with patch.object(self.config, 'get_vertex_ai_credentials', return_value=None), \
+             patch.object(self.config, 'get_vertex_ai_project', return_value="test-project-123"):
+            
+            headers = self.config.validate_environment(
+                headers={},
+                model=self.model,
+                api_key=None
+            )
+            
+            expected_headers = {
+                "Authorization": "Bearer test-access-token",
+                "Content-Type": "application/json",
+                "X-Goog-User-Project": "test-project-123"
+            }
+            assert headers == expected_headers
+
+    def test_transform_rerank_request_basic(self):
+        """Test basic request transformation for Vertex AI Discovery Engine format."""
+        optional_params = {
+            "query": "What is Google Gemini?",
+            "documents": [
+                "Gemini is a cutting edge large language model created by Google.",
+                "The Gemini zodiac symbol often depicts two figures standing side-by-side."
+            ],
+            "top_n": 2
+        }
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params,
+            headers={}
+        )
+        
+        # Verify basic structure
+        assert request_data["model"] == self.model
+        assert request_data["query"] == "What is Google Gemini?"
+        assert request_data["topN"] == 2
+        assert "records" in request_data
+        assert len(request_data["records"]) == 2
+        
+        # Verify record structure
+        for i, record in enumerate(request_data["records"]):
+            assert "id" in record
+            assert "title" in record
+            assert "content" in record
+            assert record["id"] == str(i)  # 0-based indexing
+            assert len(record["title"].split()) <= 3  # First 3 words as title
+
+    def test_transform_rerank_request_with_dict_documents(self):
+        """Test request transformation with dictionary documents."""
+        optional_params = {
+            "query": "What is Google Gemini?",
+            "documents": [
+                {"text": "Gemini is a cutting edge large language model created by Google.", "title": "Custom Title 1"},
+                {"text": "The Gemini zodiac symbol often depicts two figures standing side-by-side."}
+            ]
+        }
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params,
+            headers={}
+        )
+        
+        # Verify record structure with custom titles
+        assert request_data["records"][0]["title"] == "Custom Title 1"
+        assert request_data["records"][1]["title"] == "The Gemini zodiac"  # First 3 words
+
+    def test_transform_rerank_request_return_documents_mapping(self):
+        """Test return_documents to ignoreRecordDetailsInResponse mapping."""
+        # Test return_documents=True (default)
+        optional_params_true = {
+            "query": "test query",
+            "documents": ["doc1", "doc2"],
+            "return_documents": True
+        }
+        
+        request_data_true = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params_true,
+            headers={}
+        )
+        assert request_data_true["ignoreRecordDetailsInResponse"] == False
+        
+        # Test return_documents=False
+        optional_params_false = {
+            "query": "test query",
+            "documents": ["doc1", "doc2"],
+            "return_documents": False
+        }
+        
+        request_data_false = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params_false,
+            headers={}
+        )
+        assert request_data_false["ignoreRecordDetailsInResponse"] == True
+        
+        # Test return_documents not specified (should default to True)
+        optional_params_default = {
+            "query": "test query",
+            "documents": ["doc1", "doc2"]
+        }
+        
+        request_data_default = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params_default,
+            headers={}
+        )
+        assert request_data_default["ignoreRecordDetailsInResponse"] == False
+
+    def test_transform_rerank_request_missing_required_params(self):
+        """Test that transform_rerank_request handles missing required parameters."""
+        # Test missing query
+        with pytest.raises(ValueError, match="query is required for Vertex AI rerank"):
+            self.config.transform_rerank_request(
+                model=self.model,
+                optional_rerank_params={"documents": ["doc1"]},
+                headers={}
+            )
+        
+        # Test missing documents
+        with pytest.raises(ValueError, match="documents is required for Vertex AI rerank"):
+            self.config.transform_rerank_request(
+                model=self.model,
+                optional_rerank_params={"query": "test query"},
+                headers={}
+            )
+
+    def test_transform_rerank_response_success(self):
+        """Test successful response transformation."""
+        # Mock Vertex AI Discovery Engine response format
+        response_data = {
+            "records": [
+                {
+                    "id": "1",
+                    "score": 0.98,
+                    "title": "The Science of a Blue Sky",
+                    "content": "The sky appears blue due to a phenomenon called Rayleigh scattering."
+                },
+                {
+                    "id": "0",
+                    "score": 0.64,
+                    "title": "The Color of the Sky: A Poem",
+                    "content": "A canvas stretched across the day, Where sunlight learns to dance and play."
+                }
+            ]
+        }
+        
+        # Create mock httpx response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = response_data
+        mock_response.text = json.dumps(response_data)
+        
+        # Create mock logging object
+        mock_logging = MagicMock()
+        
+        model_response = RerankResponse()
+        
+        result = self.config.transform_rerank_response(
+            model=self.model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+        )
+        
+        # Verify response structure
+        assert result.id == f"vertex_ai_rerank_{self.model}"
+        assert len(result.results) == 2
+        assert result.results[0]["index"] == 1  # Converted back to 0-based index
+        assert result.results[0]["relevance_score"] == 0.98
+        assert result.results[1]["index"] == 0
+        assert result.results[1]["relevance_score"] == 0.64
+        
+        # Verify metadata
+        assert result.meta["billed_units"]["search_units"] == 2
+
+    def test_transform_rerank_response_with_ignore_record_details(self):
+        """Test response transformation when ignoreRecordDetailsInResponse=true."""
+        # Mock response with only IDs (when ignoreRecordDetailsInResponse=true)
+        response_data = {
+            "records": [
+                {"id": "1"},
+                {"id": "0"}
+            ]
+        }
+        
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = response_data
+        mock_response.text = json.dumps(response_data)
+        
+        mock_logging = MagicMock()
+        model_response = RerankResponse()
+        
+        result = self.config.transform_rerank_response(
+            model=self.model,
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=mock_logging,
+        )
+        
+        # Verify response structure with default scores
+        assert len(result.results) == 2
+        assert result.results[0]["index"] == 1  # 0-based index
+        assert result.results[0]["relevance_score"] == 1.0  # Default score
+        assert result.results[1]["index"] == 0
+        assert result.results[1]["relevance_score"] == 1.0
+
+    def test_transform_rerank_response_json_error(self):
+        """Test response transformation with JSON parsing error."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
+        mock_response.text = "Invalid JSON response"
+        
+        mock_logging = MagicMock()
+        model_response = RerankResponse()
+        
+        with pytest.raises(ValueError, match="Failed to parse response"):
+            self.config.transform_rerank_response(
+                model=self.model,
+                raw_response=mock_response,
+                model_response=model_response,
+                logging_obj=mock_logging,
+            )
+
+    def test_get_supported_cohere_rerank_params(self):
+        """Test getting supported parameters for Vertex AI rerank."""
+        supported_params = self.config.get_supported_cohere_rerank_params(self.model)
+        expected_params = ["query", "documents", "top_n", "return_documents"]
+        assert supported_params == expected_params
+
+    def test_map_cohere_rerank_params(self):
+        """Test parameter mapping for Vertex AI rerank."""
+        params = self.config.map_cohere_rerank_params(
+            non_default_params={"documents": ["doc1", "doc2"]},
+            model=self.model,
+            drop_params=False,
+            query="test query",
+            documents=["doc1", "doc2"],
+            top_n=2,
+            return_documents=True
+        )
+        
+        expected_params = {
+            "query": "test query",
+            "documents": ["doc1", "doc2"],
+            "top_n": 2,
+            "return_documents": True
+        }
+        assert params == expected_params
+
+    def test_title_generation_from_content(self):
+        """Test that titles are generated correctly from document content."""
+        optional_params = {
+            "query": "test query",
+            "documents": [
+                "This is a very long document with many words that should be truncated to only the first three words for the title",
+                "Short doc",
+                "Another document with multiple words here"
+            ]
+        }
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params,
+            headers={}
+        )
+        
+        # Verify title generation
+        assert request_data["records"][0]["title"] == "This is a"  # First 3 words
+        assert request_data["records"][1]["title"] == "Short doc"  # Less than 3 words
+        assert request_data["records"][2]["title"] == "Another document with"  # First 3 words
+
+    def test_record_id_generation(self):
+        """Test that record IDs are generated correctly with 0-based indexing."""
+        optional_params = {
+            "query": "test query",
+            "documents": ["doc1", "doc2", "doc3", "doc4"]
+        }
+        
+        request_data = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params=optional_params,
+            headers={}
+        )
+        
+        # Verify 0-based indexing
+        for i, record in enumerate(request_data["records"]):
+            assert record["id"] == str(i)


### PR DESCRIPTION
## Title

Add Vertex AI Discovery Engine Rerank Support

## Relevant issues

Fixes LIT-1107

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### **Implementation**
- **Added Vertex AI Discovery Engine rerank support** via `VertexAIRerankConfig` class
- **Authentication**: Reuses existing Vertex AI authentication infrastructure with proper Google Cloud headers
- **URL Construction**: Returns Discovery Engine ranking API URL with project ID
- **Request Transformation**: Converts Cohere-format requests to Vertex AI Discovery Engine format
- **Response Transformation**: Converts Vertex AI responses back to Cohere format for consistency
- **Parameter Mapping**: Maps `return_documents` to `ignoreRecordDetailsInResponse` for ID-only responses

### **Usage Examples**

**SDK Usage:**
```python
from litellm import rerank

response = rerank(
    model="vertex_ai/semantic-ranker-default@latest",
    query="What is Google Gemini?",
    documents=["doc1", "doc2", "doc3"],
    top_n=2,
    return_documents=True
)
```

**Proxy Usage:**
```yaml
model_list:
  - model_name: semantic-ranker-default@latest
    litellm_params:
      model: vertex_ai/semantic-ranker-default@latest
      vertex_ai_project: "your-project-id"
      vertex_ai_location: "us-central1"
      vertex_ai_credentials: "path/to/service-account.json"
```

### **Supported Models**
- `semantic-ranker-default@latest` (1024 tokens, 25 languages)
- `semantic-ranker-fast@latest` (1024 tokens, 25 languages)  
- `semantic-ranker-default-003` (512 tokens, 25 languages)
- `semantic-ranker-default-002` (512 tokens, English only)

### **Testing**
<img width="1098" height="192" alt="Screenshot 2025-10-14 at 4 54 24 PM" src="https://github.com/user-attachments/assets/3383fc41-cd06-4391-a465-7426a7fbf073" />

<img width="1110" height="452" alt="Screenshot 2025-10-14 at 4 54 41 PM" src="https://github.com/user-attachments/assets/daa3e076-ba72-4725-9554-2ec8ec35d8a5" />

