### PR TITLE
Remove minimum validation for cache control injection index

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/cache_control_settings.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/cache_control_settings.tsx
@@ -111,7 +111,6 @@ const CacheControlSettings: React.FC<CacheControlSettingsProps> = ({
                         type="number"
                         placeholder="Optional"
                         step={1}
-                        min={0}
                         onChange={() => {
                           const values = form.getFieldValue("cache_control_points");
                           updateCacheControlPoints(values);


### PR DESCRIPTION
## Title

Remove UI validation that the value for `index` in a `cache_control_injection_points` is greater than or equal to 0. https://docs.litellm.ai/docs/tutorials/prompt_caching#target-specific-messages-by-index shows assigning a negative value to a cache control injection point index. 

## Relevant issues

https://github.com/BerriAI/litellm/issues/15696
https://github.com/BerriAI/litellm/issues/14317

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

