### PR TITLE
[Fix] CI/CD - Missing env key & Linter type error

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -752,6 +752,7 @@ router_settings:
 | SPEND_LOGS_URL | URL for retrieving spend logs
 | SPEND_LOG_CLEANUP_BATCH_SIZE | Number of logs deleted per batch during cleanup. Default is 1000
 | SSL_CERTIFICATE | Path to the SSL certificate file
+| SSL_ECDH_CURVE | ECDH curve for SSL/TLS key exchange (e.g., 'X25519' to disable PQC).
 | SSL_SECURITY_LEVEL | [BETA] Security level for SSL/TLS connections. E.g. `DEFAULT@SECLEVEL=1`
 | SSL_VERIFY | Flag to enable or disable SSL certificate verification
 | SSL_CERT_FILE | Path to the SSL certificate file for custom CA bundle

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Collection, Dict, List, Optional
 
 import orjson
 from fastapi import Request, UploadFile, status
@@ -149,7 +149,7 @@ def _safe_get_request_headers(request: Optional[Request]) -> dict:
 def check_file_size_under_limit(
     request_data: dict,
     file: UploadFile,
-    router_model_names: List[str],
+    router_model_names: Collection[str],
 ) -> bool:
     """
     Check if any files passed in request are under max_file_size_mb


### PR DESCRIPTION
## Title

[Fix] CI/CD - Missing env key & Linter type error

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

- Added SSL_ECDH_CURVE env to the config_setting.md file.
- Fixed mypy type error where router_model_names (a set) was incompatible
with List[str] parameter type.

## Test Results

<img width="1429" height="206" alt="Screenshot 2025-10-16 at 11 37 45 AM" src="https://github.com/user-attachments/assets/e1f1b9d4-1e8b-41c9-8d5d-a33018d4b57f" />

- Failures seem unrelated.

