### PR TITLE
fix: Sanitize null token usage in OpenAI-compatible responses

### DIFF
--- a/tests/test_litellm/llms/openai_like/chat/test_transformation.py
+++ b/tests/test_litellm/llms/openai_like/chat/test_transformation.py
@@ -1,0 +1,49 @@
+import pytest
+from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
+
+
+def test_sanitize_usage_obj_handles_null_tokens():
+    """
+    Tests that _sanitize_usage_obj correctly converts None values for token counts to 0.
+    """
+    response_json = {
+        "choices": [],
+        "usage": {"prompt_tokens": None, "completion_tokens": 50, "total_tokens": None},
+    }
+
+    sanitized_json = OpenAILikeChatConfig._sanitize_usage_obj(response_json)
+
+    # Assert
+    assert sanitized_json["usage"]["prompt_tokens"] == 0
+    assert sanitized_json["usage"]["completion_tokens"] == 50  # Should remain unchanged
+    assert sanitized_json["usage"]["total_tokens"] == 0
+
+
+def test_sanitize_usage_obj_no_usage():
+    """
+    Tests that the sanitizer handles cases where the 'usage' object is missing.
+    """
+    response_json = {"choices": []}
+
+    sanitized_json = OpenAILikeChatConfig._sanitize_usage_obj(response_json)
+
+    # Assert
+    assert "usage" not in sanitized_json  # Should not add a usage key
+
+
+def test_sanitize_usage_obj_valid_usage():
+    """
+    Tests that the sanitizer does not modify a valid usage object.
+    """
+    response_json = {
+        "choices": [],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+
+    # Create a copy to compare against
+    original_json = response_json.copy()
+
+    sanitized_json = OpenAILikeChatConfig._sanitize_usage_obj(response_json)
+
+    # Assert
+    assert sanitized_json == original_json  # The object should be unchanged


### PR DESCRIPTION
##  Sanitize null token usage in OpenAI-compatible responses



## Relevant issues

Addresses the root cause of #16330
Related PR: #16396

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1831" height="315" alt="image" src="https://github.com/user-attachments/assets/abed73ad-10b1-4dca-a05b-c14a11005bc1" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

This pull request implements the architectural improvement  to fix the root cause of `null` values in `usage` objects from some OpenAI-compatible providers.

Instead of fixing the symptom within a specific integration (e.g., Langfuse), this change moves the data sanitization logic to the source, right where the provider's response is first processed.

### What was changed:

1.  **Added `_sanitize_usage_obj` to `litellm/llms/openai_like/chat/transformation.py`:**
    *   A new static method has been introduced to check for a `usage` object in the response.
    *   This method robustly iterates through all keys in the `usage` dictionary. If a key ends with `_tokens` and its value is `None`, it is replaced with `0`.
    *   This ensures that any non-compliant provider response is normalized to be truly OpenAI-compatible before it is passed further into the LiteLLM system.

2.  **Integrated Sanitization into `_transform_response`:**
    *   The new sanitizer is called immediately after the provider's JSON response is parsed, ensuring that all downstream components receive clean data.

3.  **Added New Unit Tests:**
    *   A new test file, `tests/test_litellm/llms/openai_like/chat/test_transformation.py`, has been created.
    *   It includes tests to verify that `None` token values are correctly converted to `0`, while valid data remains untouched and responses without a `usage` object are handled gracefully.