### PR TITLE
Fix: Respect `LiteLLM-Disable-Message-Redaction` header for Responses API

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -138,6 +138,22 @@ def add_missing_spend_metadata_to_litellm_metadata(
     return litellm_metadata
 
 
+def get_metadata_variable_name_from_kwargs(
+    kwargs: dict,
+) -> str:
+    """
+    Helper to return what the "metadata" field should be called in the request data
+
+    - New endpoints return `litellm_metadata`
+    - Old endpoints return `metadata`
+
+    Context:
+    - LiteLLM used `metadata` as an internal field for storing metadata
+    - OpenAI then started using this field for their metadata
+    - LiteLLM is now moving to using `litellm_metadata` for our metadata
+    """
+    return "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+    
 def get_litellm_metadata_from_kwargs(kwargs: dict):
     """
     Helper to get litellm metadata from all litellm request kwargs

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -112,8 +112,6 @@ def should_redact_message_logging(model_call_details: dict) -> bool:
     """
     litellm_params = model_call_details.get("litellm_params", {})
     
-    # Get the appropriate metadata field based on what's present in litellm_params
-    # Responses API uses 'litellm_metadata', completion API uses 'metadata'
     metadata_field = get_metadata_variable_name_from_kwargs(litellm_params)
     metadata = litellm_params.get(metadata_field, {})
     

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -54,7 +54,10 @@ from litellm.caching.caching import (
 from litellm.constants import DEFAULT_MAX_LRU_CACHE_SIZE
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
-from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
+from litellm.litellm_core_utils.core_helpers import (
+    _get_parent_otel_span_from_kwargs,
+    get_metadata_variable_name_from_kwargs,
+)
 from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.dd_tracing import tracer
@@ -4756,7 +4759,7 @@ class Router:
         - OpenAI then started using this field for their metadata
         - LiteLLM is now moving to using `litellm_metadata` for our metadata
         """
-        return "litellm_metadata" if "litellm_metadata" in kwargs else "metadata"
+        return get_metadata_variable_name_from_kwargs(kwargs)
 
     def log_retry(self, kwargs: dict, e: Exception) -> dict:
         """

--- a/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
+++ b/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
@@ -279,3 +279,88 @@ async def test_redaction_with_streaming_response():
         "logged standard logging payload for streaming with coroutine handling",
         json.dumps(standard_logging_payload, indent=2),
     )
+
+
+@pytest.mark.asyncio
+async def test_disable_redaction_header_responses_api():
+    """
+    Test that LiteLLM-Disable-Message-Redaction header works for Responses API.
+    
+    This test verifies the fix for the issue where the header wasn't respected
+    because Responses API uses 'litellm_metadata' instead of 'metadata'.
+    """
+    litellm.turn_off_message_logging = True
+    test_custom_logger = TestCustomLogger()
+    litellm.callbacks = [test_custom_logger]
+    
+    # Mock a ResponsesAPIResponse-style response
+    mock_response = {
+        "output": [{"text": "This is a test response"}],
+        "model": "gpt-3.5-turbo",
+        "usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10}
+    }
+    
+    # Pass the header via litellm_metadata (as the proxy does for Responses API)
+    response = await litellm.aresponses(
+        model="gpt-3.5-turbo",
+        input="hi",
+        mock_response=mock_response,
+        litellm_metadata={
+            "headers": {
+                "litellm-disable-message-redaction": "true"
+            }
+        }
+    )
+
+    await asyncio.sleep(1)
+    standard_logging_payload = test_custom_logger.logged_standard_logging_payload
+    assert standard_logging_payload is not None
+    
+    # Verify that messages are NOT redacted because the header was set
+    print(
+        "logged standard logging payload for ResponsesAPI with disable header",
+        json.dumps(standard_logging_payload, indent=2, default=str),
+    )
+    
+    # The content should NOT be redacted
+    assert standard_logging_payload["response"] != {"text": "redacted-by-litellm"}
+    assert standard_logging_payload["messages"][0]["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_disable_redaction_header_completion_api():
+    """
+    Test that LiteLLM-Disable-Message-Redaction header works for Completion API.
+    
+    This test verifies that the header still works for completion API which uses 'metadata'.
+    """
+    litellm.turn_off_message_logging = True
+    test_custom_logger = TestCustomLogger()
+    litellm.callbacks = [test_custom_logger]
+    
+    # Pass the header via metadata (as the proxy does for Completion API)
+    response = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="hello",
+        metadata={
+            "headers": {
+                "litellm-disable-message-redaction": "true"
+            }
+        }
+    )
+
+    await asyncio.sleep(1)
+    standard_logging_payload = test_custom_logger.logged_standard_logging_payload
+    assert standard_logging_payload is not None
+    
+    # Verify that messages are NOT redacted because the header was set
+    print(
+        "logged standard logging payload for Completion API with disable header",
+        json.dumps(standard_logging_payload, indent=2),
+    )
+    
+    # The content should NOT be redacted
+    assert standard_logging_payload["response"] != {"text": "redacted-by-litellm"}
+    assert standard_logging_payload["messages"][0]["content"] == "hi"
+    assert standard_logging_payload["response"]["choices"][0]["message"]["content"] == "hello"


### PR DESCRIPTION
## Title

Fix: Respect `LiteLLM-Disable-Message-Redaction` header for Responses API

## Relevant issues

Fixes  #15913


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
When `turn_off_message_logging: True` is set in the config and the `LiteLLM-Disable-Message-Redaction: true` header is sent, the header works correctly for the Completion API but is **ignored for the Responses API**, causing all messages to remain redacted.

### Root Cause
The Responses API stores request headers in `litellm_metadata`, while the Completion API uses `metadata`. The redaction logic in `should_redact_message_logging()` was using an `or` operator to check these fields:

```python
_request_headers = (
    litellm_params.get("metadata", {}) or litellm_params.get("litellm_metadata", {}) or {}
)
```

When `metadata` exists (even without headers), it would never check `litellm_metadata`, causing the header to be ignored for Responses API.

### Solution
Modified `should_redact_message_logging()` in `litellm/litellm_core_utils/redact_messages.py` to:
1. Extract headers from **both** `metadata` and `litellm_metadata` 
2. Merge them together (with `litellm_metadata` taking precedence)
3. Check the merged headers for redaction control
<img width="727" height="785" alt="image" src="https://github.com/user-attachments/assets/97ab3eb8-c8b3-4fdd-86ba-b551d9637e3b" />
