### PR TITLE
Fix: Azure OpenAI Responses API incorrectly blocking temperature parameter for GPT-5

### DIFF
--- a/litellm/llms/azure/responses/o_series_transformation.py
+++ b/litellm/llms/azure/responses/o_series_transformation.py
@@ -88,5 +88,10 @@ class AzureOpenAIOSeriesResponsesAPIConfig(AzureOpenAIResponsesAPIConfig):
         Returns:
             True if it's an O-series model, False otherwise
         """
-        # Check for explicit o_series prefix or o1/o3/o4 model names
-        return "o_series" in model.lower() or "o1" in model or "o3" in model or "o4" in model 
+        # Check if path contains o_series/ routing prefix (e.g., azure/responses/o_series/model)
+        if "o_series/" in model:
+            return True
+        
+        # Check if the base model name starts with o1/o3/o4 prefixes
+        model_basename = model.split("/")[-1]  # could be "azure/o3" or "o3"
+        return any(model_basename.startswith(pfx) for pfx in ("o1", "o3", "o4")) 

--- a/litellm/llms/azure/responses/o_series_transformation.py
+++ b/litellm/llms/azure/responses/o_series_transformation.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from litellm._logging import verbose_logger
 from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
-from litellm.utils import supports_reasoning
 
 from .transformation import AzureOpenAIResponsesAPIConfig
 
@@ -79,15 +78,15 @@ class AzureOpenAIOSeriesResponsesAPIConfig(AzureOpenAIResponsesAPIConfig):
         """
         Check if the model is an O-series model.
         
+        O-series models include o1, o3, o4, etc. families (e.g., o1-preview, o3-mini).
+        Note: This is different from models that support reasoning - GPT-5 supports
+        reasoning but is NOT an O-series model.
+        
         Args:
             model: The model name to check
             
         Returns:
             True if it's an O-series model, False otherwise
         """
-        # Check if model name contains o_series or if it's a known O-series model
-        if "o_series" in model.lower():
-            return True
-            
-        # Check if the model supports reasoning (which is O-series specific)
-        return supports_reasoning(model) 
+        # Check for explicit o_series prefix or o1/o3/o4 model names
+        return "o_series" in model.lower() or "o1" in model or "o3" in model or "o4" in model 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7396,8 +7396,10 @@ class ProviderConfigManager:
         if litellm.LlmProviders.OPENAI == provider:
             return litellm.OpenAIResponsesAPIConfig()
         elif litellm.LlmProviders.AZURE == provider:
-            # Check if it's an O-series model
-            if model and ("o_series" in model.lower() or supports_reasoning(model)):
+            # Check if it's an O-series model (o1, o3, o4, etc.)
+            # Note: We check for specific O-series model names, not just "supports_reasoning"
+            # since GPT-5 supports reasoning but is NOT an O-series model
+            if model and ("o_series" in model.lower() or "o1" in model or "o3" in model or "o4" in model):
                 return litellm.AzureOpenAIOSeriesResponsesAPIConfig()
             else:
                 return litellm.AzureOpenAIResponsesAPIConfig()

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7399,10 +7399,15 @@ class ProviderConfigManager:
             # Check if it's an O-series model (o1, o3, o4, etc.)
             # Note: We check for specific O-series model names, not just "supports_reasoning"
             # since GPT-5 supports reasoning but is NOT an O-series model
-            if model and ("o_series" in model.lower() or "o1" in model or "o3" in model or "o4" in model):
-                return litellm.AzureOpenAIOSeriesResponsesAPIConfig()
-            else:
-                return litellm.AzureOpenAIResponsesAPIConfig()
+            if model:
+                # Check if path contains o_series/ routing prefix
+                if "o_series/" in model:
+                    return litellm.AzureOpenAIOSeriesResponsesAPIConfig()
+                # Check if the base model name starts with o1/o3/o4 prefixes
+                _model = model.split("/")[-1]  # could be "azure/o3" or "o3"
+                if any(_model.startswith(pfx) for pfx in ("o1", "o3", "o4")):
+                    return litellm.AzureOpenAIOSeriesResponsesAPIConfig()
+            return litellm.AzureOpenAIResponsesAPIConfig()
         elif litellm.LlmProviders.LITELLM_PROXY == provider:
             return litellm.LiteLLMProxyResponsesAPIConfig()
         return None

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -194,9 +194,25 @@ def test_o_series_model_detection():
     assert config.is_o_series_model("o_series/gpt-o1") == True
     assert config.is_o_series_model("azure/o_series/gpt-o3") == True
 
+    # Test O1 models
+    assert config.is_o_series_model("o1") == True
+    assert config.is_o_series_model("o1-preview") == True
+    assert config.is_o_series_model("o1-mini") == True
+    assert config.is_o_series_model("azure/o1-preview") == True
+
+    # Test O3 models
+    assert config.is_o_series_model("o3") == True
+    assert config.is_o_series_model("o3-mini") == True
+    assert config.is_o_series_model("azure/o3-mini") == True
+
     # Test regular models
     assert config.is_o_series_model("gpt-4o") == False
     assert config.is_o_series_model("gpt-3.5-turbo") == False
+    
+    # Test GPT-5 (supports reasoning but is NOT an O-series model)
+    assert config.is_o_series_model("gpt-5") == False
+    assert config.is_o_series_model("gpt-5-turbo") == False
+    assert config.is_o_series_model("azure/gpt-5") == False
 
 
 @pytest.mark.serial
@@ -211,12 +227,34 @@ def test_provider_config_manager_o_series_selection():
     )
     assert isinstance(o_series_config, AzureOpenAIOSeriesResponsesAPIConfig)
 
+    # Test O1 model selection
+    o1_config = ProviderConfigManager.get_provider_responses_api_config(
+        provider=litellm.LlmProviders.AZURE, model="o1-preview"
+    )
+    assert isinstance(o1_config, AzureOpenAIOSeriesResponsesAPIConfig)
+
+    # Test O3 model selection
+    o3_config = ProviderConfigManager.get_provider_responses_api_config(
+        provider=litellm.LlmProviders.AZURE, model="o3-mini"
+    )
+    assert isinstance(o3_config, AzureOpenAIOSeriesResponsesAPIConfig)
+
     # Test regular model selection
     regular_config = ProviderConfigManager.get_provider_responses_api_config(
         provider=litellm.LlmProviders.AZURE, model="gpt-4o"
     )
     assert isinstance(regular_config, AzureOpenAIResponsesAPIConfig)
     assert not isinstance(regular_config, AzureOpenAIOSeriesResponsesAPIConfig)
+
+    # Test GPT-5 model selection (supports reasoning but is NOT O-series)
+    gpt5_config = ProviderConfigManager.get_provider_responses_api_config(
+        provider=litellm.LlmProviders.AZURE, model="gpt-5"
+    )
+    assert isinstance(gpt5_config, AzureOpenAIResponsesAPIConfig)
+    assert not isinstance(gpt5_config, AzureOpenAIOSeriesResponsesAPIConfig)
+    # Verify temperature is supported for GPT-5
+    gpt5_params = gpt5_config.get_supported_openai_params("gpt-5")
+    assert "temperature" in gpt5_params, "GPT-5 should support temperature parameter"
 
     # Test with no model specified (should default to regular)
     default_config = ProviderConfigManager.get_provider_responses_api_config(

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -213,6 +213,12 @@ def test_o_series_model_detection():
     assert config.is_o_series_model("gpt-5") == False
     assert config.is_o_series_model("gpt-5-turbo") == False
     assert config.is_o_series_model("azure/gpt-5") == False
+    
+    # Edge cases: Models with "o1", "o3", "o4" in the middle or end should NOT match
+    # (using startswith ensures only models that START with these prefixes match)
+    assert config.is_o_series_model("gpt-4o1") == False  # has "o1" but doesn't start with it
+    assert config.is_o_series_model("gpto1") == False  # has "o1" but doesn't start with it
+    assert config.is_o_series_model("model-o3-test") == False  # has "o3" but doesn't start with it
 
 
 @pytest.mark.serial


### PR DESCRIPTION
## Problem

Azure OpenAI Responses API was incorrectly blocking the `temperature` parameter for GPT-5 models with the following error:

```
litellm.exceptions.UnsupportedParamsError: LlmProviders.AZURE does not support parameters: {'temperature': 1.0}, for model=gpt-5
```

However, according to both [OpenAI documentation](https://platform.openai.com/docs/api-reference/responses/create#responses_create-temperature) and [Azure AI documentation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference-preview-latest#request-body-14), the Responses API **does support** the `temperature` parameter for non-O-series models.

Source issue: fix https://github.com/OpenHands/software-agent-sdk/issues/986

## Root Cause

The bug occurred because LiteLLM was using `supports_reasoning(model)` as a proxy to detect O-series models (o1, o3, o4). This caused GPT-5 to be incorrectly classified:

1. **In `litellm/utils.py` (line 7400)**: Used `supports_reasoning(model)` to determine if a model should use `AzureOpenAIOSeriesResponsesAPIConfig`
2. **In `litellm/llms/azure/responses/o_series_transformation.py` (line 93)**: The `is_o_series_model()` method also used `supports_reasoning(model)`
3. **The Issue**: GPT-5 has `"supports_reasoning": true` in `model_prices_and_context_window.json`, but GPT-5 is **NOT** an O-series model
4. **Result**: GPT-5 incorrectly used `AzureOpenAIOSeriesResponsesAPIConfig` which blocks `temperature`, instead of `AzureOpenAIResponsesAPIConfig` which allows it

### The Key Distinction

- **O-series models** are specific model families: o1, o3, o4 (e.g., o1-preview, o3-mini)
  - These models have parameter restrictions (no temperature, etc.)
- **Models that support reasoning** is a broader category that includes:
  - O-series models (o1, o3, o4)
  - GPT-5 (supports reasoning but is NOT O-series)

## Solution

Updated the O-series detection logic to check for specific model name patterns instead of using the `supports_reasoning` flag:

### Changes Made

1. **`litellm/llms/azure/responses/o_series_transformation.py`**:
   - Updated `is_o_series_model()` to check for explicit O-series model names: `"o1"`, `"o3"`, `"o4"`, or `"o_series"` in model name
   - Removed dependency on `supports_reasoning()`
   - Removed unused `supports_reasoning` import

2. **`litellm/utils.py`**:
   - Updated `ProviderConfigManager.get_provider_responses_api_config()` to use explicit O-series model name checks
   - No longer relies on `supports_reasoning()` for determining config selection

3. **`tests/test_litellm/llms/azure/response/test_azure_transformation.py`**:
   - Enhanced `test_o_series_model_detection()` to include GPT-5 test cases
   - Enhanced `test_provider_config_manager_o_series_selection()` to verify:
     - GPT-5 gets `AzureOpenAIResponsesAPIConfig` (not O-series config)
     - GPT-5 supports the `temperature` parameter
     - O1/O3 models still correctly get `AzureOpenAIOSeriesResponsesAPIConfig`

## Verification

### Before Fix
```python
config = ProviderConfigManager.get_provider_responses_api_config(
    provider=litellm.LlmProviders.AZURE, model="gpt-5"
)
# Returns: AzureOpenAIOSeriesResponsesAPIConfig (WRONG!)
# Temperature supported: False (BUG!)
```

### After Fix
```python
config = ProviderConfigManager.get_provider_responses_api_config(
    provider=litellm.LlmProviders.AZURE, model="gpt-5"
)
# Returns: AzureOpenAIResponsesAPIConfig (CORRECT!)
# Temperature supported: True (FIXED!)
```

### Test Results
```
Model: gpt-5          (Regular model with reasoning support)
  Config: AzureOpenAIResponsesAPIConfig
  Supports temperature: True ✓

Model: gpt-4o         (Regular model)
  Config: AzureOpenAIResponsesAPIConfig
  Supports temperature: True ✓

Model: o1-preview     (O-series model)
  Config: AzureOpenAIOSeriesResponsesAPIConfig
  Supports temperature: False ✓

Model: o3-mini        (O-series model)
  Config: AzureOpenAIOSeriesResponsesAPIConfig
  Supports temperature: False ✓
```

All 15 tests in `test_azure_transformation.py` pass ✅

## Impact

- ✅ GPT-5 now correctly supports the `temperature` parameter on Azure Responses API
- ✅ O-series models (o1, o3, o4) continue to work correctly with appropriate restrictions
- ✅ All existing functionality remains intact
- ✅ No breaking changes

## Files Changed

- `litellm/llms/azure/responses/o_series_transformation.py` (+7, -6)
- `litellm/utils.py` (+4, -2)
- `tests/test_litellm/llms/azure/response/test_azure_transformation.py` (+38, -0)

**Total: 3 files changed, 48 insertions(+), 9 deletions(-)**

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f876aee5bab7450e9abcfb999450fc89)