### PR TITLE
Update model logging format for custom LLM provider

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -314,7 +314,7 @@ class LLMCachingHandler:
                     )
                     self._update_litellm_logging_obj_environment(
                         logging_obj=logging_obj,
-                        model=model,
+                        model=f"{custom_llm_provider}/{model}",
                         kwargs=kwargs,
                         cached_result=cached_result,
                         is_async=False,


### PR DESCRIPTION
This avoids the annoying red message 
```
Provider List: https://docs.litellm.ai/docs/providers
```
when there is a cache hit.

🐛 Bug Fix
