### PR TITLE
fix: Add function responsible to call precall

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -265,6 +265,7 @@ class ProxyBaseLLMRequestProcessing:
             "acreate_batch",
             "aretrieve_batch",
             "afile_content",
+            "afile_retrieve",
             "atext_completion",
             "acreate_fine_tuning_job",
             "acancel_fine_tuning_job",

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -583,7 +583,6 @@ async def get_file(
     ```
     """
     from litellm.proxy.proxy_server import (
-        add_litellm_data_to_request,
         general_settings,
         proxy_config,
         proxy_logging_obj,
@@ -592,20 +591,27 @@ async def get_file(
 
     data: Dict = {}
     try:
+
         custom_llm_provider = (
             provider
             or get_custom_llm_provider_from_request_query(request=request)
             or await get_custom_llm_provider_from_request_body(request=request)
             or "openai"
         )
+
         # Include original request and headers in the data
-        data = await add_litellm_data_to_request(
-            data=data,
+        base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
+        (
+            data,
+            litellm_logging_obj,
+        ) = await base_llm_response_processor.common_processing_pre_call_logic(
             request=request,
             general_settings=general_settings,
             user_api_key_dict=user_api_key_dict,
             version=version,
+            proxy_logging_obj=proxy_logging_obj,
             proxy_config=proxy_config,
+            route_type="afile_content",
         )
 
         ## check if file_id is a litellm managed file

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -611,7 +611,7 @@ async def get_file(
             version=version,
             proxy_logging_obj=proxy_logging_obj,
             proxy_config=proxy_config,
-            route_type="afile_content",
+            route_type="afile_retrieve",
         )
 
         ## check if file_id is a litellm managed file


### PR DESCRIPTION
## Title

fix: Add a function responsible to call precall

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- ✅ I have added a screenshot of my new test passing locally 
- ✅ My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- ✅ My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->

🐛 Bug Fix

## Changes

I basically add the ProxyBaseLLMRequestProcessing class inside the get_file function. I'm using this logic because it's the same logic used in the get_file_content and list_files function. Inside the ProxyBaseLLMRequestProcessing it's a call for the function pre_call_hook, who is responsible to call the custom callbacks. 

The add_litellm_data_to_request it's removed because this function it's already called inside the ProxyBaseLLMRequestProcessing.common_processing_pre_call_logic.

**Tests**
I basically add a "print" function inside our `async_pre_call_hook` custom callback. You can see in the image below this print it's not called, so some metadata is not injected into the object. 
<img width="1094" height="55" alt="Screenshot 2025-10-17 at 02 03 40" src="https://github.com/user-attachments/assets/c16ca00b-1f22-4452-a184-d6c7385a78d2" />

Here is after the fix, you can check the print is called now.
<img width="1094" height="74" alt="Screenshot 2025-10-17 at 02 01 27" src="https://github.com/user-attachments/assets/830d6bf1-970c-4004-acd2-163abe3942bf" />

Note: We don't have an unit test specific for this function. I used the only one that indirectly call this functions
<img width="1094" height="236" alt="image" src="https://github.com/user-attachments/assets/15b8b3e2-8aa6-4cac-bec6-9dfef4404e3a" />

