### PR TITLE
fix: preserve $defs for Anthropic tools input schema

### DIFF
--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -24,7 +24,7 @@ AnthropicInputSchema = TypedDict(
         "properties": Optional[dict],
         "additionalProperties": Optional[bool],
         "required": Optional[List[str]],
-        "$defs": Optional[Dict],   # allowed here
+        "$defs": Optional[Dict],
     },
     total=False,
 )

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -17,11 +17,17 @@ class AnthropicMessagesToolChoice(TypedDict, total=False):
     disable_parallel_tool_use: bool  # default is false
 
 
-class AnthropicInputSchema(TypedDict, total=False):
-    type: Optional[str]
-    properties: Optional[dict]
-    additionalProperties: Optional[bool]
-    required: Optional[List[str]]
+AnthropicInputSchema = TypedDict(
+    "AnthropicInputSchema",
+    {
+        "type": Optional[str],
+        "properties": Optional[dict],
+        "additionalProperties": Optional[bool],
+        "required": Optional[List[str]],
+        "$defs": Optional[Dict],   # allowed here
+    },
+    total=False,
+)
 
 
 class AnthropicMessagesTool(TypedDict, total=False):


### PR DESCRIPTION
## Fix: Preserve $defs for Anthropic tools input schema

## Relevant issues

Fixes [#13837](https://github.com/BerriAI/litellm/issues/13837)

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - No, they weren't even passing before my PR.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1395" height="208" alt="Screenshot 2025-11-14 at 15 23 20" src="https://github.com/user-attachments/assets/a89dda4c-10d6-4d1e-887e-f5f2985d2f67" />

## Type

🐛 Bug Fix

## Changes

- `litellm/types/llms/anthropic.py` - Changed `TypedDict` definition in order to keep the current `AnthropicInputSchema` usage, but with additional `$defs` key
- `tests/llm_translation/test_anthropic_completion.py` - Added a test case that covers Anthropic tools with nested objects as args

## Additional Notes

There is an existing PR (#14215) addressing this issue; however, it has not seen activity for a while and may be stale. This PR proposes a minimal and self-contained fix for the same problem. I’m happy to adjust or close this PR if maintainers would prefer to proceed with the original contribution.