### PR TITLE
perf(router): optimize model lookups with O(1) data structures

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -189,7 +189,7 @@ class RoutingArgs(enum.Enum):
 
 
 class Router:
-    model_names: List = []
+    model_names: set = set()
     cache_responses: Optional[bool] = False
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
     tenacity = None
@@ -5154,7 +5154,7 @@ class Router:
         verbose_router_logger.debug(
             f"\nInitialized Model List {self.get_model_names()}"
         )
-        self.model_names = [m["model_name"] for m in model_list]
+        self.model_names = {m["model_name"] for m in model_list}
         
         # Build model_name index for O(1) lookups
         self._build_model_name_index(self.model_list)
@@ -5360,7 +5360,7 @@ class Router:
         self._add_model_to_list_and_index_map(
             model=_deployment, model_id=deployment.model_info.id
         )
-        self.model_names.append(deployment.model_name)
+        self.model_names.add(deployment.model_name)
         return deployment
 
     def _update_deployment_indices_after_removal(

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -177,3 +177,11 @@ class TestRouterIndexManagement:
         # Verify: New entry is added
         assert "claude-3" in router.model_name_to_deployment_indices
         assert router.model_name_to_deployment_indices["claude-3"] == [0]
+
+    def test_model_names_is_set(self):
+        """Verify that model_names uses a set for O(1) lookups, not a list (O(n))"""
+        router = Router(model_list=[])
+        
+        assert isinstance(router.model_names, set), (
+            f"model_names should be a set for O(1) lookups, but got {type(router.model_names)}"
+        )


### PR DESCRIPTION
## Title

perf(router): optimize model lookups with O(1) data structures

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Changed model_names from list to set to improve look up time.

## Test Results

<img width="1391" height="189" alt="Screenshot 2025-10-15 at 4 47 00 PM" src="https://github.com/user-attachments/assets/3302b24d-dbb2-485c-ba85-692d0011a5da" />

- Failures seem to be unrelated.
