### PR TITLE
Add Qwen3 imported model support for AWS Bedrock

### DIFF
--- a/docs/my-website/docs/providers/bedrock.md
+++ b/docs/my-website/docs/providers/bedrock.md
@@ -7,7 +7,7 @@ ALL Bedrock models (Anthropic, Meta, Deepseek, Mistral, Amazon, etc.) are Suppor
 | Property | Details |
 |-------|-------|
 | Description | Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs). |
-| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1) |
+| Provider Route on LiteLLM | `bedrock/`, [`bedrock/converse/`](#set-converse--invoke-route), [`bedrock/invoke/`](#set-invoke-route), [`bedrock/converse_like/`](#calling-via-internal-proxy), [`bedrock/llama/`](#deepseek-not-r1), [`bedrock/deepseek_r1/`](#deepseek-r1), [`bedrock/qwen3/`](#qwen3-imported-models) |
 | Provider Doc | [Amazon Bedrock ↗](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) |
 | Supported OpenAI Endpoints | `/chat/completions`, `/completions`, `/embeddings`, `/images/generations` |
 | Rerank Endpoint | `/rerank` |
@@ -1734,7 +1734,69 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 </TabItem>
 </Tabs>
 
+### Qwen3 Imported Models
 
+| Property | Details |
+|----------|---------|
+| Provider Route | `bedrock/qwen3/{model_arn}` |
+| Provider Documentation | [Bedrock Imported Models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html), [Qwen3 Models](https://aws.amazon.com/about-aws/whats-new/2025/09/qwen3-models-fully-managed-amazon-bedrock/) |
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+response = completion(
+    model="bedrock/qwen3/arn:aws:bedrock:us-east-1:086734376398:imported-model/your-qwen3-model",  # bedrock/qwen3/{your-model-arn}
+    messages=[{"role": "user", "content": "Tell me a joke"}],
+    max_tokens=100,
+    temperature=0.7
+)
+```
+
+</TabItem>
+
+<TabItem value="proxy" label="Proxy">
+
+**1. Add to config**
+
+```yaml
+model_list:
+    - model_name: Qwen3-32B
+      litellm_params:
+        model: bedrock/qwen3/arn:aws:bedrock:us-east-1:086734376398:imported-model/your-qwen3-model
+
+```
+
+**2. Start proxy**
+
+```bash
+litellm --config /path/to/config.yaml
+
+# RUNNING at http://0.0.0.0:4000
+```
+
+**3. Test it!**
+
+```bash
+curl --location 'http://0.0.0.0:4000/chat/completions' \
+      --header 'Authorization: Bearer sk-1234' \
+      --header 'Content-Type: application/json' \
+      --data '{
+            "model": "Qwen3-32B", # 👈 the 'model_name' in config
+            "messages": [
+                {
+                "role": "user",
+                "content": "what llm are you"
+                }
+            ],
+        }'
+```
+
+</TabItem>
+</Tabs>
 
 ### OpenAI GPT OSS
 

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1138,6 +1138,9 @@ from .llms.bedrock.chat.invoke_transformations.amazon_ai21_transformation import
 from .llms.bedrock.chat.invoke_transformations.amazon_nova_transformation import (
     AmazonInvokeNovaConfig,
 )
+from .llms.bedrock.chat.invoke_transformations.amazon_qwen3_transformation import (
+    AmazonQwen3Config,
+)
 from .llms.bedrock.chat.invoke_transformations.anthropic_claude2_transformation import (
     AmazonAnthropicConfig,
 )

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -810,6 +810,7 @@ BEDROCK_INVOKE_PROVIDERS_LITERAL = Literal[
     "ai21",
     "nova",
     "deepseek_r1",
+    "qwen3",
 ]
 
 BEDROCK_EMBEDDING_PROVIDERS_LITERAL = Literal[

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen3_transformation.py
@@ -1,0 +1,209 @@
+"""
+Handles transforming requests for `bedrock/invoke/{qwen3} models`
+
+Inherits from `AmazonInvokeConfig`
+
+Qwen3 + Invoke API Tutorial: https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html
+"""
+
+from typing import List, Optional
+
+from litellm.llms.base_llm.chat.transformation import BaseConfig
+from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+    AmazonInvokeConfig,
+)
+
+
+class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
+    """
+    Config for sending `qwen3` requests to `/bedrock/invoke/`
+    
+    Reference: https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html
+    """
+
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    stop: Optional[List[str]] = None
+
+    def __init__(
+        self,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        stop: Optional[List[str]] = None,
+    ) -> None:
+        locals_ = locals().copy()
+        for key, value in locals_.items():
+            if key != "self" and value is not None:
+                setattr(self.__class__, key, value)
+        AmazonInvokeConfig.__init__(self)
+
+    def get_supported_openai_params(self, model: str) -> List:
+        return [
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "stop",
+            "stream",
+        ]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        for k, v in non_default_params.items():
+            if k == "max_tokens":
+                optional_params["max_tokens"] = v
+            if k == "temperature":
+                optional_params["temperature"] = v
+            if k == "top_p":
+                optional_params["top_p"] = v
+            if k == "top_k":
+                optional_params["top_k"] = v
+            if k == "stop":
+                optional_params["stop"] = v
+            if k == "stream":
+                optional_params["stream"] = v
+        return optional_params
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Transform OpenAI format to Qwen3 Bedrock invoke format
+        """
+        # Convert messages to prompt format
+        prompt = self._convert_messages_to_prompt(messages)
+        
+        # Build the request body
+        request_body = {
+            "prompt": prompt,
+        }
+        
+        # Add optional parameters
+        if "max_tokens" in optional_params:
+            request_body["max_gen_len"] = optional_params["max_tokens"]
+        if "temperature" in optional_params:
+            request_body["temperature"] = optional_params["temperature"]
+        if "top_p" in optional_params:
+            request_body["top_p"] = optional_params["top_p"]
+        if "top_k" in optional_params:
+            request_body["top_k"] = optional_params["top_k"]
+        if "stop" in optional_params:
+            request_body["stop"] = optional_params["stop"]
+            
+        return request_body
+
+    def _convert_messages_to_prompt(self, messages: List) -> str:
+        """
+        Convert OpenAI messages format to Qwen3 prompt format
+        Supports tool calls, multimodal content, and various message types
+        """
+        prompt_parts = []
+        
+        for message in messages:
+            role = message.get("role", "")
+            content = message.get("content", "")
+            tool_calls = message.get("tool_calls", [])
+            tool_call_id = message.get("tool_call_id", "")
+            
+            if role == "system":
+                prompt_parts.append(f"<|im_start|>system\n{content}<|im_end|>")
+            elif role == "user":
+                # Handle multimodal content
+                if isinstance(content, list):
+                    text_content = []
+                    for item in content:
+                        if item.get("type") == "text":
+                            text_content.append(item.get("text", ""))
+                        elif item.get("type") == "image_url":
+                            # For Qwen3, we can include image placeholders
+                            text_content.append("<|vision_start|><|image_pad|><|vision_end|>")
+                    content = "".join(text_content)
+                prompt_parts.append(f"<|im_start|>user\n{content}<|im_end|>")
+            elif role == "assistant":
+                if tool_calls:
+                    # Handle tool calls
+                    for tool_call in tool_calls:
+                        function_name = tool_call.get("function", {}).get("name", "")
+                        function_args = tool_call.get("function", {}).get("arguments", "")
+                        prompt_parts.append(f"<|im_start|>assistant\n<tool_call>\n{{\"name\": \"{function_name}\", \"arguments\": \"{function_args}\"}}\n</tool_call><|im_end|>")
+                else:
+                    prompt_parts.append(f"<|im_start|>assistant\n{content}<|im_end|>")
+            elif role == "tool":
+                # Handle tool responses
+                prompt_parts.append(f"<|im_start|>tool\n{content}<|im_end|>")
+        
+        # Add assistant start token for response generation
+        prompt_parts.append("<|im_start|>assistant\n")
+        
+        return "\n".join(prompt_parts)
+
+    def transform_response(
+        self,
+        model: str,
+        raw_response: any,
+        model_response: any,
+        logging_obj: any,
+        request_data: dict,
+        messages: List,
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> any:
+        """
+        Transform Qwen3 Bedrock response to OpenAI format
+        """
+        try:
+            if hasattr(raw_response, 'json'):
+                response_data = raw_response.json()
+            else:
+                response_data = raw_response
+            
+            # Extract the generated text - Qwen3 uses "generation" field
+            generated_text = response_data.get("generation", "")
+            
+            # Clean up the response (remove assistant start token if present)
+            if generated_text.startswith("<|im_start|>assistant\n"):
+                generated_text = generated_text[len("<|im_start|>assistant\n"):]
+            if generated_text.endswith("<|im_end|>"):
+                generated_text = generated_text[:-len("<|im_end|>")]
+            
+            # Set the content in the existing model_response structure
+            if hasattr(model_response, 'choices') and len(model_response.choices) > 0:
+                model_response.choices[0].message.content = generated_text
+                model_response.choices[0].finish_reason = "stop"
+            
+            # Set usage information if available in response
+            if "usage" in response_data:
+                usage_data = response_data["usage"]
+                if hasattr(model_response, 'usage'):
+                    model_response.usage.prompt_tokens = usage_data.get("prompt_tokens", 0)
+                    model_response.usage.completion_tokens = usage_data.get("completion_tokens", 0)
+                    model_response.usage.total_tokens = usage_data.get("total_tokens", 0)
+            
+            return model_response
+            
+        except Exception as e:
+            if logging_obj:
+                logging_obj.post_call(
+                    input=messages,
+                    api_key=api_key,
+                    original_response=raw_response,
+                    additional_args={"error": str(e)},
+                )
+            raise e

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_qwen3_transformation.py
@@ -6,12 +6,17 @@ Inherits from `AmazonInvokeConfig`
 Qwen3 + Invoke API Tutorial: https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional, Union
+
+import httpx
 
 from litellm.llms.base_llm.chat.transformation import BaseConfig
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
+    LiteLLMLoggingObj,
 )
+from litellm.types.llms.openai import AllMessageValues
+from litellm.types.utils import ModelResponse
 
 
 class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
@@ -41,7 +46,7 @@ class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
                 setattr(self.__class__, key, value)
         AmazonInvokeConfig.__init__(self)
 
-    def get_supported_openai_params(self, model: str) -> List:
+    def get_supported_openai_params(self, model: str) -> List[str]:
         return [
             "max_tokens",
             "temperature",
@@ -76,7 +81,7 @@ class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
     def transform_request(
         self,
         model: str,
-        messages: List,
+        messages: List[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
@@ -106,7 +111,7 @@ class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
             
         return request_body
 
-    def _convert_messages_to_prompt(self, messages: List) -> str:
+    def _convert_messages_to_prompt(self, messages: List[AllMessageValues]) -> str:
         """
         Convert OpenAI messages format to Qwen3 prompt format
         Supports tool calls, multimodal content, and various message types
@@ -154,17 +159,17 @@ class AmazonQwen3Config(AmazonInvokeConfig, BaseConfig):
     def transform_response(
         self,
         model: str,
-        raw_response: any,
-        model_response: any,
-        logging_obj: any,
+        raw_response: httpx.Response,
+        model_response: ModelResponse,
+        logging_obj: LiteLLMLoggingObj,
         request_data: dict,
-        messages: List,
+        messages: List[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
-        encoding: any,
+        encoding: Any,
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
-    ) -> any:
+    ) -> ModelResponse:
         """
         Transform Qwen3 Bedrock response to OpenAI format
         """

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7152,6 +7152,8 @@ class ProviderConfigManager:
                 return litellm.AmazonDeepSeekR1Config()
             elif bedrock_invoke_provider == "nova":
                 return litellm.AmazonInvokeNovaConfig()
+            elif bedrock_invoke_provider == "qwen3":
+                return litellm.AmazonQwen3Config()
             else:
                 return litellm.AmazonInvokeConfig()
         elif litellm.LlmProviders.LITELLM_PROXY == provider:

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen3_transformation.py
@@ -1,0 +1,211 @@
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+# Ensure the project root is on the import path so `litellm` can be imported when
+# tests are executed from any working directory.
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.bedrock.chat.invoke_transformations.amazon_qwen3_transformation import (
+    AmazonQwen3Config,
+)
+from litellm.types.utils import ModelResponse
+
+
+def test_qwen3_get_supported_params():
+    """Test that Qwen3 config returns correct supported parameters"""
+    config = AmazonQwen3Config()
+    params = config.get_supported_openai_params(model="qwen3/test-model")
+    
+    expected_params = ["max_tokens", "temperature", "top_p", "top_k", "stop", "stream"]
+    for param in expected_params:
+        assert param in params
+
+
+def test_qwen3_map_openai_params():
+    """Test that OpenAI parameters are correctly mapped to Qwen3 format"""
+    config = AmazonQwen3Config()
+    non_default_params = {
+        "max_tokens": 100,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "top_k": 40,
+        "stop": ["</s>", "<|im_end|>"],
+        "stream": True
+    }
+    optional_params = {}
+    
+    result = config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="qwen3/test-model",
+        drop_params=False
+    )
+    
+    assert result["max_tokens"] == 100
+    assert result["temperature"] == 0.7
+    assert result["top_p"] == 0.9
+    assert result["top_k"] == 40
+    assert result["stop"] == ["</s>", "<|im_end|>"]
+    assert result["stream"] is True
+
+
+def test_qwen3_convert_messages_to_prompt():
+    """Test that messages are correctly converted to Qwen3 prompt format"""
+    config = AmazonQwen3Config()
+    
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, how are you?"},
+        {"role": "assistant", "content": "I'm doing well, thank you!"},
+        {"role": "user", "content": "What's the weather like?"}
+    ]
+    
+    prompt = config._convert_messages_to_prompt(messages)
+    
+    expected_prompt = """<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+Hello, how are you?<|im_end|>
+<|im_start|>assistant
+I'm doing well, thank you!<|im_end|>
+<|im_start|>user
+What's the weather like?<|im_end|>
+<|im_start|>assistant
+"""
+    
+    assert prompt == expected_prompt
+
+
+def test_qwen3_transform_request():
+    """Test that the request is correctly transformed to Qwen3 format"""
+    config = AmazonQwen3Config()
+    
+    messages = [
+        {"role": "user", "content": "Hello, world!"}
+    ]
+    
+    optional_params = {
+        "max_tokens": 50,
+        "temperature": 0.8,
+        "top_p": 0.9
+    }
+    
+    request_body = config.transform_request(
+        model="qwen3/test-model",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={}
+    )
+    
+    assert "prompt" in request_body
+    assert request_body["max_gen_len"] == 50
+    assert request_body["temperature"] == 0.8
+    assert request_body["top_p"] == 0.9
+    
+    # Check that the prompt contains the expected format
+    assert "<|im_start|>user" in request_body["prompt"]
+    assert "Hello, world!" in request_body["prompt"]
+    assert "<|im_end|>" in request_body["prompt"]
+
+
+def test_qwen3_transform_response():
+    """Test that Qwen3 response is correctly transformed to OpenAI format"""
+    config = AmazonQwen3Config()
+    
+    # Mock response data
+    mock_response_data = {
+        "generation": "<|im_start|>assistant\nHello! How can I help you today?<|im_end|>",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25
+        }
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen3/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Check that the response is correctly formatted
+    assert len(result.choices) == 1
+    assert result.choices[0]["message"]["role"] == "assistant"
+    assert result.choices[0]["message"]["content"] == "Hello! How can I help you today?"
+    assert result.choices[0]["finish_reason"] == "stop"
+    
+    # Check usage information
+    assert result.usage["prompt_tokens"] == 10
+    assert result.usage["completion_tokens"] == 15
+    assert result.usage["total_tokens"] == 25
+
+
+def test_qwen3_transform_response_without_usage():
+    """Test response transformation when usage information is not provided"""
+    config = AmazonQwen3Config()
+    
+    # Mock response data without usage
+    mock_response_data = {
+        "generation": "Hello! How can I help you today?"
+    }
+    
+    # Mock the raw response
+    mock_raw_response = Mock()
+    mock_raw_response.json.return_value = mock_response_data
+    
+    model_response = ModelResponse()
+    messages = [{"role": "user", "content": "Hello!"}]
+    
+    result = config.transform_response(
+        model="qwen3/test-model",
+        messages=messages,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+        request_data={},
+        encoding=None
+    )
+    
+    # Check that the response is correctly formatted
+    assert len(result.choices) == 1
+    assert result.choices[0]["message"]["role"] == "assistant"
+    assert result.choices[0]["message"]["content"] == "Hello! How can I help you today?"
+    assert result.choices[0]["finish_reason"] == "stop"
+
+
+def test_qwen3_provider_detection():
+    """Test that Qwen3 provider is correctly detected from model names"""
+    from litellm.utils import ProviderConfigManager
+    from litellm.types.utils import LlmProviders
+    
+    # Test with qwen3/ prefix
+    config = ProviderConfigManager.get_provider_chat_config(
+        model="qwen3/arn:aws:bedrock:us-east-1:123456789012:imported-model/test-qwen3",
+        provider=LlmProviders.BEDROCK
+    )
+    
+    assert config is not None
+    assert isinstance(config, AmazonQwen3Config)


### PR DESCRIPTION
## Title

Add Qwen3 imported model support for AWS Bedrock

## Relevant issues

Fixes #15735

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds support for Qwen3 imported models in AWS Bedrock through the `bedrock/qwen3/` provider route.

**Key additions:**
- Added `"qwen3"` to `BEDROCK_INVOKE_PROVIDERS_LITERAL` in `constants.py`
- Created `AmazonQwen3Config` transformation class in `amazon_qwen3_transformation.py`
- Updated `ProviderConfigManager` to route Qwen3 models to the new config
- Added import for `AmazonQwen3Config` in `__init__.py`
- Added comprehensive unit tests in `test_amazon_qwen3_transformation.py`
- Updated Bedrock documentation with Qwen3 usage examples


**Usage:**
```python
response = completion(
    model="bedrock/qwen3/arn:aws:bedrock:us-east-1:123456789012:imported-model/your-qwen3-model",
    messages=[{"role": "user", "content": "Hello!"}],
    max_tokens=100,
    temperature=0.7
)
```

<img width="827" height="589" alt="image" src="https://github.com/user-attachments/assets/9668c277-2b0d-4138-9d60-66c6d5e1e673" />
