### PR TITLE
Perf speed up pytest

### DIFF
--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -40,4 +40,4 @@ jobs:
         cd ..
     - name: Run tests
       run: |
-        poetry run pytest tests/test_litellm --tb=short -vv --maxfail=10 -n 4 
+        poetry run pytest tests/test_litellm --tb=short -vv --maxfail=10 -n 4 --durations=50

--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -33,7 +33,7 @@ jobs:
         poetry run pip install "google-genai==1.22.0"
         poetry run pip install "google-cloud-aiplatform>=1.38"
         poetry run pip install "fastapi-offline==1.7.3"
-        poetry run pip install python-multipart==0.0.18"
+        poetry run pip install "python-multipart==0.0.18"
     - name: Setup litellm-enterprise as local package
       run: |
         cd enterprise

--- a/.github/workflows/test-litellm.yml
+++ b/.github/workflows/test-litellm.yml
@@ -33,6 +33,7 @@ jobs:
         poetry run pip install "google-genai==1.22.0"
         poetry run pip install "google-cloud-aiplatform>=1.38"
         poetry run pip install "fastapi-offline==1.7.3"
+        poetry run pip install python-multipart==0.0.18"
     - name: Setup litellm-enterprise as local package
       run: |
         cd enterprise

--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -26,7 +26,7 @@ def event_loop():
 
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def setup_and_teardown():
     """
     This fixture reloads litellm before every function. To speed up testing by removing callbacks being chained.

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
@@ -4,13 +4,11 @@ import sys
 import unittest.mock as mock
 from unittest.mock import patch
 
+from enterprise.litellm_enterprise.enterprise_callbacks.send_emails.base_email import BaseEmailLogger
 import pytest
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath("../../.."))
-from litellm_enterprise.enterprise_callbacks.send_emails.base_email import (
-    BaseEmailLogger,
-)
 from litellm_enterprise.types.enterprise_callbacks.send_emails import (
     EmailEvent,
     SendKeyCreatedEmailEvent,
@@ -19,6 +17,13 @@ from litellm_enterprise.types.enterprise_callbacks.send_emails import (
 from litellm.integrations.email_templates.email_footer import EMAIL_FOOTER
 from litellm.proxy._types import Litellm_EntityType, WebhookEvent
 
+
+@pytest.fixture(autouse=True)
+def no_invitation_wait(monkeypatch):
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(BaseEmailLogger, "_wait_for_invitation_creation", _noop)
 
 @pytest.fixture
 def base_email_logger():

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -188,6 +188,8 @@ async def test_handle_async_request_uses_env_proxy(monkeypatch):
     monkeypatch.setenv("HTTPS_PROXY", proxy_url)
     monkeypatch.setenv("https_proxy", proxy_url)
     monkeypatch.delenv("DISABLE_AIOHTTP_TRUST_ENV", raising=False)
+    monkeypatch.setattr("urllib.request.getproxies", lambda: {"http": proxy_url, "https": proxy_url})
+    monkeypatch.setattr("urllib.request.proxy_bypass", lambda host: False)
 
     captured = {}
 

--- a/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
@@ -11,6 +11,13 @@ import pytest
 
 import litellm
 
+@pytest.fixture(autouse=True)
+def _reset_litellm_http_client_cache():
+    """Ensure each test gets a fresh async HTTP client mock."""
+    from litellm import in_memory_llm_clients_cache
+
+    in_memory_llm_clients_cache.flush_cache()
+
 
 class TestVertexGemmaCompletion:
     """Test completion flow for Vertex AI Gemma models using litellm.acompletion()"""

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -125,16 +125,14 @@ def test_get_microsoft_callback_response():
         "surname": "User",
     }
 
-    future = asyncio.Future()
-    future.set_result(mock_response)
-
     with patch.dict(
         os.environ,
         {"MICROSOFT_CLIENT_SECRET": "mock_secret", "MICROSOFT_TENANT": "mock_tenant"},
     ):
+        mock_verify = AsyncMock(return_value=mock_response)
         with patch(
             "fastapi_sso.sso.microsoft.MicrosoftSSO.verify_and_process",
-            return_value=future,
+            new=mock_verify,
         ):
             # Act
             result = asyncio.run(
@@ -166,15 +164,14 @@ def test_get_microsoft_callback_response_raw_sso_response():
         "surname": "User",
     }
 
-    future = asyncio.Future()
-    future.set_result(mock_response)
     with patch.dict(
         os.environ,
         {"MICROSOFT_CLIENT_SECRET": "mock_secret", "MICROSOFT_TENANT": "mock_tenant"},
     ):
+        mock_verify = AsyncMock(return_value=mock_response)
         with patch(
             "fastapi_sso.sso.microsoft.MicrosoftSSO.verify_and_process",
-            return_value=future,
+            new=mock_verify,
         ):
             # Act
             result = asyncio.run(
@@ -207,12 +204,10 @@ def test_get_google_callback_response():
         "family_name": "User",
     }
 
-    future = asyncio.Future()
-    future.set_result(mock_response)
-
     with patch.dict(os.environ, {"GOOGLE_CLIENT_SECRET": "mock_secret"}):
+        mock_verify = AsyncMock(return_value=mock_response)
         with patch(
-            "fastapi_sso.sso.google.GoogleSSO.verify_and_process", return_value=future
+            "fastapi_sso.sso.google.GoogleSSO.verify_and_process", new=mock_verify
         ):
             # Act
             result = asyncio.run(
@@ -2072,4 +2067,3 @@ class TestPKCEFunctionality:
                 assert "code_challenge=" in updated_location
                 assert "code_challenge_method=S256" in updated_location
                 assert f"state={test_state}" in updated_location
-

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -71,6 +71,14 @@ def disable_budget_sync(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def reset_router_callbacks():
+    """Ensure router budget callbacks from previous tests do not leak state."""
+    litellm.logging_callback_manager._reset_all_callbacks()
+    yield
+    litellm.logging_callback_manager._reset_all_callbacks()
+
+
 @pytest.mark.asyncio
 async def test_ui_view_spend_logs_with_user_id(client, monkeypatch):
     # Mock data for the test


### PR DESCRIPTION
## Title

speed up pytest

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring
✅ Test

## Changes

### Summary
While running tests locally, I identified the following slow tests:

```
▌ 20.48s call     tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py::test_get_invitation_link
▌ 14.34s setup    tests/test_litellm/proxy/test_common_request_processing.py::TestCommonRequestProcessingHelpers::test_create_streaming_response_first_chunk_error_string_code
▌ 13.07s setup    tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py::test_handle_async_request_uses_env_proxy
▌ 12.45s setup    tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py::TestMCPServerManager::test_deserialize_env_dict
▌ 10.56s call     tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py::test_get_invitation_link_uses_existing_when_available
▌ 10.20s call     tests/test_litellm/proxy/test_proxy_cli.py::TestProxyInitializationHelpers::test_skip_server_startup
▌ 10.01s call     tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py::test_get_invitation_link_creates_new_when_list_is_none
▌ 10.01s call     tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py::test_get_invitation_link_creates_new_when_none_exist
▌ 9.99s setup    tests/test_litellm/test_utils.py::TestProxyFunctionCalling::test_proxy_custom_model_names_without_config[litellm_proxy/groq-gemma-groq/gemma-7b-it-False]
▌ 9.87s setup    tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_get_enforced_params[general_settings2-user_api_key_dict2-expected_enforced_params2]
▌ 9.63s setup    tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py::test_guardrail_information_in_metadata
▌ 9.52s setup    tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py::TestLassoGuardrail::test_post_call_with_violations
▌ 9.45s call     tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py::test_100_concurrent_priority_requests
▌ 9.31s setup    tests/test_litellm/proxy/auth/test_handle_jwt.py::test_map_user_to_teams_user_already_in_team
▌ 9.25s setup    tests/test_litellm/llms/mistral/test_mistral_completion.py::test_mistral_transform_response_empty_content_conversion[False]
▌ 9.16s setup    tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_endpoints_common_utils.py::test_encode_bedrock_runtime_modelid_arn_edge_cases
▌ 8.99s setup    tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py::TestPerplexityChatTransformation::test_enhance_usage_with_missing_fields
▌ 8.91s setup    tests/test_litellm/proxy/db/db_transaction_queue/test_daily_spend_update_queue.py::test_queue_max_size_triggers_aggregation
▌ 8.87s setup    tests/test_litellm/test_router.py::test_arouter_should_include_deployment
▌ 8.82s setup    tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py::test_assistant_tool_calls_cache_control
▌ 8.76s setup    tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py::test_patch_guardrail_endpoint[database_error]
▌ 8.68s setup    tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py::TestMoonshotConfig::test_map_openai_params_max_completion_tokens_mapping
▌ 8.59s setup    tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py::TestPerplexityCostCalculator::test_cost_calculation_combinations[15-5-10]
▌ 8.45s setup    tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py::test_anthropic_stream_wrapper_back_to_back_tool_calls
▌ 8.18s setup    tests/test_litellm/integrations/arize/test_arize_utils.py::test_arize_dynamic_params
▌ 7.77s setup    tests/test_litellm/llms/watsonx/test_watsonx.py::test_watsonx_gpt_oss_uses_async_http_handler
▌ 7.76s setup    tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_content_after_stop_reason.py::test_anthropic_stream_wrapper_content_after_stop_reason
▌ 7.54s setup    tests/test_litellm/llms/chat/test_converse_handler.py::test_encode_model_id_with_inference_profile
▌ 7.34s setup    tests/test_litellm/llms/watsonx/test_watsonx.py::test_watsonx_completion_deployment_model_id_not_in_payload
▌ 7.28s setup    tests/test_litellm/router_utils/test_cooldown_cache.py::TestCooldownCacheExceptionMasking::test_custom_masker_settings
▌ 7.27s setup    tests/test_litellm/integrations/test_braintrust_logging.py::TestBraintrustLogger::test_span_name_with_multiple_metadata_fields
▌ 7.15s setup    tests/test_litellm/integrations/gitlab/test_gitlab_prompt_manager.py::test_gitlab_client_initialization_token_vs_oauth
▌ 7.09s setup    tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py::TestPanwAirsMaskingFunctionality::test_prompt_masking_with_content_list
▌ 6.94s setup    tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py::test_guarded_text_wraps_in_guardrail_converse_content
▌ 6.86s setup    tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma.py::TestNomaGuardrailHooks::test_api_failure_no_block
▌ 6.78s setup    tests/test_litellm/proxy/auth/test_auth_checks.py::test_get_key_object_from_ui_hash_key_invalid
▌ 6.68s setup    tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py::test_update_user_not_found
▌ 6.68s setup    tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py::TestDataRobotConfig::test_resolve_api_key_with_environment_variable
▌ 6.65s setup    tests/test_litellm/litellm_core_utils/test_token_counter_tool.py::test_grow[t_short-long-arr-obj]
▌ 6.58s setup    tests/test_litellm/llms/recraft/image_edit/test_recraft_image_edit_transformation.py::TestRecraftImageEditTransformation::test_transform_image_edit_request
▌ 6.57s setup    tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetry::test_get_litellm_resource_with_otel_resource_attributes
▌ 6.50s setup    tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py::TestPerplexityChatTransformation::test_enhance_usage_with_empty_citations
▌ 6.49s setup    tests/test_litellm/test_router.py::test_arouter_ignore_invalid_deployments
▌ 6.42s setup    tests/test_litellm/proxy/test_common_request_processing.py::TestCommonRequestProcessingHelpers::test_create_streaming_response_first_chunk_is_error
▌ 6.35s setup    tests/test_litellm/llms/perplexity/test_perplexity.py::TestPerplexityWebSearch::test_web_search_options_in_supported_params[perplexity/sonar]
▌ 6.31s setup    tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_assume_role_with_external_id
▌ 6.23s setup    tests/test_litellm/proxy/auth/test_auth_exception_handler.py::test_handle_authentication_error_db_unavailable[prisma_error1]
▌ 6.13s setup    tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py::test_apply_tool_call_transformation_if_needed
```

From these results, I picked a few representative test cases and applied targeted optimizations.
As a result, the GitHub Actions test run now completes in 17m 27s (down from significantly longer before).

<img width="1876" height="734" alt="image" src="https://github.com/user-attachments/assets/cdf32874-7aa9-4d36-bd90-d8b37808e525" />

### Improvements Included
- tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
Mocked sleep calls to eliminate unnecessary wait times.

- tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py and tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
Mocked datetime.now to avoid real-time waits in rate limiter tests.

- tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
Mocked urllib system calls to skip real network lookups and reduce setup latency.

- tests/test_litellm/conftest.py
Reduced setup phase overhead by widening fixture scope to module
(previously reloaded litellm and its submodules on every test).

- .github/workflows/test-litellm.yml
Added --durations=50 to visualize the 50 slowest tests in CI without performance impact.

- other files
fix stabilize flaky tests