### PR TITLE
fix: respect user-configured timeout in OpenRouter requests

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -253,6 +253,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             allow_redirects=False,
             auto_decompress=False,
             timeout=ClientTimeout(
+                total=timeout.get("timeout"),
                 sock_connect=timeout.get("connect"),
                 sock_read=timeout.get("read"),
                 connect=timeout.get("pool"),


### PR DESCRIPTION
## What happened?

Fixes #16394 

When setting a timeout for OpenRouter requests (e.g., `timeout=10`), the request does not timeout at 10 seconds. Instead, it continues for up to 300 seconds (aiohttp's default total timeout).

## Root Cause

In `aiohttp_transport.py`, the `ClientTimeout` was created without setting the `total` field:

```python
timeout=ClientTimeout(
    sock_connect=timeout.get("connect"),
    sock_read=timeout.get("read"),
    connect=timeout.get("pool"),
)
```

This meant that while socket-level timeouts were set, the overall request timeout was not, causing it to default to aiohttp's 300-second timeout.

## Solution

Added the `total` parameter to `ClientTimeout`:

```python
timeout=ClientTimeout(
    total=timeout.get("timeout"),  # ← Added this line
    sock_connect=timeout.get("connect"),
    sock_read=timeout.get("read"),
    connect=timeout.get("pool"),
)
```

Now when a user specifies `timeout=10`, the request will properly timeout after 10 seconds.

## Impact

- **Affected**: OpenRouter users (and potentially other providers using `base_llm_http_handler` with `aiohttp_transport`)
- **Severity**: High - Users cannot reliably control request timeouts
- **Backward compatibility**: No breaking changes - only fixes existing broken behavior

## Testing

The fix is straightforward and low-risk:
- Adds a single parameter that was missing
- Uses the same timeout dict structure already in use
- Does not change any other timeout behavior