### PR TITLE
(feat) Add OpenAI Container API Support to LiteLLM SDK

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1340,6 +1340,7 @@ from .batch_completion.main import *  # type: ignore
 from .rerank_api.main import *
 from .llms.anthropic.experimental_pass_through.messages.handler import *
 from .responses.main import *
+from .containers.main import *
 from .ocr.main import *
 from .search.main import *
 from .realtime_api.main import _arealtime

--- a/litellm/containers/__init__.py
+++ b/litellm/containers/__init__.py
@@ -1,0 +1,24 @@
+"""Container management functions for LiteLLM."""
+
+from .main import (
+    acreate_container,
+    create_container,
+    alist_containers,
+    list_containers,
+    aretrieve_container,
+    retrieve_container,
+    adelete_container,
+    delete_container,
+)
+
+__all__ = [
+    "acreate_container",
+    "create_container",
+    "alist_containers",
+    "list_containers",
+    "aretrieve_container",
+    "retrieve_container",
+    "adelete_container",
+    "delete_container",
+]
+

--- a/litellm/containers/__init__.py
+++ b/litellm/containers/__init__.py
@@ -2,23 +2,23 @@
 
 from .main import (
     acreate_container,
-    create_container,
-    alist_containers,
-    list_containers,
-    aretrieve_container,
-    retrieve_container,
     adelete_container,
+    alist_containers,
+    aretrieve_container,
+    create_container,
     delete_container,
+    list_containers,
+    retrieve_container,
 )
 
 __all__ = [
     "acreate_container",
-    "create_container",
-    "alist_containers",
-    "list_containers",
-    "aretrieve_container",
-    "retrieve_container",
     "adelete_container",
+    "alist_containers",
+    "aretrieve_container",
+    "create_container",
     "delete_container",
+    "list_containers",
+    "retrieve_container",
 ]
 

--- a/litellm/containers/main.py
+++ b/litellm/containers/main.py
@@ -1,0 +1,786 @@
+import asyncio
+import contextvars
+from functools import partial
+from typing import Any, Coroutine, Literal, Optional, Union, overload, Dict, List
+
+import json
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.types.containers.main import (
+    ContainerCreateOptionalRequestParams,
+    ContainerListOptionalRequestParams,
+    ContainerObject,
+    DeleteContainerResult,
+    ContainerListResponse,
+)
+from litellm.constants import request_timeout as DEFAULT_REQUEST_TIMEOUT
+from litellm.utils import client, ProviderConfigManager
+from litellm.types.utils import CallTypes
+from litellm.types.router import GenericLiteLLMParams
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.containers.utils import ContainerRequestUtils
+from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
+from litellm.main import base_llm_http_handler
+
+# Default model for container operations - can be any provider that supports containers
+DEFAULT_CONTAINER_ENDPOINT_MODEL = "openai/gpt-4"
+
+__all__ = [
+    "create_container",
+    "acreate_container",
+    "list_containers",
+    "alist_containers",
+    "retrieve_container",
+    "aretrieve_container",
+    "delete_container",
+    "adelete_container",
+]
+
+##### Container Create #######################
+@client
+async def acreate_container(
+    name: str,
+    expires_after: Optional[Dict[str, Any]] = None,
+    file_ids: Optional[List[str]] = None,
+    timeout=600,  # default to 10 minutes
+    # LiteLLM specific params,
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> ContainerObject:
+    """
+    Asynchronously calls the `create_container` function with the given arguments and keyword arguments.
+
+    Parameters:
+    - `name` (str): Name of the container to create
+    - `expires_after` (Optional[Dict[str, Any]]): Container expiration time settings
+    - `file_ids` (Optional[List[str]]): IDs of files to copy to the container
+    - `timeout` (int): Request timeout in seconds
+    - `custom_llm_provider` (Optional[Literal["openai"]]): The LLM provider to use
+    - `extra_headers` (Optional[Dict[str, Any]]): Additional headers
+    - `extra_query` (Optional[Dict[str, Any]]): Additional query parameters
+    - `extra_body` (Optional[Dict[str, Any]]): Additional body parameters
+    - `kwargs` (dict): Additional keyword arguments
+
+    Returns:
+    - `response` (ContainerObject): The created container object
+    """
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["async_call"] = True
+
+        func = partial(
+            create_container,
+            name=name,
+            expires_after=expires_after,
+            file_ids=file_ids,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+# fmt: off
+
+# Overload for when acreate_container=True (returns Coroutine)
+@overload
+def create_container(
+    name: str,
+    expires_after: Optional[Dict[str, Any]] = None,
+    file_ids: Optional[List[str]] = None,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    acreate_container: Literal[True],
+    **kwargs,
+) -> Coroutine[Any, Any, ContainerObject]:
+    ...
+
+
+@overload
+def create_container(
+    name: str,
+    expires_after: Optional[Dict[str, Any]] = None,
+    file_ids: Optional[List[str]] = None,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    acreate_container: Literal[False] = False,
+    **kwargs,
+) -> ContainerObject:
+    ...
+
+# fmt: on
+
+
+@client
+def create_container(  # noqa: PLR0915
+    name: str,
+    expires_after: Optional[Dict[str, Any]] = None,
+    file_ids: Optional[List[str]] = None,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Union[
+    ContainerObject,
+    Coroutine[Any, Any, ContainerObject],
+]:
+    """
+    Create a container using the OpenAI Container API.
+
+    Currently supports OpenAI
+
+    Example:
+    ```python
+    import litellm
+    
+    response = litellm.create_container(
+        name="My Container",
+        custom_llm_provider="openai",
+    )
+    print(response)
+    ```
+    """
+    local_vars = locals()
+    try:
+        litellm_logging_obj: LiteLLMLoggingObj = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        _is_async = kwargs.pop("async_call", False) is True
+
+        # Check for mock response first
+        mock_response = kwargs.get("mock_response", None)
+        if mock_response is not None:
+            if isinstance(mock_response, str):
+                mock_response = json.loads(mock_response)
+
+            response = ContainerObject(**mock_response)
+            return response
+
+        # get llm provider logic
+        litellm_params = GenericLiteLLMParams(**kwargs)
+        # get provider config
+        container_provider_config: Optional[BaseContainerConfig] = (
+            ProviderConfigManager.get_provider_container_config(
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if container_provider_config is None:
+            raise ValueError(f"container operations are not supported for {custom_llm_provider}")
+
+        local_vars.update(kwargs)
+        # Get ContainerCreateOptionalRequestParams with only valid parameters
+        container_create_optional_params: ContainerCreateOptionalRequestParams = (
+            ContainerRequestUtils.get_requested_container_create_optional_param(local_vars)
+        )
+
+        # Get optional parameters for the container API
+        container_create_request_params: Dict = (
+            ContainerRequestUtils.get_optional_params_container_create(
+                container_provider_config=container_provider_config,
+                container_create_optional_params=container_create_optional_params,
+            )
+        )
+
+        # Pre Call logging
+        litellm_logging_obj.update_environment_variables(
+            model="",
+            optional_params=dict(container_create_request_params),
+            litellm_params={
+                "litellm_call_id": litellm_call_id,
+                **container_create_request_params,
+            },
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        # Set the correct call type for container creation
+        litellm_logging_obj.call_type = CallTypes.create_container.value
+
+        return base_llm_http_handler.container_create_handler(
+            name=name,
+            container_create_request_params=container_create_request_params,
+            container_provider_config=container_provider_config,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            extra_headers=extra_headers,
+            timeout=timeout or DEFAULT_REQUEST_TIMEOUT,
+            _is_async=_is_async,
+        )
+        
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+##### Container List #######################
+@client
+async def alist_containers(
+    after: Optional[str] = None,
+    limit: Optional[int] = None,
+    order: Optional[str] = None,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> ContainerListResponse:
+    """
+    Asynchronously list containers.
+
+    Parameters:
+    - `after` (Optional[str]): A cursor for pagination
+    - `limit` (Optional[int]): Number of items to return (1-100, default 20)
+    - `order` (Optional[str]): Sort order ('asc' or 'desc', default 'desc')
+    - `timeout` (int): Request timeout in seconds
+    - `custom_llm_provider` (Literal["openai"]): The LLM provider to use
+    - `extra_headers` (Optional[Dict[str, Any]]): Additional headers
+    - `extra_query` (Optional[Dict[str, Any]]): Additional query parameters
+    - `extra_body` (Optional[Dict[str, Any]]): Additional body parameters
+    - `kwargs` (dict): Additional keyword arguments
+
+    Returns:
+    - `response` (ContainerListResponse): The list of containers
+    """
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["async_call"] = True
+
+        func = partial(
+            list_containers,
+            after=after,
+            limit=limit,
+            order=order,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+# fmt: off
+
+@overload
+def list_containers(
+    after: Optional[str] = None,
+    limit: Optional[int] = None,
+    order: Optional[str] = None,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    alist_containers: Literal[True],
+    **kwargs,
+) -> Coroutine[Any, Any, ContainerListResponse]:
+    ...
+
+
+@overload
+def list_containers(
+    after: Optional[str] = None,
+    limit: Optional[int] = None,
+    order: Optional[str] = None,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    alist_containers: Literal[False] = False,
+    **kwargs,
+) -> ContainerListResponse:
+    ...
+
+# fmt: on
+
+
+@client
+def list_containers(  # noqa: PLR0915
+    after: Optional[str] = None,
+    limit: Optional[int] = None,
+    order: Optional[str] = None,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Union[
+    ContainerListResponse,
+    Coroutine[Any, Any, ContainerListResponse],
+]:
+    """
+    List containers using the OpenAI Container API.
+
+    Currently supports OpenAI
+    """
+    local_vars = locals()
+    try:
+        litellm_logging_obj: LiteLLMLoggingObj = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        _is_async = kwargs.pop("async_call", False) is True
+
+        # get llm provider logic
+        litellm_params = GenericLiteLLMParams(**kwargs)
+        # get provider config
+        container_provider_config: Optional[BaseContainerConfig] = (
+            ProviderConfigManager.get_provider_container_config(
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if container_provider_config is None:
+            raise ValueError(f"Container provider config not found for provider: {custom_llm_provider}")
+
+        # Get container list request parameters
+        container_list_optional_params: ContainerListOptionalRequestParams = (
+            ContainerRequestUtils.get_requested_container_list_optional_param(local_vars)
+        )
+
+        # Pre Call logging
+        litellm_logging_obj.update_environment_variables(
+            model="",
+            optional_params=dict(container_list_optional_params),
+            litellm_params={
+                "litellm_call_id": litellm_call_id,
+                **container_list_optional_params,
+            },
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        # Set the correct call type
+        litellm_logging_obj.call_type = CallTypes.list_containers.value
+
+        return base_llm_http_handler.container_list_handler(
+            container_provider_config=container_provider_config,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            after=after,
+            limit=limit,
+            order=order,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            timeout=timeout or DEFAULT_REQUEST_TIMEOUT,
+            _is_async=_is_async,
+        )
+
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+##### Container Retrieve #######################
+@client
+async def aretrieve_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> ContainerObject:
+    """
+    Asynchronously retrieve a container.
+
+    Parameters:
+    - `container_id` (str): The ID of the container to retrieve
+    - `timeout` (int): Request timeout in seconds
+    - `custom_llm_provider` (Literal["openai"]): The LLM provider to use
+    - `extra_headers` (Optional[Dict[str, Any]]): Additional headers
+    - `extra_query` (Optional[Dict[str, Any]]): Additional query parameters
+    - `extra_body` (Optional[Dict[str, Any]]): Additional body parameters
+    - `kwargs` (dict): Additional keyword arguments
+
+    Returns:
+    - `response` (ContainerObject): The container object
+    """
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["async_call"] = True
+
+        func = partial(
+            retrieve_container,
+            container_id=container_id,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+# fmt: off
+
+@overload
+def retrieve_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    aretrieve_container: Literal[True],
+    **kwargs,
+) -> Coroutine[Any, Any, ContainerObject]:
+    ...
+
+
+@overload
+def retrieve_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    aretrieve_container: Literal[False] = False,
+    **kwargs,
+) -> ContainerObject:
+    ...
+
+# fmt: on
+
+
+@client
+def retrieve_container(  # noqa: PLR0915
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Union[
+    ContainerObject,
+    Coroutine[Any, Any, ContainerObject],
+]:
+    """
+    Retrieve a container using the OpenAI Container API.
+
+    Currently supports OpenAI
+    """
+    local_vars = locals()
+    try:
+        litellm_logging_obj: LiteLLMLoggingObj = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        _is_async = kwargs.pop("async_call", False) is True
+
+        # get llm provider logic
+        litellm_params = GenericLiteLLMParams(**kwargs)
+        # get provider config
+        container_provider_config: Optional[BaseContainerConfig] = (
+            ProviderConfigManager.get_provider_container_config(
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if container_provider_config is None:
+            raise ValueError(f"Container provider config not found for provider: {custom_llm_provider}")
+
+        # Pre Call logging
+        litellm_logging_obj.update_environment_variables(
+            model="",
+            optional_params={},
+            litellm_params={
+                "litellm_call_id": litellm_call_id,
+            },
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        # Set the correct call type
+        litellm_logging_obj.call_type = CallTypes.retrieve_container.value
+
+        return base_llm_http_handler.container_retrieve_handler(
+            container_id=container_id,
+            container_provider_config=container_provider_config,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            timeout=timeout or DEFAULT_REQUEST_TIMEOUT,
+            _is_async=_is_async,
+        )
+
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+##### Container Delete #######################
+@client
+async def adelete_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> DeleteContainerResult:
+    """
+    Asynchronously delete a container.
+
+    Parameters:
+    - `container_id` (str): The ID of the container to delete
+    - `timeout` (int): Request timeout in seconds
+    - `custom_llm_provider` (Literal["openai"]): The LLM provider to use
+    - `extra_headers` (Optional[Dict[str, Any]]): Additional headers
+    - `extra_query` (Optional[Dict[str, Any]]): Additional query parameters
+    - `extra_body` (Optional[Dict[str, Any]]): Additional body parameters
+    - `kwargs` (dict): Additional keyword arguments
+
+    Returns:
+    - `response` (DeleteContainerResult): The deletion result
+    """
+    local_vars = locals()
+    try:
+        loop = asyncio.get_event_loop()
+        kwargs["async_call"] = True
+
+        func = partial(
+            delete_container,
+            container_id=container_id,
+            timeout=timeout,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            **kwargs,
+        )
+
+        ctx = contextvars.copy_context()
+        func_with_context = partial(ctx.run, func)
+        init_response = await loop.run_in_executor(None, func_with_context)
+
+        if asyncio.iscoroutine(init_response):
+            response = await init_response
+        else:
+            response = init_response
+
+        return response
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+
+
+# fmt: off
+
+@overload
+def delete_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    adelete_container: Literal[True],
+    **kwargs,
+) -> Coroutine[Any, Any, DeleteContainerResult]:
+    ...
+
+
+@overload
+def delete_container(
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    api_key: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_version: Optional[str] = None,
+    custom_llm_provider: Literal["openai"] = "openai",
+    *,
+    adelete_container: Literal[False] = False,
+    **kwargs,
+) -> DeleteContainerResult:
+    ...
+
+# fmt: on
+
+
+@client
+def delete_container(  # noqa: PLR0915
+    container_id: str,
+    timeout=600,  # default to 10 minutes
+    custom_llm_provider: Literal["openai"] = "openai",
+    # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+    # The extra values given here take precedence over values defined on the client or passed to this method.
+    extra_headers: Optional[Dict[str, Any]] = None,
+    extra_query: Optional[Dict[str, Any]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+    **kwargs,
+) -> Union[
+    DeleteContainerResult,
+    Coroutine[Any, Any, DeleteContainerResult],
+]:
+    """
+    Delete a container using the OpenAI Container API.
+
+    Currently supports OpenAI
+    """
+    local_vars = locals()
+    try:
+        litellm_logging_obj: LiteLLMLoggingObj = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
+        _is_async = kwargs.pop("async_call", False) is True
+
+        # get llm provider logic
+        litellm_params = GenericLiteLLMParams(**kwargs)
+        # get provider config
+        container_provider_config: Optional[BaseContainerConfig] = (
+            ProviderConfigManager.get_provider_container_config(
+                provider=litellm.LlmProviders(custom_llm_provider),
+            )
+        )
+
+        if container_provider_config is None:
+            raise ValueError(f"Container provider config not found for provider: {custom_llm_provider}")
+
+        # Pre Call logging
+        litellm_logging_obj.update_environment_variables(
+            model="",
+            optional_params={},
+            litellm_params={
+                "litellm_call_id": litellm_call_id,
+            },
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        # Set the correct call type
+        litellm_logging_obj.call_type = CallTypes.delete_container.value
+
+        return base_llm_http_handler.container_delete_handler(
+            container_id=container_id,
+            container_provider_config=container_provider_config,
+            litellm_params=litellm_params,
+            logging_obj=litellm_logging_obj,
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            timeout=timeout or DEFAULT_REQUEST_TIMEOUT,
+            _is_async=_is_async,
+        )
+
+    except Exception as e:
+        raise litellm.exception_type(
+            model="",
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            completion_kwargs=local_vars,
+            extra_kwargs=kwargs,
+        )
+

--- a/litellm/containers/utils.py
+++ b/litellm/containers/utils.py
@@ -1,6 +1,8 @@
-from litellm.types.containers.main import ContainerCreateOptionalRequestParams, ContainerListOptionalRequestParams
-from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
 from typing import Dict
+
+from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
+from litellm.types.containers.main import ContainerCreateOptionalRequestParams, ContainerListOptionalRequestParams
+
 
 class ContainerRequestUtils:
     @staticmethod
@@ -9,18 +11,18 @@ class ContainerRequestUtils:
     ) -> ContainerCreateOptionalRequestParams:
         """Extract only valid container creation parameters from the passed parameters."""
         container_create_optional_params = ContainerCreateOptionalRequestParams()
-        
+
         valid_params = [
             "expires_after",
             "file_ids",
             "extra_headers",
             "extra_body",
         ]
-        
+
         for param in valid_params:
             if param in passed_params and passed_params[param] is not None:
                 container_create_optional_params[param] = passed_params[param]  # type: ignore
-        
+
         return container_create_optional_params
 
     @staticmethod
@@ -30,14 +32,14 @@ class ContainerRequestUtils:
     ) -> Dict:
         """Get the optional parameters for container creation."""
         supported_params = container_provider_config.get_supported_openai_params()
-        
+
         # Filter out unsupported parameters
         filtered_params = {
             k: v
             for k, v in container_create_optional_params.items()
             if k in supported_params
         }
-        
+
         return container_provider_config.map_openai_params(
             container_create_optional_params=filtered_params,  # type: ignore
             drop_params=False,
@@ -49,7 +51,7 @@ class ContainerRequestUtils:
     ) -> ContainerListOptionalRequestParams:
         """Extract only valid container list parameters from the passed parameters."""
         container_list_optional_params = ContainerListOptionalRequestParams()
-        
+
         valid_params = [
             "after",
             "limit",
@@ -57,9 +59,9 @@ class ContainerRequestUtils:
             "extra_headers",
             "extra_query",
         ]
-        
+
         for param in valid_params:
             if param in passed_params and passed_params[param] is not None:
                 container_list_optional_params[param] = passed_params[param]  # type: ignore
-        
+
         return container_list_optional_params

--- a/litellm/containers/utils.py
+++ b/litellm/containers/utils.py
@@ -1,0 +1,65 @@
+from litellm.types.containers.main import ContainerCreateOptionalRequestParams, ContainerListOptionalRequestParams
+from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
+from typing import Dict
+
+class ContainerRequestUtils:
+    @staticmethod
+    def get_requested_container_create_optional_param(
+        passed_params: dict,
+    ) -> ContainerCreateOptionalRequestParams:
+        """Extract only valid container creation parameters from the passed parameters."""
+        container_create_optional_params = ContainerCreateOptionalRequestParams()
+        
+        valid_params = [
+            "expires_after",
+            "file_ids",
+            "extra_headers",
+            "extra_body",
+        ]
+        
+        for param in valid_params:
+            if param in passed_params and passed_params[param] is not None:
+                container_create_optional_params[param] = passed_params[param]  # type: ignore
+        
+        return container_create_optional_params
+
+    @staticmethod
+    def get_optional_params_container_create(
+        container_provider_config: BaseContainerConfig,
+        container_create_optional_params: ContainerCreateOptionalRequestParams,
+    ) -> Dict:
+        """Get the optional parameters for container creation."""
+        supported_params = container_provider_config.get_supported_openai_params()
+        
+        # Filter out unsupported parameters
+        filtered_params = {
+            k: v
+            for k, v in container_create_optional_params.items()
+            if k in supported_params
+        }
+        
+        return container_provider_config.map_openai_params(
+            container_create_optional_params=filtered_params,  # type: ignore
+            drop_params=False,
+        )
+
+    @staticmethod
+    def get_requested_container_list_optional_param(
+        passed_params: dict,
+    ) -> ContainerListOptionalRequestParams:
+        """Extract only valid container list parameters from the passed parameters."""
+        container_list_optional_params = ContainerListOptionalRequestParams()
+        
+        valid_params = [
+            "after",
+            "limit",
+            "order",
+            "extra_headers",
+            "extra_query",
+        ]
+        
+        for param in valid_params:
+            if param in passed_params and passed_params[param] is not None:
+                container_list_optional_params[param] = passed_params[param]  # type: ignore
+        
+        return container_list_optional_params

--- a/litellm/llms/base_llm/containers/transformation.py
+++ b/litellm/llms/base_llm/containers/transformation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import types
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -12,9 +12,13 @@ from litellm.types.router import GenericLiteLLMParams
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
     from litellm.types.containers.main import (
-        ContainerObject as _ContainerObject,
-        DeleteContainerResult as _DeleteContainerResult,
         ContainerListResponse as _ContainerListResponse,
+    )
+    from litellm.types.containers.main import (
+        ContainerObject as _ContainerObject,
+    )
+    from litellm.types.containers.main import (
+        DeleteContainerResult as _DeleteContainerResult,
     )
 
     from ..chat.transformation import BaseLLMException as _BaseLLMException

--- a/litellm/llms/base_llm/containers/transformation.py
+++ b/litellm/llms/base_llm/containers/transformation.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import types
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Union
+
+import httpx
+
+from litellm.types.containers.main import ContainerCreateOptionalRequestParams
+from litellm.types.router import GenericLiteLLMParams
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+    from litellm.types.containers.main import (
+        ContainerObject as _ContainerObject,
+        DeleteContainerResult as _DeleteContainerResult,
+        ContainerListResponse as _ContainerListResponse,
+    )
+
+    from ..chat.transformation import BaseLLMException as _BaseLLMException
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+    BaseLLMException = _BaseLLMException
+    ContainerObject = _ContainerObject
+    DeleteContainerResult = _DeleteContainerResult
+    ContainerListResponse = _ContainerListResponse
+else:
+    LiteLLMLoggingObj = Any
+    BaseLLMException = Any
+    ContainerObject = Any
+    DeleteContainerResult = Any
+    ContainerListResponse = Any
+
+
+class BaseContainerConfig(ABC):
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_config(cls):
+        return {
+            k: v
+            for k, v in cls.__dict__.items()
+            if not k.startswith("__")
+            and not k.startswith("_abc")
+            and not isinstance(
+                v,
+                (
+                    types.FunctionType,
+                    types.BuiltinFunctionType,
+                    classmethod,
+                    staticmethod,
+                ),
+            )
+            and v is not None
+        }
+
+    @abstractmethod
+    def get_supported_openai_params(self) -> list:
+        pass
+
+    @abstractmethod
+    def map_openai_params(
+        self,
+        container_create_optional_params: ContainerCreateOptionalRequestParams,
+        drop_params: bool,
+    ) -> dict:
+        pass
+
+    @abstractmethod
+    def validate_environment(
+        self,
+        headers: dict,
+        api_key: str | None = None,
+    ) -> dict:
+        return {}
+
+    @abstractmethod
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        litellm_params: dict,
+    ) -> str:
+        """Get the complete url for the request.
+        
+        OPTIONAL - Some providers need `model` in `api_base`.
+        """
+        if api_base is None:
+            msg = "api_base is required"
+            raise ValueError(msg)
+        return api_base
+
+    @abstractmethod
+    def transform_container_create_request(
+        self,
+        name: str,
+        container_create_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> dict:
+        """Transform the container creation request.
+        
+        Returns:
+            dict: Request data for container creation.
+        """
+        ...
+
+    @abstractmethod
+    def transform_container_create_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerObject:
+        """Transform the container creation response."""
+        ...
+
+    @abstractmethod
+    def transform_container_list_request(
+        self,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        after: str | None = None,
+        limit: int | None = None,
+        order: str | None = None,
+        extra_query: dict[str, Any] | None = None,
+    ) -> tuple[str, dict]:
+        """Transform the container list request into a URL and params.
+        
+        Returns:
+            tuple[str, dict]: (url, params) for the container list request.
+        """
+        ...
+
+    @abstractmethod
+    def transform_container_list_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerListResponse:
+        """Transform the container list response."""
+        ...
+
+    @abstractmethod
+    def transform_container_retrieve_request(
+        self,
+        container_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> tuple[str, dict]:
+        """Transform the container retrieve request into a URL and data/params.
+        
+        Returns:
+            tuple[str, dict]: (url, params) for the container retrieve request.
+        """
+        ...
+
+    @abstractmethod
+    def transform_container_retrieve_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerObject:
+        """Transform the container retrieve response."""
+        ...
+
+    @abstractmethod
+    def transform_container_delete_request(
+        self,
+        container_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> tuple[str, dict]:
+        """Transform the container delete request into a URL and data.
+        
+        Returns:
+            tuple[str, dict]: (url, data) for the container delete request.
+        """
+        ...
+
+    @abstractmethod
+    def transform_container_delete_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> DeleteContainerResult:
+        """Transform the container delete response."""
+        ...
+
+    def get_error_class(
+        self, 
+        error_message: str, 
+        status_code: int, 
+        headers: dict | httpx.Headers,
+    ) -> BaseLLMException:
+        from ..chat.transformation import BaseLLMException
+
+        raise BaseLLMException(
+            status_code=status_code,
+            message=error_message,
+            headers=headers,
+        )
+

--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -1,0 +1,243 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
+
+import httpx
+
+from litellm.types.containers.main import (
+    ContainerCreateOptionalRequestParams,
+    ContainerObject,
+    DeleteContainerResult,
+    ContainerListResponse,
+)
+from litellm.types.router import GenericLiteLLMParams
+from litellm.secret_managers.main import get_secret_str
+import litellm
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    from ...base_llm.containers.transformation import BaseContainerConfig as _BaseContainerConfig
+    from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+    BaseContainerConfig = _BaseContainerConfig
+    BaseLLMException = _BaseLLMException
+else:
+    LiteLLMLoggingObj = Any
+    BaseContainerConfig = Any
+    BaseLLMException = Any
+
+
+class OpenAIContainerConfig(BaseContainerConfig):
+    """Configuration class for OpenAI container API.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def get_supported_openai_params(self) -> list:
+        """Get the list of supported OpenAI parameters for container API.
+        """
+        return [
+            "name",
+            "expires_after",
+            "file_ids",
+            "extra_headers",
+        ]
+
+    def map_openai_params(
+        self,
+        container_create_optional_params: ContainerCreateOptionalRequestParams,
+        drop_params: bool,
+    ) -> Dict:
+        """No mapping applied since inputs are in OpenAI spec already"""
+        return dict(container_create_optional_params)
+
+    def validate_environment(
+        self,
+        headers: dict,
+        api_key: Optional[str] = None,
+    ) -> dict:
+        api_key = (
+            api_key
+            or litellm.api_key
+            or litellm.openai_key
+            or get_secret_str("OPENAI_API_KEY")
+        )
+        headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+            }
+        )
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        """Get the complete URL for OpenAI container API.
+        """
+        if api_base is None:
+            api_base = "https://api.openai.com/v1"
+
+        return f"{api_base.rstrip('/')}/containers"
+
+    def transform_container_create_request(
+        self,
+        name: str,
+        container_create_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Dict:
+        """Transform the container creation request for OpenAI API.
+        """
+        # Remove extra_headers from optional params as they're handled separately
+        container_create_optional_request_params = {
+            k: v for k, v in container_create_optional_request_params.items()
+            if k not in ["extra_headers"]
+        }
+
+        # Create the request data
+        request_dict = {
+            "name": name,
+            **container_create_optional_request_params
+        }
+
+        return request_dict
+
+    def transform_container_create_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerObject:
+        """Transform the OpenAI container creation response.
+        """
+        response_data = raw_response.json()
+
+        # Transform the response data
+        container_obj = ContainerObject(**response_data)  # type: ignore[arg-type]
+
+        return container_obj
+
+    def transform_container_list_request(
+        self,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+        after: Optional[str] = None,
+        limit: Optional[int] = None,
+        order: Optional[str] = None,
+        extra_query: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, Dict]:
+        """Transform the container list request for OpenAI API.
+        
+        OpenAI API expects the following request:
+        - GET /v1/containers
+        """
+        # Use the api_base directly for container list
+        url = api_base
+
+        # Prepare query parameters
+        params = {}
+        if after is not None:
+            params["after"] = after
+        if limit is not None:
+            params["limit"] = str(limit)
+        if order is not None:
+            params["order"] = order
+
+        # Add any extra query parameters
+        if extra_query:
+            params.update(extra_query)
+
+        return url, params
+
+    def transform_container_list_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerListResponse:
+        """Transform the OpenAI container list response.
+        """
+        response_data = raw_response.json()
+
+        # Transform the response data
+        container_list = ContainerListResponse(**response_data)  # type: ignore[arg-type]
+
+        return container_list
+
+    def transform_container_retrieve_request(
+        self,
+        container_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Tuple[str, Dict]:
+        """Transform the OpenAI container retrieve request.
+        """
+        # For container retrieve, we just need to construct the URL
+        url = f"{api_base.rstrip('/')}/{container_id}"
+
+        # No additional data needed for GET request
+        data: Dict[str, Any] = {}
+
+        return url, data
+
+    def transform_container_retrieve_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ContainerObject:
+        """Transform the OpenAI container retrieve response.
+        """
+        response_data = raw_response.json()
+        # Transform the response data
+        container_obj = ContainerObject(**response_data)  # type: ignore[arg-type]
+
+        return container_obj
+
+    def transform_container_delete_request(
+        self,
+        container_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Tuple[str, Dict]:
+        """Transform the container delete request for OpenAI API.
+        
+        OpenAI API expects the following request:
+        - DELETE /v1/containers/{container_id}
+        """
+        # Construct the URL for container delete
+        url = f"{api_base.rstrip('/')}/{container_id}"
+
+        # No data needed for DELETE request
+        data: Dict[str, Any] = {}
+
+        return url, data
+
+    def transform_container_delete_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> DeleteContainerResult:
+        """Transform the OpenAI container delete response.
+        """
+        response_data = raw_response.json()
+
+        # Transform the response data
+        delete_result = DeleteContainerResult(**response_data)  # type: ignore[arg-type]
+
+        return delete_result
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        from ...base_llm.chat.transformation import BaseLLMException
+
+        raise BaseLLMException(
+            status_code=status_code,
+            message=error_message,
+            headers=headers,
+        )
+

--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -1,22 +1,22 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 import httpx
 
+import litellm
+from litellm.secret_managers.main import get_secret_str
 from litellm.types.containers.main import (
     ContainerCreateOptionalRequestParams,
+    ContainerListResponse,
     ContainerObject,
     DeleteContainerResult,
-    ContainerListResponse,
 )
 from litellm.types.router import GenericLiteLLMParams
-from litellm.secret_managers.main import get_secret_str
-import litellm
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
 
-    from ...base_llm.containers.transformation import BaseContainerConfig as _BaseContainerConfig
     from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
+    from ...base_llm.containers.transformation import BaseContainerConfig as _BaseContainerConfig
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
     BaseContainerConfig = _BaseContainerConfig
@@ -66,7 +66,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         headers.update(
             {
                 "Authorization": f"Bearer {api_key}",
-            }
+            },
         )
         return headers
 
@@ -100,7 +100,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         # Create the request data
         request_dict = {
             "name": name,
-            **container_create_optional_request_params
+            **container_create_optional_request_params,
         }
 
         return request_dict
@@ -231,7 +231,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         return delete_result
 
     def get_error_class(
-        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers],
     ) -> BaseLLMException:
         from ...base_llm.chat.transformation import BaseLLMException
 

--- a/litellm/types/containers/main.py
+++ b/litellm/types/containers/main.py
@@ -1,0 +1,122 @@
+from typing import Any, Dict, List, Literal, Optional
+from typing_extensions import TypedDict
+
+from pydantic import BaseModel
+
+
+class ExpiresAfter(BaseModel):
+    """Container expiration settings."""
+    anchor: Literal["last_active_at"]
+    minutes: int
+
+
+class ContainerObject(BaseModel):
+    """Represents a container object."""
+    id: str
+    object: Literal["container"]
+    created_at: int
+    status: str
+    expires_after: Optional[ExpiresAfter] = None
+    last_active_at: Optional[int] = None
+    name: Optional[str] = None
+    _hidden_params: Dict[str, Any] = {}
+
+    def __contains__(self, key):
+        # Define custom behavior for the 'in' operator
+        return hasattr(self, key)
+
+    def get(self, key, default=None):
+        # Custom .get() method to access attributes with a default value if the attribute doesn't exist
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        # Allow dictionary-style access to attributes
+        return getattr(self, key)
+
+    def json(self, **kwargs):  # type: ignore
+        try:
+            return self.model_dump(**kwargs)
+        except Exception:
+            # if using pydantic v1
+            return self.dict()
+
+
+class DeleteContainerResult(BaseModel):
+    """Result of a delete container request."""
+    id: str
+    object: Literal["container.deleted"]
+    deleted: bool
+
+    def __contains__(self, key):
+        return hasattr(self, key)
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def json(self, **kwargs):  # type: ignore
+        try:
+            return self.model_dump(**kwargs)
+        except Exception:
+            return self.dict()
+
+
+class ContainerListResponse(BaseModel):
+    """Response object for list containers request."""
+    object: Literal["list"]
+    data: List[ContainerObject]
+    first_id: Optional[str] = None
+    last_id: Optional[str] = None
+    has_more: bool
+
+    def __contains__(self, key):
+        return hasattr(self, key)
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def json(self, **kwargs):  # type: ignore
+        try:
+            return self.model_dump(**kwargs)
+        except Exception:
+            return self.dict()
+
+
+class ContainerCreateOptionalRequestParams(TypedDict, total=False):
+    """
+    TypedDict for Optional parameters supported by OpenAI's container creation API.
+    
+    Params here: https://platform.openai.com/docs/api-reference/containers/create
+    """
+    expires_after: Optional[Dict[str, Any]]  # ExpiresAfter object
+    file_ids: Optional[List[str]]
+    extra_headers: Optional[Dict[str, str]]
+    extra_body: Optional[Dict[str, str]]
+
+
+class ContainerCreateRequestParams(ContainerCreateOptionalRequestParams, total=False):
+    """
+    TypedDict for request parameters supported by OpenAI's container creation API.
+    
+    Params here: https://platform.openai.com/docs/api-reference/containers/create
+    """
+    name: str
+
+
+class ContainerListOptionalRequestParams(TypedDict, total=False):
+    """
+    TypedDict for Optional parameters supported by OpenAI's container list API.
+    
+    Params here: https://platform.openai.com/docs/api-reference/containers/list
+    """
+    after: Optional[str]
+    limit: Optional[int]
+    order: Optional[str]
+    extra_headers: Optional[Dict[str, str]]
+    extra_query: Optional[Dict[str, str]]
+

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -298,6 +298,19 @@ class CallTypes(str, Enum):
     avideo_retrieve_job = "avideo_retrieve_job"
     video_delete = "video_delete"
     avideo_delete = "avideo_delete"
+    
+    #########################################################
+    # Container Call Types
+    #########################################################
+    create_container = "create_container"
+    acreate_container = "acreate_container"
+    list_containers = "list_containers"
+    alist_containers = "alist_containers"
+    retrieve_container = "retrieve_container"
+    aretrieve_container = "aretrieve_container"
+    delete_container = "delete_container"
+    adelete_container = "adelete_container"
+    
     acancel_fine_tuning_job = "acancel_fine_tuning_job"
     cancel_fine_tuning_job = "cancel_fine_tuning_job"
     alist_fine_tuning_jobs = "alist_fine_tuning_jobs"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -273,6 +273,7 @@ from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.llms.base_llm.vector_store.transformation import BaseVectorStoreConfig
 from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
+from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
 
 from ._logging import _is_debugging_on, verbose_logger
 from .caching.caching import (
@@ -7662,6 +7663,15 @@ class ProviderConfigManager:
             return AzureVideoConfig()
         return None
 
+    @staticmethod
+    def get_provider_container_config(
+        provider: LlmProviders,
+    ) -> Optional[BaseContainerConfig]:
+        if LlmProviders.OPENAI == provider:
+            from litellm.llms.openai.containers.transformation import OpenAIContainerConfig
+
+            return OpenAIContainerConfig()
+        return None
 
     @staticmethod
     def get_provider_realtime_config(

--- a/tests/test_litellm/containers/test_container_api.py
+++ b/tests/test_litellm/containers/test_container_api.py
@@ -1,0 +1,363 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+import asyncio
+
+import pytest
+import httpx
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.types.containers.main import ContainerObject, ContainerListResponse, DeleteContainerResult
+from litellm.containers.main import (
+    create_container, acreate_container,
+    list_containers, alist_containers,
+    retrieve_container, aretrieve_container,
+    delete_container, adelete_container
+)
+from litellm.llms.openai.containers.transformation import OpenAIContainerConfig
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+
+
+class TestContainerAPI:
+    """Test suite for container API functionality."""
+
+    def test_create_container_basic(self):
+        """Test basic container creation functionality."""
+        # Mock the container creation response
+        mock_response = ContainerObject(
+            id="cntr_123456",
+            object="container",
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Test Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.return_value = mock_response
+            
+            response = create_container(
+                name="Test Container",
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerObject)
+            assert response.id == "cntr_123456"
+            assert response.name == "Test Container"
+            assert response.status == "running"
+            assert response.object == "container"
+
+    def test_create_container_with_expires_after(self):
+        """Test container creation with expires_after parameter."""
+        mock_response = ContainerObject(
+            id="cntr_789",
+            object="container", 
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 30},
+            last_active_at=1747857508,
+            name="Expiring Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.return_value = mock_response
+            
+            response = create_container(
+                name="Expiring Container",
+                expires_after={"anchor": "last_active_at", "minutes": 30},
+                custom_llm_provider="openai"
+            )
+            
+            assert response.expires_after.minutes == 30
+            assert response.expires_after.anchor == "last_active_at"
+
+    def test_create_container_with_file_ids(self):
+        """Test container creation with file_ids parameter."""
+        mock_response = ContainerObject(
+            id="cntr_file_test",
+            object="container",
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Container with Files"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.return_value = mock_response
+            
+            response = create_container(
+                name="Container with Files",
+                file_ids=["file_123", "file_456"],
+                custom_llm_provider="openai"
+            )
+            
+            assert response.name == "Container with Files"
+
+    @pytest.mark.asyncio
+    async def test_acreate_container_basic(self):
+        """Test basic async container creation functionality."""
+        mock_response = ContainerObject(
+            id="cntr_async_123",
+            object="container",
+            created_at=1747857508,
+            status="running", 
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Async Test Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.return_value = mock_response
+            
+            response = await acreate_container(
+                name="Async Test Container",
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerObject)
+            assert response.id == "cntr_async_123"
+            assert response.name == "Async Test Container"
+
+    def test_list_containers_basic(self):
+        """Test basic container listing functionality."""
+        mock_response = ContainerListResponse(
+            object="list",
+            data=[
+                ContainerObject(
+                    id="cntr_1",
+                    object="container",
+                    created_at=1747857508,
+                    status="running",
+                    expires_after={"anchor": "last_active_at", "minutes": 20},
+                    last_active_at=1747857508,
+                    name="Container 1"
+                ),
+                ContainerObject(
+                    id="cntr_2", 
+                    object="container",
+                    created_at=1747857600,
+                    status="running",
+                    expires_after={"anchor": "last_active_at", "minutes": 15},
+                    last_active_at=1747857600,
+                    name="Container 2"
+                )
+            ],
+            first_id="cntr_1",
+            last_id="cntr_2",
+            has_more=False
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_list_handler.return_value = mock_response
+            
+            response = list_containers(
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerListResponse)
+            assert len(response.data) == 2
+            assert response.data[0].id == "cntr_1"
+            assert response.data[1].id == "cntr_2"
+            assert response.has_more == False
+
+    def test_list_containers_with_params(self):
+        """Test container listing with parameters."""
+        mock_response = ContainerListResponse(
+            object="list",
+            data=[
+                ContainerObject(
+                    id="cntr_limited",
+                    object="container",
+                    created_at=1747857508,
+                    status="running",
+                    expires_after={"anchor": "last_active_at", "minutes": 20},
+                    last_active_at=1747857508,
+                    name="Limited Container"
+                )
+            ],
+            first_id="cntr_limited",
+            last_id="cntr_limited", 
+            has_more=True
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_list_handler.return_value = mock_response
+            
+            response = list_containers(
+                limit=1,
+                order="desc",
+                after="cntr_prev",
+                custom_llm_provider="openai"
+            )
+            
+            assert len(response.data) == 1
+            assert response.has_more == True
+
+    @pytest.mark.asyncio
+    async def test_alist_containers_basic(self):
+        """Test basic async container listing functionality."""
+        mock_response = ContainerListResponse(
+            object="list",
+            data=[
+                ContainerObject(
+                    id="cntr_async_list",
+                    object="container",
+                    created_at=1747857508,
+                    status="running",
+                    expires_after={"anchor": "last_active_at", "minutes": 20},
+                    last_active_at=1747857508,
+                    name="Async List Container"
+                )
+            ],
+            first_id="cntr_async_list",
+            last_id="cntr_async_list",
+            has_more=False
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_list_handler.return_value = mock_response
+            
+            response = await alist_containers(
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerListResponse)
+            assert len(response.data) == 1
+
+    def test_retrieve_container_basic(self):
+        """Test basic container retrieval functionality."""
+        container_id = "cntr_retrieve_test"
+        mock_response = ContainerObject(
+            id=container_id,
+            object="container",
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Retrieved Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_retrieve_handler.return_value = mock_response
+            
+            response = retrieve_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerObject)
+            assert response.id == container_id
+            assert response.name == "Retrieved Container"
+
+    @pytest.mark.asyncio
+    async def test_aretrieve_container_basic(self):
+        """Test basic async container retrieval functionality."""
+        container_id = "cntr_async_retrieve"
+        mock_response = ContainerObject(
+            id=container_id,
+            object="container",
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Async Retrieved Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_retrieve_handler.return_value = mock_response
+            
+            response = await aretrieve_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, ContainerObject)
+            assert response.id == container_id
+
+    def test_delete_container_basic(self):
+        """Test basic container deletion functionality."""
+        container_id = "cntr_delete_test"
+        mock_response = DeleteContainerResult(
+            id=container_id,
+            object="container.deleted",
+            deleted=True
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_delete_handler.return_value = mock_response
+            
+            response = delete_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, DeleteContainerResult)
+            assert response.id == container_id
+            assert response.deleted == True
+            assert response.object == "container.deleted"
+
+    @pytest.mark.asyncio
+    async def test_adelete_container_basic(self):
+        """Test basic async container deletion functionality."""
+        container_id = "cntr_async_delete"
+        mock_response = DeleteContainerResult(
+            id=container_id,
+            object="container.deleted",
+            deleted=True
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_delete_handler.return_value = mock_response
+            
+            response = await adelete_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            assert isinstance(response, DeleteContainerResult)
+            assert response.id == container_id
+            assert response.deleted == True
+
+    def test_create_container_error_handling(self):
+        """Test error handling in container creation."""
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.side_effect = Exception("API Error")
+            
+            with pytest.raises(Exception):
+                create_container(
+                    name="Error Test Container",
+                    custom_llm_provider="openai"
+                )
+
+    def test_container_provider_config_retrieval(self):
+        """Test that provider config is retrieved correctly."""
+        with patch('litellm.containers.main.ProviderConfigManager') as mock_config_manager:
+            mock_config_manager.get_provider_container_config.return_value = OpenAIContainerConfig()
+            
+            with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+                mock_response = ContainerObject(
+                    id="cntr_config_test",
+                    object="container",
+                    created_at=1747857508,
+                    status="running",
+                    expires_after={"anchor": "last_active_at", "minutes": 20},
+                    last_active_at=1747857508,
+                    name="Config Test"
+                )
+                mock_handler.container_create_handler.return_value = mock_response
+                
+                response = create_container(
+                    name="Config Test",
+                    custom_llm_provider="openai"
+                )
+                
+                # Verify provider config was requested
+                mock_config_manager.get_provider_container_config.assert_called_once()
+                assert response.name == "Config Test"

--- a/tests/test_litellm/containers/test_container_integration.py
+++ b/tests/test_litellm/containers/test_container_integration.py
@@ -1,0 +1,396 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import httpx
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.types.containers.main import ContainerObject, ContainerListResponse, DeleteContainerResult
+from litellm.containers.main import (
+    create_container, acreate_container,
+    list_containers, alist_containers,
+    retrieve_container, aretrieve_container,
+    delete_container, adelete_container
+)
+
+
+class TestContainerIntegration:
+    """Integration tests for the complete container API flow."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Mock environment variable for API key
+        os.environ["OPENAI_API_KEY"] = "sk-test123"
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        if "OPENAI_API_KEY" in os.environ:
+            del os.environ["OPENAI_API_KEY"]
+
+    @patch('litellm.llms.custom_httpx.llm_http_handler.HTTPHandler')
+    def test_container_create_full_flow(self, mock_http_handler):
+        """Test the complete container creation flow with mocked HTTP."""
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "cntr_integration_test",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Integration Test Container"
+        }
+        mock_response.status_code = 200
+        
+        # Mock the HTTP handler
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+        mock_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler._get_httpx_client') as mock_get_client:
+            mock_get_client.return_value = mock_client
+            
+            # Execute
+            response = create_container(
+                name="Integration Test Container",
+                expires_after={"anchor": "last_active_at", "minutes": 20},
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, ContainerObject)
+            assert response.id == "cntr_integration_test"
+            assert response.name == "Integration Test Container"
+            assert response.status == "running"
+
+    @patch('litellm.llms.custom_httpx.llm_http_handler.HTTPHandler')
+    def test_container_list_full_flow(self, mock_http_handler):
+        """Test the complete container listing flow with mocked HTTP."""
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [
+                {
+                    "id": "cntr_list_1",
+                    "object": "container",
+                    "created_at": 1747857508,
+                    "status": "running",
+                    "expires_after": {"anchor": "last_active_at", "minutes": 20},
+                    "last_active_at": 1747857508,
+                    "name": "List Container 1"
+                },
+                {
+                    "id": "cntr_list_2",
+                    "object": "container",
+                    "created_at": 1747857600,
+                    "status": "running",
+                    "expires_after": {"anchor": "last_active_at", "minutes": 15},
+                    "last_active_at": 1747857600,
+                    "name": "List Container 2"
+                }
+            ],
+            "first_id": "cntr_list_1",
+            "last_id": "cntr_list_2",
+            "has_more": False
+        }
+        mock_response.status_code = 200
+        
+        # Mock the HTTP handler
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler._get_httpx_client') as mock_get_client:
+            mock_get_client.return_value = mock_client
+            
+            # Execute
+            response = list_containers(
+                limit=10,
+                order="desc",
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, ContainerListResponse)
+            assert len(response.data) == 2
+            assert response.data[0].id == "cntr_list_1"
+            assert response.data[1].id == "cntr_list_2"
+            assert response.has_more == False
+
+    @patch('litellm.llms.custom_httpx.llm_http_handler.HTTPHandler')
+    def test_container_retrieve_full_flow(self, mock_http_handler):
+        """Test the complete container retrieval flow with mocked HTTP."""
+        container_id = "cntr_retrieve_integration"
+        
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": container_id,
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Retrieved Integration Container"
+        }
+        mock_response.status_code = 200
+        
+        # Mock the HTTP handler
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler._get_httpx_client') as mock_get_client:
+            mock_get_client.return_value = mock_client
+            
+            # Execute
+            response = retrieve_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, ContainerObject)
+            assert response.id == container_id
+            assert response.name == "Retrieved Integration Container"
+
+    @patch('litellm.llms.custom_httpx.llm_http_handler.HTTPHandler')
+    def test_container_delete_full_flow(self, mock_http_handler):
+        """Test the complete container deletion flow with mocked HTTP."""
+        container_id = "cntr_delete_integration"
+        
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": container_id,
+            "object": "container.deleted",
+            "deleted": True
+        }
+        mock_response.status_code = 200
+        
+        # Mock the HTTP handler
+        mock_client = MagicMock()
+        mock_client.delete.return_value = mock_response
+        mock_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler._get_httpx_client') as mock_get_client:
+            mock_get_client.return_value = mock_client
+            
+            # Execute
+            response = delete_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, DeleteContainerResult)
+            assert response.id == container_id
+            assert response.deleted == True
+            assert response.object == "container.deleted"
+
+    @pytest.mark.asyncio
+    @patch('litellm.llms.custom_httpx.llm_http_handler.AsyncHTTPHandler')
+    async def test_async_container_create_full_flow(self, mock_async_http_handler):
+        """Test the complete async container creation flow with mocked HTTP."""
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "cntr_async_integration",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 30},
+            "last_active_at": 1747857508,
+            "name": "Async Integration Container"
+        }
+        mock_response.status_code = 200
+        
+        # Mock the async HTTP handler
+        mock_client = MagicMock()
+        
+        async def mock_post(*args, **kwargs):
+            return mock_response
+            
+        mock_client.post = mock_post
+        mock_async_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client') as mock_get_async_client:
+            mock_get_async_client.return_value = mock_client
+            
+            # Execute
+            response = await acreate_container(
+                name="Async Integration Container",
+                expires_after={"anchor": "last_active_at", "minutes": 30},
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, ContainerObject)
+            assert response.id == "cntr_async_integration"
+            assert response.name == "Async Integration Container"
+
+    @pytest.mark.asyncio
+    @patch('litellm.llms.custom_httpx.llm_http_handler.AsyncHTTPHandler')
+    async def test_async_container_list_full_flow(self, mock_async_http_handler):
+        """Test the complete async container listing flow with mocked HTTP."""
+        # Setup mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [
+                {
+                    "id": "cntr_async_list",
+                    "object": "container",
+                    "created_at": 1747857508,
+                    "status": "running",
+                    "expires_after": {"anchor": "last_active_at", "minutes": 25},
+                    "last_active_at": 1747857508,
+                    "name": "Async List Container"
+                }
+            ],
+            "first_id": "cntr_async_list",
+            "last_id": "cntr_async_list",
+            "has_more": False
+        }
+        mock_response.status_code = 200
+        
+        # Mock the async HTTP handler
+        mock_client = MagicMock()
+        
+        async def mock_get(*args, **kwargs):
+            return mock_response
+            
+        mock_client.get = mock_get
+        mock_async_http_handler.return_value = mock_client
+        
+        with patch('litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client') as mock_get_async_client:
+            mock_get_async_client.return_value = mock_client
+            
+            # Execute
+            response = await alist_containers(
+                limit=5,
+                custom_llm_provider="openai"
+            )
+            
+            # Verify
+            assert isinstance(response, ContainerListResponse)
+            assert len(response.data) == 1
+            assert response.data[0].id == "cntr_async_list"
+
+    def test_container_workflow_simulation(self):
+        """Test a complete workflow: create -> list -> retrieve -> delete."""
+        container_id = "cntr_workflow_test"
+        
+        # Mock all HTTP responses
+        create_response = MagicMock(spec=httpx.Response)
+        create_response.json.return_value = {
+            "id": container_id,
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Workflow Test Container"
+        }
+        
+        list_response = MagicMock(spec=httpx.Response)
+        list_response.json.return_value = {
+            "object": "list",
+            "data": [create_response.json.return_value],
+            "first_id": container_id,
+            "last_id": container_id,  
+            "has_more": False
+        }
+        
+        retrieve_response = create_response  # Same as create
+        
+        delete_response = MagicMock(spec=httpx.Response)
+        delete_response.json.return_value = {
+            "id": container_id,
+            "object": "container.deleted",
+            "deleted": True
+        }
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            # Setup different responses for different operations
+            mock_handler.container_create_handler.return_value = ContainerObject(**create_response.json.return_value)
+            mock_handler.container_list_handler.return_value = ContainerListResponse(**list_response.json.return_value)
+            mock_handler.container_retrieve_handler.return_value = ContainerObject(**retrieve_response.json.return_value)
+            mock_handler.container_delete_handler.return_value = DeleteContainerResult(**delete_response.json.return_value)
+            
+            # Execute workflow
+            # 1. Create container
+            created = create_container(
+                name="Workflow Test Container",
+                custom_llm_provider="openai"
+            )
+            assert created.id == container_id
+            
+            # 2. List containers (should include our created one)
+            containers = list_containers(custom_llm_provider="openai")
+            assert len(containers.data) == 1
+            assert containers.data[0].id == container_id
+            
+            # 3. Retrieve specific container
+            retrieved = retrieve_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            assert retrieved.id == container_id
+            assert retrieved.name == "Workflow Test Container"
+            
+            # 4. Delete container
+            deleted = delete_container(
+                container_id=container_id,
+                custom_llm_provider="openai"
+            )
+            assert deleted.id == container_id
+            assert deleted.deleted == True
+
+    def test_error_handling_integration(self):
+        """Test error handling in the integration flow."""
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            # Simulate an API error
+            mock_handler.container_create_handler.side_effect = litellm.APIError(
+                status_code=400,
+                message="API Error occurred", 
+                llm_provider="openai",
+                model=""
+            )
+            
+            with pytest.raises(litellm.APIError):
+                create_container(
+                    name="Error Test Container",
+                    custom_llm_provider="openai"
+                )
+
+    @pytest.mark.parametrize("provider", ["openai"])
+    def test_provider_support(self, provider):
+        """Test that the container API works with supported providers."""
+        mock_response = ContainerObject(
+            id="cntr_provider_test",
+            object="container",
+            created_at=1747857508,
+            status="running",
+            expires_after={"anchor": "last_active_at", "minutes": 20},
+            last_active_at=1747857508,
+            name="Provider Test Container"
+        )
+        
+        with patch('litellm.containers.main.base_llm_http_handler') as mock_handler:
+            mock_handler.container_create_handler.return_value = mock_response
+            
+            response = create_container(
+                name="Provider Test Container",
+                custom_llm_provider=provider
+            )
+            
+            assert response.name == "Provider Test Container"

--- a/tests/test_litellm/containers/test_container_transformation.py
+++ b/tests/test_litellm/containers/test_container_transformation.py
@@ -1,0 +1,323 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+import httpx
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.llms.openai.containers.transformation import OpenAIContainerConfig
+from litellm.llms.base_llm.containers.transformation import BaseContainerConfig
+from litellm.types.containers.main import ContainerObject, ContainerListResponse, DeleteContainerResult
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+
+
+class TestOpenAIContainerTransformation:
+    """Test suite for OpenAI container transformation functionality."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = OpenAIContainerConfig()
+        self.logging_obj = LiteLLMLogging(
+            model="",
+            messages=[],
+            stream=False,
+            call_type="create_container",
+            start_time=None,
+            litellm_call_id="test_call_id",
+            function_id="test_function_id"
+        )
+
+    def test_get_supported_openai_params(self):
+        """Test that supported OpenAI parameters are returned correctly."""
+        supported_params = self.config.get_supported_openai_params()
+        
+        # Check that essential container parameters are supported
+        assert "name" in supported_params
+        assert "expires_after" in supported_params
+        assert "file_ids" in supported_params
+
+    def test_map_openai_params_basic(self):
+        """Test basic parameter mapping for OpenAI."""
+        from litellm.types.containers.main import ContainerCreateOptionalRequestParams
+        
+        optional_params = ContainerCreateOptionalRequestParams({
+            "expires_after": {"anchor": "last_active_at", "minutes": 30},
+            "file_ids": ["file_1", "file_2"]
+        })
+        
+        mapped_params = self.config.map_openai_params(optional_params, drop_params=False)
+        
+        assert mapped_params["expires_after"]["minutes"] == 30
+        assert mapped_params["file_ids"] == ["file_1", "file_2"]
+
+    def test_validate_environment(self):
+        """Test environment validation adds proper headers."""
+        headers = {}
+        api_key = "sk-test123"
+        
+        validated_headers = self.config.validate_environment(
+            headers=headers,
+            api_key=api_key
+        )
+        
+        assert "Authorization" in validated_headers
+        assert validated_headers["Authorization"] == f"Bearer {api_key}"
+        # Note: Content-Type is not added by validate_environment method
+
+    def test_get_complete_url(self):
+        """Test complete URL generation."""
+        api_base = "https://api.openai.com/v1"
+        litellm_params = {}
+        
+        url = self.config.get_complete_url(
+            api_base=api_base,
+            litellm_params=litellm_params
+        )
+        
+        assert url == "https://api.openai.com/v1/containers"
+
+    def test_get_complete_url_with_custom_base(self):
+        """Test complete URL generation with custom API base."""
+        api_base = "https://custom.openai.com/v1"
+        litellm_params = {}
+        
+        url = self.config.get_complete_url(
+            api_base=api_base,
+            litellm_params=litellm_params
+        )
+        
+        assert url == "https://custom.openai.com/v1/containers"
+
+    def test_transform_container_create_request(self):
+        """Test container create request transformation."""
+        from litellm.types.router import GenericLiteLLMParams
+        
+        litellm_params = GenericLiteLLMParams()
+        headers = {"Authorization": "Bearer sk-test123"}
+        name = "Test Container"
+        container_create_optional_request_params = {
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "file_ids": ["file_123"]
+        }
+        
+        data = self.config.transform_container_create_request(
+            name=name,
+            container_create_optional_request_params=container_create_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        assert data["name"] == name
+        assert data["expires_after"] == container_create_optional_request_params["expires_after"]
+        assert data["file_ids"] == container_create_optional_request_params["file_ids"]
+
+    def test_transform_container_create_response(self):
+        """Test container create response transformation."""
+        # Mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "cntr_123456",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Test Container"
+        }
+        
+        container = self.config.transform_container_create_response(
+            raw_response=mock_response,
+            logging_obj=self.logging_obj
+        )
+        
+        assert isinstance(container, ContainerObject)
+        assert container.id == "cntr_123456"
+        assert container.name == "Test Container"
+        assert container.status == "running"
+        assert container.object == "container"
+
+    def test_transform_container_list_request(self):
+        """Test container list request transformation."""
+        api_base = "https://api.openai.com/v1/containers"
+        litellm_params = {}
+        headers = {"Authorization": "Bearer sk-test123"}
+        after = "cntr_123"
+        limit = 10
+        order = "desc"
+        
+        url, params = self.config.transform_container_list_request(
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers,
+            after=after,
+            limit=limit,
+            order=order
+        )
+        
+        assert url == api_base
+        assert params["after"] == after
+        assert params["limit"] == str(limit)  # Should be string for query params
+        assert params["order"] == order
+
+    def test_transform_container_list_response(self):
+        """Test container list response transformation."""
+        # Mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [
+                {
+                    "id": "cntr_1",
+                    "object": "container",
+                    "created_at": 1747857508,
+                    "status": "running",
+                    "expires_after": {"anchor": "last_active_at", "minutes": 20},
+                    "last_active_at": 1747857508,
+                    "name": "Container 1"
+                },
+                {
+                    "id": "cntr_2",
+                    "object": "container", 
+                    "created_at": 1747857600,
+                    "status": "running",
+                    "expires_after": {"anchor": "last_active_at", "minutes": 15},
+                    "last_active_at": 1747857600,
+                    "name": "Container 2"
+                }
+            ],
+            "first_id": "cntr_1",
+            "last_id": "cntr_2",
+            "has_more": False
+        }
+        
+        container_list = self.config.transform_container_list_response(
+            raw_response=mock_response,
+            logging_obj=self.logging_obj
+        )
+        
+        assert isinstance(container_list, ContainerListResponse)
+        assert len(container_list.data) == 2
+        assert container_list.first_id == "cntr_1"
+        assert container_list.last_id == "cntr_2"
+        assert container_list.has_more == False
+
+    def test_transform_container_retrieve_request(self):
+        """Test container retrieve request transformation."""
+        container_id = "cntr_test123"
+        api_base = "https://api.openai.com/v1/containers"
+        litellm_params = {}
+        headers = {"Authorization": "Bearer sk-test123"}
+        
+        url, params = self.config.transform_container_retrieve_request(
+            container_id=container_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        assert url == f"{api_base}/{container_id}"
+        assert params == {}  # No query params for retrieve
+
+    def test_transform_container_retrieve_response(self):
+        """Test container retrieve response transformation."""
+        # Mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "cntr_retrieve_123",
+            "object": "container",
+            "created_at": 1747857508,
+            "status": "running",
+            "expires_after": {"anchor": "last_active_at", "minutes": 20},
+            "last_active_at": 1747857508,
+            "name": "Retrieved Container"
+        }
+        
+        container = self.config.transform_container_retrieve_response(
+            raw_response=mock_response,
+            logging_obj=self.logging_obj
+        )
+        
+        assert isinstance(container, ContainerObject)
+        assert container.id == "cntr_retrieve_123"
+        assert container.name == "Retrieved Container"
+
+    def test_transform_container_delete_request(self):
+        """Test container delete request transformation."""
+        container_id = "cntr_delete_123"
+        api_base = "https://api.openai.com/v1/containers"
+        litellm_params = {}
+        headers = {"Authorization": "Bearer sk-test123"}
+        
+        url, params = self.config.transform_container_delete_request(
+            container_id=container_id,
+            api_base=api_base,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        assert url == f"{api_base}/{container_id}"
+        assert params == {}  # No query params for delete
+
+    def test_transform_container_delete_response(self):
+        """Test container delete response transformation."""
+        # Mock HTTP response
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "cntr_delete_123",
+            "object": "container.deleted",
+            "deleted": True
+        }
+        
+        delete_result = self.config.transform_container_delete_response(
+            raw_response=mock_response,
+            logging_obj=self.logging_obj
+        )
+        
+        assert isinstance(delete_result, DeleteContainerResult)
+        assert delete_result.id == "cntr_delete_123"
+        assert delete_result.object == "container.deleted"
+        assert delete_result.deleted == True
+
+    def test_get_error_class(self):
+        """Test error class handling."""
+        import httpx
+        from litellm.llms.base_llm.chat.transformation import BaseLLMException
+        
+        with pytest.raises(BaseLLMException) as exc_info:
+            self.config.get_error_class(
+                error_message="Test error",
+                status_code=400,
+                headers={}
+            )
+        
+        assert "Test error" in str(exc_info.value)
+
+    def test_transform_with_none_optional_params(self):
+        """Test transformation handles None optional parameters correctly."""
+        from litellm.types.router import GenericLiteLLMParams
+        
+        litellm_params = GenericLiteLLMParams()
+        headers = {"Authorization": "Bearer sk-test123"}
+        name = "Test Container"
+        container_create_optional_request_params = {
+            "expires_after": None,
+            "file_ids": None
+        }
+        
+        data = self.config.transform_container_create_request(
+            name=name,
+            container_create_optional_request_params=container_create_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers
+        )
+        
+        assert data["name"] == name
+        # None values should be included as None
+        assert data["expires_after"] is None
+        assert data["file_ids"] is None

--- a/tests/test_litellm/containers/test_container_utils.py
+++ b/tests/test_litellm/containers/test_container_utils.py
@@ -1,0 +1,230 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+import litellm
+from litellm.containers.utils import ContainerRequestUtils
+from litellm.llms.openai.containers.transformation import OpenAIContainerConfig
+from litellm.types.containers.main import (
+    ContainerCreateOptionalRequestParams,
+    ContainerListOptionalRequestParams
+)
+
+
+class TestContainerRequestUtils:
+    """Test suite for container request utilities."""
+
+    def test_get_optional_params_container_create_basic(self):
+        """Test that optional parameters are correctly processed for container creation."""
+        # Setup
+        config = OpenAIContainerConfig()
+        optional_params = ContainerCreateOptionalRequestParams(
+            {
+                "expires_after": {"anchor": "last_active_at", "minutes": 30},
+                "file_ids": ["file_123", "file_456"]
+            }
+        )
+
+        # Execute
+        result = ContainerRequestUtils.get_optional_params_container_create(
+            container_provider_config=config,
+            container_create_optional_params=optional_params,
+        )
+
+        # Assert
+        assert result == optional_params
+        assert "expires_after" in result
+        assert result["expires_after"]["minutes"] == 30
+        assert "file_ids" in result
+        assert result["file_ids"] == ["file_123", "file_456"]
+
+    def test_get_optional_params_container_create_unsupported_param(self):
+        """Test that unsupported parameters are filtered out by ContainerCreateOptionalRequestParams."""
+        # Setup
+        config = OpenAIContainerConfig()
+        
+        # ContainerCreateOptionalRequestParams will only accept valid parameters
+        # so this test verifies the type validation works correctly
+        valid_params = ContainerCreateOptionalRequestParams(
+            {
+                "expires_after": {"anchor": "last_active_at", "minutes": 30},
+                "file_ids": ["file_123"]
+            }
+        )
+
+        # Execute - should work fine with valid parameters
+        result = ContainerRequestUtils.get_optional_params_container_create(
+            container_provider_config=config,
+            container_create_optional_params=valid_params,
+        )
+
+        assert result["expires_after"]["minutes"] == 30
+        assert result["file_ids"] == ["file_123"]
+
+    def test_get_requested_container_create_optional_param(self):
+        """Test filtering parameters to only include those in ContainerCreateOptionalRequestParams."""
+        # Setup
+        params = {
+            "name": "Test Container",  # This should be excluded as it's required
+            "expires_after": {"anchor": "last_active_at", "minutes": 30},
+            "file_ids": ["file_123"],
+            "invalid_param": "value",
+            "custom_llm_provider": "openai",  # This should be excluded
+        }
+
+        # Execute
+        result = ContainerRequestUtils.get_requested_container_create_optional_param(
+            params
+        )
+
+        # Assert
+        assert "expires_after" in result
+        assert "file_ids" in result
+        assert "invalid_param" not in result
+        assert "name" not in result
+        assert "custom_llm_provider" not in result
+        assert result["expires_after"]["minutes"] == 30
+        assert result["file_ids"] == ["file_123"]
+
+    def test_get_requested_container_list_optional_param(self):
+        """Test filtering parameters for container list requests."""
+        # Setup
+        params = {
+            "after": "cntr_123",
+            "limit": 10,
+            "order": "desc",
+            "invalid_param": "value",
+            "custom_llm_provider": "openai",  # This should be excluded
+        }
+
+        # Execute
+        result = ContainerRequestUtils.get_requested_container_list_optional_param(
+            params
+        )
+
+        # Assert
+        assert "after" in result
+        assert "limit" in result
+        assert "order" in result
+        assert "invalid_param" not in result
+        assert "custom_llm_provider" not in result
+        assert result["after"] == "cntr_123"
+        assert result["limit"] == 10
+        assert result["order"] == "desc"
+
+    def test_get_optional_params_container_create_empty_params(self):
+        """Test handling of empty optional parameters."""
+        # Setup
+        config = OpenAIContainerConfig()
+        optional_params = ContainerCreateOptionalRequestParams({})
+
+        # Execute
+        result = ContainerRequestUtils.get_optional_params_container_create(
+            container_provider_config=config,
+            container_create_optional_params=optional_params,
+        )
+
+        # Assert
+        assert result == optional_params
+        assert len(result) == 0
+
+    def test_get_optional_params_container_create_with_none_values(self):
+        """Test handling of None values in optional parameters."""
+        # Setup
+        config = OpenAIContainerConfig()
+        optional_params = ContainerCreateOptionalRequestParams(
+            {
+                "expires_after": None,
+                "file_ids": None
+            }
+        )
+
+        # Execute
+        result = ContainerRequestUtils.get_optional_params_container_create(
+            container_provider_config=config,
+            container_create_optional_params=optional_params,
+        )
+
+        # Assert
+        assert result == optional_params
+        assert "expires_after" in result
+        assert "file_ids" in result
+        assert result["expires_after"] is None
+        assert result["file_ids"] is None
+
+    def test_get_requested_container_list_optional_param_partial(self):
+        """Test filtering with only some list parameters present."""
+        # Setup
+        params = {
+            "limit": 5,
+            "custom_llm_provider": "openai",  # Should be excluded
+            "timeout": 600,  # Should be excluded
+        }
+
+        # Execute
+        result = ContainerRequestUtils.get_requested_container_list_optional_param(
+            params
+        )
+
+        # Assert
+        assert "limit" in result
+        assert "custom_llm_provider" not in result
+        assert "timeout" not in result
+        assert "after" not in result  # Not present in input
+        assert "order" not in result  # Not present in input
+        assert result["limit"] == 5
+
+    def test_container_create_optional_params_type_validation(self):
+        """Test that ContainerCreateOptionalRequestParams validates types correctly."""
+        # Test with valid expires_after
+        valid_params = ContainerCreateOptionalRequestParams(
+            {
+                "expires_after": {"anchor": "last_active_at", "minutes": 20},
+                "file_ids": ["file_1", "file_2"]
+            }
+        )
+        
+        assert valid_params["expires_after"]["anchor"] == "last_active_at"
+        assert valid_params["expires_after"]["minutes"] == 20
+        assert valid_params["file_ids"] == ["file_1", "file_2"]
+
+    def test_container_list_optional_params_type_validation(self):
+        """Test that ContainerListOptionalRequestParams validates types correctly."""
+        # Test with valid parameters
+        valid_params = ContainerListOptionalRequestParams(
+            {
+                "after": "cntr_123",
+                "limit": 10,
+                "order": "desc"
+            }
+        )
+        
+        assert valid_params["after"] == "cntr_123"
+        assert valid_params["limit"] == 10
+        assert valid_params["order"] == "desc"
+
+    def test_get_optional_params_with_supported_params_check(self):
+        """Test that only supported parameters are accepted."""
+        # Setup
+        config = OpenAIContainerConfig()
+        
+        # Get supported params to understand what should be allowed
+        supported_params = config.get_supported_openai_params()
+        
+        # Create params with only valid parameters
+        test_params = {"expires_after": {"anchor": "last_active_at", "minutes": 15}}
+        
+        optional_params = ContainerCreateOptionalRequestParams(test_params)
+
+        # Execute - should work fine with supported params
+        result = ContainerRequestUtils.get_optional_params_container_create(
+            container_provider_config=config,
+            container_create_optional_params=optional_params,
+        )
+        
+        assert result["expires_after"]["minutes"] == 15


### PR DESCRIPTION
## Title

Add OpenAI Container API Support to LiteLLM SDK

## Relevant issues

Adds support for OpenAI Container APIs (create, list, retrieve, delete) similar to existing video and responses APIs.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Summary
Implements complete OpenAI Container API support in LiteLLM SDK, enabling users to manage containers with `litellm.create_container()`, `litellm.list_containers()`, `litellm.retrieve_container()`, and `litellm.delete_container()` (plus async versions).

### Key Features Added
- **Complete CRUD operations**: Create, list, retrieve, and delete containers
- **Sync & Async support**: All operations available in both synchronous and asynchronous versions
- **Type safety**: Full TypeScript-style type definitions for all container objects and parameters
- **OpenAI compatibility**: Direct integration with OpenAI's Container API specification

### Usage Examples

```python
import litellm

# Create container
container = litellm.create_container(
    name="My Container",
    expires_after={"anchor": "last_active_at", "minutes": 20},
    custom_llm_provider="openai"
)

# List containers
containers = litellm.list_containers(limit=10, custom_llm_provider="openai")

# Retrieve specific container
container = litellm.retrieve_container(container_id="cntr_123", custom_llm_provider="openai")

# Delete container
result = litellm.delete_container(container_id="cntr_123", custom_llm_provider="openai")

# All operations support async versions
container = await litellm.acreate_container(name="Async Container")
```
