### PR TITLE
[Buf fix] - Azure OpenAI, fix ContextWindowExceededError is not mapped from Azure openai errors

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -67,6 +67,7 @@ class ExceptionCheckers:
             "string too long. expected a string with maximum length",
             "model's maximum context limit",
             "is longer than the model's context length",
+            "input tokens exceed the configured limit",
         ]
         for substring in known_exception_substrings:
             if substring in _error_str_lowercase:

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -11,6 +11,7 @@ context_window_test_cases = [
     ("Validation Error: string too long. expected a string with maximum length 1000.", True),
     ("Your prompt is longer than the model's context length of 2048.", True),
     ("AWS Bedrock Error: The request payload size has exceed context limit.", True),
+    ("Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 509178 tokens. Please reduce the length of the messages.", True),
 
     # Test case insensitivity
     ("ERROR: THIS MODEL'S MAXIMUM CONTEXT LENGTH IS 1024.", True),


### PR DESCRIPTION
## [Buf fix] - Azure OpenAI, fix ContextWindowExceededError is not mapped from Azure openai errors

Fixes https://github.com/BerriAI/litellm/issues/15968 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


