### PR TITLE
fix: prevent httpx DeprecationWarning memory leak in AsyncHTTPHandler

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -47,6 +47,46 @@ headers = {
 _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
 
 
+def _prepare_request_data_and_content(
+    data: Optional[Union[dict, str, bytes]] = None,
+    content: Any = None,
+) -> tuple[Optional[Union[dict, Mapping]], Any]:
+    """
+    Helper function to route data/content parameters correctly for httpx requests
+    
+    This prevents httpx DeprecationWarnings that cause memory leaks.
+    
+    Background:
+    - httpx shows a DeprecationWarning when you pass bytes/str to `data=`
+    - It wants you to use `content=` instead for bytes/str
+    - The warning itself leaks memory when triggered repeatedly
+    
+    Solution:
+    - Move bytes/str from `data=` to `content=` before calling build_request
+    - Keep dicts in `data=` (that's still the correct parameter for dicts)
+    
+    Args:
+        data: Request data (can be dict, str, or bytes)
+        content: Request content (raw bytes/str)
+        
+    Returns:
+        Tuple of (request_data, request_content) properly routed for httpx
+    """
+    request_data = None
+    request_content = content
+    
+    if data is not None:
+        if isinstance(data, (bytes, str)):
+            # Bytes/strings belong in content= (only if not already provided)
+            if content is None:
+                request_content = data
+        else:
+            # dict/Mapping stays in data= parameter
+            request_data = data
+    
+    return request_data, request_content
+
+
 def get_ssl_configuration(
     ssl_verify: Optional[VerifyTypes] = None,
 ) -> Union[bool, str, ssl.SSLContext]:
@@ -301,33 +341,8 @@ class AsyncHTTPHandler:
             if timeout is None:
                 timeout = self.timeout
 
-            # ============================================================================
-            # MEMORY LEAK FIX — Prevent httpx DeprecationWarning
-            # ============================================================================
-            # Problem:
-            #   httpx shows a DeprecationWarning when you pass bytes/str to `data=`.
-            #   It wants you to use `content=` instead.
-            #
-            # Impact:
-            #   The warning leaks memory. Preventing the warning fixes the leak.
-            #
-            # Fix:
-            #   Move bytes/str from `data=` to `content=` before calling build_request.
-            #   Keep dicts in `data=` (that's still correct).
-            # ============================================================================
-            
-            request_data = None
-            request_content = content
-            
-            # Route data parameter to the correct httpx parameter based on type
-            if data is not None:
-                if isinstance(data, (bytes, str)):
-                    # Bytes/strings belong in content= (only if not already provided)
-                    if content is None:
-                        request_content = data
-                else:
-                    # dict/Mapping stays in data= parameter
-                    request_data = data
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
                 
             req = self.client.build_request(
                 "POST",
@@ -392,19 +407,23 @@ class AsyncHTTPHandler:
     async def put(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,  # type: ignore
+        data: Optional[Union[dict, str, bytes]] = None,  # type: ignore
         json: Optional[dict] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         stream: bool = False,
+        content: Any = None,
     ):
         try:
             if timeout is None:
                 timeout = self.timeout
 
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+
             req = self.client.build_request(
-                "PUT", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                "PUT", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
             )
             response = await self.client.send(req)
             response.raise_for_status()
@@ -452,19 +471,23 @@ class AsyncHTTPHandler:
     async def patch(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,  # type: ignore
+        data: Optional[Union[dict, str, bytes]] = None,  # type: ignore
         json: Optional[dict] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         stream: bool = False,
+        content: Any = None,
     ):
         try:
             if timeout is None:
                 timeout = self.timeout
 
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+
             req = self.client.build_request(
-                "PATCH", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                "PATCH", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
             )
             response = await self.client.send(req)
             response.raise_for_status()
@@ -512,18 +535,23 @@ class AsyncHTTPHandler:
     async def delete(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,  # type: ignore
+        data: Optional[Union[dict, str, bytes]] = None,  # type: ignore
         json: Optional[dict] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         stream: bool = False,
+        content: Any = None,
     ):
         try:
             if timeout is None:
                 timeout = self.timeout
+            
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+            
             req = self.client.build_request(
-                "DELETE", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                "DELETE", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
             )
             response = await self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -571,8 +599,11 @@ class AsyncHTTPHandler:
 
         Used for retrying connection client errors.
         """
+        # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+        request_data, request_content = _prepare_request_data_and_content(data, content)
+        
         req = client.build_request(
-            "POST", url, data=data, json=json, params=params, headers=headers, content=content  # type: ignore
+            "POST", url, data=request_data, json=json, params=params, headers=headers, content=request_content  # type: ignore
         )
         response = await client.send(req, stream=stream)
         response.raise_for_status()
@@ -826,21 +857,24 @@ class HTTPHandler:
         logging_obj: Optional[LiteLLMLoggingObject] = None,
     ):
         try:
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+            
             if timeout is not None:
                 req = self.client.build_request(
                     "POST",
                     url,
-                    data=data,  # type: ignore
+                    data=request_data,  # type: ignore
                     json=json,
                     params=params,
                     headers=headers,
                     timeout=timeout,
                     files=files,
-                    content=content,  # type: ignore
+                    content=request_content,  # type: ignore
                 )
             else:
                 req = self.client.build_request(
-                    "POST", url, data=data, json=json, params=params, headers=headers, files=files, content=content  # type: ignore
+                    "POST", url, data=request_data, json=json, params=params, headers=headers, files=files, content=request_content  # type: ignore
                 )
             response = self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -868,21 +902,25 @@ class HTTPHandler:
     def patch(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,
+        data: Optional[Union[dict, str, bytes]] = None,
         json: Optional[Union[dict, str]] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         stream: bool = False,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        content: Any = None,
     ):
         try:
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+            
             if timeout is not None:
                 req = self.client.build_request(
-                    "PATCH", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                    "PATCH", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
                 )
             else:
                 req = self.client.build_request(
-                    "PATCH", url, data=data, json=json, params=params, headers=headers  # type: ignore
+                    "PATCH", url, data=request_data, json=json, params=params, headers=headers, content=request_content  # type: ignore
                 )
             response = self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -911,21 +949,25 @@ class HTTPHandler:
     def put(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,
+        data: Optional[Union[dict, str, bytes]] = None,
         json: Optional[Union[dict, str]] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         stream: bool = False,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        content: Any = None,
     ):
         try:
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+            
             if timeout is not None:
                 req = self.client.build_request(
-                    "PUT", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                    "PUT", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
                 )
             else:
                 req = self.client.build_request(
-                    "PUT", url, data=data, json=json, params=params, headers=headers  # type: ignore
+                    "PUT", url, data=request_data, json=json, params=params, headers=headers, content=request_content  # type: ignore
                 )
             response = self.client.send(req, stream=stream)
             return response
@@ -941,21 +983,25 @@ class HTTPHandler:
     def delete(
         self,
         url: str,
-        data: Optional[Union[dict, str]] = None,  # type: ignore
+        data: Optional[Union[dict, str, bytes]] = None,  # type: ignore
         json: Optional[dict] = None,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         stream: bool = False,
+        content: Any = None,
     ):
         try:
+            # Prepare data/content parameters to prevent httpx DeprecationWarning (memory leak fix)
+            request_data, request_content = _prepare_request_data_and_content(data, content)
+            
             if timeout is not None:
                 req = self.client.build_request(
-                    "DELETE", url, data=data, json=json, params=params, headers=headers, timeout=timeout  # type: ignore
+                    "DELETE", url, data=request_data, json=json, params=params, headers=headers, timeout=timeout, content=request_content  # type: ignore
                 )
             else:
                 req = self.client.build_request(
-                    "DELETE", url, data=data, json=json, params=params, headers=headers  # type: ignore
+                    "DELETE", url, data=request_data, json=json, params=params, headers=headers, content=request_content  # type: ignore
                 )
             response = self.client.send(req, stream=stream)
             response.raise_for_status()

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -3,7 +3,7 @@ import os
 import ssl
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import certifi
 import httpx
@@ -50,7 +50,7 @@ _DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0, connect=5.0)
 def _prepare_request_data_and_content(
     data: Optional[Union[dict, str, bytes]] = None,
     content: Any = None,
-) -> tuple[Optional[Union[dict, Mapping]], Any]:
+) -> Tuple[Optional[Union[dict, Mapping]], Any]:
     """
     Helper function to route data/content parameters correctly for httpx requests
     


### PR DESCRIPTION
## Title

fix: prevent httpx DeprecationWarning memory leak in AsyncHTTPHandler

## Relevant issues

addresses #12685

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Fixed memory leak in AsyncHTTPHandler by routing bytes/str to content= parameter instead of data= when building httpx requests, preventing DeprecationWarning that was leaking memory

## Memory Impact
### Before

```bash
======================================================================
SDK Async Memory Leak Detection Test
======================================================================
Warming up...
Warm-up complete. Starting measured phase...

Batch 1/15: Current=0.72 MB | Peak=0.78 MB
Batch 2/15: Current=0.80 MB | Peak=0.86 MB
Batch 3/15: Current=0.87 MB | Peak=0.93 MB
Batch 4/15: Current=0.95 MB | Peak=1.00 MB
Batch 5/15: Current=1.02 MB | Peak=1.07 MB
Batch 6/15: Current=1.09 MB | Peak=1.14 MB
Batch 7/15: Current=1.16 MB | Peak=1.22 MB
Batch 8/15: Current=1.23 MB | Peak=1.29 MB
Batch 9/15: Current=1.30 MB | Peak=1.36 MB
Batch 10/15: Current=1.37 MB | Peak=1.43 MB
Batch 11/15: Current=1.44 MB | Peak=1.50 MB
Batch 12/15: Current=1.51 MB | Peak=1.57 MB
Batch 13/15: Current=1.58 MB | Peak=1.64 MB
Batch 14/15: Current=1.66 MB | Peak=1.71 MB
Batch 15/15: Current=1.73 MB | Peak=1.78 MB

======================================================================
Memory Growth Analysis
======================================================================
Initial avg: 0.98 MB
Final avg:   1.41 MB
Growth:      0.43 MB (43.6%)
FAILED[FIXTURE] Test done, running teardown...
```

### After

```bash
======================================================================
SDK Async Memory Leak Detection Test
======================================================================
Warming up...
Warm-up complete. Starting measured phase...

Batch 1/15: Current=0.54 MB | Peak=1.11 MB
Batch 2/15: Current=0.55 MB | Peak=1.11 MB
Batch 3/15: Current=0.55 MB | Peak=1.11 MB
Batch 4/15: Current=0.55 MB | Peak=1.11 MB
Batch 5/15: Current=0.55 MB | Peak=1.11 MB
Batch 6/15: Current=0.55 MB | Peak=1.11 MB
Batch 7/15: Current=0.55 MB | Peak=1.11 MB
Batch 8/15: Current=0.53 MB | Peak=1.11 MB
Batch 9/15: Current=0.54 MB | Peak=1.11 MB
Batch 10/15: Current=0.54 MB | Peak=1.11 MB
Batch 11/15: Current=0.54 MB | Peak=1.11 MB
Batch 12/15: Current=0.54 MB | Peak=1.11 MB
Batch 13/15: Current=0.54 MB | Peak=1.11 MB
Batch 14/15: Current=0.55 MB | Peak=1.11 MB
Batch 15/15: Current=0.55 MB | Peak=1.11 MB

======================================================================
Memory Growth Analysis
======================================================================
Initial avg: 0.55 MB
Final avg:   0.54 MB
Growth:      -0.01 MB (-1.4%)
Memory stabilized — no leak detected
```

## Leaky Function

> The severe memory leak observed in the SDK was caused by an HTTPX deprecation warning function, not by LiteLLM.

```python
    """
    Handles encoding the given `content`, `data`, `files`, and `json`,
    returning a two-tuple of (<headers>, <stream>).
    """
    if data is not None and not isinstance(data, Mapping):
        # We prefer to separate `content=<bytes|str|byte iterator|bytes aiterator>`
        # for raw request content, and `data=<form data>` for url encoded or
        # multipart form content.
        #
        # However for compat with requests, we *do* still support
        # `data=<bytes...>` usages. We deal with that case here, treating it
        # as if `content=<...>` had been supplied instead.
        message = "Use 'content=<...>' to upload raw bytes/text content."
        
        
				<<< leaking memory >>> 
				warnings.warn(message, DeprecationWarning, stacklevel=2)
				<<< leaking memory >>> 
				
				
        return encode_content(data)
```

### Test Results

```json
[
    {
        "request_number": 1,
        "memory_allocations": [
            {
                "filename": "  File \"/Users/alexsandergomes/.pyenv/versions/3.12.10/lib/python3.12/site-packages/httpx/_content.py\", line 206",
                "size_diff_bytes": 624,
                "size_bytes": 624,
                "count_diff": 7,
                "count": 7
            }
        ]
    },
    {
        "request_number": 2,
        "memory_allocations": [
            {
                "filename": "  File \"/Users/alexsandergomes/.pyenv/versions/3.12.10/lib/python3.12/site-packages/httpx/_content.py\", line 206",
                "size_diff_bytes": 552,
                "size_bytes": 1088,
                "count_diff": 6,
                "count": 12
            }
        ]
    },
    {
        "request_number": 3,
        "memory_allocations": [
            {
                "filename": "  File \"/Users/alexsandergomes/.pyenv/versions/3.12.10/lib/python3.12/site-packages/httpx/_content.py\", line 206",
                "size_diff_bytes": 536,
                "size_bytes": 1536,
                "count_diff": 6,
                "count": 17
            }
        ]
    },
    {
        "request_number": 4,
        "memory_allocations": [
            {
                "filename": "  File \"/Users/alexsandergomes/.pyenv/versions/3.12.10/lib/python3.12/site-packages/httpx/_content.py\", line 206",
                "size_diff_bytes": 528,
                "size_bytes": 1976,
                "count_diff": 6,
                "count": 22
            }
        ]
    },
    {
        "request_number": 5,
        "memory_allocations": [
            {
                "filename": "  File \"/Users/alexsandergomes/.pyenv/versions/3.12.10/lib/python3.12/site-packages/httpx/_content.py\", line 206",
                "size_diff_bytes": 520,
                "size_bytes": 2408,
                "count_diff": 6,
                "count": 27
            }
        ]
    }
]
```