### PR TITLE
[Fix] UI - Remove azure/ prefix in Placeholder for Azure in Add Model

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/litellm_model_name.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/litellm_model_name.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import { Form } from "antd";
+import { describe, expect, it } from "vitest";
+import { getPlaceholder, Providers } from "../provider_info_helpers";
+import LiteLLMModelNameField from "./litellm_model_name";
+
+describe("LitellmModelNameField", () => {
+  it("should render", () => {
+    const { getByText } = render(
+      <Form>
+        <LiteLLMModelNameField
+          selectedProvider={Providers.OpenAI}
+          providerModels={[]}
+          getPlaceholder={getPlaceholder}
+        />
+      </Form>,
+    );
+    expect(getByText("LiteLLM Model Name(s)")).toBeInTheDocument();
+  });
+
+  it("should show Azure placeholder as 'my-deployment'", () => {
+    const { getByPlaceholderText, queryByPlaceholderText } = render(
+      <Form>
+        <LiteLLMModelNameField selectedProvider={Providers.Azure} providerModels={[]} getPlaceholder={getPlaceholder} />
+      </Form>,
+    );
+    expect(getByPlaceholderText("my-deployment")).toBeInTheDocument();
+    expect(queryByPlaceholderText("gpt-3.5-turbo")).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -173,7 +173,7 @@ export const getPlaceholder = (selectedProvider: string): string => {
   } else if (selectedProvider == Providers.Azure_AI_Studio) {
     return "azure_ai/command-r-plus";
   } else if (selectedProvider == Providers.Azure) {
-    return "azure/my-deployment";
+    return "my-deployment";
   } else if (selectedProvider == Providers.Oracle) {
     return "oci/xai.grok-4";
   } else if (selectedProvider == Providers.Snowflake) {


### PR DESCRIPTION
## [Fix] UI - Remove azure/ prefix in Placeholder for Azure in Add Model

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
When adding a model with Azure as the provider, The UI prepends `azure` for the user. The previous placeholder text made was confusing as it prompted the user to enter `azure/my-deployment` causing the UI to map it to `azure/azure/my-deployment`. This removes the azure from the placeholder to prevent confusion

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

## Screenshot
<img width="688" height="199" alt="image" src="https://github.com/user-attachments/assets/c2cb3355-3d1c-4f43-b55a-5469782f07c4" />

<img width="1215" height="297" alt="image" src="https://github.com/user-attachments/assets/6dc15d46-eaa9-4774-92df-1a7a5dbecaa7" />

<img width="1218" height="189" alt="image" src="https://github.com/user-attachments/assets/354b84f1-900f-4320-94af-76620bc08865" />


