### PR TITLE
docs: add LiteLLM proxy latency badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+<div style="line-height:0;">
+  <a href="https://docs.litellm.ai/docs/benchmarks" style="text-decoration:none; display:inline-block;">
+    <img src="https://img.shields.io/badge/Proxy_Overhead-8ms_median_│_45ms_p99-0056D2?style=for-the-badge" alt="LiteLLM Proxy Latency">
+  </a>
+</div>
+<div style="line-height:0;">
+  <a href="https://docs.litellm.ai/docs/benchmarks" style="text-decoration:none; display:inline-block;">
+    <img src="https://img.shields.io/badge/Tested_on-4×_4CPU_│_8GB-4B5563?style=for-the-badge" alt="LiteLLM Benchmark Specs">
+  </a>
+</div>
+
 <h1 align="center">
         🚅 LiteLLM
     </h1>


### PR DESCRIPTION
## Title

docs(readme): add performance badges showing LiteLLM proxy overhead

## Type

📖 Documentation

## Changes

- Added badges showing LiteLLM's overhead at the top of the readme.

## Result 
<img width="1410" height="777" alt="Screenshot 2025-11-11 at 4 59 15 PM" src="https://github.com/user-attachments/assets/f323b6a3-b39b-4ca8-a568-4e18028b9ded" />
