### PR TITLE
[Fix] UI - Remove Description Field from LLM Credentials

### DIFF
--- a/ui/litellm-dashboard/src/components/model_add/credentials.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.test.tsx
@@ -1,0 +1,50 @@
+import { CredentialItem } from "@/components/networking";
+import { render, waitFor } from "@testing-library/react";
+import { UploadProps } from "antd/es/upload";
+import { describe, expect, it, vi } from "vitest";
+import CredentialsPanel from "./credentials";
+
+const DEFAULT_UPLOAD_PROPS = {} as UploadProps;
+
+describe("CredentialsPanel", () => {
+  it("renders without crashing and fetches credentials when token exists", async () => {
+    const fetchCredentials = vi.fn(() => Promise.resolve());
+
+    const { getByRole, getByText } = render(
+      <CredentialsPanel
+        accessToken="test-token"
+        uploadProps={DEFAULT_UPLOAD_PROPS}
+        credentialList={[]}
+        fetchCredentials={fetchCredentials}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole("button", { name: /add credential/i })).toBeInTheDocument();
+      expect(getByText("Credential Name")).toBeInTheDocument();
+      expect(getByText("Provider")).toBeInTheDocument();
+    });
+  });
+
+  it("displays provided credentials and still calls the fetch helper", async () => {
+    const fetchCredentials = vi.fn(() => Promise.resolve());
+    const credentials: CredentialItem[] = [
+      {
+        credential_name: "openai-key",
+        credential_values: {},
+        credential_info: { custom_llm_provider: "openai" },
+      },
+    ];
+
+    const { getByText } = render(
+      <CredentialsPanel
+        accessToken="another-token"
+        uploadProps={DEFAULT_UPLOAD_PROPS}
+        credentialList={credentials}
+        fetchCredentials={fetchCredentials}
+      />,
+    );
+
+    await waitFor(() => expect(getByText("openai-key")).toBeInTheDocument());
+  });
+});

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -143,7 +143,6 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({
             <TableRow>
               <TableHeaderCell>Credential Name</TableHeaderCell>
               <TableHeaderCell>Provider</TableHeaderCell>
-              <TableHeaderCell>Description</TableHeaderCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -160,7 +159,6 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({
                   <TableCell>
                     {renderProviderBadge((credential.credential_info?.custom_llm_provider as string) || "-")}
                   </TableCell>
-                  <TableCell>{credential.credential_info?.description || "-"}</TableCell>
                   <TableCell>
                     <Button
                       icon={PencilAltIcon}


### PR DESCRIPTION
## [Fix] UI - Remove Description Field from LLM Credentials

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
At no point in credential creation / update do we have a description field for the credential. The UI displays a description field on the table, but it always falls back to "-". This removes the column entirely.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

## Screenshot
<img width="1622" height="490" alt="image" src="https://github.com/user-attachments/assets/042fccd1-6961-4a59-9704-57e0b092a2c8" />
<img width="672" height="252" alt="image" src="https://github.com/user-attachments/assets/a28cec03-11bf-4ccc-bf2d-e6173591422c" />

<img width="856" height="147" alt="image" src="https://github.com/user-attachments/assets/25355ac4-3b84-4351-8774-7fae047b80f2" />


