### PR TITLE
[Infra] UI - Show Deprecation Warning for Model Analytics Tab

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelAnalyticsTab/ModelAnalyticsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/ModelAnalyticsTab/ModelAnalyticsTab.tsx
@@ -227,6 +227,11 @@ const ModelAnalyticsTab = ({
 
   return (
     <TabPanel>
+      <div className="mb-4 rounded-md border border-red-500 bg-red-50 p-4">
+        <Text className="font-semibold text-red-700">
+          This page is deprecated and will be removed in the future. Some functionality may not work as expected.
+        </Text>
+      </div>
       <Grid numItems={4} className="mt-2 mb-2">
         <Col>
           <UsageDatePicker


### PR DESCRIPTION
## [Infra] UI - Show Deprecation Warning for Model Analytics Tab

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR adds a banner notifying the user that the model analytics page is deprecated.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure

## Changes

## Screenshot
<img width="1236" height="141" alt="image" src="https://github.com/user-attachments/assets/d66f72d4-0395-48a0-9f6b-3d4ea8e476a7" />


