### PR TITLE
docs: update broken Slack invite links to support page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ docker run \
 If you need help:
 
 - 💬 [Join our Discord](https://discord.gg/wuPM9dRgDw)
-- 💬 [Join our Slack](https://join.slack.com/share/enQtOTE0ODczMzk2Nzk4NC01YjUxNjY2YjBlYTFmNDRiZTM3NDFiYTM3MzVkODFiMDVjOGRjMmNmZTZkZTMzOWQzZGQyZWIwYjQ0MWExYmE3)
+- 💬 [Join our Slack](https://www.litellm.ai/support)
 - 📧 Email us: ishaan@berri.ai / krrish@berri.ai
 - 🐛 [Create an issue](https://github.com/BerriAI/litellm/issues/new)
 

--- a/docs/my-website/docs/contact.md
+++ b/docs/my-website/docs/contact.md
@@ -2,6 +2,6 @@
 
 [![](https://dcbadge.vercel.app/api/server/wuPM9dRgDw)](https://discord.gg/wuPM9dRgDw)
 
-* [Community Slack 💭](https://join.slack.com/share/enQtOTE0ODczMzk2Nzk4NC01YjUxNjY2YjBlYTFmNDRiZTM3NDFiYTM3MzVkODFiMDVjOGRjMmNmZTZkZTMzOWQzZGQyZWIwYjQ0MWExYmE3)
+* [Community Slack 💭](https://www.litellm.ai/support)
 * [Meet with us 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
 * Contact us at ishaan@berri.ai / krrish@berri.ai

--- a/docs/my-website/docs/proxy/docker_quick_start.md
+++ b/docs/my-website/docs/proxy/docker_quick_start.md
@@ -504,7 +504,7 @@ LiteLLM Proxy uses the [LiteLLM Python SDK](https://docs.litellm.ai/docs/routing
 - [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
 
 - [Community Discord 💭](https://discord.gg/wuPM9dRgDw)
-- [Community Slack 💭](https://join.slack.com/share/enQtOTE0ODczMzk2Nzk4NC01YjUxNjY2YjBlYTFmNDRiZTM3NDFiYTM3MzVkODFiMDVjOGRjMmNmZTZkZTMzOWQzZGQyZWIwYjQ0MWExYmE3)
+- [Community Slack 💭](https://www.litellm.ai/support)
 
 - Our emails ✉️ ishaan@berri.ai / krrish@berri.ai
 

--- a/docs/my-website/docs/troubleshoot.md
+++ b/docs/my-website/docs/troubleshoot.md
@@ -2,7 +2,7 @@
 [Schedule Demo 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
 
 [Community Discord 💭](https://discord.gg/wuPM9dRgDw)
-[Community Slack 💭](https://litellmossslack.slack.com/)
+[Community Slack 💭](https://www.litellm.ai/support)
 
 Our numbers 📞 +1 (770) 8783-106 / ‭+1 (412) 618-6238‬
 

--- a/docs/my-website/src/pages/contact.md
+++ b/docs/my-website/src/pages/contact.md
@@ -4,5 +4,5 @@
 
 
 * [Meet with us 👋](https://calendly.com/d/4mp-gd3-k5k/berriai-1-1-onboarding-litellm-hosted-version)
-* [Community Slack 💭](https://join.slack.com/share/enQtOTE0ODczMzk2Nzk4NC01YjUxNjY2YjBlYTFmNDRiZTM3NDFiYTM3MzVkODFiMDVjOGRjMmNmZTZkZTMzOWQzZGQyZWIwYjQ0MWExYmE3)
+* [Community Slack 💭](https://www.litellm.ai/support)
 * Contact us at ishaan@berri.ai / krrish@berri.ai


### PR DESCRIPTION
## Title

  docs: update broken Slack invite links to support page

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [] I have added a screenshot of my new test passing locally
  - [] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  📖 Documentation

  ## Changes

  Fixed broken Slack community links across all documentation files. The old links were either pointing to a non-functional Slack workspace
  (`https://litellmossslack.slack.com/`) or using expired invite URLs. All links have been updated to point to the correct support page: `https://www.litellm.ai/support`

  **Files updated:**
  - `CONTRIBUTING.md` - Updated "Getting Help" section
  - `docs/my-website/docs/contact.md` - Updated contact page
  - `docs/my-website/docs/proxy/docker_quick_start.md` - Updated "Support & Talk with founders" section
  - `docs/my-website/docs/troubleshoot.md` - Updated support links
  - `docs/my-website/src/pages/contact.md` - Updated contact page