### PR TITLE
Add type hint to function_to_dict and fix typo

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5121,9 +5121,9 @@ def json_schema_type(python_type_name: str):
     return python_to_json_schema_types.get(python_type_name, "string")
 
 
-def function_to_dict(input_function):  # noqa: C901
+def function_to_dict(input_function) -> dict:  # noqa: C901
     """Using type hints and numpy-styled docstring,
-    produce a dictionnary usable for OpenAI function calling
+    produce a dictionary usable for OpenAI function calling
 
     Parameters
     ----------


### PR DESCRIPTION
## Type hints

Updated type hint for `function_to_dict` and fixed typo in docstring.

PS: Type hints in this project is severely lacking and makes it harder to work with autocomplete in IDEs. If maintainers are okay with it, I'd like to submit more PRs covering wider addition of type hints. 

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring
📖 Documentation

## Changes


