### PR TITLE
fix images being dropped from tool results for bedrock

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2914,7 +2914,7 @@ def _convert_to_bedrock_tool_call_result(
     """
     - 
     """
-    tool_result_content_blocks = []
+    tool_result_content_blocks:List[BedrockToolResultContentBlock] = []
     if isinstance(message["content"], str):
         tool_result_content_blocks.append(BedrockToolResultContentBlock(text=message["content"]))
     elif isinstance(message["content"], List):
@@ -2929,10 +2929,12 @@ def _convert_to_bedrock_tool_call_result(
                     format = content["image_url"].get("format")
                 else:
                     image_url = content["image_url"]
-                tool_result_content_blocks.append(BedrockImageProcessor.process_image_sync(
+                _block:BedrockContentBlock = BedrockImageProcessor.process_image_sync(
                     image_url=image_url,
                     format=format,
-                ))
+                )
+                if "image" in _block:
+                    tool_result_content_blocks.append(BedrockToolResultContentBlock(image=_block["image"]))
 
     message.get("name", "")
     id = str(message.get("tool_call_id", str(uuid.uuid4())))

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2914,21 +2914,31 @@ def _convert_to_bedrock_tool_call_result(
     """
     - 
     """
-    content_str: str = ""
+    tool_result_content_blocks = []
     if isinstance(message["content"], str):
-        content_str = message["content"]
+        tool_result_content_blocks.append(BedrockToolResultContentBlock(text=message["content"]))
     elif isinstance(message["content"], List):
         content_list = message["content"]
         for content in content_list:
             if content["type"] == "text":
-                content_str += content["text"]
+                tool_result_content_blocks.append(BedrockToolResultContentBlock(text=content["text"]))
+            elif content["type"] == "image_url":
+                format: Optional[str] = None
+                if isinstance(content["image_url"], dict):
+                    image_url = content["image_url"]["url"]
+                    format = content["image_url"].get("format")
+                else:
+                    image_url = content["image_url"]
+                tool_result_content_blocks.append(BedrockImageProcessor.process_image_sync(
+                    image_url=image_url,
+                    format=format,
+                ))
 
     message.get("name", "")
     id = str(message.get("tool_call_id", str(uuid.uuid4())))
 
-    tool_result_content_block = BedrockToolResultContentBlock(text=content_str)
     tool_result = BedrockToolResultBlock(
-        content=[tool_result_content_block],
+        content=tool_result_content_blocks,
         toolUseId=id,
     )
 


### PR DESCRIPTION
1) Fixes https://github.com/BerriAI/litellm/issues/16195
2) Also keeps text in dedicated blocks rather than concatenating them