### PR TITLE
Changes to fix frequency_penalty and presence_penalty issue for gemini-2.5-pro model

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -221,9 +221,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _supports_penalty_parameters(self, model: str) -> bool:
         unsupported_models = ["gemini-2.5-pro-preview-06-05"]
 
-        for pattern in unsupported_models:
-            if model in pattern:
-                return False
+        for model in unsupported_models:
+            return False
 
         return True
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -220,11 +220,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     
     def _supports_penalty_parameters(self, model: str) -> bool:
         unsupported_models = ["gemini-2.5-pro-preview-06-05"]
-
-        for unsupported_model in unsupported_models:
-            if model == unsupported_model:
-                return False
-
+        if model in unsupported_models:
+            return False
         return True
 
     def get_supported_openai_params(self, model: str) -> List[str]:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -221,8 +221,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _supports_penalty_parameters(self, model: str) -> bool:
         unsupported_models = ["gemini-2.5-pro-preview-06-05"]
 
-        for model in unsupported_models:
-            return False
+        for unsupported_model in unsupported_models:
+            if model == unsupported_model:
+                return False
 
         return True
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -985,7 +985,7 @@ class ProxyLogging:
                     )
                 else:
                     _callback = callback  # type: ignore
-                if _callback is not None and isinstance(_callback, CustomGuardrail):
+                if _callback is not None and isinstance(_callback, CustomGuardrail) and data is not None:
                     result = await self._process_guardrail_callback(
                         callback=_callback,
                         data=data,


### PR DESCRIPTION
## Title
Changes to fix frequency_penalty and presence_penalty issue for gemini-2.5-pro model

## Relevant issues

Fixes: https://github.com/BerriAI/litellm/issues/16031

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Unit tests:
```
=========================== short test summary info ============================
FAILED tests/test_litellm/test_constants.py::test_all_numeric_constants_can_be_overridden - AssertionError: Failed to override APSCHEDULER_COALESCE with environment variable. Expected 2, got True
assert True == 2
FAILED tests/test_litellm/test_utils.py::test_anthropic_web_search_in_model_info - AssertionError: Model anthropic/claude-sonnet-4-5-20250929 should support web search
assert None is True
FAILED tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py::test_mock_create_audio_file - assert 500 == 200
````
I am seeing these 2 test failures happening consistently but those are not related to my changes.



