### PR TITLE
Fix image_config.aspect_ratio not working for gemini-2.5-flash-image

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -473,7 +473,7 @@ def _transform_request_body(
                 labels = {k: v for k, v in rm.items() if isinstance(v, str)}
 
         filtered_params = {
-            k: v for k, v in optional_params.items() if _get_equivalent_key(k, config_fields)
+            k: v for k, v in optional_params.items() if _get_equivalent_key(k, set(config_fields))
         }
 
         generation_config: Optional[GenerationConfig] = GenerationConfig(

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -473,7 +473,7 @@ def _transform_request_body(
                 labels = {k: v for k, v in rm.items() if isinstance(v, str)}
 
         filtered_params = {
-            k: v for k, v in optional_params.items() if k in config_fields
+            k: v for k, v in optional_params.items() if _get_equivalent_key(k, config_fields)
         }
 
         generation_config: Optional[GenerationConfig] = GenerationConfig(

--- a/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -151,5 +151,44 @@ async def test__transform_request_body_image_config():
 
     rb: RequestBody = transformation._transform_request_body(**transform_request_params)
 
-    assert "imageConfig" in rb
-    assert rb["imageConfig"] == {"aspectRatio": "16:9"}
+    assert "generationConfig" in rb
+    assert "imageConfig" in rb["generationConfig"]
+    assert rb["generationConfig"]["imageConfig"] == {"aspectRatio": "16:9"}
+
+
+@pytest.mark.asyncio
+async def test__transform_request_body_image_config_snake_case():
+    """
+    Test that Vertex AI Gemini supports the image_config parameter (snake_case) for gemini-2.5-flash-image model.
+    This should be transformed to imageConfig with aspectRatio.
+    """
+    model = "gemini-2.5-flash-image"
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme"
+                }
+            ]
+        }
+    ]
+    optional_params = {
+        "image_config": {"aspect_ratio": "16:9"}
+    }
+    litellm_params = {}
+    transform_request_params = {
+        "messages": messages,
+        "model": model,
+        "optional_params": optional_params,
+        "custom_llm_provider": "gemini",
+        "litellm_params": litellm_params,
+        "cached_content": None,
+    }
+
+    rb: RequestBody = transformation._transform_request_body(**transform_request_params)
+
+    assert "generationConfig" in rb
+    assert "image_config" in rb["generationConfig"]
+    assert rb["generationConfig"]["image_config"] == {"aspect_ratio": "16:9"}


### PR DESCRIPTION
## Title

Fix image_config.aspect_ratio not working for gemini-2.5-flash-image

## Relevant issues

Fixes #15956

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
Gemini image generation requests were inconsistent in parameter handling:
- ✅ `imageConfig: {"aspectRatio": "1:1"}` worked
- ❌ `image_config: {"aspect_ratio": "16:9"}` failed

This created poor developer experience as users had to remember specific casing requirements.

### Solution
Updated the parameter filtering logic in `litellm/llms/vertex_ai/gemini/transformation.py` to use `_get_equivalent_key()` function, which supports both camelCase and snake_case parameter names.

**Before:**
```python
filtered_params = {
    k: v for k, v in optional_params.items() if k in config_fields
}
```

**After:**
```python
filtered_params = {
    k: v for k, v in optional_params.items() if _get_equivalent_key(k, config_fields)
}
```

### Testing
**16:9**
<img width="1344" height="768" alt="image" src="https://github.com/user-attachments/assets/d0880e60-9823-4649-8723-0d959a029fd7" />

**1:1**
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/65d97986-a8ca-4402-ba27-1717ddebe858" />
