### PR TITLE
Add Xai websearch cost

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -351,12 +351,6 @@ class StandardBuiltInToolCostTracking:
                 and usage.prompt_tokens_details.web_search_requests is not None
             ):
                 return True
-            elif (
-                hasattr(usage, "num_sources_used")
-                and usage.num_sources_used is not None
-                and usage.server_tool_use.web_search_requests is not None
-            ):
-                return True
 
         return False
 

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -351,6 +351,12 @@ class StandardBuiltInToolCostTracking:
                 and usage.prompt_tokens_details.web_search_requests is not None
             ):
                 return True
+            elif (
+                hasattr(usage, "num_sources_used")
+                and usage.num_sources_used is not None
+                and usage.server_tool_use.web_search_requests is not None
+            ):
+                return True
 
         return False
 

--- a/litellm/llms/__init__.py
+++ b/litellm/llms/__init__.py
@@ -43,6 +43,9 @@ def get_cost_for_web_search_request(
         # Perplexity handles search costs internally in its own cost calculator
         # Return 0.0 to indicate costs are already accounted for
         return 0.0
+    elif custom_llm_provider == "xai":
+        from .xai.cost_calculator import cost_per_web_search_request
+        return cost_per_web_search_request(usage=usage, model_info=model_info)
     else:
         return None
 

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -1,16 +1,17 @@
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import httpx
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     filter_value_from_dict,
     strip_name_from_messages,
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
-from litellm.types.utils import Choices, ModelResponse
+from litellm.types.utils import Choices, ModelResponse, Usage, PromptTokensDetailsWrapper
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -170,6 +171,8 @@ class XAIChatConfig(OpenAIGPTConfig):
         
         XAI API returns empty string for finish_reason when using tools,
         so we need to fix this after the standard OpenAI transformation.
+        
+        Also handles X.AI web search usage tracking by extracting num_sources_used.
         """
         
         # First, let the parent class handle the standard transformation
@@ -193,4 +196,34 @@ class XAIChatConfig(OpenAIGPTConfig):
                 if isinstance(choice, Choices):
                     self._fix_choice_finish_reason_for_tool_calls(choice)
 
+        # Handle X.AI web search usage tracking
+        try:
+            raw_response_json = raw_response.json()
+            self._enhance_usage_with_xai_web_search_fields(response, raw_response_json)
+        except Exception as e:
+            verbose_logger.debug(f"Error extracting X.AI web search usage: {e}")
         return response
+
+    def _enhance_usage_with_xai_web_search_fields(
+        self, model_response: ModelResponse, raw_response_json: dict
+    ) -> None:
+        """
+        Extract num_sources_used from X.AI response and map it to web_search_requests.
+        """
+        if not hasattr(model_response, "usage") or model_response.usage is None:
+            return
+
+        usage: Usage = model_response.usage
+        num_sources_used = None
+        response_usage = raw_response_json.get("usage", {})
+        if isinstance(response_usage, dict) and "num_sources_used" in response_usage:
+            num_sources_used = response_usage.get("num_sources_used")
+        
+        # Map num_sources_used to web_search_requests for cost detection
+        if num_sources_used is not None and num_sources_used > 0:
+            if usage.prompt_tokens_details is None:
+                usage.prompt_tokens_details = PromptTokensDetailsWrapper()
+            
+            usage.prompt_tokens_details.web_search_requests = int(num_sources_used)
+            setattr(usage, "num_sources_used", int(num_sources_used))
+            verbose_logger.debug(f"X.AI web search sources used: {num_sources_used}")

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -1,10 +1,9 @@
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import httpx
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     filter_value_from_dict,
     strip_name_from_messages,

--- a/litellm/llms/xai/cost_calculator.py
+++ b/litellm/llms/xai/cost_calculator.py
@@ -4,10 +4,13 @@ Helper util for handling XAI-specific cost calculation
 - Handles XAI-specific reasoning token billing (billed as part of completion tokens)
 """
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 from litellm.types.utils import Usage
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+
+if TYPE_CHECKING:
+    from litellm.types.utils import ModelInfo
 
 
 def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
@@ -46,3 +49,35 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     )
 
     return prompt_cost, completion_cost
+
+
+def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> float:
+    """
+    Calculate the cost of web search requests for X.AI models.
+    
+    X.AI Live Search costs $25 per 1,000 sources used.
+    Each source costs $0.025.
+    
+    The number of sources is stored in prompt_tokens_details.web_search_requests
+    by the transformation layer to be compatible with the existing detection system.
+    """
+    # Cost per source used: $25 per 1,000 sources = $0.025 per source
+    cost_per_source = 25.0 / 1000.0  # $0.025
+    
+    num_sources_used = 0
+    
+    if (
+        hasattr(usage, "prompt_tokens_details") 
+        and usage.prompt_tokens_details is not None
+        and hasattr(usage.prompt_tokens_details, "web_search_requests")
+        and usage.prompt_tokens_details.web_search_requests is not None
+    ):
+        num_sources_used = int(usage.prompt_tokens_details.web_search_requests)
+    
+    # Fallback: try to get from num_sources_used if set directly
+    elif hasattr(usage, "num_sources_used") and usage.num_sources_used is not None:
+        num_sources_used = int(usage.num_sources_used)
+
+    total_cost = cost_per_source * num_sources_used
+    
+    return total_cost


### PR DESCRIPTION
## Title

Add Xai websearch cost

## Relevant issues

Fixes #15907


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix

## Changes
- Added a websearch cost calculation method for xai
- Added the elif statement for detecting xai
- Added a method to convert xai num_sources_used to web_search_requests in usage object.

<img width="894" height="142" alt="image" src="https://github.com/user-attachments/assets/00c158b3-1003-4a9e-91ee-2e21117b6371" />
