### PR TITLE
Add Add per model group header forwarding for Bedrock Invoke API

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1774,11 +1774,16 @@ class BaseLLMHTTPHandler:
             provider_specific_header=provider_specific_header,
             custom_llm_provider=custom_llm_provider,
         )
+        forwarded_headers = kwargs.get("headers", None)
+        if forwarded_headers and extra_headers:
+            merged_headers = {**forwarded_headers, **extra_headers}
+        else:
+            merged_headers = forwarded_headers or extra_headers
         (
             headers,
             api_base,
         ) = anthropic_messages_provider_config.validate_anthropic_messages_environment(
-            headers=extra_headers or {},
+            headers=merged_headers or {},
             model=model,
             messages=messages,
             optional_params=anthropic_messages_optional_request_params,


### PR DESCRIPTION
## Title

Add per-model-group header forwarding for Bedrock Invoke API (Messages API)

## Relevant issues

Fixes LIT-1360

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
When calling Anthropic models via the Messages API (`/v1/messages`), custom headers configured via `model_group_settings.forward_client_headers_to_llm_api` were not being forwarded to Bedrock's Invoke API, even though they worked correctly for Chat Completions API with Bedrock's Converse API.

### Solution
Modified `async_anthropic_messages_handler` in `llm_http_handler.py` to:
1. Extract headers from `kwargs["headers"]` (set by proxy's `add_headers_to_llm_call_by_model_group`)
2. Merge them with `extra_headers` from `provider_specific_header`
3. Pass merged headers to `validate_anthropic_messages_environment`

<img width="930" height="713" alt="image" src="https://github.com/user-attachments/assets/5ec0aec6-9f6f-4ce6-b6db-6783708e45da" />
<img width="1062" height="99" alt="Screenshot 2025-10-29 at 11 19 49 AM" src="https://github.com/user-attachments/assets/1be9768c-34a7-4839-8924-9c2a0855d721" />

