### PR TITLE
fix(mcp): Fix Gemini conversation format issue with MCP auto-execution

### DIFF
--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -526,8 +526,10 @@ class LiteLLM_Proxy_MCP_Handler:
                     else:
                         assistant_message_content.append(content)
 
-        # Add assistant message with content and function calls
-        if assistant_message_content or function_calls:
+        # Add assistant message only if there's actual content (not empty)
+        # For example, gemini requires that function call turns come immediately after user turns,
+        # so we should not add empty assistant messages
+        if assistant_message_content:
             follow_up_input.append(
                 {
                     "type": "message",
@@ -536,9 +538,9 @@ class LiteLLM_Proxy_MCP_Handler:
                 }
             )
 
-            # Add function calls after assistant message
-            for function_call in function_calls:
-                follow_up_input.append(function_call)
+        # Add function calls (these can come directly after user message for LLM)
+        for function_call in function_calls:
+            follow_up_input.append(function_call)
 
         # Add tool results (function call outputs)
         for tool_result in tool_results:


### PR DESCRIPTION
## Problem
When using MCP tools with `require_approval='never'` and Gemini models, the follow-up call after tool execution fails with:

```
Please ensure that function call turn comes immediately after a user turn or after a function response turn.
```

This occurs because Gemini has strict requirements about conversation structure - function calls must come immediately after user messages, without an empty assistant message in between.

## Root Cause
In `litellm_proxy_mcp_handler.py`, the `_create_follow_up_input()` method was adding an assistant message even when it had no content, creating this sequence:
1. User message
2. **Empty assistant message** ← Problem
3. Function call
4. Function result

Gemini rejects this format.

## Solution
Modified the code to only add the assistant message if it contains actual content. This allows the correct sequence:
1. User message
2. Function call (directly after user)
3. Function result
4. Final response

## Changes
- Updated `_create_follow_up_input()` in `litellm/responses/mcp/litellm_proxy_mcp_handler.py`
- Only appends assistant message if `assistant_message_content` is non-empty
- Added explanatory comments about Gemini's format requirements

## Testing
Tested with:
- ✅ Gemini 2.5 Flash with MCP auto-execution
- ✅ Tool calls are executed successfully
- ✅ Follow-up calls complete without errors

## Compatibility
This change is backward compatible - it only affects the case where assistant message content is empty, which was causing errors anyway. Other models (Claude, GPT-4, etc.) continue to work as before.

## Related Issues
Fixes the Gemini conversation format error when using MCP with `require_approval: never`