### PR TITLE
fix empty user message error

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -239,12 +239,12 @@ def _check_text_in_content(parts: List[PartType]) -> bool:
     """
     check that user_content has 'text' parameter.
         - Known Vertex Error: Unable to submit request because it must have a text parameter.
-        - 'text' param needs to be len > 0
+        - 'text' param needs to be present (empty strings are valid)
         - Relevant Issue: https://github.com/BerriAI/litellm/issues/5515
     """
     has_text_param = False
     for part in parts:
-        if "text" in part and part.get("text"):
+        if "text" in part and part.get("text") is not None:
             has_text_param = True
 
     return has_text_param

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -263,7 +263,6 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 elif (
                     _message_content is not None
                     and isinstance(_message_content, str)
-                    and len(_message_content) > 0
                 ):
                     _part = PartType(text=_message_content)
                     user_content.append(_part)
@@ -335,9 +334,8 @@ def _gemini_convert_messages_with_history(  # noqa: PLR0915
                 elif (
                     _message_content is not None
                     and isinstance(_message_content, str)
-                    and _message_content
                 ):
-                    assistant_text = _message_content  # either string or none
+                    assistant_text = _message_content
                     assistant_content.append(PartType(text=assistant_text))  # type: ignore
 
                 ## HANDLE ASSISTANT FUNCTION CALL

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1,6 +1,7 @@
 from litellm.llms.vertex_ai.gemini.transformation import (
     check_if_part_exists_in_parts,
     _transform_request_body,
+    _gemini_convert_messages_with_history,
 )
 
 
@@ -155,3 +156,23 @@ def test_metadata_to_labels_vertex_only():
     )
     assert "labels" in result
     assert result["labels"] == {"user": "john_doe", "project": "test-project"}
+
+
+def test_empty_content_handling():
+    """Test that empty content strings are properly handled in Gemini message transformation"""
+    # Test with empty content in user message
+    messages = [
+        {
+            "content": "",
+            "role": "user"
+        }
+    ]
+    
+    contents = _gemini_convert_messages_with_history(messages=messages)
+    
+    # Verify that the content was properly transformed
+    assert len(contents) == 1
+    assert contents[0]["role"] == "user"
+    assert len(contents[0]["parts"]) == 1
+    assert "text" in contents[0]["parts"][0]
+    assert contents[0]["parts"][0]["text"] == ""


### PR DESCRIPTION
## Title

Fix Gemini empty content handling in message transformation

## Relevant issues

Fixes #15620

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
LiteLLM was failing to properly convert OpenAI format requests with empty content fields (`"content": ""`) to Gemini's native format. This caused issues when using tool calling with empty user messages, resulting in a 400 error:

```
Please ensure that function call turn comes immediately after a user turn or after a function response turn.
```

### Root Cause
The issue was in the `_gemini_convert_messages_with_history` function in `litellm/litellm/llms/vertex_ai/gemini/transformation.py`. When processing user and assistant messages with empty content strings, the code was skipping these messages due to length check conditions:

```python
# For user messages (line 263-270):
elif (
    _message_content is not None
    and isinstance(_message_content, str)
    and len(_message_content) > 0  # <-- This condition excluded empty strings
):
    _part = PartType(text=_message_content)
    user_content.append(_part)
```

When a message had `"content": ""`, it passed the first two conditions but failed the length check, so no part was added to the content list.

### Solution
1. **Removed length checks** in the transformation logic to allow empty strings to be properly processed
2. **Updated `_check_text_in_content` function** in `common_utils.py` to accept empty strings as valid text content
3. **Added comprehensive tests** to verify the fix works correctly

### Files Changed
- `litellm/litellm/llms/vertex_ai/gemini/transformation.py` - Fixed empty content handling in message transformation
- `litellm/litellm/llms/vertex_ai/common_utils.py` - Updated `_check_text_in_content` function
- `litellm/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py` - Added tests for empty content handling

**Before**
<img width="1073" height="555" alt="image" src="https://github.com/user-attachments/assets/fc7a0c19-a7f8-4fe8-8cca-f0f4997e81a1" />

**After**
<img width="1073" height="555" alt="image" src="https://github.com/user-attachments/assets/ee43490e-9eaa-4aec-9f48-39095cce4883" />
