### PR TITLE
fix: Add pre and post call for list batches

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -369,7 +369,13 @@ async def list_batches(
 
     ```
     """
-    from litellm.proxy.proxy_server import llm_router, proxy_logging_obj, version
+    from litellm.proxy.proxy_server import (
+        llm_router,
+        proxy_logging_obj,
+        version,
+        general_settings,
+        proxy_config,
+    )
 
     verbose_proxy_logger.debug("GET /v1/batches after={} limit={}".format(after, limit))
     try:
@@ -379,8 +385,23 @@ async def list_batches(
                 detail={"error": CommonProxyErrors.no_llm_router.value},
             )
 
-        ## check for target model names
+        # Include original request and headers in the data
         data = await _read_request_body(request=request)
+        base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
+        (
+            data,
+            litellm_logging_obj,
+        ) = await base_llm_response_processor.common_processing_pre_call_logic(
+            request=request,
+            general_settings=general_settings,
+            user_api_key_dict=user_api_key_dict,
+            version=version,
+            proxy_logging_obj=proxy_logging_obj,
+            proxy_config=proxy_config,
+            route_type="alist_batches",
+        )
+
+        ## check for target model names
         target_model_names = target_model_names or data.get("target_model_names", None)
         if target_model_names:
             model = target_model_names.split(",")[0]
@@ -388,6 +409,7 @@ async def list_batches(
                 model=model,
                 after=after,
                 limit=limit,
+                **data,
             )
         else:
             custom_llm_provider = (
@@ -399,7 +421,15 @@ async def list_batches(
                 custom_llm_provider=custom_llm_provider,  # type: ignore
                 after=after,
                 limit=limit,
+                **data,
             )
+
+        ## POST CALL HOOKS ###
+        _response = await proxy_logging_obj.post_call_success_hook(
+            data=data, user_api_key_dict=user_api_key_dict, response=response
+        )
+        if _response is not None and type(response) == type(_response):
+            response = _response
 
         ### RESPONSE HEADERS ###
         hidden_params = getattr(response, "_hidden_params", {}) or {}

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -295,6 +295,7 @@ class ProxyBaseLLMRequestProcessing:
             "acancel_responses",
             "acreate_batch",
             "aretrieve_batch",
+            "alist_batches",
             "afile_content",
             "atext_completion",
             "acreate_fine_tuning_job",


### PR DESCRIPTION
## Title

fix: Add pre and post call for list batches

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- ✅I have added a screenshot of my new test passing locally 
- ✅ My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- ✅ My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

The list_batches (get /batches) wasn't calling the async_pre_call_hook and async_post_call_success_hook. This was causing some problems for clients that have these two functions implemented. To solve this we basically add the functions
- common_processing_pre_call_logic
- post_call_success_hook
Both are following the logic of list_files (get /files) endpoint.

Please, ignore the others erros but note that we don't have a display message for
- `"######### async_post_call_success_hook #########"`
or
- `"######### async_pre_call_hook #########"`
<img width="1265" height="358" alt="Screenshot 2025-10-17 at 16 20 27" src="https://github.com/user-attachments/assets/6e7b3c15-e2fc-481c-8c56-c567ea321d4a" />

In the print bellow both functions are called
<img width="1265" height="358" alt="Screenshot 2025-10-17 at 16 29 17" src="https://github.com/user-attachments/assets/0c2fe995-1d47-4bfe-8783-08affb86f97d" />

**Tests**
<img width="1265" height="358" alt="Screenshot 2025-10-17 at 16 42 25" src="https://github.com/user-attachments/assets/1ce1ff3c-30b3-40f4-a20c-7e3752cca2c6" />
<img width="1265" height="358" alt="Screenshot 2025-10-17 at 16 43 33" src="https://github.com/user-attachments/assets/1acf9675-30e9-440f-8799-4809d5b9902e" />
