### PR TITLE
[Feature] UI -  Config Guardrails should not be editable and guardrail info fix

### DIFF
--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -635,6 +635,7 @@ async def get_guardrail_info(guardrail_id: str):
         raise HTTPException(status_code=500, detail="Prisma client not initialized")
 
     try:
+        guardrail_definition_location = "db"
         result = await GUARDRAIL_REGISTRY.get_guardrail_by_id_from_db(
             guardrail_id=guardrail_id, prisma_client=prisma_client
         )
@@ -642,6 +643,7 @@ async def get_guardrail_info(guardrail_id: str):
             result = IN_MEMORY_GUARDRAIL_HANDLER.get_guardrail_by_id(
                 guardrail_id=guardrail_id
             )
+            guardrail_definition_location = "config"
 
         if result is None:
             raise HTTPException(
@@ -669,6 +671,7 @@ async def get_guardrail_info(guardrail_id: str):
             guardrail_info=dict(result.get("guardrail_info") or {}),
             created_at=result.get("created_at"),
             updated_at=result.get("updated_at"),
+            guardrail_definition_location=guardrail_definition_location,
         )
     except HTTPException as e:
         raise e

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -630,12 +630,13 @@ async def get_guardrail_info(guardrail_id: str):
     from litellm.litellm_core_utils.litellm_logging import _get_masked_values
     from litellm.proxy.guardrails.guardrail_registry import IN_MEMORY_GUARDRAIL_HANDLER
     from litellm.proxy.proxy_server import prisma_client
+    from litellm.types.guardrails import GUARDRAIL_DEFINITION_LOCATION
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Prisma client not initialized")
 
     try:
-        guardrail_definition_location = "db"
+        guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.DB
         result = await GUARDRAIL_REGISTRY.get_guardrail_by_id_from_db(
             guardrail_id=guardrail_id, prisma_client=prisma_client
         )
@@ -643,7 +644,7 @@ async def get_guardrail_info(guardrail_id: str):
             result = IN_MEMORY_GUARDRAIL_HANDLER.get_guardrail_by_id(
                 guardrail_id=guardrail_id
             )
-            guardrail_definition_location = "config"
+            guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.CONFIG
 
         if result is None:
             raise HTTPException(

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -589,6 +589,9 @@ class GuardrailEventHooks(str, Enum):
 class DynamicGuardrailParams(TypedDict):
     extra_body: Dict[str, Any]
 
+class GUARDRAIL_DEFINITION_LOCATION(str, Enum):
+    DB = "db"
+    CONFIG = "config"
 
 class GuardrailInfoResponse(BaseModel):
     guardrail_id: Optional[str] = None
@@ -597,7 +600,7 @@ class GuardrailInfoResponse(BaseModel):
     guardrail_info: Optional[Dict] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    guardrail_definition_location: Literal["config", "db"] = "config"
+    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.CONFIG
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import GuardrailInfoView from "./guardrail_info";
 import * as networking from "@/components/networking";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import GuardrailInfoView from "./guardrail_info";
 
 // Mock the networking module
 vi.mock("@/components/networking", () => ({

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import GuardrailInfoView from "./guardrail_info";
+import * as networking from "@/components/networking";
+
+// Mock the networking module
+vi.mock("@/components/networking", () => ({
+  getGuardrailInfo: vi.fn(),
+  getGuardrailUISettings: vi.fn(),
+  getGuardrailProviderSpecificParams: vi.fn(),
+  updateGuardrailCall: vi.fn(),
+}));
+
+describe("Guardrail Info", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the guardrail info after loading", async () => {
+    // Mock the network responses
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "presidio",
+        mode: "pre_call",
+        default_on: true,
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "database",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: ["PERSON", "EMAIL"],
+      supported_actions: ["MASK", "REDACT"],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call", "post_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { getAllByText, getByText } = render(
+      <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} />,
+    );
+
+    // Wait for the loading to complete and data to be rendered
+    await waitFor(() => {
+      // The guardrail name appears in multiple places (title and settings tab)
+      const elements = getAllByText("Test Guardrail");
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    // Verify other key elements are present
+    expect(getByText("Back to Guardrails")).toBeInTheDocument();
+    expect(getByText("Overview")).toBeInTheDocument();
+    expect(getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("should not render the edit button for config guardrails", async () => {
+    // Mock the network responses
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "presidio",
+        mode: "pre_call",
+        default_on: true,
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "config",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: ["PERSON", "EMAIL"],
+      supported_actions: ["MASK", "REDACT"],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call", "post_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { getByText, container } = render(
+      <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText("Settings")).toBeInTheDocument();
+    });
+
+    // Click the Settings tab
+    fireEvent.click(getByText("Settings"));
+
+    // Wait for the Settings panel to render
+    await waitFor(() => {
+      expect(getByText("Guardrail Settings")).toBeInTheDocument();
+    });
+
+    // Find the info icon and hover over it
+    const infoIcon = container.querySelector(".anticon-info-circle");
+    expect(infoIcon).toBeInTheDocument();
+
+    if (infoIcon) {
+      fireEvent.mouseEnter(infoIcon);
+
+      // Wait for the tooltip to appear
+      await waitFor(() => {
+        expect(getByText("Guardrail is defined in the config file and cannot be edited.")).toBeInTheDocument();
+      });
+    }
+  });
+});

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -13,7 +13,8 @@ import {
   TabPanels,
   TextInput,
 } from "@tremor/react";
-import { Button, Form, Input, Select, Divider } from "antd";
+import { Button, Form, Input, Select, Divider, Tooltip } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import {
   getGuardrailInfo,
   updateGuardrailCall,
@@ -328,6 +329,8 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
     }
   };
 
+  const isConfigGuardrail = guardrailData.guardrail_definition_location === "config";
+
   return (
     <div className="p-4">
       <div>
@@ -434,7 +437,14 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
               <Card>
                 <div className="flex justify-between items-center mb-4">
                   <Title>Guardrail Settings</Title>
-                  {!isEditing && <TremorButton onClick={() => setIsEditing(true)}>Edit Settings</TremorButton>}
+                  {isConfigGuardrail && (
+                    <Tooltip title="Guardrail is defined in the config file and cannot be edited.">
+                      <InfoCircleOutlined />
+                    </Tooltip>
+                  )}
+                  {!isEditing && !isConfigGuardrail && (
+                    <TremorButton onClick={() => setIsEditing(true)}>Edit Settings</TremorButton>
+                  )}
                 </div>
 
                 {isEditing ? (


### PR DESCRIPTION
## Config Guardrails should not be editable and guardrail info fix

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR implements a feature on the front end to prevent users from being able to enter the edit page for a guardrail defined in the config file. Trying to edit a config guardrail will always result in an error. This also implements a fix on the back end where /guardrails/{guardrail_id}/info always returns `guardrail_definition_location = "config"`

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
✅ Test

## Changes

## Screenshot
<img width="748" height="182" alt="image" src="https://github.com/user-attachments/assets/a333bd5a-a7a6-48ea-b2af-6792b381a379" />

<img width="748" height="238" alt="image" src="https://github.com/user-attachments/assets/17f59cee-dcf4-4a25-9963-32bd615d14b5" />

<img width="1279" height="336" alt="image" src="https://github.com/user-attachments/assets/1382aeae-6871-4c54-af6f-d39b248b88ad" />
