### PR TITLE
Fix Gemini minimal reasoning env overrides disabling thoughts

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -543,32 +543,39 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             else:
                 budget = DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET
 
-            return {
-                "thinkingBudget": budget,
-                "includeThoughts": True,
-            }
+            return VertexGeminiConfig._build_thinking_config(budget)
         elif reasoning_effort == "low":
-            return {
-                "thinkingBudget": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
-                "includeThoughts": True,
-            }
+            return VertexGeminiConfig._build_thinking_config(
+                DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET
+            )
         elif reasoning_effort == "medium":
-            return {
-                "thinkingBudget": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
-                "includeThoughts": True,
-            }
+            return VertexGeminiConfig._build_thinking_config(
+                DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET
+            )
         elif reasoning_effort == "high":
-            return {
-                "thinkingBudget": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
-                "includeThoughts": True,
-            }
+            return VertexGeminiConfig._build_thinking_config(
+                DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET
+            )
         elif reasoning_effort == "disable":
-            return {
-                "thinkingBudget": DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET,
-                "includeThoughts": False,
-            }
+            return VertexGeminiConfig._build_thinking_config(
+                DEFAULT_REASONING_EFFORT_DISABLE_THINKING_BUDGET,
+                include_thoughts=False,
+            )
         else:
             raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+
+    @staticmethod
+    def _build_thinking_config(
+        budget: int, include_thoughts: Optional[bool] = None
+    ) -> GeminiThinkingConfig:
+        safe_budget = max(budget, 0)
+        include_thoughts = (
+            safe_budget > 0 if include_thoughts is None else include_thoughts
+        )
+        return {
+            "thinkingBudget": safe_budget,
+            "includeThoughts": include_thoughts,
+        }
 
     @staticmethod
     def _is_thinking_budget_zero(thinking_budget: Optional[int]) -> bool:


### PR DESCRIPTION
## Title
Fix Gemini minimal reasoning env overrides disabling thoughts

## Relevant issues
Fixes #15958

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [ ] I have added a screenshot of my new test passing locally *(blocked: local pytest cannot import `litellm` inside sandbox)*

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(not run; same environment limitation as above—needs repo on PYTHONPATH)*

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type
🐛 Bug Fix

## Changes
- Updated `vertex_and_google_ai_studio_gemini._map_reasoning_effort_to_thinking_budget` to clamp negative budgets and automatically toggle `includeThoughts` when the budget is zero, using a shared `_build_thinking_config` helper.
- Added `test_gemini_reasoning_effort_env_override` to confirm environment overrides propagate through the Gemini request payload and disable thoughts at zero budget.

**Testing**
<img width="1114" height="487" alt="image" src="https://github.com/user-attachments/assets/772a8f10-3578-4927-8b58-81c136821c93" />
