### PR TITLE
Add allowing Key based prefix to s3 path

### DIFF
--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1457,7 +1457,7 @@ litellm_settings:
     # from logged messages to avoid large payloads. SQS has a 1 MB payload size limit.
     s3_use_team_prefix: false
     # If true, Litellm will add the team alias prefix to s3 path
-    s3_use_keyprefix: false
+    s3_use_key_prefix: false
     # If true, Litellm will add the key alias prefix to s3 path
 
 ```

--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1366,14 +1366,12 @@ Your logs should be available on the specified s3 Bucket
 
 ### Team Alias Prefix in Object Key
 
-**This is a preview feature**
-
-You can add the team alias to the object key by setting the `team_alias` in the `config.yaml` file. This will prefix the object key with the team alias.
+You can add the team alias to the object key by setting the `team_alias` in the `config.yaml` file. 
+This will prefix the object key with the team alias.
 
 ```yaml
 litellm_settings:
   callbacks: ["s3_v2"]
-  enable_preview_features: true
   s3_callback_params:
     s3_bucket_name: logs-bucket-litellm
     s3_region_name: us-west-2
@@ -1385,6 +1383,28 @@ litellm_settings:
 ```
 
 On s3 bucket, you will see the object key as `my-test-path/my-team-alias/...`
+
+### Key Alias Prefix in Object Key
+
+You can add the user api key alias to the s3 object key by enabling s3_use_key_prefix.
+
+```yaml
+litellm_settings:
+  callbacks: ["s3_v2"]
+  s3_callback_params:
+    s3_bucket_name: logs-bucket-litellm
+    s3_region_name: us-west-2
+    s3_aws_access_key_id: os.environ/AWS_ACCESS_KEY_ID
+    s3_aws_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
+    s3_path: my-test-path
+    s3_endpoint_url: https://s3.amazonaws.com
+    s3_use_key_prefix: true
+```
+
+On s3 bucket, you will see the object key as `my-test-path/my-key-alias/...`
+
+if both team alias and key alias are enabled then the path becomes
+`my-test-path/my-team-alias/my-key-alias/...`
 
 ## AWS SQS
 

--- a/docs/my-website/docs/proxy/logging.md
+++ b/docs/my-website/docs/proxy/logging.md
@@ -1432,9 +1432,13 @@ litellm_settings:
     # AWS Region for your SQS queue (e.g., us-east-1, eu-central-1, etc.)
     
     # --- Logging Controls ---
-    sqs_strip_base64_files: true
+    sqs_strip_base64_files: false
     # If true, LiteLLM will remove or redact base64-encoded binary data (e.g., PDFs, images, audio)
     # from logged messages to avoid large payloads. SQS has a 1 MB payload size limit.
+    s3_use_team_prefix: false
+    # If true, Litellm will add the team alias prefix to s3 path
+    s3_use_keyprefix: false
+    # If true, Litellm will add the key alias prefix to s3 path
 
 ```
 

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -181,13 +181,13 @@ class S3Logger:
 
 def get_s3_object_key(
     s3_path: str,
-    team_alias_prefix: str,
+    prefix: str,
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
     s3_object_key = (
         (s3_path.rstrip("/") + "/" if s3_path else "")
-        + team_alias_prefix
+        + prefix
         + start_time.strftime("%Y-%m-%d")
         + "/"
         + s3_file_name

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -478,3 +478,146 @@ async def test_strip_base64_recursive_redaction():
             s = json.dumps(c).lower()
             # "[base64_redacted]" is fine, but raw base64 is not
             assert "base64," not in s, f"Found real base64 blob in: {s}"
+
+import pytest
+from datetime import datetime
+from unittest.mock import patch
+from litellm.integrations.s3_v2 import S3Logger
+from litellm.types.utils import StandardLoggingPayload
+
+
+# --------------------------------------------------------------
+# Shared fixture that silences asyncio.create_task during tests
+# --------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def patch_asyncio_create_task():
+    """Prevent 'no running event loop' errors when S3Logger calls asyncio.create_task()."""
+    with patch("asyncio.create_task"):
+        yield
+
+
+# --------------------------------------------------------------
+# Parametrized prefix combination test
+# --------------------------------------------------------------
+@pytest.mark.parametrize(
+    "use_team_prefix,use_key_prefix,team_alias,key_alias,expected_prefix",
+    [
+        (False, False, "teamA", "keyA", ""),
+        (True, False, "teamA", "keyA", "teamA/"),
+        (False, True, "teamA", "keyA", "keyA/"),
+        (True, True, "teamA", "keyA", "teamA/keyA/"),
+        (True, True, None, "keyA", "keyA/"),
+        (True, True, "teamA", None, "teamA/"),
+        (True, True, None, None, ""),
+    ],
+)
+def test_s3_object_key_prefix_combinations(
+        use_team_prefix, use_key_prefix, team_alias, key_alias, expected_prefix
+):
+    """
+    Validate correct S3 prefix composition for team alias + key alias combinations.
+    """
+    with patch("litellm.integrations.s3_v2.get_s3_object_key") as mock_get_key:
+        mock_get_key.return_value = "mocked/s3/object/key.json"
+
+        logger = S3Logger(
+            s3_bucket_name="test-bucket",
+            s3_region_name="us-east-1",
+            s3_use_team_prefix=use_team_prefix,
+            s3_use_key_prefix=use_key_prefix,
+        )
+
+        payload = StandardLoggingPayload(
+            id="abc123",
+            metadata={
+                "user_api_key_team_alias": team_alias,
+                "user_api_key_alias": key_alias,
+            },
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        )
+
+        result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+        assert result is not None
+        mock_get_key.assert_called_once()
+
+        prefix_arg = mock_get_key.call_args.kwargs.get("prefix")
+        assert prefix_arg == expected_prefix, (
+            f"Expected prefix '{expected_prefix}', got '{prefix_arg}' "
+            f"for team={team_alias}, key={key_alias}, "
+            f"use_team_prefix={use_team_prefix}, use_key_prefix={use_key_prefix}"
+        )
+
+
+# --------------------------------------------------------------
+# Test prefix priority and concatenation
+# --------------------------------------------------------------
+def test_prefix_priority_and_path_construction():
+    """
+    Validate that prefix components are ordered and joined with '/' only once.
+    """
+    with patch("litellm.integrations.s3_v2.get_s3_object_key") as mock_get_key:
+        mock_get_key.return_value = "mocked/key"
+
+        logger = S3Logger(s3_use_team_prefix=True, s3_use_key_prefix=True)
+        payload = StandardLoggingPayload(
+            id="xyz999",
+            metadata={
+                "user_api_key_team_alias": "Team-Alpha",
+                "user_api_key_alias": "API-12345",
+            },
+            messages=[],
+        )
+
+        logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+        prefix_arg = mock_get_key.call_args.kwargs.get("prefix", "")
+
+        assert prefix_arg == "Team-Alpha/API-12345/"
+        assert "//" not in prefix_arg
+
+
+# --------------------------------------------------------------
+# Test when prefixes are disabled
+# --------------------------------------------------------------
+def test_prefix_absent_when_flags_disabled():
+    """
+    Verify prefix is omitted entirely when prefix flags are False.
+    """
+    with patch("litellm.integrations.s3_v2.get_s3_object_key") as mock_get_key:
+        mock_get_key.return_value = "mocked/key"
+
+        logger = S3Logger(s3_use_team_prefix=False, s3_use_key_prefix=False)
+        payload = StandardLoggingPayload(
+            id="no-prefix",
+            metadata={
+                "user_api_key_team_alias": "team-x",
+                "user_api_key_alias": "key-x",
+            },
+            messages=[],
+        )
+
+        logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+        prefix_arg = mock_get_key.call_args.kwargs.get("prefix", None)
+        assert prefix_arg == "", f"Expected empty prefix, got {prefix_arg}"
+
+
+# --------------------------------------------------------------
+# Integration-style test (asyncio fixture will patch create_task)
+# --------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_combined_prefix_reflects_in_s3_object_key():
+    """
+    Integration-style test ensuring final s3_object_key includes both prefixes correctly.
+    """
+    logger = S3Logger(s3_use_team_prefix=True, s3_use_key_prefix=True)
+    payload = StandardLoggingPayload(
+        id="int-test",
+        metadata={
+            "user_api_key_team_alias": "myteam",
+            "user_api_key_alias": "apikey",
+        },
+        messages=[],
+    )
+
+    result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)
+    key = result.s3_object_key
+    assert "myteam/apikey/" in key, f"Expected both prefixes in key: {key}"

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -479,11 +479,6 @@ async def test_strip_base64_recursive_redaction():
             # "[base64_redacted]" is fine, but raw base64 is not
             assert "base64," not in s, f"Found real base64 blob in: {s}"
 
-import pytest
-from datetime import datetime
-from unittest.mock import patch
-from litellm.integrations.s3_v2 import S3Logger
-from litellm.types.utils import StandardLoggingPayload
 
 
 # --------------------------------------------------------------


### PR DESCRIPTION
## Allow adding s3 team and user_api_key alias 

<!-- e.g. "Implement user authentication feature" -->




Also adds a small bug fix for the bug I introduced for stripping base64 files in s3.

```
  s3_callback_params:
    s3_bucket_name: os.environ/S3_BUCKET  # AWS Bucket Name for S3
    s3_region_name: us-west-2              # AWS Region Name for S3
    s3_path: litellm_test # [OPTIONAL] set path in bucket you want to write logs to
    s3_strip_base64_files: true # [OPTIONAL] Whether to strip base64 files from messages (default: false)
    s3_use_team_prefix: true
    s3_use_key_prefix: true
 ```  
 
 
 Base64 is stripped correctly from s3 too now
 




## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

```
(litellm-py3.12) (base) ➜  litellm git:(feature/support_key_based_prefix) poetry run pytest tests/test_litellm/integrations/test_s3_v2.py
=========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.12.2, pytest-7.4.4, pluggy-1.5.0
rootdir: /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm
configfile: pyproject.toml
plugins: respx-0.22.0, xdist-3.8.0, anyio-4.5.2, mock-3.14.1, asyncio-0.21.2, retry-1.6.3, requests-mock-1.12.1
asyncio: mode=Mode.AUTO
collected 21 items                                                                                                                                                                                        

tests/test_litellm/integrations/test_s3_v2.py .....................                                                                                                                                 [100%]

============================================================================================ warnings summary =============================================================================================
litellm/litellm_core_utils/get_model_cost_map.py:41
tests/test_litellm/integrations/test_s3_v2.py::test_combined_prefix_reflects_in_s3_object_key
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/litellm/litellm_core_utils/get_model_cost_map.py:41: DeprecationWarning: open_text is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with importlib.resources.open_text(

tests/test_litellm/integrations/test_s3_v2.py::test_combined_prefix_reflects_in_s3_object_key
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/tests/test_litellm/integrations/test_s3_v2.py:621: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)

tests/test_litellm/integrations/test_s3_v2.py::test_prefix_absent_when_flags_disabled
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/tests/test_litellm/integrations/test_s3_v2.py:598: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    logger.create_s3_batch_logging_element(datetime.utcnow(), payload)

tests/test_litellm/integrations/test_s3_v2.py::test_prefix_priority_and_path_construction
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-True-teamA-None-teamA/]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_verify_false_handling
tests/test_litellm/integrations/test_s3_v2.py::test_strip_base64_mixed_nested_objects
  /opt/anaconda3/lib/python3.12/unittest/mock.py:2185: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    def __init__(self, name, parent):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/integrations/test_s3_v2.py::test_prefix_priority_and_path_construction
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/tests/test_litellm/integrations/test_s3_v2.py:571: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    logger.create_s3_batch_logging_element(datetime.utcnow(), payload)

tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[False-False-teamA-keyA-]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[False-True-teamA-keyA-keyA/]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-False-teamA-keyA-teamA/]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-True-None-None-]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-True-None-keyA-keyA/]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-True-teamA-None-teamA/]
tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-True-teamA-keyA-teamA/keyA/]
  /Users/deepanshu.deepanshu/code/code/litellm/deepanshu/litellm/tests/test_litellm/integrations/test_s3_v2.py:539: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    result = logger.create_s3_batch_logging_element(datetime.utcnow(), payload)

tests/test_litellm/integrations/test_s3_v2.py::test_s3_object_key_prefix_combinations[True-False-teamA-keyA-teamA/]
  /opt/anaconda3/lib/python3.12/unittest/mock.py:767: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    def __setattr__(self, name, value):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
  /opt/anaconda3/lib/python3.12/importlib/__init__.py:90: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    return _bootstrap._gcd_import(name[level:], package, level)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
  /Users/deepanshu.deepanshu/Library/Caches/pypoetry/virtualenvs/litellm-ohMn1BPm-py3.12/lib/python3.12/site-packages/dateutil/parser/__init__.py:2: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
    from ._parser import parse, parser, parserinfo, ParserError
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::TestS3V2UnitTests::test_s3_v2_endpoint_url
tests/test_litellm/integrations/test_s3_v2.py::test_s3_verify_false_async_client
  /Users/deepanshu.deepanshu/Library/Caches/pypoetry/virtualenvs/litellm-ohMn1BPm-py3.12/lib/python3.12/site-packages/botocore/auth.py:425: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 21 passed, 25 warnings in 0.39s =====================================================================================
sys:1: RuntimeWarning: coroutine 'CustomBatchLogger.periodic_flush' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback

```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature


## Changes


