### PR TITLE
[Feature] UI - Improve Usage Indicator

### DIFF
--- a/ui/litellm-dashboard/src/components/usage_indicator.test.tsx
+++ b/ui/litellm-dashboard/src/components/usage_indicator.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import UsageIndicator from "./usage_indicator";
+
+vi.mock("./networking", () => {
+  return {
+    getRemainingUsers: vi.fn(),
+  };
+});
+
+import { getRemainingUsers } from "./networking";
+
+describe("UsageIndicator", () => {
+  it("does not show Near limit when users usage is below 80% (1/100 -> 1%)", async () => {
+    (getRemainingUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      total_users: 100,
+      total_users_used: 1,
+      total_users_remaining: 99,
+      total_teams: null,
+      total_teams_used: 0,
+      total_teams_remaining: null,
+    });
+
+    const { queryByText, findByText } = render(<UsageIndicator accessToken={"token"} width={220} />);
+
+    await findByText("Usage");
+
+    expect(queryByText("Near limit")).toBeNull();
+  });
+
+  it("handles null totals shape by rendering nothing", async () => {
+    (getRemainingUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      total_users: null,
+      total_teams: null,
+      total_users_used: 520,
+      total_teams_used: 4,
+      total_teams_remaining: null,
+      total_users_remaining: null,
+    });
+
+    const { container } = render(<UsageIndicator accessToken={"token"} width={220} />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("shows Near limit for Teams at 80% usage (4/5)", async () => {
+    (getRemainingUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      total_users: null,
+      total_users_used: 0,
+      total_users_remaining: null,
+      total_teams: 5,
+      total_teams_used: 4,
+      total_teams_remaining: 1,
+    });
+
+    const { findByText, getByText } = render(<UsageIndicator accessToken={"token"} width={220} />);
+
+    await findByText("Usage");
+
+    // Teams section should show Near limit indicator
+    expect(getByText("Teams")).toBeTruthy();
+    expect(getByText("Near limit")).toBeTruthy();
+  });
+
+  it("shows Over limit for Users when usage exceeds 100% (105/100)", async () => {
+    (getRemainingUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      total_users: 100,
+      total_users_used: 105,
+      total_users_remaining: -5,
+      total_teams: null,
+      total_teams_used: 0,
+      total_teams_remaining: null,
+    });
+
+    const { findByText, getByText } = render(<UsageIndicator accessToken={"token"} width={220} />);
+
+    await findByText("Usage");
+
+    // Users section should show Over limit indicator
+    expect(getByText("Users")).toBeTruthy();
+    expect(getByText("Over limit")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## [Feature] UI - Improve Usage Indicator

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Currently, the usage indicator shows near limit when there are 4 teams left, this causes confusion because this is nowhere near "Near Limit". The PR changes the usage indicator to have 2 different compartments for users and teams, and will individually show near limit or over limit for each resource.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="783" height="207" alt="image" src="https://github.com/user-attachments/assets/40c80d54-a560-415a-9add-c9394e94318f" />
<img width="334" height="480" alt="image" src="https://github.com/user-attachments/assets/922b72e6-787b-44bc-95a9-c68399fcdb9c" />
<img width="345" height="480" alt="image" src="https://github.com/user-attachments/assets/7c848deb-655f-483e-a082-cc7d79721b03" />

