### PR TITLE
Fix: Redact reasoning summaries in ResponsesAPI output when message logging is disabled

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -58,8 +58,18 @@ def perform_redaction(model_call_details: dict, result):
             for choice in _streaming_response.choices:
                 if isinstance(choice, litellm.Choices):
                     choice.message.content = "redacted-by-litellm"
+                    # Redact reasoning-related fields
+                    if hasattr(choice.message, "reasoning_content"):
+                        choice.message.reasoning_content = "redacted-by-litellm"
+                    if hasattr(choice.message, "thinking_blocks"):
+                        choice.message.thinking_blocks = None
                 elif isinstance(choice, litellm.utils.StreamingChoices):
                     choice.delta.content = "redacted-by-litellm"
+                    # Redact reasoning-related fields
+                    if hasattr(choice.delta, "reasoning_content"):
+                        choice.delta.reasoning_content = "redacted-by-litellm"
+                    if hasattr(choice.delta, "thinking_blocks"):
+                        choice.delta.thinking_blocks = None
         elif hasattr(_streaming_response, "output"):
             # Handle ResponsesAPIResponse format
             for output_item in _streaming_response.output:
@@ -69,6 +79,17 @@ def perform_redaction(model_call_details: dict, result):
                     for content_part in output_item.content:
                         if hasattr(content_part, "text"):
                             content_part.text = "redacted-by-litellm"
+                
+                # Redact reasoning items in output array
+                if hasattr(output_item, "type") and output_item.type == "reasoning":
+                    if hasattr(output_item, "summary") and isinstance(output_item.summary, list):
+                        for summary_item in output_item.summary:
+                            if hasattr(summary_item, "text"):
+                                summary_item.text = "redacted-by-litellm"
+            
+            # Redact reasoning field in ResponsesAPIResponse
+            if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
+                _streaming_response.reasoning = None
 
     # Redact result
     if result is not None:
@@ -86,8 +107,18 @@ def perform_redaction(model_call_details: dict, result):
                 for choice in _result.choices:
                     if isinstance(choice, litellm.Choices):
                         choice.message.content = "redacted-by-litellm"
+                        # Redact reasoning-related fields
+                        if hasattr(choice.message, "reasoning_content"):
+                            choice.message.reasoning_content = "redacted-by-litellm"
+                        if hasattr(choice.message, "thinking_blocks"):
+                            choice.message.thinking_blocks = None
                     elif isinstance(choice, litellm.utils.StreamingChoices):
                         choice.delta.content = "redacted-by-litellm"
+                        # Redact reasoning-related fields
+                        if hasattr(choice.delta, "reasoning_content"):
+                            choice.delta.reasoning_content = "redacted-by-litellm"
+                        if hasattr(choice.delta, "thinking_blocks"):
+                            choice.delta.thinking_blocks = None
         elif isinstance(_result, litellm.ResponsesAPIResponse):
             if hasattr(_result, "output"):
                 for output_item in _result.output:
@@ -95,6 +126,17 @@ def perform_redaction(model_call_details: dict, result):
                         for content_part in output_item.content:
                             if hasattr(content_part, "text"):
                                 content_part.text = "redacted-by-litellm"
+                    
+                    # Redact reasoning items in output array
+                    if hasattr(output_item, "type") and output_item.type == "reasoning":
+                        if hasattr(output_item, "summary") and isinstance(output_item.summary, list):
+                            for summary_item in output_item.summary:
+                                if hasattr(summary_item, "text"):
+                                    summary_item.text = "redacted-by-litellm"
+            
+            # Redact reasoning field in ResponsesAPIResponse
+            if hasattr(_result, "reasoning") and _result.reasoning is not None:
+                _result.reasoning = None
         elif isinstance(_result, litellm.EmbeddingResponse):
             if hasattr(_result, "data") and _result.data is not None:
                 _result.data = []


### PR DESCRIPTION
## Title

Fix: Redact reasoning summaries in ResponsesAPI output when message logging is disabled

## Relevant issues

Fixes #15913

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
When `turn_off_message_logging: True` was configured, message content was properly redacted but **reasoning summaries** in ResponsesAPI responses remained visible in observability tools (Langfuse, Datadog, etc.). This leaked sensitive reasoning data even when users explicitly disabled message logging.

**Example of leaked data:**
```json
{
  "type": "reasoning",
  "summary": [
    {
      "text": "**Delivering a joke** The user wants a random joke...",
      "type": "summary_text"
    }
  ]
}
```

### Solution
Extended the `perform_redaction()` function in `litellm/litellm_core_utils/redact_messages.py` to:
1. Detect reasoning items in ResponsesAPI `output` array (items with `type: "reasoning"`)
2. Redact the `summary[].text` fields within reasoning items
3. Remove the top-level `reasoning` field from ResponsesAPIResponse
<img width="727" height="785" alt="image" src="https://github.com/user-attachments/assets/e5f09c43-9692-48ae-9be0-ef681cef191a" />
