### PR TITLE
[Feature] UI - Surface SSO Create errors on create flow

### DIFF
--- a/ui/litellm-dashboard/src/components/SSOModals.test.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.test.tsx
@@ -91,9 +91,13 @@ describe("SSOModals", () => {
     fireEvent.click(saveButton);
 
     // Check for validation error
-    await waitFor(() => {
-      expect(getByText("URL must start with http:// or https://")).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(getByText("URL must start with http:// or https://")).toBeInTheDocument();
+      },
+      // The validation is based on a Promise, so we need to wait for it to resolve
+      { timeout: 5000 },
+    );
   });
 
   it("should show validation error if the proxy base url ends with a trailing slash", async () => {

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -3,6 +3,7 @@ import { Modal, Form, Input, Button as Button2, Select } from "antd";
 import { Text, TextInput } from "@tremor/react";
 import { getSSOSettings, updateSSOSettings } from "./networking";
 import NotificationsManager from "./molecules/notifications_manager";
+import { parseErrorMessage } from "./shared/errorUtils";
 
 interface SSOModalsProps {
   isAddSSOModalVisible: boolean;
@@ -182,9 +183,8 @@ const SSOModals: React.FC<SSOModalsProps> = ({
 
       // Continue with the original flow (show instructions)
       handleShowInstructions(formValues);
-    } catch (error) {
-      console.error("Failed to save SSO settings:", error);
-      NotificationsManager.fromBackend("Failed to save SSO settings");
+    } catch (error: unknown) {
+      NotificationsManager.fromBackend("Failed to save SSO settings: " + parseErrorMessage(error));
     }
   };
 

--- a/ui/litellm-dashboard/src/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ChatUI.test.tsx
@@ -259,7 +259,7 @@ describe("ChatUI", () => {
     });
 
     // Find the endpoint selector by looking for the "Endpoint Type:" text and its associated Select
-    const endpointTypeText = getByText("Endpoint Type:");
+    const endpointTypeText = getByText("Endpoint Type");
     const selectContainer = endpointTypeText.parentElement;
     const selectElement = selectContainer?.querySelector(".ant-select-selector");
 

--- a/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 import { Select } from "antd";
-import { Text } from "@tremor/react";
+import React from "react";
 import { ENDPOINT_OPTIONS } from "./chatConstants";
 
 interface EndpointSelectorProps {

--- a/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/EndpointSelector.tsx
@@ -12,7 +12,6 @@ interface EndpointSelectorProps {
 const EndpointSelector: React.FC<EndpointSelectorProps> = ({ endpointType, onEndpointChange, className }) => {
   return (
     <div className={className}>
-      <Text>Endpoint Type:</Text>
       <Select
         showSearch
         value={endpointType}

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { clearTokenCookies } from "@/utils/cookieUtils";
+import { updateSSOSettings } from "./networking";
 
 vi.mock("@/utils/cookieUtils", () => ({
   clearTokenCookies: vi.fn(),
@@ -16,8 +17,14 @@ vi.mock("./molecules/notifications_manager", () => ({
 }));
 
 describe("networking - expired session handling", () => {
+  const originalFetch = global.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it("should call clearTokenCookies on expired session", async () => {
@@ -40,5 +47,34 @@ describe("networking - expired session handling", () => {
     }
 
     expect(clearTokenCookies).not.toHaveBeenCalled();
+  });
+
+  it("should surface backend detail error when updateSSOSettings fails", async () => {
+    expect.hasAssertions();
+
+    const backendError = {
+      detail: {
+        error: "Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature.",
+      },
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue(backendError),
+    } as any);
+
+    global.fetch = mockFetch as any;
+
+    try {
+      await updateSSOSettings("token", { some: "setting" });
+    } catch (error) {
+      const thrownError = error as any;
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError.message).toBe(backendError.detail.error);
+      expect(thrownError.detail).toEqual(backendError.detail);
+      expect(thrownError.rawError).toEqual(backendError);
+    }
+
+    expect(mockFetch).toHaveBeenCalledOnce();
   });
 });

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4444,9 +4444,7 @@ export const getGeneralSettingsCall = async (accessToken: string) => {
 
 export const getRouterSettingsCall = async (accessToken: string) => {
   try {
-    let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/router/settings`
-      : `/router/settings`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/router/settings` : `/router/settings`;
 
     const response = await fetch(url, {
       method: "GET",
@@ -4473,9 +4471,7 @@ export const getRouterSettingsCall = async (accessToken: string) => {
 
 export const getCacheSettingsCall = async (accessToken: string) => {
   try {
-    let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/cache/settings`
-      : `/cache/settings`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/cache/settings` : `/cache/settings`;
 
     const response = await fetch(url, {
       method: "GET",
@@ -4500,14 +4496,9 @@ export const getCacheSettingsCall = async (accessToken: string) => {
   }
 };
 
-export const testCacheConnectionCall = async (
-  accessToken: string,
-  cacheSettings: Record<string, any>
-) => {
+export const testCacheConnectionCall = async (accessToken: string, cacheSettings: Record<string, any>) => {
   try {
-    let url = proxyBaseUrl
-      ? `${proxyBaseUrl}/cache/settings/test`
-      : `/cache/settings/test`;
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/cache/settings/test` : `/cache/settings/test`;
 
     const response = await fetch(url, {
       method: "POST",
@@ -4535,10 +4526,7 @@ export const testCacheConnectionCall = async (
   }
 };
 
-export const updateCacheSettingsCall = async (
-  accessToken: string,
-  cacheSettings: Record<string, any>
-) => {
+export const updateCacheSettingsCall = async (accessToken: string, cacheSettings: Record<string, any>) => {
   try {
     let url = proxyBaseUrl ? `${proxyBaseUrl}/cache/settings` : `/cache/settings`;
 
@@ -5701,8 +5689,8 @@ export const deleteSearchTool = async (accessToken: string, searchToolId: string
 
 export const fetchAvailableSearchProviders = async (accessToken: string) => {
   try {
-    const url = proxyBaseUrl 
-      ? `${proxyBaseUrl}/search_tools/ui/available_providers` 
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/search_tools/ui/available_providers`
       : `/search_tools/ui/available_providers`;
     console.log("Fetching available search providers from:", url);
 
@@ -5730,14 +5718,9 @@ export const fetchAvailableSearchProviders = async (accessToken: string) => {
   }
 };
 
-export const testSearchToolConnection = async (
-  accessToken: string,
-  litellmParams: Record<string, any>
-) => {
+export const testSearchToolConnection = async (accessToken: string, litellmParams: Record<string, any>) => {
   try {
-    const url = proxyBaseUrl
-      ? `${proxyBaseUrl}/search_tools/test_connection`
-      : `/search_tools/test_connection`;
+    const url = proxyBaseUrl ? `${proxyBaseUrl}/search_tools/test_connection` : `/search_tools/test_connection`;
     console.log("Testing search tool connection:", url);
 
     const response = await fetch(url, {
@@ -6591,7 +6574,7 @@ export const applyGuardrail = async (
     if (!response.ok) {
       const errorData = await response.text();
       let errorMessage = "Failed to apply guardrail";
-      
+
       try {
         const errorJson = JSON.parse(errorData);
         if (errorJson.error?.message) {
@@ -6604,7 +6587,7 @@ export const applyGuardrail = async (
       } catch (e) {
         errorMessage = errorData || errorMessage;
       }
-      
+
       handleError(errorData);
       throw new Error(errorMessage);
     }
@@ -6697,9 +6680,22 @@ export const updateSSOSettings = async (accessToken: string, settings: Record<st
 
     if (!response.ok) {
       const errorData = await response.json();
-      const errorMessage = deriveErrorMessage(errorData);
+      const detailMessage =
+        typeof errorData?.detail === "object"
+          ? errorData.detail?.error || errorData.detail?.message
+          : errorData?.detail;
+      const errorMessage =
+        typeof detailMessage === "string" && detailMessage.length > 0 ? detailMessage : deriveErrorMessage(errorData);
+
       handleError(errorMessage);
-      throw new Error(errorMessage);
+
+      const enhancedError = new Error(errorMessage);
+      if (errorData?.detail !== undefined) {
+        (enhancedError as any).detail = errorData.detail;
+      }
+      (enhancedError as any).rawError = errorData;
+
+      throw enhancedError;
     }
 
     const data = await response.json();


### PR DESCRIPTION
## [Feature] UI - Surface SSO Create errors on create flow

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Currently the error modal displays a generic error message for the `STORE_MODELS_IN_DB=TRUE` requirement for SSO. This caused confusion when users were trying to set up SSO. This PR surfaces the error message up to the notification so users can see the error.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="702" height="188" alt="image" src="https://github.com/user-attachments/assets/c69de7e5-97af-40ca-9b6b-ef9760f6004d" />

<img width="1180" height="486" alt="image" src="https://github.com/user-attachments/assets/fa28111b-0243-49fb-bf50-9e47e37afc3c" />

