### PR TITLE
fix(responses-api): apply drop_params for GPT-5 temperature validation

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -56,8 +56,37 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         model: str,
         drop_params: bool,
     ) -> Dict:
-        """No mapping applied since inputs are in OpenAI spec already"""
-        return dict(response_api_optional_params)
+        """
+        Apply model-specific parameter validations.
+
+        While inputs are in OpenAI spec, some models have specific constraints
+        that need to be validated (e.g., gpt-5 only accepts temperature=1).
+        """
+        params_dict = dict(response_api_optional_params)
+
+        # Apply gpt-5 specific temperature validation
+        if "gpt-5" in model.lower() and "temperature" in params_dict:
+            from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+
+            temperature_value = params_dict.pop("temperature")
+
+            # Use the same validation logic as chat completions
+            gpt5_config = OpenAIGPT5Config()
+            non_default_params = {"temperature": temperature_value}
+            optional_params: Dict = {}
+
+            validated_params = gpt5_config.map_openai_params(
+                non_default_params=non_default_params,
+                optional_params=optional_params,
+                model=model,
+                drop_params=drop_params
+            )
+
+            # Merge validated temperature back if it was kept
+            if "temperature" in validated_params:
+                params_dict["temperature"] = validated_params["temperature"]
+
+        return params_dict
 
     def transform_responses_api_request(
         self,

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -776,3 +776,114 @@ def test_get_supported_openai_params():
     assert "stream" in params
     assert "background" in params
     assert "stream" in params
+
+
+class TestGPT5TemperatureValidation:
+    """Test suite for GPT-5 temperature parameter validation in responses API"""
+
+    def setup_method(self):
+        self.config = OpenAIResponsesAPIConfig()
+
+    def test_gpt5_temperature_not_one_with_drop_params_true(self):
+        """Test that temperature != 1 is dropped for gpt-5 when drop_params=True"""
+        test_params = {"input": "Hello", "temperature": 0.7}
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-5",
+            drop_params=True,
+        )
+
+        # temperature should be dropped
+        assert "temperature" not in result
+        assert result["input"] == "Hello"
+
+    def test_gpt5_temperature_not_one_with_drop_params_false(self):
+        """Test that temperature != 1 raises error for gpt-5 when drop_params=False"""
+        test_params = {"input": "Hello", "temperature": 0.7}
+
+        with pytest.raises(litellm.utils.UnsupportedParamsError) as exc_info:
+            self.config.map_openai_params(
+                response_api_optional_params=test_params,
+                model="gpt-5",
+                drop_params=False,
+            )
+
+        # Verify error message mentions gpt-5 and temperature
+        assert "gpt-5" in str(exc_info.value)
+        assert "temperature" in str(exc_info.value)
+
+    def test_gpt5_temperature_equals_one_is_kept(self):
+        """Test that temperature=1 is kept for gpt-5"""
+        test_params = {"input": "Hello", "temperature": 1}
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-5",
+            drop_params=False,
+        )
+
+        # temperature=1 should be kept
+        assert result["temperature"] == 1
+        assert result["input"] == "Hello"
+
+    def test_gpt5_codex_temperature_validation(self):
+        """Test that temperature validation also applies to gpt-5-codex"""
+        test_params = {"input": "Hello", "temperature": 0.5}
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-5-codex",
+            drop_params=True,
+        )
+
+        # temperature should be dropped for gpt-5-codex too
+        assert "temperature" not in result
+
+    def test_gpt5_no_temperature_param(self):
+        """Test that requests without temperature work fine for gpt-5"""
+        test_params = {"input": "Hello", "stream": True}
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-5",
+            drop_params=False,
+        )
+
+        # Should return params unchanged
+        assert result == test_params
+
+    def test_non_gpt5_model_temperature_not_affected(self):
+        """Test that other models can use any temperature value"""
+        test_params = {"input": "Hello", "temperature": 0.7}
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-4o",
+            drop_params=False,
+        )
+
+        # temperature should be kept for non-gpt-5 models
+        assert result["temperature"] == 0.7
+        assert result["input"] == "Hello"
+
+    def test_gpt5_with_multiple_params(self):
+        """Test gpt-5 temperature validation with multiple parameters"""
+        test_params = {
+            "input": "Hello",
+            "temperature": 0.8,
+            "stream": True,
+            "background": False,
+        }
+
+        result = self.config.map_openai_params(
+            response_api_optional_params=test_params,
+            model="gpt-5",
+            drop_params=True,
+        )
+
+        # Only temperature should be dropped, other params kept
+        assert "temperature" not in result
+        assert result["input"] == "Hello"
+        assert result["stream"] is True
+        assert result["background"] is False


### PR DESCRIPTION
## Title

fix(responses-api): apply drop_params for GPT-5  temperature validation

## Relevant issues

Fixes #16090

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

  🐛 Bug Fix

  ## Changes

  ### Problem
  The Responses API (`/v1/responses`) was not applying model-specific parameter validation. While `temperature` is listed in supported params, GPT-5 has a specific constraint (only accepts `temperature=1`).
  The `drop_params` setting was not being respected because the code wasn't checking model-specific restrictions.

  ### Solution
  - Modified
  `OpenAIResponsesAPIConfig.map_openai_params()` to apply model-specific validation for GPT-5
  - Reuses existing `OpenAIGPT5Config` validation logic from chat completions endpoint
  - Now `drop_params=True` correctly drops `temperature != 1` for GPT-5
  - Ensures consistent behavior between `/v1/chat/completions` and `/v1/responses`
  
## Breaking Changes
  None

 **Tests Added** ✅