### PR TITLE
Bugfix: Ensure detector-id is passed as header to IBM detector server

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
@@ -127,12 +127,8 @@ class IBMGuardrailDetector(CustomGuardrail):
         headers = {
             "Authorization": f"Bearer {self.auth_token}",
             "content-type": "application/json",
+            "detector-id": self.detector_id,
         }
-
-        query_params = {"detector_id": self.detector_id}
-
-        # update the api_url with the query params
-        self.api_url = f"{self.api_url}?{urlencode(query_params)}"
 
         verbose_proxy_logger.debug(
             "IBM Detector Server request to %s with payload: %s",

--- a/scripts/mock_ibm_guardrails_server.py
+++ b/scripts/mock_ibm_guardrails_server.py
@@ -234,8 +234,8 @@ async def root():
 
 @app.post("/api/v1/text/contents")
 async def text_detection(
-    detector_id: str,  # query parameter
     request: TextDetectionRequest,
+    detector_id: str = Header(None),  # query parameter
     authorization: Optional[str] = Header(None),
 ):
     """
@@ -243,6 +243,7 @@ async def text_detection(
 
     Args:
         request: Detection request with content and detector ID
+        detector_id: ID of detector
         authorization: Bearer token for authentication
 
     Returns:


### PR DESCRIPTION
## IBM Detector Parameter Fix
The IBM detector servers require "detector-id" to be passed as a header, not as a query parameter. This PR fixes that, and updates the test server accordingly. 


## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
- Pass`detector_id` to a header value to IBM detector servers, instead of as a query parameter

