### PR TITLE
[Fix] Azure OpenAI - Add handling for `v1` under azure api versions 

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -759,4 +759,4 @@ class BaseAzureLLM(BaseOpenAILLM):
     def _is_azure_v1_api_version(api_version: Optional[str]) -> bool:
         if api_version is None:
             return False
-        return api_version == "preview" or api_version == "latest"
+        return api_version in {"preview", "latest", "v1"}

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1504,3 +1504,23 @@ def test_get_azure_ad_token_fallback_to_default_azure_credential(setup_mocks, mo
 
     # Verify the token is what we expect from our DefaultAzureCredential mock
     assert token == "mock-default-azure-credential-token"
+
+
+@pytest.mark.parametrize(
+    "api_version,expected",
+    [
+        ("preview", True),
+        ("latest", True),
+        ("v1", True),
+        (None, False),
+        ("2023-05-15", False),
+        ("2024-01-01", False),
+        ("", False),
+    ],
+)
+def test_is_azure_v1_api_version(api_version, expected):
+    """
+    Test that _is_azure_v1_api_version correctly identifies v1 API versions.
+    """
+    result = BaseAzureLLM._is_azure_v1_api_version(api_version=api_version)
+    assert result == expected


### PR DESCRIPTION
## [Fix] Azure OpenAI - Add handling for `v1` under azure api versions 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


