### PR TITLE
Add bytedance and ideogram support in fal ai

### DIFF
--- a/docs/my-website/docs/providers/fal_ai.md
+++ b/docs/my-website/docs/providers/fal_ai.md
@@ -32,9 +32,12 @@ Get your API key from [fal.ai](https://fal.ai/).
 | Model Name | Description | Documentation |
 |------------|-------------|---------------|
 | `fal_ai/flux/schnell` | Flux Schnell - Low-latency generation with `image_size` support | [Docs ↗](https://fal.ai/models/fal-ai/flux/schnell) |
+| `fal_ai/fal-ai/bytedance/seedream/v3/text-to-image` | ByteDance Seedream v3 - Text-to-image with `image_size` control | [Docs ↗](https://fal.ai/models/fal-ai/bytedance/seedream/v3/text-to-image) |
+| `fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image` | ByteDance Dreamina v3.1 - Text-to-image with `image_size` control | [Docs ↗](https://fal.ai/models/fal-ai/bytedance/dreamina/v3.1/text-to-image) |
 | `fal_ai/fal-ai/flux-pro/v1.1-ultra` | FLUX Pro v1.1 Ultra - High-quality image generation | [Docs ↗](https://fal.ai/models/fal-ai/flux-pro/v1.1-ultra) |
 | `fal_ai/fal-ai/imagen4/preview` | Google's Imagen 4 - Highest quality model | [Docs ↗](https://fal.ai/models/fal-ai/imagen4/preview) |
 | `fal_ai/fal-ai/recraft/v3/text-to-image` | Recraft v3 - Multiple style options | [Docs ↗](https://fal.ai/models/fal-ai/recraft/v3/text-to-image) |
+| `fal_ai/fal-ai/ideogram/v3` | Ideogram v3 - Lettering-first creative model (Balanced: $0.06/image) | [Docs ↗](https://fal.ai/models/fal-ai/ideogram/v3) |
 | `fal_ai/fal-ai/stable-diffusion-v35-medium` | Stable Diffusion v3.5 Medium | [Docs ↗](https://fal.ai/models/fal-ai/stable-diffusion-v35-medium) |
 | `fal_ai/bria/text-to-image/3.2` | Bria 3.2 - Commercial-grade generation | [Docs ↗](https://fal.ai/models/bria/text-to-image/3.2) |
 

--- a/litellm/llms/fal_ai/image_generation/__init__.py
+++ b/litellm/llms/fal_ai/image_generation/__init__.py
@@ -7,8 +7,13 @@ from .flux_pro_v11_ultra_transformation import FalAIFluxProV11UltraConfig
 from .flux_schnell_transformation import FalAIFluxSchnellConfig
 from .imagen4_transformation import FalAIImagen4Config
 from .recraft_v3_transformation import FalAIRecraftV3Config
+from .ideogram_v3_transformation import FalAIIdeogramV3Config
 from .stable_diffusion_transformation import FalAIStableDiffusionConfig
 from .transformation import FalAIBaseConfig, FalAIImageGenerationConfig
+from .bytedance_transformation import (
+    FalAIBytedanceSeedreamV3Config,
+    FalAIBytedanceDreaminaV31Config,
+)
 
 __all__ = [
     "FalAIBaseConfig",
@@ -19,6 +24,9 @@ __all__ = [
     "FalAIFluxProV11UltraConfig",
     "FalAIFluxSchnellConfig",
     "FalAIStableDiffusionConfig",
+    "FalAIBytedanceSeedreamV3Config",
+    "FalAIBytedanceDreaminaV31Config",
+    "FalAIIdeogramV3Config",
 ]
 
 
@@ -45,6 +53,12 @@ def get_fal_ai_image_generation_config(model: str) -> BaseImageGenerationConfig:
         return FalAIFluxProV11UltraConfig()
     elif "flux/schnell" in model_lower or "flux-schnell" in model_lower or "schnell" in model_lower:
         return FalAIFluxSchnellConfig()
+    elif "bytedance/seedream" in model_lower:
+        return FalAIBytedanceSeedreamV3Config()
+    elif "bytedance/dreamina" in model_lower:
+        return FalAIBytedanceDreaminaV31Config()
+    elif "ideogram" in model_lower:
+        return FalAIIdeogramV3Config()
     elif "stable-diffusion" in model_lower:
         return FalAIStableDiffusionConfig()
     

--- a/litellm/llms/fal_ai/image_generation/bytedance_transformation.py
+++ b/litellm/llms/fal_ai/image_generation/bytedance_transformation.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+from .flux_pro_v11_ultra_transformation import FalAIFluxProV11UltraConfig
+
+
+class FalAIBytedanceBaseConfig(FalAIFluxProV11UltraConfig):
+    """
+    Shared configuration for Fal AI ByteDance text-to-image models that follow
+    the Flux Schnell style parameter mapping.
+
+    These models accept the OpenAI-compatible `size` parameter in LiteLLM
+    requests but expect `image_size` enums or custom size objects on Fal AI.
+    """
+
+    _OPENAI_SIZE_TO_IMAGE_SIZE = {
+        "1024x1024": "square_hd",
+        "512x512": "square",
+        "1792x1024": "landscape_16_9",
+        "1024x1792": "portrait_16_9",
+        "1024x768": "landscape_4_3",
+        "768x1024": "portrait_4_3",
+    }
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+
+        param_mapping = {
+            "n": "num_images",
+            "response_format": "output_format",
+            "size": "image_size",
+        }
+
+        for k in non_default_params.keys():
+            if k not in optional_params.keys():
+                if k in supported_params:
+                    mapped_key = param_mapping.get(k, k)
+                    mapped_value = non_default_params[k]
+
+                    if k == "response_format":
+                        if mapped_value in ["b64_json", "url"]:
+                            mapped_value = "jpeg"
+                    elif k == "size":
+                        mapped_value = self._map_image_size(mapped_value)
+
+                    optional_params[mapped_key] = mapped_value
+                elif drop_params:
+                    continue
+                else:
+                    raise ValueError(
+                        f"Parameter {k} is not supported for model {model}. "
+                        f"Supported parameters are {supported_params}. "
+                        "Set drop_params=True to drop unsupported parameters."
+                    )
+
+        return optional_params
+
+    def _map_image_size(self, size: Any) -> Any:
+        if isinstance(size, dict):
+            return size
+
+        if not isinstance(size, str):
+            return size
+
+        if size in self._OPENAI_SIZE_TO_IMAGE_SIZE:
+            return self._OPENAI_SIZE_TO_IMAGE_SIZE[size]
+
+        if "x" in size:
+            try:
+                width_str, height_str = size.split("x")
+                width = int(width_str)
+                height = int(height_str)
+                return {"width": width, "height": height}
+            except (ValueError, AttributeError, ZeroDivisionError):
+                pass
+
+        return "landscape_4_3"
+
+
+class FalAIBytedanceSeedreamV3Config(FalAIBytedanceBaseConfig):
+    """
+    Configuration for Fal AI ByteDance Seedream v3 text-to-image model.
+
+    Model endpoint: fal-ai/bytedance/seedream/v3/text-to-image
+    Documentation: https://fal.ai/models/fal-ai/bytedance/seedream/v3/text-to-image
+    """
+
+    IMAGE_GENERATION_ENDPOINT: str = "fal-ai/bytedance/seedream/v3/text-to-image"
+
+
+class FalAIBytedanceDreaminaV31Config(FalAIBytedanceBaseConfig):
+    """
+    Configuration for Fal AI ByteDance Dreamina v3.1 text-to-image model.
+
+    Model endpoint: fal-ai/bytedance/dreamina/v3.1/text-to-image
+    Documentation: https://fal.ai/models/fal-ai/bytedance/dreamina/v3.1/text-to-image
+    """
+
+    IMAGE_GENERATION_ENDPOINT: str = "fal-ai/bytedance/dreamina/v3.1/text-to-image"
+
+

--- a/litellm/llms/fal_ai/image_generation/ideogram_v3_transformation.py
+++ b/litellm/llms/fal_ai/image_generation/ideogram_v3_transformation.py
@@ -1,0 +1,193 @@
+from typing import TYPE_CHECKING, Any, List, Optional
+
+import httpx
+
+from litellm.types.llms.openai import OpenAIImageGenerationOptionalParams
+from litellm.types.utils import ImageObject, ImageResponse
+
+from .transformation import FalAIBaseConfig
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+class FalAIIdeogramV3Config(FalAIBaseConfig):
+    """
+    Configuration for fal-ai/ideogram/v3 image generation.
+
+    The Ideogram v3 endpoint exposes multiple generation modes (text-to-image,
+    remixing, reframing, background replacement, character workflows, etc.).
+    LiteLLM focuses on the text-to-image interface to maintain OpenAI parity.
+
+    Model endpoint: fal-ai/ideogram/v3
+    Documentation: https://fal.ai/models/fal-ai/ideogram/v3
+    """
+
+    IMAGE_GENERATION_ENDPOINT: str = "fal-ai/ideogram/v3"
+
+    _OPENAI_SIZE_TO_IMAGE_SIZE = {
+        "1024x1024": "square_hd",
+        "512x512": "square",
+        "1024x768": "landscape_4_3",
+        "768x1024": "portrait_4_3",
+        "1536x1024": "landscape_16_9",
+        "1024x1536": "portrait_16_9",
+    }
+
+    def get_supported_openai_params(
+        self, model: str
+    ) -> List[OpenAIImageGenerationOptionalParams]:
+        """
+        Ideogram v3 accepts the core OpenAI image parameters.
+        """
+
+        return [
+            "n",
+            "response_format",
+            "size",
+        ]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Map OpenAI-style parameters onto Ideogram's request schema.
+        """
+
+        supported_params = self.get_supported_openai_params(model)
+
+        for k in non_default_params.keys():
+            if k in optional_params:
+                continue
+
+            if k not in supported_params:
+                if drop_params:
+                    continue
+                raise ValueError(
+                    f"Parameter {k} is not supported for model {model}. "
+                    f"Supported parameters are {supported_params}. "
+                    "Set drop_params=True to drop unsupported parameters."
+                )
+
+            value = non_default_params[k]
+
+            if k == "n":
+                optional_params["num_images"] = value
+            elif k == "size":
+                optional_params["image_size"] = self._map_image_size(value)
+            elif k == "response_format":
+                # Ideogram always returns URLs; nothing to map but don't error.
+                continue
+
+        return optional_params
+
+    def _map_image_size(self, size: Any) -> Any:
+        if isinstance(size, dict):
+            width = size.get("width")
+            height = size.get("height")
+            if isinstance(width, int) and isinstance(height, int):
+                return {"width": width, "height": height}
+            return size
+
+        if not isinstance(size, str):
+            return size
+
+        normalized = size.strip()
+        if normalized in self._OPENAI_SIZE_TO_IMAGE_SIZE:
+            return self._OPENAI_SIZE_TO_IMAGE_SIZE[normalized]
+
+        if "x" in normalized:
+            try:
+                width_str, height_str = normalized.split("x")
+                width = int(width_str)
+                height = int(height_str)
+                return {"width": width, "height": height}
+            except (ValueError, AttributeError):
+                pass
+
+        # Fallback to a safe default that Ideogram accepts.
+        return "square_hd"
+
+    def transform_image_generation_request(
+        self,
+        model: str,
+        prompt: str,
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        """
+        Construct the request payload for Ideogram v3.
+
+        Required:
+            - prompt: text prompt describing the scene.
+
+        Optional (subset):
+            - rendering_speed, style_preset, style, style_codes, color_palette,
+              image_urls, style_reference_images, expand_prompt, seed,
+              negative_prompt, image_size, etc.
+        """
+
+        return {
+            "prompt": prompt,
+            **optional_params,
+        }
+
+    def transform_image_generation_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ImageResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+        encoding: Any,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ImageResponse:
+        """
+        Parse Ideogram v3 responses which contain a list of File objects.
+        """
+
+        try:
+            response_data = raw_response.json()
+        except Exception as e:
+            raise self.get_error_class(
+                error_message=f"Error transforming image generation response: {e}",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if not model_response.data:
+            model_response.data = []
+
+        images = response_data.get("images", [])
+        if isinstance(images, list):
+            for image_entry in images:
+                if isinstance(image_entry, dict):
+                    url = image_entry.get("url")
+                else:
+                    url = image_entry
+
+                model_response.data.append(
+                    ImageObject(
+                        url=url,
+                        b64_json=None,
+                    )
+                )
+
+        if hasattr(model_response, "_hidden_params") and "seed" in response_data:
+            model_response._hidden_params["seed"] = response_data["seed"]
+
+        return model_response
+
+

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8531,6 +8531,30 @@
             "/v1/images/generations"
         ]
     },
+    "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "fal_ai/fal-ai/ideogram/v3": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "fal_ai/fal-ai/imagen4/preview": {
         "litellm_provider": "fal_ai",
         "mode": "image_generation",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8531,6 +8531,30 @@
             "/v1/images/generations"
         ]
     },
+    "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.03,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
+    "fal_ai/fal-ai/ideogram/v3": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.06,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
+    },
     "fal_ai/fal-ai/imagen4/preview": {
         "litellm_provider": "fal_ai",
         "mode": "image_generation",

--- a/tests/image_gen_tests/test_fal_ai_image_generation.py
+++ b/tests/image_gen_tests/test_fal_ai_image_generation.py
@@ -15,7 +15,10 @@ from litellm import aimage_generation
     [
         "fal_ai/fal-ai/flux-pro/v1.1-ultra",
         "fal_ai/fal-ai/flux/schnell",
+        "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image",
+        "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image",
         "fal_ai/fal-ai/recraft/v3/text-to-image",
+        "fal_ai/fal-ai/ideogram/v3",
         "fal_ai/bria/text-to-image/3.2",
         "fal_ai/fal-ai/stable-diffusion-v35-medium"
     ],


### PR DESCRIPTION
## Title

Add bytedance and ideogram support in fal ai

## Relevant issues

Fixes LIT-1433

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature

## Changes
Added support for bytedance and ideogram in fal ai

**Testing**
1. fal-ai/bytedance/seedream/v3/text-to-image 
<img width="2462" height="1548" alt="image" src="https://github.com/user-attachments/assets/49c1fdb7-2a1b-4827-ad0f-093324c7d064" />
2. fal-ai/ideogram/v3
<img width="2462" height="1548" alt="image" src="https://github.com/user-attachments/assets/49e2e85c-abf7-4569-af9c-f21eac7c54f2" />
3. fal-ai/bytedance/dreamina/v3.1/text-to-image
<img width="1231" height="774" alt="image" src="https://github.com/user-attachments/assets/e414cff6-cab6-4f66-a748-784eb679a7af" />



