### PR TITLE
[Bug Fix]: ErrorEvent ValidationError when OpenAI Responses API returns nested error structure

### DIFF
--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1408,11 +1408,18 @@ class ImageGenerationPartialImageEvent(BaseLiteLLMOpenAIResponseObject):
     b64_json: str
 
 
-class ErrorEvent(BaseLiteLLMOpenAIResponseObject):
-    type: Literal[ResponsesAPIStreamEvents.ERROR]
-    code: Optional[str]
+class ErrorEventError(BaseLiteLLMOpenAIResponseObject):
+    """Nested error object within ErrorEvent"""
+    type: str  # e.g., 'invalid_request_error'
+    code: str  # e.g., 'context_length_exceeded'
     message: str
     param: Optional[str]
+
+
+class ErrorEvent(BaseLiteLLMOpenAIResponseObject):
+    type: Literal[ResponsesAPIStreamEvents.ERROR]
+    sequence_number: int
+    error: ErrorEventError
 
 
 class GenericEvent(BaseLiteLLMOpenAIResponseObject):

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -1508,3 +1508,21 @@ async def test_basic_openai_responses_with_websearch(stream):
             print("chunk=", json.dumps(chunk, indent=4, default=str))
     else:
         print("response=", json.dumps(response, indent=4, default=str))
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_api_token_limit_error():
+    litellm._turn_on_debug()
+
+    # Generate text with >400k tokens to trigger token limit error
+    oversized_text = "This is a test sentence. " * 50000  # ~400k tokens
+
+    # This will raise ValidationError instead of showing the real error
+    response = await litellm.aresponses(
+        model="gpt-5-mini",
+        input=oversized_text,
+        stream=True
+    )
+
+    async for event in response:
+        print(event)  # Never reaches here - ValidationError is raised

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -1512,6 +1512,14 @@ async def test_basic_openai_responses_with_websearch(stream):
 
 @pytest.mark.asyncio
 async def test_openai_responses_api_token_limit_error():
+    """
+    Relevant issue: https://github.com/BerriAI/litellm/issues/15785
+
+
+    When this fails you'll see:
+    "pydantic_core._pydantic_core.ValidationError: 3 validation errors for ErrorEvent"
+    in the console.
+    """
     litellm._turn_on_debug()
 
     # Generate text with >400k tokens to trigger token limit error


### PR DESCRIPTION
## [Bug Fix]: ErrorEvent ValidationError when OpenAI Responses API returns nested error structure

Fixes https://github.com/BerriAI/litellm/issues/15785

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


