### PR TITLE
Use proper bedrock model name in health check

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -138,6 +138,7 @@ def _update_litellm_params_for_health_check(
     - gets a short `messages` param for health check
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
+    - updates the `model` param with the Bedrock base model name if it is a Bedrock model
     """
     litellm_params["messages"] = _get_random_llm_message()
     _health_check_model = model_info.get("health_check_model", None)
@@ -145,6 +146,9 @@ def _update_litellm_params_for_health_check(
         litellm_params["model"] = _health_check_model
     if model_info.get("mode", None) == "audio_speech":
         litellm_params["voice"] = model_info.get("health_check_voice", "alloy")
+    if "bedrock" in litellm_params["model"]:
+        from litellm.llms.bedrock.common_utils import BedrockModelInfo
+        litellm_params["model"] = BedrockModelInfo.get_base_model(litellm_params["model"])
     return litellm_params
 
 

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -304,6 +304,15 @@ def test_update_litellm_params_for_health_check():
     updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
     assert "voice" not in updated_params
 
+    # Test with Bedrock model
+    model_info = {}
+    litellm_params = {
+        "model": "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0",
+        "api_key": "fake_key",
+    }
+    updated_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+    assert updated_params["model"] == "anthropic.claude-3-7-sonnet-20250219-v1:0"
+
 @pytest.mark.asyncio
 async def test_perform_health_check_with_health_check_model():
     """


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Fixes #15807 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
<img width="717" height="368" alt="image" src="https://github.com/user-attachments/assets/bdd98510-aaa4-45c1-a54f-e66c15add73c" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Updates `_update_litellm_params_for_health_check` to update the `model` param with the Bedrock base model name if it is a Bedrock model
