### PR TITLE
strip base64 in s3

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1335,6 +1335,7 @@ litellm_settings:
     s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY  # AWS Secret Access Key for S3
     s3_path: my-test-path # [OPTIONAL] set path in bucket you want to write logs to
     s3_endpoint_url: https://s3.amazonaws.com  # [OPTIONAL] S3 endpoint URL, if you want to use Backblaze/cloudflare s3 buckets
+    s3_strip_base64_files: false # [OPTIONAL] remove base64 files before storing in s3
 ```
 
 **Step 3**: Start the proxy, make a test request

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -49,6 +49,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_batch_size: Optional[int] = DEFAULT_S3_BATCH_SIZE,
         s3_config=None,
         s3_use_team_prefix: bool = False,
+        s3_strip_base64_files: bool = False
         **kwargs,
     ):
         try:
@@ -80,6 +81,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 s3_config=s3_config,
                 s3_path=s3_path,
                 s3_use_team_prefix=s3_use_team_prefix,
+                s3_strip_base64_files=s3_strip_base64_files
             )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
 

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -124,6 +124,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_config=None,
         s3_path: Optional[str] = None,
         s3_use_team_prefix: bool = False,
+        s3_strip_base64_files: bool = False,
     ):
         """
         Initialize the s3 params for this logging callback
@@ -190,7 +191,12 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         self.s3_path = litellm.s3_callback_params.get("s3_path") or s3_path
         # done reading litellm.s3_callback_params
         self.s3_use_team_prefix = (
-            bool(litellm.s3_callback_params.get("s3_use_team_prefix", False))
+            bool(litellm.s3_callback_params.get("s3_strip_base64_files", False))
+            or s3_use_team_prefix
+        )
+
+        self.s3_strip_base64_files = (
+            bool(litellm.s3_callback_params.get("s3_strip_base64_files", False))
             or s3_use_team_prefix
         )
 
@@ -363,6 +369,10 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         """
         if standard_logging_payload is None:
             return None
+
+        if self.s3_strip_base64_files:
+            import asyncio
+            standard_logging_payload = asyncio.run(self._strip_base64_from_messages(standard_logging_payload))
 
         team_alias = standard_logging_payload["metadata"].get("user_api_key_team_alias")
 

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -49,7 +49,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_batch_size: Optional[int] = DEFAULT_S3_BATCH_SIZE,
         s3_config=None,
         s3_use_team_prefix: bool = False,
-        s3_strip_base64_files: bool = False
+        s3_strip_base64_files: bool = False,
         **kwargs,
     ):
         try:

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -191,13 +191,13 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         self.s3_path = litellm.s3_callback_params.get("s3_path") or s3_path
         # done reading litellm.s3_callback_params
         self.s3_use_team_prefix = (
-            bool(litellm.s3_callback_params.get("s3_strip_base64_files", False))
+            bool(litellm.s3_callback_params.get("s3_use_team_prefix", False))
             or s3_use_team_prefix
         )
 
         self.s3_strip_base64_files = (
             bool(litellm.s3_callback_params.get("s3_strip_base64_files", False))
-            or s3_use_team_prefix
+            or s3_strip_base64_files
         )
 
         return

--- a/litellm/integrations/sqs.py
+++ b/litellm/integrations/sqs.py
@@ -256,6 +256,8 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
             standard_logging_payload = kwargs.get("standard_logging_object")
             if standard_logging_payload is None:
                 raise ValueError("standard_logging_payload is None")
+            if self.sqs_strip_base64_files:
+                standard_logging_payload = await self._strip_base64_from_messages(standard_logging_payload)
 
             self.log_queue.append(standard_logging_payload)
             verbose_logger.debug(


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Strips base64 file contents in s3.

Also a small bug fix for sqs, it was not skipping stripping of base64 files on failure events



## Relevant issues

<!-- e.g. "Fixes #000" -->

```
(litellm-py3.12) (base) ➜  litellm git:(feature/s3_strip_base64) poetry run pytest tests/test_litellm/integrations/test_s3_v2.py --tb=short -vv --maxfail=10 -n 4 
=========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.12.2, pytest-7.4.4, pluggy-1.5.0 -- /Users/deepanshu.deepanshu/Library/Caches/pypoetry/virtualenvs/litellm-ohMn1BPm-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm
configfile: pyproject.toml
plugins: respx-0.22.0, xdist-3.8.0, anyio-4.5.2, mock-3.14.1, asyncio-0.21.2, retry-1.6.3, requests-mock-1.12.1
asyncio: mode=Mode.AUTO
4 workers [7 items]     
scheduling tests via LoadScheduling

tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_keeps_non_file_content 
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_handles_empty_or_missing_messages 
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_source_code_analysis 
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url 
[gw1] [ 14%] PASSED tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_source_code_analysis 
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_recursive_redaction 
[gw2] [ 28%] PASSED tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_handles_empty_or_missing_messages 
[gw3] [ 42%] PASSED tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_keeps_non_file_content 
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_removes_file_and_nontext_entries 
[gw2] [ 57%] PASSED tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_removes_file_and_nontext_entries 
[gw1] [ 71%] PASSED tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_recursive_redaction 
[gw0] [ 85%] PASSED tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url 
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_mixed_nested_objects 
[gw0] [100%] PASSED tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_mixed_nested_objects Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<CustomBatchLogger.periodic_flush() done, defined at /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/integrations/custom_batch_logger.py:36> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-4' coro=<CustomBatchLogger.periodic_flush() done, defined at /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/integrations/custom_batch_logger.py:36> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<CustomBatchLogger.periodic_flush() done, defined at /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/integrations/custom_batch_logger.py:36> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<CustomBatchLogger.periodic_flush() done, defined at /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/integrations/custom_batch_logger.py:36> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-14' coro=<CustomBatchLogger.periodic_flush() done, defined at /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/integrations/custom_batch_logger.py:36> wait_for=<Future pending cb=[Task.task_wakeup()]>>


============================================================================================ warnings summary =============================================================================================
litellm/litellm_core_utils/get_model_cost_map.py:41
litellm/litellm_core_utils/get_model_cost_map.py:41
litellm/litellm_core_utils/get_model_cost_map.py:41
litellm/litellm_core_utils/get_model_cost_map.py:41
litellm/litellm_core_utils/get_model_cost_map.py:41
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_source_code_analysis
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_handles_empty_or_missing_messages
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_keeps_non_file_content
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/litellm_core_utils/get_model_cost_map.py:41: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with importlib.resources.open_text(

tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
  /Users/deepanshu.deepanshu/Library/Caches/pypoetry/virtualenvs/litellm-ohMn1BPm-py3.12/lib/python3.12/site-packages/botocore/auth.py:425: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 7 passed, 14 warnings in 2.06s ======================================================================================
(litellm-py3.12) (base) ➜  litellm git:(feature/s3_strip_base64) 

```

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix


## Changes


