### PR TITLE
Fix HostedVLLMRerankConfig will not be used

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1093,6 +1093,7 @@ from .llms.azure_ai.rerank.transformation import AzureAIRerankConfig
 from .llms.infinity.rerank.transformation import InfinityRerankConfig
 from .llms.jina_ai.rerank.transformation import JinaAIRerankConfig
 from .llms.deepinfra.rerank.transformation import DeepinfraRerankConfig
+from .llms.hosted_vllm.rerank.transformation import HostedVLLMRerankConfig
 from .llms.nvidia_nim.rerank.transformation import NvidiaNimRerankConfig
 from .llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
 from .llms.clarifai.chat.transformation import ClarifaiConfig

--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -156,7 +156,7 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
                 f"Error parsing response: {raw_response.text}, status_code={raw_response.status_code}"
             )
 
-        return RerankResponse(**raw_response_json)
+        return self._transform_response(raw_response_json)
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7288,6 +7288,8 @@ class ProviderConfigManager:
             return litellm.InfinityRerankConfig()
         elif litellm.LlmProviders.JINA_AI == provider:
             return litellm.JinaAIRerankConfig()
+        elif litellm.LlmProviders.HOSTED_VLLM == provider:
+            return litellm.HostedVLLMRerankConfig()
         elif litellm.LlmProviders.HUGGINGFACE == provider:
             return litellm.HuggingFaceRerankConfig()
         elif litellm.LlmProviders.DEEPINFRA == provider:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -852,7 +852,7 @@ def test_get_provider_rerank_config():
     from litellm import HostedVLLMRerankConfig
     from litellm.utils import LlmProviders, ProviderConfigManager
 
-    # Test for openai provider
+    # Test for hosted_vllm provider
     config = ProviderConfigManager.get_provider_rerank_config("my_model", LlmProviders.HOSTED_VLLM, 'http://localhost', [])
     assert isinstance(config, HostedVLLMRerankConfig)
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -845,6 +845,16 @@ def test_check_provider_match():
     model_info = {"litellm_provider": "bedrock"}
     assert litellm.utils._check_provider_match(model_info, "openai") is False
 
+def test_get_provider_rerank_config():
+    """
+    Test the get_provider_rerank_config function for various providers
+    """
+    from litellm import HostedVLLMRerankConfig
+    from litellm.utils import LlmProviders, ProviderConfigManager
+
+    # Test for openai provider
+    config = ProviderConfigManager.get_provider_rerank_config("my_model", LlmProviders.HOSTED_VLLM, 'http://localhost', [])
+    assert isinstance(config, HostedVLLMRerankConfig)
 
 # Models that should be skipped during testing
 OLD_PROVIDERS = ["aleph_alpha", "palm"]


### PR DESCRIPTION
When using `hosted_vllm` with reranker model (in my case, it's https://huggingface.co/BAAI/bge-reranker-v2-m3), the `usage` output by vllm is not in litellm's output.

## Type

🐛 Bug Fix

## Changes

1. Fix the reranker config getter. Before this PR, it will use `litellm.CohereRerankConfig` rather than `litellm.HostedVLLMRerankConfig`.
2. Fix the output has no `usage`.