### PR TITLE
fix: add missing context to benchmark docs

### DIFF
--- a/docs/my-website/docs/benchmarks.md
+++ b/docs/my-website/docs/benchmarks.md
@@ -55,6 +55,10 @@ Each machine deploying LiteLLM had the following specs:
 - 4 CPU
 - 8GB RAM
 
+## Configuration
+
+- Database: PostgreSQL
+- Redis: Not used
 
 ## Locust Settings
 


### PR DESCRIPTION
## Title

fix: add missing context to benchmark docs

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

- Clarified that these benchmarks used the database only, not Redis.
