### PR TITLE
Add tags and descriptions support to aws secrets manager

### DIFF
--- a/docs/my-website/docs/secret.md
+++ b/docs/my-website/docs/secret.md
@@ -71,8 +71,8 @@ general_settings:
     store_virtual_keys: true # OPTIONAL. Defaults to False, when True will store virtual keys in secret manager
     prefix_for_stored_virtual_keys: "litellm/" # OPTIONAL. If set, this prefix will be used for stored virtual keys in the secret manager
     access_mode: "write_only" # Literal["read_only", "write_only", "read_and_write"]
-    description: "litellm virtual key" # OPTIONAL, if set will set this as the description
-    tags:
+    description: "litellm virtual key" # OPTIONAL, if set will set this as the description for all virtual keys
+    tags: # OPTIONAL, if set will set this as the tags for all virtual keys
       Environment: "Prod"
       Owner: "AI Platform team"
 ```

--- a/docs/my-website/docs/secret.md
+++ b/docs/my-website/docs/secret.md
@@ -71,6 +71,10 @@ general_settings:
     store_virtual_keys: true # OPTIONAL. Defaults to False, when True will store virtual keys in secret manager
     prefix_for_stored_virtual_keys: "litellm/" # OPTIONAL. If set, this prefix will be used for stored virtual keys in the secret manager
     access_mode: "write_only" # Literal["read_only", "write_only", "read_and_write"]
+    description: "litellm virtual key" # OPTIONAL, if set will set this as the description
+    tags:
+      Environment: "Prod"
+      Owner: "AI Platform team"
 ```
 </TabItem>
 <TabItem value="read_and_write" label="Read + Write Keys with AWS Secret Manager">

--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -234,11 +234,21 @@ class KeyManagementEventHooks:
 
                 # store the key in the secret manager
                 if isinstance(litellm.secret_manager_client, BaseSecretManager):
+                    tags = getattr(litellm._key_management_settings, "tags", None)
+                    description = getattr(
+                        litellm._key_management_settings, "description", None
+                    )
+                    verbose_proxy_logger.debug(
+                        f"Creating secret with {secret_name} and tags={tags} and description={description}"
+                    )
+
                     await litellm.secret_manager_client.async_write_secret(
                         secret_name=KeyManagementEventHooks._get_secret_name(
                             secret_name
                         ),
+                        description=description,
                         secret_value=secret_token,
+                        tags=tags
                     )
 
     @staticmethod

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -198,12 +198,13 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
         return primary_secret_kv_pairs.get(secret_name)
 
     async def async_write_secret(
-        self,
-        secret_name: str,
-        secret_value: str,
-        description: Optional[str] = None,
-        optional_params: Optional[dict] = None,
-        timeout: Optional[Union[float, httpx.Timeout]] = None,
+            self,
+            secret_name: str,
+            secret_value: str,
+            description: Optional[str] = None,
+            optional_params: Optional[dict] = None,
+            timeout: Optional[Union[float, httpx.Timeout]] = None,
+            tags: Optional[Union[dict, list]] = None
     ) -> dict:
         """
         Async function to write a secret to AWS Secrets Manager
@@ -214,22 +215,37 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
             description: Optional description for the secret
             optional_params: Additional AWS parameters
             timeout: Request timeout
+            tags: Optional dict or list of tags to apply, e.g.
+                  {"Environment": "Prod", "Owner": "AI-Platform"} or
+                  [{"Key": "Environment", "Value": "Prod"}]
         """
         from litellm._uuid import uuid
 
-        # Prepare the request data
-        data = {"Name": secret_name, "SecretString": secret_value}
+        data = {
+            "Name": secret_name,
+            "SecretString": secret_value,
+            "ClientRequestToken": str(uuid.uuid4()),
+        }
+
         if description:
             data["Description"] = description
 
-        data["ClientRequestToken"] = str(uuid.uuid4())
+        # ✅ Normalize tags to AWS format
+        if tags:
+            if isinstance(tags, dict):
+                tags_list = [{"Key": k, "Value": str(v)} for k, v in tags.items()]
+            elif isinstance(tags, list):
+                tags_list = tags
+            else:
+                raise ValueError("Tags must be a dict or list of {Key, Value} pairs")
+            data["Tags"] = tags_list
 
         endpoint_url, headers, body = self._prepare_request(
             action="CreateSecret",
             secret_name=secret_name,
             secret_value=secret_value,
             optional_params=optional_params,
-            request_data=data,  # Pass the complete request data
+            request_data=data,
         )
 
         async_client = get_async_httpx_client(
@@ -354,7 +370,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
 # if __name__ == "__main__":
 #     print("loading aws secret manager v2")
 #     aws_secret_manager_v2 = AWSSecretsManagerV2()
-
+#     import asyncio
 #     print("writing secret to aws secret manager v2")
 #     asyncio.run(aws_secret_manager_v2.async_write_secret(secret_name="test_secret_3", secret_value="test_value_2"))
 #     print("reading secret from aws secret manager v2")

--- a/litellm/secret_managers/base_secret_manager.py
+++ b/litellm/secret_managers/base_secret_manager.py
@@ -59,6 +59,7 @@ class BaseSecretManager(ABC):
         description: Optional[str] = None,
         optional_params: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        tags: Optional[Union[dict, list]] = None
     ) -> Dict[str, Any]:
         """
         Asynchronously write a secret to the secret manager.
@@ -69,6 +70,9 @@ class BaseSecretManager(ABC):
             description (Optional[str]): Description of the secret. Some secret managers allow storing a description with the secret.
             optional_params (Optional[dict]): Additional parameters specific to the secret manager
             timeout (Optional[Union[float, httpx.Timeout]]): Request timeout
+            tags: Optional dict or list of tags to apply, e.g.
+                  {"Environment": "Prod", "Owner": "AI-Platform"} or
+                  [{"Key": "Environment", "Value": "Prod"}]
         Returns:
             Dict[str, Any]: Response from the secret manager containing write operation details
         """

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -202,6 +202,7 @@ class HashicorpSecretManager(BaseSecretManager):
         description: Optional[str] = None,
         optional_params: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
+        tags: Optional[Union[dict, list]] = None
     ) -> Dict[str, Any]:
         """
         Writes a secret to Vault KV v2 using an async HTTPX client.

--- a/litellm/types/secret_managers/main.py
+++ b/litellm/types/secret_managers/main.py
@@ -1,5 +1,5 @@
 import enum
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Dict
 
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
 
@@ -36,3 +36,10 @@ class KeyManagementSettings(LiteLLMPydanticObjectBase):
 
     eg. on AWS you can store multiple secret values as K/V pairs in a single secret
     """
+
+    description: Optional[str] = None
+    """Optional description attached when creating secrets (visible in AWS console)."""
+
+
+    tags: Optional[Dict[str, str]] = None
+    """Optional tags to attach when creating secrets (e.g. {"Environment": "Prod", "Owner": "AI-Platform"})."""


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Adds support for tags and description in AWS secrets manager
<img width="1715" height="743" alt="image" src="https://github.com/user-attachments/assets/651a032b-14ea-469b-b5e2-042b8202cea4" />

```
litellm_settings:
  key_management_system: "aws_secret_manager" # REQUIRED
  key_management_settings:
    # Storing Virtual Keys Settings
    store_virtual_keys: true # OPTIONAL. Defaults to False, when True will store virtual keys in secret manager
    prefix_for_stored_virtual_keys: "dev-shared-litellm-testkey-" # OPTIONAL.I f set, this prefix will be used for stored virtual keys in the secret manager
    # Access Mode Settings
    access_mode: "write_only" # OPTIONAL. Literal["read_only", "write_only", "read_and_write"]. Defaults to "read_only"
    description: "Gateway key for agent"
    tags:
      Environment: "Prod"
      Owner: "John doe"
```     

## Relevant issues

<!-- e.g. "Fixes #000" -->



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes

add tags and description


