### PR TITLE
[Feat] OTEL - Ensure error information is logged on OTEL

### DIFF
--- a/litellm/integrations/_types/open_inference.py
+++ b/litellm/integrations/_types/open_inference.py
@@ -387,3 +387,42 @@ class OpenInferenceLLMProviderValues(Enum):
     GOOGLE = "google"
     AZURE = "azure"
     AWS = "aws"
+
+
+class ErrorAttributes:
+    """
+    Attributes for error information in spans.
+    
+    These attributes follow OpenTelemetry semantic conventions for exceptions
+    and are used to record error information from StandardLoggingPayloadErrorInformation.
+    """
+
+    ERROR_TYPE = "error.type"
+    """
+    The type/class of the error (e.g., 'ValueError', 'OpenAIError', 'RateLimitError').
+    Corresponds to StandardLoggingPayloadErrorInformation.error_class
+    """
+
+    ERROR_MESSAGE = "error.message"
+    """
+    The error message describing what went wrong.
+    Corresponds to StandardLoggingPayloadErrorInformation.error_message
+    """
+
+    ERROR_CODE = "error.code"
+    """
+    The error code (e.g., HTTP status code like '500', '429', or provider-specific codes).
+    Corresponds to StandardLoggingPayloadErrorInformation.error_code
+    """
+
+    ERROR_STACK_TRACE = "error.stack_trace"
+    """
+    The full stack trace of the error.
+    Corresponds to StandardLoggingPayloadErrorInformation.traceback
+    """
+
+    ERROR_LLM_PROVIDER = "error.llm_provider"
+    """
+    The LLM provider where the error occurred (e.g., 'openai', 'anthropic', 'azure').
+    Corresponds to StandardLoggingPayloadErrorInformation.llm_provider
+    """

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -13,15 +13,13 @@ from litellm.caching.caching import DualCache
 from litellm.cost_calculator import _infer_call_type
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.llms import (
-    endpoint_guardrail_translation_mappings,
-    load_guardrail_translation_mappings,
-)
+from litellm.llms import load_guardrail_translation_mappings
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import CallTypes, ModelResponseStream
 
 GUARDRAIL_NAME = "unified_llm_guardrails"
+endpoint_guardrail_translation_mappings = None
 
 
 class UnifiedLLMGuardrails(CustomLogger):


### PR DESCRIPTION
## [Feat] OTEL - Ensure error information is logged on OTEL

- Ensure error fields are populated on OTEL 

<img width="1503" height="893" alt="Screenshot 2025-10-27 at 11 27 48 AM" src="https://github.com/user-attachments/assets/b85cbefa-3f8b-4f00-8e7e-557c31916ed6" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


