### PR TITLE
fix: unable to delete MCP server from permission settings

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -357,23 +357,22 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         servers: [],
         accessGroups: [],
       };
-      const mcpToolPermissions = values.mcp_tool_permissions || {};
+      const serverIds = new Set(servers || []);
+      const mcpToolPermissions = Object.fromEntries(
+        Object.entries(values.mcp_tool_permissions || {}).filter(([serverId]) =>
+          serverIds.has(serverId)
+        )
+      );
 
-      if (
-        (servers && servers.length > 0) ||
-        (accessGroups && accessGroups.length > 0) ||
-        Object.keys(mcpToolPermissions).length > 0
-      ) {
-        updateData.object_permission = {};
-        if (servers && servers.length > 0) {
-          updateData.object_permission.mcp_servers = servers;
-        }
-        if (accessGroups && accessGroups.length > 0) {
-          updateData.object_permission.mcp_access_groups = accessGroups;
-        }
-        if (Object.keys(mcpToolPermissions).length > 0) {
-          updateData.object_permission.mcp_tool_permissions = mcpToolPermissions;
-        }
+      updateData.object_permission = {};
+      if (servers) {
+        updateData.object_permission.mcp_servers = servers;
+      }
+      if (accessGroups) {
+        updateData.object_permission.mcp_access_groups = accessGroups;
+      }
+      if (mcpToolPermissions) {
+        updateData.object_permission.mcp_tool_permissions = mcpToolPermissions;
       }
       delete values.mcp_servers_and_groups;
       delete values.mcp_tool_permissions;


### PR DESCRIPTION
## Title

unable to delete MCP server from permission settings

## Relevant issues

Fixes #16124

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

https://www.loom.com/share/1db446017e7748cf90a6558ba43b1d6f
