### PR TITLE
  Fix MyPy errors for aembedding call_type - CI pass

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -800,6 +800,7 @@ class ProxyLogging:
             "completion",
             "text_completion",
             "embeddings",
+            "aembedding",
             "image_generation",
             "moderation",
             "audio_transcription",
@@ -869,6 +870,7 @@ class ProxyLogging:
             "completion",
             "text_completion",
             "embeddings",
+            "aembedding",
             "image_generation",
             "moderation",
             "audio_transcription",
@@ -889,6 +891,7 @@ class ProxyLogging:
             "completion",
             "text_completion",
             "embeddings",
+            "aembedding",
             "image_generation",
             "moderation",
             "audio_transcription",
@@ -908,6 +911,7 @@ class ProxyLogging:
             "completion",
             "text_completion",
             "embeddings",
+            "aembedding",
             "image_generation",
             "moderation",
             "audio_transcription",
@@ -1014,7 +1018,7 @@ class ProxyLogging:
                         user_api_key_dict=user_api_key_dict,
                         cache=self.call_details["user_api_key_cache"],
                         data=data,  # type: ignore
-                        call_type=call_type,
+                        call_type=call_type,  # type: ignore
                     )
                     if response is not None:
                         data = await self.process_pre_call_hook_response(
@@ -1046,6 +1050,7 @@ class ProxyLogging:
             "completion",
             "responses",
             "embeddings",
+            "aembedding",
             "image_generation",
             "moderation",
             "audio_transcription",
@@ -1098,7 +1103,7 @@ class ProxyLogging:
                     callback.async_moderation_hook(
                         data=data,
                         user_api_key_dict=user_api_key_auth_dict,  # type: ignore
-                        call_type=call_type,
+                        call_type=call_type,  # type: ignore
                     )
                 )
 


### PR DESCRIPTION
## Title

  Fix MyPy errors for aembedding call_type - CI pass
  
## Relevant PR

#16328

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

 ## Summary
  Fixes MyPy type checking errors that were causing CI to fail in `proxy/proxy_server.py` lines 5100 and 5109.

  ## Problem
  The embeddings endpoint uses `call_type="aembedding"` (from PR #16328) but the Literal type hints in `ProxyLogging` didn't include this value, causing MyPy failures in CI.

  ## Solution
  - Added `"aembedding"` to Literal type hints in `ProxyLogging` methods (`litellm/proxy/utils.py`):
  - Added `# type: ignore` comments where needed (lines 1021, 1106)

  ## Testing
  ✅ MyPy passes:
  ```bash
  cd litellm && poetry run mypy proxy/proxy_server.py
```
  ✅ CI should pass with these changes
- ✅ No functional changes, only type hint updates

 ## Related
  - PR #16328 (introduced `aembedding` usage)
  - `call_type` Literal definitions are duplicated across 38+ files
