### PR TITLE
feat(proxy): support absolute RPM/TPM in priority_reservation

### DIFF
--- a/docs/my-website/docs/proxy/dynamic_rate_limit.md
+++ b/docs/my-website/docs/proxy/dynamic_rate_limit.md
@@ -136,9 +136,16 @@ model_list:
 
 litellm_settings:
   callbacks: ["dynamic_rate_limiter_v3"]
-  priority_reservation: 
-    "prod": 0.9  # 90% reserved for production (9 RPM)
-    "dev": 0.1   # 10% reserved for development (1 RPM)
+  priority_reservation:
+    "prod": 0.9 # 90% reserved for production (9 RPM)
+    "dev": 0.1 # 10% reserved for development (1 RPM)
+    # Alternative format:
+    # "prod":
+    #   type: "rpm"    # Reserve based on requests per minute
+    #   value: 9       # 9 RPM = 90% of 10 RPM capacity
+    # "dev":
+    #   type: "tpm"    # Reserve based on tokens per minute
+    #   value: 100     # 100 TPM
   priority_reservation_settings:
     default_priority: 0  # Weight (0%) assigned to keys without explicit priority metadata
     saturation_threshold: 0.50 #  A model is saturated if it has hit 50% of its RPM limit
@@ -150,10 +157,12 @@ general_settings:
 
 **Configuration Details:**
 
-`priority_reservation`: Dict[str, float]
+`priority_reservation`: Dict[str, Union[float, PriorityReservationDict]]
 - **Key (str)**: Priority level name (can be any string like "prod", "dev", "critical", etc.)
-- **Value (float)**: Percentage of total TPM/RPM to reserve (0.0 to 1.0)
-- **Note**: Values should sum to 1.0 or less
+- **Value**: Either a float (0.0-1.0) or dict with `type` and `value`
+  - Float: `0.9` = 90% of capacity
+  - Dict: `{"type": "rpm", "value": 9}` = 9 requests/min
+  - Supported types: `"percent"`, `"rpm"`, `"tpm"`
 
 `priority_reservation_settings`: Object (Optional)
 - **default_priority (float)**: Weight/percentage (0.0 to 1.0) assigned to API keys that have no priority metadata set (defaults to 0.5)

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -28,6 +28,7 @@ from litellm.types.utils import (
     all_litellm_params,
     all_litellm_params as _litellm_completion_params,
     CredentialItem,
+    PriorityReservationDict,
 )  # maintain backwards compatibility for root param
 from litellm._logging import (
     set_verbose,
@@ -369,7 +370,7 @@ disable_copilot_system_to_assistant: bool = False  # If false (default), convert
 public_model_groups: Optional[List[str]] = None
 public_model_groups_links: Dict[str, str] = {}
 #### REQUEST PRIORITIZATION #######
-priority_reservation: Optional[Dict[str, Union[float, Dict]]] = None
+priority_reservation: Optional[Dict[str, Union[float, PriorityReservationDict]]] = None
 priority_reservation_settings: "PriorityReservationSettings" = (
     PriorityReservationSettings()
 )

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -369,7 +369,7 @@ disable_copilot_system_to_assistant: bool = False  # If false (default), convert
 public_model_groups: Optional[List[str]] = None
 public_model_groups_links: Dict[str, str] = {}
 #### REQUEST PRIORITIZATION #######
-priority_reservation: Optional[Dict[str, float]] = None
+priority_reservation: Optional[Dict[str, Union[float, Dict]]] = None
 priority_reservation_settings: "PriorityReservationSettings" = (
     PriorityReservationSettings()
 )

--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -17,6 +17,8 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.router import ModelGroupInfo
 from litellm.utils import get_utc_datetime
 
+from .rate_limiter_utils import convert_priority_to_percent
+
 
 class DynamicRateLimiterCache:
     """
@@ -99,6 +101,11 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
             - active_projects: int or null
         """
         try:
+            # Get model info first for conversion
+            model_group_info: Optional[
+                ModelGroupInfo
+            ] = self.llm_router.get_model_group_info(model_group=model)
+            
             weight: float = 1
             if (
                 litellm.priority_reservation is None
@@ -115,7 +122,8 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
                         "PREMIUM FEATURE: Reserving tpm/rpm by priority is a premium feature. Please add a 'LITELLM_LICENSE' to your .env to enable this.\nGet a license: https://docs.litellm.ai/docs/proxy/enterprise."
                     )
                 else:
-                    weight = litellm.priority_reservation[priority]
+                    value = litellm.priority_reservation[priority]
+                    weight = convert_priority_to_percent(value, model_group_info)
 
             active_projects = await self.internal_usage_cache.async_get_cache(
                 model=model
@@ -124,9 +132,6 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
                 current_model_tpm,
                 current_model_rpm,
             ) = await self.llm_router.get_model_group_usage(model_group=model)
-            model_group_info: Optional[
-                ModelGroupInfo
-            ] = self.llm_router.get_model_group_info(model_group=model)
             total_model_tpm: Optional[int] = None
             total_model_rpm: Optional[int] = None
             if model_group_info is not None:

--- a/litellm/proxy/hooks/rate_limiter_utils.py
+++ b/litellm/proxy/hooks/rate_limiter_utils.py
@@ -1,0 +1,54 @@
+"""
+Shared utility functions for rate limiter hooks.
+"""
+
+from typing import Dict, Optional, Union
+
+from litellm.types.router import ModelGroupInfo
+
+
+def convert_priority_to_percent(
+    value: Union[float, Dict], model_info: Optional[ModelGroupInfo]
+) -> float:
+    """
+    Convert priority reservation value to percentage (0.0-1.0).
+
+    Supports three formats:
+    1. Plain float/int: 0.9 -> 0.9 (90%)
+    2. Dict with percent: {"type": "percent", "value": 0.9} -> 0.9
+    3. Dict with rpm: {"type": "rpm", "value": 900} -> 900/model_rpm
+    4. Dict with tpm: {"type": "tpm", "value": 900000} -> 900000/model_tpm
+
+    Args:
+        value: Priority value as float or dict with type/value keys
+        model_info: Model configuration containing rpm/tpm limits
+
+    Returns:
+        float: Percentage value between 0.0 and 1.0
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, dict):
+        val_type = value.get("type", "percent")
+        val_num = value.get("value", 1.0)
+
+        if val_type == "percent":
+            return float(val_num)
+        elif (
+            val_type == "rpm"
+            and model_info
+            and model_info.rpm
+            and model_info.rpm > 0
+        ):
+            return float(val_num) / model_info.rpm
+        elif (
+            val_type == "tpm"
+            and model_info
+            and model_info.tpm
+            and model_info.tpm > 0
+        ):
+            return float(val_num) / model_info.tpm
+
+        # Fallback: treat as percent
+        return float(val_num)

--- a/litellm/proxy/hooks/rate_limiter_utils.py
+++ b/litellm/proxy/hooks/rate_limiter_utils.py
@@ -2,13 +2,14 @@
 Shared utility functions for rate limiter hooks.
 """
 
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from litellm.types.router import ModelGroupInfo
+from litellm.types.utils import PriorityReservationDict
 
 
 def convert_priority_to_percent(
-    value: Union[float, Dict], model_info: Optional[ModelGroupInfo]
+    value: Union[float, PriorityReservationDict], model_info: Optional[ModelGroupInfo]
 ) -> float:
     """
     Convert priority reservation value to percentage (0.0-1.0).

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2763,6 +2763,25 @@ CostResponseTypes = Union[
 ]
 
 
+class PriorityReservationDict(TypedDict, total=False):
+    """
+    Dictionary format for priority reservation values.
+    
+    Used in litellm.priority_reservation to specify how much capacity to reserve
+    for each priority level. Supports three formats:
+    1. Percentage-based: {"type": "percent", "value": 0.9} -> 90% of capacity
+    2. RPM-based: {"type": "rpm", "value": 900} -> 900 requests per minute
+    3. TPM-based: {"type": "tpm", "value": 900000} -> 900,000 tokens per minute
+    
+    Attributes:
+        type: The type of value - "percent", "rpm", or "tpm". Defaults to "percent".
+        value: The numeric value. For percent (0.0-1.0), for rpm/tpm (absolute value).
+    """
+
+    type: Literal["percent", "rpm", "tpm"]
+    value: float
+
+
 class PriorityReservationSettings(BaseModel):
     """
     Settings for priority-based rate limiting reservation.


### PR DESCRIPTION
## Title

feat(proxy): support absolute RPM/TPM in priority_reservation

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

• Extended `priority_reservation` to accept both float and dict values (absolute RPM/TPM support)
• Added `convert_priority_to_percent` helper in `rate_limiter_utils.py`
• Updated `dynamic_rate_limiter` and `dynamic_rate_limiter_v3` to use the new conversion logic

## Local Results

<img width="1155" height="270" alt="Screenshot 2025-10-22 at 2 38 34 PM" src="https://github.com/user-attachments/assets/b30a89a9-5787-406b-81f3-a6c69092270e" />


