### PR TITLE
fix: Add cooldown for 400 Bad Request errors

### DIFF
--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -25,9 +25,8 @@ from .router_callbacks.track_deployment_metrics import (
 )
 
 if TYPE_CHECKING:
-    from opentelemetry.trace import Span as _Span
-
     from litellm.router import Router as _Router
+    from opentelemetry.trace import Span as _Span
 
     LitellmRouter = _Router
     Span = Union[_Span, Any]
@@ -79,6 +78,10 @@ def _is_cooldown_required(
                 return True
 
             elif exception_status == 404:
+                return True
+
+            elif exception_status == 400:
+                # Cool down 400 Bad Request Errors (e.g., anthropic credit balance too low)
                 return True
 
             else:


### PR DESCRIPTION
## Summary
Fixes an issue where deployments returning 400 Bad Request errors (specifically Anthropic when credit balance is too low) are not automatically cooled down, causing the router to continue sending traffic to failing deployments.

## Key Changes

**Added 400 status code handling**
- Enables cooldown for 400 errors in `_is_cooldown_required()` function
- Location: `litellm/router_utils/cooldown_handlers.py:83-85`

**Code quality improvement**
- Alphabetized TYPE_CHECKING imports for consistency

## Impact

✅ **Primary fix:** Anthropic deployments with insufficient credits now trigger cooldown instead of receiving continuous failed requests

✅ **Prevents routing traffic to deployments returning 400 errors** due to:
- Credit balance issues
- Quota limits
- Other account-level problems

✅ **Improves router reliability** by reducing failed request rates

✅ **Maintains service availability** through automatic cooldown of problematic deployments

## Background
When Anthropic accounts have low credit balance, the API returns a 400 Bad Request error. Without this change, the router continued routing traffic to these failing deployments, resulting in repeated failures.