### PR TITLE
[Fix] Bedrock Knowledge bases - ensure users can access `search_results` for both stream + non stream response to /chat/completions 

### DIFF
--- a/litellm/proxy/proxy_config.yaml
+++ b/litellm/proxy/proxy_config.yaml
@@ -29,6 +29,7 @@ search_tools:
   
 
 litellm_settings:
+  max_end_user_budget_id: "2f6634cd-c631-4d3b-96c7-ad510ea06eaf"
   # Comprehensive logging settings
   store_audit_logs: true
   verbose: true
@@ -50,3 +51,13 @@ litellm_settings:
 
 general_settings:
   store_prompts_in_spend_logs: True
+
+
+vector_store_registry:
+  - vector_store_name: "bedrock-litellm-website-knowledgebase"
+    litellm_params:
+      vector_store_id: "T37J8R4WTM"
+      custom_llm_provider: "bedrock"
+      vector_store_description: "Bedrock vector store for the Litellm website knowledgebase"
+      vector_store_metadata:
+        source: "https://www.litellm.com/docs"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -632,9 +632,7 @@ class Message(OpenAIObject):
     thinking_blocks: Optional[
         List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]
     ] = None
-    provider_specific_fields: Optional[Dict[str, Any]] = Field(
-        default=None, exclude=True
-    )
+    provider_specific_fields: Optional[Dict[str, Any]] = Field(default=None)
     annotations: Optional[List[ChatCompletionAnnotation]] = None
 
     def __init__(

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -125,7 +125,7 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call(setup_vecto
     litellm._turn_on_debug()
     async_client = AsyncHTTPHandler()
     response = await litellm.acompletion(
-        model="anthropic/claude-3-5-haiku-latest",
+        model="bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
         messages=[{"role": "user", "content": "what is litellm?"}],
         vector_store_ids = [
             "T37J8R4WTM"
@@ -622,3 +622,124 @@ async def test_e2e_bedrock_knowledgebase_retrieval_with_vector_store_not_in_regi
         assert len(content) == 1
         assert content[0]["type"] == "text"
         
+
+@pytest.mark.asyncio
+async def test_provider_specific_fields_in_proxy_http_response(setup_vector_store_registry):
+    """
+    Test that provider_specific_fields (like search_results) are included 
+    in the proxy HTTP JSON response, not just in Python SDK objects.
+    
+    This test catches serialization bugs where exclude=True would strip 
+    provider_specific_fields from the HTTP response.
+    """
+    from fastapi.testclient import TestClient
+    from litellm.proxy.proxy_server import app, initialize
+    from litellm.proxy.utils import ProxyLogging
+    import litellm.proxy.proxy_server as proxy_server
+    
+    # Initialize proxy
+    await initialize(
+        model=None,
+        alias=None,
+        api_base=None,
+        debug=False,
+        temperature=None,
+        max_tokens=None,
+        request_timeout=600,
+        max_budget=None,
+        telemetry=False,
+        drop_params=True,
+        add_function_to_prompt=False,
+        headers=None,
+        save=False,
+        use_queue=False,
+        config=None
+    )
+    
+    # Create test client
+    client = TestClient(app)
+    
+    # Create mock response with provider_specific_fields
+    mock_response = litellm.ModelResponse(
+        id="test-123",
+        model="bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        created=1234567890,
+        object="chat.completion"
+    )
+    
+    # Create message with provider_specific_fields
+    mock_message = litellm.Message(
+        content="LiteLLM is a tool that simplifies working with multiple LLMs.",
+        role="assistant",
+        provider_specific_fields={
+            "search_results": [{
+                "object": "vector_store.search_results.page",
+                "search_query": "what is litellm?",
+                "data": [{
+                    "score": 0.95,
+                    "content": [{"text": "Test content", "type": "text"}],
+                    "file_id": "test-file",
+                    "filename": "test.txt"
+                }]
+            }]
+        }
+    )
+    
+    mock_choice = litellm.Choices(
+        finish_reason="stop",
+        index=0,
+        message=mock_message
+    )
+    
+    mock_response.choices = [mock_choice]
+    mock_response.usage = litellm.Usage(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30
+    )
+    
+    # Patch the completion call
+    with patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
+        # Make HTTP request to proxy
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "messages": [{"role": "user", "content": "What is litellm?"}],
+                "tools": [{
+                    "type": "file_search",
+                    "vector_store_ids": ["T37J8R4WTM"]
+                }]
+            }
+        )
+        
+        # Check HTTP response
+        assert response.status_code == 200
+        result = response.json()
+        
+        print("HTTP Response JSON:", json.dumps(result, indent=2))
+        
+        # THE KEY ASSERTIONS - These would FAIL with exclude=True!
+        assert "choices" in result
+        assert len(result["choices"]) > 0
+        
+        choice = result["choices"][0]
+        assert "message" in choice
+        
+        message = choice["message"]
+        
+        # Verify provider_specific_fields is in the JSON response
+        assert "provider_specific_fields" in message, \
+            "provider_specific_fields missing from HTTP JSON response! This means exclude=True is preventing serialization."
+        
+        assert "search_results" in message["provider_specific_fields"]
+        search_results = message["provider_specific_fields"]["search_results"]
+        assert len(search_results) > 0
+        
+        # Verify search result structure
+        first_result = search_results[0]
+        assert first_result["object"] == "vector_store.search_results.page"
+        assert "data" in first_result
+        assert len(first_result["data"]) > 0
+        
+        print("✅ provider_specific_fields successfully serialized in HTTP response")

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -636,10 +636,11 @@ async def test_provider_specific_fields_in_proxy_http_response(setup_vector_stor
     from litellm.proxy.proxy_server import app, initialize
     from litellm.proxy.utils import ProxyLogging
     import litellm.proxy.proxy_server as proxy_server
+    from unittest.mock import patch as mock_patch
     
     # Initialize proxy
     await initialize(
-        model=None,
+        model="gpt-3.5-turbo",
         alias=None,
         api_base=None,
         debug=False,
@@ -662,7 +663,7 @@ async def test_provider_specific_fields_in_proxy_http_response(setup_vector_stor
     # Create mock response with provider_specific_fields
     mock_response = litellm.ModelResponse(
         id="test-123",
-        model="bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        model="gpt-3.5-turbo",
         created=1234567890,
         object="chat.completion"
     )
@@ -698,18 +699,14 @@ async def test_provider_specific_fields_in_proxy_http_response(setup_vector_stor
         total_tokens=30
     )
     
-    # Patch the completion call
-    with patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
+    # Patch the completion call at the proxy level
+    with mock_patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
         # Make HTTP request to proxy
         response = client.post(
             "/v1/chat/completions",
             json={
-                "model": "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-                "messages": [{"role": "user", "content": "What is litellm?"}],
-                "tools": [{
-                    "type": "file_search",
-                    "vector_store_ids": ["T37J8R4WTM"]
-                }]
+                "model": "gpt-3.5-turbo",
+                "messages": [{"role": "user", "content": "What is litellm?"}]
             }
         )
         


### PR DESCRIPTION
## [Fix] Bedrock Knowledge bases - ensure users can access `search_results` for both stream + non stream response to /chat/completions 

This PR fixes a serialization bug where provider_specific_fields (including vector store search results) were being stripped from HTTP responses in the LiteLLM proxy, despite being correctly populated in the Python SDK response objects.


## non streaming response 

<img width="1728" height="717" alt="Screenshot 2025-11-10 at 3 45 33 PM" src="https://github.com/user-attachments/assets/9cc055f4-4662-41e9-9600-a12752196b11" />

## streaming response 

<img width="1728" height="815" alt="Screenshot 2025-11-10 at 3 46 20 PM" src="https://github.com/user-attachments/assets/b94b0f9b-5cc3-48e5-9033-d709db463ce8" />




<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


