### PR TITLE
Fix: Filter AWS authentication params from Bedrock InvokeModel request body

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -69,11 +69,19 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
+        # Filter out AWS authentication parameters before passing to Anthropic transformation
+        # AWS params should only be used for signing requests, not included in request body
+        filtered_params = {
+            k: v
+            for k, v in optional_params.items()
+            if k not in self.aws_authentication_params
+        }
+        
         _anthropic_request = AnthropicConfig.transform_request(
             self,
             model=model,
             messages=messages,
-            optional_params=optional_params,
+            optional_params=filtered_params, 
             litellm_params=litellm_params,
             headers=headers,
         )

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -20,3 +20,87 @@ def test_get_supported_params_thinking():
         model="anthropic.claude-sonnet-4-20250514-v1:0"
     )
     assert "thinking" in params
+
+
+def test_aws_params_filtered_from_request_body():
+    """
+    Test that AWS authentication parameters are filtered out from the request body.
+    
+    This is a security test to ensure AWS credentials are not leaked in the request
+    body sent to Bedrock. AWS params should only be used for request signing.
+    
+    Regression test for: AWS params (aws_role_name, aws_session_name, etc.) 
+    being included in the Bedrock InvokeModel request body.
+    """
+    config = AmazonAnthropicClaudeConfig()
+    
+    # Test messages
+    messages = [
+        {"role": "user", "content": "Hello, how are you?"}
+    ]
+    
+    # Optional params with AWS authentication parameters that should be filtered out
+    optional_params = {
+        # Regular Anthropic params - these SHOULD be in the request
+        "max_tokens": 100,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        
+        # AWS authentication params - these should NOT be in the request body
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "aws_session_token": "FwoGZXIvYXdzEBYaDH...",
+        "aws_region_name": "us-west-2",
+        "aws_role_name": "arn:aws:iam::123456789012:role/test-role",
+        "aws_session_name": "test-session",
+        "aws_profile_name": "default",
+        "aws_web_identity_token": "token123",
+        "aws_sts_endpoint": "https://sts.amazonaws.com",
+        "aws_bedrock_runtime_endpoint": "https://bedrock-runtime.us-west-2.amazonaws.com",
+        "aws_external_id": "external-id-123",
+    }
+    
+    # Transform the request
+    result = config.transform_request(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=messages,
+        optional_params=optional_params.copy(),  # Copy to avoid mutation
+        litellm_params={},
+        headers={},
+    )
+    
+    # Convert result to JSON string to check what would be sent in the request
+    result_json = json.dumps(result)
+    
+    # Verify AWS authentication params are NOT in the request body
+    assert "aws_access_key_id" not in result_json, "AWS access key should not be in request body"
+    assert "aws_secret_access_key" not in result_json, "AWS secret key should not be in request body"
+    assert "aws_session_token" not in result_json, "AWS session token should not be in request body"
+    assert "aws_region_name" not in result_json, "AWS region should not be in request body"
+    assert "aws_role_name" not in result_json, "AWS role name should not be in request body"
+    assert "aws_session_name" not in result_json, "AWS session name should not be in request body"
+    assert "aws_profile_name" not in result_json, "AWS profile name should not be in request body"
+    assert "aws_web_identity_token" not in result_json, "AWS web identity token should not be in request body"
+    assert "aws_sts_endpoint" not in result_json, "AWS STS endpoint should not be in request body"
+    assert "aws_bedrock_runtime_endpoint" not in result_json, "AWS bedrock endpoint should not be in request body"
+    assert "aws_external_id" not in result_json, "AWS external ID should not be in request body"
+    
+    # Also check that the sensitive values themselves are not in the response
+    assert "AKIAIOSFODNN7EXAMPLE" not in result_json, "AWS access key value leaked in request body"
+    assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result_json, "AWS secret key value leaked in request body"
+    assert "arn:aws:iam::123456789012:role/test-role" not in result_json, "AWS role ARN leaked in request body"
+    assert "test-session" not in result_json, "AWS session name leaked in request body"
+    
+    # Verify normal params ARE still in the request body
+    assert result["max_tokens"] == 100, "max_tokens should be in request body"
+    assert result["temperature"] == 0.7, "temperature should be in request body"
+    assert result["top_p"] == 0.9, "top_p should be in request body"
+    
+    # Verify Bedrock-specific params are added
+    assert result["anthropic_version"] == "bedrock-2023-05-31", "anthropic_version should be set"
+    assert "model" not in result, "model should be removed for Bedrock Invoke API"
+    assert "stream" not in result, "stream should be removed for Bedrock Invoke API"
+    
+    # Verify messages are present
+    assert "messages" in result, "messages should be in request body"
+    assert len(result["messages"]) == 1, "should have 1 message"


### PR DESCRIPTION
## Title

Fix: Filter AWS authentication params from Bedrock InvokeModel request body

## Relevant issues

Fixes #15848

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem**: AWS authentication parameters (`aws_role_name`, `aws_session_name`, `aws_access_key_id`, etc.) were being included in the Bedrock InvokeModel request body, causing credentials to leak in logs and potentially fail requests.

**Solution**: Filter AWS authentication params in `AmazonAnthropicClaudeConfig.transform_request()` before passing to parent transformation.

**Files Changed**:
- `litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py` - Added filtering logic
- `tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py` - Added security test

<img width="955" height="681" alt="image" src="https://github.com/user-attachments/assets/76b3ab0d-4096-4dc8-aa4d-a31ccae8416b" />

<img width="812" height="192" alt="Screenshot 2025-11-06 at 4 56 52 PM" src="https://github.com/user-attachments/assets/9900b51a-e0c8-450b-8e0a-7a57ea29468e" />