### PR TITLE
fix(responses): Add image generation support for Responses API

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -811,7 +811,7 @@ class LiteLLMCompletionResponsesConfig:
                     OutputImageGenerationCall(
                         type="image_generation_call",
                         id=f"{chat_completion_response.id}_img_{idx}",
-                        status=LiteLLMCompletionResponsesConfig._map_chat_completion_finish_reason_to_responses_status(
+                        status=LiteLLMCompletionResponsesConfig._map_finish_reason_to_image_generation_status(
                             choice.finish_reason
                         ),
                         result=base64_data,
@@ -819,6 +819,26 @@ class LiteLLMCompletionResponsesConfig:
                 )
 
         return image_generation_items
+
+    @staticmethod
+    def _map_finish_reason_to_image_generation_status(
+        finish_reason: Optional[str],
+    ) -> Literal["in_progress", "completed", "incomplete", "failed"]:
+        """
+        Map finish_reason to image generation status.
+
+        Image generation status only supports: in_progress, completed, incomplete, failed
+        (does not support: cancelled, queued like general ResponsesAPIStatus)
+        """
+        if finish_reason == "stop":
+            return "completed"
+        elif finish_reason == "length":
+            return "incomplete"
+        elif finish_reason in ["content_filter", "error"]:
+            return "failed"
+        else:
+            # Default to completed for other cases
+            return "completed"
 
     @staticmethod
     def _extract_base64_from_data_url(data_url: str) -> Optional[str]:

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -65,6 +65,7 @@ from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
 from litellm.types.responses.main import (
     GenericResponseOutputItem,
     OutputFunctionToolCall,
+    OutputImageGenerationCall,
 )
 
 FileContent = Union[IO[bytes], bytes, PathLike]
@@ -1059,7 +1060,7 @@ class ResponsesAPIResponse(BaseLiteLLMOpenAIResponseObject):
     object: Optional[str] = None
     output: Union[
         List[Union[ResponseOutputItem, Dict]],
-        List[Union[GenericResponseOutputItem, OutputFunctionToolCall]],
+        List[Union[GenericResponseOutputItem, OutputFunctionToolCall, OutputImageGenerationCall]],
     ]
     parallel_tool_calls: Optional[bool] = None
     temperature: Optional[float] = None

--- a/litellm/types/responses/main.py
+++ b/litellm/types/responses/main.py
@@ -36,6 +36,15 @@ class OutputFunctionToolCall(BaseLiteLLMOpenAIResponseObject):
     status: Literal["in_progress", "completed", "incomplete"]
 
 
+class OutputImageGenerationCall(BaseLiteLLMOpenAIResponseObject):
+    """An image generation call output"""
+
+    type: Literal["image_generation_call"]
+    id: str
+    status: Literal["in_progress", "completed", "incomplete", "failed"]
+    result: Optional[str]  # Base64 encoded image data (without data:image prefix)
+
+
 class GenericResponseOutputItem(BaseLiteLLMOpenAIResponseObject):
     """
     Generic response API output item

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_image_generation_output.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_image_generation_output.py
@@ -1,0 +1,313 @@
+"""
+Unit tests for Responses API image generation support
+
+Tests the fix for Issue #16227:
+https://github.com/BerriAI/litellm/issues/16227
+
+Verifies that image generation outputs are correctly transformed
+from /chat/completions format to /responses API format.
+"""
+import pytest
+from unittest.mock import Mock
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+from litellm.types.responses.main import OutputImageGenerationCall
+from litellm.types.utils import ModelResponse, Choices, Message
+
+
+class TestExtractBase64FromDataUrl:
+    """Tests for _extract_base64_from_data_url helper function"""
+
+    def test_extracts_base64_from_data_url(self):
+        """Should extract pure base64 from data URL with prefix"""
+        data_url = "data:image/png;base64,iVBORw0KGgoAAAANS"
+        result = LiteLLMCompletionResponsesConfig._extract_base64_from_data_url(
+            data_url
+        )
+        assert result == "iVBORw0KGgoAAAANS"
+
+    def test_returns_base64_as_is_if_no_prefix(self):
+        """Should return base64 as-is if no data: prefix"""
+        pure_base64 = "iVBORw0KGgoAAAANS"
+        result = LiteLLMCompletionResponsesConfig._extract_base64_from_data_url(
+            pure_base64
+        )
+        assert result == pure_base64
+
+    def test_handles_empty_string(self):
+        """Should return None for empty string"""
+        result = LiteLLMCompletionResponsesConfig._extract_base64_from_data_url("")
+        assert result is None
+
+    def test_handles_none(self):
+        """Should return None for None input"""
+        result = LiteLLMCompletionResponsesConfig._extract_base64_from_data_url(None)
+        assert result is None
+
+    def test_handles_data_url_without_comma(self):
+        """Should return None if data URL has no comma separator"""
+        invalid_url = "data:image/png;base64"
+        result = LiteLLMCompletionResponsesConfig._extract_base64_from_data_url(
+            invalid_url
+        )
+        assert result is None
+
+
+class TestExtractImageGenerationOutputItems:
+    """Tests for _extract_image_generation_output_items function"""
+
+    def test_extracts_single_image(self):
+        """Should extract one OutputImageGenerationCall for one image"""
+        # Mock objects
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "test_response_123"
+
+        mock_message = Mock(spec=Message)
+        mock_message.images = [
+            {
+                "image_url": {"url": "data:image/png;base64,ABC123"},
+                "type": "image_url",
+                "index": 0,
+            }
+        ]
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        # Execute
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        # Verify
+        assert len(result) == 1
+        assert isinstance(result[0], OutputImageGenerationCall)
+        assert result[0].type == "image_generation_call"
+        assert result[0].id == "test_response_123_img_0"
+        assert result[0].status == "completed"
+        assert result[0].result == "ABC123"
+
+    def test_extracts_multiple_images(self):
+        """Should extract multiple OutputImageGenerationCall objects"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "test_response_456"
+
+        mock_message = Mock(spec=Message)
+        mock_message.images = [
+            {
+                "image_url": {"url": "data:image/png;base64,IMG1"},
+                "type": "image_url",
+                "index": 0,
+            },
+            {
+                "image_url": {"url": "data:image/jpeg;base64,IMG2"},
+                "type": "image_url",
+                "index": 1,
+            },
+        ]
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        assert len(result) == 2
+        assert result[0].result == "IMG1"
+        assert result[1].result == "IMG2"
+        assert result[0].id == "test_response_456_img_0"
+        assert result[1].id == "test_response_456_img_1"
+
+    def test_returns_empty_list_if_no_images(self):
+        """Should return empty list if message has no images"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_message = Mock(spec=Message)
+        mock_message.images = []
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        assert result == []
+
+    def test_returns_empty_list_if_images_attribute_missing(self):
+        """Should return empty list if message doesn't have images attribute"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_message = Mock(spec=Message)
+        # No images attribute
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        assert result == []
+
+    def test_skips_images_with_invalid_url(self):
+        """Should skip images that don't have valid base64 data"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "test_789"
+
+        mock_message = Mock(spec=Message)
+        mock_message.images = [
+            {"image_url": {"url": ""}, "type": "image_url", "index": 0},  # Empty URL
+            {
+                "image_url": {"url": "data:image/png;base64,VALID"},
+                "type": "image_url",
+                "index": 1,
+            },
+        ]
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        # Should only extract the valid one
+        assert len(result) == 1
+        assert result[0].result == "VALID"
+
+    def test_maps_finish_reason_to_status(self):
+        """Should correctly map finish_reason to status"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "test_finish"
+
+        mock_message = Mock(spec=Message)
+        mock_message.images = [
+            {
+                "image_url": {"url": "data:image/png;base64,TEST"},
+                "type": "image_url",
+                "index": 0,
+            }
+        ]
+
+        # Test with 'length' finish_reason (should map to 'incomplete')
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "length"
+
+        result = LiteLLMCompletionResponsesConfig._extract_image_generation_output_items(
+            chat_completion_response=mock_response,
+            choice=mock_choice,
+        )
+
+        assert result[0].status == "incomplete"
+
+
+class TestOutputImageGenerationCallType:
+    """Tests for OutputImageGenerationCall type definition"""
+
+    def test_creates_valid_instance(self):
+        """Should create valid OutputImageGenerationCall instance"""
+        output = OutputImageGenerationCall(
+            type="image_generation_call",
+            id="img_123",
+            status="completed",
+            result="base64data",
+        )
+
+        assert output.type == "image_generation_call"
+        assert output.id == "img_123"
+        assert output.status == "completed"
+        assert output.result == "base64data"
+
+    def test_allows_none_result(self):
+        """Should allow None as result value"""
+        output = OutputImageGenerationCall(
+            type="image_generation_call",
+            id="img_456",
+            status="failed",
+            result=None,
+        )
+
+        assert output.result is None
+
+    def test_type_is_literal(self):
+        """Type field should only accept 'image_generation_call'"""
+        # Valid
+        output = OutputImageGenerationCall(
+            type="image_generation_call",
+            id="img_789",
+            status="completed",
+            result="data",
+        )
+        assert output.type == "image_generation_call"
+
+
+class TestExtractMessageOutputItemsIntegration:
+    """Integration tests for _extract_message_output_items with images"""
+
+    def test_detects_images_and_creates_image_generation_call(self):
+        """Should detect images in message and create image_generation_call output"""
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "integration_test_123"
+
+        mock_message = Mock(spec=Message)
+        mock_message.images = [
+            {
+                "image_url": {"url": "data:image/png;base64,INTEGRATION_TEST"},
+                "type": "image_url",
+                "index": 0,
+            }
+        ]
+        mock_message.role = "assistant"
+        mock_message.content = "Here's your image!"
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_message_output_items(
+            chat_completion_response=mock_response,
+            choices=[mock_choice],
+        )
+
+        # Should return image_generation_call, NOT regular message
+        assert len(result) == 1
+        assert isinstance(result[0], OutputImageGenerationCall)
+        assert result[0].type == "image_generation_call"
+        assert result[0].result == "INTEGRATION_TEST"
+
+    def test_creates_regular_message_when_no_images(self):
+        """Should create regular GenericResponseOutputItem when no images"""
+        from litellm.types.responses.main import GenericResponseOutputItem
+
+        mock_response = Mock(spec=ModelResponse)
+        mock_response.id = "no_images_123"
+
+        mock_message = Mock(spec=Message)
+        # No images attribute or empty
+        mock_message.role = "assistant"
+        mock_message.content = "Just text, no images"
+
+        mock_choice = Mock(spec=Choices)
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = "stop"
+
+        result = LiteLLMCompletionResponsesConfig._extract_message_output_items(
+            chat_completion_response=mock_response,
+            choices=[mock_choice],
+        )
+
+        assert len(result) == 1
+        assert isinstance(result[0], GenericResponseOutputItem)
+        assert result[0].type == "message"


### PR DESCRIPTION
 ## Title

  fix(responses): Add image generation support for Responses API

  ## Relevant issues

  Fixes #16227

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


  ## Type

  🐛 Bug Fix
  📖 Documentation
  ✅ Test

  ## Changes

  ### Problem
  The Responses API (`/responses` endpoint) was not correctly handling image generation outputs. When models like Gemini 2.5 Flash Image or OpenAI's GPT-4o generated images, the response would return empty content instead of the generated images.

  ### Solution
  Added proper detection and transformation of image generation outputs in the Responses API:

  1. **New Type Definition** (`litellm/types/responses/main.py`):
     - Created `OutputImageGenerationCall` type to represent image generation outputs
     - Follows OpenAI Responses API specification with `type: "image_generation_call"`, `status`, and `result` fields

  2. **Transformation Logic** (`litellm/responses/litellm_completion_transformation/transformation.py`):
     - Added detection for `message.images` in completion responses
     - Extract base64 image data from data URLs
     - Transform to proper `OutputImageGenerationCall` format
     - Map finish reasons to appropriate status values

  3. **Type Updates** (`litellm/types/llms/openai.py`):
     - Updated `ResponsesAPIResponse.output` type to include `OutputImageGenerationCall`

  4. **Documentation** (`docs/my-website/docs/response_api.md`):
     - Added comprehensive image generation examples for Gemini and OpenAI
     - Documented response format and base64 handling
     - Created supported models table with provider-specific requirements

  5. **Tests** (`tests/test_litellm/responses/litellm_completion_transformation/test_image_generation_output.py`):
     - Unit tests for base64 extraction helper function
     - Tests for image generation output item extraction
     - Integration tests for message output transformation
     - Validates status mapping and proper format conversion

  ### Extras
  - ✅ Works for **all providers** that use `message.images` format (Gemini, OpenAI, Bedrock, Fal AI, etc.)
  - ✅ Properly converts from data URL format to pure base64 as per OpenAI spec
  - ✅ Maintains backward compatibility with existing text/tool call outputs
  - ✅ No breaking changes to existing functionality