### PR TITLE
Update bedrock_guardrails.py

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -522,6 +522,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         If `self.mask_request_content` or `self.mask_response_content` is set to `True`, then use the output from the guardrail to mask the request or response content.
         """
+        
+        #The blocked content should be prioritized over the configuration parameters.
 
         # if user opted into masking, return False. since we'll use the masked output from the guardrail
         if self.mask_request_content or self.mask_response_content:
@@ -587,6 +589,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     if grounding_filter.get("action") == "BLOCKED":
                         return True
 
+        #If the content is not blocked then will pass the masked content from guardrail into LLM call
+
+        # if user opted into masking, return False. since we'll use the masked output from the guardrail
+        if self.mask_request_content or self.mask_response_content:
+            return False
+
+        # if no intervention, return False
+        if response.get("action") != "GUARDRAIL_INTERVENED":
+            return False
+
+        
         # If we got here, intervention occurred but no BLOCKED actions found
         # This means all actions were ANONYMIZED or NONE, so don't raise exception
         return False

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -525,14 +525,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         
         #The blocked content should be prioritized over the configuration parameters.
 
-        # if user opted into masking, return False. since we'll use the masked output from the guardrail
-        if self.mask_request_content or self.mask_response_content:
-            return False
-
-        # if no intervention, return False
-        if response.get("action") != "GUARDRAIL_INTERVENED":
-            return False
-
         # Check assessments to determine if any actions were BLOCKED (vs ANONYMIZED)
         assessments = response.get("assessments", [])
         if not assessments:


### PR DESCRIPTION
prioritized over the configuration parameters.

## Title

litellm bedrock guardrails block content feature : Litellm need to block the PII content before sending to LLM.
 
This change is corressponds to the fix required for implementing guardrails and not share PII data with models.

[EXT_ Re_ EXT_ Re_ EXT_ Re_ EXT_ Next Release.msg](https://github.com/user-attachments/files/23196343/EXT_.Re_.EXT_.Re_.EXT_.Re_.EXT_.Next.Release.msg)

