### PR TITLE
[Fix] UI - Test Key Page Revert Model To Single Select

### DIFF
--- a/ui/litellm-dashboard/src/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ChatUI.test.tsx
@@ -49,197 +49,7 @@ describe("ChatUI", () => {
         disabledPersonalKeyCreation={false}
       />,
     );
-
-    await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
-    });
-  });
-
-  it("should render the chat UI with selected models", async () => {
-    const { getByText, container, getAllByText } = render(
-      <ChatUI
-        accessToken="1234567890"
-        token="1234567890"
-        userRole="user"
-        userID="1234567890"
-        disabledPersonalKeyCreation={false}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
-    });
-
-    // Wait for the first model to be auto-selected (default behavior)
-    await waitFor(() => {
-      expect(getByText("Model 1")).toBeInTheDocument();
-    });
-
-    // Now click the Select dropdown to open it and check other models
-    const selectComponent = container.querySelectorAll(".ant-select-selector")[1]; // Second select is for models
-    expect(selectComponent).toBeTruthy();
-
-    // Click to open the dropdown
-    fireEvent.mouseDown(selectComponent!);
-
-    // Wait for dropdown to open and check for all models
-    await waitFor(() => {
-      const dropdown = document.querySelector(".ant-select-dropdown");
-      expect(dropdown).toBeTruthy();
-
-      // All three models should be in the dropdown as options
-      // Use getAllByTitle since Ant Design Select renders options with title attributes
-      const model2Elements = screen.queryAllByText("Model 2");
-      const model3Elements = screen.queryAllByText("Model 3");
-
-      expect(model2Elements.length).toBeGreaterThan(0);
-      expect(model3Elements.length).toBeGreaterThan(0);
-    });
-  });
-
-  it("should allow users to pick multiple models and render badges for selected models", async () => {
-    const { getByText, container } = render(
-      <ChatUI
-        accessToken="1234567890"
-        token="1234567890"
-        userRole="user"
-        userID="1234567890"
-        disabledPersonalKeyCreation={false}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(getByText("Model 1")).toBeInTheDocument();
-    });
-
-    const selectComponent = container.querySelectorAll(".ant-select-selector")[1];
-    expect(selectComponent).toBeTruthy();
-
-    fireEvent.mouseDown(selectComponent!);
-
-    let model2Option: HTMLElement | null = null;
-    await waitFor(() => {
-      const dropdown = document.querySelector(".ant-select-dropdown");
-      expect(dropdown).toBeTruthy();
-      const options = document.querySelectorAll(".ant-select-item-option-content");
-      model2Option = Array.from(options).find((opt) => opt.textContent === "Model 2") as HTMLElement;
-      expect(model2Option).toBeTruthy();
-    });
-
-    fireEvent.click(model2Option!);
-
-    await waitFor(() => {
-      const model1Badges = screen.getAllByText("Model 1");
-      const model2Badges = screen.getAllByText("Model 2");
-
-      expect(model1Badges.length).toBeGreaterThan(0);
-      expect(model2Badges.length).toBeGreaterThan(0);
-    });
-
-    fireEvent.mouseDown(selectComponent!);
-
-    let model3Option: HTMLElement | null = null;
-    await waitFor(() => {
-      const dropdown = document.querySelector(".ant-select-dropdown");
-      expect(dropdown).toBeTruthy();
-      const options = document.querySelectorAll(".ant-select-item-option-content");
-      model3Option = Array.from(options).find((opt) => opt.textContent === "Model 3") as HTMLElement;
-      expect(model3Option).toBeTruthy();
-    });
-
-    fireEvent.click(model3Option!);
-
-    // Verify all three models have badges rendered
-    await waitFor(() => {
-      const model1Badges = screen.getAllByText("Model 1");
-      const model2Badges = screen.getAllByText("Model 2");
-      const model3Badges = screen.getAllByText("Model 3");
-
-      expect(model1Badges.length).toBeGreaterThan(0);
-      expect(model2Badges.length).toBeGreaterThan(0);
-      expect(model3Badges.length).toBeGreaterThan(0);
-    });
-    const tags = container.querySelectorAll(".ant-tag");
-    expect(tags.length).toBe(3);
-  });
-
-  it("should manage selectedModels state and its side effects", async () => {
-    const { getByText, container } = render(
-      <ChatUI
-        accessToken="1234567890"
-        token="1234567890"
-        userRole="user"
-        userID="1234567890"
-        disabledPersonalKeyCreation={false}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(getByText("Test Key")).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(getByText("Model 1")).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      const storedModels = sessionStorage.getItem("selectedModels");
-      expect(storedModels).toBeTruthy();
-      const parsedModels = JSON.parse(storedModels!);
-      expect(parsedModels).toContain("Model 1");
-    });
-
-    const selectComponent = container.querySelectorAll(".ant-select-selector")[1];
-
-    fireEvent.mouseDown(selectComponent!);
-
-    let model2Option: HTMLElement | null = null;
-    await waitFor(() => {
-      const dropdown = document.querySelector(".ant-select-dropdown");
-      expect(dropdown).toBeTruthy();
-      const options = document.querySelectorAll(".ant-select-item-option-content");
-      model2Option = Array.from(options).find((opt) => opt.textContent === "Model 2") as HTMLElement;
-      expect(model2Option).toBeTruthy();
-    });
-
-    fireEvent.click(model2Option!);
-
-    await waitFor(() => {
-      const model2Badges = screen.getAllByText("Model 2");
-      expect(model2Badges.length).toBeGreaterThan(0);
-    });
-
-    await waitFor(() => {
-      const storedModels = sessionStorage.getItem("selectedModels");
-      const parsedModels = JSON.parse(storedModels!);
-      expect(parsedModels).toContain("Model 1");
-      expect(parsedModels).toContain("Model 2");
-      expect(parsedModels.length).toBe(2);
-    });
-
-    const tags = container.querySelectorAll(".ant-tag");
-    expect(tags.length).toBe(2);
-
-    const firstTagCloseButton = tags[0].querySelector(".ant-tag-close-icon");
-    expect(firstTagCloseButton).toBeTruthy();
-    fireEvent.click(firstTagCloseButton!);
-
-    await waitFor(() => {
-      const storedModels = sessionStorage.getItem("selectedModels");
-      const parsedModels = JSON.parse(storedModels!);
-      expect(parsedModels).not.toContain("Model 1");
-      expect(parsedModels).toContain("Model 2");
-      expect(parsedModels.length).toBe(1);
-    });
-
-    await waitFor(() => {
-      const remainingTags = container.querySelectorAll(".ant-tag");
-      expect(remainingTags.length).toBe(1);
-    });
+    expect(getByText("Test Key")).toBeInTheDocument();
   });
 
   it("should show the voice selector when the endpoint type is audio_speech", async () => {
@@ -290,5 +100,36 @@ describe("ChatUI", () => {
     const voiceSelectContainer = voiceText.parentElement;
     const voiceSelectElement = voiceSelectContainer?.querySelector(".ant-select");
     expect(voiceSelectElement).toBeInTheDocument();
+  });
+
+  it("should allow the user to select a model", async () => {
+    const { getByText, container } = render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    // Wait for the component to render
+    await waitFor(() => {
+      expect(getByText("Test Key")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(getByText("Model 1")).toBeInTheDocument();
+    });
+
+    const selectComponent = container.querySelectorAll(".ant-select-selector")[1];
+    expect(selectComponent).toBeTruthy();
+
+    fireEvent.mouseDown(selectComponent!);
+
+    await waitFor(() => {
+      const model1Label = screen.getAllByText("Model 1");
+      expect(model1Label.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/content_filter/ContentFilterManager.tsx
@@ -114,13 +114,7 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
 
   // Read-only display mode
   if (!isEditing) {
-    return (
-      <ContentFilterDisplay
-        patterns={selectedPatterns}
-        blockedWords={blockedWords}
-        readOnly={true}
-      />
-    );
+    return <ContentFilterDisplay patterns={selectedPatterns} blockedWords={blockedWords} readOnly={true} />;
   }
 
   // Edit mode
@@ -130,7 +124,8 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
       {hasUnsavedChanges && (
         <div className="mb-4 px-4 py-3 bg-yellow-50 border border-yellow-200 rounded-md">
           <p className="text-sm text-yellow-800 font-medium">
-            ⚠️ You have unsaved changes to patterns or keywords. Remember to click "Save Changes" at the bottom.
+            ⚠️ You have unsaved changes to patterns or keywords. Remember to click &quot;Save Changes&quot; at the
+            bottom.
           </p>
         </div>
       )}
@@ -165,10 +160,7 @@ const ContentFilterManager: React.FC<ContentFilterManagerProps> = ({
 export default ContentFilterManager;
 
 // Helper function to format data for API
-export const formatContentFilterDataForAPI = (
-  patterns: Pattern[],
-  blockedWords: BlockedWord[]
-) => {
+export const formatContentFilterDataForAPI = (patterns: Pattern[], blockedWords: BlockedWord[]) => {
   return {
     patterns: patterns.map((p) => ({
       pattern_type: p.type === "prebuilt" ? "prebuilt" : "regex",
@@ -184,4 +176,3 @@ export const formatContentFilterDataForAPI = (
     })),
   };
 };
-

--- a/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/components/guardrails/guardrail_info.tsx
@@ -21,7 +21,7 @@ import {
   getGuardrailUISettings,
   getGuardrailProviderSpecificParams,
 } from "@/components/networking";
-import { getGuardrailLogoAndName, guardrail_provider_map, shouldRenderContentFilterConfigSettings } from "./guardrail_info_helpers";
+import { getGuardrailLogoAndName, guardrail_provider_map } from "./guardrail_info_helpers";
 import PiiConfiguration from "./pii_configuration";
 import GuardrailProviderFields from "./guardrail_provider_fields";
 import GuardrailOptionalParams from "./guardrail_optional_params";
@@ -83,7 +83,7 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
   } | null>(null);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [hasUnsavedContentFilterChanges, setHasUnsavedContentFilterChanges] = useState(false);
-  
+
   // Content Filter data ref (managed by ContentFilterManager)
   const contentFilterDataRef = React.useRef<{ patterns: any[]; blockedWords: any[] }>({
     patterns: [],
@@ -240,10 +240,10 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
       if (guardrailData.litellm_params?.guardrail === "litellm_content_filter") {
         const originalPatterns = guardrailData.litellm_params?.patterns || [];
         const originalBlockedWords = guardrailData.litellm_params?.blocked_words || [];
-        
+
         const formattedData = formatContentFilterDataForAPI(
           contentFilterDataRef.current.patterns,
-          contentFilterDataRef.current.blockedWords
+          contentFilterDataRef.current.blockedWords,
         );
 
         if (JSON.stringify(originalPatterns) !== JSON.stringify(formattedData.patterns)) {
@@ -615,10 +615,14 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
                     </Form.Item>
 
                     <div className="flex justify-end gap-2 mt-6">
-                      <Button onClick={() => {
-                        setIsEditing(false);
-                        setHasUnsavedContentFilterChanges(false);
-                      }}>Cancel</Button>
+                      <Button
+                        onClick={() => {
+                          setIsEditing(false);
+                          setHasUnsavedContentFilterChanges(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
                       <TremorButton>Save Changes</TremorButton>
                     </div>
                   </Form>

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -25,11 +25,7 @@ interface CreateMCPServerProps {
   availableAccessGroups: string[];
 }
 
-const AUTH_TYPES_REQUIRING_AUTH_VALUE = [
-  AUTH_TYPE.API_KEY,
-  AUTH_TYPE.BEARER_TOKEN,
-  AUTH_TYPE.BASIC,
-];
+const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.BASIC];
 
 const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   userRole,
@@ -50,9 +46,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   const [searchValue, setSearchValue] = useState<string>("");
   const [urlWarning, setUrlWarning] = useState<string>("");
   const authType = formValues.auth_type as string | undefined;
-  const shouldShowAuthValueField = authType
-    ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType)
-    : false;
+  const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
 
   // Function to check URL format based on transport type
   const checkUrlFormat = (url: string, transport: string) => {
@@ -92,7 +86,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             acc[header] = entry?.value ?? "";
             return acc;
           }, {})
-        : {} as Record<string, string>;
+        : ({} as Record<string, string>);
 
       const credentialsPayload =
         credentialValues && typeof credentialValues === "object"
@@ -154,7 +148,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       }
 
       // Prepare the payload with cost configuration and allowed tools
-      const payload = {
+      const payload: Record<string, any> = {
         ...restValues,
         ...stdioFields,
         // Remove the raw stdio_config field as we've extracted its components
@@ -171,14 +165,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       };
 
       payload.static_headers = staticHeaders;
-      const includeCredentials =
-        restValues.auth_type && AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type);
+      const includeCredentials = restValues.auth_type && AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type);
 
-      if (
-        includeCredentials &&
-        credentialsPayload &&
-        Object.keys(credentialsPayload).length > 0
-      ) {
+      if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
         payload.credentials = credentialsPayload;
       }
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -18,11 +18,7 @@ interface MCPServerEditProps {
   availableAccessGroups: string[];
 }
 
-const AUTH_TYPES_REQUIRING_AUTH_VALUE = [
-  AUTH_TYPE.API_KEY,
-  AUTH_TYPE.BEARER_TOKEN,
-  AUTH_TYPE.BASIC,
-];
+const AUTH_TYPES_REQUIRING_AUTH_VALUE = [AUTH_TYPE.API_KEY, AUTH_TYPE.BEARER_TOKEN, AUTH_TYPE.BASIC];
 
 const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   mcpServer,
@@ -39,9 +35,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const [aliasManuallyEdited, setAliasManuallyEdited] = useState(false);
   const [allowedTools, setAllowedTools] = useState<string[]>([]);
   const authType = Form.useWatch("auth_type", form) as string | undefined;
-  const shouldShowAuthValueField = authType
-    ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType)
-    : false;
+  const shouldShowAuthValueField = authType ? AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(authType) : false;
 
   const initialStaticHeaders = React.useMemo(() => {
     if (!mcpServer.static_headers) {
@@ -159,11 +153,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     if (!accessToken) return;
     try {
       // Ensure access groups is always a string array
-      const {
-        static_headers: staticHeadersList,
-        credentials: credentialValues,
-        ...restValues
-      } = values;
+      const { static_headers: staticHeadersList, credentials: credentialValues, ...restValues } = values;
 
       const accessGroups = (restValues.mcp_access_groups || []).map((g: any) =>
         typeof g === "string" ? g : g.name || String(g),
@@ -178,7 +168,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             acc[header] = entry?.value ?? "";
             return acc;
           }, {})
-        : {} as Record<string, string>;
+        : ({} as Record<string, string>);
 
       const credentialsPayload =
         credentialValues && typeof credentialValues === "object"
@@ -201,7 +191,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           : undefined;
 
       // Prepare the payload with cost configuration and permission fields
-      const payload = {
+      const payload: Record<string, any> = {
         ...restValues,
         server_id: mcpServer.server_id,
         mcp_info: {
@@ -218,14 +208,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         static_headers: staticHeaders,
       };
 
-      const includeCredentials =
-        restValues.auth_type && AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type);
+      const includeCredentials = restValues.auth_type && AUTH_TYPES_REQUIRING_AUTH_VALUE.includes(restValues.auth_type);
 
-      if (
-        includeCredentials &&
-        credentialsPayload &&
-        Object.keys(credentialsPayload).length > 0
-      ) {
+      if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
         payload.credentials = credentialsPayload;
       }
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -1,14 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { ToolTestPanel } from "./ToolTestPanel";
 import { MCPTool, MCPToolsViewerProps, CallMCPToolResponse } from "./types";
 import { listMCPTools, callMCPTool } from "../networking";
 
-import { Modal, Input, Form } from "antd";
-import { Button, Card, Title, Text } from "@tremor/react";
-import { RobotOutlined, SafetyOutlined, ToolOutlined } from "@ant-design/icons";
-
-import NotificationsManager from "../molecules/notifications_manager";
+import { Card, Title, Text } from "@tremor/react";
+import { RobotOutlined, ToolOutlined } from "@ant-design/icons";
 
 const MCPToolsViewer = ({
   serverId,
@@ -43,11 +40,7 @@ const MCPToolsViewer = ({
       if (!accessToken) throw new Error("Access Token required");
 
       try {
-        const result = await callMCPTool(
-          accessToken,
-          args.tool.name,
-          args.arguments,
-        );
+        const result = await callMCPTool(accessToken, args.tool.name, args.arguments);
         return result;
       } catch (error) {
         throw error;


### PR DESCRIPTION
## [Fix] UI - Test Key Page Revert Model To Single Select

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This reverts the test key page model select to a single select again, and this fixes build issues.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

## Screenshots
<img width="1274" height="737" alt="image" src="https://github.com/user-attachments/assets/24dcbf9d-de0b-4d86-9275-cbe9ead86681" />

<img width="714" height="236" alt="image" src="https://github.com/user-attachments/assets/760d2360-d984-48a0-8d87-095707092b15" />

<img width="599" height="139" alt="image" src="https://github.com/user-attachments/assets/b422e171-fe7a-4b8b-b7cb-0649435ee541" />

