### PR TITLE
Update Fireworks audio endpoints to new `api.fireworks.ai` domains

### DIFF
--- a/docs/my-website/docs/providers/fireworks_ai.md
+++ b/docs/my-website/docs/providers/fireworks_ai.md
@@ -204,7 +204,7 @@ from litellm import completion
 import os
 
 os.environ["FIREWORKS_AI_API_KEY"] = "YOUR_API_KEY"
-os.environ["FIREWORKS_AI_API_BASE"] = "https://audio-prod.us-virginia-1.direct.fireworks.ai/v1"
+os.environ["FIREWORKS_AI_API_BASE"] = "https://audio-prod.api.fireworks.ai/v1"
 
 completion = litellm.completion(
     model="fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct",
@@ -343,7 +343,7 @@ from litellm import transcription
 import os
 
 os.environ["FIREWORKS_AI_API_KEY"] = "YOUR_API_KEY"
-os.environ["FIREWORKS_AI_API_BASE"] = "https://audio-prod.us-virginia-1.direct.fireworks.ai/v1"
+os.environ["FIREWORKS_AI_API_BASE"] = "https://audio-prod.api.fireworks.ai/v1"
 
 response = transcription(
     model="fireworks_ai/whisper-v3",
@@ -363,7 +363,7 @@ model_list:
   - model_name: whisper-v3
     litellm_params:
       model: fireworks_ai/whisper-v3
-      api_base: https://audio-prod.us-virginia-1.direct.fireworks.ai/v1
+      api_base: https://audio-prod.api.fireworks.ai/v1
       api_key: os.environ/FIREWORKS_API_KEY
     model_info:
       mode: audio_transcription

--- a/tests/llm_translation/test_fireworks_ai_translation.py
+++ b/tests/llm_translation/test_fireworks_ai_translation.py
@@ -93,7 +93,7 @@ class TestFireworksAIAudioTranscription(BaseLLMAudioTranscriptionTest):
     def get_base_audio_transcription_call_args(self) -> dict:
         return {
             "model": "fireworks_ai/whisper-v3",
-            "api_base": "https://audio-prod.us-virginia-1.direct.fireworks.ai/v1",
+            "api_base": "https://audio-prod.api.fireworks.ai/v1",
         }
 
     def get_custom_llm_provider(self) -> litellm.LlmProviders:


### PR DESCRIPTION
## Title
Update Fireworks audio endpoints to new `api.fireworks.ai` domains

## Relevant issues
None

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix  
📖 Documentation  
✅ Test

## Changes
- Point Fireworks Whisper transcription test to the new `https://audio-prod.api.fireworks.ai/v1` base URL.  
- Update provider documentation examples and proxy config snippet to reference the new Fireworks audio endpoint.