### PR TITLE
fix: Rename configured_cold_storage_logger to cold_storage_custom_logger

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -156,7 +156,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "cloudzero",
     "posthog",
 ]
-configured_cold_storage_logger: Optional[
+cold_storage_custom_logger: Optional[
     _custom_logger_compatible_callbacks_literal
 ] = None
 logged_real_time_event_types: Optional[Union[List[str], Literal["*"]]] = None

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4281,8 +4281,8 @@ class StandardLoggingPayloadSetup:
         from litellm.integrations.s3 import get_s3_object_key
 
         # Only generate object key if cold storage is configured
-        configured_cold_storage_logger = litellm.configured_cold_storage_logger
-        if configured_cold_storage_logger is None:
+        cold_storage_custom_logger = litellm.cold_storage_custom_logger
+        if cold_storage_custom_logger is None:
             return None
 
         try:
@@ -4295,7 +4295,7 @@ class StandardLoggingPayloadSetup:
             # Try to get the actual logger instance from the logger name
             try:
                 custom_logger = litellm.logging_callback_manager.get_active_custom_logger_for_callback_name(
-                    configured_cold_storage_logger
+                    cold_storage_custom_logger
                 )
                 if (
                     custom_logger

--- a/litellm/proxy/spend_tracking/cold_storage_handler.py
+++ b/litellm/proxy/spend_tracking/cold_storage_handler.py
@@ -56,6 +56,6 @@ class ColdStorageHandler:
     def _select_custom_logger_for_cold_storage(
         self,
     ) -> Optional[_custom_logger_compatible_callbacks_literal]:
-        cold_storage_custom_logger: Optional[_custom_logger_compatible_callbacks_literal] = litellm.configured_cold_storage_logger
+        cold_storage_custom_logger: Optional[_custom_logger_compatible_callbacks_literal] = litellm.cold_storage_custom_logger
 
         return cold_storage_custom_logger

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -236,10 +236,10 @@ class ResponsesSessionHandler:
         """
         Only check cold storage when both are true 
         1. `LITELLM_TRUNCATED_PAYLOAD_FIELD` is in the proxy server request dict
-        2. `litellm.configured_cold_storage_logger` is not None
+        2. `litellm.cold_storage_custom_logger` is not None
         """
         from litellm.constants import LITELLM_TRUNCATED_PAYLOAD_FIELD
-        configured_cold_storage_custom_logger = litellm.configured_cold_storage_logger
+        configured_cold_storage_custom_logger = litellm.cold_storage_custom_logger
         if configured_cold_storage_custom_logger is None:
             return False
         if proxy_server_request_dict is None:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -485,7 +485,7 @@ async def test_e2e_generate_cold_storage_object_key_successful():
     response_id = "chatcmpl-test-12345"
     team_alias = "test-team"
     
-    with patch("litellm.configured_cold_storage_logger", return_value="s3"), \
+    with patch("litellm.cold_storage_custom_logger", return_value="s3"), \
          patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key:
         
         # Mock the S3 object key generation to return a predictable result
@@ -530,7 +530,7 @@ async def test_e2e_generate_cold_storage_object_key_with_custom_logger_s3_path()
     mock_custom_logger = MagicMock()
     mock_custom_logger.s3_path = "storage"
     
-    with patch("litellm.configured_cold_storage_logger", "s3_v2"), \
+    with patch("litellm.cold_storage_custom_logger", "s3_v2"), \
          patch("litellm.logging_callback_manager.get_active_custom_logger_for_callback_name") as mock_get_logger, \
          patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key:
         
@@ -577,7 +577,7 @@ async def test_e2e_generate_cold_storage_object_key_with_logger_no_s3_path():
     mock_custom_logger = MagicMock()
     mock_custom_logger.s3_path = None  # or could be missing attribute
     
-    with patch("litellm.configured_cold_storage_logger", "s3_v2"), \
+    with patch("litellm.cold_storage_custom_logger", "s3_v2"), \
          patch("litellm.logging_callback_manager.get_active_custom_logger_for_callback_name") as mock_get_logger, \
          patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key:
         
@@ -620,7 +620,7 @@ async def test_e2e_generate_cold_storage_object_key_not_configured():
     team_alias = "another-team"
 
     # Use patch to ensure test isolation
-    with patch.object(litellm, 'configured_cold_storage_logger', None):
+    with patch.object(litellm, 'cold_storage_custom_logger', None):
         # Call the function
         result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
             start_time=start_time,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -223,7 +223,7 @@ async def test_e2e_cold_storage_successful_retrieval():
         new_callable=AsyncMock,
     ) as mock_get_spend_logs, \
     patch.object(session_handler, "COLD_STORAGE_HANDLER") as mock_cold_storage, \
-    patch("litellm.configured_cold_storage_logger", return_value="s3"):
+    patch("litellm.cold_storage_custom_logger", return_value="s3"):
         
         # Setup mocks
         mock_get_spend_logs.return_value = mock_spend_logs
@@ -343,7 +343,7 @@ async def test_should_check_cold_storage_for_full_payload():
     # Test case 4: None request (should return True)
     proxy_request_none = None
     
-    with patch("litellm.configured_cold_storage_logger", return_value="s3"):
+    with patch("litellm.cold_storage_custom_logger", return_value="s3"):
         # Test case 1: Should return True for truncated content
         result1 = ResponsesSessionHandler._should_check_cold_storage_for_full_payload(proxy_request_with_truncated_pdf)
         assert result1 == True, "Should return True for proxy request with truncated PDF content"
@@ -361,7 +361,7 @@ async def test_should_check_cold_storage_for_full_payload():
         assert result4 == True, "Should return True for None proxy request"
     
     # Test case 5: Should return False when cold storage is not configured
-    with patch.object(litellm, 'configured_cold_storage_logger', None):
+    with patch.object(litellm, 'cold_storage_custom_logger', None):
         result5 = ResponsesSessionHandler._should_check_cold_storage_for_full_payload(proxy_request_with_truncated_pdf)
         assert result5 == False, "Should return False when cold storage is not configured, even with truncated content"
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Fix: Rename configured_cold_storage_logger to cold_storage_custom_logger

## Relevant issues

<!-- e.g. "Fixes #000" -->
Fixes https://github.com/BerriAI/litellm/issues/15796

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


```
============================= test session starts ==============================
tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_e2e_generate_cold_storage_object_key_not_configured PASSED [ 33%]
tests/test_litellm/litellm_core_utils/test_litellm_logging.py::test_e2e_generate_cold_storage_object_key_successful PASSED [ 66%]
tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py::test_should_check_cold_storage_for_full_payload PASSED [100%]
============================== 3 passed in 0.47s
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes

### Problem
The codebase has an inconsistent variable name that causes cold storage logging to fail silently:

- `litellm/__init__.py` declares the variable as `configured_cold_storage_logger`
- Configuration files use `cold_storage_custom_logger` as the key
- Result: Configuration value is never loaded into the variable (name mismatch)
- `litellm.configured_cold_storage_logger` remains `None` even when properly configured
- In `litellm_logging.py:4285`, early return when `None` prevents cold storage object key generation
- **No error messages are shown**, making it extremely difficult to debug

### Solution
Standardize the variable name to `cold_storage_custom_logger` throughout the codebase to match the configuration key.

