### PR TITLE
[Fix] - Responses API - add /openai routes for responses API. (Azure OpenAI SDK Compatibility)

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -17,6 +17,11 @@ router = APIRouter()
     dependencies=[Depends(user_api_key_auth)],
     tags=["responses"],
 )
+@router.post(
+    "/openai/v1/responses",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["responses"],
+)
 async def responses_api(
     request: Request,
     fastapi_response: Response,
@@ -87,6 +92,11 @@ async def responses_api(
 )
 @router.get(
     "/responses/{response_id}",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["responses"],
+)
+@router.get(
+    "/openai/v1/responses/{response_id}",
     dependencies=[Depends(user_api_key_auth)],
     tags=["responses"],
 )
@@ -162,6 +172,11 @@ async def get_response(
     dependencies=[Depends(user_api_key_auth)],
     tags=["responses"],
 )
+@router.delete(
+    "/openai/v1/responses/{response_id}",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["responses"],
+)
 async def delete_response(
     response_id: str,
     request: Request,
@@ -234,6 +249,11 @@ async def delete_response(
     dependencies=[Depends(user_api_key_auth)],
     tags=["responses"],
 )
+@router.get(
+    "/openai/v1/responses/{response_id}/input_items",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["responses"],
+)
 async def get_response_input_items(
     response_id: str,
     request: Request,
@@ -294,6 +314,11 @@ async def get_response_input_items(
 )
 @router.post(
     "/responses/{response_id}/cancel",
+    dependencies=[Depends(user_api_key_auth)],
+    tags=["responses"],
+)
+@router.post(
+    "/openai/v1/responses/{response_id}/cancel",
     dependencies=[Depends(user_api_key_auth)],
     tags=["responses"],
 )

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -1,0 +1,53 @@
+"""
+Test for response_api_endpoints/endpoints.py
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from litellm.proxy.proxy_server import app
+
+
+class TestResponsesAPIEndpoints(unittest.TestCase):
+    @pytest.mark.asyncio
+    @patch("litellm.proxy.proxy_server.llm_router")
+    @patch("litellm.proxy.proxy_server.user_api_key_auth")
+    async def test_openai_v1_responses_route(self, mock_auth, mock_router):
+        """
+        Test that /openai/v1/responses endpoint is correctly registered and accessible.
+        """
+        mock_auth.return_value = MagicMock(
+            token="test_token",
+            user_id="test_user",
+            team_id=None,
+        )
+
+        mock_router.aresponses = AsyncMock(
+            return_value={
+                "id": "resp_abc123",
+                "object": "realtime.response",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Test response"}],
+                    }
+                ],
+            }
+        )
+
+        client = TestClient(app)
+
+        test_data = {"model": "gpt-4o", "input": "Tell me about AI"}
+
+        response = client.post(
+            "/openai/v1/responses",
+            json=test_data,
+            headers={"Authorization": "Bearer sk-1234"},
+        )
+
+        assert response.status_code in [200, 401, 500]
+


### PR DESCRIPTION
## [Fix] - Responses API - add /openai routes for responses API. (Azure OpenAI SDK Compatibility)

Add Azure OpenAI SDK compatible Responses API routes 

Ensures this set of routes works with LiteLLM AI Gateway https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=rest-api 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


