### PR TITLE
docs: fix image generation response format - use 'images' array instead of 'image' object

### DIFF
--- a/docs/my-website/docs/completion/image_generation_chat.md
+++ b/docs/my-website/docs/completion/image_generation_chat.md
@@ -15,16 +15,22 @@ Supported Providers:
 - Google AI Studio (`gemini`)
 - Vertex AI (`vertex_ai/`)
 
-LiteLLM will standardize the `image` response in the assistant message for models that support image generation during chat completions.
+LiteLLM will standardize the `images` response in the assistant message for models that support image generation during chat completions.
 
 ```python title="Example response from litellm"
 "message": {
     ...
     "content": "Here's the image you requested:",
-    "image": {
-        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
-        "detail": "auto"
-    }
+    "images": [
+        {
+            "image_url": {
+                "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+                "detail": "auto"
+            },
+            "index": 0,
+            "type": "image_url"
+        }
+    ]
 }
 ```
 
@@ -47,7 +53,7 @@ response = completion(
 )
 
 print(response.choices[0].message.content)  # Text response
-print(response.choices[0].message.image)    # Image data
+print(response.choices[0].message.images)   # List of image objects
 ```
 
 </TabItem>
@@ -103,10 +109,16 @@ curl http://0.0.0.0:4000/v1/chat/completions \
             "message": {
                 "content": "Here's the image you requested:",
                 "role": "assistant",
-                "image": {
-                    "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
-                    "detail": "auto"
-                }
+                "images": [
+                    {
+                        "image_url": {
+                            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+                            "detail": "auto"
+                        },
+                        "index": 0,
+                        "type": "image_url"
+                    }
+                ]
             }
         }
     ],
@@ -141,8 +153,8 @@ response = completion(
 )
 
 for chunk in response:
-    if hasattr(chunk.choices[0].delta, "image") and chunk.choices[0].delta.image is not None:
-        print("Generated image:", chunk.choices[0].delta.image["url"])
+    if hasattr(chunk.choices[0].delta, "images") and chunk.choices[0].delta.images is not None:
+        print("Generated image:", chunk.choices[0].delta.images[0]["image_url"]["url"])
         break
 ```
 
@@ -175,7 +187,7 @@ data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1723323084
 
 data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1723323084,"model":"gemini/gemini-2.5-flash-image-preview","choices":[{"index":0,"delta":{"content":"Here's the image you requested:"},"finish_reason":null}]}
 
-data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1723323084,"model":"gemini/gemini-2.5-flash-image-preview","choices":[{"index":0,"delta":{"image":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...","detail":"auto"}},"finish_reason":null}]}
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1723323084,"model":"gemini/gemini-2.5-flash-image-preview","choices":[{"index":0,"delta":{"images":[{"image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...","detail":"auto"},"index":0,"type":"image_url"}]},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1723323084,"model":"gemini/gemini-2.5-flash-image-preview","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
 
@@ -200,8 +212,8 @@ async def generate_image():
     )
     
     print(response.choices[0].message.content)  # Text response
-    print(response.choices[0].message.image)    # Image data
-    
+    print(response.choices[0].message.images)   # List of image objects
+
     return response
 
 # Run the async function
@@ -215,18 +227,28 @@ asyncio.run(generate_image())
 | Google AI Studio | `gemini/gemini-2.5-flash-image-preview` |
 | Vertex AI | `vertex_ai/gemini-2.5-flash-image-preview` |
 
-## Spec 
+## Spec
 
-The `image` field in the response follows this structure:
+The `images` field in the response follows this structure:
 
 ```python
-"image": {
-    "url": "data:image/png;base64,<base64_encoded_image>",
-    "detail": "auto"
-}
+"images": [
+    {
+        "image_url": {
+            "url": "data:image/png;base64,<base64_encoded_image>",
+            "detail": "auto"
+        },
+        "index": 0,
+        "type": "image_url"
+    }
+]
 ```
 
-- `url` - str: Base64 encoded image data in data URI format
-- `detail` - str: Image detail level (always "auto" for generated images)
+- `images` - List[ImageURLListItem]: Array of generated images
+  - `image_url` - ImageURLObject: Container for image data
+    - `url` - str: Base64 encoded image data in data URI format
+    - `detail` - str: Image detail level (always "auto" for generated images)
+  - `index` - int: Index of the image in the response
+  - `type` - str: Type identifier (always "image_url")
 
-The image is returned as a base64-encoded data URI that can be directly used in HTML `<img>` tags or saved to a file.
+The images are returned as base64-encoded data URIs that can be directly used in HTML `<img>` tags or saved to files.


### PR DESCRIPTION
## Title

[<!-- e.g. "Implement user authentication feature" -->](docs: fix image generation response format - use 'images' array instead of 'image' object)

## Relevant issues

Related to issue #16227

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

  ## Summary
  Fixes incorrect documentation for image generation in chat completions. The docs showed `image` (singular object) but the actual implementation uses `images` (plural array).

  ## Problem
  Documentation was inconsistent with the actual code implementation, causing confusion for developers using Gemini image  generation models.

  **Docs (incorrect)):**
  ```python
  "message": {
      "content": "Here's the image you requested:",
      "image": {  # ← Singular, object
          "url": "data:image/png;base64,...",
          "detail": "auto"
      }
  }
```
  ### Actual implementation returns:
```python
  "message": {
      "content": "Here's the image you requested:",
      "images": [  # ← Plural, array
          {
              "image_url": {
                  "url": "data:image/png;base64,...",
                  "detail": "auto"
              },
              "index": 0,
              "type": "image_url"
          }
      ]
  }
```
  **From Codebase**

  **1. Message Type Definition**

  File: litellm/types/utils.py (Line 636)

```python
  class Message(OpenAIObject):
      content: Optional[str]
      role: Literal["assistant", "user", "system", "tool", "function"]
      # ...
      images: Optional[List[ImageURLListItem]] = None  # ← Plural array

```
  **2. Gemini Transformation Code**

```python
  File: litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py (Lines 959-965)
  images.append(
      ImageURLListItem(
          image_url=ImageURLObject(url=data_uri, detail="auto"),
          index=0,
          type="image_url",
      )
  )

```
  File: litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py (Line 1500)
` cast(Dict[str, Any], chat_completion_message)["images"] = image_response`

  **3. Test**

  File: tests/llm_translation/test_gemini.py (Lines 734, 762)
Non-streaming test (line 734)
` IMAGE_URL = response.choices[0].message.images[0]["image_url"]`

Streaming test (line 762)
`  if hasattr(chunk.choices[0].delta, "images") and chunk.choices[0].delta.images is not None:`

  Changes Made

  - ✅ Changed all instances of image → images
  - ✅ Updated structure to show array of ImageURLListItem objects
  - ✅ Added index and type fields (set by LiteLLM, not Vertex AI)
  - ✅ Fixed code examples: message.image → message.images
  - ✅ Fixed streaming examples: delta.image → delta.images[0]["image_url"]["url"]
  - ✅ Updated Spec section with accurate type information

  Files Changed

  - docs/my-website/docs/completion/image_generation_chat.md

  Related

  - Issue #16227 - User reported incorrect format in documentation