### PR TITLE
Fix: Support us-gov prefix for AWS GovCloud Bedrock models

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -440,7 +440,7 @@ class BedrockModelInfo(BaseLLMModelInfo):
         """
         Abbreviations of regions AWS Bedrock supports for cross region inference
         """
-        return ["global", "us", "eu", "apac", "jp", "au"]
+        return ["global", "us", "eu", "apac", "jp", "au", "us-gov"]
 
     @staticmethod
     def get_bedrock_route(
@@ -826,6 +826,7 @@ class CommonBatchFilesUtils:
             Tuple of (bucket_name, object_key)
         """
         import time
+
         from litellm._uuid import uuid
 
         # Get bucket name

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -14,8 +14,44 @@ from litellm.llms.bedrock.common_utils import BedrockModelInfo
 
 
 def test_deepseek_cris():
+    """
+    Test that DeepSeek models with cross-region inference prefix use converse route
+    """
     bedrock_model_info = BedrockModelInfo
     bedrock_route = bedrock_model_info.get_bedrock_route(
         model="bedrock/us.deepseek.r1-v1:0"
     )
     assert bedrock_route == "converse"
+
+
+def test_govcloud_cross_region_inference_prefix():
+    """
+    Test that GovCloud models with cross-region inference prefix (us-gov.) are parsed correctly
+    """
+    bedrock_model_info = BedrockModelInfo
+    
+    # Test us-gov prefix is stripped correctly for Claude models
+    base_model = bedrock_model_info.get_base_model(
+        model="bedrock/us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
+    assert base_model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    
+    # Test us-gov prefix is stripped correctly for different Claude versions
+    base_model = bedrock_model_info.get_base_model(
+        model="bedrock/us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    )
+    assert base_model == "anthropic.claude-sonnet-4-5-20250929-v1:0"
+    
+    # Test us-gov prefix is stripped correctly for Haiku models
+    base_model = bedrock_model_info.get_base_model(
+        model="bedrock/us-gov.anthropic.claude-3-haiku-20240307-v1:0"
+    )
+    assert base_model == "anthropic.claude-3-haiku-20240307-v1:0"
+    
+    # Test us-gov prefix is stripped correctly for Meta models
+    base_model = bedrock_model_info.get_base_model(
+        model="bedrock/us-gov.meta.llama3-8b-instruct-v1:0"
+    )
+    assert base_model == "meta.llama3-8b-instruct-v1:0"
+
+


### PR DESCRIPTION
## Fix: Support us-gov prefix for AWS GovCloud Bedrock models

Fixes https://github.com/BerriAI/litellm/issues/15603

Problem
When sending requests to AWS Bedrock Anthropic models in GovCloud regions with cross-region inference prefixes (e.g., bedrock/us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0), the model name parser was not stripping the us-gov prefix correctly. This caused the system to fail to recognize the base model name, leading to incorrect API parameter transformations and errors like:

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


