### PR TITLE
Fix: Gemini 2.5 Flash Image should not have supports_web_search=true

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9649,7 +9649,7 @@
         "supports_tool_choice": true,
         "supports_url_context": true,
         "supports_vision": true,
-        "supports_web_search": true,
+        "supports_web_search": false,
         "tpm": 8000000
     },
     "gemini-2.5-flash-image-preview": {


### PR DESCRIPTION
## Relevant issues

The litellm model info states that Gemini 2.5 Flash Image supports web search, which it does not, as per the docs: 

https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash-image

Corrected this so that the correct capabilities are communicated to the users.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

<s>- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)</s>
<s>- [ ] I have added a screenshot of my new test passing locally</s>
<s>- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)</s>
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


