### PR TITLE
Fix: Support tool usage messages with Langfuse OTEL integration

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -48,11 +48,12 @@ class LangfuseOtelLogger(OpenTelemetry):
         _utils.set_attributes(span, kwargs, response_obj)
 
         #########################################################
-        # Set Langfuse specific attributes eg Langfuse Environment
+        # Set Langfuse specific attributes
         #########################################################
         LangfuseOtelLogger._set_langfuse_specific_attributes(
             span=span,
-            kwargs=kwargs
+            kwargs=kwargs,
+            response_obj=response_obj
         )
         return
 
@@ -86,7 +87,7 @@ class LangfuseOtelLogger(OpenTelemetry):
         return metadata
 
     @staticmethod
-    def _set_langfuse_specific_attributes(span: Span, kwargs):
+    def _set_langfuse_specific_attributes(span: Span, kwargs, response_obj):
         """
         Sets Langfuse specific metadata attributes onto the OTEL span.
 
@@ -96,6 +97,7 @@ class LangfuseOtelLogger(OpenTelemetry):
         compatibility.
         """
         from litellm.integrations.arize._utils import safe_set_attribute
+        from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
         # 1) Environment variable override
         langfuse_environment = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
@@ -140,6 +142,75 @@ class LangfuseOtelLogger(OpenTelemetry):
                     except Exception:
                         value = str(value)
                 safe_set_attribute(span, enum_attr.value, value)
+
+        # 3) Set observation input/output for better UI display
+        #
+        # These Langfuse-specific attributes provide better UI display,
+        # especially for tool calls and function calling.
+        # Set observation input (messages)
+        messages = kwargs.get("messages")
+        if messages:
+            safe_set_attribute(
+                span,
+                LangfuseSpanAttributes.OBSERVATION_INPUT.value,
+                safe_dumps(messages),
+            )
+
+        # Set observation output (response with tool_calls if present)
+        if response_obj and hasattr(response_obj, "get"):
+            choices = response_obj.get("choices", [])
+            if choices:
+                # Extract the first choice's message
+                first_choice = choices[0]
+                message = first_choice.get("message", {})
+
+                # Check if there are tool_calls
+                tool_calls = message.get("tool_calls")
+                if tool_calls:
+                    # Transform tool_calls to Langfuse-expected format
+                    transformed_tool_calls = []
+                    for tool_call in tool_calls:
+                        function = tool_call.get("function", {})
+                        arguments_str = function.get("arguments", "{}")
+
+                        # Parse arguments from JSON string to object
+                        try:
+                            arguments_obj = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                        except json.JSONDecodeError:
+                            arguments_obj = {}
+
+                        # Create Langfuse-compatible tool call object
+                        langfuse_tool_call = {
+                            "name": function.get("name", ""),
+                            "call_id": tool_call.get("id", ""),
+                            "type": "function_call",
+                            "arguments": arguments_obj,
+                            "status": "completed"
+                        }
+                        transformed_tool_calls.append(langfuse_tool_call)
+
+                    # Set the observation output with transformed tool_calls
+                    safe_set_attribute(
+                        span,
+                        LangfuseSpanAttributes.OBSERVATION_OUTPUT.value,
+                        safe_dumps(transformed_tool_calls),
+                    )
+                else:
+                    # No tool_calls, use regular content-based output
+                    output_data = {}
+
+                    if message.get("role"):
+                        output_data["role"] = message.get("role")
+
+                    if message.get("content") is not None:
+                        output_data["content"] = message.get("content")
+
+                    if output_data:
+                        safe_set_attribute(
+                            span,
+                            LangfuseSpanAttributes.OBSERVATION_OUTPUT.value,
+                            safe_dumps(output_data),
+                        )
 
     @staticmethod
     def _get_langfuse_otel_host() -> Optional[str]:

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -181,11 +181,11 @@ class LangfuseOtelLogger(OpenTelemetry):
 
                         # Create Langfuse-compatible tool call object
                         langfuse_tool_call = {
+                            "id": response_obj.get("id", ""),
                             "name": function.get("name", ""),
                             "call_id": tool_call.get("id", ""),
                             "type": "function_call",
                             "arguments": arguments_obj,
-                            "status": "completed"
                         }
                         transformed_tool_calls.append(langfuse_tool_call)
 

--- a/litellm/types/integrations/langfuse_otel.py
+++ b/litellm/types/integrations/langfuse_otel.py
@@ -24,6 +24,10 @@ class LangfuseSpanAttributes(str, Enum):
     MASK_INPUT = "langfuse.generation.mask_input"
     MASK_OUTPUT = "langfuse.generation.mask_output"
 
+    # ---- Observation input/output ----
+    OBSERVATION_INPUT = "langfuse.observation.input"
+    OBSERVATION_OUTPUT = "langfuse.observation.output"
+
     # ---- Trace-level metadata ----
     TRACE_USER_ID = "user.id"
     SESSION_ID = "session.id"


### PR DESCRIPTION
## Support tool usage messages with Langfuse OTEL integration

Langfuse OTEL integration now correctly logs and displays tool calls (function calling) from chat completions.

<img width="795" height="579" alt="image" src="https://github.com/user-attachments/assets/da0c4b6e-5ba4-4759-bdba-49a69f3cfc54" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/13764

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1244" height="537" alt="image" src="https://github.com/user-attachments/assets/06456c68-192c-43b0-b02e-17102cc17146" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


