### PR TITLE
[Feature] UI - Test Key Page show models based on selected endpoint

### DIFF
--- a/ui/litellm-dashboard/src/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ChatUI.tsx
@@ -48,7 +48,7 @@ import { makeOpenAIImageEditsRequest } from "./llm_calls/image_edits";
 import { makeOpenAIImageGenerationRequest } from "./llm_calls/image_generation";
 import { makeOpenAIResponsesRequest } from "./llm_calls/responses_api";
 import MCPEventsDisplay, { MCPEvent } from "./MCPEventsDisplay";
-import { EndpointType } from "./mode_endpoint_mapping";
+import { EndpointType, getEndpointType } from "./mode_endpoint_mapping";
 import ReasoningContent from "./ReasoningContent";
 import ResponseMetrics, { TokenUsage } from "./ResponseMetrics";
 import ResponsesImageRenderer from "./ResponsesImageRenderer";
@@ -106,9 +106,7 @@ const ChatUI: React.FC<ChatUIProps> = ({ accessToken, token, userRole, userID, d
       return [];
     }
   });
-  const [selectedModel, setSelectedModel] = useState<string | undefined>(
-    () => sessionStorage.getItem("selectedModel") || undefined,
-  );
+  const [selectedModel, setSelectedModel] = useState<string | undefined>(undefined);
   const [showCustomModelInput, setShowCustomModelInput] = useState<boolean>(false);
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const customModelTimeout = useRef<NodeJS.Timeout | null>(null);
@@ -311,7 +309,7 @@ const ChatUI: React.FC<ChatUIProps> = ({ accessToken, token, userRole, userID, d
         if (!uniqueModels.length) {
           setSelectedModel(undefined);
         } else if (!hasSelection) {
-          setSelectedModel(uniqueModels[0].model_group);
+          setSelectedModel(undefined);
         }
       } catch (error) {
         console.error("Error fetching model info:", error);
@@ -980,50 +978,18 @@ const ChatUI: React.FC<ChatUIProps> = ({ accessToken, token, userRole, userID, d
 
               <div>
                 <Text className="font-medium block mb-2 text-gray-700 flex items-center">
-                  <RobotOutlined className="mr-2" /> Select Model
-                </Text>
-                <Select
-                  value={selectedModel}
-                  placeholder="Select a Model"
-                  onChange={onModelChange}
-                  options={[
-                    ...Array.from(new Set(modelInfo.map((option) => option.model_group))).map((model_group, index) => ({
-                      value: model_group,
-                      label: model_group,
-                      key: index,
-                    })),
-                    { value: "custom", label: "Enter custom model", key: "custom" },
-                  ]}
-                  style={{ width: "100%" }}
-                  showSearch={true}
-                  className="rounded-md"
-                />
-                {showCustomModelInput && (
-                  <TextInput
-                    className="mt-2"
-                    placeholder="Enter custom model name"
-                    onValueChange={(value) => {
-                      // Using setTimeout to create a simple debounce effect
-                      if (customModelTimeout.current) {
-                        clearTimeout(customModelTimeout.current);
-                      }
-
-                      customModelTimeout.current = setTimeout(() => {
-                        setSelectedModel(value);
-                      }, 500); // 500ms delay after typing stops
-                    }}
-                  />
-                )}
-              </div>
-
-              <div>
-                <Text className="font-medium block mb-2 text-gray-700 flex items-center">
                   <ApiOutlined className="mr-2" /> Endpoint Type
                 </Text>
                 <EndpointSelector
                   endpointType={endpointType}
                   onEndpointChange={(value) => {
                     setEndpointType(value);
+                    // Clear model selection when switching endpoint type
+                    setSelectedModel(undefined);
+                    setShowCustomModelInput(false);
+                    try {
+                      sessionStorage.removeItem("selectedModel");
+                    } catch {}
                   }}
                   className="mb-4"
                 />
@@ -1055,6 +1021,68 @@ const ChatUI: React.FC<ChatUIProps> = ({ accessToken, token, userRole, userID, d
                   useApiSessionManagement={useApiSessionManagement}
                   onToggleSessionManagement={handleToggleSessionManagement}
                 />
+              </div>
+
+              <div>
+                <Text className="font-medium block mb-2 text-gray-700 flex items-center">
+                  <RobotOutlined className="mr-2" /> Select Model
+                </Text>
+                <Select
+                  value={selectedModel}
+                  placeholder="Select a Model"
+                  onChange={onModelChange}
+                  options={[
+                    ...Array.from(
+                      new Set(
+                        modelInfo
+                          .filter((option) => {
+                            if (!option.mode) {
+                              //If no mode, show all models
+                              return true;
+                            }
+                            const optionEndpoint = getEndpointType(option.mode);
+                            // Show chat models for responses/anthropic_messages endpoints as they are compatible
+                            if (
+                              endpointType === EndpointType.RESPONSES ||
+                              endpointType === EndpointType.ANTHROPIC_MESSAGES
+                            ) {
+                              return optionEndpoint === endpointType || optionEndpoint === EndpointType.CHAT;
+                            }
+                            // Show image models for image_edits endpoint as they are compatible
+                            if (endpointType === EndpointType.IMAGE_EDITS) {
+                              return optionEndpoint === endpointType || optionEndpoint === EndpointType.IMAGE;
+                            }
+                            return optionEndpoint === endpointType;
+                          })
+                          .map((option) => option.model_group),
+                      ),
+                    ).map((model_group, index) => ({
+                      value: model_group,
+                      label: model_group,
+                      key: index,
+                    })),
+                    { value: "custom", label: "Enter custom model", key: "custom" },
+                  ]}
+                  style={{ width: "100%" }}
+                  showSearch={true}
+                  className="rounded-md"
+                />
+                {showCustomModelInput && (
+                  <TextInput
+                    className="mt-2"
+                    placeholder="Enter custom model name"
+                    onValueChange={(value) => {
+                      // Using setTimeout to create a simple debounce effect
+                      if (customModelTimeout.current) {
+                        clearTimeout(customModelTimeout.current);
+                      }
+
+                      customModelTimeout.current = setTimeout(() => {
+                        setSelectedModel(value);
+                      }, 500); // 500ms delay after typing stops
+                    }}
+                  />
+                )}
               </div>
 
               <div>

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -10,6 +10,7 @@ export enum ModelMode {
   RESPONSES = "responses",
   IMAGE_EDITS = "image_edits",
   ANTHROPIC_MESSAGES = "anthropic_messages",
+  EMBEDDING = "embedding",
   // add additional modes as needed
 }
 
@@ -37,6 +38,7 @@ export const litellmModeMapping: Record<ModelMode, EndpointType> = {
   [ModelMode.ANTHROPIC_MESSAGES]: EndpointType.ANTHROPIC_MESSAGES,
   [ModelMode.AUDIO_SPEECH]: EndpointType.SPEECH,
   [ModelMode.AUDIO_TRANSCRIPTION]: EndpointType.TRANSCRIPTION,
+  [ModelMode.EMBEDDING]: EndpointType.EMBEDDINGS,
 };
 
 export const getEndpointType = (mode: string): EndpointType => {


### PR DESCRIPTION
## [Feature] UI - Test Key Page show models based on selected endpoint

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR implements a feature where the models dropdown in the test key page is now filtered based on the selected endpoint. This prevents users from accidentally selecting an invalid endpoint to use with models such as /images with an embedding model.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="750" height="199" alt="image" src="https://github.com/user-attachments/assets/a6b7c2d6-9c58-414b-b252-f0cf7b5bb334" />

<img width="276" height="441" alt="image" src="https://github.com/user-attachments/assets/6c1ad183-f5f9-4361-8786-d4a18210ef90" />
