### PR TITLE
[fix] Remove adding server root path in ui login

### DIFF
--- a/litellm/proxy/common_utils/html_forms/ui_login.py
+++ b/litellm/proxy/common_utils/html_forms/ui_login.py
@@ -1,9 +1,6 @@
 import os
 
 url_to_redirect_to = os.getenv("PROXY_BASE_URL", "")
-server_root_path = os.getenv("SERVER_ROOT_PATH", "")
-if server_root_path != "":
-    url_to_redirect_to += server_root_path
 url_to_redirect_to += "/login"
 html_form = f"""
 <!DOCTYPE html>


### PR DESCRIPTION
## Title

Small bugfix for SERVER_ROOT_PATH

## Relevant issues

Fixes #12856

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
Fixes the issue with the double redirect in path which was introduced with SERVER_ROOT_PATH: https://github.com/BerriAI/litellm/pull/11337

