### PR TITLE
Add prompt.name and prompt.version attributes to Langfuse OpenTelemetry integration

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -109,6 +109,8 @@ class LangfuseOtelLogger(OpenTelemetry):
             "existing_trace_id": LangfuseSpanAttributes.EXISTING_TRACE_ID,
             "update_trace_keys": LangfuseSpanAttributes.UPDATE_TRACE_KEYS,
             "debug_langfuse": LangfuseSpanAttributes.DEBUG_LANGFUSE,
+            "prompt_name": LangfuseSpanAttributes.PROMPT_NAME,
+            "prompt_version": LangfuseSpanAttributes.PROMPT_VERSION,
         }
 
         for key, enum_attr in mapping.items():

--- a/litellm/types/integrations/langfuse_otel.py
+++ b/litellm/types/integrations/langfuse_otel.py
@@ -23,6 +23,8 @@ class LangfuseSpanAttributes(str, Enum):
     GENERATION_VERSION = "langfuse.generation.version"
     MASK_INPUT = "langfuse.generation.mask_input"
     MASK_OUTPUT = "langfuse.generation.mask_output"
+    PROMPT_NAME = "langfuse.prompt.name"
+    PROMPT_VERSION = "langfuse.prompt.version"
 
     # ---- Observation input/output ----
     OBSERVATION_INPUT = "langfuse.observation.input"


### PR DESCRIPTION
## Title

Add prompt.name and prompt.version attributes to Langfuse OpenTelemetry integration
<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


