### PR TITLE
docs: Add documentation for Anthropic Memory Tool

### DIFF
--- a/docs/my-website/docs/providers/anthropic.md
+++ b/docs/my-website/docs/providers/anthropic.md
@@ -953,7 +953,7 @@ except Exception as e:
 
 s/o @[Shekhar Patnaik](https://www.linkedin.com/in/patnaikshekhar) for requesting this!
 
-### Anthropic Hosted Tools (Computer, Text Editor, Web Search)
+### Anthropic Hosted Tools (Computer, Text Editor, Web Search, Memory)
 
 
 <Tabs>
@@ -1183,6 +1183,72 @@ curl http://0.0.0.0:4000/v1/chat/completions \
 </Tabs>
 
 </TabItem>
+
+<TabItem value="memory" label="Memory">
+
+:::info
+The Anthropic Memory tool is currently in beta.
+:::
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+
+tools = [{
+    "type": "memory_20250818",
+    "name": "memory"
+}]
+
+model = "claude-sonnet-4-5-20250929" 
+messages = [{"role": "user", "content": "Please remember that my favorite color is blue."}]
+
+response = completion(
+    model=model,
+    messages=messages,
+    tools=tools,
+)
+
+print(response)
+```
+
+</TabItem>
+<TabItem value="proxy" label="Proxy">
+
+1. Setup config.yaml
+
+```yaml
+model_list:
+    - model_name: claude-memory-model
+    litellm_params:
+        model: anthropic/claude-sonnet-4-5-20250929
+        api_key: os.environ/ANTHROPIC_API_KEY
+```
+
+2. Start proxy
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+3. Test it! 
+
+```bash
+curl http://0.0.0.0:4000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $LITELLM_KEY" \
+    -d '{
+    "model": "claude-memory-model",
+    "messages": [{"role": "user", "content": "Please remember that my favorite color is blue."}],
+    "tools": [{"type": "memory_20250818", "name": "memory"}]
+    }'
+```
+</TabItem>
+</Tabs>
+
+</TabItem>
+
 </Tabs>
 
 


### PR DESCRIPTION
##  Add documentation for Anthropic Memory Tool



## Relevant issues

This documentation update is for the feature implemented in PR #16115

## Pre-Submission checklist

**Please complete all items before asking a Lite_llm maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - *N/A: This is a documentation-only change.*
- [x] I have added a screenshot of my new test passing locally
  - *N/A: This is a documentation-only change.*
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

📖 Documentation

## Changes

This PR adds documentation for the newly supported Anthropic Memory Tool, as requested by the maintainer.

The changes are made in `docs/my-website/docs/providers/anthropic.md`:

1.  The heading for "Anthropic Hosted Tools" has been updated to include "Memory".
2.  A new "Memory" tab has been added to the "Anthropic Hosted Tools" section.
3.  The new documentation includes:
    *   An `:::info` block explaining that LiteLLM automatically adds the required beta header for this feature.
    *   A code example showing how to use the memory tool with the LiteLLM SDK.
    *   A code example showing how to use the memory tool with the LiteLLM Proxy.

