### PR TITLE
Refactor Video API: Encode provider and model in video_id

### DIFF
--- a/docs/my-website/docs/providers/azure/videos.md
+++ b/docs/my-website/docs/providers/azure/videos.md
@@ -53,8 +53,7 @@ print(f"Initial Status: {response.status}")
 # Check status until video is ready
 while True:
     status_response = video_status(
-        video_id=response.id,
-        custom_llm_provider="azure"
+        video_id=response.id
     )
     
     print(f"Current Status: {status_response.status}")
@@ -69,8 +68,7 @@ while True:
 
 # Download video content when ready
 video_bytes = video_content(
-    video_id=response.id,
-    custom_llm_provider="azure"
+    video_id=response.id
 )
 
 # Save to file
@@ -211,8 +209,7 @@ general_settings:
 ```python
 # Download video content
 video_bytes = video_content(
-    video_id="video_1234567890",
-    model="azure/sora-2"
+    video_id="video_1234567890"
 )
 
 # Save to file
@@ -243,8 +240,7 @@ def generate_and_download_video(prompt):
     
     # Step 3: Download video
     video_bytes = litellm.video_content(
-        video_id=video_id,
-        custom_llm_provider="azure"
+        video_id=video_id
     )
     
     # Step 4: Save to file
@@ -264,9 +260,9 @@ video_file = generate_and_download_video(
 ```python
 # Video editing with reference image
 response = litellm.video_remix(
+    video_id="video_456",
     prompt="Make the cat jump higher",
     input_reference=open("path/to/image.jpg", "rb"),  # Reference image as file object
-    custom_llm_provider="azure"
     seconds="8"
 )
 

--- a/docs/my-website/docs/providers/openai/videos.md
+++ b/docs/my-website/docs/providers/openai/videos.md
@@ -36,7 +36,6 @@ print(f"Status: {response.status}")
 # Download video content when ready
 video_bytes = video_content(
     video_id=response.id,
-    model="sora-2"
 )
 
 # Save to file
@@ -64,8 +63,7 @@ with open("generated_video.mp4", "wb") as f:
 ```python
 # Download video content
 video_bytes = video_content(
-    video_id="video_1234567890",
-    custom_llm_provider="openai"  # Or use model="sora-2"
+    video_id="video_1234567890"
 )
 
 # Save to file
@@ -96,8 +94,7 @@ def generate_and_download_video(prompt):
     
     # Step 3: Download video
     video_bytes = litellm.video_content(
-        video_id=video_id,
-        custom_llm_provider="openai"  
+        video_id=video_id
     )
     
     # Step 4: Save to file
@@ -133,8 +130,7 @@ from litellm.exceptions import BadRequestError, AuthenticationError
 
 try:
     response = video_generation(
-        prompt="A cat playing with a ball of yarn",
-        model="sora-2"
+        prompt="A cat playing with a ball of yarn"
     )
 except AuthenticationError as e:
     print(f"Authentication failed: {e}")

--- a/docs/my-website/docs/videos.md
+++ b/docs/my-website/docs/videos.md
@@ -41,8 +41,7 @@ print(f"Initial Status: {response.status}")
 # Check status until video is ready
 while True:
     status_response = video_status(
-        video_id=response.id,
-        custom_llm_provider="openai"
+        video_id=response.id
     )
     
     print(f"Current Status: {status_response.status}")
@@ -57,8 +56,7 @@ while True:
 
 # Download video content when ready
 video_bytes = video_content(
-    video_id=response.id,
-    custom_llm_provider="openai"
+    video_id=response.id
 )
 
 # Save to file
@@ -88,8 +86,7 @@ async def test_async_video():
     # Check status until video is ready
     while True:
         status_response = await avideo_status(
-            video_id=response.id,
-            custom_llm_provider="openai"
+            video_id=response.id
         )
         
         print(f"Current Status: {status_response.status}")
@@ -104,8 +101,7 @@ async def test_async_video():
     
     # Download video content when ready
     video_bytes = await avideo_content(
-        video_id=response.id,
-        custom_llm_provider="openai"
+        video_id=response.id
     )
     
     # Save to file
@@ -120,21 +116,27 @@ asyncio.run(test_async_video())
 ```python
 from litellm import video_status
 
-# Check the status of a video generation
 status_response = video_status(
-    video_id="video_1234567890",
-    custom_llm_provider="openai"
+    video_id="video_1234567890"
 )
 
 print(f"Video Status: {status_response.status}")
 print(f"Created At: {status_response.created_at}")
 print(f"Model: {status_response.model}")
+```
 
-# Possible status values:
-# - "queued": Video is in the queue
-# - "processing": Video is being generated
-# - "completed": Video is ready for download
-# - "failed": Video generation failed
+### List Videos
+
+For listing videos, you need to specify the provider since there's no video_id to decode from:
+
+```python
+from litellm import video_list
+
+# List videos from OpenAI
+videos = video_list(custom_llm_provider="openai")
+
+for video in videos:
+    print(f"Video ID: {video['id']}")
 ```
 
 ### Video Generation with Reference Image
@@ -253,31 +255,14 @@ curl --location 'http://localhost:4000/v1/videos' \
 Test video status request
 
 ```bash
-# Using custom-llm-provider header
-curl --location 'http://localhost:4000/v1/videos/video_id' \
---header 'Accept: application/json' \
---header 'x-litellm-api-key: sk-1234' \
---header 'custom-llm-provider: azure'
-
-# Or using query parameter
-curl --location 'http://localhost:4000/v1/videos/video_id?custom_llm_provider=azure' \
---header 'Accept: application/json' \
+curl --location 'http://localhost:4000/v1/videos/{video_id}' \
 --header 'x-litellm-api-key: sk-1234'
 ```
 
 Test video retrieval request
 
 ```bash
-# Using custom-llm-provider header
-curl --location 'http://localhost:4000/v1/videos/video_id/content' \
---header 'Accept: application/json' \
---header 'x-litellm-api-key: sk-1234' \
---header 'custom-llm-provider: openai' \
---output video.mp4
-
-# Or using query parameter
-curl --location 'http://localhost:4000/v1/videos/video_id/content?custom_llm_provider=openai' \
---header 'Accept: application/json' \
+curl --location 'http://localhost:4000/v1/videos/{video_id}/content' \
 --header 'x-litellm-api-key: sk-1234' \
 --output video.mp4
 ```
@@ -285,25 +270,25 @@ curl --location 'http://localhost:4000/v1/videos/video_id/content?custom_llm_pro
 Test video remix request
 
 ```bash
-# Using custom_llm_provider in request body
-curl --location --request POST 'http://localhost:4000/v1/videos/video_id/remix' \
---header 'Accept: application/json' \
+curl --location --request POST 'http://localhost:4000/v1/videos/{video_id}/remix' \
 --header 'Content-Type: application/json' \
 --header 'x-litellm-api-key: sk-1234' \
---data '{
-    "prompt": "New remix instructions",
-    "custom_llm_provider": "azure"
-}'
-
-# Or using custom-llm-provider header
-curl --location --request POST 'http://localhost:4000/v1/videos/video_id/remix' \
---header 'Accept: application/json' \
---header 'Content-Type: application/json' \
---header 'x-litellm-api-key: sk-1234' \
---header 'custom-llm-provider: azure' \
 --data '{
     "prompt": "New remix instructions"
 }'
+```
+
+Test video list request (requires custom_llm_provider)
+
+```bash
+# Note: video_list requires custom_llm_provider since there's no video_id to decode from
+curl --location 'http://localhost:4000/v1/videos?custom_llm_provider=openai' \
+--header 'x-litellm-api-key: sk-1234'
+
+# Or using header
+curl --location 'http://localhost:4000/v1/videos' \
+--header 'x-litellm-api-key: sk-1234' \
+--header 'custom-llm-provider: azure'
 ```
 
 Test Azure video generation request

--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -104,6 +104,7 @@ class BaseVideoConfig(ABC):
         model: str,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
         pass
 
@@ -154,6 +155,7 @@ class BaseVideoConfig(ABC):
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
         pass
 
@@ -181,6 +183,7 @@ class BaseVideoConfig(ABC):
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> Dict[str,str]:
         pass
 
@@ -229,6 +232,7 @@ class BaseVideoConfig(ABC):
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
         pass
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4084,43 +4084,23 @@ class BaseLLMHTTPHandler:
 
         try:
             # Use JSON when no files, otherwise use form data with files
-            # if files and len(files) > 0:
-            #     # Use multipart/form-data when files are present
-            #     response = sync_httpx_client.post(
-            #         url=api_base,
-            #         headers=headers,
-            #         data=data,
-            #         files=files,
-            #         timeout=timeout,
-            #     )
+            if files and len(files) > 0:
+                # Use multipart/form-data when files are present
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                )
 
-            # # --- END MOCK VIDEO RESPONSE ---
-            # else:
-            #     response = sync_httpx_client.post(
-            #         url=api_base,
-            #         headers=headers,
-            #         json=data,
-            #         timeout=timeout,
-            #     )
-        # Mock response for testing: return a fake httpx.Response with expected JSON
-            import httpx
-            from httpx import Response, Request
-
-            mock_json = {
-                "id": "video_123",
-                "object": "video",
-                "model": "sora-2",
-                "status": "queued",
-                "progress": 0,
-                "created_at": 1712697600,
-                "size": "1024x1808",
-                "seconds": "8",
-                "quality": "standard"
-            }
-            response = httpx.Response(
-                status_code=200,
-                json=mock_json,
-                request=Request("POST", api_base)
+            # --- END MOCK VIDEO RESPONSE ---
+            else:
+                response = sync_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
                 )
 
         except Exception as e:
@@ -4201,40 +4181,21 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            # Use JSON when no files, otherwise use form data with files
-            # if files is None or len(files) == 0:
-            #     response = await async_httpx_client.post(
-            #         url=api_base,
-            #         headers=headers,
-            #         json=data,
-            #         timeout=timeout,
-            #     )
-            # else:
-            #     response = await async_httpx_client.post(
-            #         url=api_base,
-            #         headers=headers,
-            #         data=data,
-            #         files=files,
-            #         timeout=timeout,
-            #     )
-            import httpx
-            from httpx import Response, Request
-
-            mock_json = {
-                "id": "video_123",
-                "object": "video",
-                "model": "sora-2",
-                "status": "queued",
-                "progress": 0,
-                "created_at": 1712697600,
-                "size": "1024x1808",
-                "seconds": "8",
-                "quality": "standard"
-            }
-            response = httpx.Response(
-                status_code=200,
-                json=mock_json,
-                request=Request("POST", api_base)
+            #Use JSON when no files, otherwise use form data with files
+            if files is None or len(files) == 0:
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    json=data,
+                    timeout=timeout,
+                )
+            else:
+                response = await async_httpx_client.post(
+                    url=api_base,
+                    headers=headers,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
                 )
 
         except Exception as e:
@@ -4865,29 +4826,11 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            # response = sync_httpx_client.get(
-            #     url=url,
-            #     headers=headers,
-            # )
-            import httpx
-            from httpx import Response, Request
-
-            mock_json = {
-                "id": "video_123",
-                "object": "video",
-                "model": "sora-2",
-                "status": "queued",
-                "progress": 0,
-                "created_at": 1712697600,
-                "size": "1024x1808",
-                "seconds": "8",
-                "quality": "standard"
-            }
-            response = httpx.Response(
-                status_code=200,
-                json=mock_json,
-                request=Request("POST", api_base)
+            response = sync_httpx_client.get(
+                url=url,
+                headers=headers,
             )
+
             return video_status_provider_config.transform_video_status_retrieve_response(
                 raw_response=response,
                 logging_obj=logging_obj,
@@ -4959,28 +4902,9 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            # response = await async_httpx_client.get(
-            #     url=url,
-            #     headers=headers,
-            # )
-            import httpx
-            from httpx import Response, Request
-
-            mock_json = {
-                "id": "video_123",
-                "object": "video",
-                "model": "sora-2",
-                "status": "queued",
-                "progress": 0,
-                "created_at": 1712697600,
-                "size": "1024x1808",
-                "seconds": "8",
-                "quality": "standard"
-            }
-            response = httpx.Response(
-                status_code=200,
-                json=mock_json,
-                request=Request("POST", api_base)
+            response = await async_httpx_client.get(
+                url=url,
+                headers=headers,
             )
             return video_status_provider_config.transform_video_status_retrieve_response(
                 raw_response=response,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4084,23 +4084,43 @@ class BaseLLMHTTPHandler:
 
         try:
             # Use JSON when no files, otherwise use form data with files
-            if files and len(files) > 0:
-                # Use multipart/form-data when files are present
-                response = sync_httpx_client.post(
-                    url=api_base,
-                    headers=headers,
-                    data=data,
-                    files=files,
-                    timeout=timeout,
-                )
+            # if files and len(files) > 0:
+            #     # Use multipart/form-data when files are present
+            #     response = sync_httpx_client.post(
+            #         url=api_base,
+            #         headers=headers,
+            #         data=data,
+            #         files=files,
+            #         timeout=timeout,
+            #     )
 
-            # --- END MOCK VIDEO RESPONSE ---
-            else:
-                response = sync_httpx_client.post(
-                    url=api_base,
-                    headers=headers,
-                    json=data,
-                    timeout=timeout,
+            # # --- END MOCK VIDEO RESPONSE ---
+            # else:
+            #     response = sync_httpx_client.post(
+            #         url=api_base,
+            #         headers=headers,
+            #         json=data,
+            #         timeout=timeout,
+            #     )
+        # Mock response for testing: return a fake httpx.Response with expected JSON
+            import httpx
+            from httpx import Response, Request
+
+            mock_json = {
+                "id": "video_123",
+                "object": "video",
+                "model": "sora-2",
+                "status": "queued",
+                "progress": 0,
+                "created_at": 1712697600,
+                "size": "1024x1808",
+                "seconds": "8",
+                "quality": "standard"
+            }
+            response = httpx.Response(
+                status_code=200,
+                json=mock_json,
+                request=Request("POST", api_base)
                 )
 
         except Exception as e:
@@ -4113,6 +4133,7 @@ class BaseLLMHTTPHandler:
             model=model,
             raw_response=response,
             logging_obj=logging_obj,
+            custom_llm_provider=custom_llm_provider,
         )
 
     async def async_video_generation_handler(
@@ -4181,20 +4202,39 @@ class BaseLLMHTTPHandler:
 
         try:
             # Use JSON when no files, otherwise use form data with files
-            if files is None or len(files) == 0:
-                response = await async_httpx_client.post(
-                    url=api_base,
-                    headers=headers,
-                    json=data,
-                    timeout=timeout,
-                )
-            else:
-                response = await async_httpx_client.post(
-                    url=api_base,
-                    headers=headers,
-                    data=data,
-                    files=files,
-                    timeout=timeout,
+            # if files is None or len(files) == 0:
+            #     response = await async_httpx_client.post(
+            #         url=api_base,
+            #         headers=headers,
+            #         json=data,
+            #         timeout=timeout,
+            #     )
+            # else:
+            #     response = await async_httpx_client.post(
+            #         url=api_base,
+            #         headers=headers,
+            #         data=data,
+            #         files=files,
+            #         timeout=timeout,
+            #     )
+            import httpx
+            from httpx import Response, Request
+
+            mock_json = {
+                "id": "video_123",
+                "object": "video",
+                "model": "sora-2",
+                "status": "queued",
+                "progress": 0,
+                "created_at": 1712697600,
+                "size": "1024x1808",
+                "seconds": "8",
+                "quality": "standard"
+            }
+            response = httpx.Response(
+                status_code=200,
+                json=mock_json,
+                request=Request("POST", api_base)
                 )
 
         except Exception as e:
@@ -4207,6 +4247,7 @@ class BaseLLMHTTPHandler:
             model=model,
             raw_response=response,
             logging_obj=logging_obj,
+            custom_llm_provider=custom_llm_provider,
         )
 
     ###### VIDEO CONTENT HANDLER ######
@@ -4446,6 +4487,7 @@ class BaseLLMHTTPHandler:
             return video_remix_provider_config.transform_video_remix_response(
                 raw_response=response,
                 logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
             )
 
         except Exception as e:
@@ -4527,6 +4569,7 @@ class BaseLLMHTTPHandler:
             return video_remix_provider_config.transform_video_remix_response(
                 raw_response=response,
                 logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
             )
 
         except Exception as e:
@@ -4662,6 +4705,7 @@ class BaseLLMHTTPHandler:
             return video_list_provider_config.transform_video_list_response(
                 raw_response=response,
                 logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
             )
 
         except Exception as e:
@@ -4821,13 +4865,33 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = sync_httpx_client.get(
-                url=url,
-                headers=headers,
+            # response = sync_httpx_client.get(
+            #     url=url,
+            #     headers=headers,
+            # )
+            import httpx
+            from httpx import Response, Request
+
+            mock_json = {
+                "id": "video_123",
+                "object": "video",
+                "model": "sora-2",
+                "status": "queued",
+                "progress": 0,
+                "created_at": 1712697600,
+                "size": "1024x1808",
+                "seconds": "8",
+                "quality": "standard"
+            }
+            response = httpx.Response(
+                status_code=200,
+                json=mock_json,
+                request=Request("POST", api_base)
             )
             return video_status_provider_config.transform_video_status_retrieve_response(
                 raw_response=response,
                 logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
             )
 
         except Exception as e:
@@ -4895,13 +4959,33 @@ class BaseLLMHTTPHandler:
         )
 
         try:
-            response = await async_httpx_client.get(
-                url=url,
-                headers=headers,
+            # response = await async_httpx_client.get(
+            #     url=url,
+            #     headers=headers,
+            # )
+            import httpx
+            from httpx import Response, Request
+
+            mock_json = {
+                "id": "video_123",
+                "object": "video",
+                "model": "sora-2",
+                "status": "queued",
+                "progress": 0,
+                "created_at": 1712697600,
+                "size": "1024x1808",
+                "seconds": "8",
+                "quality": "standard"
+            }
+            response = httpx.Response(
+                status_code=200,
+                json=mock_json,
+                request=Request("POST", api_base)
             )
             return video_status_provider_config.transform_video_status_retrieve_response(
                 raw_response=response,
                 logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
             )
 
         except Exception as e:

--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -9,6 +9,7 @@ from litellm.types.llms.openai import CreateVideoRequest
 from litellm.types.router import GenericLiteLLMParams
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.videos.main import VideoObject
+from litellm.types.videos.utils import encode_video_id_with_provider, decode_video_id_with_provider, extract_original_video_id
 import litellm
 from litellm.llms.openai.image_edit.transformation import ImageEditRequestUtils
 if TYPE_CHECKING:
@@ -137,18 +138,16 @@ class OpenAIVideoConfig(BaseVideoConfig):
         model: str,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
-        """
-        Transform the OpenAI video creation response.
-        """
+        """Transform the OpenAI video creation response."""
         response_data = raw_response.json()
-        
-        # Transform the response data
     
         video_obj = VideoObject(**response_data)  # type: ignore[arg-type]
         
-        # Create usage object with duration information for cost calculation
-        # Video generation API doesn't provide usage, so we create one with duration
+        if custom_llm_provider and video_obj.id:
+            video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, model)
+        
         usage_data = {}
         if video_obj:
             if hasattr(video_obj, 'seconds') and video_obj.seconds:
@@ -156,9 +155,7 @@ class OpenAIVideoConfig(BaseVideoConfig):
                     usage_data["duration_seconds"] = float(video_obj.seconds)
                 except (ValueError, TypeError):
                     pass
-        # Create the response
         video_obj.usage = usage_data
-
         
         return video_obj
 
@@ -175,11 +172,13 @@ class OpenAIVideoConfig(BaseVideoConfig):
         OpenAI API expects the following request:
         - GET /v1/videos/{video_id}/content
         """
+        original_video_id = extract_original_video_id(video_id)
+        
         # Construct the URL for video content download
-        url = f"{api_base.rstrip('/')}/{video_id}/content"
+        url = f"{api_base.rstrip('/')}/{original_video_id}/content"
         
         # Add video_id as query parameter
-        params = {"video_id": video_id}
+        params = {"video_id": original_video_id}
         
         return url, params
 
@@ -198,8 +197,10 @@ class OpenAIVideoConfig(BaseVideoConfig):
         OpenAI API expects the following request:
         - POST /v1/videos/{video_id}/remix
         """
+        original_video_id = extract_original_video_id(video_id)
+        
         # Construct the URL for video remix
-        url = f"{api_base.rstrip('/')}/{video_id}/remix"
+        url = f"{api_base.rstrip('/')}/{original_video_id}/remix"
         
         # Prepare the request data
         data = {"prompt": prompt}
@@ -215,17 +216,14 @@ class OpenAIVideoConfig(BaseVideoConfig):
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
     ) -> bytes:
-        """
-        Transform the OpenAI video content download response.
-        Returns raw video content as bytes.
-        """
-        # For video content download, return the raw content as bytes
+        """Transform the OpenAI video content download response."""
         return raw_response.content
 
     def transform_video_remix_response(
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
         """
         Transform the OpenAI video remix response.
@@ -234,6 +232,9 @@ class OpenAIVideoConfig(BaseVideoConfig):
         
         # Transform the response data
         video_obj = VideoObject(**response_data)  # type: ignore[arg-type]
+        
+        if custom_llm_provider and video_obj.id:
+            video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, None)
         
         # Create usage object with duration information for cost calculation
         # Video remix API doesn't provide usage, so we create one with duration
@@ -287,8 +288,20 @@ class OpenAIVideoConfig(BaseVideoConfig):
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> Dict[str,str]:
-        return raw_response.json()
+        response_data = raw_response.json()
+        
+        if custom_llm_provider and "data" in response_data:
+            for video_obj in response_data.get("data", []):
+                if isinstance(video_obj, dict) and "id" in video_obj:
+                    video_obj["id"] = encode_video_id_with_provider(
+                        video_obj["id"], 
+                        custom_llm_provider, 
+                        video_obj.get("model")
+                    )
+        
+        return response_data
 
     def transform_video_delete_request(
         self,
@@ -303,8 +316,10 @@ class OpenAIVideoConfig(BaseVideoConfig):
         OpenAI API expects the following request:
         - DELETE /v1/videos/{video_id}
         """
+        original_video_id = extract_original_video_id(video_id)
+        
         # Construct the URL for video delete
-        url = f"{api_base.rstrip('/')}/{video_id}"
+        url = f"{api_base.rstrip('/')}/{original_video_id}"
         
         # No data needed for DELETE request
         data: Dict[str, Any] = {}
@@ -336,8 +351,11 @@ class OpenAIVideoConfig(BaseVideoConfig):
         """
         Transform the OpenAI video retrieve request.
         """
+        # Extract the original video_id (remove provider encoding if present)
+        original_video_id = extract_original_video_id(video_id)
+        
         # For video retrieve, we just need to construct the URL
-        url = f"{api_base.rstrip('/')}/{video_id}"
+        url = f"{api_base.rstrip('/')}/{original_video_id}"
         
         # No additional data needed for GET request
         data: Dict[str, Any] = {}
@@ -348,6 +366,7 @@ class OpenAIVideoConfig(BaseVideoConfig):
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
+        custom_llm_provider: Optional[str] = None,
     ) -> VideoObject:
         """
         Transform the OpenAI video retrieve response.
@@ -355,6 +374,9 @@ class OpenAIVideoConfig(BaseVideoConfig):
         response_data = raw_response.json()
         # Transform the response data
         video_obj = VideoObject(**response_data)  # type: ignore[arg-type]
+        
+        if custom_llm_provider and video_obj.id:
+            video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, None)
 
         return video_obj
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2782,6 +2782,10 @@ class SpecialEnums(Enum):
 
     LITELLM_MANAGED_GENERIC_RESPONSE_COMPLETE_STR = "litellm_proxy;model_id:{};generic_response_id:{}"  # generic implementation of 'managed batches' - used for finetuning and any future work.
 
+    LITELLM_MANAGED_VIDEO_COMPLETE_STR = (
+        "litellm:custom_llm_provider:{};model_id:{};video_id:{}"
+    )
+
 
 class ServiceTier(Enum):
     """Enum for service tier types used in cost calculations."""

--- a/litellm/types/videos/main.py
+++ b/litellm/types/videos/main.py
@@ -87,3 +87,10 @@ class VideoCreateRequestParams(VideoCreateOptionalRequestParams, total=False):
     Params here: https://platform.openai.com/docs/api-reference/videos/create
     """
     prompt: str
+
+class DecodedVideoId(TypedDict, total=False):
+    """Structure representing a decoded video ID"""
+
+    custom_llm_provider: Optional[str]
+    model_id: Optional[str]
+    video_id: str

--- a/litellm/types/videos/utils.py
+++ b/litellm/types/videos/utils.py
@@ -1,0 +1,100 @@
+"""
+Utility functions for video ID encoding/decoding with provider information.
+
+Follows the pattern used in responses/utils.py for consistency.
+Format: vid_{base64_encoded_string}
+"""
+import base64
+from typing import Tuple, Optional
+from litellm.types.utils import SpecialEnums
+from litellm.types.videos.main import DecodedVideoId    
+from litellm._logging import verbose_logger
+
+
+
+VIDEO_ID_PREFIX = "vid_"
+
+
+def encode_video_id_with_provider(
+    video_id: str, 
+    provider: str,
+    model_id: Optional[str] = None
+) -> str:
+    """Encode provider and model_id into video_id using base64."""
+    if not provider or not video_id:
+        return video_id
+    
+    if video_id.startswith(VIDEO_ID_PREFIX):
+        return video_id
+    
+    assembled_id = str(
+        SpecialEnums.LITELLM_MANAGED_VIDEO_COMPLETE_STR.value
+    ).format(provider, model_id or "", video_id)
+    
+    base64_encoded_id: str = base64.b64encode(assembled_id.encode("utf-8")).decode("utf-8")
+    
+    return f"{VIDEO_ID_PREFIX}{base64_encoded_id}"
+
+
+def decode_video_id_with_provider(encoded_video_id: str) -> DecodedVideoId:
+    """Decode provider and model_id from encoded video_id."""
+    if not encoded_video_id:
+        return DecodedVideoId(
+            custom_llm_provider=None,
+            model_id=None,
+            video_id=encoded_video_id,
+        )
+    
+    if not encoded_video_id.startswith(VIDEO_ID_PREFIX):
+        return DecodedVideoId(
+            custom_llm_provider=None,
+            model_id=None,
+            video_id=encoded_video_id,
+        )
+    
+    try:
+        cleaned_id = encoded_video_id.replace(VIDEO_ID_PREFIX, "")
+        decoded_id = base64.b64decode(cleaned_id.encode("utf-8")).decode("utf-8")
+
+        if ";" not in decoded_id:
+            return DecodedVideoId(
+                custom_llm_provider=None,
+                model_id=None,
+                video_id=encoded_video_id,
+            )
+
+        parts = decoded_id.split(";")
+
+        custom_llm_provider = None
+        model_id = None
+        decoded_video_id = encoded_video_id
+
+        if len(parts) >= 3:
+            custom_llm_provider_part = parts[0]
+            model_id_part = parts[1]
+            video_id_part = parts[2]
+
+            custom_llm_provider = custom_llm_provider_part.replace(
+                "litellm:custom_llm_provider:", ""
+            )
+            model_id = model_id_part.replace("model_id:", "")
+            decoded_video_id = video_id_part.replace("video_id:", "")
+
+        return DecodedVideoId(
+            custom_llm_provider=custom_llm_provider,
+            model_id=model_id,
+            video_id=decoded_video_id,
+        )
+    except Exception as e:
+        verbose_logger.debug(f"Error decoding video_id '{encoded_video_id}': {e}")
+        return DecodedVideoId(
+            custom_llm_provider=None,
+            model_id=None,
+            video_id=encoded_video_id,
+        )
+
+
+def extract_original_video_id(encoded_video_id: str) -> str:
+    """Extract original video ID without encoding."""
+    decoded = decode_video_id_with_provider(encoded_video_id)
+    return decoded.get("video_id", encoded_video_id)

--- a/litellm/types/videos/utils.py
+++ b/litellm/types/videos/utils.py
@@ -12,7 +12,7 @@ from litellm._logging import verbose_logger
 
 
 
-VIDEO_ID_PREFIX = "vid_"
+VIDEO_ID_PREFIX = "video_"
 
 
 def encode_video_id_with_provider(

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -19,6 +19,7 @@ from litellm.types.router import GenericLiteLLMParams
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.types.videos.utils import decode_video_id_with_provider
 
 #################### Initialize provider clients ####################
 llm_http_handler: BaseLLMHTTPHandler = BaseLLMHTTPHandler()
@@ -198,6 +199,9 @@ def video_generation(  # noqa: PLR0915
             model=model or DEFAULT_VIDEO_ENDPOINT_MODEL,
             custom_llm_provider=custom_llm_provider,
         )
+        print("custom_llm_provider", custom_llm_provider)
+        print("model", model)
+        print("DEFAULT_VIDEO_ENDPOINT_MODEL", DEFAULT_VIDEO_ENDPOINT_MODEL)
 
         # get provider config
         video_generation_provider_config: Optional[BaseVideoConfig] = (
@@ -303,13 +307,10 @@ def video_content(
         ```python
         import litellm
 
-        # Download video content
         video_bytes = litellm.video_content(
-            video_id="video_123",
-            custom_llm_provider="openai"
+            video_id="video_123"
         )
 
-        # Save to file
         with open("video.mp4", "wb") as f:
             f.write(video_bytes)
         ```
@@ -320,9 +321,10 @@ def video_content(
         litellm_call_id: Optional[str] = kwargs.get("litellm_call_id", None)
         _is_async = kwargs.pop("async_call", False) is True
 
-        # Ensure custom_llm_provider is not None - default to openai if not provided
+        # Try to decode provider from video_id if not explicitly provided
         if custom_llm_provider is None:
-            custom_llm_provider = "openai"
+            decoded = decode_video_id_with_provider(video_id)
+            custom_llm_provider = decoded.get("custom_llm_provider") or "openai"
 
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)
@@ -594,9 +596,10 @@ def video_remix(  # noqa: PLR0915
             response = VideoObject(**mock_response)
             return response
 
-        # Ensure custom_llm_provider is not None - default to openai if not provided
+        # Try to decode provider from video_id if not explicitly provided
         if custom_llm_provider is None:
-            custom_llm_provider = "openai"
+            decoded = decode_video_id_with_provider(video_id)
+            custom_llm_provider = decoded.get("custom_llm_provider") or "openai"
 
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)
@@ -907,7 +910,7 @@ async def avideo_status(
 
     Returns:
     - `response` (VideoObject): The response returned by the `video_status` function.
-"""
+    """
     local_vars = locals()
     try:
         loop = asyncio.get_event_loop()
@@ -1015,8 +1018,7 @@ def video_status(  # noqa: PLR0915
 
         # Get video status
         video_status = litellm.video_status(
-            video_id="video_123",
-            custom_llm_provider="openai"
+            video_id="video_123"
         )
 
         print(f"Video status: {video_status.status}")
@@ -1038,9 +1040,10 @@ def video_status(  # noqa: PLR0915
             response = VideoObject(**mock_response)
             return response
 
-        # Ensure custom_llm_provider is not None - default to openai if not provided
+        # Try to decode provider from video_id if not explicitly provided
         if custom_llm_provider is None:
-            custom_llm_provider = "openai"
+            decoded = decode_video_id_with_provider(video_id)
+            custom_llm_provider = decoded.get("custom_llm_provider") or "openai"
 
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -199,8 +199,6 @@ def video_generation(  # noqa: PLR0915
             model=model or DEFAULT_VIDEO_ENDPOINT_MODEL,
             custom_llm_provider=custom_llm_provider,
         )
-        print("model", model)
-        print("DEFAULT_VIDEO_ENDPOINT_MODEL", DEFAULT_VIDEO_ENDPOINT_MODEL)
 
         # get provider config
         video_generation_provider_config: Optional[BaseVideoConfig] = (

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -199,7 +199,6 @@ def video_generation(  # noqa: PLR0915
             model=model or DEFAULT_VIDEO_ENDPOINT_MODEL,
             custom_llm_provider=custom_llm_provider,
         )
-        print("custom_llm_provider", custom_llm_provider)
         print("model", model)
         print("DEFAULT_VIDEO_ENDPOINT_MODEL", DEFAULT_VIDEO_ENDPOINT_MODEL)
 


### PR DESCRIPTION
## Title
**Refactor Video API: Encode provider and model in video_id**

## Relevant issues
Improves developer experience by eliminating the need to pass `custom_llm_provider` as a separate header/parameter for video operations.
Fixes LIT-1406

## Summary
This PR refactors the video API to encode `custom_llm_provider` and `model_id` directly into the `video_id` using base64 encoding. This eliminates the awkward need for users to pass `custom_llm_provider` as a separate header for video operations like status, content, remix, and delete.

### Before (Awkward)
```bash
curl --location 'http://localhost:4000/v1/videos/video_69065c4ba9808190942abf87d534e8190bcf61df3535e115/content' \
  --header 'Accept: application/json' \
  --header 'x-litellm-api-key: sk-1234' \
  --header "custom-llm-provider: openai" \  # ❌ Extra header required
  --output video_demo.mp4
```

### After (Clean)
```bash
curl --location 'http://localhost:4000/v1/videos/video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpzb3JhLTI7dmlkZW9faWQ6dmlkZW9fMTIz/content' \
  --header 'Accept: application/json' \
  --header 'x-litellm-api-key: sk-1234' \  # ✅ No extra header needed
  --output video_demo.mp4
```

## Key Changes

### 1. **New Video ID Format**
- Format: `vid_{base64_encoded_string}`
- Encoded string contains: `litellm:custom_llm_provider:{provider};model_id:{model};video_id:{original_id}`
- Example: `vid_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpzb3JhLTI7dmlkZW9faWQ6dmlkZW9fMTIz`

### 2. **New Utility Functions** (`litellm/types/videos/utils.py`)
- `encode_video_id_with_provider()` - Encodes provider, model_id, and video_id into a single base64 string
- `decode_video_id_with_provider()` - Decodes the video_id to extract provider, model_id, and original video_id
- `extract_original_video_id()` - Helper to get the original provider video_id for API calls

### 3. **Updated Transformation Classes**
- **Base class** (`litellm/llms/base_llm/videos/transformation.py`): Added `custom_llm_provider` parameter to response transformation methods
- **OpenAI provider** (`litellm/llms/openai/videos/transformation.py`): 
  - Encodes video IDs in all response transformations
  - Decodes video IDs in all request transformations
  - Added robust error handling for API errors
- **HTTP handlers** (`litellm/llms/custom_httpx/llm_http_handler.py`): Pass `custom_llm_provider` to transformation methods

### 4. **Updated Proxy Endpoints** (`litellm/proxy/video_endpoints/endpoints.py`)
- Video status, content, remix, and delete endpoints now extract provider from `video_id`
- Removed requirement for `custom_llm_provider` header/parameter (except for `video_list`)

### 5. **Updated SDK Functions** (`litellm/videos/main.py`)
- `video_status()`, `video_content()`, `video_remix()` now decode provider from `video_id`
- Maintains backward compatibility - `custom_llm_provider` parameter still works if explicitly provided

### 6. **Updated Documentation**
- Added "Video ID Format" section explaining the encoding scheme
- Updated all Python SDK and cURL examples
- Clarified that `custom_llm_provider` is only required for `video_list` endpoint

### Example Video ID Format
```python
# Encoded video ID
video_id = "video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpzb3JhLTI7dmlkZW9faWQ6dmlkZW9fMTIz"

# Decodes to:
{
    "custom_llm_provider": "openai",
    "model_id": "sora-2",
    "video_id": "video_123"
}
```

---
