### PR TITLE
feat(openai): Add support for reasoning_effort='none' in GPT-5.1

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -412,7 +412,7 @@ Expected Response:
 
 ### Advanced: Using `reasoning_effort` with `summary` field
 
-By default, `reasoning_effort` accepts a string value (`"low"`, `"medium"`, `"high"`, `"minimal"`) and only sets the effort level without including a reasoning summary.
+By default, `reasoning_effort` accepts a string value (`"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`) and only sets the effort level without including a reasoning summary.
 
 To opt-in to the `summary` feature, you can pass `reasoning_effort` as a dictionary. **Note:** The `summary` field requires your OpenAI organization to have verification status. Using `summary` without verification will result in a 400 error from OpenAI.
 
@@ -472,12 +472,17 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 
 | Model | Default (when not set) | Supported Values |
 |-------|----------------------|------------------|
+| `gpt-5.1` | `none` | `none`, `low`, `medium`, `high` |
 | `gpt-5` | `medium` | `minimal`, `low`, `medium`, `high` |
-| `gpt-5-mini` | `medium` | `minimal`, `low`, `medium`, `high` |
+| `gpt-5-mini` | `medium` | `none`, `minimal`, `low`, `medium`, `high` |
+| `gpt-5-nano` | `none` | `none`, `low`, `medium`, `high` |
 | `gpt-5-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5-pro` | `high` | `high` only |
 
-**Note:** `gpt-5-pro` only accepts `reasoning_effort="high"`. Other values will return an error. When `reasoning_effort` is not set (None), OpenAI defaults to the value shown in the "Default" column.
+**Note:**
+- GPT-5.1 introduced a new `reasoning_effort="none"` setting for faster, lower-latency responses. This replaces the `"minimal"` setting from GPT-5.
+- `gpt-5-pro` only accepts `reasoning_effort="high"`. Other values will return an error.
+- When `reasoning_effort` is not set (None), OpenAI defaults to the value shown in the "Default" column.
 
 See [OpenAI Reasoning documentation](https://platform.openai.com/docs/guides/reasoning) for more details on organization verification requirements.
 

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -544,7 +544,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return Reasoning(**reasoning_effort)  # type: ignore[typeddict-item]
 
         # If string is passed, map without summary (default)
-        if reasoning_effort == "high":
+        if reasoning_effort == "none":
+            return Reasoning(effort="none")
+        elif reasoning_effort == "high":
             return Reasoning(effort="high")
         elif reasoning_effort == "medium":
             return Reasoning(effort="medium")

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1475,7 +1475,7 @@ ResponsesAPIStreamingResponse = Annotated[
 ]
 
 
-REASONING_EFFORT = Literal["minimal", "low", "medium", "high"]
+REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high"]
 
 
 class OpenAIRealtimeStreamSession(TypedDict, total=False):

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -153,3 +153,33 @@ def test_gpt5_codex_supports_function_calling(config: OpenAIConfig):
     assert "functions" in supported_params
     assert "function_call" in supported_params
     assert "tools" in supported_params
+
+
+def test_gpt5_1_reasoning_effort_none(config: OpenAIConfig):
+    """Test that GPT-5.1 supports reasoning_effort='none' parameter.
+
+    Related issue: https://github.com/BerriAI/litellm/issues/16633
+    GPT-5.1 introduced 'none' as the new default reasoning effort setting
+    for faster, lower-latency responses.
+    """
+    # Test that reasoning_effort is a supported parameter
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5.1")
+
+    # Test that reasoning_effort="none" passes through correctly
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "none"},
+        optional_params={},
+        model="gpt-5.1",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "none"
+
+    # Test with other valid values for GPT-5.1
+    for effort in ["low", "medium", "high"]:
+        params = config.map_openai_params(
+            non_default_params={"reasoning_effort": effort},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+        assert params["reasoning_effort"] == effort


### PR DESCRIPTION
 ## Title

  Add support for reasoning_effort='none' in GPT-5.1

  ## Relevant issues

  Fixes #16633

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] I have added a screenshot of my new test passing locally 
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🆕 New Feature

  ## Summary

  OpenAI's GPT-5.1 introduced a new `reasoning_effort="none"` parameter value which replaces the previous `"minimal"` setting for faster, lower-latency responses. This is
  now the default setting for GPT-5.1. This PR adds full support for this new parameter value.

  ## Details

  **Code:**
  - Updated `REASONING_EFFORT` type in `litellm/types/llms/openai.py` to include `"none"` value
  - The type now supports: `Literal["none", "minimal", "low", "medium", "high"]`

  **Documentation:**
  - Updated `docs/my-website/docs/providers/openai.md` to include GPT-5.1, GPT-5-mini, and GPT-5-nano models
  - Added documentation showing `"none"` as GPT-5.1's default reasoning effort
  - Clarified that `"none"` replaces `"minimal"` in the GPT-5.1 model family

  **Tests:**
  - Added `test_gpt5_1_reasoning_effort_none()` test that verifies:
    - `reasoning_effort="none"` passes through correctly
    - Other valid values (`"low"`, `"medium"`, `"high"`) continue to work
  - All existing tests continue to pass (15/15)

  ## Tests

  `tests/test_litellm/llms/openai/test_gpt5_transformation.py::test_gpt5_1_reasoning_effort_none PASSED [100%]`

  **All GPT-5 transformation tests pass:**

  ## Related Documentation

  Reference: [OpenAI GPT-5.1 Documentation](https://platform.openai.com/docs/guides/gpt-5-1)