### PR TITLE
feat(opentelemetry): Respect `log_raw_request_response` setting

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -605,8 +605,13 @@ class OpenTelemetry(CustomLogger):
         from opentelemetry import trace
         from opentelemetry.trace import Status, StatusCode
 
-        # only log raw LLM request/response if message_logging is on and not globally turned off
-        if litellm.turn_off_message_logging or not self.message_logging:
+        # only log raw LLM request/response if message_logging is on, not globally turned off,
+        # and if raw request logging is enabled
+        if (
+            litellm.turn_off_message_logging
+            or not self.message_logging
+            or not litellm.log_raw_request_response
+        ):
             return
 
         litellm_params = kwargs.get("litellm_params", {})
@@ -1078,7 +1083,9 @@ class OpenTelemetry(CustomLogger):
                     span=span, key="hidden_params", value=safe_dumps(hidden_params)
                 )
             # Cost breakdown tracking
-            cost_breakdown: Optional[CostBreakdown] = standard_logging_payload.get("cost_breakdown")
+            cost_breakdown: Optional[CostBreakdown] = standard_logging_payload.get(
+                "cost_breakdown"
+            )
             if cost_breakdown:
                 for key, value in cost_breakdown.items():
                     if value is not None:

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -40,7 +40,9 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
         }
 
         # Create a kwargs dict with standard_logging_object containing guardrail information
-        kwargs = {"standard_logging_object": {"guardrail_information": [ guardrail_info ]}}
+        kwargs = {
+            "standard_logging_object": {"guardrail_information": [guardrail_info]}
+        }
 
         # Call the method
         otel._create_guardrail_span(kwargs=kwargs, context=None)
@@ -248,7 +250,9 @@ class TestOpenTelemetry(unittest.TestCase):
         }
 
         # Create a kwargs dict with standard_logging_object containing guardrail information
-        kwargs = {"standard_logging_object": {"guardrail_information": [ guardrail_info ]}}
+        kwargs = {
+            "standard_logging_object": {"guardrail_information": [guardrail_info]}
+        }
 
         # Call the method
         otel._create_guardrail_span(kwargs=kwargs, context=None)
@@ -618,8 +622,6 @@ class TestOpenTelemetry(unittest.TestCase):
         # But other attributes from OTEL_RESOURCE_ATTRIBUTES should still be present
         self.assertEqual(attributes.get("extra.attr"), "extra-value")
 
-
-
     def test_handle_success_spans_only(self):
         # make sure neither events nor metrics is on
         os.environ.pop("LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS", None)
@@ -769,6 +771,7 @@ class TestOpenTelemetry(unittest.TestCase):
         result = otel._get_span_name(kwargs)
         self.assertEqual(result, LITELLM_REQUEST_SPAN_NAME)
 
+    @patch("litellm.log_raw_request_response", True)
     @patch("litellm.turn_off_message_logging", False)
     def test_maybe_log_raw_request_creates_span(self):
         """Test _maybe_log_raw_request creates span when logging enabled"""
@@ -807,6 +810,52 @@ class TestOpenTelemetry(unittest.TestCase):
         )
 
         mock_tracer.start_span.assert_not_called()
+
+    @patch("litellm.log_raw_request_response", False)
+    @patch("litellm.turn_off_message_logging", False)
+    def test_maybe_log_raw_request_skips_when_log_raw_request_is_false(self):
+        """
+        Test that _maybe_log_raw_request skips creating a span when the global
+        litellm.log_raw_request_response setting is False.
+        """
+
+        otel = OpenTelemetry()
+        otel.message_logging = True
+        mock_tracer = MagicMock()
+        otel.get_tracer_to_use_for_request = MagicMock(return_value=mock_tracer)
+
+        kwargs = {"litellm_params": {"metadata": {}}}
+        otel._maybe_log_raw_request(
+            kwargs, {}, datetime.now(), datetime.now(), MagicMock()
+        )
+
+        # Assert
+        mock_tracer.start_span.assert_not_called()
+
+    @patch("litellm.log_raw_request_response", True)
+    @patch("litellm.turn_off_message_logging", False)
+    def test_maybe_log_raw_request_creates_span_when_log_raw_request_is_true(self):
+        """
+        Test that _maybe_log_raw_request creates a span when the global
+        litellm.log_raw_request_response setting is explicitly True.
+        """
+
+        otel = OpenTelemetry()
+        otel.message_logging = True
+        mock_tracer = MagicMock()
+        mock_span = MagicMock()
+        mock_tracer.start_span.return_value = mock_span
+        otel.get_tracer_to_use_for_request = MagicMock(return_value=mock_tracer)
+        otel.set_raw_request_attributes = MagicMock()
+        otel._to_ns = MagicMock(return_value=1234567890)
+
+        kwargs = {"litellm_params": {"metadata": {}}}
+        otel._maybe_log_raw_request(
+            kwargs, {}, datetime.now(), datetime.now(), MagicMock()
+        )
+
+        # Assert
+        mock_tracer.start_span.assert_called_once()
 
 
 class TestOpenTelemetryHeaderSplitting(unittest.TestCase):


### PR DESCRIPTION
##  Respect `log_raw_request_response` setting



## Relevant issues

Fixes #16465

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1673" height="656" alt="image" src="https://github.com/user-attachments/assets/3287bed7-faa9-42a7-b8b4-88425bba4236" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix

## Changes

This pull request implements the feature requested in issue #16465, allowing users to prevent the creation of the `raw_gen_ai_request` span in the OpenTelemetry integration.

### Problem
The OpenTelemetry logger did not respect the existing global setting `litellm.log_raw_request_response`. It would always create the verbose `raw_gen_ai_request` span, leading to unwanted telemetry data and increased costs for users who intended to disable it.

### Solution
1.  **Modified `litellm/integrations/opentelemetry.py`**: The `_maybe_log_raw_request` function now checks the value of `litellm.log_raw_request_response`. If it is `False` (the default), the function returns early, preventing the span from being created.

2.  **Added Unit Tests**: Added two new tests to `tests/test_litellm/integrations/test_opentelemetry.py` to verify:
    - The span is **not** created when `log_raw_request_response` is `False`.
    - The span **is** created when `log_raw_request_response` is `True`.

3.  **Updated Existing Test**: Updated the original `test_maybe_log_raw_request_creates_span` test to account for the new logic, ensuring the test suite remains consistent and all tests pass.

