### PR TITLE
Fix duplicate trace in langfuse_otel

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -186,9 +186,11 @@ class OpenTelemetry(CustomLogger):
             )
             return
 
-        # Add Otel as a service callback
-        if "otel" not in litellm.service_callback:
-            litellm.service_callback.append("otel")
+        # Add self as a service callback
+        if "otel" not in litellm.service_callback and all(
+            not isinstance(cb, OpenTelemetry) for cb in litellm.service_callback
+        ):
+            litellm.service_callback.append(self)
         setattr(proxy_server, "open_telemetry_logger", self)
 
     def _init_tracing(self, tracer_provider):


### PR DESCRIPTION
## Fix duplicate trace in langfuse_otel

### Cause

This occurred because both the “otel” string and the `OpenTelemetry` instance were registered in `litellm.service_callback`.

These are registered as follows:
1. `OpenTelemetry.__init__()` added the “otel” string to `litellm.service_callback`
2. `_init_litellm_callbacks()` added the OpenTelemetry instance to `litellm.service_callback`
 
Although duplicate checks exist during registration in `_init_litellm_callbacks()`, they were recognized as distinct entities, leading to duplicate logging.

### Solution
I modified the behavior so that the OpenTelemetry instance itself is registered during `OpenTelemetry.__init__()`. This ensures the duplicate check in `_init_litellm_callbacks()` functions correctly.

<!-- e.g. "Implement user authentication feature" -->

| Before | After |
| -- | -- |
| <img width="518" height="982" alt="image" src="https://github.com/user-attachments/assets/4226e15f-41fe-4555-bbe7-19d1c610ffae" /> | <img width="494" height="956" alt="image" src="https://github.com/user-attachments/assets/33cffc68-5888-464a-afa0-dbcd60aad145" /> |

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes https://github.com/BerriAI/litellm/issues/14020

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

Since it's a minor change, I'm manually testing functionality instead of adding unit tests.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


