### PR TITLE
fix: install runtime node for prisma

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -57,6 +57,9 @@ USER root
 # Install only runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
+    libatomic1 \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Title
fix: install runtime node for prisma

## Problem
Prisma CLI's `generate` command fails in Docker with a cache error when it attempts to bootstrap npm@10 in the slim Python base image. This breaks the build process for any application using Prisma.

**Error screenshot:**
<img width="1356" height="574" alt="Screenshot 2025-11-08 at 3 33 33 PM" src="https://github.com/user-attachments/assets/2495c624-3a5d-4f0a-bb2d-0fc7bf3eb193" />

## Solution
Install Node.js, npm, and libatomic1 as runtime dependencies in the Dockerfile. This allows Prisma to use the system Node.js binaries instead of attempting to bootstrap its own, which resolves the sizeCalculation cache error.

## Type
🐛 Bug Fix

## Changes
- Added `libatomic1`, `nodejs`, and `npm` to the runtime dependency installation step in `docker/Dockerfile.dev`

## Manual Test
<img width="1338" height="527" alt="Screenshot 2025-11-08 at 3 40 03 PM" src="https://github.com/user-attachments/assets/713be1ed-cdc7-4b1e-b086-ca8a330722e9" />
