### PR TITLE
Add grounding info to responses API

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -54,7 +54,6 @@ from litellm.types.llms.openai import (
     ImageURLListItem,
     ImageURLObject,
     OpenAIChatCompletionFinishReason,
-    ChatCompletionAnnotation
 )
 from litellm.types.llms.vertex_ai import (
     VERTEX_CREDENTIALS_TYPES,
@@ -1386,14 +1385,12 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         "url": web_data.get("uri", ""),
                         "title": web_data.get("title", ""),
                     }
-                    print(f"[VERTEX_ANNOTATION_DEBUG] Chunk {idx} -> URL: {web_data.get('uri', '')}, Title: {web_data.get('title', '')}")
 
             # Process each grounding support to create annotations
             for support in grounding_supports:
                 segment = support.get("segment", {})
                 start_index = segment.get("startIndex")
                 end_index = segment.get("endIndex")
-                text = segment.get("text", "")
                 
                 # Get the chunk indices for this support
                 chunk_indices = support.get("groundingChunkIndices", [])
@@ -1417,7 +1414,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         return annotations
 
     @staticmethod
-    def _process_candidates(
+    def _process_candidates(  # noqa: PLR0915
         _candidates: List[Candidates],
         model_response: Union[ModelResponse, "ModelResponseStream"],
         standard_optional_params: dict,

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -46,6 +46,8 @@ from litellm.types.llms.anthropic import AnthropicThinkingParam
 from litellm.types.llms.gemini import BidiGenerateContentServerMessage
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAnnotation,
+    ChatCompletionAnnotationURLCitation,
     ChatCompletionResponseMessage,
     ChatCompletionThinkingBlock,
     ChatCompletionToolCallChunk,
@@ -1363,12 +1365,12 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _convert_grounding_metadata_to_annotations(
         grounding_metadata: List[dict],
         content_text: Optional[str],
-    ) -> List[Dict[str, Any]]:
+    ) -> List[ChatCompletionAnnotation]:
         """
         Convert Vertex AI grounding metadata to OpenAI-style annotations.
         """
 
-        annotations: List[Dict[str, Any]] = []
+        annotations: List[ChatCompletionAnnotation] = []
 
         
         for metadata in grounding_metadata:
@@ -1401,14 +1403,16 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     if first_chunk_idx in chunk_to_uri_map:
                         uri_info = chunk_to_uri_map[first_chunk_idx]
                         
-                        annotation: Dict[str, Any] = {
+                        url_citation: ChatCompletionAnnotationURLCitation = {
+                            "start_index": start_index,
+                            "end_index": end_index,
+                            "url": uri_info["url"],
+                            "title": uri_info["title"],
+                        }
+                        
+                        annotation: ChatCompletionAnnotation = {
                             "type": "url_citation",
-                            "url_citation": {
-                                "start_index": start_index,
-                                "end_index": end_index,
-                                "url": uri_info["url"],
-                                "title": uri_info["title"],
-                            }
+                            "url_citation": url_citation,
                         }
                         annotations.append(annotation)
         return annotations

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6258,6 +6258,18 @@ def stream_chunk_builder(  # noqa: PLR0915
                 processor.get_combined_reasoning_content(reasoning_chunks)
             )
 
+        annotation_chunks = [
+            chunk
+            for chunk in chunks
+            if len(chunk["choices"]) > 0
+            and "annotations" in chunk["choices"][0]["delta"]
+            and chunk["choices"][0]["delta"]["annotations"] is not None
+        ]
+
+        if len(annotation_chunks) > 0:
+            annotations = annotation_chunks[0]["choices"][0]["delta"]["annotations"]
+            response["choices"][0]["message"]["annotations"] = annotations
+
         audio_chunks = [
             chunk
             for chunk in chunks

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -464,7 +464,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         # This happens when the current chunk has no text/reasoning content
         if hasattr(self, '_pending_annotation_events') and self._pending_annotation_events:
             event = self._pending_annotation_events.pop(0)
-            print(f"[STREAMING_ANNOTATION_DEBUG] Emitting queued annotation event, {len(self._pending_annotation_events)} remaining")
             return event
 
         return None

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -29,6 +29,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
     ResponsesAPIStreamingResponse,
+    OutputTextAnnotationAddedEvent
 )
 from litellm.types.utils import Delta as ChatCompletionDelta
 from litellm.types.utils import (
@@ -73,6 +74,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.sent_output_text_done_event: bool = False
         self.sent_output_content_part_done_event: bool = False
         self.sent_output_item_done_event: bool = False
+        self.sent_annotation_events: bool = False
         self.litellm_model_response: Optional[
             Union[ModelResponse, TextCompletionResponse]
         ] = None
@@ -201,6 +203,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         text = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
         reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""  # type: ignore
+        annotations = getattr(litellm_complete_object.choices[0].message, "annotations", None)  # type: ignore
 
         part: Optional[PART_UNION_TYPES] = None
         if reasoning_content:
@@ -210,10 +213,13 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             )
 
         else:
+            response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+                annotations=annotations
+            )
             part = ContentPartDonePartOutputText(
                 type="output_text",
                 text=text,
-                annotations=[],
+                annotations=response_annotations,
                 logprobs=None,
             )
 
@@ -229,6 +235,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self, litellm_complete_object: ModelResponse
     ) -> OutputItemDoneEvent:
         text = self.litellm_model_response.choices[0].message.content or ""  # type: ignore
+        annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)  # type: ignore
+
+        response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+            annotations=annotations
+        )
         return OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
             output_index=0,
@@ -243,7 +254,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         {
                             "type": "output_text",
                             "text": text,
-                            "annotations": [],
+                            "annotations": response_annotations,
                         }
                     ],
                 }
@@ -397,7 +408,33 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         This currently handles emitting the OutputTextDeltaEvent, which is used by other tools using the responses API
         and the ReasoningSummaryTextDeltaEvent, which is used by the responses API to emit reasoning content.
+        It also handles emitting annotation.added events when annotations are detected in the chunk.
         """
+        # Check if this chunk has annotations first (before processing text/reasoning)
+        # This ensures we detect and queue annotation events from the annotation chunk
+        if chunk.choices and hasattr(chunk.choices[0].delta, "annotations"):
+            annotations = chunk.choices[0].delta.annotations
+            if annotations and self.sent_annotation_events is False:
+                self.sent_annotation_events = True
+                # Store annotation events to emit them one by one
+                if not hasattr(self, '_pending_annotation_events'):
+                    
+                    response_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+                        annotations=annotations
+                    )                    
+                    self._pending_annotation_events = []
+                    for idx, annotation in enumerate(response_annotations):
+                        annotation_dict = annotation.model_dump() if hasattr(annotation, 'model_dump') else dict(annotation)
+                        event = OutputTextAnnotationAddedEvent(
+                            type=ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED,
+                            item_id=chunk.id,
+                            output_index=0,
+                            content_index=0,
+                            annotation_index=idx,
+                            annotation=annotation_dict,
+                        )
+                        self._pending_annotation_events.append(event)        
+        # Priority 1: Handle reasoning content (highest priority)
         if (
             chunk.choices
             and hasattr(chunk.choices[0].delta, "reasoning_content")
@@ -411,16 +448,24 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 output_index=0,
                 delta=reasoning_content,
             )
-        else:
-            delta_content = self._get_delta_string_from_streaming_choices(chunk.choices)
-            if delta_content:
-                return OutputTextDeltaEvent(
-                    type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA,
-                    item_id=chunk.id,
-                    output_index=0,
-                    content_index=0,
-                    delta=delta_content,
-                )
+        
+        # Priority 2: Handle text deltas
+        delta_content = self._get_delta_string_from_streaming_choices(chunk.choices)
+        if delta_content:
+            return OutputTextDeltaEvent(
+                type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA,
+                item_id=chunk.id,
+                output_index=0,
+                content_index=0,
+                delta=delta_content,
+            )
+        
+        # Priority 3: If we have pending annotation events, emit the next one
+        # This happens when the current chunk has no text/reasoning content
+        if hasattr(self, '_pending_annotation_events') and self._pending_annotation_events:
+            event = self._pending_annotation_events.pop(0)
+            print(f"[STREAMING_ANNOTATION_DEBUG] Emitting queued annotation event, {len(self._pending_annotation_events)} remaining")
+            return event
 
         return None
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -219,7 +219,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             part = ContentPartDonePartOutputText(
                 type="output_text",
                 text=text,
-                annotations=response_annotations,
+                annotations=response_annotations,  # type: ignore
                 logprobs=None,
             )
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -800,12 +800,15 @@ class LiteLLMCompletionResponsesConfig:
     def _transform_chat_message_to_response_output_text(
         message: Message,
     ) -> OutputText:
+        annotations = getattr(message, "annotations", None)
+        transformed_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+            annotations=annotations
+        )
+        
         return OutputText(
             type="output_text",
             text=message.content,
-            annotations=LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
-                annotations=getattr(message, "annotations", None)
-            ),
+            annotations=transformed_annotations,
         )
 
     @staticmethod


### PR DESCRIPTION
## Title

Add real-time annotation streaming support for Vertex AI Gemini

## Relevant issues

Fixes #14140
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

**Added real-time annotation streaming for Vertex AI Gemini to match OpenAI Responses API behavior:**

- **Streaming Iterator**: Modified `streaming_iterator.py` to emit `response.output_text.annotation.added` events in real-time when grounding metadata is detected in streaming chunks
- **Vertex AI Integration**: Enhanced `vertex_and_google_ai_studio_gemini.py` to convert grounding metadata to OpenAI-style annotations and include them in streaming deltas
- **Message Building**: Updated `main.py` to properly accumulate annotations in the final response
- **Transformation**: Enhanced `transformation.py` to handle annotation conversion for the Responses API

This ensures Vertex AI Gemini users get the same `response.output_text.annotation.added` events as OpenAI models when using the Responses API.

Streaming:
<img width="1056" height="789" alt="image" src="https://github.com/user-attachments/assets/75ec1578-2713-4db1-aa06-e24a0166af25" />

Non-streaming:
<img width="1206" height="709" alt="image" src="https://github.com/user-attachments/assets/17b8101c-5f43-46a6-b491-25d4ed31a3a0" />
