### PR TITLE
Add moonshot/kimi-k2-thinking to backup pricing map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16557,6 +16557,20 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "moonshot/kimi-k2-thinking": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,


### PR DESCRIPTION
 ## Title

  Add moonshot/kimi-k2-thinking to model_prices_and_context_window_backup.json

  ## Relevant issues

  Refs #16435

  ## Type

 🆕 New Feature

  ## Changes

  Adds `moonshot/kimi-k2-thinking` model to the backup pricing map for local development testing with `LITELLM_LOCAL_MODEL_COST_MAP=True`.

  Model specs:
  - Input cost: $0.60/1M tokens
  - Output cost: $2.50/1M tokens  
  - Cache hit: $0.15/1M tokens
  - Context: 262,144 tokens
  - Supports: function_calling, tool_choice, web_search

  Note: Main pricing file already updated in #16445