### PR TITLE
fix: wrong timestamps in opentelemetry

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1144,6 +1144,7 @@ class Router:
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             request_priority = kwargs.get("priority") or self.default_priority
             start_time = time.perf_counter()
+            start_time_real = time.time()
             _is_prompt_management_model = self._is_prompt_management_model(model)
 
             if _is_prompt_management_model:
@@ -1156,6 +1157,7 @@ class Router:
                 response = await self.schedule_acompletion(**kwargs)
             else:
                 response = await self.async_function_with_fallbacks(**kwargs)
+            end_time_real = time.time()
             end_time = time.perf_counter()
             _duration = end_time - start_time
             asyncio.create_task(
@@ -1163,8 +1165,8 @@ class Router:
                     service=ServiceTypes.ROUTER,
                     duration=_duration,
                     call_type="acompletion",
-                    start_time=start_time,
-                    end_time=end_time,
+                    start_time=start_time_real,
+                    end_time=end_time_real,
                     parent_otel_span=_get_parent_otel_span_from_kwargs(kwargs),
                 )
             )
@@ -1332,6 +1334,7 @@ class Router:
 
             parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             start_time = time.perf_counter()
+            start_time_real = time.time()
             deployment = await self.async_get_available_deployment(
                 model=model,
                 messages=messages,
@@ -1340,6 +1343,7 @@ class Router:
             )
 
             _timeout_debug_deployment_dict = deployment
+            end_time_real = time.time()
             end_time = time.perf_counter()
             _duration = end_time - start_time
             asyncio.create_task(
@@ -1347,8 +1351,8 @@ class Router:
                     service=ServiceTypes.ROUTER,
                     duration=_duration,
                     call_type="async_get_available_deployment",
-                    start_time=start_time,
-                    end_time=end_time,
+                    start_time=start_time_real,
+                    end_time=end_time_real,
                     parent_otel_span=_get_parent_otel_span_from_kwargs(kwargs),
                 )
             )
@@ -7353,6 +7357,7 @@ class Router:
                 return healthy_deployments
 
             start_time = time.perf_counter()
+            start_time_real = time.time()
             if (
                 self.routing_strategy == "usage-based-routing-v2"
                 and self.lowesttpm_logger_v2 is not None
@@ -7419,6 +7424,7 @@ class Router:
                 f"get_available_deployment for model: {model}, Selected deployment: {self.print_deployment(deployment)} for model: {model}"
             )
 
+            end_time_real = time.time()
             end_time = time.perf_counter()
             _duration = end_time - start_time
             asyncio.create_task(
@@ -7427,8 +7433,8 @@ class Router:
                     duration=_duration,
                     call_type="<routing_strategy>.async_get_available_deployments",
                     parent_otel_span=parent_otel_span,
-                    start_time=start_time,
-                    end_time=end_time,
+                    start_time=start_time_real,
+                    end_time=end_time_real,
                 )
             )
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1315,7 +1315,7 @@ class Router:
 
         return FallbackStreamWrapper(stream_with_fallbacks())
 
-    async def _acompletion(
+    async def _acompletion(  # noqa: PLR0915
         self, model: str, messages: List[Dict[str, str]], **kwargs
     ) -> Union[ModelResponse, CustomStreamWrapper,]:
         """


### PR DESCRIPTION
## Title

Timestamps are wrong for router telemetries.

```
>>> Span: proxy_pre_call
>>> Start time: 1762997955.6862755
>>> End time: 1762997955.686303
>>> Span: proxy_pre_call
>>> Start time: 1762997955.6862755
>>> End time: 1762997955.686303
>>> Span: router
>>> Start time: 3655.258719016
>>> End time: 3655.259057477
>>> Span: router
>>> Start time: 3655.258719016
>>> End time: 3655.259057477
>>> Span: self
>>> Start time: 1762997955.6922054
>>> End time: 1762997955.7288463
>>> Span: self
>>> Start time: 1762997955.6922054
>>> End time: 1762997955.7288463
>>> Span: router
>>> Start time: 3655.258657346
>>> End time: 3655.301371203
>>> Span: router
>>> Start time: 3655.258657346
>>> End time: 3655.301371203
>>> Span: litellm_request
>>> Start time: 1762997955.687342
>>> End time: 1762997955.729035
>>> Span: raw_gen_ai_request
>>> Start time: 1762997955.687342
>>> End time: 1762997955.729035
>>> Span: Received Proxy Server Request
>>> Start time: 1762997955.685619
>>> End time: 1762997955.731397
```

Results in:

<img width="3472" height="602" alt="image" src="https://github.com/user-attachments/assets/1c471304-0b23-44c8-bf97-7152036477a9" />

The problem is that `time.perf_counter()` does not return the real time clock.

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


