### PR TITLE
fix(guardrails): support array-type content in Presidio pre-call hook

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -14,8 +14,10 @@ from datetime import datetime
 from typing import (
     Any,
     AsyncGenerator,
+    Coroutine,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -404,8 +406,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             verbose_proxy_logger.debug("content_safety: %s", content_safety)
             presidio_config = self.get_presidio_settings_from_request_data(data)
             messages = data["messages"]
-            tasks = []
-            targets = []  # track where to write back each presidio result
+            tasks: list[Coroutine[Any, Any, str]] = []
+            targets: list[
+                tuple[Literal["str"], int] | tuple[Literal["block"], int, int, str]
+            ] = []  # track where to write back each presidio result
 
             for msg_idx, m in enumerate(messages):
                 content = m.get("content", None)


### PR DESCRIPTION
## Title

fix(guardrails): support array-type content in Presidio pre-call hook

## Description

Previously, the` async_pre_call_hook` in Presidio PII masking only handled messages with content as strings, and ignored messages where content was structured as a list of text blocks.

This caused PII in messages like the following to go unmasked:
```
{
  "messages": [
    {
      "role": "user",
      "content": [
        {"type": "text", "text": "My credit card is 4111-1111-1111-1111."},
        {"type": "text", "text": "My email is test@example.com."}
      ]
    }
  ]
}
```
Only messages with a simple string like this were being processed correctly:
```
{
  "messages": [
    {
      "role": "user",
      "content": "My credit card is 4111-1111-1111-1111."
    }
  ]
}
```
This PR adds proper handling for list-type content, ensuring PII detection and anonymization works consistently for both string and list message formats.

## Pre-Submission checklist

* [x] I have Added testing in the [`[tests/litellm/](https://github.com/BerriAI/litellm/tree/main/tests/litellm)`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
* [x] I have added a screenshot of my new test passing locally
* [x] My PR passes all unit tests on [`[make test-unit](https://docs.litellm.ai/docs/extras/contributing_code)`](https://docs.litellm.ai/docs/extras/contributing_code)
* [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

* Updated `async_pre_call_hook` in `_OPTIONAL_PresidioPIIMasking` to handle messages where `content` can be a list of text blocks instead of just a string.
* Introduced minimal `targets` tracking to ensure PII-masked text is written back to the correct location.
* Added new unit tests covering:

  * single text block inside a list
  * mixed string and list messages to verify target alignment
* No changes to existing behavior for string-only messages.