### PR TITLE
docs: use custom-llm-provider header in examples

### DIFF
--- a/docs/my-website/docs/files_endpoints.md
+++ b/docs/my-website/docs/files_endpoints.md
@@ -57,7 +57,7 @@ client = OpenAI(
 client.files.create(
     file=wav_data,
     purpose="user_data",
-    extra_body={"custom_llm_provider": "openai"}
+    extra_headers={"custom-llm-provider": "openai"}
 )
 ```
 
@@ -71,7 +71,7 @@ client = OpenAI(
     base_url="http://0.0.0.0:4000/v1"
 )
 
-files = client.files.list(extra_body={"custom_llm_provider": "openai"})
+files = client.files.list(extra_headers={"custom-llm-provider": "openai"})
 print("files=", files)
 ```
 
@@ -85,7 +85,7 @@ client = OpenAI(
     base_url="http://0.0.0.0:4000/v1"
 )
 
-file = client.files.retrieve(file_id="file-abc123", extra_body={"custom_llm_provider": "openai"})
+file = client.files.retrieve(file_id="file-abc123", extra_headers={"custom-llm-provider": "openai"})
 print("file=", file)
 ```
 
@@ -99,7 +99,7 @@ client = OpenAI(
     base_url="http://0.0.0.0:4000/v1"
 )
 
-response = client.files.delete(file_id="file-abc123", extra_body={"custom_llm_provider": "openai"})
+response = client.files.delete(file_id="file-abc123", extra_headers={"custom-llm-provider": "openai"})
 print("delete response=", response)
 ```
 
@@ -113,7 +113,7 @@ client = OpenAI(
     base_url="http://0.0.0.0:4000/v1"
 )
 
-content = client.files.content(file_id="file-abc123", extra_body={"custom_llm_provider": "openai"})
+content = client.files.content(file_id="file-abc123", extra_headers={"custom-llm-provider": "openai"})
 print("content=", content)
 ```
 

--- a/docs/my-website/docs/fine_tuning.md
+++ b/docs/my-website/docs/fine_tuning.md
@@ -62,7 +62,7 @@ client = AsyncOpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000") # base_u
 
 file_name = "openai_batch_completions.jsonl"
 response = await client.files.create(
-    extra_body={"custom_llm_provider": "azure"}, # tell litellm proxy which provider to use
+    extra_headers={"custom-llm-provider": "azure"}, # tell litellm proxy which provider to use
     file=open(file_name, "rb"),
     purpose="fine-tune",
 )
@@ -73,8 +73,8 @@ response = await client.files.create(
 ```shell
 curl http://localhost:4000/v1/files \
     -H "Authorization: Bearer sk-1234" \
+    -H "custom-llm-provider: azure" \
     -F purpose="batch" \
-    -F custom_llm_provider="azure"\
     -F file="@mydata.jsonl"
 ```
 </TabItem>
@@ -92,7 +92,7 @@ curl http://localhost:4000/v1/files \
 ft_job = await client.fine_tuning.jobs.create(
     model="gpt-35-turbo-1106",                   # Azure OpenAI model you want to fine-tune
     training_file="file-abc123",                 # file_id from create file response
-    extra_body={"custom_llm_provider": "azure"}, # tell litellm proxy which provider to use
+    extra_headers={"custom-llm-provider": "azure"}, # tell litellm proxy which provider to use
 )
 ```
 </TabItem>
@@ -103,8 +103,8 @@ ft_job = await client.fine_tuning.jobs.create(
 curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer sk-1234" \
+    -H "custom-llm-provider: azure" \
     -d '{
-    "custom_llm_provider": "azure",
     "model": "gpt-35-turbo-1106",
     "training_file": "file-abc123"
     }'
@@ -215,7 +215,7 @@ curl http://localhost:4000/v1/fine_tuning/jobs \
 # cancel specific fine tuning job
 cancel_ft_job = await client.fine_tuning.jobs.cancel(
     fine_tuning_job_id="123",                          # fine tuning job id
-    extra_body={"custom_llm_provider": "azure"},       # tell litellm proxy which provider to use
+    extra_headers={"custom-llm-provider": "azure"},       # tell litellm proxy which provider to use
 )
 
 print("response from cancel ft job={}".format(cancel_ft_job))
@@ -228,7 +228,7 @@ print("response from cancel ft job={}".format(cancel_ft_job))
 curl -X POST http://localhost:4000/v1/fine_tuning/jobs/ftjob-abc123/cancel \
   -H "Authorization: Bearer sk-1234" \
   -H "Content-Type: application/json" \
-  -d '{"custom_llm_provider": "azure"}'
+  -H "custom-llm-provider: azure"
 ```
 </TabItem>
 
@@ -242,7 +242,7 @@ curl -X POST http://localhost:4000/v1/fine_tuning/jobs/ftjob-abc123/cancel \
 
 ```python
 list_ft_jobs = await client.fine_tuning.jobs.list(
-    extra_query={"custom_llm_provider": "azure"}   # tell litellm proxy which provider to use
+    extra_headers={"custom-llm-provider": "azure"}   # tell litellm proxy which provider to use
 )
 
 print("list of ft jobs={}".format(list_ft_jobs))
@@ -252,9 +252,10 @@ print("list of ft jobs={}".format(list_ft_jobs))
 <TabItem value="curl" label="curl">
 
 ```shell
-curl -X GET 'http://localhost:4000/v1/fine_tuning/jobs?custom_llm_provider=azure' \
+curl -X GET 'http://localhost:4000/v1/fine_tuning/jobs' \
      -H "Content-Type: application/json" \
-     -H "Authorization: Bearer sk-1234"
+     -H "Authorization: Bearer sk-1234" \
+     -H "custom-llm-provider: azure"
 ```
 </TabItem>
 

--- a/docs/my-website/docs/providers/azure/azure.md
+++ b/docs/my-website/docs/providers/azure/azure.md
@@ -834,7 +834,7 @@ client = OpenAI(
 batch_input_file = client.files.create(
     file=open("mydata.jsonl", "rb"),
     purpose="batch",
-    extra_body={"custom_llm_provider": "azure"}
+    extra_headers={"custom-llm-provider": "azure"}
 )
 file_id = batch_input_file.id
 ```
@@ -870,7 +870,7 @@ batch = client.batches.create( # re use client from above
     endpoint="/v1/chat/completions",
     completion_window="24h",
     metadata={"description": "My batch job"},
-    extra_body={"custom_llm_provider": "azure"}
+    extra_headers={"custom-llm-provider": "azure"}
 )
 ```
 
@@ -898,7 +898,7 @@ curl http://localhost:4000/v1/batches \
 ```python
 retrieved_batch = client.batches.retrieve(
     batch.id,
-    extra_query={"custom_llm_provider": "azure"}
+    extra_headers={"custom-llm-provider": "azure"}
 )
 ```
 
@@ -922,7 +922,7 @@ curl http://localhost:4000/v1/batches/batch_abc123 \
 ```python
 cancelled_batch = client.batches.cancel(
     batch.id,
-    extra_body={"custom_llm_provider": "azure"}
+    extra_headers={"custom-llm-provider": "azure"}
 )
 ```
 
@@ -945,7 +945,7 @@ curl http://localhost:4000/v1/batches/batch_abc123/cancel \
 <TabItem value="sdk" label="OpenAI Python SDK">
 
 ```python
-client.batches.list(extra_query={"custom_llm_provider": "azure"})
+client.batches.list(extra_headers={"custom-llm-provider": "azure"})
 ```
 
 </TabItem>

--- a/docs/my-website/docs/providers/google_ai_studio/files.md
+++ b/docs/my-website/docs/providers/google_ai_studio/files.md
@@ -39,7 +39,7 @@ encoded_string = base64.b64encode(wav_data).decode('utf-8')
 file = create_file(
     file=wav_data,
     purpose="user_data",
-    extra_body={"custom_llm_provider": "gemini"},
+    extra_headers={"custom-llm-provider": "gemini"},
     api_key=os.getenv("GEMINI_API_KEY"),
 )
 

--- a/docs/my-website/docs/providers/vertex.md
+++ b/docs/my-website/docs/providers/vertex.md
@@ -2935,7 +2935,7 @@ finetune_settings:
 ft_job = await client.fine_tuning.jobs.create(
     model="gemini-1.0-pro-002",                  # Vertex model you want to fine-tune
     training_file="gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl",                 # file_id from create file response
-    extra_body={"custom_llm_provider": "vertex_ai"}, # tell litellm proxy which provider to use
+    extra_headers={"custom-llm-provider": "vertex_ai"}, # tell litellm proxy which provider to use
 )
 ```
 </TabItem>
@@ -2946,8 +2946,8 @@ ft_job = await client.fine_tuning.jobs.create(
 curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer sk-1234" \
+    -H "custom-llm-provider: vertex_ai" \
     -d '{
-    "custom_llm_provider": "vertex_ai",
     "model": "gemini-1.0-pro-002",
     "training_file": "gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl"
     }'
@@ -2975,9 +2975,7 @@ ft_job = client.fine_tuning.jobs.create(
         "learning_rate_multiplier": 0.1,    # learning_rate_multiplier on Vertex
         "adapter_size": "ADAPTER_SIZE_ONE"  # type: ignore, vertex specific hyperparameter
     },
-    extra_body={
-        "custom_llm_provider": "vertex_ai",
-    },
+    extra_headers={"custom-llm-provider": "vertex_ai"},
 )
 ```
 </TabItem>
@@ -2988,8 +2986,8 @@ ft_job = client.fine_tuning.jobs.create(
 curl http://localhost:4000/v1/fine_tuning/jobs \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer sk-1234" \
+    -H "custom-llm-provider: vertex_ai" \
     -d '{
-    "custom_llm_provider": "vertex_ai",
     "model": "gemini-1.0-pro-002",
     "training_file": "gs://cloud-samples-data/ai-platform/generative_ai/sft_train_data.jsonl",
     "hyperparameters": {

--- a/docs/my-website/docs/providers/vertex_batch.md
+++ b/docs/my-website/docs/providers/vertex_batch.md
@@ -50,7 +50,7 @@ oai_client = OpenAI(
 file_obj = oai_client.files.create(
     file=open("batch_requests.jsonl", "rb"),
     purpose="batch",
-    extra_body={"custom_llm_provider": "vertex_ai"}
+    extra_headers={"custom-llm-provider": "vertex_ai"}
 )
 
 print(f"File uploaded with ID: {file_obj.id}")
@@ -63,9 +63,9 @@ print(f"File uploaded with ID: {file_obj.id}")
 curl --request POST \
   --url http://localhost:4000/v1/files \
   --header 'Content-Type: multipart/form-data' \
+  --header 'custom-llm-provider: vertex_ai' \
   --form purpose=batch \
-  --form file=@batch_requests.jsonl \
-  --form custom_llm_provider=vertex_ai
+  --form file=@batch_requests.jsonl
 ```
 
 </TabItem>
@@ -100,7 +100,7 @@ create_batch_response = oai_client.batches.create(
     completion_window="24h",
     endpoint="/v1/chat/completions",
     input_file_id=batch_input_file_id, # e.g. "gs://my-batch-bucket/litellm-vertex-files/publishers/google/models/gemini-2.5-flash-lite/abc123-def4-5678-9012-34567890abcd"
-    extra_body={"custom_llm_provider": "vertex_ai"}
+    extra_headers={"custom-llm-provider": "vertex_ai"}
 )
 
 print(f"Batch created with ID: {create_batch_response.id}")
@@ -113,11 +113,11 @@ print(f"Batch created with ID: {create_batch_response.id}")
 curl --request POST \
   --url http://localhost:4000/v1/batches \
   --header 'Content-Type: application/json' \
+  --header 'custom-llm-provider: vertex_ai' \
   --data '{         
     "input_file_id": "gs://my-batch-bucket/litellm-vertex-files/publishers/google/models/gemini-2.5-flash-lite/abc123-def4-5678-9012-34567890abcd",
     "endpoint": "/v1/chat/completions",
-    "completion_window": "24h",
-    "custom_llm_provider": "vertex_ai"
+    "completion_window": "24h"
 }'
 ```
 
@@ -162,7 +162,7 @@ Check the status of your batch job. The batch will progress through states: `val
 ```python showLineNumbers title="retrieve_batch.py"
 retrieved_batch = oai_client.batches.retrieve(
     batch_id=create_batch_response.id, # Created batch id, e.g. 7814463557919047680
-    extra_query={"custom_llm_provider": "vertex_ai"}
+    extra_headers={"custom-llm-provider": "vertex_ai"}
 )
 
 print(f"Batch status: {retrieved_batch.status}")
@@ -230,7 +230,7 @@ encoded_file_id = urllib.parse.quote_plus(output_file_id)
 # Get file content
 file_content = oai_client.files.content(
     file_id=encoded_file_id,
-    extra_body={"custom_llm_provider": "vertex_ai"}
+    extra_headers={"custom-llm-provider": "vertex_ai"}
 )
 
 # Process the results


### PR DESCRIPTION
## Title

Adjust documentation to use the "custom-llm-provider" header instead of a field in the request body or query parameter.

## Relevant issues

Add documentation following issue #15522 and PR #15528.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [N/A] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [N/A] I have added a screenshot of my new test passing locally 
- [N/A] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

In PR #15528 support was added to read from the "custom-llm-provider" header, which is more consistent across all requests, supported by both the Python and .NET clients for OpenAI, and easy to manipulate in a proxy. Here we adjust the examples to use this new approach.