### PR TITLE
[Fix] UI - Button Styles and Sizing in Settings Pages

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -493,22 +493,14 @@ export default function ModelInfoView({
                 <Title>Model Settings</Title>
                 <div className="flex gap-2">
                   {isAutoRouter && canEditModel && !isEditing && (
-                    <TremorButton
-                      variant="primary"
-                      onClick={() => setIsAutoRouterModalOpen(true)}
-                      className="flex items-center"
-                    >
+                    <TremorButton onClick={() => setIsAutoRouterModalOpen(true)} className="flex items-center">
                       Edit Auto Router
                     </TremorButton>
                   )}
                   {canEditModel ? (
                     !isEditing && (
-                      <TremorButton
-                        variant="secondary"
-                        onClick={() => setIsEditing(true)}
-                        className="flex items-center"
-                      >
-                        Edit Model
+                      <TremorButton onClick={() => setIsEditing(true)} className="flex items-center">
+                        Edit Settings
                       </TremorButton>
                     )
                   ) : (

--- a/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { vi, test, expect } from "vitest";
+import OrganizationInfoView from "./organization_view";
+
+// Mock networking calls used by the component
+vi.mock("../networking", () => {
+  return {
+    __esModule: true,
+    organizationInfoCall: vi.fn(),
+    organizationMemberAddCall: vi.fn(),
+    organizationMemberUpdateCall: vi.fn(),
+    organizationMemberDeleteCall: vi.fn(),
+    organizationUpdateCall: vi.fn(),
+  };
+});
+
+// Mock noisy/heavy child components to keep this test focused on render
+vi.mock("../object_permissions_view", () => ({
+  __esModule: true,
+  default: () => <div data-testid="object-permissions-view" />,
+}));
+vi.mock("../molecules/notifications_manager", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), fromBackend: vi.fn() },
+}));
+vi.mock("../team/edit_membership", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("../common_components/user_search_modal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("../vector_store_management/VectorStoreSelector", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+vi.mock("../mcp_server_management/MCPServerSelector", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockOrg = {
+  organization_alias: "Acme Corp",
+  organization_id: "org_123",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  created_by: "admin@example.com",
+  spend: 0,
+  models: ["gpt-4o-mini"],
+  litellm_budget_table: {
+    tpm_limit: null,
+    rpm_limit: null,
+    max_budget: 1000,
+    budget_duration: "30d",
+    max_parallel_requests: null,
+  },
+  object_permission: {},
+  members: [],
+  teams: [],
+  metadata: null,
+};
+
+test("renders organization view after loading data", async () => {
+  const { organizationInfoCall } = await import("../networking");
+  (organizationInfoCall as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockOrg);
+
+  const { findAllByText } = render(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={false}
+      userModels={[]}
+      editOrg={false}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(findAllByText("Acme Corp")).toBeTruthy();
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -1,46 +1,46 @@
-import React, { useState, useEffect } from "react";
+import { formatNumberWithCommas, copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
+import { ArrowLeftIcon, PencilAltIcon, TrashIcon } from "@heroicons/react/outline";
 import {
-  Card,
-  Title,
-  Text,
-  TextInput,
-  Tab,
-  TabList,
-  TabGroup,
-  TabPanel,
-  TabPanels,
-  Grid,
   Badge,
+  Card,
+  Grid,
+  Icon,
+  Tab,
+  TabGroup,
   Table,
-  TableHead,
-  TableRow,
-  TableHeaderCell,
   TableBody,
   TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Text,
+  TextInput,
+  Title,
   Button as TremorButton,
-  Icon,
 } from "@tremor/react";
-import NumericalInput from "../shared/numerical_input";
 import { Button, Form, Input, Select } from "antd";
-import { ArrowLeftIcon, PencilAltIcon, TrashIcon } from "@heroicons/react/outline";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import UserSearchModal from "../common_components/user_search_modal";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
+import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import NotificationsManager from "../molecules/notifications_manager";
 import {
   Member,
   Organization,
   organizationInfoCall,
   organizationMemberAddCall,
-  organizationMemberUpdateCall,
   organizationMemberDeleteCall,
+  organizationMemberUpdateCall,
   organizationUpdateCall,
 } from "../networking";
-import UserSearchModal from "../common_components/user_search_modal";
-import MemberModal from "../team/edit_membership";
 import ObjectPermissionsView from "../object_permissions_view";
+import NumericalInput from "../shared/numerical_input";
+import MemberModal from "../team/edit_membership";
 import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
-import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
-import { copyToClipboard as utilCopyToClipboard, formatNumberWithCommas } from "@/utils/dataUtils";
-import { CheckIcon, CopyIcon } from "lucide-react";
-import NotificationsManager from "../molecules/notifications_manager";
 
 interface OrganizationInfoProps {
   organizationId: string;
@@ -492,7 +492,9 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 
                   <div className="sticky z-10 bg-white p-4 border-t border-gray-200 bottom-[-1.5rem] inset-x-[-1.5rem]">
                     <div className="flex justify-end items-center gap-2">
-                      <Button onClick={() => setIsEditing(false)}>Cancel</Button>
+                      <TremorButton variant="secondary" onClick={() => setIsEditing(false)}>
+                        Cancel
+                      </TremorButton>
                       <TremorButton type="submit">Save Changes</TremorButton>
                     </div>
                   </div>

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -14,7 +14,6 @@ import { getProviderLogoAndName } from "./provider_info_helpers";
 import Navbar from "./navbar";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import NotificationsManager from "./molecules/notifications_manager";
-// Simple approach without react-markdown dependency
 
 interface ModelGroupInfo {
   model_group: string;

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -1,6 +1,6 @@
 import GuardrailSelector from "@/components/guardrails/GuardrailSelector";
 import { TextInput, Button as TremorButton } from "@tremor/react";
-import { Button as AntdButton, Form, Input, Select, Tooltip } from "antd";
+import { Form, Input, Select, Tooltip } from "antd";
 import { useEffect, useState } from "react";
 import { mapInternalToDisplayNames } from "../callback_info_helpers";
 import KeyLifecycleSettings from "../common_components/KeyLifecycleSettings";
@@ -548,7 +548,9 @@ export function KeyEditView({
 
       <div className="sticky z-10 bg-white p-4 border-t border-gray-200 bottom-[-1.5rem] inset-x-[-1.5rem]">
         <div className="flex justify-end items-center gap-2">
-          <AntdButton onClick={onCancel}>Cancel</AntdButton>
+          <TremorButton variant="secondary" onClick={onCancel}>
+            Cancel
+          </TremorButton>
           <TremorButton type="submit">Save Changes</TremorButton>
         </div>
       </div>

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -545,9 +545,7 @@ export default function KeyInfoView({
               <div className="flex justify-between items-center mb-4">
                 <Title>Key Settings</Title>
                 {!isEditing && userRole && rolesWithWriteAccess.includes(userRole) && (
-                  <Button variant="light" onClick={() => setIsEditing(true)}>
-                    Edit Settings
-                  </Button>
+                  <Button onClick={() => setIsEditing(true)}>Edit Settings</Button>
                 )}
               </div>
 

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import UserInfoView from "./user_info_view";
+
+vi.mock("../networking", () => {
+  const MOCK_USER_DATA = {
+    user_id: "user-123",
+    user_info: {
+      user_email: "test@example.com",
+      user_role: "admin",
+      teams: [],
+      models: [],
+      max_budget: 100,
+      budget_duration: "30d",
+      spend: 0,
+      metadata: {},
+      created_at: "2025-01-01T00:00:00.000Z",
+      updated_at: "2025-01-02T00:00:00.000Z",
+    },
+    keys: [],
+    teams: [],
+  };
+
+  return {
+    userInfoCall: vi.fn().mockResolvedValue(MOCK_USER_DATA),
+    userDeleteCall: vi.fn(),
+    userUpdateUserCall: vi.fn(),
+    modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+    invitationCreateCall: vi.fn(),
+    getProxyBaseUrl: () => "https://litellm.test",
+  };
+});
+
+describe("UserInfoView", () => {
+  const defaultProps = {
+    userId: "user-123",
+    onClose: vi.fn(),
+    accessToken: "test-token",
+    userRole: null,
+    possibleUIRoles: null,
+  };
+
+  it("renders loading state and then the user email", async () => {
+    const { getByText, findAllByText } = render(<UserInfoView {...defaultProps} />);
+
+    expect(getByText("Loading user data...")).toBeInTheDocument();
+
+    const emails = await findAllByText("test@example.com");
+    expect(emails.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -343,9 +343,7 @@ export default function UserInfoView({
               <div className="flex justify-between items-center mb-4">
                 <Title>User Settings</Title>
                 {!isEditing && userRole && rolesWithWriteAccess.includes(userRole) && (
-                  <Button variant="light" onClick={() => setIsEditing(true)}>
-                    Edit Settings
-                  </Button>
+                  <Button onClick={() => setIsEditing(true)}>Edit Settings</Button>
                 )}
               </div>
 


### PR DESCRIPTION
## [Fix] UI - Button Styles and Sizing in Settings Pages

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

The Edit Settings buttons were different between various pages, this PR sets them all to the tremor primary button. The cancel button also used the antd button. This sets it to use Tremor's light variant for all the cancel buttons.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

## Screenshot
<img width="1589" height="179" alt="image" src="https://github.com/user-attachments/assets/e0232aee-b4f2-48f8-ad44-8ee93183304b" />

<img width="303" height="112" alt="image" src="https://github.com/user-attachments/assets/a5f6222f-66fd-4ab9-94c9-6ceb7b30b564" />

<img width="677" height="203" alt="image" src="https://github.com/user-attachments/assets/2601cee8-b15a-4278-8e72-bc7a65ef18f2" />


