### PR TITLE
[Feature] Pagination for /spend/logs/session/ui endpoint

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2968,10 +2968,30 @@ async def ui_view_session_spend_logs(
     session_id: str = fastapi.Query(
         description="Get all spend logs for a particular session",
     ),
+    page: int = fastapi.Query(
+        default=1,
+        ge=1,
+        description="Page number for pagination",
+    ),
+    page_size: int = fastapi.Query(
+        default=50,
+        ge=1,
+        le=100,
+        description="Number of items per page",
+    ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
-    Get all spend logs for a particular session
+    Get paginated spend logs for a particular session.
+
+    Returns:
+        {
+            "data": List[LiteLLM_SpendLogs],
+            "total": int,
+            "page": int,
+            "page_size": int,
+            "total_pages": int,
+        }
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -2984,11 +3004,32 @@ async def ui_view_session_spend_logs(
 
         # Build query conditions
         where_conditions = {"session_id": session_id}
-        # Query the database
-        result = await prisma_client.db.litellm_spendlogs.find_many(
-            where=where_conditions, order={"startTime": "asc"}
+
+        # Calculate pagination offsets
+        skip = (page - 1) * page_size
+
+        # Get total count for pagination metadata
+        total_records = await prisma_client.db.litellm_spendlogs.count(
+            where=where_conditions
         )
-        return result
+
+        # Query the database with pagination
+        result = await prisma_client.db.litellm_spendlogs.find_many(
+            where=where_conditions,
+            order={"startTime": "asc"},
+            skip=skip,
+            take=page_size,
+        )
+
+        total_pages = (total_records + page_size - 1) // page_size
+
+        return {
+            "data": result,
+            "total": total_records,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+        }
     except Exception as e:
         if isinstance(e, HTTPException):
             raise e


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixes #16131 

This is caused by the endpoint returning the entire query without pagination. Too many logs will crash the ui. I added pagination to this endpoint. UI changes pending, but the default pagination values should fit most use cases

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## Screenshot
<img width="682" height="263" alt="image" src="https://github.com/user-attachments/assets/3f8669e2-74a3-43b5-a999-8c22e85bc9c7" />

<img width="1074" height="694" alt="image" src="https://github.com/user-attachments/assets/64e226c0-e927-4ad7-a86b-2183bec8bbc2" />

