### PR TITLE
fix: exclude unauthorized MCP servers from allowed server list

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -628,8 +628,10 @@ if MCP_AVAILABLE:
             )
 
         ## CHECK IF USER IS ALLOWED TO CALL THIS TOOL
-        allowed_mcp_server_ids = await MCPRequestHandler.get_allowed_mcp_servers(
-            user_api_key_auth=user_api_key_auth,
+        allowed_mcp_server_ids = (
+            await global_mcp_server_manager.get_allowed_mcp_servers(
+                user_api_key_auth=user_api_key_auth,
+            )
         )
 
         allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(
@@ -638,7 +640,7 @@ if MCP_AVAILABLE:
 
         allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
             mcp_servers=mcp_servers,
-            allowed_mcp_servers=allowed_mcp_servers,
+            allowed_mcp_servers=allowed_mcp_servers
         )
 
         server_name: Optional[str]

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -88,7 +88,15 @@ async def test_mcp_server_manager_https_server():
             }
         )
 
-        tools = await mcp_server_manager.list_tools()
+        allowed_server_ids = list(mcp_server_manager.get_registry().keys())
+        assert allowed_server_ids, "Expected registry to contain the configured server"
+
+        with patch.object(
+            mcp_server_manager,
+            "get_allowed_mcp_servers",
+            new=AsyncMock(return_value=allowed_server_ids),
+        ):
+            tools = await mcp_server_manager.list_tools()
         print("TOOLS FROM MCP SERVER MANAGER== ", tools)
 
         # Verify tools were returned and properly prefixed
@@ -192,7 +200,15 @@ async def test_mcp_http_transport_list_tools_mock():
         )
 
         # Call list_tools
-        tools = await test_manager.list_tools()
+        allowed_server_ids = list(test_manager.get_registry().keys())
+        assert allowed_server_ids, "Expected registry to contain configured server"
+
+        with patch.object(
+            test_manager,
+            "get_allowed_mcp_servers",
+            new=AsyncMock(return_value=allowed_server_ids),
+        ):
+            tools = await test_manager.list_tools()
 
         # Assertions
         assert len(tools) == 2
@@ -1530,8 +1546,16 @@ async def test_mcp_protocol_version_passed_to_client():
             }
         )
 
-        # Call list_tools with a specific protocol version from request
-        await test_manager.list_tools()
+        allowed_server_ids = list(test_manager.get_registry().keys())
+        assert allowed_server_ids, "Expected registry to contain configured server"
+
+        with patch.object(
+            test_manager,
+            "get_allowed_mcp_servers",
+            new=AsyncMock(return_value=allowed_server_ids),
+        ):
+            # Call list_tools with a specific protocol version from request
+            await test_manager.list_tools()
 
         # Verify the client was created with the correct protocol version
         mock_client.list_tools.assert_called()
@@ -2436,3 +2460,130 @@ async def test_mcp_server_manager_with_access_groups_integration():
         # Should only get servers user has access to
         assert len(allowed_servers) >= 0  # At least verify no errors
         mock_get_allowed.assert_called_once_with(user_auth)
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_returns_registry_for_admin():
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+
+    test_manager = MCPServerManager()
+    test_manager.load_servers_from_config(
+        {
+            "alpha_server": {
+                "url": "https://alpha.server/mcp",
+                "transport": MCPTransport.http,
+            },
+            "beta_server": {
+                "url": "https://beta.server/mcp",
+                "transport": MCPTransport.http,
+            },
+        }
+    )
+
+    admin_auth = UserAPIKeyAuth(
+        api_key="admin-key",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with patch.object(
+        MCPRequestHandler, "get_allowed_mcp_servers", new_callable=AsyncMock
+    ) as mock_permission_lookup:
+        allowed_servers = await test_manager.get_allowed_mcp_servers(admin_auth)
+
+    assert set(allowed_servers) == set(test_manager.get_registry().keys())
+    mock_permission_lookup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_returns_empty_for_non_admin_without_permissions():
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+
+    test_manager = MCPServerManager()
+    test_manager.load_servers_from_config(
+        {
+            "alpha_server": {
+                "url": "https://alpha.server/mcp",
+                "transport": MCPTransport.http,
+            },
+            "beta_server": {
+                "url": "https://beta.server/mcp",
+                "transport": MCPTransport.http,
+            },
+        }
+    )
+
+    user_auth = UserAPIKeyAuth(
+        api_key="user-key",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    with patch.object(
+        MCPRequestHandler, "get_allowed_mcp_servers", new_callable=AsyncMock
+    ) as mock_permission_lookup:
+        mock_permission_lookup.return_value = []
+        allowed_servers = await test_manager.get_allowed_mcp_servers(user_auth)
+
+    assert allowed_servers == []
+    mock_permission_lookup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_call_mcp_tool_uses_manager_permission_lookup():
+    from litellm.proxy._experimental.mcp_server.server import (
+        call_mcp_tool,
+        global_mcp_server_manager,
+    )
+
+    mock_server = MCPServer(
+        server_id="server-123",
+        name="test_server",
+        url="https://test-server.com/mcp",
+        transport=MCPTransport.http,
+        mcp_info={"server_name": "test_server"},
+    )
+
+    expected_response = [TextContent(type="text", text="ok")]
+
+    with patch.object(
+        global_mcp_server_manager,
+        "get_allowed_mcp_servers",
+        new_callable=AsyncMock,
+    ) as mock_get_allowed, patch.object(
+        global_mcp_server_manager,
+        "get_mcp_server_names_from_ids",
+        return_value=["test-server"],
+    ), patch.object(
+        global_mcp_server_manager,
+        "_get_mcp_server_from_tool_name",
+        return_value=mock_server,
+    ) as mock_get_server, patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_tool_registry"
+    ) as mock_tool_registry, patch(
+        "litellm.proxy._experimental.mcp_server.server._handle_managed_mcp_tool",
+        new_callable=AsyncMock,
+    ) as mock_handle_managed, patch(
+        "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.is_tool_allowed",
+        return_value=True,
+    ):
+        mock_get_allowed.return_value = [mock_server.server_id]
+        mock_tool_registry.get_tool.return_value = None
+        mock_handle_managed.return_value = expected_response
+
+        result = await call_mcp_tool(
+            name=f"{mock_server.name}/gmail_send_email",
+            arguments={"body": "hello"},
+        )
+
+    assert result == expected_response
+    mock_get_allowed.assert_awaited_once()
+    assert mock_get_server.call_count == 2
+    assert (
+        mock_get_server.call_args_list[0][0][0]
+        == f"{mock_server.name}/gmail_send_email"
+    )

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -2543,6 +2543,8 @@ async def test_call_mcp_tool_uses_manager_permission_lookup():
     mock_server = MCPServer(
         server_id="server-123",
         name="test_server",
+        alias="test_server",
+        server_name="test_server",
         url="https://test-server.com/mcp",
         transport=MCPTransport.http,
         mcp_info={"server_name": "test_server"},
@@ -2556,8 +2558,8 @@ async def test_call_mcp_tool_uses_manager_permission_lookup():
         new_callable=AsyncMock,
     ) as mock_get_allowed, patch.object(
         global_mcp_server_manager,
-        "get_mcp_server_names_from_ids",
-        return_value=["test-server"],
+        "get_mcp_servers_from_ids",
+        return_value=[mock_server],
     ), patch.object(
         global_mcp_server_manager,
         "_get_mcp_server_from_tool_name",
@@ -2578,6 +2580,7 @@ async def test_call_mcp_tool_uses_manager_permission_lookup():
         result = await call_mcp_tool(
             name=f"{mock_server.name}/gmail_send_email",
             arguments={"body": "hello"},
+            mcp_servers=["test_server"],
         )
 
     assert result == expected_response


### PR DESCRIPTION
## Title

exclude unauthorized MCP servers from allowed server list

## Relevant issues

#N/A

**Problem**
Internal users were able to view all MCP servers on the Gateway, regardless of their access permissions.

https://www.loom.com/share/95466c51ce084a99acba587565c1f281

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes


