### PR TITLE
Vertex ai Rerank safe load vertex ai creds

### DIFF
--- a/litellm/llms/vertex_ai/rerank/transformation.py
+++ b/litellm/llms/vertex_ai/rerank/transformation.py
@@ -40,8 +40,8 @@ class VertexAIRerankConfig(BaseRerankConfig, VertexBase):
         params = optional_params or {}
         
         # Get credentials to extract project ID if needed
-        vertex_credentials = self.get_vertex_ai_credentials(params.copy())
-        vertex_project = self.get_vertex_ai_project(params.copy())
+        vertex_credentials = self.safe_get_vertex_ai_credentials(params.copy())
+        vertex_project = self.safe_get_vertex_ai_project(params.copy())
         
         # Use _ensure_access_token to extract project_id from credentials
         # This is the same method used in vertex embeddings
@@ -76,9 +76,9 @@ class VertexAIRerankConfig(BaseRerankConfig, VertexBase):
         Validate and set up authentication for Vertex AI Discovery Engine API
         """
         # Get credentials and project info from optional_params (which contains vertex_credentials, etc.)
-        litellm_params = optional_params or {}
-        vertex_credentials = self.get_vertex_ai_credentials(litellm_params)
-        vertex_project = self.get_vertex_ai_project(litellm_params)
+        litellm_params = optional_params.copy() if optional_params else {}
+        vertex_credentials = self.safe_get_vertex_ai_credentials(litellm_params)
+        vertex_project = self.safe_get_vertex_ai_project(litellm_params)
         
         # Get access token using the base class method
         access_token, project_id = self._ensure_access_token(


### PR DESCRIPTION
## Title

Vertex ai Rerank safe load vertex ai creds

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes

Used safe_get_vertex_ai_project instead of get_vertex_ai_project which poped the creds
<img width="1041" height="768" alt="Screenshot 2025-11-11 at 12 43 14 PM" src="https://github.com/user-attachments/assets/bf1e1d23-3c8a-4d55-b77d-770e09a48cbf" />
