### PR TITLE
fix the wrong request body in json mode doc

### DIFF
--- a/docs/my-website/docs/completion/json_mode.md
+++ b/docs/my-website/docs/completion/json_mode.md
@@ -309,33 +309,30 @@ curl http://0.0.0.0:4000/v1/chat/completions \
         {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
     ],
     "response_format": { 
-        "type": "json_object",
-        "response_schema": { 
-            "type": "json_schema",
-            "json_schema": {
-              "name": "math_reasoning",
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "steps": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "explanation": { "type": "string" },
-                        "output": { "type": "string" }
-                      },
-                      "required": ["explanation", "output"],
-                      "additionalProperties": false
-                    }
+        "type": "json_schema",
+        "json_schema": {
+          "name": "math_reasoning",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "steps": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "explanation": { "type": "string" },
+                    "output": { "type": "string" }
                   },
-                  "final_answer": { "type": "string" }
-                },
-                "required": ["steps", "final_answer"],
-                "additionalProperties": false
+                  "required": ["explanation", "output"],
+                  "additionalProperties": false
+                }
               },
-              "strict": true
+              "final_answer": { "type": "string" }
             },
+            "required": ["steps", "final_answer"],
+            "additionalProperties": false
+          },
+          "strict": true
         }
     },
   }'


### PR DESCRIPTION
## Title

Fix incorrect response_format documentation with response_schema parameter

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

**Problem:**
The documentation incorrectly shows `response_schema` as a parameter within `response_format`, which is not a valid OpenAI API format. This causes confusion and errors when users try to use the documented format.

**Root Cause:**
Multiple documentation files show the incorrect format:
```json
{
  "response_format": {
    "type": "json_object",
    "response_schema": { ... }
  }
}
```

**Solution:**
Updated documentation to show the correct OpenAI API format:
```json
{
  "response_format": {
    "type": "json_schema", 
    "json_schema": { ... }
  }
}
```

**Note:** 
The `response_schema` parameter is not a valid OpenAI API parameter. The correct approach is to use `json_schema` directly within `response_format` with `type: "json_schema"`.