### PR TITLE
[Feat] OTEL - Log Cost Breakdown on OTEL Logger

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -10,6 +10,7 @@ from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.types.services import ServiceLoggerPayload
 from litellm.types.utils import (
     ChatCompletionMessageToolCall,
+    CostBreakdown,
     Function,
     StandardCallbackDynamicParams,
     StandardLoggingPayload,
@@ -1076,6 +1077,16 @@ class OpenTelemetry(CustomLogger):
                 self.safe_set_attribute(
                     span=span, key="hidden_params", value=safe_dumps(hidden_params)
                 )
+            # Cost breakdown tracking
+            cost_breakdown: Optional[CostBreakdown] = standard_logging_payload.get("cost_breakdown")
+            if cost_breakdown:
+                for key, value in cost_breakdown.items():
+                    if value is not None:
+                        self.safe_set_attribute(
+                            span=span,
+                            key=f"gen_ai.cost.{key}",
+                            value=value,
+                        )
             #############################################
             ########## LLM Request Attributes ###########
             #############################################

--- a/litellm/llms/xai/responses/transformation.py
+++ b/litellm/llms/xai/responses/transformation.py
@@ -85,7 +85,7 @@ class XAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
                     # XAI supports code_interpreter but doesn't use the container field
                     # Keep only the type field
                     verbose_logger.debug(
-                        f"XAI: Transforming code_interpreter tool, removing container field"
+                        "XAI: Transforming code_interpreter tool, removing container field"
                     )
                     transformed_tools.append({"type": "code_interpreter"})
                 else:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3704,7 +3704,6 @@
         "output_cost_per_token": 2.75e-05,
         "source": "https://azure.microsoft.com/en-us/blog/grok-4-is-now-available-in-azure-ai-foundry-unlock-frontier-intelligence-and-business-ready-capabilities/",
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_web_search": true
@@ -3732,7 +3731,6 @@
         "mode": "chat",
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/announcing-the-grok-4-fast-models-from-xai-now-available-in-azure-ai-foundry/4456701",
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_web_search": true

--- a/tests/logging_callback_tests/test_otel_logging.py
+++ b/tests/logging_callback_tests/test_otel_logging.py
@@ -281,11 +281,13 @@ def validate_redacted_message_span_attributes(span):
         _all_attributes
     ), f"Missing required attributes: {required_set - _all_attributes}"
 
-    # Check that any additional attributes are metadata fields (start with "metadata.")
+    # Check that any additional attributes are metadata fields (start with "metadata.") or cost fields
     non_required_attrs = _all_attributes - required_set
     for attr in non_required_attrs:
-        assert attr.startswith("metadata.") or attr.startswith(
-            "hidden_params"
+        assert (
+            attr.startswith("metadata.")
+            or attr.startswith("hidden_params")
+            or attr.startswith("gen_ai.cost.")
         ), f"Non-metadata attribute found: {attr}"
 
     pass


### PR DESCRIPTION
## [Feat] OTEL - Log Cost Breakdown on OTEL Logger

Fixes LIT-1422

This PR adds detailed cost breakdown tracking to the OpenTelemetry integration. Cost breakdown information from StandardLoggingPayload is now emitted as span attributes in OpenTelemetry traces, enabling better cost observability and analysis.

<img width="1728" height="916" alt="Screenshot 2025-11-06 at 11 51 19 AM" src="https://github.com/user-attachments/assets/cea31365-6e4d-4967-a602-a7a21822f2bf" />

following fields are emitted to OpenTelemetry spans:

- gen_ai.cost.input_cost - Cost of input/prompt tokens
- gen_ai.cost.output_cost - Cost of output/completion tokens
- gen_ai.cost.total_cost - Total cost (input + output + tool usage)
- gen_ai.cost.tool_usage_cost - Cost of built-in tool usage
- gen_ai.cost.original_cost - Cost before discount (when applicable)
- gen_ai.cost.discount_percent - Discount percentage applied (when applicable)
- gen_ai.cost.discount_amount - Discount amount in USD (when applicable)




<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


