### PR TITLE
Add support for responses mode in health check

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5906,6 +5906,7 @@ async def ahealth_check(
             "batch",
             "rerank",
             "realtime",
+            "responses",
         ]
     ] = "chat",
     prompt: Optional[str] = None,
@@ -6013,6 +6014,10 @@ async def ahealth_check(
             ),
             "batch": lambda: litellm.alist_batches(
                 **_filter_model_params(model_params),
+            ),
+            "responses": lambda: litellm.aresponses(
+                **_filter_model_params(model_params),
+                input=prompt or "test",
             ),
         }
 


### PR DESCRIPTION
## Title

Fix "responses" model mode not supported by /health endpoint

## Relevant issues

Fixes #15655

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes
1. **Added "responses" to type annotation**: Updated the `Literal` type in the `ahealth_check` function to include "responses" as a valid mode
2. **Added responses mode handler**: Implemented a handler in `mode_handlers` that calls `litellm.aresponses()` with appropriate parameters

<img width="843" height="586" alt="image" src="https://github.com/user-attachments/assets/8c9fceaf-2b76-4d09-b520-d6fb0c4d4e09" />
