### PR TITLE
Fix: Moderations endpoint now respects `api_base` configuration parameter

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5303,10 +5303,10 @@ def moderation(
 
     openai_client = kwargs.get("client", None)
     if openai_client is None:
-        client_kwargs = {"api_key": api_key}
         if api_base is not None:
-            client_kwargs["base_url"] = api_base
-        openai_client = openai.OpenAI(**client_kwargs)
+            openai_client = openai.OpenAI(api_key=api_key, base_url=api_base)
+        else:
+            openai_client = openai.OpenAI(api_key=api_key)
 
     if model is not None:
         response = openai_client.moderations.create(input=input, model=model)

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -264,7 +264,6 @@ async def test_moderation_endpoint(model):
 async def test_moderation_endpoint_with_api_base():
     """
     Test that the moderation endpoint respects api_base configuration
-    Regression test for: https://github.com/BerriAI/litellm/issues/XXXX
     """
     from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -260,6 +260,62 @@ async def test_moderation_endpoint(model):
     print("moderation response: ", response)
 
 
+@pytest.mark.asyncio()
+async def test_moderation_endpoint_with_api_base():
+    """
+    Test that the moderation endpoint respects api_base configuration
+    Regression test for: https://github.com/BerriAI/litellm/issues/XXXX
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    custom_api_base = "https://us.api.openai.com/v1"
+    
+    router = Router(
+        model_list=[
+            {
+                "model_name": "openai/omni-moderation-latest",
+                "litellm_params": {
+                    "model": "openai/omni-moderation-latest",
+                    "api_base": custom_api_base,
+                    "api_key": "test-key"
+                },
+            },
+        ]
+    )
+
+    # Mock the OpenAI client to verify api_base is passed
+    with patch("litellm.main.openai_chat_completions._get_openai_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "modr-123",
+            "model": "omni-moderation-latest",
+            "results": [
+                {
+                    "flagged": False,
+                    "categories": {},
+                    "category_scores": {},
+                    "category_applied_input_types": {}
+                }
+            ]
+        }
+        mock_client.moderations.create = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+        
+        response = await router.amoderation(
+            model="openai/omni-moderation-latest",
+            input="hello this is a test"
+        )
+        
+        # Verify that _get_openai_client was called with the custom api_base
+        mock_get_client.assert_called()
+        call_kwargs = mock_get_client.call_args.kwargs
+        assert call_kwargs.get("api_base") == custom_api_base, \
+            f"Expected api_base to be {custom_api_base}, but got {call_kwargs.get('api_base')}"
+        
+        print(f"✓ Moderation endpoint correctly uses api_base: {custom_api_base}")
+
+
 @pytest.mark.parametrize("sync_mode", [True, False])
 @pytest.mark.asyncio
 async def test_aaaaatext_completion_endpoint(model_list, sync_mode):


### PR DESCRIPTION
## Title

Fix: Moderations endpoint now respects `api_base` configuration parameter

## Relevant issues

Fixes LIT-1385
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
The Moderations endpoint (`/v1/moderations`) was not respecting the `api_base` configuration parameter. When making requests with a custom `api_base` in the config (e.g., for OpenAI Data Residency using `https://us.api.openai.com`), requests were still being sent to the default OpenAI endpoint.

### Root Cause
Both the synchronous `moderation()` and asynchronous `amoderation()` functions in `litellm/main.py` were not passing the `api_base` parameter when creating the OpenAI client.

### Solution

**1. Fixed `amoderation()` (async function) - Line 5335-5366**
- Moved `optional_params` extraction and `get_llm_provider()` call before creating the OpenAI client
- Added `api_base=optional_params.api_base or _dynamic_api_base` parameter when calling `_get_openai_client()`

**2. Fixed `moderation()` (sync function) - Line 5290-5319**
- Extracted `api_base` from kwargs
- Conditionally added `base_url` parameter to OpenAI client initialization when `api_base` is provided

**3. Added regression test - `test_moderation_endpoint_with_api_base()`**
- Location: `tests/router_unit_tests/test_router_endpoints.py`
- Verifies that custom `api_base` is correctly passed to the OpenAI client
- Uses mocking to ensure the parameter flows through correctly

```
- model_name: "*"
    litellm_params:
      model: "openai/*"
      api_base: http://host.docker.internal:8080/
      api_key: dummy
  - model_name: "openai/*"
    litellm_params:
      model: "openai/*"
      api_base: http://host.docker.internal:8080/
      api_key: dummy
```
```
curl http://localhost:4000/v1/moderations \  
 -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $API_KEY" \
 -d '{
  "model": "openai/omni-moderation-latest",
  "input": "...text to classify goes here..."
 }'
```
**It shows it is trying to use http://host.docker.internal:8080/**
<img width="675" height="92" alt="image" src="https://github.com/user-attachments/assets/863cb24e-aee5-4c91-8687-4325d8216341" />
