### PR TITLE
Fix azure doesn't accept extra body param

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1110,7 +1110,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     "base_model"
                 )
 
-            data = {"model": model, "prompt": prompt, **optional_params}
+            # Azure image generation API doesn't support extra_body parameter
+            extra_body = optional_params.pop("extra_body", {})
+            flattened_params = {**optional_params, **extra_body}
+            
+            data = {"model": model, "prompt": prompt, **flattened_params}
             max_retries = data.pop("max_retries", 2)
             if not isinstance(max_retries, int):
                 raise AzureOpenAIError(

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -40,7 +40,7 @@ def test_azure_image_generation_flattens_extra_body():
     Azure's image generation API doesn't support the extra_body parameter,
     so we need to flatten any parameters in extra_body to the top level.
     
-    This test verifies the fix for: https://github.com/BerriAI/litellm/issues/...
+    This test verifies the fix for: https://github.com/BerriAI/litellm/issues/16059
     Where partial_images and stream parameters were incorrectly sent in extra_body.
     """
     # Test 1: Verify get_optional_params_image_gen puts extra params in extra_body

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -11,10 +11,12 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 import litellm
+from litellm.llms.azure.azure import AzureChatCompletion
 from litellm.llms.azure.image_generation import (
     AzureDallE3ImageGenerationConfig,
     get_azure_image_generation_config,
 )
+from litellm.utils import get_optional_params_image_gen
 
 
 @pytest.mark.parametrize(
@@ -29,3 +31,59 @@ def test_azure_image_generation_config(received_model, expected_config):
     assert isinstance(
         get_azure_image_generation_config(received_model), expected_config
     )
+
+
+def test_azure_image_generation_flattens_extra_body():
+    """
+    Test that Azure image generation correctly flattens extra_body parameters.
+    
+    Azure's image generation API doesn't support the extra_body parameter,
+    so we need to flatten any parameters in extra_body to the top level.
+    
+    This test verifies the fix for: https://github.com/BerriAI/litellm/issues/...
+    Where partial_images and stream parameters were incorrectly sent in extra_body.
+    """
+    # Test 1: Verify get_optional_params_image_gen puts extra params in extra_body
+    optional_params = get_optional_params_image_gen(
+        model="gpt-image-1",
+        n=1,
+        size="1024x1024",
+        custom_llm_provider="azure",
+        partial_images=2,
+        stream=True
+    )
+    
+    assert "extra_body" in optional_params
+    assert "partial_images" in optional_params["extra_body"]
+    assert "stream" in optional_params["extra_body"]
+    assert optional_params["extra_body"]["partial_images"] == 2
+    assert optional_params["extra_body"]["stream"] is True
+    
+    # Test 2: Verify Azure flattens extra_body when building request data
+    # Simulate what happens in Azure's image_generation method
+    test_optional_params = {
+        "n": 1,
+        "size": "1024x1024",
+        "extra_body": {
+            "partial_images": 2,
+            "stream": True,
+            "custom_param": "test_value"
+        }
+    }
+    
+    # This is what the Azure image_generation method does
+    extra_body = test_optional_params.pop("extra_body", {})
+    flattened_params = {**test_optional_params, **extra_body}
+    
+    data = {"model": "gpt-image-1", "prompt": "A cute sea otter", **flattened_params}
+    
+    # Verify the final data structure
+    assert "extra_body" not in data, "extra_body should NOT be in the final data dict"
+    assert "partial_images" in data, "partial_images should be at top level"
+    assert "stream" in data, "stream should be at top level"
+    assert "custom_param" in data, "custom_param should be at top level"
+    assert data["partial_images"] == 2
+    assert data["stream"] is True
+    assert data["custom_param"] == "test_value"
+    assert data["n"] == 1
+    assert data["size"] == "1024x1024"


### PR DESCRIPTION
## Title

Fix Azure image generation `extra_body` parameter error for partial_images and stream

## Relevant issues

Fixes #16059

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem:**
Azure's image generation API doesn't support the `extra_body` parameter. When users tried to use `partial_images` or `stream` parameters, the request failed with:
```
BadRequestError: Unknown parameter: 'extra_body'
```

**Root Cause:**
- `get_optional_params_image_gen()` correctly places non-standard OpenAI params into `extra_body` for Azure
- However, Azure's API expects all parameters at the top level of the request body, not nested in `extra_body`

**Solution:**
Modified Azure's `image_generation()` and `aimage_generation()` methods in `litellm/llms/azure/azure.py` to flatten `extra_body` parameters to the top level before sending the request.


**Before**
<img width="2122" height="222" alt="image" src="https://github.com/user-attachments/assets/508c9a8c-3a50-4eca-9942-6ff034e6dd38" />

**After**
<img width="1061" height="111" alt="Screenshot 2025-10-31 at 9 17 08 AM" src="https://github.com/user-attachments/assets/8669bc7e-8881-45c2-8674-72b805af1834" />

