### PR TITLE
docs: improve Grayswan guardrail documentation

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/grayswan.md
+++ b/docs/my-website/docs/proxy/guardrails/grayswan.md
@@ -18,6 +18,7 @@ Cygnal returns a `violation` score between `0` and `1` (higher means more likely
 
 ```bash
 export GRAYSWAN_API_KEY="your-grayswan-key"
+export GRAYSWAN_API_BASE="https://api.grayswan.ai"
 ```
 
 ### 2. Configure `config.yaml`
@@ -37,6 +38,7 @@ guardrails:
       guardrail: grayswan
       mode: [pre_call, post_call]            # monitor both input and output
       api_key: os.environ/GRAYSWAN_API_KEY
+      api_base: os.environ/GRAYSWAN_API_BASE  # optional
       optional_params:
         on_flagged_action: monitor             # or "block"
         violation_threshold: 0.5               # score >= threshold is flagged


### PR DESCRIPTION
Unclear how to set custom url on the guardrail. added api_base for clarity its an option
📖 Documentation

