### PR TITLE
Fix Azure DALL-E-3 health check content policy violation by using safe default prompt

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -470,6 +470,7 @@ router_settings:
 | DEFAULT_FAILURE_THRESHOLD_PERCENT | Threshold percentage of failures to cool down a deployment. Default is 0.5 (50%)
 | DEFAULT_FLUSH_INTERVAL_SECONDS | Default interval in seconds for flushing operations. Default is 5
 | DEFAULT_HEALTH_CHECK_INTERVAL | Default interval in seconds for health checks. Default is 300 (5 minutes)
+| DEFAULT_HEALTH_CHECK_PROMPT | Default prompt used during health checks for non-image models. Default is "test from litellm"
 | DEFAULT_IMAGE_HEIGHT | Default height for images. Default is 300
 | DEFAULT_IMAGE_TOKEN_COUNT | Default token count for images. Default is 250
 | DEFAULT_IMAGE_WIDTH | Default width for images. Default is 300

--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -106,6 +106,23 @@ model_list:
       mode: image_generation # 👈 ADD THIS
 ```
 
+#### Custom Health Check Prompt
+
+By default, health checks for image generation models use the prompt `"a simple white circle"` to avoid triggering content safety filters (e.g., Azure's content policy). You can customize this prompt if needed:
+
+```yaml
+model_list:
+  - model_name: dall-e-3
+    litellm_params:
+      model: azure/dall-e-3
+      api_base: os.environ/AZURE_API_BASE
+      api_key: os.environ/AZURE_API_KEY
+      api_version: "2023-07-01-preview"
+    model_info:
+      mode: image_generation
+      health_check_prompt: "a blue square" # 👈 CUSTOM PROMPT (optional)
+```
+
 
 ### Text Completion Models 
 

--- a/docs/my-website/docs/proxy/health.md
+++ b/docs/my-website/docs/proxy/health.md
@@ -108,21 +108,11 @@ model_list:
 
 #### Custom Health Check Prompt
 
-By default, health checks for image generation models use the prompt `"a simple white circle"` to avoid triggering content safety filters (e.g., Azure's content policy). You can customize this prompt if needed:
+By default, health checks use the prompt `"test from litellm"`. You can customize this prompt globally by setting an environment variable, or per-model via config:
 
-```yaml
-model_list:
-  - model_name: dall-e-3
-    litellm_params:
-      model: azure/dall-e-3
-      api_base: os.environ/AZURE_API_BASE
-      api_key: os.environ/AZURE_API_KEY
-      api_version: "2023-07-01-preview"
-    model_info:
-      mode: image_generation
-      health_check_prompt: "a blue square" # 👈 CUSTOM PROMPT (optional)
+```bash
+DEFAULT_HEALTH_CHECK_PROMPT="this is a test prompt"
 ```
-
 
 ### Text Completion Models 
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Literal
 
+DEFAULT_HEALTH_CHECK_PROMPT = str(os.getenv("DEFAULT_HEALTH_CHECK_PROMPT", "test from litellm"))
 AZURE_DEFAULT_RESPONSES_API_VERSION = str(
     os.getenv("AZURE_DEFAULT_RESPONSES_API_VERSION", "preview")
 )

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import litellm
 
 logger = logging.getLogger(__name__)
-from litellm.constants import HEALTH_CHECK_TIMEOUT_SECONDS
+from litellm.constants import HEALTH_CHECK_TIMEOUT_SECONDS, DEFAULT_HEALTH_CHECK_PROMPT
 
 ILLEGAL_DISPLAY_PARAMS = [
     "messages",
@@ -95,19 +95,11 @@ async def _perform_health_check(model_list: list, details: Optional[bool] = True
         )
         timeout = model_info.get("health_check_timeout") or HEALTH_CHECK_TIMEOUT_SECONDS
 
-        # Use configurable health_check_prompt
-        health_check_prompt = model_info.get("health_check_prompt", None)
-        if health_check_prompt is None:
-            if mode == "image_generation":
-                health_check_prompt = "a simple white circle"
-            else:
-                health_check_prompt = "test from litellm"
-        
         task = run_with_timeout(
             litellm.ahealth_check(
                 model["litellm_params"],
                 mode=mode,
-                prompt=health_check_prompt,
+                prompt=DEFAULT_HEALTH_CHECK_PROMPT,
                 input=["test from litellm"],
             ),
             timeout,

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -138,7 +138,6 @@ def _update_litellm_params_for_health_check(
     - gets a short `messages` param for health check
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
-    - updates the `prompt` param with the `health_check_prompt` for `image_generation` mode if it exists (handled in _perform_health_check)
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID
     """
     litellm_params["messages"] = _get_random_llm_message()


### PR DESCRIPTION
## Title

Fix Azure DALL-E-3 health check content policy violation by using safe default prompt

## Relevant issues

Fixes #16072

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem
Health checks for DALL-E-3 on Azure were failing with `ContentPolicyViolationError` because the default prompt `"test from litellm"` triggered Azure's content safety filters.

### Solution
1. **Changed default prompt for image generation models** from `"test from litellm"` to `"a simple white circle"` - a safe prompt that won't trigger content filters
2. **Added configurable `health_check_prompt` parameter** in `model_info` (similar to existing `health_check_voice` for audio models)

### Usage
```
**Default (recommended):**
model_list:
  - model_name: dall-e-3
    litellm_params:
      model: azure/dall-e-3
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
    model_info:
      mode: image_generation  # Auto uses "a simple white circle"**Custom prompt (optional):**
model_list:
  - model_name: dall-e-3
    litellm_params:
      model: azure/dall-e-3
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
    model_info:
      mode: image_generation
      health_check_prompt: "a blue square"  # Custom safe prompt### Test Results
```
<img width="808" height="157" alt="image" src="https://github.com/user-attachments/assets/cc6f49e1-3b48-4c39-8394-33748f0475dd" />
