### PR TITLE
fix(proxy): handle None values in daily spend sort key

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -997,7 +997,7 @@ class DBSpendUpdateWriter:
                             # should sort by the table first.
                             key=lambda x: (
                                 x[1]["date"],
-                                x[1].get(entity_id_field),
+                                x[1].get(entity_id_field) or "",
                                 x[1]["api_key"],
                                 x[1]["model"],
                                 x[1]["custom_llm_provider"],


### PR DESCRIPTION
## Title

fix(proxy): handle None values in daily spend sort key

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- get() may return None, which can't be compared with strings during sorting.

## Test Results

<img width="1404" height="189" alt="Screenshot 2025-11-04 at 9 52 01 AM" src="https://github.com/user-attachments/assets/78c49705-eb6c-4867-904d-029840160658" />

- Failures seem unrelated
