### PR TITLE
Add gemini/gemini-embedding-001 pricing entry for Google GenAI API

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10469,6 +10469,16 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gemini/gemini-embedding-001": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "embedding",
+        "output_cost_per_token": 0,
+        "output_vector_size": 3072,
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions"
+    },
     "gemini/gemini-1.5-flash": {
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10477,7 +10477,9 @@
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions"
+        "rpm": 10000,
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions",
+        "tpm": 10000000
     },
     "gemini/gemini-1.5-flash": {
         "input_cost_per_token": 7.5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10469,6 +10469,16 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "gemini/gemini-embedding-001": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 2048,
+        "max_tokens": 2048,
+        "mode": "embedding",
+        "output_cost_per_token": 0,
+        "output_vector_size": 3072,
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions"
+    },
     "gemini/gemini-1.5-flash": {
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10477,7 +10477,9 @@
         "mode": "embedding",
         "output_cost_per_token": 0,
         "output_vector_size": 3072,
-        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions"
+        "rpm": 10000,
+        "source": "https://ai.google.dev/gemini-api/docs/embeddings#model-versions",
+        "tpm": 10000000
     },
     "gemini/gemini-1.5-flash": {
         "input_cost_per_token": 7.5e-08,


### PR DESCRIPTION


## Title

Add "gemini/gemini-embedding-001" cost.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Add pricing and configuration entry for "gemini/gemini-embedding-001" model when called via Google GenAI API (google-genai provider). This mirrors the existing Vertex AI entry ("gemini-embedding-001") but uses the 'gemini' provider instead.

Tested the backup one locally with `LITELLM_LOCAL_MODEL_COST_MAP=True` env var.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
Add "gemini/gemini-embedding-001" entry to `model_prices_and_context_window.json` and `model_prices_and_context_window_backup.json` file.

