### PR TITLE
Support responses API streaming in langfuse otel

### DIFF
--- a/litellm/integrations/_types/open_inference.py
+++ b/litellm/integrations/_types/open_inference.py
@@ -201,6 +201,10 @@ class MessageAttributes:
     """
     The id of the tool call.
     """
+    MESSAGE_REASONING_SUMMARY = "message.reasoning_summary"
+    """
+    The reasoning summary from the model's chain-of-thought process.
+    """
 
 
 class MessageContentAttributes:

--- a/tests/test_litellm/integrations/arize/test_arize_utils.py
+++ b/tests/test_litellm/integrations/arize/test_arize_utils.py
@@ -181,6 +181,107 @@ def test_arize_set_attributes():
     span.set_attribute.assert_any_call(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, 40)
 
 
+def test_arize_set_attributes_responses_api():
+    """
+    Test setting attributes for Responses API with mixed output (reasoning + message).
+    Verifies that multiple output types are correctly handled.
+    """
+    from unittest.mock import MagicMock
+    from litellm.types.llms.openai import ResponsesAPIResponse, ResponseAPIUsage, OutputTokensDetails
+    from openai.types.responses import ResponseReasoningItem, ResponseOutputMessage, ResponseOutputText
+    from openai.types.responses.response_reasoning_item import Summary
+
+    span = MagicMock()  # Mocked tracing span to test attribute setting
+
+    # Construct kwargs to simulate a real LLM request scenario
+    kwargs = {
+        "model": "o3-mini",
+        "messages": [{"role": "user", "content": "What is the answer?"}],
+        "standard_logging_object": {
+            "model_parameters": {"user": "test_user", "stream": True},
+            "metadata": {"key_1": "value_1", "key_2": None},
+            "call_type": "responses",
+        },
+        "optional_params": {
+            "max_tokens": "100",
+            "temperature": "1",
+            "top_p": "5",
+            "stream": True,
+            "user": "test_user",
+        },
+        "litellm_params": {"custom_llm_provider": "openai"},
+    }
+
+    # Simulate Responses API response with mixed output
+    response_obj = ResponsesAPIResponse(
+        id="response-123",
+        created_at=1625247600,
+        output=[
+            ResponseReasoningItem(
+                id="reasoning-001",
+                type="reasoning",
+                summary=[
+                    Summary(
+                        text="First, I need to analyze...",
+                        type="summary_text"
+                    )
+                ]
+            ),
+            ResponseOutputMessage(
+                id="msg-001",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText(
+                        annotations=[],
+                        text="The answer is 42",
+                        type="output_text",
+                    )
+                ]
+            )
+        ],
+        usage=ResponseAPIUsage(
+            input_tokens=120,
+            output_tokens=250,
+            total_tokens=370,
+            output_tokens_details=OutputTokensDetails(
+                reasoning_tokens=180
+            )
+        )
+    )
+
+    ArizeLogger.set_arize_attributes(span, kwargs, response_obj)
+
+    # Verify reasoning summary was set (index 0)
+    span.set_attribute.assert_any_call(
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.0.{MessageAttributes.MESSAGE_REASONING_SUMMARY}",
+        "First, I need to analyze..."
+    )
+
+    # Verify message content was set (index 1)
+    span.set_attribute.assert_any_call(
+        SpanAttributes.OUTPUT_VALUE,
+        "The answer is 42"
+    )
+    span.set_attribute.assert_any_call(
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_CONTENT}",
+        "The answer is 42"
+    )
+    span.set_attribute.assert_any_call(
+        f"{SpanAttributes.LLM_OUTPUT_MESSAGES}.1.{MessageAttributes.MESSAGE_ROLE}",
+        "assistant"
+    )
+
+    # Verify token counts including reasoning tokens
+    span.set_attribute.assert_any_call(SpanAttributes.LLM_TOKEN_COUNT_TOTAL, 370)
+    span.set_attribute.assert_any_call(SpanAttributes.LLM_TOKEN_COUNT_COMPLETION, 250)
+    span.set_attribute.assert_any_call(SpanAttributes.LLM_TOKEN_COUNT_PROMPT, 120)
+    span.set_attribute.assert_any_call(
+        SpanAttributes.LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING, 180
+    )
+
+
 class TestArizeLogger(CustomLogger):
     """
     Custom logger implementation to capture standard_callback_dynamic_params.

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -474,6 +474,132 @@ class TestLangfuseOtelResponsesAPI:
             for expected_call in expected_calls:
                 mock_safe_set_attribute.assert_any_call(*expected_call)
 
+    def test_responses_api_with_output(self):
+        """Test Langfuse OTEL logger with Responses API output (reasoning + message)."""
+        from openai.types.responses import ResponseReasoningItem, ResponseOutputMessage, ResponseOutputText
+        from openai.types.responses.response_reasoning_item import Summary
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+
+        # Create Responses API response with reasoning and message
+        response_obj = ResponsesAPIResponse(
+            id="response-456",
+            created_at=1625247600,
+            output=[
+                ResponseReasoningItem(
+                    id="reasoning-001",
+                    type="reasoning",
+                    summary=[
+                        Summary(
+                            text="Let me analyze this problem step by step...",
+                            type="summary_text"
+                        )
+                    ]
+                ),
+                ResponseOutputMessage(
+                    id="msg-001",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        ResponseOutputText(
+                            annotations=[],
+                            text="The weather in San Francisco is sunny, 20°C.",
+                            type="output_text",
+                        )
+                    ]
+                )
+            ]
+        )
+
+        kwargs = {
+            "call_type": "responses",
+            "messages": [{"role": "user", "content": "What's the weather in San Francisco?"}],
+            "model": "gpt-4o",
+            "optional_params": {},
+        }
+
+        mock_span = MagicMock()
+
+        with patch('litellm.integrations.arize._utils.safe_set_attribute') as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(mock_span, kwargs, response_obj)
+
+            # Verify observation output was set
+            output_calls = [
+                call for call in mock_safe_set_attribute.call_args_list
+                if call.args[1] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value
+            ]
+
+            assert len(output_calls) > 0, "observation.output should be set"
+            output_json = output_calls[0].args[2]
+            output_data = json.loads(output_json)
+
+            # Verify output contains reasoning and message
+            assert isinstance(output_data, list)
+            assert len(output_data) == 2
+
+            # Verify reasoning summary
+            assert output_data[0]["role"] == "reasoning_summary"
+            assert output_data[0]["content"] == "Let me analyze this problem step by step..."
+
+            # Verify message
+            assert output_data[1]["role"] == "assistant"
+            assert output_data[1]["content"] == "The weather in San Francisco is sunny, 20°C."
+
+    def test_responses_api_with_function_calls(self):
+        """Test Langfuse OTEL logger with Responses API function_call output."""
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+        from openai.types.responses import ResponseFunctionToolCall
+
+        # Create Responses API response with function call
+        response_obj = ResponsesAPIResponse(
+            id="response-789",
+            created_at=1625247700,
+            output=[
+                ResponseFunctionToolCall(
+                    id="fc-123",
+                    type="function_call",
+                    name="get_weather",
+                    call_id="call-abc",
+                    arguments='{"location": "San Francisco", "unit": "celsius"}',
+                    status="completed"
+                )
+            ]
+        )
+
+        kwargs = {
+            "call_type": "responses",
+            "messages": [{"role": "user", "content": "What's the weather in San Francisco?"}],
+            "model": "gpt-4o",
+            "optional_params": {},
+        }
+
+        mock_span = MagicMock()
+
+        with patch('litellm.integrations.arize._utils.safe_set_attribute') as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(mock_span, kwargs, response_obj)
+
+            # Verify observation output was set
+            output_calls = [
+                call for call in mock_safe_set_attribute.call_args_list
+                if call.args[1] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value
+            ]
+
+            assert len(output_calls) > 0, "observation.output should be set"
+            output_json = output_calls[0].args[2]
+            output_data = json.loads(output_json)
+
+            # Verify output contains function call
+            assert isinstance(output_data, list)
+            assert len(output_data) == 1
+
+            # Verify function call details
+            assert output_data[0]["type"] == "function_call"
+            assert output_data[0]["id"] == "fc-123"
+            assert output_data[0]["name"] == "get_weather"
+            assert output_data[0]["call_id"] == "call-abc"
+            assert output_data[0]["arguments"]["location"] == "San Francisco"
+            assert output_data[0]["arguments"]["unit"] == "celsius"
+
 
 if __name__ == "__main__":
     pytest.main([__file__]) 


### PR DESCRIPTION
## Support responses API streaming in langfuse otel

I have fixed the following combinations to ensure traces display correctly:
- Langfuse OTEL with Chat Completion streaming
- Langfuse OTEL with Responses API streaming
- Langfuse OTEL with v1 messages (Anthropic) streaming

<!-- e.g. "Implement user authentication feature" -->

Results for each combination and code to reproduce them (collapsible)

<details><summary>Langfuse OTEL with Chat Completion streaming</summary>

```python
import litellm

response = litellm.completion(
    model = "gemini/gemini-2.5-pro",
    stream=True,
    messages=[{ "content": "Edit the note with the content: 'This is a test note.'","role": "user"}],
    tools=[
        {
            "type": "function",
            "function": {
                "name": "edit_note",
                "description": "Edit the note with the content specified in the user's message.",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "content": {"type": "string"},
                    },
                },
            },
        },
    ],
)
```
</details>

<img width="874" height="939" alt="image" src="https://github.com/user-attachments/assets/a900a449-f7e4-4600-b220-9315b20bbf88" />

<details><summary>Langfuse OTEL with Responses API streaming</summary>

```python
import litellm

response = litellm.responses(
    model="openai/o3-mini",
    input="Please calculate 4329 multiplied by 5952 and edit the note with the result.",
	stream=True,
    reasoning={"effort": "medium", "summary": "auto"},
    tools=[
        {
            "type": "function",
            "name": "edit_note",
            "description": "Edit the note with the content specified in the user's message.",
            "parameters": {
                "type": "object",
                "properties": {
                    "content": {
                        "type": "string",
                        "description": "The content to update the note with.",
                    },
                },
                "required": ["content"],
            },
        }
    ]
)
```

</details>

<img width="877" height="936" alt="image" src="https://github.com/user-attachments/assets/85aa745b-de84-43e0-84a1-e9490d112332" />

I also ensured that the response API output and reasoning summary are appropriately added to the metadata.
<img width="877" height="936" alt="image" src="https://github.com/user-attachments/assets/36900e8b-e2ea-4374-bd20-1f5e924b5507" />

<details><summary>Langfuse OTEL with v1 messages (Anthropic) streaming</summary>

```python
import litellm
async def func():
    response = await litellm.anthropic.messages.acreate(
        messages=[{"role": "user", "content": "Edit the note with the content: 'This is a test note.'"}],
        model="anthropic/claude-3-haiku-20240307",
        max_tokens=100,
        stream=True,
        tools=[
            {
                "name": "edit_note",
                "description": "Edit the note with the content specified in the user's message.",
                "input_schema": {
                    "type": "object",
                    "properties": {
                        "content": {"type": "string"},
                    },
                    "required": ["content"],
                },
            },
        ],
    )
    async for chunk in response:
        event, data = chunk.decode().strip().split("\n", 1)
        if "content_block_delta" in event:
            print(data, flush=True)

asyncio.run(func())
```

</details>

<img width="878" height="940" alt="image" src="https://github.com/user-attachments/assets/cc4d989f-92ea-4fd2-8b12-afb4f8e6d1cd" />

## Relevant issues

None

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1276" height="291" alt="image" src="https://github.com/user-attachments/assets/29f76597-cf41-4533-84f1-1100bf8bc4be" />

<img width="1273" height="306" alt="image" src="https://github.com/user-attachments/assets/868e8466-337f-4e31-8850-fddf1d2fb736" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


