### PR TITLE
[Fix] UI -  SSO Proxy Base URL input validation and remove normalizing /

### DIFF
--- a/ui/litellm-dashboard/src/components/SSOModals.test.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.test.tsx
@@ -96,7 +96,7 @@ describe("SSOModals", () => {
     });
   });
 
-  it("should automatically remove trailing slash from the proxy base url", async () => {
+  it("should show validation error if the proxy base url ends with a trailing slash", async () => {
     const TestWrapper = () => {
       const [form] = Form.useForm();
       return (
@@ -115,18 +115,137 @@ describe("SSOModals", () => {
       );
     };
 
-    const { getByLabelText, container } = render(<TestWrapper />);
+    const { getByLabelText, getByText, container } = render(<TestWrapper />);
 
-    // Fill in the proxy base url with a trailing slash
+    // Find and interact with the SSO provider select
+    const ssoProviderSelect = container.querySelector("#sso_provider");
+    if (ssoProviderSelect) {
+      fireEvent.mouseDown(ssoProviderSelect);
+      // Wait for dropdown and select Google
+      await waitFor(() => {
+        const googleOption = getByText("Google SSO");
+        fireEvent.click(googleOption);
+      });
+    }
+
+    // Fill in the email field
+    const emailInput = getByLabelText("Proxy Admin Email");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    // Fill in a URL with trailing slash
     const urlInput = getByLabelText("PROXY BASE URL") as HTMLInputElement;
     fireEvent.change(urlInput, { target: { value: "https://example.com/" } });
 
-    // Trigger blur to ensure normalization is applied
-    fireEvent.blur(urlInput);
+    // Submit the form
+    const saveButton = getByText("Save");
+    fireEvent.click(saveButton);
 
-    // Check that the trailing slash was removed by the normalize function
+    // Check for validation error
     await waitFor(() => {
-      expect(urlInput.value).toBe("https://example.com");
+      expect(getByText("URL must not end with a trailing slash")).toBeInTheDocument();
     });
+  });
+
+  it("should allow typing https:// without interfering with slashes", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      return (
+        <SSOModals
+          isAddSSOModalVisible={true}
+          isInstructionsModalVisible={false}
+          handleAddSSOOk={() => {}}
+          handleAddSSOCancel={() => {}}
+          handleShowInstructions={() => {}}
+          handleInstructionsOk={() => {}}
+          handleInstructionsCancel={() => {}}
+          form={form}
+          accessToken={null}
+          ssoConfigured={false}
+        />
+      );
+    };
+
+    const { getByLabelText } = render(<TestWrapper />);
+
+    const urlInput = getByLabelText("PROXY BASE URL") as HTMLInputElement;
+
+    // Simulate user typing "https://"
+    fireEvent.change(urlInput, { target: { value: "h" } });
+    expect(urlInput.value).toBe("h");
+
+    fireEvent.change(urlInput, { target: { value: "ht" } });
+    expect(urlInput.value).toBe("ht");
+
+    fireEvent.change(urlInput, { target: { value: "http" } });
+    expect(urlInput.value).toBe("http");
+
+    fireEvent.change(urlInput, { target: { value: "https" } });
+    expect(urlInput.value).toBe("https");
+
+    fireEvent.change(urlInput, { target: { value: "https:" } });
+    expect(urlInput.value).toBe("https:");
+
+    fireEvent.change(urlInput, { target: { value: "https:/" } });
+    expect(urlInput.value).toBe("https:/");
+
+    fireEvent.change(urlInput, { target: { value: "https://" } });
+    expect(urlInput.value).toBe("https://");
+
+    // Continue typing the domain
+    fireEvent.change(urlInput, { target: { value: "https://example.com" } });
+    expect(urlInput.value).toBe("https://example.com");
+  });
+
+  it("should only show URL format error for incomplete URLs, not trailing slash error", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      return (
+        <SSOModals
+          isAddSSOModalVisible={true}
+          isInstructionsModalVisible={false}
+          handleAddSSOOk={() => {}}
+          handleAddSSOCancel={() => {}}
+          handleShowInstructions={() => {}}
+          handleInstructionsOk={() => {}}
+          handleInstructionsCancel={() => {}}
+          form={form}
+          accessToken={null}
+          ssoConfigured={false}
+        />
+      );
+    };
+
+    const { getByLabelText, getByText, queryByText, container } = render(<TestWrapper />);
+
+    // Find and interact with the SSO provider select
+    const ssoProviderSelect = container.querySelector("#sso_provider");
+    if (ssoProviderSelect) {
+      fireEvent.mouseDown(ssoProviderSelect);
+      // Wait for dropdown and select Google
+      await waitFor(() => {
+        const googleOption = getByText("Google SSO");
+        fireEvent.click(googleOption);
+      });
+    }
+
+    // Fill in the email field
+    const emailInput = getByLabelText("Proxy Admin Email");
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    // Fill in an incomplete URL like "http:"
+    const urlInput = getByLabelText("PROXY BASE URL");
+    fireEvent.change(urlInput, { target: { value: "http:" } });
+
+    // Submit the form
+    const saveButton = getByText("Save");
+    fireEvent.click(saveButton);
+
+    // Check that only the URL format error appears
+    await waitFor(() => {
+      expect(getByText("URL must start with http:// or https://")).toBeInTheDocument();
+    });
+
+    // Verify the trailing slash error does NOT appear
+    expect(queryByText("URL must not end with a trailing slash")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -309,7 +309,7 @@ const SSOModals: React.FC<SSOModalsProps> = ({
             <Form.Item
               label="PROXY BASE URL"
               name="proxy_base_url"
-              normalize={(value) => value?.trim().replace(/\/+$/, "")}
+              normalize={(value) => value?.trim()}
               rules={[
                 { required: true, message: "Please enter the proxy base url" },
                 {
@@ -317,8 +317,13 @@ const SSOModals: React.FC<SSOModalsProps> = ({
                   message: "URL must start with http:// or https://",
                 },
                 {
-                  pattern: /^https?:\/\/[^\s]+[^\/]$/,
-                  message: "URL must not end with a trailing slash",
+                  validator: (_, value) => {
+                    // Only check for trailing slash if the URL starts with http:// or https://
+                    if (value && /^https?:\/\/.+/.test(value) && value.endsWith("/")) {
+                      return Promise.reject("URL must not end with a trailing slash");
+                    }
+                    return Promise.resolve();
+                  },
                 },
               ]}
             >


### PR DESCRIPTION
## [Fix] UI -  SSO Proxy Base URL input validation and remove normalizing /

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The SSO Proxy Base URL input automatically deletes any trailing backslashes from the input. This is an issue because when the user types "https:/", this satisfies the condition for the trailing slash and is automatically removed. This PR changes the behavior to only show a validation message instead. Also fixes an issue where the trailing / validation message shows when the input does not end in a /

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

## Screenshot
<img width="702" height="249" alt="image" src="https://github.com/user-attachments/assets/272de275-8d0a-4726-9d37-adbe2a27fef9" />

<img width="769" height="76" alt="image" src="https://github.com/user-attachments/assets/3d25f708-d5ac-4e7b-8eee-7ccb2dfb298a" />

<img width="777" height="82" alt="image" src="https://github.com/user-attachments/assets/053bcc8a-d234-4950-a6d4-dd8119ee71d4" />

