### PR TITLE
fix: pass aws_region_name in litellm_params

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -120,5 +120,6 @@ def get_litellm_params(
         "vertex_project": kwargs.get("vertex_project"),
         "use_litellm_proxy": use_litellm_proxy,
         "litellm_request_debug": litellm_request_debug,
+        "aws_region_name": kwargs.get("aws_region_name"),
     }
     return litellm_params


### PR DESCRIPTION
## Title

Pass AWS region name in litellm params. 

Without it, when calling the `/converse` endpoint, model specific `aws_region_name` is not picked up and `AWS_REGION_NAME` env variable is used as a fallback. This routes model calls to the wrong region and fails.

@ishaan-jaff 

## Relevant issues

Fixes #16268 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes


