### PR TITLE
[Feat] Bedrock Batches - Add support for custom KMS encryption keys in Bedrock Batch operations

### DIFF
--- a/docs/my-website/docs/providers/bedrock_batches.md
+++ b/docs/my-website/docs/providers/bedrock_batches.md
@@ -40,6 +40,8 @@ model_list:
       s3_access_key_id: os.environ/AWS_ACCESS_KEY_ID
       s3_secret_access_key: os.environ/AWS_SECRET_ACCESS_KEY
       aws_batch_role_arn: arn:aws:iam::888602223428:role/service-role/AmazonBedrockExecutionRoleForAgents_BB9HNW6V4CV
+      # Optional: Custom KMS encryption key for S3 output
+      # s3_encryption_key_id: arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012
     model_info: 
       mode: batch # 👈 SPECIFY MODE AS BATCH, to tell user this is a batch model
 ```
@@ -54,6 +56,12 @@ model_list:
 | `s3_secret_access_key` | AWS secret key for S3 bucket |
 | `aws_batch_role_arn` | IAM role ARN for Bedrock batch operations. Bedrock Batch APIs require an IAM role ARN to be set. |
 | `mode: batch` | Indicates to LiteLLM this is a batch model |
+
+**Optional Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `s3_encryption_key_id` | Custom KMS encryption key ID for S3 output data. If not specified, Bedrock uses AWS managed encryption keys. |
 
 ### 2. Create Virtual Key
 
@@ -173,6 +181,29 @@ When a `target_model_names` is specified, the file is written to the S3 bucket c
 ### What models are supported?
 
 LiteLLM only supports Bedrock Anthropic Models for Batch API. If you want other bedrock models file an issue [here](https://github.com/BerriAI/litellm/issues/new/choose).
+
+### How do I use a custom KMS encryption key?
+
+If your S3 bucket requires a custom KMS encryption key, you can specify it in your configuration using `s3_encryption_key_id`. This is useful for enterprise customers with specific encryption requirements.
+
+You can set the encryption key in 2 ways:
+
+1. **In config.yaml** (recommended):
+```yaml
+model_list:
+  - model_name: "bedrock-batch-claude"
+    litellm_params:
+      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
+      s3_encryption_key_id: arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012
+      # ... other params
+```
+
+2. **As an environment variable**:
+```bash
+export AWS_S3_ENCRYPTION_KEY_ID=arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012
+```
+
+
 
 ## Further Reading
 

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -679,10 +679,11 @@ class BedrockInputDataConfig(TypedDict):
     s3InputDataConfig: BedrockS3InputDataConfig
 
 
-class BedrockS3OutputDataConfig(TypedDict):
+class BedrockS3OutputDataConfig(TypedDict, total=False):
     """S3 output data configuration for Bedrock batch jobs."""
 
     s3Uri: str
+    s3EncryptionKeyId: Optional[str]
 
 
 class BedrockOutputDataConfig(TypedDict):

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -205,6 +205,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
 
     # Batch/File API Params
     s3_bucket_name: Optional[str] = None
+    s3_encryption_key_id: Optional[str] = None
     gcs_bucket_name: Optional[str] = None
 
     # Vector Store Params
@@ -262,6 +263,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
         auto_router_embedding_model: Optional[str] = None,
         # Batch/File API Params
         s3_bucket_name: Optional[str] = None,
+        s3_encryption_key_id: Optional[str] = None,
         gcs_bucket_name: Optional[str] = None,
         **params,
     ):


### PR DESCRIPTION
## [Feat] Bedrock Batches - Add support for custom KMS encryption keys in Bedrock Batch operations

This PR adds support for specifying custom KMS encryption keys for S3 output data in Bedrock Batch inference jobs. This addresses the needs of enterprise customers who require custom encryption keys for their S3 buckets, as requested in #16645.

Fixes https://github.com/BerriAI/litellm/issues/16645

Example on litellm config.yaml 

```yaml
model_list:
  - model_name: "bedrock-batch-claude"
    litellm_params:
      model: bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0
      s3_encryption_key_id: arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012
      # ... other params
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


