### PR TITLE
fix: forward OpenAI organization for image generation

### DIFF
--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -400,6 +400,8 @@ def image_generation(  # noqa: PLR0915
             or custom_llm_provider == LlmProviders.LITELLM_PROXY.value
             or custom_llm_provider in litellm.openai_compatible_providers
         ):
+            # Forward OpenAI organization if present (set by proxy pre-call utils)
+            organization: Optional[str] = kwargs.get("organization", None)
             model_response = openai_chat_completions.image_generation(
                 model=model,
                 prompt=prompt,
@@ -409,6 +411,7 @@ def image_generation(  # noqa: PLR0915
                 logging_obj=litellm_logging_obj,
                 optional_params=optional_params,
                 model_response=model_response,
+                organization=organization,
                 aimg_generation=aimg_generation,
                 client=client,
             )

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1285,6 +1285,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         api_base: Optional[str] = None,
         client=None,
         max_retries=None,
+        organization: Optional[str] = None,
     ):
         response = None
         try:
@@ -1294,6 +1295,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 api_base=api_base,
                 timeout=timeout,
                 max_retries=max_retries,
+                organization=organization,
                 client=client,
             )
 
@@ -1328,6 +1330,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         model_response: Optional[ImageResponse] = None,
         client=None,
         aimg_generation=None,
+        organization: Optional[str] = None,
     ) -> ImageResponse:
         data = {}
         try:
@@ -1337,7 +1340,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 raise OpenAIError(status_code=422, message="max retries must be an int")
 
             if aimg_generation is True:
-                return self.aimage_generation(data=data, prompt=prompt, logging_obj=logging_obj, model_response=model_response, api_base=api_base, api_key=api_key, timeout=timeout, client=client, max_retries=max_retries)  # type: ignore
+                return self.aimage_generation(data=data, prompt=prompt, logging_obj=logging_obj, model_response=model_response, api_base=api_base, api_key=api_key, timeout=timeout, client=client, max_retries=max_retries, organization=organization)  # type: ignore
 
             openai_client: OpenAI = self._get_openai_client(  # type: ignore
                 is_async=False,
@@ -1345,6 +1348,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 api_base=api_base,
                 timeout=timeout,
                 max_retries=max_retries,
+                organization=organization,
                 client=client,
             )
 


### PR DESCRIPTION
## Title

Fix: Forward OpenAI Organization for Image Generation

## Relevant issues

- N/A — aligns /v1/images/generations with existing Chat/Responses org forwarding

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
  - litellm/images/main.py
      - Forward organization from kwargs to the OpenAI image generation handler for OpenAI-compatible providers.
  - litellm/llms/openai/openai.py
      - Add organization: Optional[str] to image_generation and aimage_generation.
      - Pass organization into _get_openai_client in both sync and async paths; include when delegating to async variant.
  - tests/llm_translation/test_openai.py
      - Add unit test test_openai_image_generation_forwards_organization to assert organization is forwarded to the OpenAI client factory.

  Note:
  - Chat/Responses already forwarded organization; this brings Images in line.
  - Organization is treated as an OpenAI client parameter (header), not a provider-specific body param; it’s excluded from optional provider kwargs.
  - No impact on non-OpenAI providers; signatures remain backward compatible.
<img width="966" height="78" alt="Screenshot 2025-11-13 at 2 56 51 PM" src="https://github.com/user-attachments/assets/f7d917e0-6abb-46cc-b3da-732c6247fac1" />
