### PR TITLE
add kimi k2 thinking

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16624,6 +16624,20 @@
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_vision": true
     },
+    "moonshot/kimi-k2-thinking": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 6e-7,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-6,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "moonshot/moonshot-v1-128k": {
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",


### PR DESCRIPTION
## Title

Add kimi k2 thinking to model prices

https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2

## Relevant issues

Refs https://github.com/BerriAI/litellm/issues/16435

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Added kimi k2 pricing + capabilties to pricing table