### PR TITLE
fix: allow internal users to access video generation routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -262,6 +262,15 @@ class LiteLLMRoutes(enum.Enum):
         # image edit
         "/images/edits",
         "/v1/images/edits",
+        # video generation
+        "/videos",
+        "/v1/videos",
+        "/videos/{video_id}",
+        "/v1/videos/{video_id}",
+        "/videos/{video_id}/content",
+        "/v1/videos/{video_id}/content",
+        "/videos/{video_id}/remix",
+        "/v1/videos/{video_id}/remix",
         # audio transcription
         "/audio/transcriptions",
         "/v1/audio/transcriptions",


### PR DESCRIPTION
## Summary
Fixes #16470

Video generation endpoints were incorrectly restricted to `proxy_admin` role only. This PR adds video routes to the `openai_routes` list, making them accessible to `internal_user` role.

## Problem
Users with `internal_user` or `internal_user_viewer` roles were receiving authentication errors when attempting to use video generation endpoints:
```
Authentication Error, Only proxy admin can be used to generate, delete, update info 
for new keys/users/teams. Route=/v1/videos. Your role=internal_user.
```

## Root Cause
The `/v1/videos` endpoints were missing from the `openai_routes` list in `litellm/proxy/_types.py`, causing them to be treated as management/admin routes instead of LLM API routes.

## Solution
Added 8 video route patterns to `LiteLLMRoutes.openai_routes`:
- `/videos` and `/v1/videos` (POST/GET - video generation & listing)
- `/videos/{video_id}` and `/v1/videos/{video_id}` (GET - video retrieval)
- `/videos/{video_id}/content` and `/v1/videos/{video_id}/content` (GET - content retrieval)
- `/videos/{video_id}/remix` and `/v1/videos/{video_id}/remix` (POST - video remixing)

## Changes
### Modified Files
- **litellm/proxy/_types.py**: Added video routes to `openai_routes` list
- **tests/test_litellm/proxy/auth/test_route_checks.py**: Added comprehensive tests

### New Tests
1. `test_videos_route_is_llm_api_route`: Parametrized test for all 8 video routes
2. `test_videos_route_accessible_to_internal_users`: Verifies internal users can access video endpoints
3. `test_videos_route_with_virtual_key_llm_api_routes`: Verifies virtual key access

## Testing
```bash
# All 44 route check tests pass
./venv/bin/python -m pytest tests/test_litellm/proxy/auth/test_route_checks.py -v
# 44 passed in 1.94s

# Linting clean
./venv/bin/ruff check litellm/proxy/_types.py tests/test_litellm/proxy/auth/test_route_checks.py
# All checks passed!
```

## Impact
- ✅ Internal users can now use video generation features (Sora-2, etc.)
- ✅ Virtual keys with `llm_api_routes` permission can access video endpoints
- ✅ No breaking changes to existing functionality
- ✅ All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)