### PR TITLE
[feat]: graceful degradation for pillar service when using litellm

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/pillar_security.md
+++ b/docs/my-website/docs/proxy/guardrails/pillar_security.md
@@ -262,9 +262,9 @@ fallback_on_error: "allow"  # Default - recommended for production resilience
 **Available Options:**
 
 - **`allow` (Default - Recommended)**: Proceed without scanning when Pillar is unavailable
-  - ✅ **No service interruption** if Pillar is down
-  - ✅ **Best for production** where availability is critical
-  - ⚠️ Security scans are skipped during outages (logged as warnings)
+  - **No service interruption** if Pillar is down
+  - **Best for production** where availability is critical
+  - Security scans are skipped during outages (logged as warnings)
 
   ```yaml
   guardrails:
@@ -275,8 +275,8 @@ fallback_on_error: "allow"  # Default - recommended for production resilience
   ```
 
 - **`block`**: Reject all requests when Pillar is unavailable
-  - 🛡️ **Fail-secure approach** - no request proceeds without scanning
-  - ⚠️ **Service interruption** during Pillar outages
+  - **Fail-secure approach** - no request proceeds without scanning
+  - **Service interruption** during Pillar outages
   - Returns 503 Service Unavailable error
 
   ```yaml
@@ -291,38 +291,6 @@ fallback_on_error: "allow"  # Default - recommended for production resilience
 
 Configure how long to wait for Pillar API responses:
 
-```yaml
-timeout: 5.0  # Default: 5 seconds
-```
-
-**Why 5 seconds?**
-- Most Pillar API calls complete in 1-3 seconds under normal conditions
-- 5 seconds provides buffer for network variance while failing fast on outages
-- Combined with `fallback_on_error: "allow"`, timeouts trigger graceful degradation
-- Fast failure detection = better user experience (no waiting when service is down)
-- Users experiencing timeouts can increase if needed for their network conditions
-
-**Timeout Recommendations by Use Case:**
-
-- **Production with Graceful Degradation (Default)**: 5 seconds
-  - Fast failure detection
-  - Timeouts trigger graceful degradation, not hard failures
-  - Optimal user experience
-
-- **Production with Fail-Secure**: 10-15 seconds
-  - Higher timeout to avoid false positives when blocking is enabled
-  - Use when `fallback_on_error: "block"`
-  - Ensures legitimate slow responses don't get blocked
-
-- **High-traffic / Low-latency**: 3-5 seconds
-  - Prevents request queuing
-  - Requires reliable network connectivity
-  - Only use with `fallback_on_error: "allow"`
-
-- **High-latency Networks**: 10-15 seconds
-  - For deployments with high network latency
-  - Accommodate slower connections
-
 **Example Configurations:**
 
 ```yaml
@@ -333,22 +301,6 @@ guardrails:
       guardrail: pillar
       timeout: 5.0               # Default - fast failure detection
       fallback_on_error: "allow"  # Graceful degradation (required)
-
-# Fail-secure: Higher timeout to avoid false blocks
-guardrails:
-  - guardrail_name: "pillar-secure"
-    litellm_params:
-      guardrail: pillar
-      timeout: 15.0              # Higher timeout for reliability
-      fallback_on_error: "block"  # Block if scan fails
-
-# High-latency network: Increased tolerance
-guardrails:
-  - guardrail_name: "pillar-tolerant"
-    litellm_params:
-      guardrail: pillar
-      timeout: 10.0              # More buffer for slow networks
-      fallback_on_error: "allow"  # Still degrade gracefully
 ```
 
 **Environment Variables:**

--- a/docs/my-website/docs/proxy/guardrails/pillar_security.md
+++ b/docs/my-website/docs/proxy/guardrails/pillar_security.md
@@ -287,18 +287,6 @@ fallback_on_error: "allow"  # Default - recommended for production resilience
         fallback_on_error: "block"  # Fail secure
   ```
 
-- **`fail`**: Raise exception when Pillar is unavailable (legacy behavior)
-  - ❌ **Service interruption** during Pillar outages
-  - Same as old behavior before fallback support was added
-
-  ```yaml
-  guardrails:
-    - guardrail_name: "pillar-legacy"
-      litellm_params:
-        guardrail: pillar
-        fallback_on_error: "fail"  # Legacy behavior
-  ```
-
 #### Timeout Configuration
 
 Configure how long to wait for Pillar API responses:

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/__init__.py
@@ -44,6 +44,10 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         include_evidence=_get_config_value(
             litellm_params, optional_params, "include_evidence"
         ),
+        fallback_on_error=_get_config_value(
+            litellm_params, optional_params, "fallback_on_error"
+        ),
+        timeout=_get_config_value(litellm_params, optional_params, "timeout"),
     )
     litellm.logging_callback_manager.add_litellm_callback(_pillar_callback)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
@@ -160,10 +160,20 @@ class PillarGuardrail(CustomGuardrail):
             f"Pillar Guardrail: Initialized with fallback_on_error: {self.fallback_on_error}"
         )
 
-        # Set timeout
-        self.timeout = timeout or float(
-            os.environ.get("PILLAR_TIMEOUT", str(self.DEFAULT_TIMEOUT))
-        )
+        # Set timeout with graceful fallback on invalid configuration
+        if timeout is not None:
+            self.timeout = timeout
+        else:
+            try:
+                self.timeout = float(
+                    os.environ.get("PILLAR_TIMEOUT", str(self.DEFAULT_TIMEOUT))
+                )
+            except (ValueError, TypeError) as e:
+                verbose_proxy_logger.warning(
+                    f"Pillar Guardrail: Invalid PILLAR_TIMEOUT value '{os.environ.get('PILLAR_TIMEOUT')}', "
+                    f"falling back to default {self.DEFAULT_TIMEOUT}s"
+                )
+                self.timeout = self.DEFAULT_TIMEOUT
 
         # Define supported event hooks
         supported_event_hooks = [

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
@@ -91,9 +91,7 @@ class PillarGuardrail(CustomGuardrail):
             timeout: Timeout for API calls in seconds
             **kwargs: Additional arguments passed to parent class
         """
-        self.async_handler = get_async_httpx_client(
-            llm_provider=httpxSpecialProvider.GuardrailCallback
-        )
+        self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
         self.api_key = api_key or os.environ.get("PILLAR_API_KEY")
 
         if self.api_key is None:
@@ -111,14 +109,10 @@ class PillarGuardrail(CustomGuardrail):
             self.on_flagged_action = action
         else:
             if action:
-                verbose_proxy_logger.warning(
-                    f"Invalid action '{action}', using default"
-                )
+                verbose_proxy_logger.warning(f"Invalid action '{action}', using default")
             self.on_flagged_action = self.DEFAULT_ON_FLAGGED_ACTION
 
-        verbose_proxy_logger.debug(
-            f"Pillar Guardrail: Initialized with on_flagged_action: {self.on_flagged_action}"
-        )
+        verbose_proxy_logger.debug(f"Pillar Guardrail: Initialized with on_flagged_action: {self.on_flagged_action}")
 
         self.async_mode = self._resolve_bool_config(
             provided_value=async_mode,
@@ -156,18 +150,14 @@ class PillarGuardrail(CustomGuardrail):
                 )
             self.fallback_on_error = self.DEFAULT_FALLBACK_ACTION
 
-        verbose_proxy_logger.debug(
-            f"Pillar Guardrail: Initialized with fallback_on_error: {self.fallback_on_error}"
-        )
+        verbose_proxy_logger.debug(f"Pillar Guardrail: Initialized with fallback_on_error: {self.fallback_on_error}")
 
         # Set timeout with graceful fallback on invalid configuration
         if timeout is not None:
             self.timeout = timeout
         else:
             try:
-                self.timeout = float(
-                    os.environ.get("PILLAR_TIMEOUT", str(self.DEFAULT_TIMEOUT))
-                )
+                self.timeout = float(os.environ.get("PILLAR_TIMEOUT", str(self.DEFAULT_TIMEOUT)))
             except (ValueError, TypeError) as e:
                 verbose_proxy_logger.warning(
                     f"Pillar Guardrail: Invalid PILLAR_TIMEOUT value '{os.environ.get('PILLAR_TIMEOUT')}', "
@@ -228,18 +218,14 @@ class PillarGuardrail(CustomGuardrail):
         """
         event_type = GuardrailEventHooks.pre_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
-            verbose_proxy_logger.debug(
-                f"Pillar Guardrail: Pre-call scanning disabled for {self.guardrail_name}"
-            )
+            verbose_proxy_logger.debug(f"Pillar Guardrail: Pre-call scanning disabled for {self.guardrail_name}")
             return data
 
         verbose_proxy_logger.debug("Pillar Guardrail: Pre-call hook")
         result = await self.run_pillar_guardrail(data)
 
         # Add guardrail name to response headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
+        add_guardrail_to_applied_guardrails_header(request_data=data, guardrail_name=self.guardrail_name)
 
         return result
 
@@ -275,18 +261,14 @@ class PillarGuardrail(CustomGuardrail):
         """
         event_type = GuardrailEventHooks.during_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
-            verbose_proxy_logger.debug(
-                f"Pillar Guardrail: During-call scanning disabled for {self.guardrail_name}"
-            )
+            verbose_proxy_logger.debug(f"Pillar Guardrail: During-call scanning disabled for {self.guardrail_name}")
             return data
 
         verbose_proxy_logger.debug("Pillar Guardrail: During-call moderation hook")
         result = await self.run_pillar_guardrail(data)
 
         # Add guardrail name to response headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
+        add_guardrail_to_applied_guardrails_header(request_data=data, guardrail_name=self.guardrail_name)
 
         return result
 
@@ -313,9 +295,7 @@ class PillarGuardrail(CustomGuardrail):
         """
         event_type = GuardrailEventHooks.post_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
-            verbose_proxy_logger.debug(
-                f"Pillar Guardrail: Post-call scanning disabled for {self.guardrail_name}"
-            )
+            verbose_proxy_logger.debug(f"Pillar Guardrail: Post-call scanning disabled for {self.guardrail_name}")
             return response
 
         verbose_proxy_logger.debug("Pillar Guardrail: Post-call hook")
@@ -323,15 +303,11 @@ class PillarGuardrail(CustomGuardrail):
         # Extract response messages in the format Pillar expects
         response_dict = response.model_dump() if hasattr(response, "model_dump") else {}
         response_messages = [
-            choice.get("message")
-            for choice in response_dict.get("choices", [])
-            if choice.get("message")
+            choice.get("message") for choice in response_dict.get("choices", []) if choice.get("message")
         ]
 
         if not response_messages:
-            verbose_proxy_logger.debug(
-                "Pillar Guardrail: No response content to scan, skipping post-call analysis"
-            )
+            verbose_proxy_logger.debug("Pillar Guardrail: No response content to scan, skipping post-call analysis")
             return response
 
         # Create complete conversation: original messages + response messages
@@ -342,9 +318,7 @@ class PillarGuardrail(CustomGuardrail):
         await self.run_pillar_guardrail(post_call_data)
 
         # Add guardrail name to response headers
-        add_guardrail_to_applied_guardrails_header(
-            request_data=data, guardrail_name=self.guardrail_name
-        )
+        add_guardrail_to_applied_guardrails_header(request_data=data, guardrail_name=self.guardrail_name)
 
         return response
 
@@ -367,9 +341,7 @@ class PillarGuardrail(CustomGuardrail):
         """
         # Check if messages are present
         if not data.get("messages"):
-            verbose_proxy_logger.debug(
-                "Pillar Guardrail: No messages detected, bypassing security scan"
-            )
+            verbose_proxy_logger.debug("Pillar Guardrail: No messages detected, bypassing security scan")
             return data
 
         try:
@@ -391,9 +363,7 @@ class PillarGuardrail(CustomGuardrail):
                 raise e
 
             # Handle API communication errors based on fallback_on_error setting
-            verbose_proxy_logger.error(
-                f"Pillar Guardrail: API communication failed - {str(e)}"
-            )
+            verbose_proxy_logger.error(f"Pillar Guardrail: API communication failed - {str(e)}")
 
             return self._handle_api_error(e, data)
 
@@ -455,9 +425,7 @@ class PillarGuardrail(CustomGuardrail):
 
         return headers
 
-    def _set_bool_header(
-        self, headers: Dict[str, str], header_name: str, value: Optional[bool]
-    ) -> None:
+    def _set_bool_header(self, headers: Dict[str, str], header_name: str, value: Optional[bool]) -> None:
         """Apply a boolean value as a lowercase string HTTP header when provided."""
 
         if value is None:
@@ -590,9 +558,7 @@ class PillarGuardrail(CustomGuardrail):
         )
         return payload
 
-    async def _call_pillar_api(
-        self, headers: Dict[str, str], payload: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    async def _call_pillar_api(self, headers: Dict[str, str], payload: Dict[str, Any]) -> Dict[str, Any]:
         """
         Call the Pillar API and return the response.
 
@@ -617,14 +583,10 @@ class PillarGuardrail(CustomGuardrail):
 
         flagged = res.get("flagged")
         session_id = res.get("session_id")
-        verbose_proxy_logger.debug(
-            f"Pillar Guardrail: Analysis complete - flagged={flagged}, session={session_id}"
-        )
+        verbose_proxy_logger.debug(f"Pillar Guardrail: Analysis complete - flagged={flagged}, session={session_id}")
         return res
 
-    def _process_pillar_response(
-        self, pillar_response: Dict[str, Any], original_data: dict
-    ) -> None:
+    def _process_pillar_response(self, pillar_response: Dict[str, Any], original_data: dict) -> None:
         """
         Process the Pillar API response and handle detections based on configuration.
 
@@ -643,9 +605,7 @@ class PillarGuardrail(CustomGuardrail):
         # Store session_id from Pillar response for potential reuse
         pillar_session_id = pillar_response.get("session_id")
         if pillar_session_id:
-            verbose_proxy_logger.debug(
-                f"Pillar Guardrail: Received session_id from server: {pillar_session_id}"
-            )
+            verbose_proxy_logger.debug(f"Pillar Guardrail: Received session_id from server: {pillar_session_id}")
             # Store in request metadata for use in subsequent hooks
             if "metadata" not in original_data:
                 original_data["metadata"] = {}
@@ -657,13 +617,9 @@ class PillarGuardrail(CustomGuardrail):
             if self.on_flagged_action == "block":
                 self._raise_pillar_detection_exception(pillar_response)
             elif self.on_flagged_action == "monitor":
-                verbose_proxy_logger.info(
-                    "Pillar Guardrail: Monitoring mode - allowing flagged content to proceed"
-                )
+                verbose_proxy_logger.info("Pillar Guardrail: Monitoring mode - allowing flagged content to proceed")
 
-    def _raise_pillar_detection_exception(
-        self, pillar_response: Dict[str, Any]
-    ) -> None:
+    def _raise_pillar_detection_exception(self, pillar_response: Dict[str, Any]) -> None:
         """
         Raise an HTTPException for Pillar security detections.
 
@@ -683,9 +639,7 @@ class PillarGuardrail(CustomGuardrail):
             },
         }
 
-        verbose_proxy_logger.warning(
-            "Pillar Guardrail: Request blocked - Security threats detected"
-        )
+        verbose_proxy_logger.warning("Pillar Guardrail: Request blocked - Security threats detected")
 
         raise HTTPException(status_code=400, detail=error_detail)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
@@ -158,7 +158,7 @@ class PillarGuardrail(CustomGuardrail):
         else:
             try:
                 self.timeout = float(os.environ.get("PILLAR_TIMEOUT", str(self.DEFAULT_TIMEOUT)))
-            except (ValueError, TypeError) as e:
+            except (ValueError, TypeError):
                 verbose_proxy_logger.warning(
                     f"Pillar Guardrail: Invalid PILLAR_TIMEOUT value '{os.environ.get('PILLAR_TIMEOUT')}', "
                     f"falling back to default {self.DEFAULT_TIMEOUT}s"
@@ -387,12 +387,12 @@ class PillarGuardrail(CustomGuardrail):
         """
         if self.fallback_on_error == "allow":
             verbose_proxy_logger.warning(
-                f"Pillar Guardrail: API unavailable, proceeding without scanning (fallback_on_error=allow)"
+                "Pillar Guardrail: API unavailable, proceeding without scanning (fallback_on_error=allow)"
             )
             return data
         else:  # fallback_on_error == "block"
             verbose_proxy_logger.warning(
-                f"Pillar Guardrail: API unavailable, blocking request (fallback_on_error=block)"
+                "Pillar Guardrail: API unavailable, blocking request (fallback_on_error=block)"
             )
             raise HTTPException(
                 status_code=503,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
@@ -32,12 +32,12 @@ class PillarGuardrailConfigModelOptionalParams(BaseModel):
         description="Include detailed evidence objects in response payloads (sets `plr_evidence` header).",
     )
     fallback_on_error: Optional[str] = Field(
-        default="allow",
-        description="Action to take when Pillar API is unavailable or errors: 'allow' (proceed without scanning) or 'block' (reject request with 503 error). Defaults to 'allow' for graceful degradation.",
+        default=None,
+        description="Action to take when Pillar API is unavailable or errors: 'allow' (proceed without scanning) or 'block' (reject request with 503 error). If not provided, the `PILLAR_FALLBACK_ON_ERROR` environment variable is checked, defaults to 'allow'.",
     )
     timeout: Optional[float] = Field(
-        default=5.0,
-        description="Timeout in seconds for Pillar API calls. Defaults to 5.0 seconds.",
+        default=None,
+        description="Timeout in seconds for Pillar API calls. If not provided, the `PILLAR_TIMEOUT` environment variable is checked, defaults to 5.0 seconds.",
     )
 
 

--- a/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
@@ -31,6 +31,14 @@ class PillarGuardrailConfigModelOptionalParams(BaseModel):
         default=True,
         description="Include detailed evidence objects in response payloads (sets `plr_evidence` header).",
     )
+    fallback_on_error: Optional[str] = Field(
+        default="allow",
+        description="Action to take when Pillar API is unavailable or errors: 'allow' (proceed without scanning), 'block' (reject request), or 'fail' (raise exception). Defaults to 'allow' for graceful degradation.",
+    )
+    timeout: Optional[float] = Field(
+        default=5.0,
+        description="Timeout in seconds for Pillar API calls. Defaults to 5.0 seconds.",
+    )
 
 
 class PillarGuardrailConfigModel(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/pillar.py
@@ -33,7 +33,7 @@ class PillarGuardrailConfigModelOptionalParams(BaseModel):
     )
     fallback_on_error: Optional[str] = Field(
         default="allow",
-        description="Action to take when Pillar API is unavailable or errors: 'allow' (proceed without scanning), 'block' (reject request), or 'fail' (raise exception). Defaults to 'allow' for graceful degradation.",
+        description="Action to take when Pillar API is unavailable or errors: 'allow' (proceed without scanning) or 'block' (reject request with 503 error). Defaults to 'allow' for graceful degradation.",
     )
     timeout: Optional[float] = Field(
         default=5.0,

--- a/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
@@ -526,7 +526,11 @@ async def test_empty_messages(pillar_guardrail_instance, user_api_key_dict, dual
 async def test_api_error_handling(
     pillar_guardrail_instance, sample_request_data, user_api_key_dict, dual_cache
 ):
-    """Test handling of API connection errors."""
+    """Test handling of API connection errors with default fallback (allow)."""
+    # Note: pillar_guardrail_instance has fallback_on_error defaulting to "allow"
+    # so this test will now pass through instead of raising an error
+    pillar_guardrail_instance.fallback_on_error = "fail"  # Set to fail for this test
+
     with pytest.raises(PillarGuardrailAPIError) as excinfo:
         with patch(
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
@@ -541,6 +545,148 @@ async def test_api_error_handling(
 
     assert "unable to verify request safety" in str(excinfo.value)
     assert "Connection error" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_api_error_fallback_allow(env_setup):
+    """Test fallback_on_error='allow' allows requests when API is down."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-fallback-allow",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        fallback_on_error="allow",
+    )
+
+    sample_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        side_effect=Exception("Connection timeout"),
+    ):
+        result = await guardrail.async_pre_call_hook(
+            data=sample_data,
+            cache=DualCache(),
+            user_api_key_dict=UserAPIKeyAuth(),
+            call_type="completion",
+        )
+
+    # Should proceed without scanning
+    assert result == sample_data
+
+
+@pytest.mark.asyncio
+async def test_api_error_fallback_block(env_setup):
+    """Test fallback_on_error='block' blocks requests when API is down."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-fallback-block",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        fallback_on_error="block",
+    )
+
+    sample_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    with pytest.raises(HTTPException) as excinfo:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            side_effect=Exception("Connection timeout"),
+        ):
+            await guardrail.async_pre_call_hook(
+                data=sample_data,
+                cache=DualCache(),
+                user_api_key_dict=UserAPIKeyAuth(),
+                call_type="completion",
+            )
+
+    # Should block with 503 Service Unavailable
+    assert excinfo.value.status_code == 503
+    assert "Pillar Security Guardrail Unavailable" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_api_error_fallback_fail(env_setup):
+    """Test fallback_on_error='fail' raises exception when API is down."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-fallback-fail",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        fallback_on_error="fail",
+    )
+
+    sample_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+
+    with pytest.raises(PillarGuardrailAPIError) as excinfo:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            side_effect=Exception("Connection timeout"),
+        ):
+            await guardrail.async_pre_call_hook(
+                data=sample_data,
+                cache=DualCache(),
+                user_api_key_dict=UserAPIKeyAuth(),
+                call_type="completion",
+            )
+
+    assert "unable to verify request safety" in str(excinfo.value)
+    assert "Connection timeout" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_custom_timeout_configuration(env_setup):
+    """Test custom timeout configuration."""
+    custom_timeout = 10.0
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-custom-timeout",
+        api_key="test-pillar-key",
+        api_base="https://api.pillar.security",
+        timeout=custom_timeout,
+    )
+
+    assert guardrail.timeout == custom_timeout
+
+
+def test_fallback_on_error_env_variable(monkeypatch):
+    """Test fallback_on_error can be set via environment variable."""
+    monkeypatch.setenv("PILLAR_API_KEY", "test-key")
+    monkeypatch.setenv("PILLAR_FALLBACK_ON_ERROR", "block")
+
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-env-fallback",
+    )
+
+    assert guardrail.fallback_on_error == "block"
+
+
+def test_timeout_env_variable(monkeypatch):
+    """Test timeout can be set via environment variable."""
+    monkeypatch.setenv("PILLAR_API_KEY", "test-key")
+    monkeypatch.setenv("PILLAR_TIMEOUT", "15.0")
+
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-env-timeout",
+    )
+
+    assert guardrail.timeout == 15.0
+
+
+def test_invalid_fallback_action_defaults_to_allow(env_setup):
+    """Test invalid fallback_on_error value defaults to 'allow'."""
+    guardrail = PillarGuardrail(
+        guardrail_name="pillar-invalid-fallback",
+        api_key="test-pillar-key",
+        fallback_on_error="invalid_action",
+    )
+
+    assert guardrail.fallback_on_error == "allow"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Title

Implement graceful degradation for pillar service when using litellm

## Relevant issues

Fixes #15853

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1493" height="694" alt="Screenshot 2025-10-23 at 20 34 01" src="https://github.com/user-attachments/assets/c8671cfa-a050-4e47-aad4-c2d8e8b84af1" />


## Type

🆕 New Feature
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

Adds resilience and graceful degradation to the Pillar Security guardrail, allowing services to continue operating when the Pillar API is unavailable or experiencing issues.

1. fallback_on_error Configuration
  - allow (Default): Proceeds without scanning when Pillar API is unavailable - recommended for production resilience
    - No service interruption during Pillar outages
    - Logs warnings when scanning is skipped
    - Best for production where availability is critical
  - block: Rejects requests with 503 Service Unavailable when Pillar API is down
    - Fail-secure approach - no request proceeds without scanning
    - Returns proper HTTP 503 error
    - Best for high-security environments

2. timeout Configuration
  - Default: 5.0 seconds for fast failure detection
  - Configurable via YAML or environment variable (PILLAR_TIMEOUT)
  - Fast timeouts combined with graceful degradation provide optimal user experience
  - Allows customization based on network conditions and security requirements

3. Environment Variable Support
  - PILLAR_FALLBACK_ON_ERROR: Set fallback behavior globally
  - PILLAR_TIMEOUT: Set timeout globally

#### Modified Files

  - litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py: Core implementation with _handle_api_error() method
  - litellm/types/proxy/guardrails/guardrail_hooks/pillar.py: Type definitions for new parameters
  - docs/my-website/docs/proxy/guardrails/pillar_security.md: Comprehensive documentation with examples and use case recommendations
  - tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py: Added 6 new tests covering all scenarios

6 new tests - all passing:
  - test_api_error_fallback_allow - Verifies "allow" mode proceeds without scanning when API is down
  - test_api_error_fallback_block - Verifies "block" mode returns 503 error when API is down
  - test_api_error_handling - Tests error handling with block mode
  - test_custom_timeout_configuration - Tests custom timeout values
  - test_fallback_on_error_env_variable - Tests environment variable configuration for fallback
  - test_timeout_env_variable - Tests environment variable configuration for timeout
  - test_invalid_fallback_action_defaults_to_allow - Tests validation and defaults
