### PR TITLE
[Fix] Management Endpoints - Fixes inconsistent error responses in customer management endpoints. Non-existent user errors now return proper 404 status codes with consistent error schema format across all endpoints.

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -120,3 +120,26 @@ def test_info_customer_not_found(mock_prisma_client, mock_user_api_key_auth):
     # Assert response
     assert response.status_code == 404
     assert "End User Id=non-existent-user does not exist in db" in response.json()["detail"]["error"]
+
+
+def test_delete_customer_not_found(mock_prisma_client, mock_user_api_key_auth):
+    """
+    Test that delete_end_user raises a 404 ProxyException when user_ids do not exist.
+    """
+    # Mock the database response to return empty list (no users found)
+    mock_prisma_client.db.litellm_endusertable.find_many = AsyncMock(return_value=[])
+
+    # Test data
+    test_data = {"user_ids": ["non-existent-user-1", "non-existent-user-2"]}
+
+    # Make the request
+    response = client.post(
+        "/customer/delete",
+        json=test_data,
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    # Assert response
+    assert response.status_code == 404
+    assert "do not exist in db" in response.json()["detail"]["error"]
+    assert "non-existent-user-1" in response.json()["detail"]["error"]

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -1,19 +1,35 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from litellm.proxy._types import (
     LiteLLM_BudgetTable,
     LiteLLM_EndUserTable,
     LitellmUserRoles,
+    ProxyException,
 )
 from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
 from litellm.proxy.management_endpoints.customer_endpoints import router
-from litellm.proxy.proxy_server import ProxyException
 
 app = FastAPI()
+
+
+@app.exception_handler(ProxyException)
+async def openai_exception_handler(request: Request, exc: ProxyException):
+    headers = exc.headers
+    error_dict = exc.to_dict()
+    return JSONResponse(
+        status_code=(
+            int(exc.code) if exc.code else status.HTTP_500_INTERNAL_SERVER_ERROR
+        ),
+        content={"detail": {"error": error_dict["message"]}},
+        headers=headers,
+    )
+
+
 app.include_router(router)
 client = TestClient(app)
 
@@ -67,6 +83,9 @@ def test_update_customer_success(mock_prisma_client, mock_user_api_key_auth):
 
 
 def test_update_customer_not_found(mock_prisma_client, mock_user_api_key_auth):
+    """
+    Test that update_end_user raises a 404 ProxyException when user_id does not exist.
+    """
     # Mock the database response to return None (user not found)
     mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(return_value=None)
 
@@ -74,14 +93,30 @@ def test_update_customer_not_found(mock_prisma_client, mock_user_api_key_auth):
     test_data = {"user_id": "non-existent-user", "alias": "Test User"}
 
     # Make the request
-    try:
-        response = client.post(
-            "/customer/update",
-            json=test_data,
-            headers={"Authorization": "Bearer test-key"},
-        )
-    except Exception as e:
-        print(e, type(e))
-        assert isinstance(e, ProxyException)
-        assert int(e.code) == 400
-        assert "End User Id=non-existent-user does not exist in db" in e.message
+    response = client.post(
+        "/customer/update",
+        json=test_data,
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    # Assert response
+    assert response.status_code == 404
+    assert "End User Id=non-existent-user does not exist in db" in response.json()["detail"]["error"]
+
+
+def test_info_customer_not_found(mock_prisma_client, mock_user_api_key_auth):
+    """
+    Test that end_user_info raises a 404 ProxyException when end_user_id does not exist.
+    """
+    # Mock the database response to return None (user not found)
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(return_value=None)
+
+    # Make the request
+    response = client.get(
+        "/customer/info?end_user_id=non-existent-user",
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    # Assert response
+    assert response.status_code == 404
+    assert "End User Id=non-existent-user does not exist in db" in response.json()["detail"]["error"]


### PR DESCRIPTION
## [Fix] Management Endpoints - Fixes inconsistent error responses in customer management endpoints + return 404 when id does not exist

Fixes inconsistent error responses in customer management endpoints. Non-existent user errors now return proper 404 status codes with consistent error schema format across all endpoints.

## Problems

1. Customer endpoints returned inconsistent error formats and status codes:
- GET `/end_user/info` returned 400 with format `{"detail":{"error":"..."}}`
- POST `/end_user/new` returned 400 with format `{"error":{"message":"...", "type":"...", "param":"...", "code":"..."}}`

2. Info, update and delete endpoints returned 400 when the id did not exist (should be 404)

## Changes

### Error Status Codes
- GET `/customer/info` - Returns 404 (was 400) when user doesn't exist
- POST `/customer/update` - Returns 404 (was 400) when user doesn't exist  
- POST `/customer/delete` - Returns 404 (was 400) when user(s) don't exist

### Error Schema Consistency
All customer endpoints now return the same OpenAI-compatible error format:
```
{
  "error": {
    "message": "End User Id=... does not exist in db",
    "type": "not_found",
    "param": "user_id",
    "code": "404"
  }
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


