### PR TITLE
fix: replace deprecated gemini-1.5-pro-preview-0514

### DIFF
--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -1730,7 +1730,7 @@ async def test_gemini_pro_function_calling(provider, sync_mode):
         ]
 
         data = {
-            "model": "{}/gemini-1.5-pro-preview-0514".format(provider),
+            "model": "{}/gemini-2.5-flash-lite".format(provider),
             "messages": messages,
             "tools": tools,
         }


### PR DESCRIPTION
## Title

fix: replace deprecated gemini-1.5-pro-preview-0514

## Relevant issues

Fixes [test_gemini_pro_function_calling](https://app.circleci.com/pipelines/github/BerriAI/litellm/46130/workflows/13f6ea20-7b06-4dbe-ac37-022b85739544/jobs/779982/tests#failed-test-1) failure.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Changed model name from preview to `gemini-2.5-flash-lite`.