### PR TITLE
[Feature] Config Models should not be editable

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -1,0 +1,179 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import ModelInfoView from "./model_info_view";
+
+vi.mock("../../utils/dataUtils", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("./networking", () => ({
+  modelInfoV1Call: vi.fn().mockResolvedValue({
+    data: [
+      {
+        model_name: "aws/anthropic/bedrock-claude-3-5-sonnet-v1",
+        litellm_params: {
+          aws_region_name: "us-east-1",
+          custom_llm_provider: "bedrock",
+          use_in_pass_through: false,
+          use_litellm_proxy: false,
+          merge_reasoning_content_in_choices: false,
+          model: "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        },
+        model_info: {
+          id: "70b94bbd2af4a75215f7e3e465b5b199529dc15deb5d395d0668a4aabc496c84",
+          db_model: false,
+          access_via_team_ids: [
+            "4fe3cfea-c907-412a-a645-60915b618d11",
+            "9a4b2d15-4198-47e4-971b-7329b77f40e4",
+            "14d55eef-b8d4-4cb8-b080-d973269dae54",
+            "693ce1d2-9fae-4605-a5c9-1c9829415e1a",
+            "fe29d910-4968-45bc-9fe0-6716e89c6270",
+          ],
+          direct_access: true,
+          key: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+          max_tokens: 4096,
+          max_input_tokens: 200000,
+          max_output_tokens: 4096,
+          input_cost_per_token: 0.000003,
+          input_cost_per_token_flex: null,
+          input_cost_per_token_priority: null,
+          cache_creation_input_token_cost: null,
+          cache_read_input_token_cost: null,
+          cache_read_input_token_cost_flex: null,
+          cache_read_input_token_cost_priority: null,
+          cache_creation_input_token_cost_above_1hr: null,
+          input_cost_per_character: null,
+          input_cost_per_token_above_128k_tokens: null,
+          input_cost_per_token_above_200k_tokens: null,
+          input_cost_per_query: null,
+          input_cost_per_second: null,
+          input_cost_per_audio_token: null,
+          input_cost_per_token_batches: null,
+          output_cost_per_token_batches: null,
+          output_cost_per_token: 0.000015,
+          output_cost_per_token_flex: null,
+          output_cost_per_token_priority: null,
+          output_cost_per_audio_token: null,
+          output_cost_per_character: null,
+          output_cost_per_reasoning_token: null,
+          output_cost_per_token_above_128k_tokens: null,
+          output_cost_per_character_above_128k_tokens: null,
+          output_cost_per_token_above_200k_tokens: null,
+          output_cost_per_second: null,
+          output_cost_per_video_per_second: null,
+          output_cost_per_image: null,
+          output_vector_size: null,
+          citation_cost_per_token: null,
+          tiered_pricing: null,
+          litellm_provider: "bedrock",
+          mode: "chat",
+          supports_system_messages: null,
+          supports_response_schema: true,
+          supports_vision: true,
+          supports_function_calling: true,
+          supports_tool_choice: true,
+          supports_assistant_prefill: null,
+          supports_prompt_caching: null,
+          supports_audio_input: null,
+          supports_audio_output: null,
+          supports_pdf_input: true,
+          supports_embedding_image_input: null,
+          supports_native_streaming: null,
+          supports_web_search: null,
+          supports_url_context: null,
+          supports_reasoning: null,
+          supports_computer_use: null,
+          search_context_cost_per_query: null,
+          tpm: null,
+          rpm: null,
+          ocr_cost_per_page: null,
+          annotation_cost_per_page: null,
+          supported_openai_params: [
+            "max_tokens",
+            "max_completion_tokens",
+            "stream",
+            "stream_options",
+            "stop",
+            "temperature",
+            "top_p",
+            "extra_headers",
+            "response_format",
+            "requestMetadata",
+            "tools",
+            "tool_choice",
+          ],
+        },
+      },
+    ],
+  }),
+  credentialGetCall: vi.fn().mockResolvedValue({}),
+}));
+
+describe("ModelInfoView", () => {
+  const modelData = {
+    model_info: {
+      id: "123",
+      created_by: "123",
+      db_model: true,
+    },
+    litellm_params: {
+      api_base: "https://api.openai.com/v1",
+      custom_llm_provider: "openai",
+    },
+    litellm_model_name: "gpt-4",
+    model_name: "GPT-4",
+    litellm_provider: "openai",
+    mode: "chat",
+    supported_openai_params: ["temperature", "max_tokens", "top_p", "frequency_penalty", "presence_penalty"],
+  };
+
+  it("should render the model info view", async () => {
+    const { getByText } = render(
+      <ModelInfoView
+        modelId="123"
+        onClose={() => {}}
+        modelData={modelData}
+        accessToken="123"
+        userID="123"
+        userRole="Admin"
+        editModel={false}
+        setEditModalVisible={() => {}}
+        setSelectedModel={() => {}}
+        onModelUpdate={() => {}}
+        modelAccessGroups={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByText("Model Settings")).toBeInTheDocument();
+    });
+  });
+
+  it("should not render an edit model button if the model is not a DB model", async () => {
+    const nonDbModelData = {
+      ...modelData,
+      model_info: {
+        ...modelData.model_info,
+        db_model: false,
+      },
+    };
+
+    const { queryByText } = render(
+      <ModelInfoView
+        modelId="123"
+        onClose={() => {}}
+        modelData={nonDbModelData}
+        accessToken="123"
+        userID="123"
+        userRole="Admin"
+        editModel={false}
+        setEditModalVisible={() => {}}
+        setSelectedModel={() => {}}
+        onModelUpdate={() => {}}
+        modelAccessGroups={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(queryByText("Edit Model")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -73,7 +73,8 @@ export default function ModelInfoView({
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [isAutoRouterModalOpen, setIsAutoRouterModalOpen] = useState(false);
   const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
-  const canEditModel = userRole === "Admin" || modelData?.model_info?.created_by === userID;
+  const canEditModel =
+    (userRole === "Admin" || modelData?.model_info?.created_by === userID) && modelData?.model_info?.db_model;
   const isAdmin = userRole === "Admin";
   const isAutoRouter = modelData?.litellm_params?.auto_router_config != null;
 
@@ -429,10 +430,20 @@ export default function ModelInfoView({
                       Edit Auto Router
                     </TremorButton>
                   )}
-                  {canEditModel && !isEditing && (
-                    <TremorButton variant="secondary" onClick={() => setIsEditing(true)} className="flex items-center">
-                      Edit Model
-                    </TremorButton>
+                  {canEditModel ? (
+                    !isEditing && (
+                      <TremorButton
+                        variant="secondary"
+                        onClick={() => setIsEditing(true)}
+                        className="flex items-center"
+                      >
+                        Edit Model
+                      </TremorButton>
+                    )
+                  ) : (
+                    <Tooltip title="Only DB models can be edited. You must be an admin or the creator of the model to edit it.">
+                      <InfoCircleOutlined />
+                    </Tooltip>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## [Feature] Config Models should not be editable

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Currently users can enter the edit model in model settings for a config model, only to get an error response from the server after they try to submit. Editing a config model always throws an error, so this change will prevent the user from entering the edit view in the UI.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Screenshots
<img width="819" height="188" alt="Screenshot 2025-10-28 at 10 48 22 AM" src="https://github.com/user-attachments/assets/4bc40524-ce83-4ad7-b0d0-717215a4d278" />
<img width="1512" height="982" alt="Screenshot 2025-10-28 at 10 49 35 AM" src="https://github.com/user-attachments/assets/64a5665b-ba62-4eda-a98c-cb21186df446" />


