### PR TITLE
fix: update model_cost_map_url to use environment variable

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -345,7 +345,10 @@ add_function_to_prompt: bool = False  # if function calling not supported by api
 client_session: Optional[httpx.Client] = None
 aclient_session: Optional[httpx.AsyncClient] = None
 model_fallbacks: Optional[List] = None  # Deprecated for 'litellm.fallbacks'
-model_cost_map_url: str = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+model_cost_map_url: str = os.getenv(
+    "LITELLM_MODEL_COST_MAP_URL",
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+)
 suppress_debug_info = False
 dynamodb_table_name: Optional[str] = None
 s3_callback_params: Optional[Dict] = None

--- a/tests/test_model_cost_map_url.py
+++ b/tests/test_model_cost_map_url.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+
+
+def test_model_cost_map_url_from_env(monkeypatch):
+    """Ensure `LITELLM_MODEL_COST_MAP_URL` env var is picked up on import and used by get_model_cost_map."""
+    test_url = "https://example.com/test_model_cost_map.json"
+
+    # A minimal model cost map we expect to be loaded
+    model_json = {
+        "my-test-model": {
+            "input_cost_per_token": 0.123,
+            "output_cost_per_token": 0.456,
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+    }
+
+    class DummyResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return model_json
+
+    # Point litellm at our test URL
+    monkeypatch.setenv("LITELLM_MODEL_COST_MAP_URL", test_url)
+
+    # Mock httpx.get to return our dummy response
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", lambda url, timeout=5: DummyResp())
+
+    # Reload the litellm package so top-level import picks up the env var
+    if "litellm" in sys.modules:
+        importlib.reload(sys.modules["litellm"])
+    else:
+        import litellm  # noqa: F401
+        importlib.reload(litellm)
+
+    import litellm as ll  # re-import for assertions
+
+    # The package should have picked up the env var and loaded our model map
+    assert getattr(ll, "model_cost_map_url") == test_url
+    assert "my-test-model" in ll.model_cost
+    assert ll.model_cost["my-test-model"]["input_cost_per_token"] == 0.123


### PR DESCRIPTION

## Title

Update model_cost_map_url to use environment variable when available, as decribed in the docs (docs/my-website/docs/proxy/sync_models_github.md)

## Relevant issues

Fixes: #15274

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="866" height="62" alt="Screenshot 2025-11-09 at 6 38 47 PM" src="https://github.com/user-attachments/assets/7ddad212-888f-4ae6-b485-2372c281d4e9" />

## Type

🐛 Bug Fix

## Changes

read the URL from the ENV var, when set.

