### PR TITLE
fix documentation for get batch req

### DIFF
--- a/docs/my-website/docs/providers/vertex_batch.md
+++ b/docs/my-website/docs/providers/vertex_batch.md
@@ -162,7 +162,7 @@ Check the status of your batch job. The batch will progress through states: `val
 ```python showLineNumbers title="retrieve_batch.py"
 retrieved_batch = oai_client.batches.retrieve(
     batch_id=create_batch_response.id, # Created batch id, e.g. 7814463557919047680
-    extra_body={"custom_llm_provider": "vertex_ai"}
+    extra_query={"custom_llm_provider": "vertex_ai"}
 )
 
 print(f"Batch status: {retrieved_batch.status}")


### PR DESCRIPTION
## Title

Fix documentation: Correct extra_body to extra_query for batch retrieve operations

## Relevant issues

<!-- Documentation incorrectly showed extra_body parameter for GET batch retrieve operations -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

### Documentation Fix
GET requests (like `retrieve_batch`) use query parameters (`extra_query`), while POST requests (like `create_batch`) use body parameters (`extra_body`)
- **Impact**: Prevents developers from using incorrect parameter names when retrieving batch information, avoiding potential API errors


Creating a new one because old one got messy - #15646