### PR TITLE
Add AWS us-gov-west-1 Claude 3.7 Sonnet costs

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4324,6 +4324,26 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-06
     },
+    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20240620-v1:0": {
+        "cache_creation_input_token_cost": 4.5e-06,
+        "cache_read_input_token_cost": 3.6e-07,
+        "input_cost_per_token": 3.6e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-05,
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4324,6 +4324,26 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-06
     },
+    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20240620-v1:0": {
+        "cache_creation_input_token_cost": 4.5e-06,
+        "cache_read_input_token_cost": 3.6e-07,
+        "input_cost_per_token": 3.6e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-05,
+        "supports_assistant_prefill": true,
+        "supports_computer_use": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",


### PR DESCRIPTION
## Title
Adds AWS `us-gov-west-1` Claude 3.7 Sonnet to the prices (i.e., `bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20240620-v1:0`)

## Relevant issues

Fixes #15508 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] ~~I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~ N/A
- [ ] ~~I have added a screenshot of my new test passing locally~~ N/A 
- [ ] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~ N/A
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

I updated this based on reviewing https://aws.amazon.com/bedrock/pricing/
 
<img width="1201" height="404" alt="image" src="https://github.com/user-attachments/assets/962f6a12-5c7e-4f55-b9a1-7c7e022ddeb3" />

