### PR TITLE
Python entry-point for CustomLLM subclasses

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -381,9 +381,7 @@ def print_verbose(
 ####### CLIENT ###################
 # make it easy to log if completion/embedding runs succeeded or failed + see what happened | Non-Blocking
 def load_custom_provider_entrypoints():
-    group_name = "litellm.providers"
-
-    found_entry_points = tuple(entry_points().select(group=group_name))  # type: ignore
+    found_entry_points = tuple(entry_points().select(group="litellm"))  # type: ignore
     for entry_point in found_entry_points:
         # types are ignored because of circular dependency issues importing CustomLLM and CustomLLMItem
         handler = entry_point.load()

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -384,7 +384,8 @@ def load_custom_provider_entrypoints():
     found_entry_points = tuple(entry_points().select(group="litellm"))  # type: ignore
     for entry_point in found_entry_points:
         # types are ignored because of circular dependency issues importing CustomLLM and CustomLLMItem
-        handler = entry_point.load()
+        HandlerClass = entry_point.load()
+        handler = HandlerClass()
         provider = {"provider": entry_point.name, "custom_handler": handler}
         litellm.custom_provider_map.append(provider)  # type: ignore
 

--- a/tests/local_testing/test_custom_llm.py
+++ b/tests/local_testing/test_custom_llm.py
@@ -551,12 +551,9 @@ def test_custom_llm_provider_entrypoint(mocker: MockerFixture):
     class AnotherCustomLLM(CustomLLM):
         pass
 
-    my_custom_llm = MyCustomLLM()
-    another_custom_llm = AnotherCustomLLM()
-
     providers = {
-        "custom_llm": my_custom_llm,
-        "another-custom-llm": another_custom_llm
+        "custom_llm": MyCustomLLM,
+        "another-custom-llm": AnotherCustomLLM
     }
 
     def load(self):

--- a/tests/local_testing/test_custom_llm.py
+++ b/tests/local_testing/test_custom_llm.py
@@ -542,7 +542,7 @@ async def test_simple_aembedding():
 
 def test_custom_llm_provider_entrypoint(mocker: MockerFixture):
     # This test mocks the use of entry-points in pyproject.toml:
-    #   [project.entry-point."litellm.provider"]
+    #   [project.entry-point.litellm]
     #   custom_llm = <module>:MyCustomLLM
     #   another-custom-llm = <module>:AnotherCustomLLM
 
@@ -566,8 +566,8 @@ def test_custom_llm_provider_entrypoint(mocker: MockerFixture):
     from importlib.metadata import EntryPoints, EntryPoint
 
     entry_points = EntryPoints([
-        EntryPoint(group="litellm.providers", name="custom_llm", value="package.module:MyCustomLLM"),
-        EntryPoint(group="litellm.providers", name="another-custom-llm", value="package.module:AnotherCustomLLM"),
+        EntryPoint(group="litellm", name="custom_llm", value="package.module:MyCustomLLM"),
+        EntryPoint(group="litellm", name="another-custom-llm", value="package.module:AnotherCustomLLM"),
     ])
     mocked = mocker.patch("litellm.utils.entry_points")
     mocked.return_value = entry_points

--- a/tests/local_testing/test_custom_llm.py
+++ b/tests/local_testing/test_custom_llm.py
@@ -10,6 +10,7 @@ import traceback
 
 import openai
 import pytest
+from pytest_mock import MockerFixture
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -537,3 +538,49 @@ async def test_simple_aembedding():
         "embedding": [0.1, 0.2, 0.3],
         "index": 1,
     }
+
+
+def test_custom_llm_provider_entrypoint(mocker: MockerFixture):
+    # This test mocks the use of entry-points in pyproject.toml:
+    #   [project.entry-point."litellm.provider"]
+    #   custom_llm = <module>:MyCustomLLM
+    #   another-custom-llm = <module>:AnotherCustomLLM
+
+    from litellm.utils import custom_llm_setup
+
+    class AnotherCustomLLM(CustomLLM):
+        pass
+
+    my_custom_llm = MyCustomLLM()
+    another_custom_llm = AnotherCustomLLM()
+
+    providers = {
+        "custom_llm": my_custom_llm,
+        "another-custom-llm": another_custom_llm
+    }
+
+    def load(self):
+        return providers[self.name]
+
+    mocker.patch("importlib.metadata.EntryPoint.load", load)
+    from importlib.metadata import EntryPoints, EntryPoint
+
+    entry_points = EntryPoints([
+        EntryPoint(group="litellm.providers", name="custom_llm", value="package.module:MyCustomLLM"),
+        EntryPoint(group="litellm.providers", name="another-custom-llm", value="package.module:AnotherCustomLLM"),
+    ])
+    mocked = mocker.patch("litellm.utils.entry_points")
+    mocked.return_value = entry_points
+
+    assert litellm.custom_provider_map == []
+    assert litellm._custom_providers == []
+
+    custom_llm_setup()
+
+    assert litellm._custom_providers == ['custom_llm', 'another-custom-llm']
+
+    assert litellm.custom_provider_map[0]["provider"] == "custom_llm"
+    assert isinstance(litellm.custom_provider_map[0]["custom_handler"], CustomLLM)
+
+    assert litellm.custom_provider_map[1]["provider"] == "another-custom-llm"
+    assert isinstance(litellm.custom_provider_map[1]["custom_handler"], AnotherCustomLLM)


### PR DESCRIPTION
## Title

Python entry-point for CustomLLM subclasses

## Relevant issues

Fixes #7733 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes

This feature allows 3rd party packages to declare custom LLM providers in the pyproject.toml file using [entry-point loading from importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#entry-points). Providers instantiated and registered at runtime automatically without having to manually populate `litellm.custom_providers_map`.

As an example I may develop a 3rd party python package called `litellm-parrot`. In my `src/litellm_parrot/provider.py` I will define my subclass of `CustomLLM`

```python
# src/litellm_parrot/provider.py
from litellm.llms.custom_llm import CustomLLM

class Parrot(CustomLLM):
    # implementation for Parrot provider
```

And then in my pyproject.toml file this section ensures that the provider is registered. (More than one provider can be defined here if desired)

```toml
[project.entry-point.litellm]
parrot = "litellm_parrot.provider:Parrot"
#  ^                                ^
#  |                                |  this specific object is imported from the module 
#  |                                |  and instantiated to become "custom_handler"
#  |
#  | - - this becomes "provider" in the llitellm.custom_providers_map entry

```

When the 3rd party package `litellm-parrot` is installed in the same env as `litellm` a user need only request inference from the `parrot` provider

```python
import litellm

response = litellm.completion(
    model='parrot/pining-model',
    messages=[{"role": "user", "content": "Hello, Polly!!!"}]
)
```

## New test
I've added a test that mocks the `importlib.metadata.entry_points` function to simulate reading the entrypoint configuration from a pyprojec.toml file.

<img width="1122" height="769" alt="Screenshot 2025-10-23 at 23 40 52" src="https://github.com/user-attachments/assets/fcae3ee0-858a-4457-babb-0fbcc9cf4bda" />
