### PR TITLE
perf(router): use shallow copy instead of deepcopy for model aliases

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6257,7 +6257,9 @@ class Router:
                     model_name=model_name, model=model, team_id=team_id
                 ):
                     if model_alias is not None:
-                        alias_model = copy.deepcopy(model)
+                        # Optimized: Use shallow copy since we only modify top-level model_name
+                        # This is much faster than deepcopy for nested dict structures
+                        alias_model = model.copy()
                         alias_model["model_name"] = model_alias
                         returned_models.append(alias_model)
                     else:
@@ -6271,7 +6273,8 @@ class Router:
                     model_name=model_name, model=model, team_id=team_id
                 ):
                     if model_alias is not None:
-                        alias_model = copy.deepcopy(model)
+                        # Optimized: Use shallow copy since we only modify top-level model_name
+                        alias_model = model.copy()
                         alias_model["model_name"] = model_alias
                         returned_models.append(alias_model)
                     else:


### PR DESCRIPTION
## Title

perf(router): use shallow copy instead of deepcopy for model aliases
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Remove unnecessary deep.copy

## Test Results

<img width="1380" height="212" alt="Screenshot 2025-10-15 at 4 30 39 PM" src="https://github.com/user-attachments/assets/b66c8282-c943-45cb-94aa-a0b1d2ba62db" />

- Failures seem unrelated.
