### PR TITLE
fix: Enable usage and cost tracking for audio transcription models

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -521,9 +521,9 @@ def convert_to_model_response_object(  # noqa: PLR0915
                         provider_specific_fields["thinking_blocks"] = thinking_blocks
 
                     if reasoning_content:
-                        provider_specific_fields["reasoning_content"] = (
-                            reasoning_content
-                        )
+                        provider_specific_fields[
+                            "reasoning_content"
+                        ] = reasoning_content
 
                     message = Message(
                         content=content,
@@ -683,6 +683,14 @@ def convert_to_model_response_object(  # noqa: PLR0915
             for key in optional_keys:  # not guaranteed to be in response
                 if key in response_object:
                     setattr(model_response_object, key, response_object[key])
+
+            if "usage" in response_object and response_object["usage"] is not None:
+                usage_object = litellm.Usage(**response_object["usage"])
+                setattr(model_response_object, "usage", usage_object)
+            else:
+                # Ensure the usage attribute always exists for consistency,
+                # as TranscriptionResponse does not have it by default.
+                setattr(model_response_object, "usage", litellm.Usage())
 
             if hidden_params is not None:
                 model_response_object._hidden_params = hidden_params

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
@@ -1,0 +1,70 @@
+import pytest
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm import TranscriptionResponse, Usage
+
+
+def test_convert_audio_transcription_with_usage():
+    """
+    Tests if the usage object is correctly parsed for an audio_transcription response.
+    """
+    # Mock response object from a provider like OpenAI for transcription
+    mock_response_object = {
+        "text": "This is a test transcription.",
+        "usage": {
+            "prompt_tokens": 784,
+            "completion_tokens": 235,
+            "total_tokens": 1019,
+        },
+    }
+
+    # Call the function to convert the dictionary to a response object
+    converted_response = convert_to_model_response_object(
+        response_object=mock_response_object,
+        response_type="audio_transcription",
+        model_response_object=TranscriptionResponse(),  # Pass a base object to be populated
+    )
+
+    # Assert: Check if the usage information was correctly populated
+    assert converted_response is not None
+    assert isinstance(converted_response, TranscriptionResponse)
+    assert hasattr(converted_response, "usage")
+    assert isinstance(converted_response.usage, Usage)
+
+    # Assert token values
+    assert converted_response.usage.prompt_tokens == 784
+    assert converted_response.usage.completion_tokens == 235
+    assert converted_response.usage.total_tokens == 1019
+
+    # Assert other fields
+    assert converted_response.text == "This is a test transcription."
+
+
+def test_convert_audio_transcription_without_usage():
+    """
+    Tests graceful handling when the usage object is missing from an audio_transcription response.
+    """
+    # Mock response object without a usage key
+    mock_response_object = {
+        "text": "This is another test transcription.",
+    }
+
+    converted_response = convert_to_model_response_object(
+        response_object=mock_response_object,
+        response_type="audio_transcription",
+        model_response_object=TranscriptionResponse(),
+    )
+
+    # Assert: Check that the usage object defaults to zero values
+    assert converted_response is not None
+    assert isinstance(converted_response, TranscriptionResponse)
+    assert hasattr(converted_response, "usage")  # The attribute should still exist
+    assert isinstance(converted_response.usage, Usage)
+
+    # Assert default token values
+    assert converted_response.usage.prompt_tokens == 0
+    assert converted_response.usage.completion_tokens == 0
+    assert converted_response.usage.total_tokens == 0
+
+    assert converted_response.text == "This is another test transcription."


### PR DESCRIPTION
##  Enable usage and cost tracking for audio transcription models



## Relevant issues

Fixes #16270

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1813" height="237" alt="image" src="https://github.com/user-attachments/assets/502b6480-fa1c-48e1-a7a3-9d3c8e2cc8ee" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

This PR fixes a bug where usage and billing information for token-based audio transcription models (e.g., `gpt-4o-transcribe`) was not being processed, leading to zero-cost logs.

### Problem

The raw API response from providers for these models includes a `usage` object with token counts, but this was being ignored during response processing. As a result, the final `TranscriptionResponse` object lacked usage data, and spend tracking recorded zero tokens and zero cost.

### Solution

The fix is implemented in the `convert_to_model_response_object` function within `litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py`.

1.  When processing a response of type `audio_transcription`, the function now checks for a `usage` key in the provider's response dictionary.
2.  If `usage` is present, it is parsed into a `litellm.Usage` object and attached to the `TranscriptionResponse` object.
3.  If `usage` is not present (for providers that bill by duration), a default `litellm.Usage` object is attached. This ensures the `.usage` attribute is always present, preventing downstream errors and maintaining consistency with other response types.

### Testing

-   A new test file has been created at `tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py` to cover this previously untested module.
-   Two test cases have been added:
    1.  `test_convert_audio_transcription_with_usage`: Verifies that token counts are correctly parsed when the `usage` object is present.
    2.  `test_convert_audio_transcription_without_usage`: Verifies that the function handles responses without a `usage` object gracefully, attaching a default zero-value `Usage` object.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parse provider `usage` into `TranscriptionResponse` for `audio_transcription`, defaulting to an empty `Usage` when absent, and add tests covering both cases.
> 
> - **Core utils**:
>   - Update `convert_to_model_response_object` in `litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py` to parse provider `usage` into a `litellm.Usage` on `TranscriptionResponse` for `audio_transcription`.
>   - Ensure a default `Usage()` is attached when `usage` is missing.
>   - Minor formatting tweak for assigning `reasoning_content` into `provider_specific_fields`.
> - **Tests**:
>   - Add `tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py` with cases for transcription responses with and without `usage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94fcb25b66fb488ef6a091beda2065c537f89bdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->