### PR TITLE
feat: Add configurable mount name and path prefix for HashiCorp Vault

### DIFF
--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -24,8 +24,13 @@ class HashicorpSecretManager(BaseSecretManager):
         # Vault-specific config
         self.vault_addr = os.getenv("HCP_VAULT_ADDR", "http://127.0.0.1:8200")
         self.vault_token = os.getenv("HCP_VAULT_TOKEN", "")
-        # If your KV engine is mounted somewhere other than "secret", adjust here:
+        # Vault namespace (for X-Vault-Namespace header)
         self.vault_namespace = os.getenv("HCP_VAULT_NAMESPACE", None)
+        # KV engine mount name (default: "secret")
+        # If your KV engine is mounted somewhere other than "secret", set HCP_VAULT_MOUNT_NAME
+        self.vault_mount_name = os.getenv("HCP_VAULT_MOUNT_NAME", "secret")
+        # Optional path prefix for secrets (e.g., "myapp" -> secret/data/myapp/{secret_name})
+        self.vault_path_prefix = os.getenv("HCP_VAULT_PATH_PREFIX", None)
 
         # Optional config for TLS cert auth
         self.tls_cert_path = os.getenv("HCP_VAULT_CLIENT_CERT", "")
@@ -118,10 +123,24 @@ class HashicorpSecretManager(BaseSecretManager):
         return {"name": self.vault_cert_role}
 
     def get_url(self, secret_name: str) -> str:
+        """
+        Constructs the Vault URL for KV v2 secrets.
+        
+        Format: {VAULT_ADDR}/v1/{NAMESPACE}/{MOUNT_NAME}/data/{PATH_PREFIX}/{SECRET_NAME}
+        
+        Examples:
+        - Default: http://127.0.0.1:8200/v1/secret/data/mykey
+        - With namespace: http://127.0.0.1:8200/v1/mynamespace/secret/data/mykey
+        - With custom mount: http://127.0.0.1:8200/v1/kv/data/mykey
+        - With path prefix: http://127.0.0.1:8200/v1/secret/data/myapp/mykey
+        """
         _url = f"{self.vault_addr}/v1/"
         if self.vault_namespace:
             _url += f"{self.vault_namespace}/"
-        _url += f"secret/data/{secret_name}"
+        _url += f"{self.vault_mount_name}/data/"
+        if self.vault_path_prefix:
+            _url += f"{self.vault_path_prefix}/"
+        _url += secret_name
         return _url
 
     def _get_request_headers(self) -> dict:


### PR DESCRIPTION
## Title

feat: Add configurable mount name and path prefix for HashiCorp Vault

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Add HCP_VAULT_MOUNT_NAME env var to override default 'secret' mount
- Add HCP_VAULT_PATH_PREFIX env var to add prefix to secret paths
- Update get_url() method to construct URLs with configurable mount and prefix
- Add test coverage for custom mount names and path prefixes
- Maintain backward compatibility with existing configurations

This allows users to configure Vault paths like:
- Custom mount: {VAULT_ADDR}/v1/{MOUNT_NAME}/data/{SECRET}
- With prefix: {VAULT_ADDR}/v1/secret/data/{PREFIX}/{SECRET}
- Both: {VAULT_ADDR}/v1/{MOUNT_NAME}/data/{PREFIX}/{SECRET}

## Test Results

<img width="1420" height="222" alt="Screenshot 2025-11-04 at 2 30 51 PM" src="https://github.com/user-attachments/assets/69a02886-1bbc-4ca7-b1a6-a7cfdfad9391" />

- Failures seem unrelated.
