### PR TITLE
Add Gemini Batch Passthrough Cost Tracking Support

### DIFF
--- a/litellm/llms/gemini/batches/__init__.py
+++ b/litellm/llms/gemini/batches/__init__.py
@@ -1,0 +1,5 @@
+# Gemini Batch API implementation
+from .handler import GeminiBatchesAPI
+
+__all__ = ["GeminiBatchesAPI"]
+

--- a/litellm/llms/gemini/batches/handler.py
+++ b/litellm/llms/gemini/batches/handler.py
@@ -1,0 +1,186 @@
+"""
+Gemini Batch API Handler
+
+Implementation for Google AI Studio Batch API endpoints
+API Ref: https://ai.google.dev/gemini-api/docs/batch-mode
+"""
+import json
+import os
+from typing import Any, Coroutine, Dict, Optional, Union
+
+import httpx
+
+from litellm.llms.custom_httpx.http_handler import (
+    _get_httpx_client,
+    get_async_httpx_client,
+)
+from litellm.types.utils import LiteLLMBatch
+
+
+class GeminiBatchesAPI:
+    """
+    Gemini Batch API methods:
+    - retrieve_batch() - Retrieve batch job status and results
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def retrieve_batch(
+        self,
+        _is_async: bool,
+        batch_id: str,
+        api_base: Optional[str],
+        api_key: str,
+        timeout: Union[float, httpx.Timeout],
+    ) -> Union[LiteLLMBatch, Coroutine[Any, Any, LiteLLMBatch]]:
+        """
+        Retrieve a Gemini batch job via Google AI Studio API
+        
+        Args:
+            _is_async: Whether to use async call
+            batch_id: Batch ID (e.g., "batches/abc123")
+            api_base: API base URL
+            api_key: Gemini API key
+            timeout: Request timeout
+            
+        Returns:
+            LiteLLMBatch object
+        """
+        # Construct the URL
+        # GET https://generativelanguage.googleapis.com/v1beta/batches/{batch_id}?key={api_key}
+        batch_url = f"{api_base}/v1beta/{batch_id}"
+        
+        headers = {
+            "Content-Type": "application/json",
+        }
+        
+        params = {
+            "key": api_key,
+        }
+        
+        if _is_async:
+            return self._async_retrieve_batch(
+                batch_url=batch_url,
+                headers=headers,
+                params=params,
+                timeout=timeout,
+            )
+        
+        # Sync call
+        sync_handler = _get_httpx_client()
+        
+        response = sync_handler.get(
+            url=batch_url,
+            headers=headers,
+            params=params,
+            timeout=timeout,
+        )
+        
+        if response.status_code != 200:
+            raise Exception(
+                f"Error retrieving Gemini batch: {response.status_code} {response.text}"
+            )
+        
+        _json_response = response.json()
+        
+        # Transform Gemini batch response to LiteLLMBatch format
+        return self._transform_gemini_batch_response(_json_response)
+
+    async def _async_retrieve_batch(
+        self,
+        batch_url: str,
+        headers: Dict[str, str],
+        params: Dict[str, str],
+        timeout: Union[float, httpx.Timeout],
+    ) -> LiteLLMBatch:
+        """Async version of Gemini batch retrieval"""
+        async_client = get_async_httpx_client()
+        
+        response = await async_client.get(
+            url=batch_url,
+            headers=headers,
+            params=params,
+            timeout=timeout,
+        )
+        
+        if response.status_code != 200:
+            raise Exception(
+                f"Error retrieving Gemini batch: {response.status_code} {response.text}"
+            )
+        
+        _json_response = response.json()
+        
+        # Transform Gemini batch response to LiteLLMBatch format
+        return self._transform_gemini_batch_response(_json_response)
+
+    def _transform_gemini_batch_response(self, gemini_response: dict) -> LiteLLMBatch:
+        """
+        Transform Gemini batch API response to LiteLLMBatch format
+        
+        Args:
+            gemini_response: Raw Gemini batch API response
+            
+        Returns:
+            LiteLLMBatch object
+        """
+        # Map Gemini states to OpenAI batch states
+        state_mapping = {
+            "JOB_STATE_PENDING": "validating",
+            "JOB_STATE_RUNNING": "in_progress",
+            "JOB_STATE_SUCCEEDED": "completed",
+            "JOB_STATE_FAILED": "failed",
+            "JOB_STATE_CANCELLED": "cancelled",
+        }
+        
+        batch_state = gemini_response.get("state", {}).get("name", "JOB_STATE_PENDING")
+        openai_status = state_mapping.get(batch_state, "validating")
+        
+        # Extract timestamps
+        create_time = gemini_response.get("createTime", "")
+        # Convert ISO timestamp to unix timestamp if present
+        created_at = 0
+        if create_time:
+            from datetime import datetime as dt
+
+            try:
+                created_at = int(
+                    dt.fromisoformat(create_time.replace("Z", "+00:00")).timestamp()
+                )
+            except:
+                pass
+        
+        # Check if this is a file-based or inline batch
+        dest = gemini_response.get("dest", {})
+        output_file_id = None
+        
+        if "fileName" in dest:
+            # File-based batch
+            output_file_id = dest.get("fileName")
+        
+        # Create LiteLLMBatch object
+        batch = LiteLLMBatch(
+            id=gemini_response.get("name", ""),
+            object="batch",
+            endpoint="/v1/chat/completions",  # Gemini batches are chat completions
+            errors=None,
+            input_file_id=gemini_response.get("src", {}).get("fileName", ""),
+            completion_window="24h",
+            status=openai_status,
+            output_file_id=output_file_id,
+            error_file_id=None,
+            created_at=created_at,
+            in_progress_at=None,
+            expires_at=None,
+            finalizing_at=None,
+            completed_at=None,
+            failed_at=None,
+            expired_at=None,
+            cancelling_at=None,
+            cancelled_at=None,
+            request_counts=None,
+            metadata=gemini_response.get("metadata", {}),
+        )
+        
+        return batch
+

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/gemini_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/gemini_passthrough_logging_handler.py
@@ -12,6 +12,7 @@ from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as GeminiModelResponseIterator,
 )
 from litellm.proxy._types import PassThroughEndpointLoggingTypedDict
+from litellm.types.llms.openai import LiteLLMBatch
 from litellm.types.utils import (
     ModelResponse,
     TextCompletionResponse,
@@ -39,6 +40,20 @@ class GeminiPassthroughLoggingHandler:
         request_body: dict,
         **kwargs,
     ) -> PassThroughEndpointLoggingTypedDict:
+        # Handle batch endpoints
+        if "batchGenerateContent" in url_route:
+            return GeminiPassthroughLoggingHandler.batch_handler(
+                httpx_response=httpx_response,
+                logging_obj=logging_obj,
+                url_route=url_route,
+                result=result,
+                start_time=start_time,
+                end_time=end_time,
+                cache_hit=cache_hit,
+                **kwargs,
+            )
+        
+        # Handle generateContent endpoints
         if "generateContent" in url_route:
             model = GeminiPassthroughLoggingHandler.extract_model_from_url(url_route)
 
@@ -202,3 +217,271 @@ class GeminiPassthroughLoggingHandler:
         logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider
         logging_obj.model_call_details["response_cost"] = response_cost
         return kwargs
+
+    @staticmethod
+    def batch_handler(  # noqa: PLR0915
+        httpx_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        url_route: str,
+        result: str,
+        start_time: datetime,
+        end_time: datetime,
+        cache_hit: bool,
+        **kwargs,
+    ) -> PassThroughEndpointLoggingTypedDict:
+        """
+        Handle Gemini batch API passthrough logging.
+        Creates a managed object for cost tracking when batch job is successfully created.
+        Supports both file-based and inline batch types.
+        """
+        from litellm._uuid import uuid
+        from litellm.types.llms.openai import LiteLLMBatch, Choices
+        from litellm.proxy._types import SpecialEnums
+        import base64
+
+        try:
+            _json_response = httpx_response.json()
+            
+            # Only handle successful batch job creation/retrieval (POST/GET requests)
+            if httpx_response.status_code == 200 and "name" in _json_response:
+                # Extract batch ID and model from the response
+                batch_id = _json_response.get("name", "")  # e.g., "batches/abc123"
+                
+                model_name = GeminiPassthroughLoggingHandler._extract_model_from_batch_response(_json_response, url_route)
+                litellm_batch_response = GeminiPassthroughLoggingHandler._transform_gemini_batch_to_litellm_batch(_json_response)
+                actual_model_id = GeminiPassthroughLoggingHandler._get_actual_model_id_from_router(model_name)
+                unified_id_string = SpecialEnums.LITELLM_MANAGED_BATCH_COMPLETE_STR.value.format(actual_model_id, batch_id)
+                unified_object_id = base64.urlsafe_b64encode(unified_id_string.encode()).decode().rstrip("=")
+                
+                GeminiPassthroughLoggingHandler._store_batch_managed_object(
+                    unified_object_id=unified_object_id,
+                    batch_object=litellm_batch_response,
+                    model_object_id=batch_id,
+                    logging_obj=logging_obj,
+                    **kwargs,
+                )
+
+                
+                # Create a batch job response for logging
+                litellm_model_response = ModelResponse()
+                litellm_model_response.id = str(uuid.uuid4())
+                litellm_model_response.model = model_name
+                litellm_model_response.object = "batch"
+                litellm_model_response.created = int(start_time.timestamp())
+                
+                # Get batch state
+                batch_state = _json_response.get("state", {}).get("name", "JOB_STATE_PENDING")
+                
+                # Add batch-specific metadata
+                litellm_model_response.choices = [Choices(
+                    finish_reason="batch_pending" if batch_state == "JOB_STATE_PENDING" else "batch_complete",
+                    index=0,
+                    message={
+                        "role": "assistant",
+                        "content": f"Batch job {batch_id} - Status: {batch_state}",
+                        "tool_calls": None,
+                        "function_call": None,
+                        "provider_specific_fields": {
+                            "batch_job_id": batch_id,
+                            "batch_job_state": batch_state,
+                            "unified_object_id": unified_object_id
+                        }
+                    }
+                )]
+                
+                # Set response cost to 0 initially (will be updated when batch completes)
+                response_cost = 0.0
+                kwargs["response_cost"] = response_cost
+                kwargs["model"] = model_name
+                kwargs["batch_id"] = batch_id
+                if unified_object_id:
+                    kwargs["unified_object_id"] = unified_object_id
+                kwargs["batch_job_state"] = batch_state
+                
+                logging_obj.model = model_name
+                logging_obj.model_call_details["model"] = logging_obj.model
+                logging_obj.model_call_details["response_cost"] = response_cost
+                logging_obj.model_call_details["batch_id"] = batch_id
+                
+                return {
+                    "result": litellm_model_response,
+                    "kwargs": kwargs,
+                }
+            else:
+                # Handle non-successful responses
+                litellm_model_response = ModelResponse()
+                litellm_model_response.id = str(uuid.uuid4())
+                litellm_model_response.model = "gemini_batch"
+                litellm_model_response.object = "batch"
+                litellm_model_response.created = int(start_time.timestamp())
+                
+                # Add error-specific metadata
+                litellm_model_response.choices = [Choices(
+                    finish_reason="batch_error",
+                    index=0,
+                    message={
+                        "role": "assistant",
+                        "content": f"Batch job creation/retrieval failed. Status: {httpx_response.status_code}",
+                        "tool_calls": None,
+                        "function_call": None,
+                        "provider_specific_fields": {
+                            "batch_job_state": "JOB_STATE_FAILED",
+                            "status_code": httpx_response.status_code
+                        }
+                    }
+                )]
+                
+                kwargs["response_cost"] = 0.0
+                kwargs["model"] = "gemini_batch"
+                kwargs["batch_job_state"] = "JOB_STATE_FAILED"
+                
+                return {
+                    "result": litellm_model_response,
+                    "kwargs": kwargs,
+                }
+                
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error in gemini batch_handler: {e}")
+            # Return basic response on error
+            litellm_model_response = ModelResponse()
+            litellm_model_response.id = str(uuid.uuid4())
+            litellm_model_response.model = "gemini_batch"
+            litellm_model_response.object = "batch"
+            litellm_model_response.created = int(start_time.timestamp())
+            
+            # Add error-specific metadata
+            litellm_model_response.choices = [Choices(
+                finish_reason="batch_error",
+                index=0,
+                message={
+                    "role": "assistant",
+                    "content": f"Error processing batch job: {str(e)}",
+                    "tool_calls": None,
+                    "function_call": None,
+                    "provider_specific_fields": {
+                        "batch_job_state": "JOB_STATE_FAILED",
+                        "error": str(e)
+                    }
+                }
+            )]
+            
+            kwargs["response_cost"] = 0.0
+            kwargs["model"] = "gemini_batch"
+            kwargs["batch_job_state"] = "JOB_STATE_FAILED"
+            
+            return {
+                "result": litellm_model_response,
+                "kwargs": kwargs,
+            }
+
+    @staticmethod
+    def _extract_model_from_batch_response(batch_response: dict, url_route: str) -> str:
+        """Extract model name from Gemini batch response or URL"""
+        # Try to get model from response metadata
+        model = batch_response.get("model", "")
+        if model:
+            # Extract just the model name from full path like "models/gemini-2.5-flash"
+            if "/" in model:
+                model = model.split("/")[-1]
+            return model
+        
+        # Fallback: try to extract from URL
+        return GeminiPassthroughLoggingHandler.extract_model_from_url(url_route)
+
+    @staticmethod
+    def _transform_gemini_batch_to_litellm_batch(gemini_response: dict) -> LiteLLMBatch:
+        """Transform Gemini batch API response to LiteLLMBatch format"""
+        from litellm.llms.gemini.batches.handler import GeminiBatchesAPI
+        
+        # Use the centralized transformation method from GeminiBatchesAPI
+        gemini_api = GeminiBatchesAPI()
+        return gemini_api._transform_gemini_batch_response(gemini_response)
+
+    @staticmethod
+    def _store_batch_managed_object(
+        unified_object_id: str,
+        batch_object: LiteLLMBatch,
+        model_object_id: str,
+        logging_obj: LiteLLMLoggingObj,
+        **kwargs,
+    ) -> None:
+        """
+        Store batch managed object for cost tracking.
+        This will be picked up by the check_batch_cost polling mechanism.
+        """
+        try:           
+            # Get the managed files hook from the logging object
+            from litellm.proxy.proxy_server import proxy_logging_obj
+            
+            managed_files_hook = proxy_logging_obj.get_proxy_hook("managed_files")
+            if managed_files_hook is not None and hasattr(managed_files_hook, 'store_unified_object_id'):
+                # Create a mock user API key dict for the managed object storage
+                from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
+                
+                user_api_key_dict = UserAPIKeyAuth(
+                    user_id=kwargs.get("user_id", "default-user"),
+                    api_key="",
+                    team_id=None,
+                    team_alias=None,
+                    user_role=LitellmUserRoles.CUSTOMER,
+                    user_email=None,
+                    max_budget=None,
+                    spend=0.0,
+                    models=[],
+                    tpm_limit=None,
+                    rpm_limit=None,
+                    budget_duration=None,
+                    budget_reset_at=None,
+                    max_parallel_requests=None,
+                    allowed_model_region=None,
+                    metadata={},
+                    key_alias=None,
+                    permissions={},
+                    model_max_budget={},
+                    model_spend={},
+                )
+                
+                # Store the unified object for batch cost tracking
+                import asyncio
+                asyncio.create_task(
+                    managed_files_hook.store_unified_object_id(
+                        unified_object_id=unified_object_id,
+                        file_object=batch_object,
+                        litellm_parent_otel_span=None,
+                        model_object_id=model_object_id,
+                        file_purpose="batch",
+                        user_api_key_dict=user_api_key_dict,
+                    )
+                )
+                
+                verbose_proxy_logger.info(
+                    f"Stored Gemini batch managed object with unified_object_id={unified_object_id}, batch_id={model_object_id}"
+                )
+            else:
+                verbose_proxy_logger.warning("Managed files hook not available, cannot store batch object for cost tracking")
+                
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error storing Gemini batch managed object: {e}")
+
+    @staticmethod
+    def _get_actual_model_id_from_router(model_name: str) -> str:
+        """Get actual model ID from router or use model name as fallback"""
+        try:
+            from litellm.proxy.proxy_server import llm_router
+            
+            if llm_router is not None:
+                # Use the existing get_model_ids method from router
+                model_ids = llm_router.get_model_ids(model_name=model_name)
+                if model_ids and len(model_ids) > 0:
+                    actual_model_id = model_ids[0]
+                    verbose_proxy_logger.info(f"Found model ID in router: {actual_model_id}")
+                    return actual_model_id
+                else:
+                    verbose_proxy_logger.warning(f"Model not found in router, using model name: {model_name}")
+                    return model_name
+            else:
+                verbose_proxy_logger.warning(f"Router not available, using model name: {model_name}")
+                return model_name
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error getting model ID from router: {e}")
+            return model_name

--- a/litellm/proxy/pass_through_endpoints/success_handler.py
+++ b/litellm/proxy/pass_through_endpoints/success_handler.py
@@ -57,7 +57,7 @@ class PassThroughEndpointLogging:
         self.TRACKED_LANGFUSE_ROUTES = ["/langfuse/"]
 
         # Gemini
-        self.TRACKED_GEMINI_ROUTES = ["generateContent", "streamGenerateContent"]
+        self.TRACKED_GEMINI_ROUTES = ["generateContent", "streamGenerateContent", "batchGenerateContent"]
 
         # Vertex AI Live API WebSocket
         self.TRACKED_VERTEX_AI_LIVE_ROUTES = ["/vertex_ai/live"]


### PR DESCRIPTION
## Title

Add Gemini Batch API Cost Tracking Support

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Implements cost tracking for Gemini batch API endpoints following the same architecture as Vertex AI batch implementation.

### New Files
- `litellm/llms/gemini/batches/handler.py` - `GeminiBatchesAPI` class with `retrieve_batch()` method
- `litellm/llms/gemini/batches/__init__.py` - Module initialization

### Modified Files

**1. `litellm/batches/main.py`**
- Added `GeminiBatchesAPI` import and instantiation
- Updated `retrieve_batch()` and `aretrieve_batch()` to support `"gemini"` provider
- Updated `_handle_retrieve_batch_providers_without_provider_config()` to handle Gemini batch retrieval

**2. `litellm/batches/batch_utils.py`**
- Added `calculate_gemini_batch_cost_and_usage()` function to calculate costs from Gemini batch responses
- Implemented `_get_gemini_batch_file_content()` to download files from Gemini Files API
- Updated all type hints to include `"gemini"` in Literal types
- Updated `_batch_cost_calculator()` and `_get_batch_job_total_usage_from_file_content()` to support Gemini

**3. `litellm/proxy/pass_through_endpoints/llm_provider_handlers/gemini_passthrough_logging_handler.py`**
- Added `batch_handler()` method to handle Gemini batch creation/retrieval
- Updated `gemini_passthrough_handler()` to route batch endpoints (`batchGenerateContent`) to batch handler
- Added helper methods: `_extract_model_from_batch_response()`, `_transform_gemini_batch_to_litellm_batch()`, `_store_batch_managed_object()`, `_get_actual_model_id_from_router()`

**4. `litellm/proxy/pass_through_endpoints/success_handler.py`**
- Added `"batchGenerateContent"` to `TRACKED_GEMINI_ROUTES`

### How It Works

1. **Batch Created** → Managed object stored with unified ID for polling
2. **Polling System** → Periodically checks batch status via `aretrieve_batch`
3. **Batch Completed** → Downloads results (file-based or inline from `inlined_responses`)
4. **Parse Responses** → Extracts `usageMetadata` from each Gemini response
5. **Transform** → Uses `GoogleAIStudioGeminiConfig` to convert to OpenAI format
6. **Calculate Cost** → Uses `litellm.completion_cost()` with batch usage metadata
7. **Log** → Calls `async_success_handler` with `batch_cost`, `batch_usage`, `batch_models`