### PR TITLE
[Fix] GPT-OSS in Bedrock now supports streaming. Revert fake streaming

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1439,11 +1439,6 @@ class AmazonConverseConfig(BaseConfig):
         if stream is True:
             if model is not None:
                 ###################################################################
-                # GPT-OSS models do not support streaming
-                ###################################################################
-                if "gpt-oss" in model:
-                    return True
-                ###################################################################
                 # AI21 models do not support streaming
                 ###################################################################
                 if "ai21" in model:

--- a/tests/llm_translation/test_bedrock_gpt_oss.py
+++ b/tests/llm_translation/test_bedrock_gpt_oss.py
@@ -13,7 +13,6 @@ from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConf
 
 class TestBedrockGPTOSS(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
-        litellm._turn_on_debug()
         return {
             "model": "bedrock/converse/openai.gpt-oss-20b-1:0",
         }


### PR DESCRIPTION
## [Fix] GPT-OSS in Bedrock now supports streaming. Revert fake streaming

Bedrock now supports streaming with gpt-oss 

Fixes https://github.com/BerriAI/litellm/issues/15649

<img width="1728" height="718" alt="Screenshot 2025-10-17 at 11 18 36 AM" src="https://github.com/user-attachments/assets/d659c3cf-282c-4b56-8678-83822e777828" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


