### PR TITLE
Enable OpenTelemetry context propagation by external tracers

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9,6 +9,7 @@
 
 import ast
 import asyncio
+import contextvars
 import base64
 import binascii
 import copy
@@ -1296,7 +1297,11 @@ def client(original_function):  # noqa: PLR0915
 
             # LOG SUCCESS - handle streaming success logging in the _next_ object, remove `handle_success` once it's deprecated
             verbose_logger.info("Wrapper: Completed Call, calling success_handler")
+            # Copy the current context to propagate it to the background thread
+            # This is essential for OpenTelemetry span context propagation
+            ctx = contextvars.copy_context()
             executor.submit(
+                ctx.run,
                 logging_obj.success_handler,
                 result,
                 start_time,

--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -56,3 +56,66 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
         await asyncio.sleep(1)
 
         parent_otel_span.end.assert_called_once()
+
+    def test_init_tracing_respects_existing_tracer_provider(self):
+        """
+        Unit test: _init_tracing() should respect existing TracerProvider.
+
+        When a TracerProvider already exists (e.g., set by Langfuse SDK),
+        LiteLLM should use it instead of creating a new one.
+        """
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from litellm.integrations.opentelemetry import OpenTelemetry
+
+        # Setup: Create and set an existing TracerProvider
+        tracer_provider = TracerProvider()
+        trace.set_tracer_provider(tracer_provider)
+        existing_provider = trace.get_tracer_provider()
+
+        # Act: Initialize OpenTelemetry integration (should detect existing provider)
+        otel_integration = OpenTelemetry()
+
+        # Assert: The existing provider should still be active
+        current_provider = trace.get_tracer_provider()
+        assert current_provider is existing_provider, (
+            "Existing TracerProvider should be respected and not overridden"
+        )
+
+    def test_get_span_context_detects_active_span(self):
+        """
+        Unit test: _get_span_context() should auto-detect active spans from global context.
+
+        Active spans should be automatically detected without explicit metadata
+        """
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from litellm.integrations.opentelemetry import OpenTelemetry
+
+        # Setup: Create TracerProvider and tracer
+        tracer_provider = TracerProvider()
+        trace.set_tracer_provider(tracer_provider)
+        tracer = trace.get_tracer(__name__)
+
+        # Create OpenTelemetry integration
+        otel_integration = OpenTelemetry()
+
+        # Act: Create an active span and test detection
+        with tracer.start_as_current_span("test_parent") as parent_span:
+            parent_span_context = parent_span.get_span_context()
+
+            # Call _get_span_context without explicit parent in metadata
+            kwargs = {"litellm_params": {"metadata": {}}}
+            detected_context, detected_span = otel_integration._get_span_context(kwargs)
+
+            # Assert: Should detect the active span
+            assert detected_span is not None, "Should detect active span from global context"
+            assert detected_span is parent_span, "Detected span should be the active parent span"
+
+            detected_span_context = detected_span.get_span_context()
+            assert detected_span_context.trace_id == parent_span_context.trace_id, (
+                "Detected span should have same trace_id as parent"
+            )
+            assert detected_span_context.span_id == parent_span_context.span_id, (
+                "Detected span should have same span_id as parent"
+            )


### PR DESCRIPTION
## Enable OpenTelemetry context propagation by external tracers

When an OpenTelemetry context is created outside a litellm function (e.g., completion), it will automatically enable propagation and display it as a single trace.

```python
from langfuse import observe

import litellm
from litellm import completion
litellm.success_callback = ["langfuse_otel"]
litellm.failure_callback = ["langfuse_otel"]

@observe(name="testing")
def f(a: int) -> int:
    completion(model="anthropic/claude-sonnet-4-20250514", messages=[{"role": "user", "content": "Hello, how are you?"}])
    return a * 2


f(a=10)
```

<img width="640" height="541" alt="image" src="https://github.com/user-attachments/assets/83b2792b-835c-4c66-85e5-94d9154d2533" />

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/11742

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="943" height="343" alt="image" src="https://github.com/user-attachments/assets/543cca7e-640d-4d6e-8736-f261edb2899e" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


