### PR TITLE
Fix pass-through endpoint budget enforcement bug

### DIFF
--- a/docs/my-website/docs/providers/vertex_batch.md
+++ b/docs/my-website/docs/providers/vertex_batch.md
@@ -162,7 +162,7 @@ Check the status of your batch job. The batch will progress through states: `val
 ```python showLineNumbers title="retrieve_batch.py"
 retrieved_batch = oai_client.batches.retrieve(
     batch_id=create_batch_response.id, # Created batch id, e.g. 7814463557919047680
-    extra_body={"custom_llm_provider": "vertex_ai"}
+    extra_query={"custom_llm_provider": "vertex_ai"}
 )
 
 print(f"Batch status: {retrieved_batch.status}")

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -46,6 +46,8 @@ from litellm.types.llms.anthropic import AnthropicThinkingParam
 from litellm.types.llms.gemini import BidiGenerateContentServerMessage
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAnnotation,
+    ChatCompletionAnnotationURLCitation,
     ChatCompletionResponseMessage,
     ChatCompletionThinkingBlock,
     ChatCompletionToolCallChunk,
@@ -1298,6 +1300,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         """
         from litellm.types.utils import Delta, StreamingChoices
 
+        annotations = chat_completion_message.get("annotations")  # type: ignore
         # create a streaming choice object
         choice = StreamingChoices(
             finish_reason=VertexGeminiConfig._check_finish_reason(
@@ -1310,6 +1313,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 tool_calls=tools,
                 images=image_response,
                 function_call=functions,
+                annotations=annotations,  # type: ignore
             ),
             logprobs=chat_completion_logprobs,
             enhancements=None,
@@ -1358,7 +1362,63 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         )
 
     @staticmethod
-    def _process_candidates(
+    def _convert_grounding_metadata_to_annotations(
+        grounding_metadata: List[dict],
+        content_text: Optional[str],
+    ) -> List[ChatCompletionAnnotation]:
+        """
+        Convert Vertex AI grounding metadata to OpenAI-style annotations.
+        """
+
+        annotations: List[ChatCompletionAnnotation] = []
+
+        
+        for metadata in grounding_metadata:
+            # Extract groundingSupports - these map text segments to sources
+            grounding_supports = metadata.get("groundingSupports", [])
+            grounding_chunks = metadata.get("groundingChunks", [])
+
+            # Build a map of chunk indices to web URIs
+            chunk_to_uri_map: Dict[int, Dict[str, str]] = {}
+            for idx, chunk in enumerate(grounding_chunks):
+                if "web" in chunk:
+                    web_data = chunk["web"]
+                    chunk_to_uri_map[idx] = {
+                        "url": web_data.get("uri", ""),
+                        "title": web_data.get("title", ""),
+                    }
+
+            # Process each grounding support to create annotations
+            for support in grounding_supports:
+                segment = support.get("segment", {})
+                start_index = segment.get("startIndex")
+                end_index = segment.get("endIndex")
+                
+                # Get the chunk indices for this support
+                chunk_indices = support.get("groundingChunkIndices", [])
+                
+                if start_index is not None and end_index is not None and chunk_indices:
+                    # Use the first chunk's URL for the annotation
+                    first_chunk_idx = chunk_indices[0]
+                    if first_chunk_idx in chunk_to_uri_map:
+                        uri_info = chunk_to_uri_map[first_chunk_idx]
+                        
+                        url_citation: ChatCompletionAnnotationURLCitation = {
+                            "start_index": start_index,
+                            "end_index": end_index,
+                            "url": uri_info["url"],
+                            "title": uri_info["title"],
+                        }
+                        
+                        annotation: ChatCompletionAnnotation = {
+                            "type": "url_citation",
+                            "url_citation": url_citation,
+                        }
+                        annotations.append(annotation)
+        return annotations
+
+    @staticmethod
+    def _process_candidates(  # noqa: PLR0915
         _candidates: List[Candidates],
         model_response: Union[ModelResponse, "ModelResponseStream"],
         standard_optional_params: dict,
@@ -1446,6 +1506,14 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
                 if reasoning_content is not None:
                     chat_completion_message["reasoning_content"] = reasoning_content
+
+                if candidate_grounding_metadata:
+                    annotations = VertexGeminiConfig._convert_grounding_metadata_to_annotations(
+                        grounding_metadata=candidate_grounding_metadata,
+                        content_text=content,
+                    )
+                    if annotations:
+                        chat_completion_message["annotations"] = annotations  # type: ignore
                 (
                     functions,
                     tools,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6258,6 +6258,18 @@ def stream_chunk_builder(  # noqa: PLR0915
                 processor.get_combined_reasoning_content(reasoning_chunks)
             )
 
+        annotation_chunks = [
+            chunk
+            for chunk in chunks
+            if len(chunk["choices"]) > 0
+            and "annotations" in chunk["choices"][0]["delta"]
+            and chunk["choices"][0]["delta"]["annotations"] is not None
+        ]
+
+        if len(annotation_chunks) > 0:
+            annotations = annotation_chunks[0]["choices"][0]["delta"]["annotations"]
+            response["choices"][0]["message"]["annotations"] = annotations
+
         audio_chunks = [
             chunk
             for chunk in chunks

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -998,7 +998,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                     )
 
             # Check 4. Token Spend is under budget
-            if route in LiteLLMRoutes.llm_api_routes.value:
+            if RouteChecks.is_llm_api_route(route=route):
                 await _virtual_key_max_budget_check(
                     valid_token=valid_token,
                     proxy_logging_obj=proxy_logging_obj,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -800,12 +800,15 @@ class LiteLLMCompletionResponsesConfig:
     def _transform_chat_message_to_response_output_text(
         message: Message,
     ) -> OutputText:
+        annotations = getattr(message, "annotations", None)
+        transformed_annotations = LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+            annotations=annotations
+        )
+        
         return OutputText(
             type="output_text",
             text=message.content,
-            annotations=LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
-                annotations=getattr(message, "annotations", None)
-            ),
+            annotations=transformed_annotations,
         )
 
     @staticmethod

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -196,3 +196,47 @@ class TestSlackAlerting(unittest.TestCase):
         self.assertIn("Level: `Medium`", formatted_message)
         self.assertIn("Timestamp: `12:34:56`", formatted_message)
         self.assertIn("Message: Test alert message", formatted_message)
+
+    def test_original_redis_error_reproduction(self):
+        """Test that reproduces the original Redis serialization error."""
+        # This test verifies that the original error would occur without our fix
+        outage_value = {
+            "alerts": [408],
+            "deployment_ids": {"zapier-multi-provider-gemini-2.5-flash-1ite-vertex"},
+            "last_updated_at": 1760601633.6620142,
+            "major_alert_sent": False,
+            "minor_alert_sent": False,
+            "provider_region_id": "vertex_aius-east1"
+        }
+        
+        # This should raise a TypeError due to set not being JSON serializable
+        with self.assertRaises(TypeError) as context:
+            json.dumps(outage_value)
+        
+        # Verify the specific error message
+        self.assertIn("Object of type set is not JSON serializable", str(context.exception))
+
+    def test_fixed_redis_serialization(self):
+        """Test that our fix resolves the Redis serialization error."""
+        # Same data that caused the original error
+        outage_value = {
+            "alerts": [408],
+            "deployment_ids": {"zapier-multi-provider-gemini-2.5-flash-1ite-vertex"},
+            "last_updated_at": 1760601633.6620142,
+            "major_alert_sent": False,
+            "minor_alert_sent": False,
+            "provider_region_id": "vertex_aius-east1"
+        }
+        
+        # Apply our fix
+        cache_value = self.slack_alerting._prepare_outage_value_for_cache(outage_value)
+        
+        # This should now work without errors
+        json_str = json.dumps(cache_value)
+        self.assertIsInstance(json_str, str)
+        
+        # Verify the data is correct
+        parsed_data = json.loads(json_str)
+        self.assertEqual(parsed_data["deployment_ids"], ["zapier-multi-provider-gemini-2.5-flash-1ite-vertex"])
+        self.assertEqual(parsed_data["alerts"], [408])
+        self.assertEqual(parsed_data["provider_region_id"], "vertex_aius-east1")


### PR DESCRIPTION
## Title

Fix pass-through endpoint budget enforcement bug

## Relevant issues

Fixes LIT-1059

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem**: Pass-through endpoints (like `/anthropic/v1/messages`) were not being checked for budget limits due to incorrect route matching logic in the virtual key budget check.

**Root Cause**: The virtual key budget check used exact string matching (`route in LiteLLMRoutes.llm_api_routes.value`) instead of the proper route matching function that handles wildcards.

**Fix**: Changed line 1001 in `litellm/proxy/auth/user_api_key_auth.py` from:
```python
if route in LiteLLMRoutes.llm_api_routes.value:
```
to:
```python
if RouteChecks.is_llm_api_route(route=route):
```

**Before**
<img width="1194" height="118" alt="Screenshot 2025-10-22 at 2 11 45 PM" src="https://github.com/user-attachments/assets/4e166afd-08b5-45d6-8c5d-29c65dba130c" />

**After**
<img width="1009" height="118" alt="image" src="https://github.com/user-attachments/assets/bf53622f-c78e-4763-959a-8a1e3392995e" />
