### PR TITLE
feat: Add /v1/tokenize endpoint for OpenAI-compatible token counting

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2370,6 +2370,22 @@ class TokenCountRequest(LiteLLMPydanticObjectBase):
     """
 
 
+class TokenizeRequest(LiteLLMPydanticObjectBase):
+    """Request model for /v1/tokenize endpoint"""
+
+    model: str
+    text: Optional[str] = None
+    messages: Optional[List[dict]] = None
+
+
+class TokenizeResponse(LiteLLMPydanticObjectBase):
+    """Response model for /v1/tokenize endpoint"""
+
+    tokens: Optional[List[int]] = None
+    total_tokens: int
+    model: str
+
+
 class CallInfo(LiteLLMPydanticObjectBase):
     """Used for slack budget alerting"""
 


### PR DESCRIPTION
This commit adds a new /v1/tokenize endpoint to the LiteLLM proxy server that provides OpenAI-compatible tokenization functionality.

Changes:
- Added TokenizeRequest and TokenizeResponse models to litellm/proxy/_types.py
- Implemented /v1/tokenize endpoint in litellm/proxy/proxy_server.py
- Supports both text and messages input for token counting
- Returns token count and optionally token IDs when available
- Integrates with existing LiteLLM router and tokenization infrastructure

Example usage:
curl -X POST http://localhost:4000/v1/tokenize \
  -H "Content-Type: application/json" \ -H "Authorization: Bearer sk-1234" \ -d '{"model": "gpt-4", "text": "Hello, how are you?"}'

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


