### PR TITLE
[Bug Fix] Tags as metadata dicts were raising exceptions 

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -263,8 +263,17 @@ def get_tags_from_request_body(request_body: dict) -> List[str]:
     """
     metadata_variable_name = get_metadata_variable_name_from_kwargs(request_body)
     metadata = request_body.get(metadata_variable_name, {})
-    tags_in_metadata: List[str] = metadata.get("tags", [])
-    tags_in_request_body: List[str] = request_body.get("tags", [])
-    combined_tags: List[str] = tags_in_metadata + tags_in_request_body
+    tags_in_metadata: Any = metadata.get("tags", [])
+    tags_in_request_body: Any = request_body.get("tags", [])
+    combined_tags: List[str] = []
+
+    ######################################
+    # Only combine tags if they are lists
+    ######################################
+    if isinstance(tags_in_metadata, list):
+        combined_tags.extend(tags_in_metadata)
+    if isinstance(tags_in_request_body, list):
+        combined_tags.extend(tags_in_request_body)
+    ######################################
     return [tag for tag in combined_tags if isinstance(tag, str)]
 

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -263,17 +263,8 @@ def get_tags_from_request_body(request_body: dict) -> List[str]:
     """
     metadata_variable_name = get_metadata_variable_name_from_kwargs(request_body)
     metadata = request_body.get(metadata_variable_name, {})
-    tags_in_metadata: Any = metadata.get("tags", [])
-    tags_in_request_body: Any = request_body.get("tags", [])
-    combined_tags: List[str] = []
-
-    ######################################
-    # Only combine tags if they are lists
-    ######################################
-    if isinstance(tags_in_metadata, list):
-        combined_tags.extend(tags_in_metadata)
-    if isinstance(tags_in_request_body, list):
-        combined_tags.extend(tags_in_request_body)
-    ######################################
+    tags_in_metadata: List[str] = metadata.get("tags", [])
+    tags_in_request_body: List[str] = request_body.get("tags", [])
+    combined_tags: List[str] = tags_in_metadata + tags_in_request_body
     return [tag for tag in combined_tags if isinstance(tag, str)]
 

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -382,3 +382,30 @@ def test_get_tags_from_request_body_no_tags():
     result = get_tags_from_request_body(request_body=request_body)
     
     assert result == []
+
+
+def test_get_tags_from_request_body_with_dict_tags():
+    """
+    Test that function handles dict tags gracefully without crashing.
+    When tags is a dict instead of a list, it should be ignored and return empty list.
+    """
+    request_body = {
+        "model": "aws/anthropic/bedrock-claude-3-5-sonnet-v1",
+        "messages": [
+            {
+                "role": "user",
+                "content": "aloha"
+            }
+        ],
+        "metadata": {
+            "tags": {
+                "litellm_id": "litellm_ratelimit_test",
+                "llm_id": "llmid_ratelimit_test"
+            }
+        }
+    }
+    
+    result = get_tags_from_request_body(request_body=request_body)
+    
+    assert result == []
+    assert isinstance(result, list)


### PR DESCRIPTION
## [Bug Fix] Tags as metadata dicts were raising exceptions 

Fixes LIT-1267

This PR fixes a bug where the get_tags_from_request_body function was raising exceptions when tags were provided as dictionary objects instead of lists in the metadata.

Added type safety by checking if tags are lists before processing them
Updated type hints to use Any instead of List[str] for initial tag extraction
Added comprehensive test coverage for the dictionary tags scenario

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes


