### PR TITLE
[Fix] Litellm non root docker Model Hub Table fix

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -8,16 +8,36 @@ ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/python:latest-dev
 FROM $LITELLM_BUILD_IMAGE AS builder
 WORKDIR /app
 
-# Install build dependencies
+# Install build dependencies including Node.js for UI build
 USER root
-RUN apk add --no-cache build-base bash \
+RUN apk add --no-cache build-base bash nodejs npm \
   && pip install --no-cache-dir --upgrade pip build
 
 # Copy project files
 COPY . .
 
+# Set LITELLM_NON_ROOT flag for build time
+ENV LITELLM_NON_ROOT=true
+
 # Build Admin UI
-RUN chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh
+RUN mkdir -p /tmp/litellm_ui && \
+  cd ui/litellm-dashboard && \
+  if [ -f "../../enterprise/enterprise_ui/enterprise_colors.json" ]; then \
+    cp ../../enterprise/enterprise_ui/enterprise_colors.json ./ui_colors.json; \
+  fi && \
+  npm install && \
+  npm run build && \
+  cp -r ./out/* /tmp/litellm_ui/ && \
+  cd /tmp/litellm_ui && \
+  for html_file in *.html; do \
+    if [ "$html_file" != "index.html" ] && [ -f "$html_file" ]; then \
+      folder_name="${html_file%.html}" && \
+      mkdir -p "$folder_name" && \
+      mv "$html_file" "$folder_name/index.html"; \
+    fi; \
+  done && \
+  cd /app/ui/litellm-dashboard && \
+  rm -rf ./out
 
 # Build package and wheel dependencies
 RUN rm -rf dist/* && python -m build && \
@@ -42,6 +62,7 @@ COPY --from=builder /app/docker/supervisord.conf /etc/supervisord.conf
 COPY --from=builder /app/schema.prisma /app/schema.prisma
 COPY --from=builder /app/dist/*.whl .
 COPY --from=builder /wheels/ /wheels/
+COPY --from=builder /tmp/litellm_ui /tmp/litellm_ui
 
 # Install package from wheel and dependencies
 RUN pip install *.whl /wheels/* --no-index --find-links=/wheels/ \
@@ -56,7 +77,6 @@ RUN pip uninstall jwt -y && \
   pip uninstall PyJWT -y && \
   pip install PyJWT==2.9.0 --no-cache-dir
 
-# --- Prisma Handling for Non-Root User ---
 # Set Prisma cache directories
 ENV PRISMA_BINARY_CACHE_DIR=/nonexistent
 ENV NPM_CONFIG_CACHE=/.npm
@@ -68,25 +88,20 @@ RUN pip install --no-cache-dir prisma && \
 
 # Create directories and set permissions for non-root user
 RUN mkdir -p /nonexistent /.npm && \
-  chown -R nobody:nogroup /app && \
-  chown -R nobody:nogroup /nonexistent /.npm && \
+  chown -R nobody:nogroup /app /tmp/litellm_ui /nonexistent /.npm && \
   PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
   chown -R nobody:nogroup $PRISMA_PATH && \
   LITELLM_PKG_MIGRATIONS_PATH="$(python -c 'import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))' 2>/dev/null || echo '')/migrations" && \
   [ -n "$LITELLM_PKG_MIGRATIONS_PATH" ] && chown -R nobody:nogroup $LITELLM_PKG_MIGRATIONS_PATH
 
-# --- OpenShift Compatibility: Apply Red Hat recommended pattern ---
-# Get paths for directories that need write access at runtime
+# OpenShift compatibility
 RUN PRISMA_PATH=$(python -c "import os, prisma; print(os.path.dirname(prisma.__file__))") && \
   LITELLM_PROXY_EXTRAS_PATH=$(python -c "import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))" 2>/dev/null || echo "") && \
-  # Set group ownership to 0 (root group) for OpenShift compatibility && \
-  chgrp -R 0 $PRISMA_PATH && \
+  chgrp -R 0 $PRISMA_PATH /tmp/litellm_ui && \
   [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chgrp -R 0 $LITELLM_PROXY_EXTRAS_PATH || true && \
-  # Mirror owner permissions to group (g=u) as recommended by Red Hat && \
-  chmod -R g=u $PRISMA_PATH && \
+  chmod -R g=u $PRISMA_PATH /tmp/litellm_ui && \
   [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g=u $LITELLM_PROXY_EXTRAS_PATH || true && \
-  # Ensure directories are writable by group && \
-  chmod -R g+w $PRISMA_PATH && \
+  chmod -R g+w $PRISMA_PATH /tmp/litellm_ui && \
   [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w $LITELLM_PROXY_EXTRAS_PATH || true
 
 # Switch to non-root user
@@ -94,14 +109,14 @@ USER nobody
 
 # Set HOME for prisma generate to have a writable directory
 ENV HOME=/app
+
+# Set LITELLM_NON_ROOT flag for runtime
+ENV LITELLM_NON_ROOT=true
+
 RUN prisma generate
-# --- End of Prisma Handling ---
 
 EXPOSE 4000/tcp
 
-# Set entrypoint and command
 ENTRYPOINT ["/app/docker/prod_entrypoint.sh"]
 
-# Append "--detailed_debug" to the end of CMD to view detailed debug logs
-# CMD ["--port", "4000", "--detailed_debug"]
 CMD ["--port", "4000"]

--- a/ui/litellm-dashboard/src/components/chat_ui/CodeSnippets.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/CodeSnippets.tsx
@@ -17,7 +17,7 @@ interface GenerateCodeParams {
   selectedVectorStores: string[];
   selectedGuardrails: string[];
   selectedMCPTools: string[];
-  selectedVoice: string;
+  selectedVoice?: string;
   endpointType: string;
   selectedModel: string | undefined;
   selectedSdk: "openai" | "azure";


### PR DESCRIPTION
## [Fix] Litellm non root docker Model Hub Table fix

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR fixes the issue for the non-root build of docker returning a 404 when the user tries to access the model_hub_table page on the UI. This was a permission issue, and the solution was to build and copy the UI files into a dedicated directory with proper permissions.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

## Screenshots
<img width="953" height="46" alt="image" src="https://github.com/user-attachments/assets/08490827-0ad1-42d3-b9e8-1bf8b82174cf" />

<img width="1482" height="882" alt="image" src="https://github.com/user-attachments/assets/baa8446a-5e93-497b-b496-585c872944c8" />

