### PR TITLE
fix: Convert object to a correct type

### DIFF
--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -276,7 +276,7 @@ async def afile_retrieve(
     extra_headers: Optional[Dict[str, str]] = None,
     extra_body: Optional[Dict[str, str]] = None,
     **kwargs,
-):
+) -> OpenAIFileObject:
     """
     Async: Get file contents
 
@@ -305,7 +305,7 @@ async def afile_retrieve(
         else:
             response = init_response
 
-        return response
+        return OpenAIFileObject(**response.model_dump())
     except Exception as e:
         raise e
 
@@ -419,6 +419,7 @@ def file_retrieve(
                     request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
                 ),
             )
+
         return cast(FileObject, response)
     except Exception as e:
         raise e


### PR DESCRIPTION
## Title

Fix the ValueError: standard_logging_payload is required

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- ✅ I have added a screenshot of my new test passing locally 
- ✅ My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- **[ ]** My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

You can check that inside the function [_is_recognized_call_type_for_logging](https://github.com/BerriAI/litellm/blob/main/litellm/litellm_core_utils/litellm_logging.py#L1592) are a lot of type validations. And the type FileObject it's not mapped in this function, that causes an error. Because of that, the standard_logging_payload it's not generated. It's possible to add FileObject as another condition, but it seems the OpenAIFileObject is already validate and its the pattern most used along all the LiteLLM library. Because of that I prefer to convert the type and keep all things consistency.

The image below show the error when we call the GET /files/{file_id}
<img width="1094" height="313" alt="Screenshot 2025-10-17 at 01 19 29" src="https://github.com/user-attachments/assets/0d5daa3a-9569-431d-af59-72ddfc003d65" />

After the fix
Note: The error you are seeing below it's from our application. Don't have relation to LiteLLM
<img width="1094" height="72" alt="Screenshot 2025-10-17 at 01 17 53" src="https://github.com/user-attachments/assets/812929fe-df18-4e7a-be51-b8ef1eff8a8e" />


**Tests**
Note: We don't have an unit test specific for this function. I used the only one that indirectly call this functions
<img width="1094" height="246" alt="Screenshot 2025-10-17 at 01 30 25" src="https://github.com/user-attachments/assets/d0f6c2d3-f7ba-42f3-a35c-0177f8f3a834" />
