### PR TITLE
fix(spend-logs): trim logged response strings

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -655,17 +655,10 @@ def _get_response_for_spend_logs_payload(
         if response_obj is None:
             return "{}"
 
-        parsed_response: Any = response_obj
-        if isinstance(response_obj, str):
-            try:
-                parsed_response = json.loads(response_obj)
-            except (TypeError, ValueError):
-                parsed_response = response_obj
-
         sanitized_wrapper = _sanitize_request_body_for_spend_logs_payload(
-            {"response": parsed_response}
+            {"response": response_obj}
         )
-        sanitized_response = sanitized_wrapper.get("response", parsed_response)
+        sanitized_response = sanitized_wrapper.get("response", response_obj)
 
         if sanitized_response is None:
             return "{}"

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -655,8 +655,6 @@ def _get_response_for_spend_logs_payload(
         if response_obj is None:
             return "{}"
 
-        # If the response is a JSON string, attempt to parse it so downstream
-        # consumers always get structured JSON instead of a double-encoded string.
         parsed_response: Any = response_obj
         if isinstance(response_obj, str):
             try:

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -651,7 +651,29 @@ def _get_response_for_spend_logs_payload(
     if payload is None:
         return "{}"
     if _should_store_prompts_and_responses_in_spend_logs():
-        return json.dumps(payload.get("response", {}))
+        response_obj: Any = payload.get("response")
+        if response_obj is None:
+            return "{}"
+
+        # If the response is a JSON string, attempt to parse it so downstream
+        # consumers always get structured JSON instead of a double-encoded string.
+        parsed_response: Any = response_obj
+        if isinstance(response_obj, str):
+            try:
+                parsed_response = json.loads(response_obj)
+            except (TypeError, ValueError):
+                parsed_response = response_obj
+
+        sanitized_wrapper = _sanitize_request_body_for_spend_logs_payload(
+            {"response": parsed_response}
+        )
+        sanitized_response = sanitized_wrapper.get("response", parsed_response)
+
+        if sanitized_response is None:
+            return "{}"
+        if isinstance(sanitized_response, str):
+            return sanitized_response
+        return safe_dumps(sanitized_response)
     return "{}"
 
 


### PR DESCRIPTION
## Title

fix(spend-logs): trim logged response strings

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- route spend-log responses through the existing string sanitizer so oversized fields are truncated before persistence
- add unit tests covering the truncation path

