### PR TITLE
fix: Handle multiple rate limit types per descriptor and prevent IndexError

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -7,7 +7,6 @@ This is currently in development and not yet ready for production.
 import binascii
 import os
 from datetime import datetime
-from math import floor
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1096,9 +1095,23 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
             if response["overall_code"] == "OVER_LIMIT":
                 # Find which descriptor hit the limit
-                for i, status in enumerate(response["statuses"]):
+                for status in response["statuses"]:
                     if status["code"] == "OVER_LIMIT":
-                        descriptor = descriptors[floor(i / 2)]
+                        # Use descriptor_key from status instead of index mapping
+                        descriptor_key = status["descriptor_key"]
+
+                        # Find the corresponding descriptor by key
+                        matching_descriptor = None
+                        for desc in descriptors:
+                            if desc["key"] == descriptor_key:
+                                matching_descriptor = desc
+                                break
+
+                        if matching_descriptor is None:
+                            # Fallback if we can't find the descriptor
+                            descriptor_value = "unknown"
+                        else:
+                            descriptor_value = matching_descriptor["value"]
 
                         # Calculate reset time (window_start + window_size)
                         now = self._get_current_time().timestamp()
@@ -1115,7 +1128,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                         current_limit = status["current_limit"]
 
                         detail = (
-                            f"Rate limit exceeded for {descriptor['key']}: {descriptor['value']}. "
+                            f"Rate limit exceeded for {descriptor_key}: {descriptor_value}. "
                             f"Limit type: {rate_limit_type}. "
                             f"Current limit: {current_limit}, Remaining: {remaining_display}. "
                             f"Limit resets at: {reset_time_formatted}"
@@ -1435,9 +1448,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         from litellm.types.caching import RedisPipelineIncrementOperation
 
         try:
-            litellm_parent_otel_span: Union[Span, None] = (
-                _get_parent_otel_span_from_kwargs(kwargs)
-            )
+            litellm_parent_otel_span: Union[
+                Span, None
+            ] = _get_parent_otel_span_from_kwargs(kwargs)
             litellm_metadata = kwargs["litellm_params"]["metadata"]
             user_api_key = (
                 litellm_metadata.get("user_api_key") if litellm_metadata else None


### PR DESCRIPTION
## Title

Fix IndexError in parallel request limiter v3 when handling multiple rate limit types per descriptor

## Relevant issues

Fixes #15716 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

- Fixed IndexError in async_pre_call_hook by replacing fragile index mapping (floor(i / 2)) with a robust lookup using descriptor_key in rate limit statuses.
- Updated logic to match statuses to descriptors by key, supporting multiple rate limit types (requests, tokens, max_parallel_requests) per descriptor.
- Added fallback handling for cases where a status's descriptor_key does not match any descriptor, ensuring graceful error messages.
- Added/updated tests to cover scenarios with multiple rate limit types per descriptor and mismatched descriptor keys.

<img width="1473" height="202" alt="image" src="https://github.com/user-attachments/assets/a034fa1c-d072-42a7-a7fc-ba7206d0d69c" />
