### PR TITLE
Update deepseek api_base url to current production endpoint - https://api.deepseek.com/v1

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -51,7 +51,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         api_base = (
             api_base
             or get_secret_str("DEEPSEEK_API_BASE")
-            or "https://api.deepseek.com/beta"
+            or "https://api.deepseek.com/v1"
         )  # type: ignore
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
         return api_base, dynamic_api_key
@@ -69,7 +69,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         If api_base is not provided, use the default DeepSeek /chat/completions endpoint.
         """
         if not api_base:
-            api_base = "https://api.deepseek.com/beta"
+            api_base = "https://api.deepseek.com/v1"
 
         if not api_base.endswith("/chat/completions"):
             api_base = f"{api_base}/chat/completions"

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -97,7 +97,7 @@ async def test_deepseek_provider_async_completion(stream):
 
     # Check request body
     request_body = json.loads(call_args.kwargs["data"])
-    assert call_args.kwargs["url"] == "https://api.deepseek.com/beta/chat/completions"
+    assert call_args.kwargs["url"] == "https://api.deepseek.com/v1/chat/completions"
     assert (
         request_body["model"] == "deepseek-reasoner"
     )  # Model name should be stripped of provider prefix


### PR DESCRIPTION
## Title

Replace beta endpoint with production endpoint as default api_base url

## Relevant issues

[Issue #15986](https://github.com/BerriAI/litellm/issues/15986)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Changed Deepseek default api_base url from beta endpoint to documented production endpoint and updated corresponding unit test.

- This is the official production endpoint according to current [Deepseek documentation](https://api-docs.deepseek.com/)

- Using the documented production API is the sane default over an experimental and poorly documented beta endpoint. It is not clear that the beta endpoint serves the latest models or is feature complete

- The header text of llms/deepseek/chat/transformation.py already states the proper production endpoint is in use https://github.com/oldheadsouf/litellm/blob/2a18b29c9caa3f5dc5cf60eee347827adefb6805/litellm/llms/deepseek/chat/transformation.py#L2

Note: the v1 has no relationship with model version


