### PR TITLE
add Usage to ModelResponseBase

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2002,11 +2002,11 @@ def calculate_total_usage(chunks: List[ModelResponse]) -> Usage:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     for chunk in chunks:
-        if "usage" in chunk:
-            if "prompt_tokens" in chunk["usage"]:
-                prompt_tokens = chunk["usage"].get("prompt_tokens", 0) or 0
-            if "completion_tokens" in chunk["usage"]:
-                completion_tokens = chunk["usage"].get("completion_tokens", 0) or 0
+        if chunk.usage is not None:
+            if chunk.usage.prompt_tokens is not None:
+                prompt_tokens = chunk.usage.prompt_tokens
+            if chunk.usage.completion_tokens is not None:
+                completion_tokens = chunk.usage.completion_tokens
 
     returned_usage_chunk = Usage(
         prompt_tokens=prompt_tokens,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1172,6 +1172,9 @@ class ModelResponseBase(OpenAIObject):
     backend changes have been made that might impact determinism.
     """
 
+    usage: Optional[Usage] = None
+    """The token usage statistics for the completion."""
+
     _hidden_params: dict = {}
 
     _response_headers: Optional[dict] = None

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -75,6 +75,25 @@ def test_usage_dump():
     assert new_usage.prompt_tokens_details.web_search_requests == 1
 
 
+def test_usage_calculation():
+    from litellm.utils import ModelResponse
+    from litellm.types.utils import Usage
+    from litellm.litellm_core_utils.streaming_handler import calculate_total_usage
+
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model="test-model",
+        object="chat.completion",
+        choices=[],
+        usage=Usage(
+            completion_tokens=37,
+            prompt_tokens=7,
+        )
+    )
+    assert calculate_total_usage(chunks=[response]).total_tokens == 44
+
+
 def test_usage_completion_tokens_details_text_tokens():
     from litellm.types.utils import Usage
 


### PR DESCRIPTION
## Title

Use `Usage` model in `ModelResponseBase`
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Fixes #15568
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


```
❯ poetry run pytest tests/test_litellm -k test_usage_calculation
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.4.4, pluggy-1.5.0
rootdir: /home/bcaswell/src/litellm
plugins: respx-0.22.0, asyncio-0.21.2, mock-3.14.1, requests-mock-1.12.1, xdist-3.8.0, anyio-4.5.2, retry-1.6.3
asyncio: mode=strict
collected 3718 items / 3717 deselected / 1 selected
tests/test_litellm/types/test_types_utils.py .                                                                                                       [100%]
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

This updates ModelResponseBase to use `Usage` rather than providing it as an `extra` field that is ignored via type checking.  This updates the usage of Usage to use the model, rather than using the `__getitem__` handler, which will allow future improvements due to type checking.
