### PR TITLE
[Bug]: Fix Incorrect status value in responses api with gemini

### DIFF
--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1037,6 +1037,15 @@ class ResponseAPIUsage(BaseLiteLLMOpenAIResponseObject):
     model_config = {"extra": "allow"}
 
 
+ResponsesAPIStatus = Literal[
+    "completed", "failed", "in_progress", "cancelled", "queued", "incomplete"
+]
+"""
+The status of the response generation.
+One of: completed, failed, in_progress, cancelled, queued, or incomplete.
+"""
+
+
 class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     id: str
     created_at: int

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -266,7 +266,7 @@ class TestLiteLLMCompletionResponsesConfig:
 
         reasoning_item = reasoning_items[0]
         assert reasoning_item.id.startswith("rs_"), f"Expected ID to start with 'rs_', got: {reasoning_item.id}"
-        assert reasoning_item.status == "stop"
+        assert reasoning_item.status == "completed"
         assert reasoning_item.role == "assistant"
         assert len(reasoning_item.content) == 1
         assert reasoning_item.content[0].type == "output_text"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -369,7 +369,94 @@ class TestLiteLLMCompletionResponsesConfig:
         ]
         assert len(message_items) == 2, "Should have two message items"
 
+    def test_transform_chat_completion_response_status_with_stop(self):
+        """
+        Test that transforming a chat completion response with 'stop' finish_reason
+        results in 'completed' status in the responses API response.
+        
+        This is the main test case for GitHub issue #15714.
+        """
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="gemini-2.5-flash-preview-09-2025",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(
+                        content="That's completely fine! How can I help you with your test?",
+                        role="assistant",
+                    ),
+                )
+            ],
+        )
 
+        responses_api_response = (
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+                request_input="this is a test",
+                responses_api_request={},
+                chat_completion_response=chat_completion_response,
+            )
+        )
+
+        assert responses_api_response.status == "completed"
+        assert responses_api_response.status in [
+            "completed",
+            "failed",
+            "in_progress",
+            "cancelled",
+            "queued",
+            "incomplete",
+        ]
+
+    def test_transform_chat_completion_response_output_item_status(self):
+        """
+        Test that output items in the transformed response also have valid status values.
+        
+        This verifies the fix for GitHub issue #15714.
+        """
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="gemini-2.5-flash-preview-09-2025",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(
+                        content="Test message",
+                        role="assistant",
+                    ),
+                )
+            ],
+        )
+
+        responses_api_response = (
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+                request_input="this is a test",
+                responses_api_request={},
+                chat_completion_response=chat_completion_response,
+            )
+        )
+
+        message_items = [
+            item for item in responses_api_response.output if item.type == "message"
+        ]
+        assert len(message_items) > 0
+
+        for item in message_items:
+            assert item.status in [
+                "completed",
+                "failed",
+                "in_progress",
+                "cancelled",
+                "queued",
+                "incomplete",
+            ]
+            assert item.status != "stop"
 
 
 class TestFunctionCallTransformation:


### PR DESCRIPTION
## [Bug]: Fix Incorrect status value in responses api with gemini

fixes https://github.com/BerriAI/litellm/issues/15714 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


