### PR TITLE
[Feature] Add license info API to proxy server

### DIFF
--- a/litellm/proxy/management_endpoints/license_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/license_management_endpoints.py
@@ -71,7 +71,6 @@ async def get_license_info(
             return LicenseInfoResponse(
                 license_configured=False,
                 license_details={},
-                error=None,
             )
 
         license_details_dict = dict(premium_user_data)
@@ -83,11 +82,10 @@ async def get_license_info(
         return LicenseInfoResponse(
             license_configured=True,
             license_details=license_details_dict,
-            error=None,
         )
 
     except HTTPException:
         # Re-raise HTTP exceptions (like RBAC checks)
         raise
     except Exception as e:
-        handle_exception_on_proxy(e)
+        raise handle_exception_on_proxy(e)

--- a/litellm/proxy/management_endpoints/license_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/license_management_endpoints.py
@@ -1,0 +1,93 @@
+"""
+License-related endpoints for viewing enterprise license information.
+"""
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from fastapi import HTTPException, status
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+from litellm.proxy.utils import (
+    handle_exception_on_proxy,
+)
+router = APIRouter()
+
+
+class LicenseInfoResponse(BaseModel):
+    """Response model for license info endpoint"""
+    license_configured: bool = Field(
+        False,
+        description="Has the proxy been configured with a license key",
+    )
+    license_details: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="License details from EnterpriseLicenseData",
+    )
+
+@router.get(
+    "/license/info",
+    tags=["license management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=LicenseInfoResponse,
+)
+async def get_license_info(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> LicenseInfoResponse:
+    """
+    Get license information.
+    
+    Returns the license configuration status and details for the deployment.
+    """
+
+    try:
+        # RBAC check - only PROXY_ADMIN and PROXY_ADMIN_VIEW_ONLY can access
+        if user_api_key_dict.user_role not in [
+            LitellmUserRoles.PROXY_ADMIN,
+            LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
+        ]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": f"Only proxy admin users can access license information. Your role: {user_api_key_dict.user_role}"
+                },
+            )
+
+        from litellm.proxy.proxy_server import premium_user_data
+
+        verbose_proxy_logger.debug(
+            "litellm.proxy.management_endpoints.license_management_endpoints.get_license_info() - "
+            "Retrieving license information"
+        )
+
+        if premium_user_data is None:
+            verbose_proxy_logger.debug(
+                "No license configured - returning empty license_details"
+            )
+            return LicenseInfoResponse(
+                license_configured=False,
+                license_details={},
+                error=None,
+            )
+
+        license_details_dict = dict(premium_user_data)
+        verbose_proxy_logger.debug(
+            f"License configured - returning license details: "
+            f"license_id={premium_user_data.get('user_id')}"
+        )
+
+        return LicenseInfoResponse(
+            license_configured=True,
+            license_details=license_details_dict,
+            error=None,
+        )
+
+    except HTTPException:
+        # Re-raise HTTP exceptions (like RBAC checks)
+        raise
+    except Exception as e:
+        handle_exception_on_proxy(e)

--- a/litellm/proxy/management_endpoints/license_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/license_management_endpoints.py
@@ -2,7 +2,7 @@
 License-related endpoints for viewing enterprise license information.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -281,6 +281,9 @@ from litellm.proxy.management_endpoints.key_management_endpoints import (
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     router as key_management_router,
 )
+from litellm.proxy.management_endpoints.license_management_endpoints import (
+    router as license_management_router,
+)
 from litellm.proxy.management_endpoints.mcp_management_endpoints import (
     router as mcp_management_router,
 )
@@ -10085,6 +10088,7 @@ app.include_router(ui_crud_endpoints_router)
 app.include_router(openai_files_router)
 app.include_router(team_callback_router)
 app.include_router(budget_management_router)
+app.include_router(license_management_router)
 app.include_router(model_management_router)
 app.include_router(tag_management_router)
 app.include_router(cost_tracking_settings_router)

--- a/tests/test_litellm/proxy/management_endpoints/test_license_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_license_management_endpoints.py
@@ -1,0 +1,100 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy._types import LitellmUserRoles
+from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth, user_api_key_auth
+from litellm.proxy.proxy_server import app
+
+# Create TestClient for making HTTP requests
+client = TestClient(app)
+
+def mock_user_auth(user_role: LitellmUserRoles):
+    return UserAPIKeyAuth(
+        user_role=user_role,
+        api_key="sk-mock-user",
+        user_id="mock-user",
+    )
+
+class TestGetLicenseInfoHTTP:
+
+    @pytest.mark.asyncio
+    async def test_license_exists(self):
+
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY)
+
+        mock_premium_user_data = {
+            "user_id": "full-license-123",
+            "expiration_date": "2025-12-31",
+            "allowed_features": ["feature1", "feature2"],
+            "max_users": 100,
+            "max_teams": 50,
+        }
+
+        with patch(
+            "litellm.proxy.proxy_server.premium_user_data",
+            mock_premium_user_data,
+            create=True,
+        ):
+            response = client.get("/license/info")
+
+            assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+
+            body = response.json()
+            assert body["license_configured"] is True
+            assert body["license_details"]["user_id"] == "full-license-123"
+            assert body["license_details"]["expiration_date"] == "2025-12-31"
+            assert body["license_details"]["allowed_features"] == ["feature1", "feature2"]
+            assert body["license_details"]["max_users"] == 100
+            assert body["license_details"]["max_teams"] == 50
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_license_does_not_exist(self):
+
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY)
+
+        with patch(
+            "litellm.proxy.proxy_server.premium_user_data",
+            None,
+            create=True,
+        ):
+            response = client.get("/license/info")
+
+            assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+
+            body = response.json()
+            assert body["license_configured"] is False
+            assert body["license_details"] == {}
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_authorization(self):
+        await self._test_role_authorization(mock_user_auth(LitellmUserRoles.PROXY_ADMIN), 200)
+        await self._test_role_authorization(mock_user_auth(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY), 200)
+
+        await self._test_role_authorization(mock_user_auth(LitellmUserRoles.INTERNAL_USER), 403)
+        await self._test_role_authorization(mock_user_auth(LitellmUserRoles.INTERNAL_USER_VIEW_ONLY), 403)
+
+    async def _test_role_authorization(self, mock_user_auth, expected_status_code:int):
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+        with patch(
+                "litellm.proxy.proxy_server.premium_user_data",
+                {"user_id": "test-license"},
+                create=True,
+        ):
+            response = client.get("/license/info")
+
+            assert response.status_code == expected_status_code, f"Role={mock_user_auth.user_role} Expected {expected_status_code}, got {response.status_code}: {response.text}"
+
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Add license info API to proxy server

Add a license info API to proxy server. 

Users can use this API to build custom license automation workflows. For e.g a monitoring job that polls the info API and warns of imminent license expiry.

The API is a read-only and available only for admin/admin_viewers.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes


