### PR TITLE
fix: resolve memory accumulation caused by Pydantic 2.11+ deprecation warnings

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -2,6 +2,9 @@
 import warnings
 
 warnings.filterwarnings("ignore", message=".*conflict with protected namespace.*")
+# Suppress Pydantic 2.11+ deprecation warning about accessing model_fields on instances
+# This warning can accumulate during streaming and cause memory leaks
+warnings.filterwarnings("ignore", message=".*Accessing the.*attribute on the instance is deprecated.*")
 ### INIT VARIABLES ######################
 import threading
 import os

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1595,7 +1595,8 @@ class BaseTokenUsageProcessor:
                     combined.prompt_tokens_details = PromptTokensDetailsWrapper()
 
                 # Check what keys exist in the model's prompt_tokens_details
-                for attr in usage.prompt_tokens_details.model_fields:
+                # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
+                for attr in type(usage.prompt_tokens_details).model_fields:
                     if (
                         hasattr(usage.prompt_tokens_details, attr)
                         and not attr.startswith("_")
@@ -1626,7 +1627,8 @@ class BaseTokenUsageProcessor:
                     )
 
                 # Check what keys exist in the model's completion_tokens_details
-                for attr in usage.completion_tokens_details.model_fields:
+                # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
+                for attr in type(usage.completion_tokens_details).model_fields:
                     if not attr.startswith("_") and not callable(
                         getattr(usage.completion_tokens_details, attr)
                     ):

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -234,7 +234,8 @@ def preserve_upstream_non_openai_attributes(
     """
     Preserve non-OpenAI attributes from the original chunk.
     """
-    expected_keys = set(model_response.model_fields.keys()).union({"usage"})
+    # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
+    expected_keys = set(type(model_response).model_fields.keys()).union({"usage"})
     for key, value in original_chunk.model_dump().items():
         if key not in expected_keys:
             setattr(model_response, key, value)

--- a/litellm/litellm_core_utils/model_response_utils.py
+++ b/litellm/litellm_core_utils/model_response_utils.py
@@ -46,7 +46,8 @@ def is_model_response_stream_empty(model_response: ModelResponseStream) -> bool:
                 return False
 
     # Check for any non-base fields that are set
-    for model_response_field in model_response.model_fields.keys():
+    # Access model_fields on the class, not the instance, to avoid Pydantic 2.11+ deprecation warnings
+    for model_response_field in type(model_response).model_fields.keys():
         # Skip base fields that are always set
         if model_response_field in BASE_FIELDS:
             continue


### PR DESCRIPTION
## Title

fix: resolve memory accumulation caused by Pydantic 2.11+ deprecation warnings

## Relevant issues

addresses #12685

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Access model_fields on class instead of instance to avoid deprecation warnings
- Add warning filter to suppress Pydantic instance attribute access warnings


## Results

**Before**

```text
======================================================================
Router acompletion Streaming Memory Leak Detection Test
======================================================================
Warming up...
Warm-up complete. Starting measured phase...

Batch 1/6: Current=6.90 MB | Peak=11.70 MB
Batch 2/6: Current=11.11 MB | Peak=12.00 MB
Batch 3/6: Current=11.53 MB | Peak=12.42 MB
Batch 4/6: Current=11.97 MB | Peak=12.86 MB
Batch 5/6: Current=12.40 MB | Peak=13.29 MB
Batch 6/6: Current=12.84 MB | Peak=13.72 MB

[INFO] Memory snapshots for test 'Router acompletion Streaming Memory Leak Detection Test' saved to: memory_snapshots/router_acompletion_streaming_memory_leak_detection_test.json
       Total requests captured: 300 (34 detailed, 266 lightweight)
       File size: 0.09 MB

======================================================================
Memory Growth Analysis
======================================================================
Memory std dev: 2.157 MB (19.4% coefficient of variation)
Initial avg: 9.85 MB
Final avg:   11.97 MB
Growth:      2.12 MB (21.5%)

================================================================================
MEMORY LEAK SOURCE ANALYSIS
================================================================================
Test: Router acompletion Streaming Memory Leak Detection Test
Found 5 leaking source(s) with significant growth:

1. /Users/alexsandergomes/miniforge3/lib/python3.12/site-packages/pydantic/_internal/_utils.py:425
   Growth: 0.753 MB (579.2%)
   Batch 1: 0.130 MB → Batch 6: 0.883 MB
   Tracked across 34 batch(es)

2. /Users/alexsandergomes/miniforge3/lib/python3.12/site-packages/pydantic/warnings.py:38
   Growth: 0.743 MB (585.0%)
   Batch 1: 0.127 MB → Batch 6: 0.870 MB
   Tracked across 34 batch(es)

3. /Users/alexsandergomes/miniforge3/lib/python3.12/site-packages/pydantic/_internal/_utils.py:426
   Growth: 0.546 MB (587.1%)
   Batch 1: 0.093 MB → Batch 6: 0.639 MB
   Tracked across 34 batch(es)

4. /Users/alexsandergomes/Documents/litellm/litellm/types/utils.py:764
   Growth: 0.365 MB (467.9%)
   Batch 1: 0.078 MB → Batch 6: 0.443 MB
   Tracked across 32 batch(es)

5. /Users/alexsandergomes/miniforge3/lib/python3.12/linecache.py:142
   Growth: 0.323 MB (66.2%)
   Batch 1: 0.488 MB → Batch 6: 0.811 MB
   Tracked across 33 batch(es)

```

**After**

```text
======================================================================
Router acompletion Streaming Memory Leak Detection Test
======================================================================
Warming up...
Warm-up complete. Starting measured phase...

Batch 1/6: Current=5.95 MB | Peak=11.69 MB
Batch 2/6: Current=9.62 MB | Peak=11.69 MB
Batch 3/6: Current=9.61 MB | Peak=11.69 MB
Batch 4/6: Current=9.61 MB | Peak=11.69 MB
Batch 5/6: Current=9.61 MB | Peak=11.69 MB
Batch 6/6: Current=9.61 MB | Peak=11.69 MB

[INFO] Memory snapshots for test 'Router acompletion Streaming Memory Leak Detection Test' saved to: memory_snapshots/router_acompletion_streaming_memory_leak_detection_test.json
       Total requests captured: 300 (33 detailed, 267 lightweight)
       File size: 0.09 MB

======================================================================
Memory Growth Analysis
======================================================================
Memory std dev: 1.495 MB (16.6% coefficient of variation)
Initial avg: 8.39 MB
Final avg:   9.61 MB
Growth:      1.22 MB (14.5%)
Memory stabilized — no leak detected
Samples (last 10): ['5.95MB', '9.62MB', '9.61MB', '9.61MB', '9.61MB', '9.61MB']
======================================================================

[TEST] ✓ Router instance ID remained consistent throughout: 4565069328
PASSED
```

**Observations**

- The periodic memory spikes still need to be addressed.
- Memory leaks when provider HTTP calls fail — needs a fix.
- Proxy server still sees memory leaks in production leading to OOM - needs fix.

## Test Results

<img width="1432" height="198" alt="Screenshot 2025-10-30 at 5 50 58 PM" src="https://github.com/user-attachments/assets/27a93bcd-cd67-4974-b0f9-bc32aa100c34" />

- Failures seem unrelated.
