### PR TITLE
[Feature] UI - Tag Usage Top Model Table View and Label Fix

### DIFF
--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -103,7 +103,6 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
     from: new Date(Date.now() - 28 * 24 * 60 * 60 * 1000),
     to: new Date(),
   });
-  const [modelViewMode, setModelViewMode] = useState<"chart" | "table">("table");
 
   const fetchSpendData = async () => {
     if (!accessToken || !dateValue.from || !dateValue.to) return;

--- a/ui/litellm-dashboard/src/components/entity_usage.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.tsx
@@ -29,6 +29,7 @@ import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { valueFormatterSpend } from "./usage/utils/value_formatters";
 import { getProviderLogoAndName } from "./provider_info_helpers";
 import { UsageExportHeader } from "./EntityUsageExport";
+import TopModelView from "./top_model_view";
 
 interface EntityMetrics {
   metrics: {
@@ -102,6 +103,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
     from: new Date(Date.now() - 28 * 24 * 60 * 60 * 1000),
     to: new Date(),
   });
+  const [modelViewMode, setModelViewMode] = useState<"chart" | "table">("table");
 
   const fetchSpendData = async () => {
     if (!accessToken || !dateValue.from || !dateValue.to) return;
@@ -550,17 +552,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
               <Col numColSpan={1}>
                 <Card>
                   <Title>Top Models</Title>
-                  <BarChart
-                    className="mt-4 h-40"
-                    data={getTopModels()}
-                    index="display_key"
-                    categories={["spend"]}
-                    colors={["cyan"]}
-                    valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
-                    layout="vertical"
-                    yAxisWidth={200}
-                    showLegend={false}
-                  />
+                  <TopModelView topModels={getTopModels()} />
                 </Card>
               </Col>
 

--- a/ui/litellm-dashboard/src/components/top_key_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/top_key_view.test.tsx
@@ -1,0 +1,110 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TopKeyView from "./top_key_view";
+
+describe("TopKeyView", () => {
+  it("should render", () => {
+    const { container } = render(
+      <TopKeyView
+        topKeys={[]}
+        accessToken={null}
+        userID={null}
+        userRole={null}
+        teams={null}
+        premiumUser={false}
+        showTags={false}
+      />,
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it("should have a table view button", () => {
+    const { getByText } = render(
+      <TopKeyView
+        topKeys={[]}
+        accessToken={null}
+        userID={null}
+        userRole={null}
+        teams={null}
+        premiumUser={false}
+        showTags={false}
+      />,
+    );
+    expect(getByText("Table View")).toBeInTheDocument();
+  });
+
+  it("should have a chart view", () => {
+    const { getByText } = render(
+      <TopKeyView
+        topKeys={[]}
+        accessToken={null}
+        userID={null}
+        userRole={null}
+        teams={null}
+        premiumUser={false}
+        showTags={false}
+      />,
+    );
+    expect(getByText("Chart View")).toBeInTheDocument();
+  });
+
+  ["Key ID", "Key Alias", "Spend (USD)"].forEach((header) => {
+    it(`should have a ${header} column`, () => {
+      const { getByText } = render(
+        <TopKeyView
+          topKeys={[]}
+          accessToken={null}
+          userID={null}
+          userRole={null}
+          teams={null}
+          premiumUser={false}
+          showTags={false}
+        />,
+      );
+      expect(getByText(header)).toBeInTheDocument();
+    });
+  });
+
+  it("should have a Tags column when showTags is true", () => {
+    const { getByText } = render(
+      <TopKeyView
+        topKeys={[]}
+        accessToken={null}
+        userID={null}
+        userRole={null}
+        teams={null}
+        premiumUser={false}
+        showTags={true}
+      />,
+    );
+    expect(getByText("Tags")).toBeInTheDocument();
+  });
+
+  it("should show the key's information on the table", () => {
+    const { getByText } = render(
+      <TopKeyView
+        topKeys={[
+          {
+            api_key: "key-123",
+            key_alias: "Test Key",
+            spend: 100,
+            tags: [
+              { tag: "tag-1", usage: 50 },
+              { tag: "tag-2", usage: 30 },
+            ],
+          },
+        ]}
+        accessToken="test-token"
+        userID={null}
+        userRole={null}
+        teams={null}
+        premiumUser={false}
+        showTags={true}
+      />,
+    );
+    expect(getByText("Test Key")).toBeInTheDocument();
+    expect(getByText(/tag-1/)).toBeInTheDocument();
+    expect(getByText(/tag-2/)).toBeInTheDocument();
+    expect(getByText("$100.00")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/top_key_view.tsx
+++ b/ui/litellm-dashboard/src/components/top_key_view.tsx
@@ -216,9 +216,8 @@ const TopKeyView: React.FC<TopKeyViewProps> = ({
             yAxisWidth={120}
             tickGap={5}
             layout="vertical"
-            showXAxis={false}
             showLegend={false}
-            valueFormatter={(value) => (value ? `$${formatNumberWithCommas(value, 2)}` : "No Key Alias")}
+            valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
             onValueChange={(item) => handleKeyClick(item)}
             showTooltip={true}
             customTooltip={(props) => {

--- a/ui/litellm-dashboard/src/components/top_model_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/top_model_view.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TopModelView from "./top_model_view";
+
+describe("TopModelView", () => {
+  it("should render", () => {
+    const { container } = render(<TopModelView topModels={[]} />);
+    expect(container).toBeTruthy();
+  });
+
+  it("should have a table view button", () => {
+    const { getByText } = render(<TopModelView topModels={[]} />);
+    expect(getByText("Table View")).toBeInTheDocument();
+  });
+
+  it("should have a chart view", () => {
+    const { getByText } = render(<TopModelView topModels={[]} />);
+    expect(getByText("Chart View")).toBeInTheDocument();
+  });
+
+  ["Model", "Spend (USD)", "Successful", "Failed", "Tokens"].forEach((header) => {
+    it(`should have a ${header} column`, () => {
+      const { getByText } = render(<TopModelView topModels={[]} />);
+      expect(getByText(header)).toBeInTheDocument();
+    });
+  });
+
+  it("should show the model's information on the table", () => {
+    const { getByText } = render(
+      <TopModelView
+        topModels={[
+          {
+            key: "gpt-4",
+            spend: 150.5,
+            successful_requests: 100,
+            failed_requests: 5,
+            tokens: 50000,
+          },
+        ]}
+      />,
+    );
+    expect(getByText("gpt-4")).toBeInTheDocument();
+    expect(getByText("$150.50")).toBeInTheDocument();
+    expect(getByText("100")).toBeInTheDocument();
+    expect(getByText("5")).toBeInTheDocument();
+    expect(getByText("50,000")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/top_model_view.tsx
+++ b/ui/litellm-dashboard/src/components/top_model_view.tsx
@@ -1,0 +1,95 @@
+import { BarChart } from "@tremor/react";
+import { formatNumberWithCommas } from "../utils/dataUtils";
+import { useState } from "react";
+import { DataTable } from "./view_logs/table";
+
+interface TopModel {
+  key: string;
+  spend: number;
+  successful_requests: number;
+  failed_requests: number;
+  tokens: number;
+}
+
+interface TopModelViewProps {
+  topModels: TopModel[];
+}
+
+export default function TopModelView({ topModels }: TopModelViewProps) {
+  const [modelViewMode, setModelViewMode] = useState<"chart" | "table">("table");
+
+  const columns = [
+    {
+      header: "Model",
+      accessorKey: "key",
+      cell: (info: any) => info.getValue() || "-",
+    },
+    {
+      header: "Spend (USD)",
+      accessorKey: "spend",
+      cell: (info: any) => {
+        const value = info.getValue();
+        return `$${formatNumberWithCommas(value, 2)}`;
+      },
+    },
+    {
+      header: "Successful",
+      accessorKey: "successful_requests",
+      cell: (info: any) => <span className="text-green-600">{info.getValue()?.toLocaleString() || 0}</span>,
+    },
+    {
+      header: "Failed",
+      accessorKey: "failed_requests",
+      cell: (info: any) => <span className="text-red-600">{info.getValue()?.toLocaleString() || 0}</span>,
+    },
+    {
+      header: "Tokens",
+      accessorKey: "tokens",
+      cell: (info: any) => info.getValue()?.toLocaleString() || 0,
+    },
+  ];
+  return (
+    <>
+      <div className="mb-4 flex justify-end items-center">
+        <div className="flex space-x-2">
+          <button
+            onClick={() => setModelViewMode("table")}
+            className={`px-3 py-1 text-sm rounded-md ${modelViewMode === "table" ? "bg-blue-100 text-blue-700" : "bg-gray-100 text-gray-700"}`}
+          >
+            Table View
+          </button>
+          <button
+            onClick={() => setModelViewMode("chart")}
+            className={`px-3 py-1 text-sm rounded-md ${modelViewMode === "chart" ? "bg-blue-100 text-blue-700" : "bg-gray-100 text-gray-700"}`}
+          >
+            Chart View
+          </button>
+        </div>
+      </div>
+      {modelViewMode === "chart" ? (
+        <div className="relative">
+          <BarChart
+            className="mt-4 h-40"
+            data={topModels}
+            index="key"
+            categories={["spend"]}
+            colors={["cyan"]}
+            valueFormatter={(value) => `$${formatNumberWithCommas(value, 2)}`}
+            layout="vertical"
+            yAxisWidth={200}
+            showLegend={false}
+          />
+        </div>
+      ) : (
+        <div className="border rounded-lg overflow-auto">
+          <DataTable
+            columns={columns}
+            data={topModels}
+            renderSubComponent={() => <></>}
+            getRowCanExpand={() => false}
+          />
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## [Feature] UI - Tag Usage Top Model Table View and Label Fix

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR adds the table view to the Top Models section in Team and Tag usage. The section on the left (Top API Keys) had both views, but the Top Models did not. This brings the Top Model section more in line with the Top API Keys section.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="1258" height="350" alt="image" src="https://github.com/user-attachments/assets/2cfc25cf-1420-41aa-b843-2ce9d85fadce" />

<img width="1267" height="295" alt="image" src="https://github.com/user-attachments/assets/8dc7b398-8d70-45d3-b2b6-915dc78e884a" />

<img width="745" height="269" alt="image" src="https://github.com/user-attachments/assets/d8d05338-a14b-47df-94d6-3d7a31399748" />

