### PR TITLE
Fix bedrock completions to use base model name

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -3157,8 +3157,9 @@ def completion(  # type: ignore # noqa: PLR0915
             bedrock_route = BedrockModelInfo.get_bedrock_route(model)
             if bedrock_route == "converse":
                 model = model.replace("converse/", "")
+                base_model = BedrockModelInfo.get_base_model(model)
                 response = bedrock_converse_chat_completion.completion(
-                    model=model,
+                    model=base_model,
                     messages=messages,
                     custom_prompt_dict=custom_prompt_dict,
                     model_response=model_response,
@@ -3176,8 +3177,9 @@ def completion(  # type: ignore # noqa: PLR0915
                 )
             elif bedrock_route == "converse_like":
                 model = model.replace("converse_like/", "")
+                base_model = BedrockModelInfo.get_base_model(model)
                 response = base_llm_http_handler.completion(
-                    model=model,
+                    model=base_model,
                     stream=stream,
                     messages=messages,
                     acompletion=acompletion,
@@ -3194,8 +3196,9 @@ def completion(  # type: ignore # noqa: PLR0915
                     client=client,
                 )
             else:
+                base_model = BedrockModelInfo.get_base_model(model)
                 response = base_llm_http_handler.completion(
-                    model=model,
+                    model=base_model,
                     stream=stream,
                     messages=messages,
                     acompletion=acompletion,
@@ -4274,8 +4277,9 @@ def embedding(  # noqa: PLR0915
                 transformed_input = [input]
             else:
                 transformed_input = input
+            base_model = BedrockModelInfo.get_base_model(model)
             response = bedrock_embedding.embeddings(
-                model=model,
+                model=base_model,
                 input=transformed_input,
                 encoding=encoding,
                 logging_obj=logging,


### PR DESCRIPTION
## Title

Fix bedrock completions to use base model name

## Relevant issues

Fixes #15819, similar to the fix in https://github.com/BerriAI/litellm/pull/15808

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] ~~I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)~~ -- not exactly sure where to add the test for this... 
- [x] I have added a screenshot of my new test passing locally 
- [ ] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~ -- I wasn't able to successfully set up my environment to get these tests working, so skipping this for now... 
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
<img width="1501" height="719" alt="image" src="https://github.com/user-attachments/assets/ef2121d7-3342-439f-8770-77c2b78873d5" />

