### PR TITLE
Allow using ARNs when generation images via Bedrock

### DIFF
--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -1,5 +1,4 @@
 import json
-import urllib
 from typing import Any, Optional, Union
 
 import httpx
@@ -83,16 +82,6 @@ def make_sync_call(
 class BedrockConverseLLM(BaseAWSLLM):
     def __init__(self) -> None:
         super().__init__()
-
-    def encode_model_id(self, model_id: str) -> str:
-        """
-        Double encode the model ID to ensure it matches the expected double-encoded format.
-        Args:
-            model_id (str): The model ID to encode.
-        Returns:
-            str: The double-encoded model ID.
-        """
-        return urllib.parse.quote(model_id, safe="")  # type: ignore
 
     async def async_streaming(
         self,

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -3,20 +3,15 @@ TODO: DELETE FILE. Bedrock LLM is no longer used. Goto `litellm/llms/bedrock/cha
 """
 
 import copy
-import json
 import time
 import types
-import urllib.parse
 from functools import partial
 from typing import (
-    Any,
     AsyncIterator,
     Callable,
     Iterator,
-    List,
     Optional,
     Tuple,
-    Union,
     cast,
     get_args,
 )
@@ -672,16 +667,6 @@ class BedrockLLM(BaseAWSLLM):
 
         return model_response
 
-    def encode_model_id(self, model_id: str) -> str:
-        """
-        Double encode the model ID to ensure it matches the expected double-encoded format.
-        Args:
-            model_id (str): The model ID to encode.
-        Returns:
-            str: The double-encoded model ID.
-        """
-        return urllib.parse.quote(model_id, safe="")
-
     def completion(  # noqa: PLR0915
         self,
         model: str,
@@ -1175,33 +1160,6 @@ class BedrockLLM(BaseAWSLLM):
             if provider in get_args(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL):
                 return cast(litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL, provider)
         return None
-
-    def get_bedrock_model_id(
-        self,
-        optional_params: dict,
-        provider: Optional[litellm.BEDROCK_INVOKE_PROVIDERS_LITERAL],
-        model: str,
-    ) -> str:
-        modelId = optional_params.pop("model_id", None)
-        if modelId is not None:
-            modelId = self.encode_model_id(model_id=modelId)
-        else:
-            modelId = model
-
-        if provider == "llama" and "llama/" in modelId:
-            modelId = self._get_model_id_for_llama_like_model(modelId)
-
-        return modelId
-
-    def _get_model_id_for_llama_like_model(
-        self,
-        model: str,
-    ) -> str:
-        """
-        Remove `llama` from modelID since `llama` is simply a spec to follow for custom bedrock models
-        """
-        model_id = model.replace("llama/", "")
-        return self.encode_model_id(model_id=model_id)
 
 
 def get_response_stream_shape():

--- a/litellm/llms/bedrock/image/image_handler.py
+++ b/litellm/llms/bedrock/image/image_handler.py
@@ -7,6 +7,7 @@ import httpx
 from pydantic import BaseModel
 
 import litellm
+from litellm import BEDROCK_INVOKE_PROVIDERS_LITERAL
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
 from litellm.llms.custom_httpx.http_handler import (
@@ -63,7 +64,7 @@ class BedrockImageGeneration(BaseAWSLLM):
             extra_headers=extra_headers,
             logging_obj=logging_obj,
             prompt=prompt,
-            api_key=api_key
+            api_key=api_key,
         )
 
         if aimg_generation is True:
@@ -174,8 +175,14 @@ class BedrockImageGeneration(BaseAWSLLM):
             optional_params, model
         )
 
+        # Use the existing ARN-aware provider detection method
+        bedrock_provider = self.get_bedrock_invoke_provider(model)
         ### SET RUNTIME ENDPOINT ###
-        modelId = model
+        modelId = self.get_bedrock_model_id(
+            model=model,
+            provider=bedrock_provider,
+            optional_params=optional_params,
+        )
         _, proxy_endpoint_url = self.get_runtime_endpoint(
             api_base=api_base,
             aws_bedrock_runtime_endpoint=boto3_credentials_info.aws_bedrock_runtime_endpoint,
@@ -183,14 +190,17 @@ class BedrockImageGeneration(BaseAWSLLM):
         )
         proxy_endpoint_url = f"{proxy_endpoint_url}/model/{modelId}/invoke"
         data = self._get_request_body(
-            model=model, prompt=prompt, optional_params=optional_params
+            model=model,
+            prompt=prompt,
+            optional_params=optional_params,
+            bedrock_provider=bedrock_provider,
         )
 
         # Make POST Request
         body = json.dumps(data).encode("utf-8")
         headers = {"Content-Type": "application/json"}
         if extra_headers is not None:
-            headers = {"Content-Type": "application/json", **extra_headers} 
+            headers = {"Content-Type": "application/json", **extra_headers}
 
         prepped = self.get_request_headers(
             credentials=boto3_credentials_info.credentials,
@@ -201,7 +211,7 @@ class BedrockImageGeneration(BaseAWSLLM):
             headers=headers,
             api_key=api_key,
         )
-            
+
         ## LOGGING
         logging_obj.pre_call(
             input=prompt,
@@ -222,6 +232,7 @@ class BedrockImageGeneration(BaseAWSLLM):
     def _get_request_body(
         self,
         model: str,
+        bedrock_provider: Optional[BEDROCK_INVOKE_PROVIDERS_LITERAL],
         prompt: str,
         optional_params: dict,
     ) -> dict:
@@ -233,9 +244,6 @@ class BedrockImageGeneration(BaseAWSLLM):
         Returns:
             dict: The request body to use for the Bedrock Image Generation API
         """
-        # Use the existing ARN-aware provider detection method
-        bedrock_provider = self.get_bedrock_invoke_provider(model)
-
         if bedrock_provider == "amazon" or bedrock_provider == "nova":
             # Handle Amazon Nova Canvas models
             provider = "amazon"

--- a/tests/test_litellm/llms/bedrock/image/test_bedrock_image_prepare_request.py
+++ b/tests/test_litellm/llms/bedrock/image/test_bedrock_image_prepare_request.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch, MagicMock
+
+from litellm.llms.bedrock.image.image_handler import BedrockImageGeneration
+
+def test_bedrock_image_prepare_request_with_arn() -> None:
+    dummy_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abcdefghi123"
+
+    image_generation = BedrockImageGeneration()
+
+    with (
+        patch("litellm.llms.bedrock.image.image_handler.BedrockImageGeneration._get_boto_credentials_from_optional_params"),
+        patch("litellm.llms.bedrock.image.image_handler.BedrockImageGeneration.get_request_headers"),
+    ):
+        request = image_generation._prepare_request(
+            model="amazon.nova-canvas-v1:0",
+            prompt="A cute baby sea otter",
+            optional_params={
+                "model_id": dummy_arn,
+            },
+            api_base="https://bedrock-runtime.test.com",
+            extra_headers=None,
+            api_key=None,
+            logging_obj=MagicMock(),
+        )
+
+    assert request.endpoint_url == "https://bedrock-runtime.test.com/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A123456789012%3Aapplication-inference-profile%2Fabcdefghi123/invoke"
+
+
+def test_bedrock_image_prepare_request_without_arn() -> None:
+    image_generation = BedrockImageGeneration()
+
+    with (
+        patch("litellm.llms.bedrock.image.image_handler.BedrockImageGeneration._get_boto_credentials_from_optional_params"),
+        patch("litellm.llms.bedrock.image.image_handler.BedrockImageGeneration.get_request_headers"),
+    ):
+        request = image_generation._prepare_request(
+            model="amazon.nova-canvas-v1:0",
+            prompt="A cute baby sea otter",
+            optional_params={},
+            api_base="https://bedrock-runtime.test.com",
+            extra_headers=None,
+            api_key=None,
+            logging_obj=MagicMock(),
+        )
+
+    assert request.endpoint_url == "https://bedrock-runtime.test.com/model/amazon.nova-canvas-v1:0/invoke"


### PR DESCRIPTION
## Title

Allow using ARNs when generation images via Bedrock

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1224" height="175" alt="Screenshot 2025-10-22 at 12 25 47 PM" src="https://github.com/user-attachments/assets/bc3b551f-3560-4211-b561-ebeed987ac8a" />

## Type

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

LiteLLM allows to use Bedrock's Application Inference Profile ARNs to access Generation AI. While it works perfectly for Chat Completions calls, ARNs are ignored for Image Generations. This PR fills this gap -- now `model_id` parameter is used to retrieve ARN for the model (as it is done for Chat Completions). 

I was running the patch locally for a long time so it proved to be working.

