### PR TITLE
Fix MLFlow tags - split request_tags into (key, val) if request_tag has colon

### DIFF
--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -273,14 +273,14 @@ class MlflowLogger(CustomLogger):
         Transform a list of colon-separated tags into a dictionary.
         Tags without colons are stored with empty string as the value.
         """
-        tag_dict = {}
+        tags = {}
         for tag in tag_list:
             if ":" in tag:
                 k, v = tag.split(":", 1)
-                tag_dict[k.strip()] = v.strip()
+                tags[k.strip()] = v.strip()
             else:
-                tag_dict[tag.strip()] = ""
-        return tag_dict
+                tags[tag.strip()] = ""
+        return tags
 
     def _end_span_or_trace(self, span, outputs, end_time_ns, status):
         """End an MLflow span or a trace."""

--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -60,7 +60,10 @@ class MlflowLogger(CustomLogger):
 
         inputs = self._construct_input(kwargs)
         input_messages = inputs.get("messages", [])
-        output_messages = [c.message.model_dump(exclude_none=True) for c in getattr(response_obj, "choices", [])]
+        output_messages = [
+            c.message.model_dump(exclude_none=True)
+            for c in getattr(response_obj, "choices", [])
+        ]
         if messages := [*input_messages, *output_messages]:
             set_span_chat_messages(span, messages)
         if tools := inputs.get("tools"):
@@ -184,7 +187,9 @@ class MlflowLogger(CustomLogger):
             "call_type": kwargs.get("call_type"),
             "model": kwargs.get("model"),
         }
-        standard_obj: Optional[StandardLoggingPayload] = kwargs.get("standard_logging_object")
+        standard_obj: Optional[StandardLoggingPayload] = kwargs.get(
+            "standard_logging_object"
+        )
         if standard_obj:
             attributes.update(
                 {
@@ -257,12 +262,25 @@ class MlflowLogger(CustomLogger):
                 span_type=span_type,
                 inputs=inputs,
                 attributes=attributes,
-                tags=self._transform_tag_list_to_dict(attributes.get("request_tags", [])),
+                tags=self._transform_tag_list_to_dict(
+                    attributes.get("request_tags", [])
+                ),
                 start_time_ns=start_time_ns,
             )
 
     def _transform_tag_list_to_dict(self, tag_list: list) -> dict:
-        return {tag: "" for tag in tag_list}
+        """
+        Transform a list of colon-separated tags into a dictionary.
+        Tags without colons are stored with empty string as the value.
+        """
+        tag_dict = {}
+        for tag in tag_list:
+            if ":" in tag:
+                k, v = tag.split(":", 1)
+                tag_dict[k.strip()] = v.strip()
+            else:
+                tag_dict[tag.strip()] = ""
+        return tag_dict
 
     def _end_span_or_trace(self, span, outputs, end_time_ns, status):
         """End an MLflow span or a trace."""

--- a/tests/test_litellm/integrations/test_mlflow.py
+++ b/tests/test_litellm/integrations/test_mlflow.py
@@ -57,7 +57,7 @@ async def test_mlflow_logging_functionality():
             messages=[{"role": "user", "content": "test message"}],
             prediction=test_prediction,
             mock_response="test response",
-            metadata={"tags": ["tag1", "tag2", "production"]},
+            metadata={"tags": ["tag1", "tag2", "production", "jobID:214590dsff09fds", "taskName:run_page_classification"]},
         )
 
         # Allow time for async processing
@@ -72,7 +72,13 @@ async def test_mlflow_logging_functionality():
 
         # Check that tags parameter was included and properly transformed
         tags_param = call_args.kwargs.get("tags", {})
-        expected_tags = {"tag1": "", "tag2": "", "production": ""}
+        expected_tags = {
+            "tag1": "",
+            "tag2": "",
+            "production": "",
+            "jobID": "214590dsff09fds",
+            "taskName": "run_page_classification",
+        }
         assert tags_param == expected_tags, f"Expected tags {expected_tags}, got {tags_param}"
 
         # Check that prediction parameter was included in inputs


### PR DESCRIPTION
## Title
Request tags are often already key value pairs delimited by colon.  Since MLFlow span tags are dicts, should match schema.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X ] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

<img width="924" height="416" alt="Screenshot 2025-10-24 at 12 24 49 PM" src="https://github.com/user-attachments/assets/9b63da0f-1bce-4402-bfd6-1119b8fcd1ab" />

