### PR TITLE
[Feature] UI - Add Key Type Select in Key Settings

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -37,6 +37,7 @@ export interface KeyResponse {
   budget_duration: string;
   budget_reset_at: string;
   allowed_cache_controls: string[];
+  allowed_routes: string[];
   permissions: Record<string, unknown>;
   model_spend: Record<string, number>;
   model_max_budget: Record<string, number>;

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -42,6 +42,7 @@ describe("KeyEditView", () => {
     budget_duration: "30d",
     budget_reset_at: "never",
     allowed_cache_controls: [],
+    allowed_routes: [],
     permissions: {},
     model_spend: {},
     model_max_budget: {},

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -1,0 +1,106 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { KeyEditView } from "./key_edit_view";
+import { KeyResponse } from "../key_team_helpers/key_list";
+
+// Mock window.matchMedia
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe("KeyEditView", () => {
+  const MOCK_KEY_DATA: KeyResponse = {
+    token: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
+    token_id: "40b7608ea43423400d5b82bb5ee11042bfb2ed4655f05b5992b5abbc2f294931",
+    key_name: "sk-...TUuw",
+    key_alias: "asdasdas",
+    spend: 0,
+    max_budget: 0,
+    expires: "null",
+    models: [],
+    aliases: {},
+    config: {},
+    user_id: "default_user_id",
+    team_id: null,
+    max_parallel_requests: 10,
+    metadata: {
+      logging: [],
+    },
+    tpm_limit: 10,
+    rpm_limit: 10,
+    duration: "30d",
+    budget_duration: "30d",
+    budget_reset_at: "never",
+    allowed_cache_controls: [],
+    permissions: {},
+    model_spend: {},
+    model_max_budget: {},
+    soft_budget_cooldown: false,
+    blocked: false,
+    litellm_budget_table: {},
+    organization_id: null,
+    created_at: "2025-10-29T01:26:41.613000Z",
+    updated_at: "2025-10-29T01:47:33.980000Z",
+    team_spend: 100,
+    team_alias: "",
+    team_tpm_limit: 100,
+    team_rpm_limit: 100,
+    team_max_budget: 100,
+    team_models: [],
+    team_blocked: false,
+    soft_budget: 200,
+    team_model_aliases: {},
+    team_member_spend: 0,
+    team_metadata: {},
+    end_user_id: "default_user_id",
+    end_user_tpm_limit: 10,
+    end_user_rpm_limit: 10,
+    end_user_max_budget: 0,
+    last_refreshed_at: Date.now(),
+    api_key: "sk-...TUuw",
+    user_role: "user",
+    rpm_limit_per_model: {},
+    tpm_limit_per_model: {},
+    user_tpm_limit: 10,
+    user_rpm_limit: 10,
+    user_email: "test@example.com",
+    object_permission: {
+      object_permission_id: "067002ed-3b01-4bb3-b942-cefa400f0049",
+      mcp_servers: [],
+      mcp_access_groups: [],
+      mcp_tool_permissions: {},
+      vector_stores: [],
+    },
+    auto_rotate: false,
+    rotation_interval: undefined,
+    last_rotation_at: undefined,
+    key_rotation_at: undefined,
+  };
+  it("should render", async () => {
+    const { getByText } = render(
+      <KeyEditView
+        keyData={MOCK_KEY_DATA}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
+        accessToken={""}
+        userID={""}
+        userRole={""}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByText("Save Changes")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -199,15 +199,83 @@ export function KeyEditView({
       </Form.Item>
 
       <Form.Item label="Models" name="models">
-        <Select mode="multiple" placeholder="Select models" style={{ width: "100%" }}>
-          {/* Only show All Team Models if team has models */}
-          {availableModels.length > 0 && <Select.Option value="all-team-models">All Team Models</Select.Option>}
-          {/* Show available team models */}
-          {availableModels.map((model) => (
-            <Select.Option key={model} value={model}>
-              {model}
-            </Select.Option>
-          ))}
+        <Form.Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.key_type !== currentValues.key_type || prevValues.models !== currentValues.models
+          }
+        >
+          {({ getFieldValue, setFieldValue }) => {
+            const keyType = getFieldValue("key_type");
+            const isDisabled = keyType === "management" || keyType === "read_only";
+            const models = getFieldValue("models") || [];
+
+            return (
+              <>
+                <Select
+                  mode="multiple"
+                  placeholder="Select models"
+                  style={{ width: "100%" }}
+                  disabled={isDisabled}
+                  value={isDisabled ? [] : models}
+                  onChange={(value) => setFieldValue("models", value)}
+                >
+                  {/* Only show All Team Models if team has models */}
+                  {availableModels.length > 0 && <Select.Option value="all-team-models">All Team Models</Select.Option>}
+                  {availableModels.map((model) => (
+                    <Select.Option key={model} value={model}>
+                      {model}
+                    </Select.Option>
+                  ))}
+                </Select>
+                {isDisabled && (
+                  <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                    Models field is disabled for this key type
+                  </div>
+                )}
+              </>
+            );
+          }}
+        </Form.Item>
+      </Form.Item>
+
+      <Form.Item label="Key Type" name="key_type">
+        <Select
+          placeholder="Select key type"
+          style={{ width: "100%" }}
+          optionLabelProp="label"
+          onChange={(value) => {
+            form.setFieldsValue({ key_type: value });
+            // Clear models field and disable if management or read_only
+            if (value === "management" || value === "read_only") {
+              form.setFieldsValue({ models: [] });
+            }
+          }}
+        >
+          <Select.Option value="default" label="Default">
+            <div style={{ padding: "4px 0" }}>
+              <div style={{ fontWeight: 500 }}>Default</div>
+              <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                Can call LLM API + Management routes
+              </div>
+            </div>
+          </Select.Option>
+          <Select.Option value="llm_api" label="LLM API">
+            <div style={{ padding: "4px 0" }}>
+              <div style={{ fontWeight: 500 }}>LLM API</div>
+              <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                Can call only LLM API routes (chat/completions, embeddings, etc.)
+              </div>
+            </div>
+          </Select.Option>
+          <Select.Option value="management" label="Management">
+            <div style={{ padding: "4px 0" }}>
+              <div style={{ fontWeight: 500 }}>Management</div>
+              <div style={{ fontSize: "11px", color: "#6b7280", marginTop: "2px" }}>
+                Can call only management routes (user/team/key management)
+              </div>
+            </div>
+          </Select.Option>
         </Select>
       </Form.Item>
 
@@ -278,7 +346,10 @@ export function KeyEditView({
       </Form.Item>
 
       <Form.Item label="Allowed Pass Through Routes" name="allowed_passthrough_routes">
-        <Tooltip title={!premiumUser ? "Setting allowed pass through routes by key is a premium feature" : ""} placement="top">
+        <Tooltip
+          title={!premiumUser ? "Setting allowed pass through routes by key is a premium feature" : ""}
+          placement="top"
+        >
           <PassThroughRoutesSelector
             onChange={(values: string[]) => form.setFieldValue("allowed_passthrough_routes", values)}
             value={form.getFieldValue("allowed_passthrough_routes")}
@@ -286,7 +357,8 @@ export function KeyEditView({
             placeholder={
               !premiumUser
                 ? "Premium feature - Upgrade to set allowed pass through routes by key"
-                : Array.isArray(keyData.metadata?.allowed_passthrough_routes) && keyData.metadata.allowed_passthrough_routes.length > 0
+                : Array.isArray(keyData.metadata?.allowed_passthrough_routes) &&
+                    keyData.metadata.allowed_passthrough_routes.length > 0
                   ? `Current: ${keyData.metadata.allowed_passthrough_routes.join(", ")}`
                   : "Select or enter allowed pass through routes"
             }


### PR DESCRIPTION
## UI - Add Key Type Select in Key Settings

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR adds the option to change the key_type in the key settings. In the backend, the key_type is only used to set the "allowed_routes" in the database. The frontend changes map the key_type to the appropriate allowed_routes when doing the update call. See screenshots for more information. 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshots
<img width="1218" height="698" alt="Screenshot 2025-10-29 at 1 30 59 PM" src="https://github.com/user-attachments/assets/c2785d95-75cb-441e-901d-85d699081133" />
<img width="892" height="199" alt="Screenshot 2025-10-29 at 11 35 43 AM" src="https://github.com/user-attachments/assets/bb1d71e3-802a-4e2c-a455-fa03687abb7d" />
<img width="1168" height="335" alt="Screenshot 2025-10-29 at 1 29 36 PM" src="https://github.com/user-attachments/assets/b8262e9d-d197-47f3-a400-94c3dc94a41f" />
<img width="1152" height="318" alt="Screenshot 2025-10-29 at 1 29 53 PM" src="https://github.com/user-attachments/assets/2a1a7e77-815b-46e4-aceb-0c14b619f2c2" />

