### PR TITLE
[Feature] UI - Prevent trailing slash in sso proxy base url input

### DIFF
--- a/ui/litellm-dashboard/src/components/SSOModals.test.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.test.tsx
@@ -95,4 +95,38 @@ describe("SSOModals", () => {
       expect(getByText("URL must start with http:// or https://")).toBeInTheDocument();
     });
   });
+
+  it("should automatically remove trailing slash from the proxy base url", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      return (
+        <SSOModals
+          isAddSSOModalVisible={true}
+          isInstructionsModalVisible={false}
+          handleAddSSOOk={() => {}}
+          handleAddSSOCancel={() => {}}
+          handleShowInstructions={() => {}}
+          handleInstructionsOk={() => {}}
+          handleInstructionsCancel={() => {}}
+          form={form}
+          accessToken={null}
+          ssoConfigured={false}
+        />
+      );
+    };
+
+    const { getByLabelText, container } = render(<TestWrapper />);
+
+    // Fill in the proxy base url with a trailing slash
+    const urlInput = getByLabelText("PROXY BASE URL") as HTMLInputElement;
+    fireEvent.change(urlInput, { target: { value: "https://example.com/" } });
+
+    // Trigger blur to ensure normalization is applied
+    fireEvent.blur(urlInput);
+
+    // Check that the trailing slash was removed by the normalize function
+    await waitFor(() => {
+      expect(urlInput.value).toBe("https://example.com");
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -309,16 +309,20 @@ const SSOModals: React.FC<SSOModalsProps> = ({
             <Form.Item
               label="PROXY BASE URL"
               name="proxy_base_url"
-              normalize={(value) => value?.trim()}
+              normalize={(value) => value?.trim().replace(/\/+$/, "")}
               rules={[
                 { required: true, message: "Please enter the proxy base url" },
                 {
                   pattern: /^https?:\/\/.+/,
                   message: "URL must start with http:// or https://",
                 },
+                {
+                  pattern: /^https?:\/\/[^\s]+[^\/]$/,
+                  message: "URL must not end with a trailing slash",
+                },
               ]}
             >
-              <TextInput />
+              <TextInput placeholder="https://example.com" />
             </Form.Item>
           </>
           <div


### PR DESCRIPTION
## UI - Prevent trailing slash in sso proxy base url input

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The current proxy base url input allows for trailing slashes to be in the URL such as `http://localhost:4000/`. This PR prevents the user from having trailing slashes in their url and it removes them automatically. There is also a fallback validation error on the input if a trailing slash was able to be inputted as the last character. Closes LIT-1316

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshots
<img width="775" height="116" alt="image" src="https://github.com/user-attachments/assets/706e5142-434c-4e1f-8542-22a3c38ea19b" />

<img width="737" height="223" alt="image" src="https://github.com/user-attachments/assets/eda31b63-73e5-4720-ae6f-878fda9bd0a2" />
