### PR TITLE
feat(ollama): set 'think' to False when reasoning effort is minimal/none/disable

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -188,7 +188,7 @@ class OllamaChatConfig(BaseConfig):
                 if model.startswith("gpt-oss"):
                     optional_params["think"] = value
                 else:
-                    optional_params["think"] = True
+                    optional_params["think"] = value in {"low", "medium", "high"}
             ### FUNCTION CALLING LOGIC ###
             if param == "tools":
                 ## CHECK IF MODEL SUPPORTS TOOL CALLING ##

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -183,7 +183,7 @@ class OllamaConfig(BaseConfig):
                 if model.startswith("gpt-oss"):
                     optional_params["think"] = value
                 else:
-                    optional_params["think"] = True
+                    optional_params["think"] = value in {"low", "medium", "high"}
             elif param == "response_format" and isinstance(value, dict):
                 if value["type"] == "json_object":
                     optional_params["format"] = "json"


### PR DESCRIPTION
## Title

Support disable Ollama reasoning model thinking when using reasoning efforts that are not in "low" "medium" or "high"

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="995" height="114" alt="image" src="https://github.com/user-attachments/assets/be76c494-3e4d-4dd3-bc9c-3fe6ed988d3a" />

## Type

🆕 New Feature

## Changes

When user sends reasoning_effort like "none", "disable" or "minimal", `think` param will be set to `False` to disable thinking in Ollama.


