### PR TITLE
[Fix] Azure AI Speech - Ensure `voice` is mapped from request body -> SSML body , allow sending `role` and `style`

### DIFF
--- a/docs/my-website/docs/providers/azure/azure_speech.md
+++ b/docs/my-website/docs/providers/azure/azure_speech.md
@@ -57,9 +57,7 @@ Azure OpenAI supports the following voices:
 
 ## Supported Parameters
 
-### OpenAI-Compatible Parameters
-
-```python showLineNumbers title="Standard Parameters"
+```python showLineNumbers title="All Parameters"
 response = speech(
     model="azure/<your-deployment-name>",
     voice="alloy",                    # Required: Voice selection
@@ -68,88 +66,6 @@ response = speech(
     response_format="mp3"             # Optional: mp3, opus, aac, flac, wav, pcm
 )
 ```
-
-## Sending Azure-Specific Params
-
-Azure TTS supports additional SSML features through optional parameters:
-
-- style: Speaking style (e.g., "cheerful", "sad", "angry")
-- styledegree: Style intensity (0.01 to 2)
-- role: Voice role (e.g., "Girl", "Boy", "SeniorFemale", "SeniorMale")
-- lang: Language code for multilingual voices (e.g., "es-ES", "fr-FR")
-
-
-#### **Using LiteLLM AI Gateway (CURL)**
-
-#### Custom Azure Voice
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "azure-tts",
-    "voice": "en-US-AndrewNeural",
-    "input": "Hello, this is a test"
-  }' \
-  --output speech.mp3
-```
-
-#### Speaking Style
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "azure-tts",
-    "voice": "en-US-AriaNeural",
-    "input": "That would be just amazing!",
-    "style": "cheerful"
-  }' \
-  --output speech.mp3
-```
-
-#### Style with Degree and Role
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "azure-tts",
-    "voice": "en-US-AriaNeural",
-    "input": "Good morning! How are you today?",
-    "style": "cheerful",
-    "styledegree": "2",
-    "role": "SeniorFemale"
-  }' \
-  --output speech.mp3
-```
-
-#### Language Override
-
-```bash
-curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
-  -H 'Authorization: Bearer sk-1234' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "azure-tts",
-    "voice": "en-US-AvaMultilingualNeural",
-    "input": "Hola, ¿cómo estás?",
-    "lang": "es-ES"
-  }' \
-  --output speech.mp3
-```
-
-## Azure-Specific Parameters Reference
-
-| Parameter | Description | Example Values | Notes |
-|-----------|-------------|----------------|-------|
-| `style` | Speaking style | `cheerful`, `sad`, `angry`, `excited`, `friendly`, `hopeful`, `shouting`, `terrified`, `unfriendly`, `whispering` | Only supported by certain voices. See [Azure voice styles documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-voice#use-speaking-styles-and-roles) |
-| `styledegree` | Style intensity | `0.01` to `2` | Higher values = more intense. Default is `1` |
-| `role` | Voice role | `Girl`, `Boy`, `YoungAdultFemale`, `YoungAdultMale`, `OlderAdultFemale`, `OlderAdultMale`, `SeniorFemale`, `SeniorMale` | Only supported by certain voices |
-| `lang` | Language code | `es-ES`, `fr-FR`, `de-DE`, etc. | For multilingual voices. Overrides the default language |
 
 ## Supported Models
 

--- a/docs/my-website/docs/providers/azure/azure_speech.md
+++ b/docs/my-website/docs/providers/azure/azure_speech.md
@@ -57,7 +57,9 @@ Azure OpenAI supports the following voices:
 
 ## Supported Parameters
 
-```python showLineNumbers title="All Parameters"
+### OpenAI-Compatible Parameters
+
+```python showLineNumbers title="Standard Parameters"
 response = speech(
     model="azure/<your-deployment-name>",
     voice="alloy",                    # Required: Voice selection
@@ -66,6 +68,88 @@ response = speech(
     response_format="mp3"             # Optional: mp3, opus, aac, flac, wav, pcm
 )
 ```
+
+## Sending Azure-Specific Params
+
+Azure TTS supports additional SSML features through optional parameters:
+
+- style: Speaking style (e.g., "cheerful", "sad", "angry")
+- styledegree: Style intensity (0.01 to 2)
+- role: Voice role (e.g., "Girl", "Boy", "SeniorFemale", "SeniorMale")
+- lang: Language code for multilingual voices (e.g., "es-ES", "fr-FR")
+
+
+#### **Using LiteLLM AI Gateway (CURL)**
+
+#### Custom Azure Voice
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "azure-tts",
+    "voice": "en-US-AndrewNeural",
+    "input": "Hello, this is a test"
+  }' \
+  --output speech.mp3
+```
+
+#### Speaking Style
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "azure-tts",
+    "voice": "en-US-AriaNeural",
+    "input": "That would be just amazing!",
+    "style": "cheerful"
+  }' \
+  --output speech.mp3
+```
+
+#### Style with Degree and Role
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "azure-tts",
+    "voice": "en-US-AriaNeural",
+    "input": "Good morning! How are you today?",
+    "style": "cheerful",
+    "styledegree": "2",
+    "role": "SeniorFemale"
+  }' \
+  --output speech.mp3
+```
+
+#### Language Override
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/v1/audio/speech' \
+  -H 'Authorization: Bearer sk-1234' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "azure-tts",
+    "voice": "en-US-AvaMultilingualNeural",
+    "input": "Hola, ¿cómo estás?",
+    "lang": "es-ES"
+  }' \
+  --output speech.mp3
+```
+
+## Azure-Specific Parameters Reference
+
+| Parameter | Description | Example Values | Notes |
+|-----------|-------------|----------------|-------|
+| `style` | Speaking style | `cheerful`, `sad`, `angry`, `excited`, `friendly`, `hopeful`, `shouting`, `terrified`, `unfriendly`, `whispering` | Only supported by certain voices. See [Azure voice styles documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-voice#use-speaking-styles-and-roles) |
+| `styledegree` | Style intensity | `0.01` to `2` | Higher values = more intense. Default is `1` |
+| `role` | Voice role | `Girl`, `Boy`, `YoungAdultFemale`, `YoungAdultMale`, `OlderAdultFemale`, `OlderAdultMale`, `SeniorFemale`, `SeniorMale` | Only supported by certain voices |
+| `lang` | Language code | `es-ES`, `fr-FR`, `de-DE`, etc. | For multilingual voices. Overrides the default language |
 
 ## Supported Models
 

--- a/litellm/llms/azure/text_to_speech/transformation.py
+++ b/litellm/llms/azure/text_to_speech/transformation.py
@@ -227,6 +227,7 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
+        kwargs: Dict = {},
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI parameters to Azure AVA TTS parameters
@@ -264,18 +265,17 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
                 mapped_params["rate"] = self._convert_speed_to_azure_rate(speed=speed)
         
         # Pass through Azure-specific SSML parameters
-        if "style" in optional_params:
-            mapped_params["style"] = optional_params["style"]
+        if "style" in kwargs:
+            mapped_params["style"] = kwargs["style"]
         
-        if "styledegree" in optional_params:
-            mapped_params["styledegree"] = optional_params["styledegree"]
+        if "styledegree" in kwargs:
+            mapped_params["styledegree"] = kwargs["styledegree"]
         
-        if "role" in optional_params:
-            mapped_params["role"] = optional_params["role"]
+        if "role" in kwargs:
+            mapped_params["role"] = kwargs["role"]
         
-        if "lang" in optional_params:
-            mapped_params["lang"] = optional_params["lang"]
-        
+        if "lang" in kwargs:
+            mapped_params["lang"] = kwargs["lang"]
         return mapped_voice, mapped_params
 
     def validate_environment(

--- a/litellm/llms/base_llm/text_to_speech/transformation.py
+++ b/litellm/llms/base_llm/text_to_speech/transformation.py
@@ -70,6 +70,7 @@ class BaseTextToSpeechConfig(ABC):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
+        kwargs: Dict = {},
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI TTS parameters to provider-specific parameters

--- a/litellm/llms/base_llm/text_to_speech/transformation.py
+++ b/litellm/llms/base_llm/text_to_speech/transformation.py
@@ -1,6 +1,6 @@
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, TypedDict, Union
 
 import httpx
 
@@ -68,8 +68,9 @@ class BaseTextToSpeechConfig(ABC):
         self,
         model: str,
         optional_params: Dict,
-        drop_params: bool,
-    ) -> Dict:
+        voice: Optional[Union[str, Dict]] = None,
+        drop_params: bool = False,
+    ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI TTS parameters to provider-specific parameters
         """

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5706,9 +5706,10 @@ def speech(  # noqa: PLR0915
     
     # Map OpenAI params to provider-specific params if config exists
     if text_to_speech_provider_config is not None:
-        optional_params = text_to_speech_provider_config.map_openai_params(
+        voice, optional_params = text_to_speech_provider_config.map_openai_params(
             model=model,
             optional_params=optional_params,
+            voice=voice,
             drop_params=False,
         )
     

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5711,13 +5711,14 @@ def speech(  # noqa: PLR0915
             optional_params=optional_params,
             voice=voice,
             drop_params=False,
+            kwargs=kwargs,
         )
     
     logging_obj: Logging = cast(Logging, kwargs.get("litellm_logging_obj"))
     logging_obj.update_environment_variables(
         model=model,
         user=user,
-        optional_params={},
+        optional_params=optional_params,
         litellm_params={
             "litellm_call_id": litellm_call_id,
             "proxy_server_request": proxy_server_request,

--- a/tests/test_litellm/llms/azure/text_to_speech/test_azure_tts_transformation.py
+++ b/tests/test_litellm/llms/azure/text_to_speech/test_azure_tts_transformation.py
@@ -19,30 +19,32 @@ def test_map_openai_params_voice_mapping(azure_tts_config: AzureAVATextToSpeechC
     """
     Test mapping OpenAI voice to Azure AVA voice
     """
-    optional_params = {"voice": "alloy"}
+    optional_params = {}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
+        voice="alloy",
         drop_params=False
     )
     
-    assert mapped["voice"] == "en-US-JennyNeural"
+    assert mapped_voice == "en-US-JennyNeural"
 
 
 def test_map_openai_params_custom_azure_voice(azure_tts_config: AzureAVATextToSpeechConfig):
     """
     Test using custom Azure voice directly
     """
-    optional_params = {"voice": "en-GB-RyanNeural"}
+    optional_params = {}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
+        voice="en-GB-RyanNeural",
         drop_params=False
     )
     
-    assert mapped["voice"] == "en-GB-RyanNeural"
+    assert mapped_voice == "en-GB-RyanNeural"
 
 
 def test_map_openai_params_response_format(azure_tts_config: AzureAVATextToSpeechConfig):
@@ -51,13 +53,13 @@ def test_map_openai_params_response_format(azure_tts_config: AzureAVATextToSpeec
     """
     optional_params = {"response_format": "mp3"}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
         drop_params=False
     )
     
-    assert mapped["output_format"] == "audio-24khz-48kbitrate-mono-mp3"
+    assert mapped_params["output_format"] == "audio-24khz-48kbitrate-mono-mp3"
 
 
 def test_map_openai_params_default_format(azure_tts_config: AzureAVATextToSpeechConfig):
@@ -66,13 +68,13 @@ def test_map_openai_params_default_format(azure_tts_config: AzureAVATextToSpeech
     """
     optional_params = {}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
         drop_params=False
     )
     
-    assert mapped["output_format"] == "audio-24khz-48kbitrate-mono-mp3"
+    assert mapped_params["output_format"] == "audio-24khz-48kbitrate-mono-mp3"
 
 
 def test_map_openai_params_speed(azure_tts_config: AzureAVATextToSpeechConfig):
@@ -81,14 +83,14 @@ def test_map_openai_params_speed(azure_tts_config: AzureAVATextToSpeechConfig):
     """
     optional_params = {"speed": 1.5}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
         drop_params=False
     )
     
     # Speed 1.5 should map to +50%
-    assert mapped["rate"] == "+50%"
+    assert mapped_params["rate"] == "+50%"
 
 
 def test_map_openai_params_slow_speed(azure_tts_config: AzureAVATextToSpeechConfig):
@@ -97,14 +99,14 @@ def test_map_openai_params_slow_speed(azure_tts_config: AzureAVATextToSpeechConf
     """
     optional_params = {"speed": 0.5}
     
-    mapped = azure_tts_config.map_openai_params(
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
         model="azure-tts",
         optional_params=optional_params,
         drop_params=False
     )
     
     # Speed 0.5 should map to -50%
-    assert mapped["rate"] == "-50%"
+    assert mapped_params["rate"] == "-50%"
 
 
 # Tests for get_complete_url
@@ -281,4 +283,173 @@ def test_transform_text_to_speech_response(azure_tts_config: AzureAVATextToSpeec
     # Should return HttpxBinaryResponseContent wrapper
     from litellm.types.llms.openai import HttpxBinaryResponseContent
     assert isinstance(result, HttpxBinaryResponseContent)
+
+
+# Tests for helper methods
+def test_build_express_as_element_with_style(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test _build_express_as_element helper with style only
+    """
+    result = azure_tts_config._build_express_as_element(
+        content="<prosody rate='+0%'>Test</prosody>",
+        style="cheerful"
+    )
+    
+    assert result == "<mstts:express-as style='cheerful'><prosody rate='+0%'>Test</prosody></mstts:express-as>"
+
+
+def test_build_express_as_element_with_all_attrs(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test _build_express_as_element helper with all attributes
+    """
+    result = azure_tts_config._build_express_as_element(
+        content="<prosody rate='+0%'>Test</prosody>",
+        style="cheerful",
+        styledegree="2",
+        role="SeniorFemale"
+    )
+    
+    assert "<mstts:express-as" in result
+    assert "style='cheerful'" in result
+    assert "styledegree='2'" in result
+    assert "role='SeniorFemale'" in result
+    assert "<prosody rate='+0%'>Test</prosody>" in result
+    assert "</mstts:express-as>" in result
+
+
+def test_build_express_as_element_no_attrs(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test _build_express_as_element helper returns content unchanged when no attrs
+    """
+    content = "<prosody rate='+0%'>Test</prosody>"
+    result = azure_tts_config._build_express_as_element(content=content)
+    
+    assert result == content
+    assert "<mstts:express-as" not in result
+
+
+# Tests for Azure-specific SSML features
+def test_map_openai_params_style(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test passing through Azure style parameter
+    """
+    optional_params = {"style": "cheerful"}
+    
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
+        model="azure-tts",
+        optional_params=optional_params,
+        drop_params=False
+    )
+    
+    assert mapped_params["style"] == "cheerful"
+
+
+def test_map_openai_params_style_and_role(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test passing through Azure style, styledegree, and role parameters
+    """
+    optional_params = {
+        "style": "cheerful",
+        "styledegree": "2",
+        "role": "SeniorFemale"
+    }
+    
+    mapped_voice, mapped_params = azure_tts_config.map_openai_params(
+        model="azure-tts",
+        optional_params=optional_params,
+        drop_params=False
+    )
+    
+    assert mapped_params["style"] == "cheerful"
+    assert mapped_params["styledegree"] == "2"
+    assert mapped_params["role"] == "SeniorFemale"
+
+
+def test_transform_text_to_speech_request_with_style(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test SSML generation with style parameter includes mstts:express-as element
+    """
+    result = azure_tts_config.transform_text_to_speech_request(
+        model="azure-tts",
+        input="Hello world",
+        voice="en-US-AriaNeural",
+        optional_params={
+            "voice": "en-US-AriaNeural",
+            "style": "cheerful"
+        },
+        litellm_params={},
+        headers={}
+    )
+    
+    ssml = result["ssml_body"]
+    
+    # Should include mstts namespace
+    assert "xmlns:mstts='https://www.w3.org/2001/mstts'" in ssml
+    
+    # Should include mstts:express-as with style
+    assert "<mstts:express-as style='cheerful'>" in ssml
+    assert "</mstts:express-as>" in ssml
+    
+    # Should still include the content
+    assert "Hello world" in ssml
+    assert "en-US-AriaNeural" in ssml
+
+
+def test_transform_text_to_speech_request_with_style_degree_role(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test SSML generation with style, styledegree, and role parameters
+    """
+    result = azure_tts_config.transform_text_to_speech_request(
+        model="azure-tts",
+        input="Test message",
+        voice="en-US-AriaNeural",
+        optional_params={
+            "voice": "en-US-AriaNeural",
+            "style": "cheerful",
+            "styledegree": "2",
+            "role": "SeniorFemale"
+        },
+        litellm_params={},
+        headers={}
+    )
+    
+    ssml = result["ssml_body"]
+    
+    # Should include mstts namespace
+    assert "xmlns:mstts='https://www.w3.org/2001/mstts'" in ssml
+    
+    # Should include mstts:express-as with all attributes
+    assert "<mstts:express-as" in ssml
+    assert "style='cheerful'" in ssml
+    assert "styledegree='2'" in ssml
+    assert "role='SeniorFemale'" in ssml
+    assert "</mstts:express-as>" in ssml
+
+
+def test_transform_text_to_speech_request_without_style(azure_tts_config: AzureAVATextToSpeechConfig):
+    """
+    Test that SSML without style does not include mstts namespace or express-as
+    """
+    result = azure_tts_config.transform_text_to_speech_request(
+        model="azure-tts",
+        input="Hello world",
+        voice="en-US-AriaNeural",
+        optional_params={"voice": "en-US-AriaNeural"},
+        litellm_params={},
+        headers={}
+    )
+    
+    ssml = result["ssml_body"]
+    
+    # Should NOT include mstts namespace
+    assert "xmlns:mstts" not in ssml
+    
+    # Should NOT include mstts:express-as
+    assert "<mstts:express-as" not in ssml
+    
+    # Should still include basic SSML structure
+    assert "<speak" in ssml
+    assert "<voice" in ssml
+    assert "en-US-AriaNeural" in ssml
+    assert "Hello world" in ssml
 


### PR DESCRIPTION
## [Fix] Azure AI Speech - Ensure `voice` is mapped from request body -> SSML body 

- Ensures `voice` is sent to Azure API.
    - If `voice` is an OpenAI value (e.g., `"alloy"`, `"fable"`), LiteLLM automatically maps it to the corresponding Azure voice (e.g., `"en-US-JennyNeural"`, `"en-GB-RyanNeural"`)
    - If `voice` is already an Azure-specific voice (e.g., `"en-US-AriaNeural"`), it's passed through as-is
- Adds support for Azure-specific SSML parameters (`style`, `styledegree`, `role`, `lang`) to enable advanced speech customization features like speaking styles, voice roles, and language overrides for multilingual voices.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


