### PR TITLE
change gpt-5-codex support in model_price json

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13197,11 +13197,11 @@
             "text"
         ],
         "supports_function_calling": true,
-        "supports_native_streaming": false,
+        "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
-        "supports_reasoning": false,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_system_messages": false,
         "supports_tool_choice": true,


### PR DESCRIPTION
## Title

Add flag to true for gpt-5-codex support in reasoning and streaming.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
The official [documentation from OpenAI](https://platform.openai.com/docs/models/gpt-5-codex) states that the model gpt-5-codex has reasoning and streaming support. Adding this flags to True in the json prevent the Fake Streaming using the `MockResponsesAPIStreamingIterator` from LiteLLM to take place instead of the real `ResponsesAPIStreamingIterator`.
