### PR TITLE
Fix Pydantic validation error for citationMetadata.citationSources in Google GenAI responses

### DIFF
--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -317,5 +317,20 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             )
 
         logging_obj.model_call_details["httpx_response"] = raw_response
+        response = self.convert_citation_sources_to_citations(response)
 
         return GenerateContentResponse(**response)
+
+    def convert_citation_sources_to_citations(self, response: Dict) -> Dict:
+        """
+        Convert citation sources to citations.
+        API's camelCase citationSources becomes the SDK's snake_case citations
+        """
+        if "candidates" in response:
+            for candidate in response["candidates"]:
+                if "citationMetadata" in candidate and isinstance(candidate["citationMetadata"], dict):
+                    citation_metadata = candidate["citationMetadata"]
+                    # Transform citationSources to citations to match expected schema
+                    if "citationSources" in citation_metadata:
+                        citation_metadata["citations"] = citation_metadata.pop("citationSources")
+        return response


### PR DESCRIPTION
## Title

Fix Pydantic validation error for citationMetadata.citationSources in Google GenAI responses

## Relevant issues

Fixes validation error when Google GenAI API returns `citationMetadata.citationSources` field that causes Pydantic validation to fail with "Extra inputs are not permitted" error.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- **Fixed Pydantic validation error**: Added transformation in `GoogleGenAIConfig.transform_generate_content_response()` to convert `citationMetadata.citationSources` to `citationMetadata.citations` to match expected schema
- **Added transformation method**: Implemented `convert_citation_sources_to_citations()` method that follows the same pattern as the official `googleapis/python-genai` SDK
- **Added comprehensive test**: Created `test_citation_metadata_transformation()` in `tests/test_litellm/google_genai/test_google_genai_handler.py` to verify the fix works correctly
- **Maintained backward compatibility**: The transformation preserves all citation data while ensuring schema compliance

This fix resolves the validation error that was occurring when processing video analysis responses from Google GenAI that include citation metadata with sources.


<img width="781" height="651" alt="image" src="https://github.com/user-attachments/assets/8e6f7421-2244-475f-84b2-5cac0785befa" />
