### PR TITLE
Add azure gpt 5 specific context window exceeded message

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -74,6 +74,21 @@ class ExceptionCheckers:
             if substring in _error_str_lowercase:
                 return True
         return False
+
+    @staticmethod
+    def is_azure_context_window_exceeded_error(error_str: str) -> bool:
+        """
+        Check if an error string indicates a context window exceeded error.
+        """
+        known_exception_substrings = [
+            "input tokens exceed the configured limit",
+            "this model's maximum context length is",
+            "please reduce the length of the messages",
+        ]
+        for substring in known_exception_substrings:
+            if substring in error_str.lower():
+                return True
+        return False
     
     @staticmethod
     def is_azure_content_policy_violation_error(error_str: str) -> bool:
@@ -2020,7 +2035,7 @@ def exception_type(  # type: ignore  # noqa: PLR0915
                         litellm_debug_info=extra_information,
                         response=getattr(original_exception, "response", None),
                     )
-                elif "This model's maximum context length is" in error_str:
+                elif ExceptionCheckers.is_azure_context_window_exceeded_error(error_str):
                     exception_mapping_worked = True
                     raise ContextWindowExceededError(
                         message=f"AzureException ContextWindowExceededError - {message}",


### PR DESCRIPTION
## Title

Add gpt 5 specific context window exceeded message

## Relevant issues

Actually closes #15981 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

This PR adds error handling specifically for azure gpt 5 deployments as they return a different message on exceeding the context window than gpt4 models.


