### PR TITLE
fix(bedrock): Ensure consistent chunk IDs in Bedrock streaming responses

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -493,9 +493,9 @@ class BedrockLLM(BaseAWSLLM):
                             content=None,
                         )
                         model_response.choices[0].message = _message  # type: ignore
-                        model_response._hidden_params["original_response"] = (
-                            outputText  # allow user to access raw anthropic tool calling response
-                        )
+                        model_response._hidden_params[
+                            "original_response"
+                        ] = outputText  # allow user to access raw anthropic tool calling response
                     if (
                         _is_function_call is True
                         and stream is not None
@@ -793,9 +793,9 @@ class BedrockLLM(BaseAWSLLM):
                     ):  # completion(top_k=3) > anthropic_config(top_k=3) <- allows for dynamic variables to be passed in
                         inference_params[k] = v
                 if stream is True:
-                    inference_params["stream"] = (
-                        True  # cohere requires stream = True in inference params
-                    )
+                    inference_params[
+                        "stream"
+                    ] = True  # cohere requires stream = True in inference params
                 data = json.dumps({"prompt": prompt, **inference_params})
         elif provider == "anthropic":
             if model.startswith("anthropic.claude-3"):
@@ -1184,6 +1184,7 @@ class AWSEventStreamDecoder:
         self.parser = EventStreamJSONParser()
         self.content_blocks: List[ContentBlockDeltaEvent] = []
         self.tool_calls_index: Optional[int] = None
+        self.response_id = f"chatcmpl-{uuid.uuid4()}"  # Create a single response ID for the entire stream session.
 
     def check_empty_tool_call_args(self) -> bool:
         """
@@ -1378,6 +1379,7 @@ class AWSEventStreamDecoder:
                         ),
                     )
                 ],
+                id=self.response_id,
                 usage=usage,
                 provider_specific_fields=model_response_provider_specific_fields,
             )


### PR DESCRIPTION
## Ensure consistent chunk IDs in Bedrock streaming responses



## Relevant issues

Fixes #16584

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1820" height="232" alt="image" src="https://github.com/user-attachments/assets/9c57d422-5bdc-4c61-a781-baaf36679664" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

This PR addresses an issue where streaming responses from AWS Bedrock Converse models (e.g., Claude 3) would generate a new, unique ID for each chunk, which violates the OpenAI streaming specification.

The fix involves two key changes to `litellm/llms/bedrock/chat/invoke_handler.py`:

1.  **Persistent Stream ID:** A single `response_id` is now generated and stored within the `AWSEventStreamDecoder` instance upon its creation.
2.  **Consistent Chunk ID:** This stored `response_id` is passed to the `ModelResponseStream` constructor for every chunk processed by the `converse_chunk_parser` method.

These changes ensure that all chunks belonging to a single streaming response share the same ID, aligning the provider's behavior with the expected standard.

A new unit test, `test_bedrock_converse_streaming_consistent_id`, has been added to `tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py` to verify this behavior and prevent future regressions.