### PR TITLE
add: shared_session support to responses API

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1945,6 +1945,7 @@ class BaseLLMHTTPHandler:
         _is_async: bool = False,
         fake_stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[
         ResponsesAPIResponse,
         BaseResponsesAPIStreamingIterator,
@@ -1973,6 +1974,7 @@ class BaseLLMHTTPHandler:
                 client=client if isinstance(client, AsyncHTTPHandler) else None,
                 fake_stream=fake_stream,
                 litellm_metadata=litellm_metadata,
+                shared_session=shared_session,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2090,15 +2092,20 @@ class BaseLLMHTTPHandler:
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         fake_stream: bool = False,
         litellm_metadata: Optional[Dict[str, Any]] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
         """
         Async version of the responses API handler.
         Uses async HTTP client to make requests.
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
+            verbose_logger.debug(
+                f"Creating HTTP client for responses API with shared_session: {id(shared_session) if shared_session else None}"
+            )
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client
@@ -2211,15 +2218,20 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> DeleteResponseResult:
         """
         Async version of the delete response API handler.
         Uses async HTTP client to make requests.
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
+            verbose_logger.debug(
+                f"Creating HTTP client for delete_response with shared_session: {id(shared_session) if shared_session else None}"
+            )
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client
@@ -2282,6 +2294,7 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[DeleteResponseResult, Coroutine[Any, Any, DeleteResponseResult]]:
         """
         Async version of the responses API handler.
@@ -2298,6 +2311,7 @@ class BaseLLMHTTPHandler:
                 extra_body=extra_body,
                 timeout=timeout,
                 client=client,
+                shared_session=shared_session,
             )
         if client is None or not isinstance(client, HTTPHandler):
             sync_httpx_client = _get_httpx_client(
@@ -2364,6 +2378,7 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
         """
         Get a response by ID
@@ -2380,6 +2395,7 @@ class BaseLLMHTTPHandler:
                 extra_body=extra_body,
                 timeout=timeout,
                 client=client,
+                shared_session=shared_session,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2443,14 +2459,19 @@ class BaseLLMHTTPHandler:
         extra_body: Optional[Dict[str, Any]] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> ResponsesAPIResponse:
         """
         Async version of get_responses
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
+            verbose_logger.debug(
+                f"Creating HTTP client for get_responses with shared_session: {id(shared_session) if shared_session else None}"
+            )
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client
@@ -2521,6 +2542,7 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[Dict, Coroutine[Any, Any, Dict]]:
         if _is_async:
             return self.async_list_responses_input_items(
@@ -2537,6 +2559,7 @@ class BaseLLMHTTPHandler:
                 extra_headers=extra_headers,
                 timeout=timeout,
                 client=client,
+                shared_session=shared_session,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -2605,11 +2628,16 @@ class BaseLLMHTTPHandler:
         extra_headers: Optional[Dict[str, Any]] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Dict:
         if client is None or not isinstance(client, AsyncHTTPHandler):
+            verbose_logger.debug(
+                f"Creating HTTP client for list_input_items with shared_session: {id(shared_session) if shared_session else None}"
+            )
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client
@@ -3296,6 +3324,7 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Union[ResponsesAPIResponse, Coroutine[Any, Any, ResponsesAPIResponse]]:
         """
         Async version of the responses API handler.
@@ -3312,6 +3341,7 @@ class BaseLLMHTTPHandler:
                 extra_body=extra_body,
                 timeout=timeout,
                 client=client,
+                shared_session=shared_session,
             )
         if client is None or not isinstance(client, HTTPHandler):
             sync_httpx_client = _get_httpx_client(
@@ -3378,15 +3408,20 @@ class BaseLLMHTTPHandler:
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
         _is_async: bool = False,
+        shared_session: Optional["ClientSession"] = None,
     ) -> ResponsesAPIResponse:
         """
         Async version of the cancel response API handler.
         Uses async HTTP client to make requests.
         """
         if client is None or not isinstance(client, AsyncHTTPHandler):
+            verbose_logger.debug(
+                f"Creating HTTP client for cancel_response with shared_session: {id(shared_session) if shared_session else None}"
+            )
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -648,6 +648,7 @@ def responses(
                 model=model, stream=stream, custom_llm_provider=custom_llm_provider
             ),
             litellm_metadata=kwargs.get("litellm_metadata", {}),
+            shared_session=kwargs.get("shared_session"),
         )
 
         # Update the responses_api_response_id with the model_id
@@ -815,6 +816,7 @@ def delete_responses(
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
+            shared_session=kwargs.get("shared_session"),
         )
 
         return response
@@ -994,6 +996,7 @@ def get_responses(
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
+            shared_session=kwargs.get("shared_session"),
         )
 
         # Update the responses_api_response_id with the model_id
@@ -1148,6 +1151,7 @@ def list_input_items(
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
+            shared_session=kwargs.get("shared_session"),
         )
 
         return response
@@ -1307,6 +1311,7 @@ def cancel_responses(
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
+            shared_session=kwargs.get("shared_session"),
         )
 
         return response


### PR DESCRIPTION
## Title

add: shared session support to Responses API

## Background

LiteLLM already supports shared sessions via `get_async_httpx_client()`, but the Responses API didn’t surface this option, resulting in a new client for every call. Under load, this led to:

* Excess memory from multiple connection pools
* Additional latency from repeated connection setup
* Avoidable resource strain in proxy workloads

## Changes

### Added

* `shared_session` parameter to all Responses API methods:

  * `responses()`
  * `delete_responses()`
  * `get_responses()`
  * `list_input_items()`
  * `cancel_responses()`

## Performance Impact

Load testing LiteLLM proxy (4 CPUs | 8 GB RAM | 4 Instances) showed significant improvements:

**Before fix:**
- Median latency: 3,600ms
- 95th percentile: 4,300ms  
- Throughput: 231 RPS
- Failure rate: 2.06% (2,248 failures / 109,073 requests)

**After fix:**
- Median latency: 140ms (**-96% reduction**)
- 95th percentile: 320ms (**-93% reduction**)
- Throughput: 1,057 RPS (**+4.5x increase**)
- Failure rate: 0.0003% (**-99.9% reduction**)

## Pre-Submission Checklist

* [ ] Added tests under `tests/litellm/` (minimum 1 required)
* [x] Included screenshot of tests passing locally
* [x] PR passes `make test-unit`
* [x] Scope limited to a single functional improvement

## Type

⚡ Performance Enhancement /  🐛 Bug Fix


