### PR TITLE
Fix: Add gpt 4.1 pricing for response endpoint

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -765,6 +765,9 @@ azure_llms = {
     "gpt-35-turbo": "azure/gpt-35-turbo",
     "gpt-35-turbo-16k": "azure/gpt-35-turbo-16k",
     "gpt-35-turbo-instruct": "azure/gpt-35-turbo-instruct",
+    "azure/gpt-41":"gpt-4.1", 
+    "azure/gpt-41-mini":"gpt-4.1-mini",
+    "azure/gpt-41-nano":"gpt-4.1-nano"
 }
 
 azure_embedding_models = {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12527,6 +12527,39 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-41": {
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "output_cost_per_token_batches": 4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
     "gpt-4.1-mini": {
         "cache_read_input_token_cost": 1e-07,
         "cache_read_input_token_cost_priority": 1.75e-07,
@@ -12596,6 +12629,39 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gpt-41-mini": {
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 4e-07,
+        "input_cost_per_token_batches": 2e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.6e-06,
+        "output_cost_per_token_batches": 8e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_web_search": false
+    },
     "gpt-4.1-nano": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
@@ -12659,6 +12725,38 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "gpt-41-nano": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_token_batches": 5e-08,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "output_cost_per_token_batches": 2e-07,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12527,39 +12527,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "gpt-41": {
-        "cache_read_input_token_cost": 5e-07,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "litellm_provider": "azure",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 8e-06,
-        "output_cost_per_token_batches": 4e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": false
-    },
     "gpt-4.1-mini": {
         "cache_read_input_token_cost": 1e-07,
         "cache_read_input_token_cost_priority": 1.75e-07,
@@ -12629,39 +12596,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "gpt-41-mini": {
-        "cache_read_input_token_cost": 1e-07,
-        "input_cost_per_token": 4e-07,
-        "input_cost_per_token_batches": 2e-07,
-        "litellm_provider": "azure",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.6e-06,
-        "output_cost_per_token_batches": 8e-07,
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": false
-    },
     "gpt-4.1-nano": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
@@ -12725,38 +12659,6 @@
         "supports_native_streaming": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "gpt-41-nano": {
-        "cache_read_input_token_cost": 2.5e-08,
-        "input_cost_per_token": 1e-07,
-        "input_cost_per_token_batches": 5e-08,
-        "litellm_provider": "azure",
-        "max_input_tokens": 1047576,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 4e-07,
-        "output_cost_per_token_batches": 2e-07,
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/batch",
-            "/v1/responses"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,


### PR DESCRIPTION
## Relevant issues

When using the /responses endpoint in our environment, the model names that litellm uses to try to attribute costs are `gpt-41`, `gpt-41-mini`, and `gpt-41-nano`, instead of the existing `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano`. Because of this, we can't attribute any costs to calls made with these models to the responses api. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

<s>- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)</s>
<s>- [ ] I have added a screenshot of my new test passing locally</s>
<s>- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)</s>
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

Add these keys to the pricing json
