### PR TITLE
Docs: clarify Quick Start proxy guide for OpenAI backend

### DIFF
--- a/litellm/docs/quickstart-proxy.md
+++ b/litellm/docs/quickstart-proxy.md
@@ -1,0 +1,56 @@
+LiteLLM Proxy Quickstart Guide (Updated)
+
+This guide clarifies common issues and environment requirements for running LiteLLM locally.
+Step 1: Start the Backend
+
+Choose either a Hugging Face or OpenAI backend.
+
+Hugging Face backend (example):
+litellm --model huggingface/bigcode/starcoder Note:Hugging Face models are not always chat-capable. Using them with Step 2 may result in 400 Bad Request.
+
+OpenAI backend (recommended for chat/completions requests):
+litellm --model gpt-3.5-turbo
+
+Step 2: Connect Python Script
+Use the OpenAI client to connect to the LiteLLM proxy:
+
+import openai
+
+client = openai.OpenAI(
+api_key="YOUR_OPENAI_API_KEY", # or set OPENAI_API_KEY in environment
+base_url="http://localhost:4000
+"
+)
+
+response = client.chat.completions.create(
+model="gpt-3.5-turbo",
+messages=[{"role": "user", "content": "Write a short poem"}]
+)
+
+print(response.choices[0].message.content)
+
+Notes:
+
+If api_key is not passed, you must set:
+export OPENAI_API_KEY="sk-xxxx"
+
+Only use chat-capable models; otherwise you’ll get 400 Bad Request.
+
+Common Issues:
+Error: 401 Unauthorized
+Cause: Using Hugging Face backend with Step 2
+Solution: Use OpenAI backend or adjust model/script
+
+Error: 400 Bad Request
+Cause: Requested model is not chat-enabled
+Solution: Use a chat-capable model like gpt-3.5-turbo
+
+Error: 500 Internal Server Error
+Cause: Missing OPENAI_API_KEY
+Solution: Set OPENAI_API_KEY in environment or pass api_key in client
+
+Summary:
+Step 1: Choose backend carefully (Hugging Face vs OpenAI)
+Step 2: Ensure OPENAI_API_KEY is set in environment or client
+Use chat-capable models for chat/completions requests
+Consult the common issues table if you encounter errors


### PR DESCRIPTION
- Fix Step 1 and Step 2 mismatch
- Explain need to set OPENAI_API_KEY in proxy environment
- Clarify chat vs completion model usage
- Include common pitfalls table

## Title
docs: clarify Quick Start proxy guide


## Relevant issues

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR passes all unit tests (docs-only PR, so no code changes)
- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation


## Changes

This PR updates the LiteLLM Quick Start proxy documentation to clarify backend and environment setup for new users. 

Changes include:

- Fix Step 1 and Step 2 mismatch (Hugging Face vs OpenAI backend)
- Explain the requirement to set OPENAI_API_KEY in the proxy environment
- Clarify chat vs completion model usage
- Include a common pitfalls table for 401, 400, and 500 errors


### Notes for users:

This guide clarifies common issues and environment requirements for running LiteLLM locally.
Step 1: Start the Backend

Choose either a Hugging Face or OpenAI backend.

Hugging Face backend (example):
litellm --model huggingface/bigcode/starcoder Note:Hugging Face models are not always chat-capable. Using them with Step 2 may result in 400 Bad Request.

OpenAI backend (recommended for chat/completions requests):
litellm --model gpt-3.5-turbo

Step 2: Connect Python Script
Use the OpenAI client to connect to the LiteLLM proxy:

import openai

client = openai.OpenAI(
api_key="YOUR_OPENAI_API_KEY", # or set OPENAI_API_KEY in environment
base_url="http://localhost:4000
"
)

response = client.chat.completions.create(
model="gpt-3.5-turbo",
messages=[{"role": "user", "content": "Write a short poem"}]
)

print(response.choices[0].message.content)

Notes:
If api_key is not passed, you must set:
export OPENAI_API_KEY="sk-xxxx"

Only use chat-capable models; otherwise you’ll get 400 Bad Request.

Common Issues:
Error: 401 Unauthorized
Cause: Using Hugging Face backend with Step 2
Solution: Use OpenAI backend or adjust model/script

Error: 400 Bad Request
Cause: Requested model is not chat-enabled
Solution: Use a chat-capable model like gpt-3.5-turbo

Error: 500 Internal Server Error
Cause: Missing OPENAI_API_KEY
Solution: Set OPENAI_API_KEY in environment or pass api_key in client

Summary:
Step 1: Choose backend carefully (Hugging Face vs OpenAI)
Step 2: Ensure OPENAI_API_KEY is set in environment or client
Use chat-capable models for chat/completions requests
Consult the common issues table if you encounter errors

