### PR TITLE
feat: Add headers to VLLM Passthrough requests [Log success Events]

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -521,6 +521,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
                     "url": str(request.url),
                     "method": request.method,
                     "body": copy.copy(_parsed_body),  # use copy instead of deepcopy
+                    "headers": request.headers,
                 },
             },
             "call_type": "pass_through_endpoint",


### PR DESCRIPTION
## Title

feat: Add headers to VLLM Passthrough requests [Log success Events]

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

I set a breakpoint inside the `async_log_success_event` function for a CustomLogger. You can check that in kwargs -> litellm_params -> proxy_server_request the `headers` do not exist.
<img width="609" height="550" alt="Screenshot 2025-11-12 at 10 33 02" src="https://github.com/user-attachments/assets/37d0bd82-4e3e-478f-9f6a-436bc461517d" />


Here it's after the modifcation, add the header to be retrieve for callback function
<img width="609" height="550" alt="Screenshot 2025-11-12 at 10 34 16" src="https://github.com/user-attachments/assets/7c637a5d-510b-42b6-a954-cbd5aabffd7a" />

Unit test for the function I make changes
<img width="1100" height="386" alt="Screenshot 2025-11-12 at 10 50 52" src="https://github.com/user-attachments/assets/2214a540-b3fb-4ad7-9773-8daceb376312" />

Just to concern, you can check the `headers` I am adding does not have relation to the headers retrieved in the request for client. The `x-requester-token` for example that appears in the other print is not shown here. 
<img width="865" height="421" alt="Screenshot 2025-11-12 at 10 54 06" src="https://github.com/user-attachments/assets/7b4ce363-5c7e-4f49-a6f4-e582ae68d698" />


