### PR TITLE
Fix: Send Gemini API key via x-goog-api-key header with custom api_base

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1743,13 +1743,15 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         messages: List[AllMessageValues],
         optional_params: Dict,
         litellm_params: Dict,
-        api_key: Optional[str] = None,
+        api_key: Optional[Union[str, Dict]] = None,
         api_base: Optional[str] = None,
     ) -> Dict:
         default_headers = {
             "Content-Type": "application/json",
         }
-        if api_key is not None:
+        if isinstance(api_key, dict):
+            default_headers.update(api_key)
+        elif api_key is not None:
             default_headers["Authorization"] = f"Bearer {api_key}"
         if headers is not None:
             default_headers.update(headers)

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -308,7 +308,8 @@ class VertexBase:
                     raise ValueError(
                         "Missing gemini_api_key, please set `GEMINI_API_KEY`"
                     )
-                auth_header = {"x-goog-api-key": gemini_api_key}
+                if gemini_api_key is not None:
+                    auth_header = {"x-goog-api-key": gemini_api_key} 
             else:
                 url = "{}:{}".format(api_base, endpoint)
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -313,7 +313,7 @@ class VertexBase:
                 url = "{}:{}".format(api_base, endpoint)
 
             if stream is True:
-                url = url + ("&alt=sse" if "?" in url else "?alt=sse")
+                url = url + "?alt=sse"
         return auth_header, url
 
     def _get_token_and_url(

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -309,7 +309,7 @@ class VertexBase:
                         "Missing gemini_api_key, please set `GEMINI_API_KEY`"
                     )
                 if gemini_api_key is not None:
-                    auth_header = {"x-goog-api-key": gemini_api_key} 
+                    auth_header = {"x-goog-api-key": gemini_api_key}  # type: ignore[assignment] 
             else:
                 url = "{}:{}".format(api_base, endpoint)
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -308,9 +308,7 @@ class VertexBase:
                     raise ValueError(
                         "Missing gemini_api_key, please set `GEMINI_API_KEY`"
                     )
-                # Append API key as query param for Google AI Studio auth
-                separator = "&" if "?" in url else "?"
-                url = f"{url}{separator}key={gemini_api_key}"
+                auth_header = {"x-goog-api-key": gemini_api_key}
             else:
                 url = "{}:{}".format(api_base, endpoint)
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -308,14 +308,14 @@ class VertexBase:
                     raise ValueError(
                         "Missing gemini_api_key, please set `GEMINI_API_KEY`"
                     )
-                auth_header = (
-                    gemini_api_key  # cloudflare expects api key as bearer token
-                )
+                # Append API key as query param for Google AI Studio auth
+                separator = "&" if "?" in url else "?"
+                url = f"{url}{separator}key={gemini_api_key}"
             else:
                 url = "{}:{}".format(api_base, endpoint)
 
             if stream is True:
-                url = url + "?alt=sse"
+                url = url + ("&alt=sse" if "?" in url else "?alt=sse")
         return auth_header, url
 
     def _get_token_and_url(

--- a/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
+++ b/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
@@ -378,8 +378,8 @@ async def test_gemini_custom_api_base_proxy_integration():
     expected_url = f"{custom_api_base}/models/{model}:{endpoint}"
     assert result_url == expected_url, f"Expected {expected_url}, got {result_url}"
     
-    # Verify the auth header is set to the API key
-    assert auth_header == "test-api-key", f"Expected 'test-api-key', got {auth_header}"
+    # Verify the auth header is set to the API key as a dictionary
+    assert auth_header == {"x-goog-api-key": "test-api-key"}, f"Expected {{'x-goog-api-key': 'test-api-key'}}, got {auth_header}"
     
     print(f"✅ Custom API base URL construction test passed: {result_url}")
     
@@ -398,6 +398,9 @@ async def test_gemini_custom_api_base_proxy_integration():
     # Verify streaming URL has ?alt=sse parameter
     expected_streaming_url = f"{custom_api_base}/models/{model}:{endpoint}?alt=sse"
     assert result_url_streaming == expected_streaming_url, f"Expected {expected_streaming_url}, got {result_url_streaming}"
+    
+    # Verify the auth header is also set correctly for streaming
+    assert auth_header_streaming == {"x-goog-api-key": "test-api-key"}, f"Expected {{'x-goog-api-key': 'test-api-key'}}, got {auth_header_streaming}"
     
     print(f"✅ Custom API base streaming URL test passed: {result_url_streaming}")
     
@@ -462,7 +465,8 @@ async def test_gemini_proxy_config_with_custom_api_base():
         
         expected_url = f"{model_config['litellm_params']['api_base']}/models/{model}:generateContent"
         assert result_url == expected_url, f"Expected {expected_url}, got {result_url} for model {model}"
-        assert auth_header == model_config["litellm_params"]["api_key"], f"Expected API key, got {auth_header} for model {model}"
+        expected_auth_header = {"x-goog-api-key": model_config["litellm_params"]["api_key"]}
+        assert auth_header == expected_auth_header, f"Expected {expected_auth_header}, got {auth_header} for model {model}"
         
         print(f"✅ Model {model} configuration test passed: {result_url}")
     

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -718,8 +718,8 @@ class TestVertexBase:
                 None,
                 "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
                 "gemini-2.5-flash-lite",
-                None,
-                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key"
+                {"x-goog-api-key": "test-api-key"},
+                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent"
             ),
             # Test case 2: Gemini with custom API base and streaming
             (
@@ -731,8 +731,8 @@ class TestVertexBase:
                 None,
                 "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
                 "gemini-2.5-flash-lite",
-                None,
-                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key&alt=sse"
+                {"x-goog-api-key": "test-api-key"},
+                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?alt=sse"
             ),
             # Test case 3: Non-Gemini provider with custom API base
             (
@@ -826,9 +826,9 @@ class TestVertexBase:
         
         # Test various Gemini models with custom API base
         test_cases = [
-            ("gemini-2.5-flash-lite", "generateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key"),
-            ("gemini-2.5-pro", "generateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent?key=test-api-key"),
-            ("gemini-1.5-flash", "streamGenerateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?key=test-api-key"),
+            ("gemini-2.5-flash-lite", "generateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent"),
+            ("gemini-2.5-pro", "generateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent"),
+            ("gemini-1.5-flash", "streamGenerateContent", "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent"),
         ]
         
         for model, endpoint, expected_url in test_cases:
@@ -861,7 +861,7 @@ class TestVertexBase:
             model="gemini-2.5-flash-lite",
         )
         
-        expected_streaming_url = "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key&alt=sse"
+        expected_streaming_url = "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?alt=sse"
         assert result_url_streaming == expected_streaming_url, f"Expected {expected_streaming_url}, got {result_url_streaming}"
         
         # Test with streaming disabled
@@ -876,7 +876,7 @@ class TestVertexBase:
             model="gemini-2.5-flash-lite",
         )
         
-        expected_no_streaming_url = "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key"
+        expected_no_streaming_url = "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent"
         assert result_url_no_streaming == expected_no_streaming_url, f"Expected {expected_no_streaming_url}, got {result_url_no_streaming}"
 
     @pytest.mark.parametrize(
@@ -892,8 +892,8 @@ class TestVertexBase:
                 None,
                 "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
                 "gemini-2.5-flash-lite",
-                None,
-                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key"
+                {"x-goog-api-key": "test-api-key"},
+                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent"
             ),
             # Test case 2: Gemini with custom API base and streaming
             (
@@ -905,8 +905,8 @@ class TestVertexBase:
                 None,
                 "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent",
                 "gemini-2.5-flash-lite",
-                None,
-                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=test-api-key&alt=sse"
+                {"x-goog-api-key": "test-api-key"},
+                "https://proxy.example.com/generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?alt=sse"
             ),
         ],
     )


### PR DESCRIPTION
### Title
Fix: Send Gemini API key via x-goog-api-key header with custom api_base

### Relevant issues
Fixes LIT-1384

### Pre-Submission checklist
- [x] I have Added testing in the `tests/litellm/` directory, Adding at least 1 test is a hard requirement
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

### Type
- 🐛 Bug Fix
- ✅ Test

### Changes
- `litellm/llms/vertex_ai/vertex_llm_base.py`
  - For `custom_llm_provider == "gemini"` with a custom `api_base`, construct the URL without `?key=...` and return `auth_header={"x-goog-api-key": <key>}`.

- `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
  - `validate_environment` now accepts a dict `api_key` (e.g., `{"x-goog-api-key": ...}`) and merges it into headers.

- Tests updated to reflect header-based auth:
  - `tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py`
    - Expect `{"x-goog-api-key": "test-api-key"}` in `expected_auth_header`.
    - URLs no longer include `?key=...`; only `?alt=sse` is added for streaming cases.
    - Added a focused test verifying header presence and correct URL formation.


**Gemini with API base**:
<img width="950" height="733" alt="image" src="https://github.com/user-attachments/assets/efba3ea5-6ca6-4fec-955d-24b864122781" />


**Gemini without API base**:
<img width="950" height="733" alt="image" src="https://github.com/user-attachments/assets/ca407f87-1031-44bc-86a1-a984dba7922e" />
