### PR TITLE
[fix] Pass user-defined headers and extra_headers to image-edit calls

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -711,6 +711,16 @@ def image_edit(
         # add images / or return a single image
         images = image if isinstance(image, list) else [image]
 
+        headers_from_kwargs = kwargs.get("headers")
+        merged_extra_headers: Dict[str, Any] = {}
+        if isinstance(headers_from_kwargs, dict):
+            merged_extra_headers.update(headers_from_kwargs)
+        if isinstance(extra_headers, dict):
+            merged_extra_headers.update(extra_headers)
+
+        if merged_extra_headers:
+            extra_headers = dict(merged_extra_headers)
+
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)
         model, custom_llm_provider, _, _ = get_llm_provider(


### PR DESCRIPTION
## Pass user-defined headers and extra_headers to image-edit calls

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/15814

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 

<img width="845" height="29" alt="image" src="https://github.com/user-attachments/assets/31e0b636-8341-48ce-a163-327fceb816c7" />


- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Image edit calls were not passing through `headers` / `extra_headers` defined statically in the config. This fixes that, merging the statically-defined headers into the final call.

This is verified by a new unit test, and I also verified in our deployed environment (against Azure gpt-image-1).
