### PR TITLE
fix: avoid crashing when MCP server record lacks credentials

### DIFF
--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -68,7 +68,9 @@ if MCP_AVAILABLE:
         except AttributeError:
             redacted_server = mcp_server.copy(deep=True)  # type: ignore[attr-defined]
 
-        redacted_server.credentials = None
+        if hasattr(redacted_server, "credentials"):
+            setattr(redacted_server, "credentials", None)
+
         return redacted_server
 
     def _redact_mcp_credentials_list(


### PR DESCRIPTION
## Title

avoid crashing when MCP server record lacks credentials

## Relevant issues

#16308

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

Fix the issue that occurs when the `credentials` field is missing.

```
INFO:     127.0.0.1:60150 - "POST /v1/mcp/server HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 186, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ~~~~~~~~~~~~~~~~~~~~~~~^^
  |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 685, in __aexit__
  |     raise BaseExceptionGroup(
  |         "unhandled errors in a TaskGroup", self._exceptions
  |     )
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         self.scope, self.receive, self.send
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     )
    |     ^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/applications.py", line 1134, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/applications.py", line 112, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 187, in __call__
    |     raise exc
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 165, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 185, in __call__
    |     with collapse_excgroups():
    |          ~~~~~~~~~~~~~~~~~~^^
    |   File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py", line 162, in __exit__
    |     self.gen.throw(value)
    |     ~~~~~~~~~~~~~~^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 187, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/middleware/prometheus_auth_middleware.py", line 47, in dispatch
    |     response = await call_next(request)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 163, in call_next
    |     raise app_exc
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 149, in coro
    |     await self.app(scope, receive_or_disconnect, send_no_error)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/cors.py", line 93, in __call__
    |     await self.simple_response(scope, receive, send, request_headers=headers)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/cors.py", line 144, in simple_response
    |     await self.app(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    |     await self.app(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 715, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 735, in app
    |     await route.handle(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 288, in handle
    |     await self.app(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 124, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 110, in app
    |     response = await f(request)
    |                ^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 390, in app
    |     raw_response = await run_endpoint_function(
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     ...<3 lines>...
    |     )
    |     ^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 289, in run_endpoint_function
    |     return await dependant.call(**values)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_helpers/utils.py", line 455, in wrapper
    |     raise e
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_helpers/utils.py", line 371, in wrapper
    |     result = await func(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_endpoints/mcp_management_endpoints.py", line 450, in add_mcp_server
    |     return _redact_mcp_credentials(new_mcp_server)
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_endpoints/mcp_management_endpoints.py", line 71, in _redact_mcp_credentials
    |     redacted_server.credentials = None
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/pydantic/main.py", line 925, in __setattr__
    |     raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
    | ValueError: "LiteLLM_MCPServerTable" object has no field "credentials"
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/applications.py", line 1134, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 185, in __call__
    with collapse_excgroups():
         ~~~~~~~~~~~~~~~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 187, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/middleware/prometheus_auth_middleware.py", line 47, in dispatch
    response = await call_next(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 163, in call_next
    raise app_exc
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 149, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/cors.py", line 93, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/cors.py", line 144, in simple_response
    await self.app(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 124, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 110, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 390, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 289, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_helpers/utils.py", line 455, in wrapper
    raise e
  File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_helpers/utils.py", line 371, in wrapper
    result = await func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_endpoints/mcp_management_endpoints.py", line 450, in add_mcp_server
    return _redact_mcp_credentials(new_mcp_server)
  File "/Users/yutasaito/dev/oss/litellm/litellm/litellm/proxy/management_endpoints/mcp_management_endpoints.py", line 71, in _redact_mcp_credentials
    redacted_server.credentials = None
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yutasaito/dev/oss/litellm/litellm/.venv/lib/python3.13/site-packages/pydantic/main.py", line 925, in __setattr__
    raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
ValueError: "LiteLLM_MCPServerTable" object has no field "credentials"
```
