### PR TITLE
[Bug Fix] Exa Search API - ensure request params are sent to Exa AI

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -17,4 +17,7 @@ search_tools:
     litellm_params:
       search_provider: perplexity
       api_key: os.environ/PERPLEXITYAI_API_KEY
-
+  - search_tool_name: exa-search
+    litellm_params:
+      search_provider: exa_ai
+      api_key: os.environ/EXA_API_KEY

--- a/litellm/search/main.py
+++ b/litellm/search/main.py
@@ -15,7 +15,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.llms.base_llm.search.transformation import BaseSearchConfig, SearchResponse
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.types.utils import SearchProviders
-from litellm.utils import ProviderConfigManager, client
+from litellm.utils import ProviderConfigManager, client, filter_out_litellm_params
 
 ####### ENVIRONMENT VARIABLES ###################
 base_llm_http_handler = BaseLLMHTTPHandler()
@@ -263,13 +263,12 @@ def search(
             country=country,
         )
         
-        # Internal LiteLLM parameters that should not be passed to providers
-        litellm_internal_params = {"litellm_call_id", "litellm_logging_obj", "litellm_params"}
+        # Filter out internal LiteLLM parameters from kwargs
+        filtered_kwargs = filter_out_litellm_params(kwargs=kwargs)
         
         # Add remaining kwargs to optional_params (for provider-specific params)
-        # Filter out internal LiteLLM parameters
-        for key, value in kwargs.items():
-            if key not in optional_params and key not in litellm_internal_params:
+        for key, value in filtered_kwargs.items():
+            if key not in optional_params:
                 optional_params[key] = value
         
         verbose_logger.debug(f"Search optional_params: {optional_params}")

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3057,6 +3057,32 @@ def _remove_unsupported_params(
     return non_default_params
 
 
+def filter_out_litellm_params(kwargs: dict) -> dict:
+    """
+    Filter out LiteLLM internal parameters from kwargs dict.
+    
+    Returns a new dict containing only non-LiteLLM parameters that should be 
+    passed to external provider APIs.
+    
+    Args:
+        kwargs: Dictionary that may contain LiteLLM internal parameters
+        
+    Returns:
+        Dictionary with LiteLLM internal parameters filtered out
+        
+    Example:
+        >>> kwargs = {"query": "test", "shared_session": session_obj, "metadata": {}}
+        >>> filtered = filter_out_litellm_params(kwargs)
+        >>> # filtered = {"query": "test"}
+    """
+    
+    return {
+        key: value
+        for key, value in kwargs.items()
+        if key not in all_litellm_params
+    }
+
+
 class PreProcessNonDefaultParams:
     @staticmethod
     def base_pre_process_non_default_params(

--- a/tests/test_litellm/test_filter_out_litellm_params.py
+++ b/tests/test_litellm/test_filter_out_litellm_params.py
@@ -1,0 +1,36 @@
+"""
+Test filter_out_litellm_params helper function.
+"""
+from litellm.utils import filter_out_litellm_params
+
+
+def test_filter_out_litellm_params():
+    """
+    Test that filter_out_litellm_params removes LiteLLM internal parameters 
+    while keeping provider-specific parameters.
+    """
+    kwargs = {
+        "query": "test query",
+        "max_results": 10,
+        "shared_session": "mock_session_object",
+        "metadata": {"key": "value"},
+        "litellm_trace_id": "trace-123",
+        "proxy_server_request": {"url": "http://example.com"},
+        "secret_fields": {"api_key": "secret"},
+        "custom_param": "should_be_kept",
+    }
+    
+    filtered = filter_out_litellm_params(kwargs=kwargs)
+    
+    # Provider-specific params are kept
+    assert filtered["query"] == "test query"
+    assert filtered["max_results"] == 10
+    assert filtered["custom_param"] == "should_be_kept"
+    
+    # LiteLLM internal params are removed
+    assert "shared_session" not in filtered
+    assert "metadata" not in filtered
+    assert "litellm_trace_id" not in filtered
+    assert "proxy_server_request" not in filtered
+    assert "secret_fields" not in filtered
+


### PR DESCRIPTION
## [Bug Fix] Exa Search API - ensure request params are sent to Exa AI

<img width="1685" height="652" alt="Screenshot 2025-10-23 at 11 44 33 AM" src="https://github.com/user-attachments/assets/6792e2f3-78e5-48cf-8052-67b05337bfca" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
✅ Test

## Changes


