### PR TITLE
feat: handle Deepgram detected language when available

### DIFF
--- a/litellm/llms/deepgram/audio_transcription/transformation.py
+++ b/litellm/llms/deepgram/audio_transcription/transformation.py
@@ -58,7 +58,7 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
     ) -> AudioTranscriptionRequestData:
         """
         Processes the audio file input based on its type and returns AudioTranscriptionRequestData.
-        
+
         For Deepgram, the binary audio data is sent directly as the request body.
 
         Args:
@@ -69,12 +69,11 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         """
         # Use common utility to process the audio file
         processed_audio = process_audio_file(audio_file)
-        
+
         # Return structured data with binary content and no files
         # For Deepgram, we send binary data directly as request body
         return AudioTranscriptionRequestData(
-            data=processed_audio.file_content,
-            files=None
+            data=processed_audio.file_content, files=None
         )
 
     def transform_audio_transcription_response(
@@ -99,9 +98,11 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
 
             # Add additional metadata matching OpenAI format
             response["task"] = "transcribe"
-            response["language"] = (
-                "english"  # Deepgram auto-detects but doesn't return language
-            )
+
+            # Use detected_language if available, otherwise default to "en"
+            detected_language = first_channel.get("detected_language")
+            response["language"] = detected_language if detected_language else "en"
+
             response["duration"] = response_json["metadata"]["duration"]
 
             # Transform words to match OpenAI format
@@ -150,7 +151,6 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
 
         return url
 
-
     def _format_param_value(self, value) -> str:
         """
         Formats a parameter value for use in query string.
@@ -180,7 +180,7 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         provider_specific_params = self.get_provider_specific_params(
             optional_params=optional_params,
             model=model,
-            openai_params=self.get_supported_openai_params(model)
+            openai_params=self.get_supported_openai_params(model),
         )
 
         for key, value in provider_specific_params.items():

--- a/tests/test_litellm/llms/deepgram/audio_transcription/test_deepgram_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/deepgram/audio_transcription/test_deepgram_audio_transcription_transformation.py
@@ -58,13 +58,13 @@ def test_audio_file_handling(fixture_name, request):
         optional_params={},
         litellm_params={},
     )
-    
+
     # Check that result is AudioTranscriptionRequestData
     assert isinstance(result, AudioTranscriptionRequestData)
-    
+
     # Check that data matches expected output
     assert result.data == expected_output
-    
+
     # Check that files is None for Deepgram (binary data)
     assert result.files is None
 
@@ -201,4 +201,40 @@ def test_get_complete_url_with_string_values():
     assert "tier=enhanced" in url
     assert "version=latest" in url
     assert "punctuate=true" in url
+    assert url.startswith("https://api.deepgram.com/v1/listen?")
+
+
+def test_get_complete_url_with_detect_language():
+    """Test URL generation with detect_language parameter"""
+    handler = DeepgramAudioTranscriptionConfig()
+    url = handler.get_complete_url(
+        api_base=None,
+        api_key=None,
+        model="nova-2",
+        optional_params={"detect_language": True},
+        litellm_params={},
+    )
+    expected_url = "https://api.deepgram.com/v1/listen?model=nova-2&detect_language=true"
+    assert url == expected_url
+
+
+def test_get_complete_url_with_detect_language_and_other_params():
+    """Test URL generation with detect_language and other parameters"""
+    handler = DeepgramAudioTranscriptionConfig()
+    url = handler.get_complete_url(
+        api_base=None,
+        api_key=None,
+        model="nova-2",
+        optional_params={
+            "detect_language": True,
+            "punctuate": True,
+            "diarize": False,
+        },
+        litellm_params={},
+    )
+    # URL should contain all parameters
+    assert "model=nova-2" in url
+    assert "detect_language=true" in url
+    assert "punctuate=true" in url
+    assert "diarize=false" in url
     assert url.startswith("https://api.deepgram.com/v1/listen?")


### PR DESCRIPTION
## Handle Deepgram detected language when available

For now, the language property is arbitrary filled with "english" value (see [here](https://github.com/BerriAI/litellm/blob/6fc33add9a6538b2cfa58e7ee87152e39a997e92/litellm/llms/deepgram/audio_transcription/transformation.py#L103)).

The Deepgram API is returning this information as `detected_langage` (see [here](https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded#response.body.ListenV1Response.results.channels.detected_language)) when using `detect_language=true` parameter in the query.

This property should be used if present in the response.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/16088

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1979" height="477" alt="image" src="https://github.com/user-attachments/assets/9e27937e-d195-4f9e-805a-520927d197d8" />
<img width="2148" height="448" alt="image" src="https://github.com/user-attachments/assets/d5ec551d-566f-46f8-9276-92ee27206845" />


## Type

🐛 Bug Fix
✅ Test

## Changes


