### PR TITLE
[Bug Fix] Remove limit from admin UI numerical input fix

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -332,3 +332,25 @@ describe("KeyInfoView handleKeyUpdate premium guard", () => {
     expect(sentPayload.key).toBe("tok_123");
   });
 });
+
+describe("KeyInfoView handleKeyUpdate empty strings", () => {
+  ["tpm_limit", "rpm_limit", "max_parallel_requests", "max_budget"].forEach((limit) => {
+    it(`maps empty strings to null for ${limit}`, async () => {
+      renderView(true); // premiumUser = true
+
+      fireEvent.click(screen.getByText("Edit Settings"));
+      (globalThis as any).__TEST_FORM_VALUES = {
+        token: "tok_123",
+        [limit]: "",
+      };
+
+      fireEvent.click(screen.getByText("Mock Submit"));
+
+      await waitFor(() => expect(keyUpdateCallMock).toHaveBeenCalled());
+
+      const [sentAccessToken, sentPayload] = keyUpdateCallMock.mock.calls[0];
+      expect(sentAccessToken).toBe("access_abc");
+      expect(sentPayload[limit]).toBeNull();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -144,10 +144,10 @@ export default function KeyInfoView({
         delete formValues.mcp_tool_permissions;
       }
 
-      // Handle max_budget empty string
-      if (formValues.max_budget === "") {
-        formValues.max_budget = null;
-      }
+      formValues.max_budget = mapEmptyStringToNull(formValues.max_budget);
+      formValues.tpm_limit = mapEmptyStringToNull(formValues.tpm_limit);
+      formValues.rpm_limit = mapEmptyStringToNull(formValues.rpm_limit);
+      formValues.max_parallel_requests = mapEmptyStringToNull(formValues.max_parallel_requests);
 
       // Convert metadata back to an object if it exists and is a string
       if (formValues.metadata && typeof formValues.metadata === "string") {


### PR DESCRIPTION
## Remove limit from admin key settings UI numerical input fix

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Inside Key Settings, if a TPM, RPM, Max Parallel Request field has been set, the user cannot remove these fields as the frontend will pass an empty string instead of null to the backend. This will always result in an error, and these changes will fix this behavior.

Closes LIT-882. The ticket was initially for the Keys, Teams, and User page, but I was only able to reproduce the issue for the Keys Edit Page. The ticket only mentioned the issue existing for TPM limit, but it also affected RPM, and Max Parallel Requests, which this PR also fixes

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

## Screenshots
<img width="1044" height="236" alt="Screenshot 2025-10-27 at 5 07 38 PM" src="https://github.com/user-attachments/assets/eef64a08-8fe3-4df1-bd7a-6151e8d519f5" />

<img width="1512" height="861" alt="Screenshot 2025-10-27 at 5 14 40 PM" src="https://github.com/user-attachments/assets/081faa65-9da3-40e0-abe2-ad626a60c491" />



