### PR TITLE
fix(opik): enhance requester metadata retrieval from API key auth

### DIFF
--- a/litellm/integrations/opik/opik.py
+++ b/litellm/integrations/opik/opik.py
@@ -204,6 +204,13 @@ class OpikLogger(CustomBatchLogger):
         # Update litellm_opik_metadata with opik metadata from requester
         standard_logging_metadata = standard_logging_object.get("metadata", {}) or {}
         requester_metadata = standard_logging_metadata.get("requester_metadata", {}) or {}
+
+        # If requester_metadata is empty, try to get it from user_api_key_auth_metadata saved in api key
+        if not requester_metadata:
+            requester_metadata = standard_logging_metadata.get(
+                "user_api_key_auth_metadata", {}
+            ) or {}
+
         requester_opik_metadata = requester_metadata.get("opik", {}) or {}
         litellm_opik_metadata.update(requester_opik_metadata)
 


### PR DESCRIPTION
## Title

Automatically read Opik metadata from the user's API key when not provided in the request.
If no metadata is stored for the API key, default to an empty value (maintaining previous behavior).

## Relevant issues

Feature Proposal for #15895 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type


🆕 New Feature


## Changes


