### PR TITLE
fix the date for sonnet 3.7 in govcloud

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4344,7 +4344,7 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-06
     },
-    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20240620-v1:0": {
+    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4344,7 +4344,7 @@
         "mode": "chat",
         "output_cost_per_token": 1.5e-06
     },
-    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20240620-v1:0": {
+    "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,
         "cache_read_input_token_cost": 3.6e-07,
         "input_cost_per_token": 3.6e-06,


### PR DESCRIPTION
## Title

Fixes the date that was introduced incorrectly in https://github.com/BerriAI/litellm/pull/15775

## Relevant issues

[<!-- e.g. "Fixes #000" -->](https://github.com/BerriAI/litellm/issues/15508)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] ~~I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~ N/A
- [ ] ~~I have added a screenshot of my new test passing locally~~ N/A
- [ ] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~ N/A
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

I've confirmed the correct value of `anthropic.claude-3-7-sonnet-20250219-v1:0` based on searching for `anthropic.claude-3-7-sonnet` at https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html. Note that if you search for `anthropic.claude-3-7-sonnet-20240620-v1:0` it does not appear at all. 
