### PR TITLE
[Bug Fix] - LiteLLM Usage shows key_hash- 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16624,6 +16624,20 @@
         "source": "https://platform.moonshot.ai/docs/pricing",
         "supports_vision": true
     },
+    "moonshot/kimi-k2-thinking": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 6e-7,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-6,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "moonshot/moonshot-v1-128k": {
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -274,8 +274,8 @@ def get_logging_payload(  # noqa: PLR0915
         end_user_id = end_user_id or standard_logging_payload["metadata"].get(
             "user_api_key_end_user_id"
         )
-    else:
-        api_key = ""
+    # BUG FIX: Don't overwrite api_key when standard_logging_payload is None
+    # The api_key was already extracted from metadata (line 243) and hashed (lines 256-259)
     request_tags = (
         json.dumps(metadata.get("tags", []))
         if isinstance(metadata.get("tags", []), list)

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -13,7 +13,7 @@ sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
 from litellm.constants import LITELLM_TRUNCATED_PAYLOAD_FIELD, REDACTED_BY_LITELM_STRING
@@ -377,4 +377,153 @@ def test_get_logging_payload_api_key_preserved_when_standard_logging_payload_is_
     assert payload["user"] == "test_user"
     
     print(f"✅ Test passed! api_key preserved: {payload['api_key']}")
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.master_key", "sk-master-key")
+@patch("litellm.proxy.proxy_server.general_settings", {})
+async def test_api_key_preserved_through_failure_hook_to_database():
+    """
+    CRITICAL E2E TEST: Validates the COMPLETE code path from failure hook to database.
+    
+    This is THE comprehensive test that protects against the production incident.
+    It tests the EXACT flow that caused the bug:
+    
+    1. async_post_call_failure_hook is called with api_key in UserAPIKeyAuth
+    2. Failure hook calls update_database with the token parameter
+    3. update_database calls get_logging_payload to create payload
+    4. BUG WAS HERE: get_logging_payload set api_key = "" when standard_logging_payload was None
+    5. Empty api_key was written to DailyUserSpend table
+    
+    This test validates the ENTIRE flow to ensure the bug cannot regress.
+    If this test fails in CI/CD, the build MUST fail.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.hooks.proxy_track_cost_callback import _ProxyDBLogger
+    from litellm.proxy.utils import hash_token
+
+    # Setup
+    test_api_key = "sk-test-critical-e2e-key"
+    hashed_key = hash_token(test_api_key)
+    
+    # Track what payload gets created
+    captured_payloads = []
+    
+    async def mock_update_database(
+        token, response_cost, user_id, end_user_id, team_id,
+        kwargs, completion_response, start_time, end_time, org_id
+    ):
+        """Mock update_database and capture the payload it creates"""
+        from litellm.proxy.spend_tracking.spend_tracking_utils import (
+            get_logging_payload,
+        )
+
+        # Call get_logging_payload EXACTLY as update_database does
+        payload = get_logging_payload(
+            kwargs=kwargs,
+            response_obj=completion_response,
+            start_time=start_time,
+            end_time=end_time
+        )
+        
+        captured_payloads.append({
+            "token": token,
+            "payload": payload,
+        })
+    
+    # Mock dependencies
+    mock_db_writer = MagicMock()
+    mock_db_writer.update_database = AsyncMock(side_effect=mock_update_database)
+    
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.db_spend_update_writer = mock_db_writer
+    
+    # Create UserAPIKeyAuth (what the failure hook receives)
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=hashed_key,
+        user_id="test_user",
+        team_id="test_team",
+        max_budget=None,
+        spend=0.0,
+        key_alias="test-key",
+        budget_reset_at=None,
+        user_email=None,
+        org_id="test_org",
+        team_alias=None,
+        end_user_id=None,
+        request_route="/chat/completions",
+        metadata={}
+    )
+    
+    # Request data with bad parameter (triggers failure)
+    request_data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "test"}],
+        "invalid_param": "causes_400_error",  # BAD PARAMETER
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": hashed_key,
+                "user_api_key_user_id": "test_user",
+                "user_api_key_team_id": "test_team",
+            }
+        }
+    }
+    
+    exception = Exception("BadRequestError: Invalid parameter 'invalid_param'")
+    
+    # Execute the ACTUAL failure hook code path
+    logger = _ProxyDBLogger()
+    
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj):
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=exception,
+            user_api_key_dict=user_api_key_dict,
+            traceback_str=None
+        )
+        
+        await asyncio.sleep(0.1)  # Wait for async operations
+    
+    # =========================================================================
+    # CRITICAL ASSERTIONS - If ANY fail, the production bug has regressed!
+    # =========================================================================
+    
+    assert len(captured_payloads) == 1, "update_database should be called once"
+    
+    data = captured_payloads[0]
+    payload = data["payload"]
+    payload_api_key = payload.get("api_key")
+    
+    # THE CRITICAL ASSERTION - This would fail with the original bug!
+    assert payload_api_key != "", \
+        "🚨 CRITICAL BUG: payload['api_key'] is empty! " \
+        "This is the EXACT production incident bug. " \
+        "get_logging_payload() is setting api_key = '' when " \
+        "standard_logging_payload is None (failure case)."
+    
+    assert payload_api_key is not None, \
+        "🚨 CRITICAL: payload['api_key'] is None!"
+    
+    assert payload_api_key == hashed_key, \
+        f"🚨 CRITICAL: Expected api_key={hashed_key}, got {payload_api_key}"
+    
+    # Verify token parameter matches
+    assert data["token"] == hashed_key, \
+        f"Token parameter should be {hashed_key}"
+    
+    # Verify other fields
+    assert payload.get("model") == "gpt-3.5-turbo"
+    assert payload.get("user") == "test_user"
+    
+    print("\n" + "="*80)
+    print("✅ CRITICAL E2E TEST PASSED")
+    print("="*80)
+    print(f"Token: {data['token']}")
+    print(f"Payload api_key: {payload_api_key}")
+    print(f"Match: {data['token'] == payload_api_key}")
+    print("="*80)
+    print("Production incident bug is FIXED and protected:")
+    print("- Failed requests preserve api_key through entire flow")
+    print("- Both SpendLogs AND DailyUserSpend will have correct api_key")
+    print("="*80 + "\n")
 


### PR DESCRIPTION
## [Bug Fix] - LiteLLM Usage shows key_hash- 

Fixes LIT-1381

Fixes an issue where the Usage was tracking `api_key` as "" on BadRequestErrors / exceptions 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


