### PR TITLE
[Feature] UI - Guardrail Info Page Show PII Config

### DIFF
--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
@@ -144,7 +144,7 @@ describe("Guardrail Info", () => {
     );
 
     await waitFor(() => {
-      expect(getByText("Guardrail Info")).toBeInTheDocument();
+      expect(getByText("PII Entity Configuration")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.test.tsx
@@ -110,4 +110,41 @@ describe("Guardrail Info", () => {
       });
     }
   });
+
+  it("should render the guardrail info", async () => {
+    // Mock the network responses
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "presidio",
+        mode: "pre_call",
+        default_on: true,
+        pii_entities_config: {
+          PERSON: "MASK",
+          EMAIL: "REDACT",
+        },
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "database",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: ["PERSON", "EMAIL"],
+      supported_actions: ["MASK", "REDACT"],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call", "post_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { getByText } = render(
+      <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText("Guardrail Info")).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -414,21 +414,22 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
                 </Card>
               )}
 
-            {guardrailData.guardrail_info && Object.keys(guardrailData.guardrail_info).length > 0 && (
-              <Card className="mt-6">
-                <Text>Guardrail Info</Text>
-                <div className="mt-2 space-y-2">
-                  {Object.entries(guardrailData.guardrail_info).map(([key, value]) => (
-                    <div key={key} className="flex">
-                      <Text className="font-medium w-1/3">{key}</Text>
-                      <Text className="w-2/3">
-                        {typeof value === "object" ? JSON.stringify(value, null, 2) : String(value)}
-                      </Text>
-                    </div>
-                  ))}
-                </div>
-              </Card>
-            )}
+            {guardrailData.litellm_params?.pii_entities_config &&
+              Object.keys(guardrailData.litellm_params.pii_entities_config).length > 0 && (
+                <Card className="mt-6">
+                  <Text>Guardrail Info</Text>
+                  <div className="mt-2 space-y-2">
+                    {Object.entries(guardrailData.litellm_params?.pii_entities_config).map(([key, value]) => (
+                      <div key={key} className="flex">
+                        <Text className="font-medium w-1/3">{key}</Text>
+                        <Text className="w-2/3">
+                          {typeof value === "object" ? JSON.stringify(value, null, 2) : String(value)}
+                        </Text>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              )}
           </TabPanel>
 
           {/* Settings Panel (only for admins) */}

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -14,7 +14,7 @@ import {
   TextInput,
 } from "@tremor/react";
 import { Button, Form, Input, Select, Divider, Tooltip } from "antd";
-import { InfoCircleOutlined } from "@ant-design/icons";
+import { InfoCircleOutlined, EyeInvisibleOutlined, StopOutlined } from "@ant-design/icons";
 import {
   getGuardrailInfo,
   updateGuardrailCall,
@@ -417,16 +417,29 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
             {guardrailData.litellm_params?.pii_entities_config &&
               Object.keys(guardrailData.litellm_params.pii_entities_config).length > 0 && (
                 <Card className="mt-6">
-                  <Text>Guardrail Info</Text>
-                  <div className="mt-2 space-y-2">
-                    {Object.entries(guardrailData.litellm_params?.pii_entities_config).map(([key, value]) => (
-                      <div key={key} className="flex">
-                        <Text className="font-medium w-1/3">{key}</Text>
-                        <Text className="w-2/3">
-                          {typeof value === "object" ? JSON.stringify(value, null, 2) : String(value)}
-                        </Text>
-                      </div>
-                    ))}
+                  <Text className="mb-4 text-lg font-semibold">PII Entity Configuration</Text>
+                  <div className="border rounded-lg overflow-hidden shadow-sm">
+                    <div className="bg-gray-50 px-5 py-3 border-b flex">
+                      <Text className="flex-1 font-semibold text-gray-700">Entity Type</Text>
+                      <Text className="flex-1 font-semibold text-gray-700">Configuration</Text>
+                    </div>
+                    <div className="max-h-[400px] overflow-y-auto">
+                      {Object.entries(guardrailData.litellm_params?.pii_entities_config).map(([key, value]) => (
+                        <div key={key} className="px-5 py-3 flex border-b hover:bg-gray-50 transition-colors">
+                          <Text className="flex-1 font-medium text-gray-900">{key}</Text>
+                          <Text className="flex-1">
+                            <span
+                              className={`inline-flex items-center gap-1.5 ${
+                                value === "MASK" ? "text-blue-600" : "text-red-600"
+                              }`}
+                            >
+                              {value === "MASK" ? <EyeInvisibleOutlined /> : <StopOutlined />}
+                              {String(value)}
+                            </span>
+                          </Text>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </Card>
               )}


### PR DESCRIPTION
## Guardrail Info Page Show PII Config

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The guardrails info page was missing the PII Configuration. Previously the user needs to go to the settings page in order to see which entities were blocked or masked. This PR introduces a new table to show this information directly on the info page.
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


Feature
✅ Test

## Changes

## Screenshots
<img width="1448" height="305" alt="image" src="https://github.com/user-attachments/assets/bc18e0e6-f861-4cfd-9d54-accc2a9750c1" />


<img width="958" height="238" alt="image" src="https://github.com/user-attachments/assets/913a10e7-ca59-4673-8ac0-bc2c815776b3" />


