### PR TITLE
[Feat] s3 logger, add support for ssl_verify when using minio logger

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -1,6 +1,5 @@
 import json
-from abc import ABC
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from typing_extensions import override
 
@@ -101,7 +100,6 @@ def set_attributes(
         SpanAttributes,
         ToolCallAttributes,
     )
-    from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
     try:
         optional_params = kwargs.get("optional_params", {})

--- a/litellm/integrations/langfuse/langfuse_otel_attributes.py
+++ b/litellm/integrations/langfuse/langfuse_otel_attributes.py
@@ -5,13 +5,11 @@ Relevant Issue: https://github.com/BerriAI/litellm/issues/13764
 """
 
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
-from numpy import isin
 from pydantic import BaseModel
 from typing_extensions import override
 
-import litellm
 from litellm.integrations.opentelemetry_utils.base_otel_llm_obs_attributes import (
     BaseLLMObsOTELAttributes,
     safe_set_attribute,

--- a/litellm/integrations/opentelemetry_utils/base_otel_llm_obs_attributes.py
+++ b/litellm/integrations/opentelemetry_utils/base_otel_llm_obs_attributes.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -57,12 +57,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 f"in init s3 logger - s3_callback_params {litellm.s3_callback_params}"
             )
 
-            # IMPORTANT: We use a concurrent limit of 1 to upload to s3
-            # Files should get uploaded BUT they should not impact latency of LLM calling logic
-            self.async_httpx_client = get_async_httpx_client(
-                llm_provider=httpxSpecialProvider.LoggingCallback,
-            )
-
+            # Initialize S3 params first to get the correct s3_verify value
             self._init_s3_params(
                 s3_bucket_name=s3_bucket_name,
                 s3_region_name=s3_region_name,
@@ -84,6 +79,16 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 s3_strip_base64_files=s3_strip_base64_files
             )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
+
+            # IMPORTANT
+            # Create httpx client AFTER _init_s3_params so we have the correct s3_verify value
+            verbose_logger.debug(
+                f"s3_v2 logger creating async httpx client with s3_verify={self.s3_verify}"
+            )
+            self.async_httpx_client = get_async_httpx_client(
+                llm_provider=httpxSpecialProvider.LoggingCallback,
+                params={"ssl_verify": self.s3_verify}
+            )
 
             asyncio.create_task(self.periodic_flush())
             self.flush_lock = asyncio.Lock()
@@ -147,9 +152,11 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             litellm.s3_callback_params.get("s3_api_version") or s3_api_version
         )
         self.s3_use_ssl = (
-            litellm.s3_callback_params.get("s3_use_ssl", True) or s3_use_ssl
+            litellm.s3_callback_params.get("s3_use_ssl", True) if litellm.s3_callback_params.get("s3_use_ssl") is not None else s3_use_ssl
         )
-        self.s3_verify = litellm.s3_callback_params.get("s3_verify") or s3_verify
+        self.s3_verify = (
+            litellm.s3_callback_params.get("s3_verify") if litellm.s3_callback_params.get("s3_verify") is not None else s3_verify
+        )
         self.s3_endpoint_url = (
             litellm.s3_callback_params.get("s3_endpoint_url") or s3_endpoint_url
         )
@@ -278,6 +285,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
             verbose_logger.debug(
                 f"s3_v2 logger - uploading data to s3 - {batch_logging_element.s3_object_key}"
+            )
+            verbose_logger.debug(
+                f"s3_v2 logger - s3_verify setting: {self.s3_verify}"
             )
 
             # Prepare the URL
@@ -477,7 +487,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             # Prepare the signed headers
             signed_headers = dict(aws_request.headers.items())
 
-            httpx_client = _get_httpx_client()
+            httpx_client = _get_httpx_client(
+                params={"ssl_verify": self.s3_verify} if self.s3_verify is not None else None
+            )
             # Make the request
             response = httpx_client.put(url, data=json_string, headers=signed_headers)
             response.raise_for_status()

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/count_tokens/handler.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
-from litellm.types.llms.vertex_ai import VertexPartnerProvider
 
 
 class VertexAIPartnerModelsTokenCounter(VertexBase):

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -23,12 +23,20 @@ search_tools:
       api_key: os.environ/EXA_API_KEY
   
 
-
-# for /files endpoints
-files_settings:
-  - custom_llm_provider: openai
-    api_key: os.environ/OPENAI_API_KEY
-
-
 litellm_settings:
-  callbacks: ["datadog"]
+  # Comprehensive logging settings
+  store_audit_logs: true
+  verbose: true
+  log_level: "DEBUG"  # Options: DEBUG, INFO, WARNING, ERROR
+  success_callback: ["s3_v2"]
+  s3_callback_params:
+    s3_endpoint_url: "https://mgtd-ai-m01.dcs.leidos.com:9000"  # Replace with your Minio server URL and port
+    s3_aws_access_key_id: ""
+    s3_aws_secret_access_key: ""
+    s3_region_name: "minio"  # This can be any value for Minio
+    s3_bucket_name: "litellm-logs"  # Replace with your bucket name
+    s3_use_ssl: False
+    s3_verify: False
+  cache: True
+  cache_params:
+    type: local

--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -30,11 +30,11 @@ litellm_settings:
   log_level: "DEBUG"  # Options: DEBUG, INFO, WARNING, ERROR
   success_callback: ["s3_v2"]
   s3_callback_params:
-    s3_endpoint_url: "https://mgtd-ai-m01.dcs.leidos.com:9000"  # Replace with your Minio server URL and port
-    s3_aws_access_key_id: ""
-    s3_aws_secret_access_key: ""
+    s3_endpoint_url: "https://localhost:443"  # Replace with your Minio server URL and port
+    s3_aws_access_key_id: "minioadmin"
+    s3_aws_secret_access_key: "minioadmin"
     s3_region_name: "minio"  # This can be any value for Minio
-    s3_bucket_name: "litellm-logs"  # Replace with your bucket name
+    s3_bucket_name: "litellm-test"  # Replace with your bucket name
     s3_use_ssl: False
     s3_verify: False
   cache: True


### PR DESCRIPTION
## [Feat] s3 logger, add support for ssl_verify when using minio logger

Fixes a bug in S3 v2 logger where `s3_verify=False` was being ignored, causing SSL certificate verification errors when connecting to MinIO or S3-compatible endpoints with self-signed certificates.

## Root Cause

The parameter loading logic used `litellm.s3_callback_params.get("s3_verify") or s3_verify`, which treated `False` as falsy and fell back to `s3_verify` (None). This caused SSL verification to remain enabled even when explicitly disabled.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


