### PR TITLE
Add Azure support for video generation functionality

### DIFF
--- a/litellm/llms/azure/videos/transformation.py
+++ b/litellm/llms/azure/videos/transformation.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from litellm.types.videos.main import VideoCreateOptionalRequestParams
+from litellm.secret_managers.main import get_secret_str
+from litellm.llms.azure.common_utils import BaseAzureLLM
+import litellm
+from litellm.llms.openai.videos.transformation import OpenAIVideoConfig
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    from ...base_llm.videos.transformation import BaseVideoConfig as _BaseVideoConfig
+    from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+    BaseVideoConfig = _BaseVideoConfig
+    BaseLLMException = _BaseLLMException
+else:
+    LiteLLMLoggingObj = Any
+    BaseVideoConfig = Any
+    BaseLLMException = Any
+
+
+class AzureVideoConfig(OpenAIVideoConfig):
+    """
+    Configuration class for OpenAI video generation.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_supported_openai_params(self, model: str) -> list:
+        """
+        Get the list of supported OpenAI parameters for video generation.
+        """
+        return [
+            "model",
+            "prompt",
+            "input_reference",
+            "seconds",
+            "size",
+            "user",
+            "extra_headers",
+        ]
+
+    def map_openai_params(
+        self,
+        video_create_optional_params: VideoCreateOptionalRequestParams,
+        model: str,
+        drop_params: bool,
+    ) -> Dict:
+        """No mapping applied since inputs are in OpenAI spec already"""
+        return dict(video_create_optional_params)
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+    ) -> dict:
+        api_key = (
+            api_key
+            or litellm.api_key
+            or litellm.azure_key
+            or get_secret_str("AZURE_OPENAI_API_KEY")
+            or get_secret_str("AZURE_API_KEY")
+        )
+
+        headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+            }
+        )
+        return headers
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        """
+        Constructs a complete URL for the API request.
+        """
+        return BaseAzureLLM._get_base_azure_url(
+            api_base=api_base,
+            litellm_params=litellm_params,
+            route="/openai/v1/videos",
+            default_api_version="",
+        )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23784,5 +23784,53 @@
         "mode": "video_generation",
         "output_cost_per_second": 0.0,
         "supports_video_generation": true
+    },
+    "azure/sora-2": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.10,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "720x1280",
+            "1280x720"
+        ]
+    },
+    "azure/sora-2-pro": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.30,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "720x1280",
+            "1280x720"
+        ]
+    },
+    "azure/sora-2-pro-high-res": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.50,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "1024x1792",
+            "1792x1024"
+        ]
     }
 }

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7578,6 +7578,12 @@ class ProviderConfigManager:
             )
 
             return OpenAIVideoConfig()
+        elif LlmProviders.AZURE == provider:
+            from litellm.llms.azure.videos.transformation import (
+                AzureVideoConfig,
+            )
+
+            return AzureVideoConfig()
         return None
 
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23793,5 +23793,53 @@
             "720x1280",
             "1280x720"
         ]
+    },
+    "azure/sora-2": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.10,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "720x1280",
+            "1280x720"
+        ]
+    },
+    "azure/sora-2-pro": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.30,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "720x1280",
+            "1280x720"
+        ]
+    },
+    "azure/sora-2-pro-high-res": {
+        "litellm_provider": "azure",
+        "mode": "video_generation",
+        "output_cost_per_video_per_second": 0.50,
+        "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "supported_resolutions": [
+            "1024x1792",
+            "1792x1024"
+        ]
     }
 }

--- a/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
+++ b/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
@@ -305,7 +305,6 @@ class TestAzureVideoConfig:
     def test_video_create_with_file_upload(self):
         """Test video creation with file upload (input_reference)."""
         video_params = {
-            "prompt": "A video with reference image",
             "seconds": 10,
             "input_reference": "test_image.png"
         }

--- a/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
+++ b/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
@@ -1,0 +1,428 @@
+import json
+import os
+import sys
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch, Mock, mock_open
+import pytest
+import httpx
+
+# Add the parent directory to the system path
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
+)
+
+import litellm
+from litellm.llms.azure.videos.transformation import AzureVideoConfig
+from litellm.types.videos.main import VideoObject, VideoResponse, VideoCreateOptionalRequestParams
+from litellm.types.router import GenericLiteLLMParams
+
+
+class TestAzureVideoConfig:
+    """Test class for Azure video configuration and transformations."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.config = AzureVideoConfig()
+        self.model = "azure/sora-2"
+        self.api_base = "https://your-resource.openai.azure.com"
+        self.api_key = "test-api-key"
+
+    def test_get_supported_openai_params(self):
+        """Test getting supported OpenAI parameters for video generation."""
+        supported_params = self.config.get_supported_openai_params(self.model)
+        
+        expected_params = [
+            "model",
+            "prompt", 
+            "input_reference",
+            "seconds",
+            "size",
+            "user",
+            "extra_headers",
+        ]
+        
+        assert supported_params == expected_params
+        assert len(supported_params) == 7
+
+    def test_map_openai_params(self):
+        """Test mapping OpenAI parameters for video generation."""
+        video_params = VideoCreateOptionalRequestParams(
+            prompt="A beautiful sunset over mountains",
+            seconds=10,
+            size="1280x720",
+            user="test_user"
+        )
+        
+        result = self.config.map_openai_params(
+            video_create_optional_params=video_params,
+            model=self.model,
+            drop_params=False
+        )
+        
+        # Should return the same dict since no mapping is needed
+        assert result["prompt"] == "A beautiful sunset over mountains"
+        assert result["seconds"] == 10
+        assert result["size"] == "1280x720"
+        assert result["user"] == "test_user"
+
+    def test_validate_environment_with_api_key(self):
+        """Test environment validation with provided API key."""
+        headers = {"Content-Type": "application/json"}
+        
+        result_headers = self.config.validate_environment(
+            headers=headers,
+            model=self.model,
+            api_key=self.api_key
+        )
+        
+        assert "Authorization" in result_headers
+        assert result_headers["Authorization"] == f"Bearer {self.api_key}"
+        assert result_headers["Content-Type"] == "application/json"
+
+    @patch('litellm.llms.azure.videos.transformation.get_secret_str')
+    @patch('litellm.llms.azure.videos.transformation.litellm')
+    def test_validate_environment_without_api_key(self, mock_litellm, mock_get_secret):
+        """Test environment validation without provided API key."""
+        mock_litellm.api_key = None
+        mock_litellm.azure_key = None
+        mock_get_secret.return_value = "secret-api-key"
+        
+        headers = {"Content-Type": "application/json"}
+        
+        result_headers = self.config.validate_environment(
+            headers=headers,
+            model=self.model,
+            api_key=None
+        )
+        
+        assert "Authorization" in result_headers
+        assert result_headers["Authorization"] == "Bearer secret-api-key"
+
+    def test_get_complete_url(self):
+        """Test URL construction for Azure video API."""
+        litellm_params = {
+            "api_base": self.api_base,
+            "api_version": "2024-02-15-preview"
+        }
+        
+        url = self.config.get_complete_url(
+            model=self.model,
+            api_base=self.api_base,
+            litellm_params=litellm_params
+        )
+        
+        # Should contain the Azure base URL and video endpoint
+        assert "/openai/v1/videos" in url
+        assert self.api_base in url
+
+    def test_transform_video_create_request(self):
+        """Test video creation request transformation."""
+        video_params = {
+            "seconds": 8,
+            "size": "720x1280"
+        }
+        
+        litellm_params = GenericLiteLLMParams(
+            model=self.model,
+            api_base=self.api_base,
+            api_key=self.api_key
+        )
+        
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        
+        data, files = self.config.transform_video_create_request(
+            model=self.model,
+            prompt="A cinematic shot of a city at night",
+            video_create_optional_request_params=video_params,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        assert data["prompt"] == "A cinematic shot of a city at night"
+        assert data["seconds"] == 8
+        assert data["size"] == "720x1280"
+        assert data["model"] == self.model
+
+    def test_transform_video_create_response(self):
+        """Test video creation response transformation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "video_azure_123",
+            "object": "video",
+            "status": "queued",
+            "created_at": 1712697600,
+            "model": "sora-2"
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_create_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert isinstance(result, VideoObject)
+        assert result.id == "video_azure_123"
+        assert result.object == "video"
+        assert result.status == "queued"
+        assert result.model == "sora-2"
+
+    def test_transform_video_remix_response(self):
+        """Test video remix response transformation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "video_remix_azure_123",
+            "object": "video",
+            "status": "queued",
+            "created_at": 1712697600,
+            "model": "sora-2",
+            "remixed_from_video_id": "video_azure_123"
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_remix_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert isinstance(result, VideoObject)
+        assert result.id == "video_remix_azure_123"
+        assert result.status == "queued"
+        assert hasattr(result, 'remixed_from_video_id')
+        assert result.remixed_from_video_id == "video_azure_123"
+
+    def test_transform_video_list_response(self):
+        """Test video list response transformation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [
+                {
+                    "id": "video_azure_1",
+                    "object": "video",
+                    "status": "completed",
+                    "created_at": 1712697600,
+                    "model": "sora-2"
+                },
+                {
+                    "id": "video_azure_2", 
+                    "object": "video",
+                    "status": "processing",
+                    "created_at": 1712697601,
+                    "model": "sora-2"
+                }
+            ],
+            "has_more": True
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_list_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert isinstance(result[0], VideoObject)
+        assert result[0].id == "video_azure_1"
+        assert result[1].id == "video_azure_2"
+
+    def test_transform_video_delete_response(self):
+        """Test video delete response transformation."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "video_azure_123",
+            "object": "video",
+            "deleted": True,
+            "status": "deleted",
+            "created_at": 1712697600
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_delete_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert isinstance(result, VideoObject)
+        assert result.id == "video_azure_123"
+        assert result.object == "video"
+        assert result.status == "deleted"
+
+    def test_transform_video_content_response(self):
+        """Test video content response transformation."""
+        mock_response = MagicMock()
+        mock_response.content = b"fake video content"
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_content_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert isinstance(result, bytes)
+        assert result == b"fake video content"
+
+    def test_url_construction_with_trailing_slash(self):
+        """Test URL construction with API base that has trailing slash."""
+        api_base_with_slash = "https://your-resource.openai.azure.com/"
+        litellm_params = {"api_base": api_base_with_slash}
+        
+        url = self.config.get_complete_url(
+            model=self.model,
+            api_base=api_base_with_slash,
+            litellm_params=litellm_params
+        )
+        
+        # Should not have double slashes
+        assert "//openai/v1/videos" not in url
+        assert "/openai/v1/videos" in url
+
+    def test_url_construction_without_trailing_slash(self):
+        """Test URL construction with API base that doesn't have trailing slash."""
+        api_base_without_slash = "https://your-resource.openai.azure.com"
+        litellm_params = {"api_base": api_base_without_slash}
+        
+        url = self.config.get_complete_url(
+            model=self.model,
+            api_base=api_base_without_slash,
+            litellm_params=litellm_params
+        )
+        
+        # Should have proper slash separation
+        assert "/openai/v1/videos" in url
+        assert url.startswith(api_base_without_slash)
+
+    def test_video_create_with_file_upload(self):
+        """Test video creation with file upload (input_reference)."""
+        video_params = {
+            "prompt": "A video with reference image",
+            "seconds": 10,
+            "input_reference": "test_image.png"
+        }
+        
+        litellm_params = GenericLiteLLMParams(
+            model=self.model,
+            api_base=self.api_base,
+            api_key=self.api_key
+        )
+        
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        
+        # Mock file existence
+        with patch('os.path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data=b"fake image data")):
+                data, files = self.config.transform_video_create_request(
+                    model=self.model,
+                    prompt="A video with reference image",
+                    video_create_optional_request_params=video_params,
+                    litellm_params=litellm_params,
+                    headers=headers
+                )
+        
+        assert data["prompt"] == "A video with reference image"
+        assert data["seconds"] == 10
+        assert len(files) == 1
+        assert files[0][0] == "input_reference"
+
+    def test_error_handling_in_response_transformation(self):
+        """Test error handling in response transformation methods."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "error": {
+                "message": "Invalid API key",
+                "type": "authentication_error"
+            }
+        }
+        mock_response.status_code = 401
+        
+        logging_obj = MagicMock()
+        
+        # Test that error responses raise exceptions
+        with pytest.raises(Exception):
+            self.config.transform_video_create_response(
+                model=self.model,
+                raw_response=mock_response,
+                logging_obj=logging_obj
+            )
+
+    def test_azure_specific_environment_validation(self):
+        """Test Azure-specific environment validation with different key sources."""
+        headers = {"Content-Type": "application/json"}
+        
+        # Test with azure_key
+        with patch('litellm.llms.azure.videos.transformation.litellm') as mock_litellm:
+            mock_litellm.api_key = None
+            mock_litellm.azure_key = "azure-test-key"
+            mock_litellm.openai_key = None
+            
+            result_headers = self.config.validate_environment(
+                headers=headers,
+                model=self.model,
+                api_key=None
+            )
+            
+            assert result_headers["Authorization"] == "Bearer azure-test-key"
+
+    def test_usage_data_creation_in_video_create(self):
+        """Test that usage data is created correctly in video create response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "video_azure_123",
+            "object": "video",
+            "status": "completed",
+            "created_at": 1712697600,
+            "model": "sora-2",
+            "seconds": "10"
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_create_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert hasattr(result, 'usage')
+        assert result.usage is not None
+        assert "duration_seconds" in result.usage
+        assert result.usage["duration_seconds"] == 10.0
+
+    def test_usage_data_creation_in_video_remix(self):
+        """Test that usage data is created correctly in video remix response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "id": "video_remix_azure_123",
+            "object": "video",
+            "status": "completed",
+            "created_at": 1712697600,
+            "model": "sora-2",
+            "seconds": "15"
+        }
+        
+        logging_obj = MagicMock()
+        
+        result = self.config.transform_video_remix_response(
+            model=self.model,
+            raw_response=mock_response,
+            logging_obj=logging_obj
+        )
+        
+        assert hasattr(result, 'usage')
+        assert result.usage is not None
+        assert "duration_seconds" in result.usage
+        assert result.usage["duration_seconds"] == 15.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Title

Add Azure support for video generation functionality

## Relevant issues

<!-- No specific issue referenced -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Added
- **Azure video support** with `AzureVideoConfig` class inheriting from `OpenAIVideoConfig`
- **Azure URL construction** using `BaseAzureLLM._get_base_azure_url()` for proper Azure endpoint handling
- **Comprehensive test coverage** with 18 test cases in `test_azure_video_transformation.py`

### Files Added/Modified
- `litellm/litellm/llms/azure/videos/transformation.py` (new file)
- `litellm/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py` (new file)

<img width="1009" height="118" alt="Screenshot 2025-10-23 at 3 15 23 PM" src="https://github.com/user-attachments/assets/d76a1659-f595-4f15-b646-aa38866195db" />
