### PR TITLE
Fix langfuse input tokens logic for cached tokens

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -688,16 +688,18 @@ class LangFuseLogger:
                         "completion_tokens": _usage_obj.completion_tokens,
                         "total_cost": cost if self._supports_costs() else None,
                     }
+                    cache_read_input_tokens = _usage_obj.get(
+                            "cache_read_input_tokens", 0
+                    )
+                    input_tokens = _usage_obj.prompt_tokens - cache_read_input_tokens
                     usage_details = LangfuseUsageDetails(
-                        input=_usage_obj.prompt_tokens,
+                        input=input_tokens,
                         output=_usage_obj.completion_tokens,
                         total=_usage_obj.total_tokens,
                         cache_creation_input_tokens=_usage_obj.get(
                             "cache_creation_input_tokens", 0
                         ),
-                        cache_read_input_tokens=_usage_obj.get(
-                            "cache_read_input_tokens", 0
-                        ),
+                        cache_read_input_tokens=cache_read_input_tokens,
                     )
 
             generation_name = clean_metadata.pop("generation_name", None)

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -691,6 +691,7 @@ class LangFuseLogger:
                     cache_read_input_tokens = _usage_obj.get(
                             "cache_read_input_tokens", 0
                     )
+                    # According to langfuse documentation: "the input value must be reduced by the number of cache_read_input_tokens"
                     input_tokens = _usage_obj.prompt_tokens - cache_read_input_tokens
                     usage_details = LangfuseUsageDetails(
                         input=input_tokens,


### PR DESCRIPTION
## Fixing issue with input_tokens and cache_read_tokens.

According to [this issue in langfuse](https://github.com/langfuse/langfuse/issues/9386#issuecomment-3396511224), LiteLLM is ingesting the data to langfuse wrongly. According to them "the input value must be reduced by the number of cache_read_input_tokens. With the current ingestion format you are using, Langfuse is interpreting that there has been 8k regular input tokens and 8k cached input tokens used for the generation input.". So the cost estimation on langfuse is also wrong because of that. 


## Relevant issues

[LangFuse Issue#9386](https://github.com/langfuse/langfuse/issues/9386#issuecomment-3396511224)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Changed the logic of input tokens when we read tokens from cache.

