### PR TITLE
Fix magistral streaming to emit reasoning chunks

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16199,6 +16199,21 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "mistral/magistral-medium-2509": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 40000,
+        "max_output_tokens": 40000,
+        "max_tokens": 40000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-06,
+        "source": "https://mistral.ai/news/magistral",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 1e-3,


### PR DESCRIPTION
## Title

Fix magistral streaming to emit reasoning chunks

## Relevant issues

Fixes #16272

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally  
  _pytest output attached in PR description_

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)  
  _`pytest litellm/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py`_

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- added `mistral/magistral-medium-2509` pricing entry in `model_prices_and_context_window*.json`  
- normalized magistral streaming chunks to populate `thinking_blocks` + `reasoning_content` with signatures in `litellm/llms/mistral/chat/transformation.py`  
- extended `tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py` to cover streaming reasoning output

<img width="948" height="683" alt="image" src="https://github.com/user-attachments/assets/ac5a855f-8225-436c-8b2b-d7384dbfbf5e" />