### PR TITLE
(Bug) Fix JSON serialization error in Helicone logging by removing OpenTelemetry span from metadata

### DIFF
--- a/litellm/integrations/helicone.py
+++ b/litellm/integrations/helicone.py
@@ -100,6 +100,11 @@ class HeliconeLogger:
         for header_key in proxy_headers:
             if header_key.startswith("helicone_"):
                 metadata[header_key] = proxy_headers.get(header_key)
+        
+        # Remove OpenTelemetry span from metadata as it's not JSON serializable
+        # The span is used internally for tracing but shouldn't be logged to external services
+        if "litellm_parent_otel_span" in metadata:
+            metadata.pop("litellm_parent_otel_span")
 
         return metadata
 

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -123,3 +123,42 @@ async def test_helicone_logging_metadata():
     print(response)
 
     time.sleep(3)
+
+
+def test_helicone_removes_otel_span_from_metadata():
+    """
+    Test that HeliconeLogger removes litellm_parent_otel_span from metadata
+    to prevent JSON serialization errors.
+    """
+    from litellm.integrations.helicone import HeliconeLogger
+    from unittest.mock import MagicMock
+    
+    # Create a mock span object (similar to what OpenTelemetry would create)
+    mock_span = MagicMock()
+    mock_span.__class__.__name__ = "_Span"
+    
+    # Create metadata with the problematic span object
+    metadata = {
+        "user_id": "test_user",
+        "request_id": "test_request_123",
+        "litellm_parent_otel_span": mock_span,  # This would cause JSON serialization error
+        "other_metadata": "some_value"
+    }
+    
+    # Create HeliconeLogger instance
+    logger = HeliconeLogger()
+    
+    # Test the add_metadata_from_header method
+    litellm_params = {"proxy_server_request": {"headers": {}}}
+    result_metadata = logger.add_metadata_from_header(litellm_params, metadata)
+    
+    # Verify that litellm_parent_otel_span was removed
+    assert "litellm_parent_otel_span" not in result_metadata
+    assert "user_id" in result_metadata
+    assert "request_id" in result_metadata
+    assert "other_metadata" in result_metadata
+    assert result_metadata["user_id"] == "test_user"
+    assert result_metadata["request_id"] == "test_request_123"
+    assert result_metadata["other_metadata"] == "some_value"
+    
+    print("✅ Test passed: litellm_parent_otel_span was successfully removed from metadata")


### PR DESCRIPTION
## Title

Fix JSON serialization error in Helicone logging by removing OpenTelemetry span from metadata

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem**: Helicone logging fails with `TypeError: Object of type _Span is not JSON serializable` when OpenTelemetry tracing is enabled, because `litellm_parent_otel_span` objects in metadata cannot be serialized to JSON.

**Solution**: Remove `litellm_parent_otel_span` from metadata before logging to Helicone, following the same pattern used in `core_helpers.py`.

**Files Changed**:
- `litellm/integrations/helicone.py`: Added 1 line to remove the problematic span object
- `litellm/tests/local_testing/test_helicone_integration.py`: Added test to verify span removal

**Code Change**:
```python
# Remove OpenTelemetry span from metadata as it's not JSON serializable
if "litellm_parent_otel_span" in metadata:
    metadata.pop("litellm_parent_otel_span")
```

**Test**: Added `test_helicone_removes_otel_span_from_metadata()` to verify the fix works correctly and prevents JSON serialization errors.

<img width="1207" height="709" alt="image" src="https://github.com/user-attachments/assets/29177cce-9ef7-4d6e-8c92-1bce122cc6a1" />
