### PR TITLE
fix: clean arize-phoenix traces

### DIFF
--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -1,7 +1,6 @@
 import os
-from typing import TYPE_CHECKING, Any, Union
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional, Union
+from datetime import datetime
 
 from litellm._logging import verbose_logger
 from litellm.integrations.arize import _utils

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -134,34 +134,16 @@ class ArizePhoenixLogger(OpenTelemetry):
         pass  # suppress additional spans
 
     async def async_health_check(self):
-        """
-        Performs a health check for Arize integration.
 
-        Returns:
-            dict: Health check result with status and message
-        """
-        try:
-            # config = self.get_arize_phoenix_config()
+        config = self.get_arize_phoenix_config()
 
-            # if not config.space_key:
-            #     return {
-            #         "status": "unhealthy",
-            #         "error_message": "ARIZE_SPACE_KEY environment variable not set",
-            #     }
-
-            # if not config.api_key:
-            #     return {
-            #         "status": "unhealthy",
-            #         "error_message": "ARIZE_API_KEY environment variable not set",
-            #     }
-
-            return {
-                "status": "healthy",
-                "message": "Arize credentials are configured properly",
-            }
-
-        except Exception as e:
+        if not config.otlp_auth_headers:
             return {
                 "status": "unhealthy",
-                "error_message": f"Arize health check failed: {str(e)}",
+                "error_message": "PHOENIX_API_KEY environment variable not set",
             }
+
+        return {
+            "status": "healthy",
+            "message": "Arize-Phoenix credentials are configured properly",
+        }

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -113,8 +113,7 @@ class ArizePhoenixLogger(OpenTelemetry):
         end_time: Optional[Union[datetime, float]] = None,
         event_metadata: Optional[dict] = None,
     ):
-        """Arize is used mainly for LLM I/O tracing, sending router+caching metrics adds bloat to arize logs"""
-        pass
+        pass  # suppress additional spans
 
     async def async_service_failure_hook(
         self,
@@ -125,16 +124,14 @@ class ArizePhoenixLogger(OpenTelemetry):
         end_time: Optional[Union[float, datetime]] = None,
         event_metadata: Optional[dict] = None,
     ):
-        """Arize is used mainly for LLM I/O tracing, sending router+caching metrics adds bloat to arize logs"""
-        pass
+        pass  # suppress additional spans
 
     def create_litellm_proxy_request_started_span(
         self,
         start_time: datetime,
         headers: dict,
     ):
-        """Arize is used mainly for LLM I/O tracing, sending Proxy Server Request adds bloat to arize logs"""
-        pass
+        pass  # suppress additional spans
 
     async def async_health_check(self):
         """

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -136,16 +136,6 @@ class ArizePhoenixLogger(OpenTelemetry):
         """Arize is used mainly for LLM I/O tracing, sending Proxy Server Request adds bloat to arize logs"""
         pass
 
-    # def log_success_event(self, kwargs, response_obj, start_time, end_time):
-    #     _, parent_span = self._get_span_context(kwargs)
-    #     if parent_span is not None:
-    #         parent_span.end(end_time=self._to_ns(datetime.now()))
-
-    # async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
-    #     _, parent_span = self._get_span_context(kwargs)
-    #     if parent_span is not None:
-    #         parent_span.end(end_time=self._to_ns(datetime.now()))
-
     async def async_health_check(self):
         """
         Performs a health check for Arize integration.

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1065,14 +1065,7 @@ class OpenTelemetry(CustomLogger):
         self, span: Span, kwargs, response_obj: Optional[Any]
     ):
         try:
-            if self.callback_name == "arize_phoenix":
-                from litellm.integrations.arize.arize_phoenix import ArizePhoenixLogger
-
-                ArizePhoenixLogger.set_arize_phoenix_attributes(
-                    span, kwargs, response_obj
-                )
-                return
-            elif self.callback_name == "langtrace":
+            if self.callback_name == "langtrace":
                 from litellm.integrations.langtrace import LangtraceAttributes
 
                 LangtraceAttributes().set_langtrace_attributes(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3600,11 +3600,11 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "arize_phoenix"
                 ):
                     return callback  # type: ignore
-            _arize_phoenix_otel_logger = ArizePhoenixLogger(
+            _otel_logger = ArizePhoenixLogger(
                 config=otel_config, callback_name="arize_phoenix"
             )
-            _in_memory_loggers.append(_arize_phoenix_otel_logger)
-            return _arize_phoenix_otel_logger  # type: ignore
+            _in_memory_loggers.append(_otel_logger)
+            return _otel_logger  # type: ignore
         elif logging_integration == "otel":
             from litellm.integrations.opentelemetry import OpenTelemetry
 
@@ -3660,9 +3660,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpenTelemetry):
                     return callback  # type: ignore
-            _arize_phoenix_otel_logger = OpenTelemetry(config=otel_config)
-            _in_memory_loggers.append(_arize_phoenix_otel_logger)
-            return _arize_phoenix_otel_logger  # type: ignore
+            _otel_logger = OpenTelemetry(config=otel_config)
+            _in_memory_loggers.append(_otel_logger)
+            return _otel_logger  # type: ignore
         elif logging_integration == "dynamic_rate_limiter":
             from litellm.proxy.hooks.dynamic_rate_limiter import (
                 _PROXY_DynamicRateLimitHandler,
@@ -3733,9 +3733,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "langtrace"
                 ):
                     return callback  # type: ignore
-            _arize_phoenix_otel_logger = OpenTelemetry(config=otel_config, callback_name="langtrace")
-            _in_memory_loggers.append(_arize_phoenix_otel_logger)
-            return _arize_phoenix_otel_logger  # type: ignore
+            _otel_logger = OpenTelemetry(config=otel_config, callback_name="langtrace")
+            _in_memory_loggers.append(_otel_logger)
+            return _otel_logger  # type: ignore
 
         elif logging_integration == "mlflow":
             for callback in _in_memory_loggers:
@@ -3774,11 +3774,11 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "langfuse_otel"
                 ):
                     return callback  # type: ignore
-            _arize_phoenix_otel_logger = LangfuseOtelLogger(
+            _otel_logger = LangfuseOtelLogger(
                 config=otel_config, callback_name="langfuse_otel"
             )
-            _in_memory_loggers.append(_arize_phoenix_otel_logger)
-            return _arize_phoenix_otel_logger  # type: ignore
+            _in_memory_loggers.append(_otel_logger)
+            return _otel_logger  # type: ignore
         elif logging_integration == "pagerduty":
             for callback in _in_memory_loggers:
                 if isinstance(callback, PagerDutyAlerting):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3600,11 +3600,11 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "arize_phoenix"
                 ):
                     return callback  # type: ignore
-            _otel_logger = ArizePhoenixLogger(
+            _arize_phoenix_otel_logger = ArizePhoenixLogger(
                 config=otel_config, callback_name="arize_phoenix"
             )
-            _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            _in_memory_loggers.append(_arize_phoenix_otel_logger)
+            return _arize_phoenix_otel_logger  # type: ignore
         elif logging_integration == "otel":
             from litellm.integrations.opentelemetry import OpenTelemetry
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3596,15 +3596,15 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
 
             for callback in _in_memory_loggers:
                 if (
-                    isinstance(callback, OpenTelemetry)
+                    isinstance(callback, ArizePhoenixLogger)
                     and callback.callback_name == "arize_phoenix"
                 ):
                     return callback  # type: ignore
-            _otel_logger = OpenTelemetry(
+            _arize_phoenix_otel_logger = ArizePhoenixLogger(
                 config=otel_config, callback_name="arize_phoenix"
             )
-            _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            _in_memory_loggers.append(_arize_phoenix_otel_logger)
+            return _arize_phoenix_otel_logger  # type: ignore
         elif logging_integration == "otel":
             from litellm.integrations.opentelemetry import OpenTelemetry
 
@@ -3660,9 +3660,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpenTelemetry):
                     return callback  # type: ignore
-            _otel_logger = OpenTelemetry(config=otel_config)
-            _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            _arize_phoenix_otel_logger = OpenTelemetry(config=otel_config)
+            _in_memory_loggers.append(_arize_phoenix_otel_logger)
+            return _arize_phoenix_otel_logger  # type: ignore
         elif logging_integration == "dynamic_rate_limiter":
             from litellm.proxy.hooks.dynamic_rate_limiter import (
                 _PROXY_DynamicRateLimitHandler,
@@ -3733,9 +3733,9 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "langtrace"
                 ):
                     return callback  # type: ignore
-            _otel_logger = OpenTelemetry(config=otel_config, callback_name="langtrace")
-            _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            _arize_phoenix_otel_logger = OpenTelemetry(config=otel_config, callback_name="langtrace")
+            _in_memory_loggers.append(_arize_phoenix_otel_logger)
+            return _arize_phoenix_otel_logger  # type: ignore
 
         elif logging_integration == "mlflow":
             for callback in _in_memory_loggers:
@@ -3774,11 +3774,11 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
                     and callback.callback_name == "langfuse_otel"
                 ):
                     return callback  # type: ignore
-            _otel_logger = LangfuseOtelLogger(
+            _arize_phoenix_otel_logger = LangfuseOtelLogger(
                 config=otel_config, callback_name="langfuse_otel"
             )
-            _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            _in_memory_loggers.append(_arize_phoenix_otel_logger)
+            return _arize_phoenix_otel_logger  # type: ignore
         elif logging_integration == "pagerduty":
             for callback in _in_memory_loggers:
                 if isinstance(callback, PagerDutyAlerting):


### PR DESCRIPTION
## Clean Arize-Phoenix traces

Previously, non-OpenInference spans were being emitted by the proxy server. Some of these spans have start time timestamps at the start of the epoch, which throws off our time range filtering. Most of our users care about the spans that are relevant to the LLM call, not other spans.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

