### PR TITLE
  docs: fix streaming example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ from litellm import completion
 
 messages = [{"content": "Hello, how are you?", "role": "user"}]
 
+# gpt-4o
 response = completion(model="openai/gpt-4o", messages=messages, stream=True)
 for part in response:
     print(part.choices[0].delta.content or "")

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ print(response)
 
 ## Streaming ([Docs](https://docs.litellm.ai/docs/completion/stream))
 
-liteLLM supports streaming the model response back, pass `stream=True` to get a streaming iterator in response.
+LiteLLM supports streaming the model response back, pass `stream=True` to get a streaming iterator in response.
 Streaming is supported for all models (Bedrock, Huggingface, TogetherAI, Azure, OpenAI, etc.)
 
 ```python

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Streaming is supported for all models (Bedrock, Huggingface, TogetherAI, Azure, 
 
 ```python
 from litellm import completion
+
+messages = [{"content": "Hello, how are you?", "role": "user"}]
+
 response = completion(model="openai/gpt-4o", messages=messages, stream=True)
 for part in response:
     print(part.choices[0].delta.content or "")


### PR DESCRIPTION
## Summary
  Fixes the streaming example in the README to make it complete and runnable.

  ## Changes
  - Add missing `messages` variable definition that was referenced but not declared
  - Capitalize "liteLLM" to "LiteLLM" for consistent branding
  - Add comment to clarify the model being used (gpt-4o)

  ## Test plan
  - [x] Verified the example code is now complete and can be run as-is
  - [x] Confirmed the streaming example follows documentation best practices

  The changes fix a bug in the documentation where the streaming code example referenced a messages variable that wasn't defined, which would cause the example to fail if users tried  to run it directly.