### PR TITLE
Add method for extracting vector store ids from path params

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -277,3 +277,78 @@ def get_tags_from_request_body(request_body: dict) -> List[str]:
     ######################################
     return [tag for tag in combined_tags if isinstance(tag, str)]
 
+
+def populate_request_with_path_params(
+    request_data: dict, request: Request
+) -> dict:
+    """
+    Copy FastAPI path params into the request payload so downstream checks
+    (e.g. vector store RBAC) see them the same way as body params.
+    
+    Since path_params may not be available during dependency injection,
+    we parse the URL path directly for known patterns.
+    
+    Args:
+        request_data: The request data dictionary to populate
+        request: The FastAPI Request object
+        
+    Returns:
+        dict: Updated request_data with path parameters added
+    """    
+    # Try to get path_params if available (sometimes populated by FastAPI)
+    path_params = getattr(request, "path_params", None)
+    if isinstance(path_params, dict) and path_params:
+        for key, value in path_params.items():
+            if key == "vector_store_id":
+                request_data.setdefault("vector_store_id", value)
+                existing_ids = request_data.get("vector_store_ids")
+                if isinstance(existing_ids, list):
+                    if value not in existing_ids:
+                        existing_ids.append(value)
+                else:
+                    request_data["vector_store_ids"] = [value]
+                continue
+            request_data.setdefault(key, value)
+        verbose_proxy_logger.debug(
+            f"populate_request_with_path_params: Found path_params, vector_store_ids={request_data.get('vector_store_ids')}"
+        )
+        return request_data
+
+    # Fallback: parse the URL path directly to extract vector_store_id
+    _add_vector_store_id_from_path(request_data=request_data, request=request)
+
+    return request_data
+
+
+def _add_vector_store_id_from_path(request_data: dict, request: Request) -> None:
+    """
+    Parse the request path to find /vector_stores/{vector_store_id}/... segments.
+
+    When found, ensure both vector_store_id and vector_store_ids are populated.
+    
+    Args:
+        request_data: The request data dictionary to populate
+        request: The FastAPI Request object
+    """
+    path = request.url.path
+    vector_store_match = re.search(r"/vector_stores/([^/]+)/", path)
+    if vector_store_match:
+        vector_store_id = vector_store_match.group(1)
+        verbose_proxy_logger.debug(
+            f"populate_request_with_path_params: Extracted vector_store_id={vector_store_id} from path={path}"
+        )
+        request_data.setdefault("vector_store_id", vector_store_id)
+        existing_ids = request_data.get("vector_store_ids")
+        if isinstance(existing_ids, list):
+            if vector_store_id not in existing_ids:
+                existing_ids.append(vector_store_id)
+        else:
+            request_data["vector_store_ids"] = [vector_store_id]
+        verbose_proxy_logger.debug(
+            f"populate_request_with_path_params: Updated request_data with vector_store_ids={request_data.get('vector_store_ids')}"
+        )
+    else:
+        verbose_proxy_logger.debug(
+            f"populate_request_with_path_params: No vector_store_id present in path={path}"
+        )
+

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -136,14 +136,16 @@ class VectorStoreRegistry:
         vector_store_ids: List[str] = []
 
         # 1. check if vector_store_ids is provided in the non_default_params
-        vector_store_ids = non_default_params.get("vector_store_ids", None) or []
+        vector_store_ids_param = non_default_params.get("vector_store_ids")
+        if isinstance(vector_store_ids_param, list):
+            vector_store_ids.extend(vector_store_ids_param)
 
         # 2. check if vector_store_ids is provided as a tool in the request
         vector_store_ids = self._get_vector_store_ids_from_tool_calls(
             tools=tools, vector_store_ids=vector_store_ids
         )
 
-        return vector_store_ids
+        return list(dict.fromkeys(vector_store_ids))
 
     def get_and_pop_recognised_vector_store_tools(
         self, tools: Optional[List[Dict]] = None, vector_store_ids: Optional[List[str]] = None


### PR DESCRIPTION
## Title

Add method for extracting vector store ids from path params

## Relevant issues

Fixes #16303

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
- /v1/vector_stores/{id}/search → FastAPI path param gets copied into vector_store_id and is picked up.
- Requests that send vector_store_ids: ["vs_1"] keep working.

