### PR TITLE
Add US endpoint for OpenAI in options

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -89,7 +89,7 @@ const PROVIDER_CREDENTIAL_FIELDS: Record<Providers, ProviderCredentialField[]> =
       key: "api_base",
       label: "API Base",
       type: "select",
-      options: ["https://api.openai.com/v1", "https://eu.api.openai.com"],
+      options: ["https://api.openai.com/v1", "https://eu.api.openai.com", "https://us.api.openai.com"],
       defaultValue: "https://api.openai.com/v1",
     },
     {

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -69,7 +69,7 @@ const PROVIDER_CREDENTIAL_FIELDS: Record<Providers, ProviderCredentialField[]> =
       key: "api_base",
       label: "API Base",
       type: "select",
-      options: ["https://api.openai.com/v1", "https://eu.api.openai.com"],
+      options: ["https://api.openai.com/v1", "https://eu.api.openai.com", "https://us.api.openai.com"],
       defaultValue: "https://api.openai.com/v1",
     },
     {


### PR DESCRIPTION
## Title

From November 4, 2025, OpenAI will enforce the use of [us.api.openai.com](http://us.api.openai.com/), and existing projects using the old endpoint will return an error.

<img width="1450" height="1294" alt="image" src="https://github.com/user-attachments/assets/b30f7518-d4d7-4bdf-a505-2cb233c66dff" />


## Relevant issues

Fixes the missing US endpoint configuration

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type



🐛 Bug Fix


## Changes

just adds an option in UI

