### PR TITLE
[Feature] UI - Key Already Exist Error Notification

### DIFF
--- a/ui/litellm-dashboard/src/components/molecules/notifications_manager.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/notifications_manager.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { notification } from "antd";
+import NotificationManager from "./notifications_manager";
+
+// Mock the antd notification module
+vi.mock("antd", () => ({
+  notification: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+describe("NotificationManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Already Exists case", () => {
+    it("should show error notification for 'already exists' message", () => {
+      const error = {
+        message: "Key with alias 'test10' already exists.",
+        type: "bad_request_error",
+        code: "400",
+      };
+
+      NotificationManager.fromBackend(error);
+
+      expect(notification.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Already Exists",
+          description: "Key with alias 'test10' already exists.",
+          duration: 6,
+          placement: "topRight",
+        }),
+      );
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/molecules/notifications_manager.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/notifications_manager.tsx
@@ -317,7 +317,8 @@ const NotificationManager = {
         title === "Authentication Error" ||
         title === "Access Denied" ||
         title === "Not Found" ||
-        title === "Error"
+        title === "Error" ||
+        title === "Already Exists"
       ) {
         notification.error({ ...payload, duration: extra?.duration ?? 6 });
         return;


### PR DESCRIPTION
## UI - Key Already Exist Error Notification

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Previously Key already exist was an info notification, this PR changes it to an error notification. Closes LIT-428.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
## Screenshots
<img width="1512" height="982" alt="Screenshot 2025-10-27 at 5 44 04 PM" src="https://github.com/user-attachments/assets/f0fa251e-5283-48fb-a325-65de4325f3b3" />

<img width="807" height="174" alt="Screenshot 2025-10-27 at 5 43 48 PM" src="https://github.com/user-attachments/assets/4998600f-9149-4833-81f5-acc58a6a9240" />



