### PR TITLE
[Fix] UI - Key Max Budget Removal Error Fix

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -43,6 +43,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { copyToClipboard as utilCopyToClipboard } from "../../utils/dataUtils";
 import NotificationsManager from "../molecules/notifications_manager";
 import PassThroughRoutesSelector from "../common_components/PassThroughRoutesSelector";
+import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 
 export interface TeamMembership {
   user_id: string;
@@ -323,6 +324,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         },
         organization_id: values.organization_id,
       };
+
+      updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);
 
       if (values.team_member_budget !== undefined) {
         updateData.team_member_budget = Number(values.team_member_budget);

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -16,6 +16,7 @@ import { CopyIcon, CheckIcon } from "lucide-react";
 import { mapInternalToDisplayNames, mapDisplayToInternalNames } from "../callback_info_helpers";
 import { parseErrorMessage } from "../shared/errorUtils";
 import AutoRotationView from "../common_components/AutoRotationView";
+import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -106,6 +107,9 @@ export default function KeyInfoView({
         delete formValues.guardrails;
         delete formValues.prompts;
       }
+
+      // Handle max budget empty string
+      formValues.max_budget = mapEmptyStringToNull(formValues.max_budget);
 
       // Handle object_permission updates
       if (formValues.vector_stores !== undefined) {
@@ -630,7 +634,8 @@ export default function KeyInfoView({
                   <div>
                     <Text className="font-medium">Allowed Pass Through Routes</Text>
                     <Text>
-                      {Array.isArray(currentKeyData.metadata?.allowed_passthrough_routes) && currentKeyData.metadata.allowed_passthrough_routes.length > 0
+                      {Array.isArray(currentKeyData.metadata?.allowed_passthrough_routes) &&
+                      currentKeyData.metadata.allowed_passthrough_routes.length > 0
                         ? currentKeyData.metadata.allowed_passthrough_routes.map((route, index) => (
                             <span key={index} className="px-2 mr-2 py-1 bg-blue-100 rounded text-xs">
                               {route}

--- a/ui/litellm-dashboard/src/utils/keyUpdateUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/keyUpdateUtils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { mapEmptyStringToNull } from "./keyUpdateUtils";
+
+describe("keyUpdateUtils", () => {
+  it("should map empty string to null", () => {
+    expect(mapEmptyStringToNull("")).toBeNull();
+  });
+
+  it("should return the original string otherwise", () => {
+    expect(mapEmptyStringToNull("500")).toBe("500");
+  });
+});

--- a/ui/litellm-dashboard/src/utils/keyUpdateUtils.ts
+++ b/ui/litellm-dashboard/src/utils/keyUpdateUtils.ts
@@ -1,0 +1,7 @@
+export function mapEmptyStringToNull(input: string): string | null {
+  if (input === "") {
+    return null;
+  }
+
+  return input;
+}


### PR DESCRIPTION
## [Fix] UI - Key Max Budget Removal Error Fix
## Relevant issues

Previously, removing the Max Budget on a key and saving will result in an error. This fixes the error, allowing users to remove the max budget from their key settings.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes

## Screenshots
<img width="1512" height="982" alt="Screenshot 2025-10-17 at 12 10 43 PM" src="https://github.com/user-attachments/assets/0c2faed7-975c-4c12-840f-dd04671c8793" />

<img width="1512" height="982" alt="Screenshot 2025-10-17 at 12 12 26 PM" src="https://github.com/user-attachments/assets/5b7b3cdc-652e-489e-9fbd-11ac4d49f34a" />


