### PR TITLE
feat(guardrails): Add content masking and streaming support to PANW Prisma AIRS guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/__init__.py
@@ -13,8 +13,8 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
 
     guardrail_name = guardrail.get("guardrail_name")
     profile_name = cast(Optional[str], getattr(litellm_params, "profile_name", None))
-    if not litellm_params.api_key:
-        raise ValueError("PANW Prisma AIRS: api_key is required")
+    
+    # Note: api_key can be None here - handler will fallback to PANW_PRISMA_AIRS_API_KEY env var
     if not profile_name:
         raise ValueError("PANW Prisma AIRS: profile_name is required")
     if not guardrail_name:

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-PANW Prisma AIRS Built-in Guardrail for LiteLLM
+Palo Alto Networks Prisma AI Runtime Security (AIRS) Guardrail Integration for LiteLLM
 
+Provides real-time threat detection, DLP, URL filtering, content masking, and policy enforcement for AI applications.
 """
 
 import os
@@ -30,15 +31,17 @@ class PanwPrismaAirsHandler(CustomGuardrail):
     """
     LiteLLM Built-in Guardrail for Palo Alto Networks Prisma AI Runtime Security (AIRS).
 
-    This guardrail scans prompts and responses using the PANW Prisma AIRS API to detect
-    malicious content, injection attempts, and policy violations.
+    Scans prompts and responses using PANW Prisma AIRS API to detect malicious content,
+    injection attempts, and policy violations. Supports content masking and fail-closed error handling.
 
     Configuration:
         guardrail_name: Name of the guardrail instance
         api_key: PANW Prisma AIRS API key
-        api_base: PANW Prisma AIRS API endpoint
-        profile_name: PANW Prisma AIRS security profile name
-        default_on: Whether to enable by default
+        api_base: PANW Prisma AIRS API endpoint (default: https://service.api.aisecurity.paloaltonetworks.com)
+        profile_name: PANW security profile name
+        mask_request_content: Apply masking to prompts (default: False)
+        mask_response_content: Apply masking to responses (default: False)
+        mask_on_block: Backwards compatible flag that enables both request and response masking
     """
 
     def __init__(
@@ -48,12 +51,26 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         api_base: str,
         profile_name: str,
         default_on: bool = True,
+        mask_on_block: bool = False,
+        mask_request_content: bool = False,
+        mask_response_content: bool = False,
         **kwargs,
     ):
         """Initialize PANW Prisma AIRS guardrail handler."""
 
-        # Initialize parent CustomGuardrail
-        super().__init__(guardrail_name=guardrail_name, default_on=default_on, **kwargs)
+        # Masking configuration - mask_on_block enables both for backwards compatibility
+        self.mask_on_block = mask_on_block
+        _mask_request_content = mask_request_content or mask_on_block
+        _mask_response_content = mask_response_content or mask_on_block
+
+        # Initialize parent CustomGuardrail with masking flags
+        super().__init__(
+            guardrail_name=guardrail_name,
+            default_on=default_on,
+            mask_request_content=_mask_request_content,
+            mask_response_content=_mask_response_content,
+            **kwargs
+        )
 
         # Store configuration
         self.api_key = api_key or os.getenv("PANW_PRISMA_AIRS_API_KEY")
@@ -64,8 +81,9 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         )
         self.profile_name = profile_name
 
-        verbose_proxy_logger.debug(
-            f"Initialized PANW Prisma AIRS Guardrail: {guardrail_name}"
+        verbose_proxy_logger.info(
+            f"Initialized PANW Prisma AIRS Guardrail: {guardrail_name} "
+            f"(mask_request={self.mask_request_content}, mask_response={self.mask_response_content})"
         )
 
     def _extract_text_from_messages(self, messages: List[Dict[str, Any]]) -> str:
@@ -104,20 +122,38 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         return " ".join(text_parts) if text_parts else ""
 
     def _extract_response_text(self, response: ModelResponse) -> str:
-        """Extract text from LLM response."""
+        """
+        Extract all text content from LLM response.
+        Handles multiple choices, tool calls, and function calls.
+        Returns concatenated text for scanning.
+        """
         try:
             from litellm.types.utils import Choices
-
-            if (
-                hasattr(response, "choices")
-                and response.choices
-                and len(response.choices) > 0
-                and hasattr(response.choices[0], "message")
-            ):
-                return cast(Choices, response.choices[0]).message.content or ""
-        except (AttributeError, IndexError):
+            
+            text_parts = []
+            
+            if hasattr(response, "choices") and response.choices:
+                for choice in response.choices:
+                    if isinstance(choice, Choices):
+                        # Extract message content
+                        if choice.message.content:
+                            text_parts.append(str(choice.message.content))
+                        
+                        # Extract tool call arguments
+                        if hasattr(choice.message, "tool_calls") and choice.message.tool_calls:
+                            for tool_call in choice.message.tool_calls:
+                                if hasattr(tool_call, "function") and hasattr(tool_call.function, "arguments"):
+                                    text_parts.append(str(tool_call.function.arguments))
+                        
+                        # Extract function call arguments (legacy)
+                        if hasattr(choice.message, "function_call") and choice.message.function_call:
+                            if hasattr(choice.message.function_call, "arguments"):
+                                text_parts.append(str(choice.message.function_call.arguments))
+            
+            return " ".join(text_parts) if text_parts else ""
+        except (AttributeError, IndexError) as e:
             verbose_proxy_logger.error(
-                "PANW Prisma AIRS: Error extracting response text"
+                f"PANW Prisma AIRS: Error extracting response text: {str(e)}"
             )
         return ""
 
@@ -191,6 +227,88 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             verbose_proxy_logger.error(f"PANW Prisma AIRS: API call failed: {str(e)}")
             return {"action": "block", "category": "api_error"}
 
+    def _get_masked_text(self, scan_result: Dict[str, Any], is_response: bool = False) -> Optional[str]:
+        """Extract masked text from PANW scan result."""
+        masked_key = "response_masked_data" if is_response else "prompt_masked_data"
+        masked_data = scan_result.get(masked_key)
+        if masked_data and isinstance(masked_data, dict):
+            return masked_data.get("data")
+        return None
+
+    def _apply_masking_to_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        masked_text: str
+    ) -> List[Dict[str, Any]]:
+        """Apply masked text to the last user message."""
+        if not messages:
+            return messages
+
+        for i, message in enumerate(reversed(messages)):
+            if message.get("role") == "user":
+                new_message = message.copy()
+                content = message.get("content")
+                
+                if isinstance(content, str):
+                    new_message["content"] = masked_text
+                elif isinstance(content, list):
+                    new_content = []
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            new_content.append({"type": "text", "text": masked_text})
+                        else:
+                            new_content.append(part)
+                    new_message["content"] = new_content
+                
+                idx = len(messages) - i - 1
+                return messages[:idx] + [new_message] + messages[idx+1:]
+        
+        return messages
+
+    def _apply_masking_to_response(
+        self, 
+        response: ModelResponse,
+        masked_text: str
+    ) -> None:
+        """
+        Apply masked text to all content in response in-place.
+        Handles message content, tool calls, and function calls across all choices.
+        Preserves list-based content structure (e.g., multimodal messages).
+        """
+        from litellm.types.utils import Choices
+        
+        if not hasattr(response, "choices") or not response.choices:
+            return
+        
+        for choice in response.choices:
+            if isinstance(choice, Choices):
+                # Mask message content - handle both string and list formats
+                content = choice.message.content
+                if content:
+                    if isinstance(content, str):
+                        choice.message.content = masked_text
+                    elif isinstance(content, list):
+                        # Preserve list structure, only replace text parts
+                        new_content = []
+                        for part in content:  # type: ignore
+                            if isinstance(part, dict) and part.get("type") == "text":
+                                new_content.append({"type": "text", "text": masked_text})
+                            else:
+                                # Preserve non-text parts (images, etc.)
+                                new_content.append(part)
+                        choice.message.content = new_content  # type: ignore
+                
+                # Mask tool call arguments
+                if hasattr(choice.message, "tool_calls") and choice.message.tool_calls:
+                    for tool_call in choice.message.tool_calls:
+                        if hasattr(tool_call, "function") and hasattr(tool_call.function, "arguments"):
+                            tool_call.function.arguments = masked_text
+                
+                # Mask function call arguments (legacy)
+                if hasattr(choice.message, "function_call") and choice.message.function_call:
+                    if hasattr(choice.message.function_call, "arguments"):
+                        choice.message.function_call.arguments = masked_text
+
     def _build_error_detail(
         self, scan_result: Dict[str, Any], is_response: bool = False
     ) -> Dict[str, Any]:
@@ -253,96 +371,320 @@ class PanwPrismaAirsHandler(CustomGuardrail):
 
         Raises HTTPException if content should be blocked.
         """
-        verbose_proxy_logger.debug("PANW Prisma AIRS: Running pre-call prompt scan")
-
-        # Extract prompt text from messages
-        messages = data.get("messages", [])
-        prompt_text = self._extract_text_from_messages(messages)
-
-        if not prompt_text:
-            verbose_proxy_logger.warning(
-                "PANW Prisma AIRS: No user prompt found in request"
-            )
-            return None
-
-        # Prepare metadata
-        metadata = {
-            "user": data.get("user", "litellm_user"),
-            "model": data.get("model", "unknown"),
-        }
-
-        # Scan prompt with PANW Prisma AIRS
-        scan_result = await self._call_panw_api(
-            content=prompt_text, is_response=False, metadata=metadata
+        from litellm.proxy.common_utils.callback_utils import (
+            add_guardrail_to_applied_guardrails_header,
         )
+        from litellm.types.guardrails import GuardrailEventHooks
 
-        action = scan_result.get("action", "block")
-        category = scan_result.get("category", "unknown")
+        verbose_proxy_logger.info("PANW Prisma AIRS: Running pre-call prompt scan")
 
-        if action == "allow":
-            verbose_proxy_logger.debug(
-                f"PANW Prisma AIRS: Response allowed (Category: {category})"
+        # Check if guardrail should run for this request
+        event_type: GuardrailEventHooks = GuardrailEventHooks.pre_call
+        if self.should_run_guardrail(data=data, event_type=event_type) is not True:
+            return data
+
+        try:
+            # Extract prompt text from messages
+            messages = data.get("messages", [])
+            prompt_text = self._extract_text_from_messages(messages)
+
+            if not prompt_text:
+                verbose_proxy_logger.warning(
+                    "PANW Prisma AIRS: No user prompt found in request"
+                )
+                return None
+
+            # Prepare metadata
+            metadata = {
+                "user": data.get("user", "litellm_user"),
+                "model": data.get("model", "unknown"),
+            }
+
+            # Scan prompt with PANW Prisma AIRS
+            scan_result = await self._call_panw_api(
+                content=prompt_text, is_response=False, metadata=metadata
             )
 
-        else:
-            error_detail = self._build_error_detail(scan_result, is_response=True)
+            action = scan_result.get("action", "block")
+            category = scan_result.get("category", "unknown")
+            masked_text = self._get_masked_text(scan_result, is_response=False)
+
+            # If action is "allow", apply masking if available and allow through
+            if action == "allow":
+                if masked_text:
+                    data["messages"] = self._apply_masking_to_messages(messages, masked_text)
+                    verbose_proxy_logger.info(
+                        f"PANW Prisma AIRS: Prompt allowed with masking (Category: {category})"
+                    )
+                else:
+                    verbose_proxy_logger.info(
+                        f"PANW Prisma AIRS: Prompt allowed (Category: {category})"
+                    )
+                add_guardrail_to_applied_guardrails_header(
+                    request_data=data, guardrail_name=self.guardrail_name
+                )
+                return None
+
+            # Action is "block" - check if we should mask instead of blocking
+            if masked_text and self.mask_request_content:
+                data["messages"] = self._apply_masking_to_messages(messages, masked_text)
+                verbose_proxy_logger.warning(
+                    f"PANW Prisma AIRS: Prompt blocked but masked instead (mask_request_content=True)"
+                )
+                add_guardrail_to_applied_guardrails_header(
+                    request_data=data, guardrail_name=self.guardrail_name
+                )
+                return None
+
+            # Block the request
+            error_detail = self._build_error_detail(scan_result, is_response=False)
             verbose_proxy_logger.warning(
                 f"PANW Prisma AIRS: {error_detail['error']['message']}"
             )
             raise HTTPException(status_code=400, detail=error_detail)
 
-        return None
+        except HTTPException:
+            raise
+        except Exception as e:
+            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {str(e)}")
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                            "message": "Security scan failed - request blocked for safety",
+                            "type": "guardrail_scan_error",
+                            "code": "panw_prisma_airs_scan_failed",
+                            "guardrail": self.guardrail_name,
+                        }
+                    }
+                )
 
     @log_guardrail_information
     async def async_post_call_success_hook(
         self,
         data: Dict[str, Any],
         user_api_key_dict: UserAPIKeyAuth,
-        response: ModelResponse,
-    ) -> ModelResponse:
+        response: Any,
+    ) -> Any:
         """
         Post-call hook to scan LLM responses before returning to user.
 
         Raises HTTPException if response should be blocked.
         """
-        verbose_proxy_logger.debug("PANW Prisma AIRS: Running post-call response scan")
+        from litellm.proxy.common_utils.callback_utils import (
+            add_guardrail_to_applied_guardrails_header,
+        )
+        from litellm.types.guardrails import GuardrailEventHooks
 
-        # Extract response text
-        response_text = self._extract_response_text(response)
-
-        if not response_text:
-            verbose_proxy_logger.warning(
-                "PANW Prisma AIRS: No response content found to scan"
-            )
+        # Only process ModelResponse objects
+        if not isinstance(response, ModelResponse):
             return response
 
-        # Prepare metadata
-        metadata = {
-            "user": data.get("user", "litellm_user"),
-            "model": data.get("model", "unknown"),
-        }
+        verbose_proxy_logger.info("PANW Prisma AIRS: Running post-call response scan")
 
-        # Scan response with PANW Prisma AIRS
-        scan_result = await self._call_panw_api(
-            content=response_text, is_response=True, metadata=metadata
-        )
+        # Check if guardrail should run for this request
+        event_type: GuardrailEventHooks = GuardrailEventHooks.post_call
+        if self.should_run_guardrail(data=data, event_type=event_type) is not True:
+            return response
 
-        action = scan_result.get("action", "block")
-        category = scan_result.get("category", "unknown")
+        try:
+            # Extract response text
+            response_text = self._extract_response_text(response)
 
-        if action == "allow":
-            verbose_proxy_logger.debug(
-                f"PANW Prisma AIRS: Response allowed (Category: {category})"
+            if not response_text:
+                verbose_proxy_logger.warning(
+                    "PANW Prisma AIRS: No response content found to scan"
+                )
+                return response
+
+            # Prepare metadata
+            metadata = {
+                "user": data.get("user", "litellm_user"),
+                "model": data.get("model", "unknown"),
+            }
+
+            # Scan response with PANW Prisma AIRS
+            scan_result = await self._call_panw_api(
+                content=response_text, is_response=True, metadata=metadata
             )
 
-        else:
+            action = scan_result.get("action", "block")
+            category = scan_result.get("category", "unknown")
+            masked_text = self._get_masked_text(scan_result, is_response=True)
+
+            # If action is "allow", apply masking if available and allow through
+            if action == "allow":
+                if masked_text:
+                    self._apply_masking_to_response(response, masked_text)
+                    verbose_proxy_logger.info(
+                        f"PANW Prisma AIRS: Response allowed with masking (Category: {category})"
+                    )
+                else:
+                    verbose_proxy_logger.info(
+                        f"PANW Prisma AIRS: Response allowed (Category: {category})"
+                    )
+                add_guardrail_to_applied_guardrails_header(
+                    request_data=data, guardrail_name=self.guardrail_name
+                )
+                return response
+
+            # Action is "block" - check if we should mask instead of blocking
+            if masked_text and self.mask_response_content:
+                self._apply_masking_to_response(response, masked_text)
+                verbose_proxy_logger.warning(
+                    f"PANW Prisma AIRS: Response blocked but masked instead (mask_response_content=True)"
+                )
+                add_guardrail_to_applied_guardrails_header(
+                    request_data=data, guardrail_name=self.guardrail_name
+                )
+                return response
+
+            # Block the response
             error_detail = self._build_error_detail(scan_result, is_response=True)
             verbose_proxy_logger.warning(
                 f"PANW Prisma AIRS: {error_detail['error']['message']}"
             )
             raise HTTPException(status_code=400, detail=error_detail)
 
-        return response
+        except HTTPException:
+            raise
+        except Exception as e:
+            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {str(e)}")
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "message": "Security scan failed - response blocked for safety",
+                        "type": "guardrail_scan_error",
+                        "code": "panw_prisma_airs_scan_failed",
+                        "guardrail": self.guardrail_name,
+                    }
+                }
+            )
+
+    @log_guardrail_information
+    async def async_post_call_streaming_iterator_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        response: Any,
+        request_data: dict,
+    ):
+        """
+        Process streaming response chunks and scan the assembled response.
+        """
+        from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
+        from litellm.main import stream_chunk_builder
+        from litellm.proxy.common_utils.callback_utils import (
+            add_guardrail_to_applied_guardrails_header,
+        )
+        
+        # Check if guardrail should run for this request
+        from litellm.types.guardrails import GuardrailEventHooks as EventHooks
+        
+        if not self.should_run_guardrail(
+            data=request_data, event_type=EventHooks.post_call
+        ):
+            async for chunk in response:
+                yield chunk
+            return
+        
+        verbose_proxy_logger.info("PANW Prisma AIRS: Running post-call streaming scan")
+        
+        all_chunks = []
+        content_was_modified = False
+        
+        try:
+            # Collect all chunks
+            async for chunk in response:
+                all_chunks.append(chunk)
+            
+            # Assemble complete response from chunks
+            assembled_model_response = stream_chunk_builder(chunks=all_chunks)
+            
+            if isinstance(assembled_model_response, ModelResponse):
+                # Extract response text for scanning
+                response_text = self._extract_response_text(assembled_model_response)
+                
+                if response_text and response_text.strip():
+                    # Prepare metadata
+                    metadata = {
+                        "user": request_data.get("user", "litellm_user"),
+                        "model": request_data.get("model", "unknown"),
+                    }
+                    
+                    # Scan assembled response with PANW Prisma AIRS
+                    scan_result = await self._call_panw_api(
+                        content=response_text, is_response=True, metadata=metadata
+                    )
+                    
+                    action = scan_result.get("action", "block")
+                    category = scan_result.get("category", "unknown")
+                    masked_text = self._get_masked_text(scan_result, is_response=True)
+                    
+                    # If action is "allow", apply masking if available
+                    if action == "allow":
+                        if masked_text:
+                            self._apply_masking_to_response(assembled_model_response, masked_text)
+                            content_was_modified = True
+                            verbose_proxy_logger.info(
+                                f"PANW Prisma AIRS: Streaming response allowed with masking (Category: {category})"
+                            )
+                        else:
+                            verbose_proxy_logger.info(
+                                f"PANW Prisma AIRS: Streaming response allowed (Category: {category})"
+                            )
+                    # Action is "block" - check if we should mask instead
+                    elif masked_text and self.mask_response_content:
+                        self._apply_masking_to_response(assembled_model_response, masked_text)
+                        content_was_modified = True
+                        verbose_proxy_logger.warning(
+                            f"PANW Prisma AIRS: Streaming response blocked but masked instead (mask_response_content=True)"
+                        )
+                    else:
+                        # Block the response
+                        error_detail = self._build_error_detail(scan_result, is_response=True)
+                        verbose_proxy_logger.warning(
+                            f"PANW Prisma AIRS: {error_detail['error']['message']}"
+                        )
+                        raise HTTPException(status_code=400, detail=error_detail)
+                else:
+                    # No content to scan, pass through
+                    verbose_proxy_logger.info("PANW Prisma AIRS: No content to scan in streaming response")
+                
+                # Add guardrail to applied guardrails header for observability
+                add_guardrail_to_applied_guardrails_header(
+                    request_data=request_data, guardrail_name=self.guardrail_name
+                )
+                
+                # Only use MockResponseIterator if content was modified
+                # Otherwise, yield original chunks to preserve streaming behavior
+                if content_was_modified:
+                    mock_response = MockResponseIterator(model_response=assembled_model_response)
+                    async for chunk in mock_response:
+                        yield chunk
+                else:
+                    for chunk in all_chunks:
+                        yield chunk
+            else:
+                # If not a ModelResponse, just yield original chunks
+                for chunk in all_chunks:
+                    yield chunk
+                    
+        except HTTPException:
+            raise
+        except Exception as e:
+            verbose_proxy_logger.error(f"PANW Prisma AIRS streaming error: {str(e)}")
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "message": "Security scan failed - streaming response blocked for safety",
+                        "type": "guardrail_scan_error",
+                        "code": "panw_prisma_airs_scan_failed",
+                        "guardrail": self.guardrail_name,
+                    }
+                }
+            )
 
     @staticmethod
     def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:

--- a/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
@@ -16,8 +16,22 @@ class PanwPrismaAirsGuardrailConfigModel(GuardrailConfigModel):
     )
 
     profile_name: str = Field(
-        default="default",
-        description="PANW Prisma AIRS security profile name. Required.",
+        description="PANW Prisma AIRS security profile name configured in Strata Cloud Manager. Required.",
+    )
+
+    mask_on_block: bool = Field(
+        default=False,
+        description="Backwards compatible flag that enables both request and response masking. When True, enables both mask_request_content and mask_response_content.",
+    )
+
+    mask_request_content: bool = Field(
+        default=False,
+        description="Apply masking to prompts that would be blocked. When True, masked content is sent to the LLM instead of blocking the request.",
+    )
+
+    mask_response_content: bool = Field(
+        default=False,
+        description="Apply masking to responses that would be blocked. When True, masked content is returned to the user instead of blocking the response.",
     )
 
     @staticmethod

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -56,7 +56,7 @@ class TestPanwAirsInitialization:
         guardrail_config = {"guardrail_name": "test_guardrail"}
 
         with patch("litellm.logging_callback_manager.add_litellm_callback"):
-            handler = initialize_guardrail(litellm_params, guardrail_config)
+            handler = initialize_guardrail(litellm_params, guardrail_config)  
 
         assert isinstance(handler, PanwPrismaAirsHandler)
         assert handler.guardrail_name == "test_guardrail"
@@ -67,12 +67,12 @@ class TestPanwAirsInitialization:
             profile_name="test_profile",
             api_base=None,
             default_on=True,
-            api_key=None,  # Missing API key
+            api_key=None,
         )
         guardrail_config = {"guardrail_name": "test_guardrail"}
 
         with pytest.raises(ValueError, match="api_key is required"):
-            initialize_guardrail(litellm_params, guardrail_config)
+            initialize_guardrail(litellm_params, guardrail_config)  
 
     def test_missing_profile_name_raises_error(self):
         """Test that missing profile name raises ValueError."""
@@ -80,12 +80,12 @@ class TestPanwAirsInitialization:
             api_key="test_key",
             api_base=None,
             default_on=True,
-            profile_name=None,  # Missing profile name
+            profile_name=None,
         )
         guardrail_config = {"guardrail_name": "test_guardrail"}
 
         with pytest.raises(ValueError, match="profile_name is required"):
-            initialize_guardrail(litellm_params, guardrail_config)
+            initialize_guardrail(litellm_params, guardrail_config)   
 
 
 class TestPanwAirsPromptScanning:
@@ -93,22 +93,20 @@ class TestPanwAirsPromptScanning:
 
     @pytest.fixture
     def handler(self):
-        """Create test handler."""
         return PanwPrismaAirsHandler(
             guardrail_name="test_panw_airs",
             api_key="test_api_key",
             api_base="https://test.panw.com/api",
             profile_name="test_profile",
+            default_on=True,
         )
 
     @pytest.fixture
     def user_api_key_dict(self):
-        """Mock user API key dict."""
         return UserAPIKeyAuth(api_key="test_key")
 
     @pytest.fixture
     def safe_prompt_data(self):
-        """Safe prompt data."""
         return {
             "model": "gpt-3.5-turbo",
             "messages": [{"role": "user", "content": "What is the capital of France?"}],
@@ -117,7 +115,6 @@ class TestPanwAirsPromptScanning:
 
     @pytest.fixture
     def malicious_prompt_data(self):
-        """Malicious prompt data."""
         return {
             "model": "gpt-3.5-turbo",
             "messages": [
@@ -134,7 +131,6 @@ class TestPanwAirsPromptScanning:
         self, handler, user_api_key_dict, safe_prompt_data
     ):
         """Test that safe prompts are allowed."""
-        # Mock PANW API response - allow
         mock_response = {"action": "allow", "category": "benign"}
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
@@ -145,7 +141,6 @@ class TestPanwAirsPromptScanning:
                 call_type="completion",
             )
 
-        # Should return None (not blocked)
         assert result is None
 
     @pytest.mark.asyncio
@@ -153,7 +148,6 @@ class TestPanwAirsPromptScanning:
         self, handler, user_api_key_dict, malicious_prompt_data
     ):
         """Test that malicious prompts are blocked."""
-        # Mock PANW API response - block
         mock_response = {"action": "block", "category": "malicious"}
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
@@ -165,7 +159,6 @@ class TestPanwAirsPromptScanning:
                     call_type="completion",
                 )
 
-        # Verify exception details
         assert exc_info.value.status_code == 400
         assert "PANW Prisma AI Security policy" in str(exc_info.value.detail)
         assert "malicious" in str(exc_info.value.detail)
@@ -182,17 +175,14 @@ class TestPanwAirsPromptScanning:
             call_type="completion",
         )
 
-        # Should return None (not blocked, no content to scan)
         assert result is None
 
     def test_extract_text_from_messages(self, handler):
         """Test text extraction from various message formats."""
-        # Test simple string content
         messages = [{"role": "user", "content": "Hello world"}]
         text = handler._extract_text_from_messages(messages)
         assert text == "Hello world"
 
-        # Test complex content format
         messages = [
             {
                 "role": "user",
@@ -205,7 +195,6 @@ class TestPanwAirsPromptScanning:
         text = handler._extract_text_from_messages(messages)
         assert text == "Analyze this image"
 
-        # Test multiple messages (should get last user message)
         messages = [
             {"role": "user", "content": "First message"},
             {"role": "assistant", "content": "Assistant response"},
@@ -220,27 +209,24 @@ class TestPanwAirsResponseScanning:
 
     @pytest.fixture
     def handler(self):
-        """Create test handler."""
         return PanwPrismaAirsHandler(
             guardrail_name="test_panw_airs",
             api_key="test_api_key",
             api_base="https://test.panw.com/api",
             profile_name="test_profile",
+            default_on=True,
         )
 
     @pytest.fixture
     def user_api_key_dict(self):
-        """Mock user API key dict."""
         return UserAPIKeyAuth(api_key="test_key")
 
     @pytest.fixture
     def request_data(self):
-        """Request data."""
         return {"model": "gpt-3.5-turbo", "user": "test_user"}
 
     @pytest.fixture
     def safe_response(self):
-        """Safe LLM response."""
         return ModelResponse(
             id="test_id",
             choices=[
@@ -256,7 +242,6 @@ class TestPanwAirsResponseScanning:
 
     @pytest.fixture
     def harmful_response(self):
-        """Harmful LLM response."""
         return ModelResponse(
             id="test_id",
             choices=[
@@ -276,7 +261,6 @@ class TestPanwAirsResponseScanning:
         self, handler, user_api_key_dict, request_data, safe_response
     ):
         """Test that safe responses are allowed."""
-        # Mock PANW API response - allow
         mock_response = {"action": "allow", "category": "benign"}
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
@@ -286,7 +270,6 @@ class TestPanwAirsResponseScanning:
                 response=safe_response,
             )
 
-        # Should return original response
         assert result == safe_response
 
     @pytest.mark.asyncio
@@ -294,7 +277,6 @@ class TestPanwAirsResponseScanning:
         self, handler, user_api_key_dict, request_data, harmful_response
     ):
         """Test that harmful responses are blocked."""
-        # Mock PANW API response - block
         mock_response = {"action": "block", "category": "harmful"}
 
         with patch.object(handler, "_call_panw_api", return_value=mock_response):
@@ -305,7 +287,6 @@ class TestPanwAirsResponseScanning:
                     response=harmful_response,
                 )
 
-        # Verify exception details
         assert exc_info.value.status_code == 400
         assert "Response blocked by PANW Prisma AI Security policy" in str(
             exc_info.value.detail
@@ -318,12 +299,12 @@ class TestPanwAirsAPIIntegration:
 
     @pytest.fixture
     def handler(self):
-        """Create test handler."""
         return PanwPrismaAirsHandler(
             guardrail_name="test_panw_airs",
             api_key="test_api_key",
             api_base="https://test.panw.com/api",
             profile_name="test_profile",
+            default_on=True,
         )
 
     @pytest.mark.asyncio
@@ -352,7 +333,6 @@ class TestPanwAirsAPIIntegration:
     @pytest.mark.asyncio
     async def test_api_error_handling(self, handler):
         """Test API error handling (fail closed)."""
-        # Mock the HTTP client to raise an exception
         with patch(
             "litellm.proxy.guardrails.guardrail_hooks.panw_prisma_airs.panw_prisma_airs.get_async_httpx_client"
         ) as mock_client:
@@ -362,18 +342,14 @@ class TestPanwAirsAPIIntegration:
 
             result = await handler._call_panw_api("test content")
 
-            # Should fail closed (block) when API is unavailable
             assert result["action"] == "block"
             assert result["category"] == "api_error"
 
     @pytest.mark.asyncio
     async def test_invalid_api_response_handling(self, handler):
         """Test handling of invalid API responses."""
-        # Mock HTTP client to return invalid response (missing "action" field)
         mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "invalid": "response"
-        }  # Missing "action" field
+        mock_response.json.return_value = {"invalid": "response"}
         mock_response.raise_for_status.return_value = None
 
         with patch(
@@ -385,7 +361,6 @@ class TestPanwAirsAPIIntegration:
 
             result = await handler._call_panw_api("test content")
 
-            # Should fail closed (block) when API response is invalid
             assert result["action"] == "block"
             assert result["category"] == "api_error"
 
@@ -396,7 +371,6 @@ class TestPanwAirsAPIIntegration:
             content="", is_response=False, metadata={"user": "test", "model": "gpt-3.5"}
         )
 
-        # Should allow empty content without API call
         assert result["action"] == "allow"
         assert result["category"] == "empty"
 
@@ -413,13 +387,13 @@ class TestPanwAirsConfiguration:
             mode="pre_call",
             api_key="test_key",
             profile_name="test_profile",
-            api_base=None,  # No api_base provided
+            api_base=None,
             default_on=True,
         )
         guardrail_config = {"guardrail_name": "test"}
 
         with patch("litellm.logging_callback_manager.add_litellm_callback"):
-            handler = initialize_guardrail(litellm_params, guardrail_config)
+            handler = initialize_guardrail(litellm_params, guardrail_config)  
 
         assert handler.api_base == "https://service.api.aisecurity.paloaltonetworks.com"
 
@@ -439,7 +413,7 @@ class TestPanwAirsConfiguration:
         guardrail_config = {"guardrail_name": "test"}
 
         with patch("litellm.logging_callback_manager.add_litellm_callback"):
-            handler = initialize_guardrail(litellm_params, guardrail_config)
+            handler = initialize_guardrail(litellm_params, guardrail_config)  
 
         assert handler.api_base == custom_base
 
@@ -455,16 +429,464 @@ class TestPanwAirsConfiguration:
             api_base=None,
             default_on=True,
         )
-        guardrail_config = {
-            "guardrail_name": "test_guardrail",
-        }  # No guardrail_name
+        guardrail_config = {"guardrail_name": "test_guardrail"}
 
         with patch("litellm.logging_callback_manager.add_litellm_callback"):
-            handler = initialize_guardrail(litellm_params, guardrail_config)
+            handler = initialize_guardrail(litellm_params, guardrail_config)   
 
         assert handler.guardrail_name == "test_guardrail"
 
 
+class TestPanwAirsMaskingFunctionality:
+    """Test content masking features."""
+
+    def test_mask_on_block_backwards_compatibility(self):
+        """Test that mask_on_block enables both request and response masking."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_on_block=True,  # Should enable both masking flags
+        )
+
+        # Verify both masking flags are enabled
+        assert handler.mask_on_block is True
+        assert handler.mask_request_content is True
+        assert handler.mask_response_content is True
+
+    def test_mask_on_block_overrides_individual_flags(self):
+        """Test that mask_on_block=True overrides individual masking flags."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_on_block=True,
+            mask_request_content=False,  # Should be overridden
+            mask_response_content=False,  # Should be overridden
+        )
+
+        # mask_on_block should take precedence
+        assert handler.mask_on_block is True
+        assert handler.mask_request_content is True
+        assert handler.mask_response_content is True
+
+    @pytest.mark.asyncio
+    async def test_prompt_masking_on_block(self):
+        """Test that prompts are masked instead of blocked when mask_request_content=True."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_request_content=True,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth()
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "Sensitive content"}],
+        }
+
+        mock_response = {
+            "action": "block",
+            "category": "sensitive",
+            "prompt_masked_data": {"data": "XXXXXXXXX content"},
+        }
+
+        with patch.object(handler, "_call_panw_api", return_value=mock_response):
+            result = await handler.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=None,
+                data=data,
+                call_type="completion",
+            )
+
+        assert result is None
+        assert data["messages"][0]["content"] == "XXXXXXXXX content"
+
+    @pytest.mark.asyncio
+    async def test_prompt_masking_with_content_list(self):
+        """Test that content lists are properly masked when mask_request_content=True."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_request_content=True,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth()
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "My SSN is 123-45-6789"},
+                    {"type": "image", "url": "data:image/jpeg;base64,abc123"}
+                ]
+            }],
+        }
+
+        mock_response = {
+            "action": "block",
+            "category": "sensitive_data",
+            "prompt_masked_data": {"data": "My SSN is XXXXXXXXXX"},
+        }
+
+        with patch.object(handler, "_call_panw_api", return_value=mock_response):
+            result = await handler.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=None,
+                data=data,
+                call_type="completion",
+            )
+
+        # Verify masking was applied to text content
+        assert result is None
+        assert isinstance(data["messages"][0]["content"], list)
+        assert data["messages"][0]["content"][0]["type"] == "text"
+        assert data["messages"][0]["content"][0]["text"] == "My SSN is XXXXXXXXXX"
+        # Image should remain unchanged
+        assert data["messages"][0]["content"][1]["type"] == "image"
+        assert data["messages"][0]["content"][1]["url"] == "data:image/jpeg;base64,abc123"
+
+    @pytest.mark.asyncio
+    async def test_response_masking_on_block(self):
+        """Test that responses are masked instead of blocked when mask_response_content=True."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_response_content=True,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth()
+        data = {"model": "gpt-3.5-turbo"}
+        response = ModelResponse(
+            id="test_id",
+            choices=[
+                Choices(
+                    index=0,
+                    message=Message(role="assistant", content="Sensitive response"),
+                )
+            ],
+            model="gpt-3.5-turbo",
+        )
+
+        mock_response = {
+            "action": "block",
+            "category": "sensitive",
+            "response_masked_data": {"data": "XXXXXXXXX response"},
+        }
+
+        with patch.object(handler, "_call_panw_api", return_value=mock_response):
+            result = await handler.async_post_call_success_hook(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                response=response,
+            )
+
+        assert result.choices[0].message.content == "XXXXXXXXX response"
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_on_api_error(self):
+        """Test fail-closed behavior on API errors (guardrail blocks on scan failures)."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth()
+        data = {
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": "Test content"}],
+        }
+
+        with patch.object(handler, "_call_panw_api", side_effect=Exception("API Error")):
+            with pytest.raises(HTTPException) as exc_info:
+                await handler.async_pre_call_hook(
+                    user_api_key_dict=user_api_key_dict,
+                    cache=None,
+                    data=data,
+                    call_type="completion",
+                )
+
+        assert exc_info.value.status_code == 500
+        assert "Security scan failed" in str(exc_info.value.detail)
+
+
+class TestPanwAirsAdvancedFeatures:
+    """Test advanced features: multi-choice, tool calls, streaming observability."""
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_response_extraction(self):
+        """Test extraction of text from responses with multiple choices."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+        )
+
+        # Create multi-choice response
+        response = ModelResponse(
+            id="test_id",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="First choice content", role="assistant"),
+                ),
+                Choices(
+                    finish_reason="stop",
+                    index=1,
+                    message=Message(content="Second choice content", role="assistant"),
+                ),
+            ],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+        )
+
+        extracted_text = handler._extract_response_text(response)
+        assert "First choice content" in extracted_text
+        assert "Second choice content" in extracted_text
+
+    @pytest.mark.asyncio
+    async def test_tool_call_extraction(self):
+        """Test extraction of text from responses with tool calls."""
+        from litellm.types.utils import ChatCompletionMessageToolCall, Function
+        
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+        )
+
+        # Create a proper ModelResponse with tool calls
+        response = ModelResponse(
+            id="test_id",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_123",
+                                type="function",
+                                function=Function(
+                                    name="get_weather",
+                                    arguments='{"location": "San Francisco", "ssn": "123-45-6789"}'
+                                )
+                            )
+                        ]
+                    ),
+                ),
+            ],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+        )
+
+        extracted_text = handler._extract_response_text(response)
+        assert "123-45-6789" in extracted_text
+        assert "San Francisco" in extracted_text
+
+    @pytest.mark.asyncio
+    async def test_tool_call_masking(self):
+        """Test masking of tool call arguments when blocked."""
+        from litellm.types.utils import ChatCompletionMessageToolCall, Function
+        
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_response_content=True,
+        )
+
+        # Create a proper ModelResponse with tool calls
+        response = ModelResponse(
+            id="test_id",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_123",
+                                type="function",
+                                function=Function(
+                                    name="get_weather",
+                                    arguments='{"location": "San Francisco", "ssn": "123-45-6789"}'
+                                )
+                            )
+                        ]
+                    ),
+                ),
+            ],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+        )
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        data = {"messages": [{"role": "user", "content": "test"}], "model": "gpt-4"}
+
+        # Mock PANW API to return block with masking
+        mock_scan_result = {
+            "action": "block",
+            "category": "sensitive_data",
+            "response_masked_data": {
+                "data": '{"location": "San Francisco", "ssn": "XXXXXXXXXX"}'
+            }
+        }
+
+        with patch.object(handler, "_call_panw_api", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_scan_result
+            
+            result = await handler.async_post_call_success_hook(
+                user_api_key_dict=user_api_key_dict, response=response, data=data
+            )
+
+            # Verify arguments were masked
+            assert result.choices[0].message.tool_calls[0].function.arguments == '{"location": "San Francisco", "ssn": "XXXXXXXXXX"}'
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_masking(self):
+        """Test masking applied to all choices in multi-choice response."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+            mask_response_content=True,
+        )
+
+        # Create multi-choice response
+        response = ModelResponse(
+            id="test_id",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="SSN is 123-45-6789", role="assistant"),
+                ),
+                Choices(
+                    finish_reason="stop",
+                    index=1,
+                    message=Message(content="Another SSN: 987-65-4321", role="assistant"),
+                ),
+            ],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+        )
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        data = {"messages": [{"role": "user", "content": "test"}], "model": "gpt-4"}
+
+        mock_scan_result = {
+            "action": "block",
+            "category": "sensitive_data",
+            "response_masked_data": {"data": "SSN is XXXXXXXXXX"}
+        }
+
+        with patch.object(handler, "_call_panw_api", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = mock_scan_result
+            
+            result = await handler.async_post_call_success_hook(
+                user_api_key_dict=user_api_key_dict, response=response, data=data
+            )
+
+            # Verify all choices were masked
+            assert result.choices[0].message.content == "SSN is XXXXXXXXXX"
+            assert result.choices[1].message.content == "SSN is XXXXXXXXXX"
+
+    @pytest.mark.asyncio
+    async def test_streaming_hook_adds_guardrail_header(self):
+        """Test that streaming hook adds guardrail to applied guardrails header."""
+        handler = PanwPrismaAirsHandler(
+            guardrail_name="test_panw_airs",
+            api_key="test_api_key",
+            api_base="https://test.panw.com/api",
+            profile_name="test_profile",
+            default_on=True,
+        )
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="test_key")
+        request_data = {
+            "messages": [{"role": "user", "content": "test"}],
+            "model": "gpt-4"
+        }
+
+        # Create mock streaming chunks
+        from litellm.types.utils import StreamingChoices, Delta
+        
+        mock_chunks = [
+            ModelResponse(
+                id="test_id",
+                choices=[StreamingChoices(delta=Delta(content="Hello", role="assistant"), finish_reason=None, index=0)],
+                created=1234567890,
+                model="gpt-4",
+                object="chat.completion.chunk",
+            ),
+            ModelResponse(
+                id="test_id",
+                choices=[StreamingChoices(delta=Delta(content=" world", role="assistant"), finish_reason="stop", index=0)],
+                created=1234567890,
+                model="gpt-4",
+                object="chat.completion.chunk",
+            ),
+        ]
+
+        async def mock_response_iter():
+            for chunk in mock_chunks:
+                yield chunk
+
+        mock_scan_result = {"action": "allow", "category": "safe"}
+
+        with patch.object(handler, "_call_panw_api", new_callable=AsyncMock) as mock_api:
+            with patch("litellm.proxy.common_utils.callback_utils.add_guardrail_to_applied_guardrails_header") as mock_header:
+                mock_api.return_value = mock_scan_result
+                
+                chunks_received = []
+                async for chunk in handler.async_post_call_streaming_iterator_hook(
+                    user_api_key_dict=user_api_key_dict,
+                    response=mock_response_iter(),
+                    request_data=request_data,
+                ):
+                    chunks_received.append(chunk)
+
+                # Verify header function was called
+                assert mock_header.called
+                mock_header.assert_called_once_with(
+                    request_data=request_data, 
+                    guardrail_name="test_panw_airs"
+                )
+
+
 if __name__ == "__main__":
-    # Run tests
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Title

Add content masking with streaming support to PANW Prisma AIRS guardrail

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem, masking with streaming support


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
📖 Documentation
✅ Test
🐛 Bug Fix


## Changes

### Features Added
- **Content masking parameters**: `mask_request_content`, `mask_response_content`, and backwards-compatible `mask_on_block`
- **Streaming support**: Real-time response scanning and masking via `async_post_call_streaming_iterator_hook`
- **Text completion support**: Handles both chat (`messages`) and text completion (`prompt`) request formats

## Fixes

- Environment variable fallback: Made api_key/api_base optional to properly support PANW_PRISMA_AIRS_API_KEY env var 

### Testing
- **31 comprehensive tests** covering initialization, masking, streaming, tool calls, multi-choice responses, text completion, and error handling
- All tests passing ✅
<img width="870" height="427" alt="Screenshot 2025-10-17 at 12 00 56 PM" src="https://github.com/user-attachments/assets/e90a5a92-c664-49ae-ad46-93b174c3d0ef" />

