### PR TITLE
[Feature] UI - Add LiteLLM Params to Edit Model

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/advanced_settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/advanced_settings.test.tsx
@@ -31,4 +31,18 @@ describe("AdvancedSettings", () => {
       expect(getByText("Tags")).toBeInTheDocument();
     });
   });
+
+  it("should render the litellm params", async () => {
+    const { getByText } = render(
+      <AdvancedSettings
+        showAdvancedSettings={true}
+        setShowAdvancedSettings={() => {}}
+        guardrailsList={[]}
+        tagsList={{}}
+      />,
+    );
+    await waitFor(() => {
+      expect(getByText("LiteLLM Params")).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/add_model/advanced_settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/advanced_settings.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AdvancedSettings from "./advanced_settings";
 
@@ -41,6 +41,9 @@ describe("AdvancedSettings", () => {
         tagsList={{}}
       />,
     );
+    act(() => {
+      fireEvent.click(getByText("Advanced Settings"));
+    });
     await waitFor(() => {
       expect(getByText("LiteLLM Params")).toBeInTheDocument();
     });

--- a/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/advanced_settings.tsx
@@ -7,6 +7,7 @@ import { InfoCircleOutlined } from "@ant-design/icons";
 import { Team } from "../key_team_helpers/key_list";
 import CacheControlSettings from "./cache_control_settings";
 import { Tag } from "../tag_management/types";
+import { formItemValidateJSON } from "../../utils/textUtils";
 const { Link } = Typography;
 
 interface AdvancedSettingsProps {
@@ -38,18 +39,6 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
       return Promise.reject("Please enter a valid positive number");
     }
     return Promise.resolve();
-  };
-
-  const validateJSON = (_: any, value: string) => {
-    if (!value) {
-      return Promise.resolve();
-    }
-    try {
-      JSON.parse(value);
-      return Promise.resolve();
-    } catch (error) {
-      return Promise.reject("Please enter valid JSON");
-    }
   };
 
   // Handle custom pricing changes
@@ -233,7 +222,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
               name="litellm_extra_params"
               tooltip="Optional litellm params used for making a litellm.completion() call."
               className="mb-4 mt-4"
-              rules={[{ validator: validateJSON }]}
+              rules={[{ validator: formItemValidateJSON }]}
             >
               <TextArea
                 rows={4}
@@ -260,7 +249,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
               name="model_info_params"
               tooltip="Optional model info params. Returned when calling `/model/info` endpoint."
               className="mb-0"
-              rules={[{ validator: validateJSON }]}
+              rules={[{ validator: formItemValidateJSON }]}
             >
               <TextArea
                 rows={4}

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -175,6 +175,13 @@ describe("ModelInfoView", () => {
         expect(getByText("Tags")).toBeInTheDocument();
       });
     });
+
+    it("should render the litellm params in the edit model", async () => {
+      const { getByText } = render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />);
+      await waitFor(() => {
+        expect(getByText("LiteLLM Params")).toBeInTheDocument();
+      });
+    });
   });
 
   it("should render a test connection button", async () => {

--- a/ui/litellm-dashboard/src/utils/textUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/textUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatLabel, truncateString } from "./textUtils";
+import { formatLabel, formItemValidateJSON, truncateString } from "./textUtils";
 
 describe("formatLabel", () => {
   it("should format label", () => {
@@ -14,5 +14,16 @@ describe("truncateString", () => {
 
   it("should return the original string if it is less than the max length", () => {
     expect(truncateString("Hello, world!", 20)).toBe("Hello, world!");
+  });
+});
+
+describe("formItemValidateJSON", () => {
+  it("should resolve for a valid JSON", async () => {
+    const validObj = { a: 1, b: "x", c: true, d: [1, 2], e: { f: "y" } };
+    await expect(formItemValidateJSON({}, JSON.stringify(validObj))).resolves.toBeUndefined();
+  });
+
+  it("should reject with an error message for invalid JSON", async () => {
+    await expect(formItemValidateJSON({}, "invalid JSON")).rejects.toBe("Please enter valid JSON");
   });
 });

--- a/ui/litellm-dashboard/src/utils/textUtils.ts
+++ b/ui/litellm-dashboard/src/utils/textUtils.ts
@@ -10,3 +10,15 @@ export const formatLabel = (text: string): string => {
 export function truncateString(str: string, maxLength: number) {
   return str.length > maxLength ? str.substring(0, maxLength) + "..." : str;
 }
+
+export const formItemValidateJSON = (_: any, value: string) => {
+  if (!value) {
+    return Promise.resolve();
+  }
+  try {
+    JSON.parse(value);
+    return Promise.resolve();
+  } catch (error) {
+    return Promise.reject("Please enter valid JSON");
+  }
+};


### PR DESCRIPTION
## [Feature] UI - Add LiteLLM Params to Edit Model

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Users have no way of editing their LiteLLM Params after they added it in the create flow, this allows the user to edit their custom params in the UI.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="1194" height="396" alt="image" src="https://github.com/user-attachments/assets/eb09a733-3a14-4573-a897-60547deef63b" />
<img width="763" height="223" alt="image" src="https://github.com/user-attachments/assets/2d269272-3c77-4429-b0be-5a6f1bce8cdf" />


