### PR TITLE
docs(openrouter): add base_url config with environment variables

### DIFF
--- a/docs/my-website/docs/providers/openrouter.md
+++ b/docs/my-website/docs/providers/openrouter.md
@@ -9,10 +9,9 @@ LiteLLM supports all the text / chat / vision models from [OpenRouter](https://o
 ```python
 import os
 from litellm import completion
+
 os.environ["OPENROUTER_API_KEY"] = ""
 os.environ["OPENROUTER_API_BASE"] = "" # [OPTIONAL] defaults to https://openrouter.ai/api/v1
-
-
 os.environ["OR_SITE_URL"] = "" # [OPTIONAL]
 os.environ["OR_APP_NAME"] = "" # [OPTIONAL]
 
@@ -22,8 +21,32 @@ response = completion(
         )
 ```
 
-## OpenRouter Completion Models
+## Configuration with Environment Variables
 
+For production environments, you can dynamically configure the base_url using environment variables:
+
+```python
+import os
+from litellm import completion
+
+# Configure with environment variables
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_API_BASE", "https://openrouter.ai/api/v1")
+
+# Set environment for LiteLLM
+os.environ["OPENROUTER_API_KEY"] = OPENROUTER_API_KEY
+os.environ["OPENROUTER_API_BASE"] = OPENROUTER_BASE_URL
+
+response = completion(
+    model="openrouter/google/palm-2-chat-bison",
+    messages=messages,
+    base_url=OPENROUTER_BASE_URL  # Explicitly pass base_url for clarity
+)
+```
+
+This approach provides better flexibility for managing configurations across different environments (dev, staging, production) and makes it easier to switch between self-hosted and cloud endpoints.
+
+## OpenRouter Completion Models
 🚨 LiteLLM supports ALL OpenRouter models, send `model=openrouter/<your-openrouter-model>` to send it to open router. See all openrouter models [here](https://openrouter.ai/models)
 
 | Model Name                | Function Call                                       |
@@ -40,12 +63,12 @@ response = completion(
 | openrouter/meta-llama/llama-2-70b-chat | `completion('openrouter/meta-llama/llama-2-70b-chat', messages)` | `os.environ['OR_SITE_URL']`,`os.environ['OR_APP_NAME']`,`os.environ['OPENROUTER_API_KEY']` |
 
 ## Passing OpenRouter Params - transforms, models, route
-
 Pass `transforms`, `models`, `route`as arguments to `litellm.completion()`
 
 ```python
 import os
 from litellm import completion
+
 os.environ["OPENROUTER_API_KEY"] = ""
 
 response = completion(


### PR DESCRIPTION
## Title
docs(openrouter): add base_url config with environment variables

## Relevant issues
N/A - Documentation improvement

## Pre-Submission checklist
This is a documentation-only change that doesn't require code testing. The PR adds helpful configuration examples to the OpenRouter provider documentation.

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
📖 Documentation

## Changes
Added a new "Configuration with Environment Variables" section to the OpenRouter provider documentation demonstrating:

- Using `os.getenv()` to dynamically retrieve OpenRouter API key and base URL configuration
- Setting default value for `OPENROUTER_BASE_URL` when environment variable is not set
- Explicitly passing `base_url` parameter to the `completion()` function for clarity
- Benefits explanation: better flexibility for managing configurations across different environments (dev, staging, production) and easier switching between self-hosted and cloud endpoints

This helps users implement production-ready configuration patterns and provides a clear example of using environment variables for dynamic configuration management.