### PR TITLE
[Feat] add support for dynamic client registration

### DIFF
--- a/docs/my-website/docs/mcp.md
+++ b/docs/my-website/docs/mcp.md
@@ -1223,6 +1223,10 @@ mcp_servers:
     scopes: ["public_repo", "user:email"]
 ```
 
+**Note**  
+In the future, users will only need to specify the `url` of the MCP server.
+LiteLLM will automatically resolve the corresponding `authorization_url`, `token_url`, and `registration_url` based on the MCP server metadata (e.g., `.well-known/oauth-authorization-server` or `oauth-protected-resource`).
+
 [**See Claude Code Tutorial**](./tutorials/claude_responses_api#connecting-mcp-servers)
 
 ## Using your MCP with client side credentials

--- a/docs/my-website/docs/tutorials/claude_responses_api.md
+++ b/docs/my-website/docs/tutorials/claude_responses_api.md
@@ -253,10 +253,11 @@ In this example, we'll add the Atlassian MCP server to our `config.yaml`
 atlassian_mcp:
   server_id: atlassian_mcp_id
   url: "https://mcp.atlassian.com/v1/sse"
+  transport: "sse"
   auth_type: oauth2
   authorization_url: https://mcp.atlassian.com/v1/authorize
-  token_url: https://atlassian-remote-mcp-production.atlassian-remote-mcp-server-production.workers.dev/v1/token
-  registration_url: https://atlassian-remote-mcp-production.atlassian-remote-mcp-server-production.workers.dev/v1/register
+  token_url: https://cf.mcp.atlassian.com/v1/token
+  registration_url: https://cf.mcp.atlassian.com/v1/register
 ```
 
 </TabItem>

--- a/docs/my-website/docs/tutorials/claude_responses_api.md
+++ b/docs/my-website/docs/tutorials/claude_responses_api.md
@@ -227,6 +227,9 @@ Limitations:
 
 1. Add the MCP server to your `config.yaml`
 
+<Tabs>
+<TabItem value="github" label="GitHub MCP">
+
 In this example, we'll add the Github MCP server to our `config.yaml`
 
 ```yaml title="config.yaml" showLineNumbers
@@ -241,6 +244,24 @@ mcp_servers:
     scopes: ["public_repo", "user:email"]
 ```
 
+</TabItem>
+<TabItem value="atlassian" label="Atlassian MCP">
+
+In this example, we'll add the Atlassian MCP server to our `config.yaml`
+
+```yaml title="config.yaml" showLineNumbers
+atlassian_mcp:
+  server_id: atlassian_mcp_id
+  url: "https://mcp.atlassian.com/v1/sse"
+  auth_type: oauth2
+  authorization_url: https://mcp.atlassian.com/v1/authorize
+  token_url: https://atlassian-remote-mcp-production.atlassian-remote-mcp-server-production.workers.dev/v1/token
+  registration_url: https://atlassian-remote-mcp-production.atlassian-remote-mcp-server-production.workers.dev/v1/register
+```
+
+</TabItem>
+</Tabs>
+
 2. Start LiteLLM Proxy
 
 ```bash
@@ -254,6 +275,8 @@ litellm --config /path/to/config.yaml
 ```bash
 claude mcp add --transport http litellm_proxy http://0.0.0.0:4000/github_mcp/mcp --header "Authorization: Bearer sk-LITELLM_VIRTUAL_KEY"
 ```
+
+For MCP servers that require dynamic client registration (such as Atlassian), please set `x-litellm-api-key: Bearer sk-LITELLM_VIRTUAL_KEY` instead of using `Authorization: Bearer LITELLM_VIRTUAL_KEY`.
 
 4. Authenticate via Claude Code
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -206,6 +206,7 @@ class MCPServerManager:
                 scopes=server_config.get("scopes", None),
                 authorization_url=server_config.get("authorization_url", None),
                 token_url=server_config.get("token_url", None),
+                registration_url=server_config.get("registration_url", None),
                 # TODO: utility fn the default values
                 transport=server_config.get("transport", MCPTransport.http),
                 auth_type=server_config.get("auth_type", None),
@@ -356,12 +357,12 @@ class MCPServerManager:
                     )
 
                     # Update tool name to server name mapping (for both prefixed and base names)
-                    self.tool_name_to_mcp_server_name_mapping[base_tool_name] = (
-                        server_prefix
-                    )
-                    self.tool_name_to_mcp_server_name_mapping[prefixed_tool_name] = (
-                        server_prefix
-                    )
+                    self.tool_name_to_mcp_server_name_mapping[
+                        base_tool_name
+                    ] = server_prefix
+                    self.tool_name_to_mcp_server_name_mapping[
+                        prefixed_tool_name
+                    ] = server_prefix
 
                     registered_count += 1
                     verbose_logger.debug(
@@ -431,6 +432,7 @@ class MCPServerManager:
                     scopes=getattr(mcp_server, "scopes", None),
                     authorization_url=getattr(mcp_server, "authorization_url", None),
                     token_url=getattr(mcp_server, "token_url", None),
+                    registration_url=getattr(mcp_server, "registration_url", None),
                     # Stdio-specific fields
                     command=getattr(mcp_server, "command", None),
                     args=getattr(mcp_server, "args", None) or [],

--- a/litellm/types/llms/custom_http.py
+++ b/litellm/types/llms/custom_http.py
@@ -16,6 +16,7 @@ class httpxSpecialProvider(str, Enum):
     GuardrailCallback = "guardrail_callback"
     Caching = "caching"
     Oauth2Check = "oauth2_check"
+    Oauth2Register = "oauth2_register"
     SecretManager = "secret_manager"
     PassThroughEndpoint = "pass_through_endpoint"
     PromptFactory = "prompt_factory"

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -1,10 +1,8 @@
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict
-from typing_extensions import TypedDict
 
 from litellm.proxy._types import MCPAuthType, MCPTransportType
-from litellm.types.mcp import MCPServerCostInfo
 
 # MCPInfo now allows arbitrary additional fields for custom metadata
 MCPInfo = Dict[str, Any]
@@ -21,26 +19,27 @@ class MCPServer(BaseModel):
     auth_type: Optional[MCPAuthType] = None
     authentication_token: Optional[str] = None
     mcp_info: Optional[MCPInfo] = None
-    extra_headers: Optional[List[str]] = (
-        None  # allow admin to specify which headers to forward from client to the MCP server
-    )
+    extra_headers: Optional[
+        List[str]
+    ] = None  # allow admin to specify which headers to forward from client to the MCP server
     allowed_tools: Optional[List[str]] = None
     disallowed_tools: Optional[List[str]] = None
-    allowed_params: Optional[Dict[str, List[str]]] = (
-        None  # map of tool names to allowed parameter lists
-    )
+    allowed_params: Optional[
+        Dict[str, List[str]]
+    ] = None  # map of tool names to allowed parameter lists
     # OAuth-specific fields
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     scopes: Optional[List[str]] = None
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
+    registration_url: Optional[str] = None
     # Stdio-specific fields
     command: Optional[str] = None
     args: Optional[List[str]] = None
     env: Optional[Dict[str, str]] = None
     access_groups: Optional[List[str]] = None
-    static_headers: Optional[Dict[str, str]] = (
-        None  # static headers to forward to the MCP server
-    )
+    static_headers: Optional[
+        Dict[str, str]
+    ] = None  # static headers to forward to the MCP server
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1351,6 +1351,7 @@ def test_add_update_server_with_alias():
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None
     mock_mcp_server.authorization_url = None
+    mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
 
     # Add server to manager
@@ -1387,6 +1388,7 @@ def test_add_update_server_without_alias():
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None
     mock_mcp_server.authorization_url = None
+    mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
 
     # Add server to manager
@@ -1423,6 +1425,7 @@ def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.client_id = None
     mock_mcp_server.client_secret = None
     mock_mcp_server.authorization_url = None
+    mock_mcp_server.registration_url = None
     mock_mcp_server.token_url = None
 
     # Add server to manager


### PR DESCRIPTION
## Title

add support for dynamic client registration

## Relevant issues

Fixes #13856

I was able to verify that it’s working correctly in Cursor.
However, in Claude Code, the issue described in Atlassian MCP project ([#8](https://github.com/atlassian/atlassian-mcp-server/issues/8)) occurs. 
Dynamic client registration and authentication have both been confirmed to work successfully.

https://www.loom.com/share/3e986172ddc44d469897aed510e05131

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

 - Dynamic Client Registration
[Dynamic Client Registration](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#dynamic-client-registration), introduced in Protocol version 2025-06-18, has now been implemented.
With this update, LiteLLM can now operate with MCPs that rely on dynamic client registration — such as Jira and Figma.

In a traditional OAuth authorization flow, we must pre-register an OAuth client and specify the issued client ID when making requests.
Thanks to the support added in Protocol version 2025-06-18, this pre-registration step is no longer required — clients can now register dynamically at runtime.

 - WWW-Authenticate Response
For OAuth2-based MCP servers, LiteLLM now returns 401 Unauthorized when the oauth2_header is missing.

reference: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location