### PR TITLE
Propagate cache creation/read token costs for model info to fix Anthropic long context cost calculations

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -128,6 +128,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
         float
     ]  # OpenAI priority service tier pricing
     cache_creation_input_token_cost: Optional[float]
+    cache_creation_input_token_cost_above_200k_tokens: Optional[float]
     cache_creation_input_token_cost_above_1hr: Optional[float]
     cache_read_input_token_cost: Optional[float]
     cache_read_input_token_cost_flex: Optional[
@@ -136,6 +137,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     cache_read_input_token_cost_priority: Optional[
         float
     ]  # OpenAI priority service tier pricing
+    cache_read_input_token_cost_above_200k_tokens: Optional[float]
     input_cost_per_character: Optional[float]  # only for vertex ai models
     input_cost_per_audio_token: Optional[float]
     input_cost_per_token_above_128k_tokens: Optional[float]  # only for vertex ai models

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4968,7 +4968,8 @@ def _get_model_info_helper(  # noqa: PLR0915
                     "cache_read_input_token_cost_priority", None
                 ),
                 cache_creation_input_token_cost_above_1hr=_model_info.get(
-                    "cache_creation_input_token_cost_above_1hr", None
+                    "cache_creation_input_token_cost_above_1hr", 
+                ),
                 input_cost_per_character=_model_info.get(
                     "input_cost_per_character", None
                 ),

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4958,7 +4958,9 @@ def _get_model_info_helper(  # noqa: PLR0915
                 cache_read_input_token_cost=_model_info.get(
                     "cache_read_input_token_cost", None
                 ),
-<<<<<<< HEAD
+                cache_read_input_token_cost_above_200k_tokens=_model_info.get(
+                    "cache_read_input_token_cost_above_200k_tokens", None
+                ),
                 cache_read_input_token_cost_flex=_model_info.get(
                     "cache_read_input_token_cost_flex", None
                 ),
@@ -4967,12 +4969,6 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 cache_creation_input_token_cost_above_1hr=_model_info.get(
                     "cache_creation_input_token_cost_above_1hr", None
-||||||| parent of b6c8bd386f (Fix)
-=======
-                cache_read_input_token_cost_above_200k_tokens=_model_info.get(
-                    "cache_read_input_token_cost_above_200k_tokens", None
->>>>>>> b6c8bd386f (Fix)
-                ),
                 input_cost_per_character=_model_info.get(
                     "input_cost_per_character", None
                 ),

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4952,9 +4952,13 @@ def _get_model_info_helper(  # noqa: PLR0915
                 cache_creation_input_token_cost=_model_info.get(
                     "cache_creation_input_token_cost", None
                 ),
+                cache_creation_input_token_cost_above_200k_tokens=_model_info.get(
+                    "cache_creation_input_token_cost_above_200k_tokens", None
+                ),
                 cache_read_input_token_cost=_model_info.get(
                     "cache_read_input_token_cost", None
                 ),
+<<<<<<< HEAD
                 cache_read_input_token_cost_flex=_model_info.get(
                     "cache_read_input_token_cost_flex", None
                 ),
@@ -4963,6 +4967,11 @@ def _get_model_info_helper(  # noqa: PLR0915
                 ),
                 cache_creation_input_token_cost_above_1hr=_model_info.get(
                     "cache_creation_input_token_cost_above_1hr", None
+||||||| parent of b6c8bd386f (Fix)
+=======
+                cache_read_input_token_cost_above_200k_tokens=_model_info.get(
+                    "cache_read_input_token_cost_above_200k_tokens", None
+>>>>>>> b6c8bd386f (Fix)
                 ),
                 input_cost_per_character=_model_info.get(
                     "input_cost_per_character", None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4968,7 +4968,7 @@ def _get_model_info_helper(  # noqa: PLR0915
                     "cache_read_input_token_cost_priority", None
                 ),
                 cache_creation_input_token_cost_above_1hr=_model_info.get(
-                    "cache_creation_input_token_cost_above_1hr", 
+                    "cache_creation_input_token_cost_above_1hr", None
                 ),
                 input_cost_per_character=_model_info.get(
                     "input_cost_per_character", None


### PR DESCRIPTION
## Title

I noticed that LiteLLM isn't calculating the long context cost calculations correctly (e.g. Anthropic Sonnet 4.5 1M tokens) because the cache creation and cache read token costs aren't getting properly propagated into model info.

I've tested this change and verified the cost calculation is now correct.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/16377

## Pre-Submission checklist

**Note**: this change seems pretty trivial so not sure if additional tests are needed but happy to add one if you think it's helpful

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


