### PR TITLE
fix: Resolve MyPy type checking errors and CI linting

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1071,9 +1071,9 @@ class RedisCache(BaseCache):
             
             # Test the connection
             ping_result = await redis_client.ping()
-            
+
             # Close the connection
-            await redis_client.aclose()
+            await redis_client.aclose()  # type: ignore[attr-defined]
             
             if ping_result:
                 return {

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -83,10 +83,10 @@ class RedisClusterCache(RedisCache):
             )
             
             # Test the connection
-            ping_result = await redis_client.ping()
-            
+            ping_result = await redis_client.ping()  # type: ignore[attr-defined]
+
             # Close the connection
-            await redis_client.aclose()
+            await redis_client.aclose()  # type: ignore[attr-defined]
             
             if ping_result:
                 return {

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -541,7 +541,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     def _map_reasoning_effort(self, reasoning_effort: Union[str, Dict[str, Any]]) -> Optional[Reasoning]:
         # If dict is passed, convert it directly to Reasoning object
         if isinstance(reasoning_effort, dict):
-            return Reasoning(**reasoning_effort)
+            return Reasoning(**reasoning_effort)  # type: ignore[typeddict-item]
 
         # If string is passed, map without summary (default)
         if reasoning_effort == "high":

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1,7 +1,6 @@
 # What is this?
 ## Common Utility file for Logging handler
 # Logging function -> log the exact model details + what's being sent | Non-Blocking
-import asyncio
 import copy
 import datetime
 import json

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -381,7 +381,7 @@ class ResponseAPILoggingUtils:
                 cached_tokens=response_api_usage.input_tokens_details.cached_tokens,
                 audio_tokens=response_api_usage.input_tokens_details.audio_tokens,
             )
-        usage = Usage(
+        usage = Usage(  # type: ignore[assignment]
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             total_tokens=prompt_tokens + completion_tokens,
@@ -392,4 +392,4 @@ class ResponseAPILoggingUtils:
         if hasattr(response_api_usage, "cost") and response_api_usage.cost is not None:
             setattr(usage, "cost", response_api_usage.cost)
 
-        return usage
+        return usage  # type: ignore[return-value]

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -361,17 +361,19 @@ class ResponseAPILoggingUtils:
 
     @staticmethod
     def _transform_response_api_usage_to_chat_usage(
-        usage: Optional[Union[dict, ResponseAPIUsage]],
+        usage_input: Optional[Union[dict, ResponseAPIUsage]],
     ) -> Usage:
         """Tranforms the ResponseAPIUsage object to a Usage object"""
-        if usage is None:
+        if usage_input is None:
             return Usage(
                 prompt_tokens=0,
                 completion_tokens=0,
                 total_tokens=0,
             )
         response_api_usage: ResponseAPIUsage = (
-            ResponseAPIUsage(**usage) if isinstance(usage, dict) else usage
+            ResponseAPIUsage(**usage_input)
+            if isinstance(usage_input, dict)
+            else usage_input
         )
         prompt_tokens: int = response_api_usage.input_tokens or 0
         completion_tokens: int = response_api_usage.output_tokens or 0
@@ -381,7 +383,7 @@ class ResponseAPILoggingUtils:
                 cached_tokens=response_api_usage.input_tokens_details.cached_tokens,
                 audio_tokens=response_api_usage.input_tokens_details.audio_tokens,
             )
-        usage = Usage(  # type: ignore[assignment]
+        chat_usage = Usage(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             total_tokens=prompt_tokens + completion_tokens,
@@ -390,6 +392,6 @@ class ResponseAPILoggingUtils:
 
         # Preserve cost attribute if it exists on ResponseAPIUsage
         if hasattr(response_api_usage, "cost") and response_api_usage.cost is not None:
-            setattr(usage, "cost", response_api_usage.cost)
+            setattr(chat_usage, "cost", response_api_usage.cost)
 
-        return usage  # type: ignore[return-value]
+        return chat_usage

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -238,7 +238,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
                 tags_list = tags
             else:
                 raise ValueError("Tags must be a dict or list of {Key, Value} pairs")
-            data["Tags"] = tags_list
+            data["Tags"] = tags_list  # type: ignore[assignment]
 
         endpoint_url, headers, body = self._prepare_request(
             action="CreateSecret",


### PR DESCRIPTION
## Title

  Fixes CI errors blocking PRs: unused import and MyPy type checking issues.  
  
## Relevant issues

Fixes #16218

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

 ## Summary
  Fixes critical CI errors blocking PRs: unused import and MyPy type checking issues.

  This PR contains only the essential fixes without any code formatting changes to minimize merge conflicts.

  ## Changes Made

  ### 1. Linting Fix
  - **File**: `litellm/litellm_core_utils/litellm_logging.py`
  - **Issue**: Unused `asyncio` import (F401 linting error)
  - **Fix**: Removed unused import

   ### 2. MyPy Type Checking

  Fixed 7 MyPy type checking errors:

  #### Redis Type Stubs (redis_cache.py, redis_cluster_cache.py) - 3 errors
  - **Issue**: `aclose()` and `ping()` methods exist but redis-py type stubs are incomplete
  - **Root cause**: Project uses `redis 5.3.1` but type stubs (`types-redis 4.6.x`) are for redis 4.x
  - **Fix**: Added `# type: ignore[attr-defined]` - methods work correctly at runtime
  - **Note**: Type stubs need to be updated when redis-py releases type hints for v5.x

  #### Variable Shadowing (responses/utils.py) - 2 errors
  - **Issue**: Parameter `usage` was shadowed by local variable with same name, confusing MyPy
  - **Fix**: Refactored to eliminate shadowing:
    - Renamed parameter: `usage` → `usage_input`
    - Renamed local variable: `usage` → `chat_usage`
  - **Result**: MyPy happy without `# type: ignore`, improved code readability

  #### Type Inference Limitations - 2 errors
  - **transformation.py**: TypedDict expansion with `Dict[str, Any]` - Added `# type: ignore[typeddict-item]`
  - **aws_secret_manager_v2.py**: Dict flexibility with `Any` type - Added `# type: ignore[assignment]`

  All fixes are safe - code functions correctly at runtime. The type ignore comments address MyPy static analysis limitations, not actual code bugs.
  
  ## Testing
  ✅ Ruff linting passes
  ✅ MyPy type checking passes
  ✅ Circular imports check passes
  ✅ Import safety check passes