### PR TITLE
[Feature] Add Langfuse OTEL and SQS to Health Check

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -38,6 +38,7 @@ services = Union[
     Literal[
         "slack_budget_alerts",
         "langfuse",
+        "langfuse_otel",
         "slack",
         "openmeter",
         "webhook",
@@ -46,6 +47,7 @@ services = Union[
         "datadog",
         "generic_api",
         "arize",
+        "sqs"
     ],
     str,
 ]
@@ -106,6 +108,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "slack_budget_alerts",
             "email",
             "langfuse",
+            "langfuse_otel",
             "slack",
             "openmeter",
             "webhook",
@@ -116,6 +119,7 @@ async def health_services_endpoint(  # noqa: PLR0915
             "datadog",
             "generic_api",
             "arize",
+            "sqs"
         ]:
             raise HTTPException(
                 status_code=400,
@@ -196,6 +200,14 @@ async def health_services_endpoint(  # noqa: PLR0915
                 type="user_budget",
                 user_info=user_info,
             )
+        elif service == "sqs":
+            from litellm.integrations.sqs import SQSLogger
+            sqs_logger = SQSLogger()
+            response = await sqs_logger.async_health_check()
+            return {
+                "status": response["status"],
+                "message": response["error_message"],
+            }
 
         if service == "slack" or service == "slack_budget_alerts":
             if "slack" in general_settings.get("alerting", []):


### PR DESCRIPTION
## [Feature] Add Langfuse OTEL and SQS to Health Check

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR adds Langfuse OTEL and SQS to the Health Check endpoint that the UI uses. Previously this endpoint will throw an error which is then surfaced to the UI, and an error will appear. 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="677" height="74" alt="image" src="https://github.com/user-attachments/assets/6ab7adfc-9104-4d4c-b7d1-16a2612c69a7" />
<img width="672" height="267" alt="image" src="https://github.com/user-attachments/assets/6a05fb24-ffd9-45c5-975d-8f185192a7e0" />
<img width="1476" height="827" alt="image" src="https://github.com/user-attachments/assets/78bae94e-20e1-44a3-9c1e-37f4b617bb0f" />

