### PR TITLE
Feat: Allow prompt caching to be used for Anthropic Claude on Databricks

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -43,6 +43,7 @@ from litellm.types.llms.openai import (
     ChatCompletionThinkingBlock,
     ChatCompletionToolChoiceFunctionParam,
     ChatCompletionToolChoiceObjectParam,
+    ChatCompletionToolParam,
 )
 from litellm.types.utils import (
     ChatCompletionMessageToolCall,
@@ -216,6 +217,21 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
 
         databricks_tool = self.convert_anthropic_tool_to_databricks_tool(tool)
         return databricks_tool
+
+    def remove_cache_control_flag_from_messages_and_tools(
+        self,
+        model: str,  # allows overrides to selectively run this
+        messages: List[AllMessageValues],
+        tools: Optional[List["ChatCompletionToolParam"]] = None,
+    ) -> Tuple[List[AllMessageValues], Optional[List["ChatCompletionToolParam"]]]:
+        """
+        Override the parent class method to preserve cache_control for models on Databricks.
+        Databricks supports Anthropic-style cache control for Claude models.
+        Databricks ignores the cache_control flag with other models.
+        """
+        # TODO: Think about how to best design the request transformation so that 
+        # every request doesn't have to be transformed for to OpenAI and Anthropic request formats.
+        return messages, tools
 
     def map_openai_params(
         self,

--- a/tests/llm_translation/test_databricks.py
+++ b/tests/llm_translation/test_databricks.py
@@ -54,6 +54,125 @@ def mock_chat_response() -> Dict[str, Any]:
     }
 
 
+def mock_chat_response_claude_prompt_caching() -> Dict[str, Any]:
+    return {
+        "id": "msg_01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "object": "chat.completion",
+        "created": 1761118943,
+        "model": "claude-3-7-sonnet", # Mock model name for testing
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "The text you've provided consists entirely of the phrase \"example text\" repeated many times without any variation or additional content. There is no specific information, narrative, argument, or structured content to explain. This appears to be placeholder or filler text that would typically be replaced with actual content in a final document.",
+                    "refusal": None,
+                    "function_call": None,
+                    "tool_calls": None,
+                    "annotations": None,
+                    "audio": None,
+                },
+                "finish_reason": "stop",
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1556,
+            "completion_tokens": 65,
+            "total_tokens": 1621,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 1552,
+        },
+        "service_tier": None,
+        "system_fingerprint": None,
+    }
+
+def mock_chat_response_claude_prompt_caching_repeat() -> Dict[str, Any]:
+    return {
+        "id": "msg_01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "object": "chat.completion",
+        "created": 1761118943,
+        "model": "claude-3-7-sonnet", # Mock model name for testing
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "The text you've provided consists entirely of the phrase \"example text\" repeated many times without any variation or additional content. There is no specific information, narrative, argument, or structured content to explain. This appears to be placeholder or filler text that would typically be replaced with actual content in a final document.",
+                    "refusal": None,
+                    "function_call": None,
+                    "tool_calls": None,
+                    "annotations": None,
+                    "audio": None,
+                },
+                "finish_reason": "stop",
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1556,
+            "completion_tokens": 65,
+            "total_tokens": 1621,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+            "cache_read_input_tokens": 1552,
+            "cache_creation_input_tokens": 0,
+        },
+        "service_tier": None,
+        "system_fingerprint": None,
+    }
+
+
+def mock_chat_response_nonclaude_prompt_caching() -> Dict[str, Any]:
+    return {
+        "id": "msg_01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        "object": "chat.completion",
+        "created": 1761119150,
+        "model": "gpt-oss-20b",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "summary": [
+                                {
+                                    "type": "summary_text",
+                                    "text": "The user just posted a block of text repeated: \"example textexample\" many times. It is unclear what they want. The instruction says: \"You are a helpful assistant that explains the content of the given text.\" So I need to explain the content.\n\nThe content is basically a repeated phrase 'example textexample' many times, possibly a demonstration of repeated words or filler text. Perhaps they test that the assistant enumerates or condenses. Should I explain that it is a repeated phrase used maybe as placeholder text? It looks like a placeholder or filler. Could say that it's essentially nonsense.\n\nExplain that the text consists of the word \"example\" concatenated with \"text\" repeated many times. It's not meaningful content. Might indicate filler text for page layout.\n\nAlternatively, explain why repeated 'example textexample' (without whitespace in some places?) is repeated. This could be a test. The user probably expects a response like: \"It says 'example textexample' several times.\" So I should summarize: The text is a repeated phrase used as filler.\n\nGiven the instruction, let's explain the content. Mention that it's repetitive placeholder, no meaningful content, just repeated phrase. Also note that \"example text\" repeated words. No specific meaning beyond being placeholder.\n\nSo respond: This is basically a placeholder used in design documents: the phrase \"example text\" repeated to fill a space, no distinct meaning beyond placeholder usage. 'text' might be part of the 'example text' phrase or 'textexample' it's concatenated. These might serve to fill text boxes, test fonts, etc.\n\nAlso mention the pattern: Could be used for testing text rendering, typographic layouts, measuring dimensions.\n\nAnswer accordingly."
+                                }
+                            ]
+                        },
+                        {
+                            "type": "text",
+                            "text": "The passage you pasted is essentially a block of **placeholder text**.  \nIt repeats the phrase \"example textexample\" (or \"example text\" in some places) over and over again.  There isn't any hidden message, concept, or argument buried in it – the purpose is purely to fill space, imitate real content, or test something like typography, layout, or rendering.\n\nIn design and copy‑editing, such repeated strings are often used to:\n\n* **Fill a page or template** so the designer can see how multiple lines of content will look.\n* **Test the appearance of fonts, line‑height, paragraph spacing, and other typographic settings.**\n* **Serve as a stand"
+                        }
+                    ],
+                    "refusal": None,
+                    "function_call": None,
+                    "tool_calls": None,
+                    "annotations": None,
+                    "audio": None,
+                },
+                "finish_reason": "stop",
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1638,
+            "completion_tokens": 500,
+            "total_tokens": 2138,
+            "completion_tokens_details": None,
+            "prompt_tokens_details": None,
+        },
+        "service_tier": None,
+        "system_fingerprint": None,
+    }
+
+
 def mock_chat_streaming_response_chunks() -> List[str]:
     return [
         json.dumps(
@@ -712,3 +831,190 @@ async def test_databricks_embeddings(sync_mode):
         # assert response.data[0]["embedding"] == [0.1, 0.2, 0.3]
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+def test_completion_with_prompt_caching_claude_model(monkeypatch):
+    base_url = "https://my.workspace.cloud.databricks.com/serving-endpoints"
+    api_key = "dapimykey"
+    monkeypatch.setenv("DATABRICKS_API_BASE", base_url)
+    monkeypatch.setenv("DATABRICKS_API_KEY", api_key)
+
+    sync_handler = HTTPHandler()
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_chat_response_claude_prompt_caching()
+
+    mock_text = 'example text' * 512
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant that explains the content of the given text."
+                }
+            ]
+        },
+        {
+            "role": "user", 
+            "content": [
+                {
+                    "type": "text", 
+                    "text": mock_text,
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }
+    ]
+
+    with patch.object(HTTPHandler, "post", return_value=mock_response) as mock_post:
+        response = litellm.completion(
+            model="databricks/databricks-claude-3-7-sonnet",
+            messages=messages,
+            client=sync_handler,
+            temperature=0.5
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Authorization"]
+            == f"Bearer {api_key}"
+        )
+        assert mock_post.call_args.kwargs["url"] == f"{base_url}/chat/completions"
+        assert mock_post.call_args.kwargs["stream"] == False
+
+        # TODO: add test for entire expected output schema in the future
+        # Check the response object returned from litellm.completion()
+        assert 'claude-3-7-sonnet' in response['model']
+        assert response['usage']['cache_read_input_tokens'] == 0
+        assert response['usage']['cache_creation_input_tokens'] == 1552
+        assert response['usage']['prompt_tokens'] == 1556
+        assert response['usage']['completion_tokens'] == 65
+        assert response['usage']['total_tokens'] == 1621
+
+
+def test_completion_with_prompt_caching_claude_model_repeat(monkeypatch):
+    base_url = "https://my.workspace.cloud.databricks.com/serving-endpoints"
+    api_key = "dapimykey"
+    monkeypatch.setenv("DATABRICKS_API_BASE", base_url)
+    monkeypatch.setenv("DATABRICKS_API_KEY", api_key)
+
+    sync_handler = HTTPHandler()
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_chat_response_claude_prompt_caching_repeat()
+
+    mock_text = 'example text' * 512
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant that explains the content of the given text."
+                }
+            ]
+        },
+        {
+            "role": "user", 
+            "content": [
+                {
+                    "type": "text", 
+                    "text": mock_text,
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }
+    ]
+
+    with patch.object(HTTPHandler, "post", return_value=mock_response) as mock_post:
+        response = litellm.completion(
+            model="databricks/databricks-claude-3-7-sonnet",
+            messages=messages,
+            client=sync_handler,
+            temperature=0.5,
+            extraparam="testpassingextraparam",
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Authorization"]
+            == f"Bearer {api_key}"
+        )
+        assert mock_post.call_args.kwargs["url"] == f"{base_url}/chat/completions"
+        assert mock_post.call_args.kwargs["stream"] == False
+
+        
+        # TODO: add test for entire expected output schema in the future
+        # Check the response object returned from litellm.completion()
+        assert 'claude-3-7-sonnet' in response['model']
+        assert response['usage']['cache_read_input_tokens'] == 1552
+        assert response['usage']['cache_creation_input_tokens'] == 0
+        assert response['usage']['prompt_tokens'] == 1556
+        assert response['usage']['completion_tokens'] == 65
+        assert response['usage']['total_tokens'] == 1621
+
+
+def test_completion_with_prompt_caching_nonclaude_model(monkeypatch):
+    base_url = "https://my.workspace.cloud.databricks.com/serving-endpoints"
+    api_key = "dapimykey"
+    monkeypatch.setenv("DATABRICKS_API_BASE", base_url)
+    monkeypatch.setenv("DATABRICKS_API_KEY", api_key)
+
+    sync_handler = HTTPHandler()
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_chat_response_nonclaude_prompt_caching()
+
+    mock_text = 'example text' * 512
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful assistant that explains the content of the given text."
+                }
+            ]
+        },
+        {
+            "role": "user", 
+            "content": [
+                {
+                    "type": "text", 
+                    "text": mock_text,
+                    "cache_control": {"type": "ephemeral"}
+                }
+            ]
+        }
+    ]
+
+    with patch.object(HTTPHandler, "post", return_value=mock_response) as mock_post:
+        response = litellm.completion(
+            model="databricks/databricks-gpt-oss-20b",
+            messages=messages,
+            client=sync_handler,
+            temperature=0.5,
+            extraparam="testpassingextraparam",
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
+        )
+        assert (
+            mock_post.call_args.kwargs["headers"]["Authorization"]
+            == f"Bearer {api_key}"
+        )
+        assert mock_post.call_args.kwargs["url"] == f"{base_url}/chat/completions"
+        assert mock_post.call_args.kwargs["stream"] == False
+
+        # TODO: add test for entire expected output schema in the future
+        # Check the response object returned from litellm.completion()
+        assert 'gpt-oss-20b' in response['model']
+        assert ('cache_read_input_tokens' not in response['usage']) or response['usage']['cache_read_input_tokens'] in [0, None]
+        assert ('cache_creation_input_tokens' not in response['usage']) or response['usage']['cache_creation_input_tokens'] in [0, None]
+        assert response['usage']['prompt_tokens'] == 1638
+        assert response['usage']['completion_tokens'] == 500
+        assert response['usage']['total_tokens'] == 2138
+        


### PR DESCRIPTION
## Title
Feat: Allow prompt caching to be used for Anthropic Claude on Databricks

## Relevant issues

## Pre-Submission checklist
Please complete all items before asking a LiteLLM maintainer to review your PR

- [X] I have Added testing in the [tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, Adding at least 1 test is a hard requirement - [see details](https://docs.litellm.ai/docs/extras/contributing_code) N/A
- [x] I have added a screenshot of my new test passing locally. [Screenshot](https://github.com/user-attachments/assets/92298daf-8779-4a3e-a29e-59c67ea9ca8e)

~- [ ] My PR passes all unit tests on [make test-unit](https://docs.litellm.ai/docs/extras/contributing_code) N/A~
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🆕 New Feature

## Changes
Currently `DatabricksConfig` inherits from `OpenAIGPTConfig`, where the 
`remove_cache_control_flag_from_messages_and_tools` method in that class would remove anthropic's prompt caching checkpoints from the content in `messages`, which would disable prompt caching for Anthropic Claude on Databricks.

This PR overrides that method with a method that skips the prompt caching checkpoints removal process mentioned above when Databricks's request transformation is used. Databricks's endpoints ignores the Anthropic prompt caching checkpoint in `messages` if the model used does not support it.

I have added test cases specifically to check on the output format and whether the cache read and creation token count would be reflected accurately in the output from LiteLLM.

`cache_control` in Databricks's documentation: https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#-textcontent