### PR TITLE
[Feat] Model Management API - Add API Endpoint for creating model access group 

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23768,6 +23768,22 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "voyage/voyage-3.5": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
+    "voyage/voyage-3.5-lite": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "voyage",
+        "max_input_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0
+    },
     "voyage/voyage-code-2": {
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -1,0 +1,234 @@
+"""
+Allow proxy admin to manage model access groups
+
+Endpoints here:
+- POST /model_group/new - Create a new access group with multiple model names
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.utils import PrismaClient
+from litellm.types.proxy.management_endpoints.model_management_endpoints import (
+    NewModelGroupRequest,
+    NewModelGroupResponse,
+)
+
+router = APIRouter()
+
+
+def validate_models_exist(
+    model_names: List[str], llm_router
+) -> Tuple[bool, List[str]]:
+    """
+    Validate that all requested model names exist in the router.
+    
+    Returns:
+        Tuple[bool, List[str]]: (all_valid, missing_models)
+    """
+    if llm_router is None:
+        return False, model_names
+    
+    router_model_names = set(llm_router.get_model_names())
+    missing = [m for m in model_names if m not in router_model_names]
+    return (len(missing) == 0, missing)
+
+
+def add_access_group_to_deployment(
+    model_info: Dict[str, Any], access_group: str
+) -> Tuple[Dict[str, Any], bool]:
+    """
+    Add an access group to a deployment's model_info.
+    
+    Args:
+        model_info: The model_info dictionary from the deployment
+        access_group: The access group name to add
+        
+    Returns:
+        Tuple[Dict[str, Any], bool]: (updated_model_info, was_modified)
+    """
+    access_groups = model_info.get("access_groups", [])
+    
+    # Check if access group already exists
+    if access_group in access_groups:
+        return model_info, False
+    
+    # Add the access group
+    access_groups.append(access_group)
+    model_info["access_groups"] = access_groups
+    
+    return model_info, True
+
+
+async def update_deployments_with_access_group(
+    model_names: List[str],
+    access_group: str,
+    prisma_client: PrismaClient,
+) -> int:
+    """
+    Update all deployments for the given model names to include the access group.
+    
+    Args:
+        model_names: List of model names whose deployments should be updated
+        access_group: The access group name to add
+        prisma_client: Database client
+        
+    Returns:
+        int: Number of deployments updated
+    """
+    models_updated = 0
+    
+    for model_name in model_names:
+        verbose_proxy_logger.debug(
+            f"Updating deployments for model_name: {model_name}"
+        )
+        
+        # Get all deployments with this model_name
+        deployments = await prisma_client.db.litellm_proxymodeltable.find_many(
+            where={"model_name": model_name}
+        )
+        
+        verbose_proxy_logger.debug(
+            f"Found {len(deployments)} deployments for model_name: {model_name}"
+        )
+        
+        # Update each deployment
+        for deployment in deployments:
+            model_info = deployment.model_info or {}
+            
+            # Add access group using helper
+            updated_model_info, was_modified = add_access_group_to_deployment(
+                model_info=model_info,
+                access_group=access_group,
+            )
+            
+            # Only update in DB if modified
+            if was_modified:
+                await prisma_client.db.litellm_proxymodeltable.update(
+                    where={"model_id": deployment.model_id},
+                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                )
+                
+                models_updated += 1
+                verbose_proxy_logger.debug(
+                    f"Updated deployment {deployment.model_id} with access group: {access_group}"
+                )
+    
+    return models_updated
+
+
+@router.post(
+    "/model_group/new",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=NewModelGroupResponse,
+)
+async def create_model_group(
+    data: NewModelGroupRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Create a new access group containing multiple model names.
+    
+    An access group is a named collection of model groups that can be referenced
+    by teams/keys for simplified access control.
+    
+    Example:
+    ```bash
+    curl -X POST 'http://localhost:4000/model_group/new' \\
+      -H 'Authorization: Bearer sk-1234' \\
+      -H 'Content-Type: application/json' \\
+      -d '{
+        "access_group": "production-models",
+        "model_names": ["gpt-4", "claude-3-opus", "gemini-pro"]
+      }'
+    ```
+    
+    Parameters:
+    - access_group: str - The access group name (e.g., "production-models")
+    - model_names: List[str] - List of existing model groups to include
+    
+    Returns:
+    - NewModelGroupResponse with the created access group details
+    
+    Raises:
+    - HTTPException 400: If any model names don't exist
+    - HTTPException 500: If database operations fail
+    """
+    from litellm.proxy.proxy_server import (
+        llm_router,
+        prisma_client,
+        proxy_config,
+        proxy_logging_obj,
+    )
+    
+    verbose_proxy_logger.debug(
+        f"Creating access group: {data.access_group} with models: {data.model_names}"
+    )
+    
+    # Validation: Check if access_group is provided
+    if not data.access_group or not data.access_group.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "access_group is required and cannot be empty"},
+        )
+    
+    # Validation: Check if model_names list is provided and not empty
+    if not data.model_names or len(data.model_names) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "model_names list is required and cannot be empty"},
+        )
+    
+    # Validation: Check if all models exist in the router
+    all_valid, missing_models = validate_models_exist(
+        model_names=data.model_names,
+        llm_router=llm_router,
+    )
+    
+    if not all_valid:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"Model(s) not found: {', '.join(missing_models)}"},
+        )
+    
+    # Check if database is connected
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected. Cannot create access group."},
+        )
+    
+    try:
+        # Update deployments using helper function
+        models_updated = await update_deployments_with_access_group(
+            model_names=data.model_names,
+            access_group=data.access_group,
+            prisma_client=prisma_client,
+        )
+        
+        verbose_proxy_logger.info(
+            f"Successfully created access group '{data.access_group}' with {models_updated} models updated"
+        )
+        
+        return NewModelGroupResponse(
+            access_group=data.access_group,
+            model_names=data.model_names,
+            models_updated=models_updated,
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error creating access group '{data.access_group}': {str(e)}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to create access group: {str(e)}"},
+        )
+

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -14,8 +14,12 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.utils import PrismaClient
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
+    AccessGroupInfo,
+    DeleteModelGroupResponse,
+    ListAccessGroupsResponse,
     NewModelGroupRequest,
     NewModelGroupResponse,
+    UpdateModelGroupRequest,
 )
 
 router = APIRouter()
@@ -121,8 +125,76 @@ async def update_deployments_with_access_group(
     return models_updated
 
 
+def remove_access_group_from_deployment(
+    model_info: Dict[str, Any], access_group: str
+) -> Tuple[Dict[str, Any], bool]:
+    """
+    Remove an access group from a deployment's model_info.
+    
+    Args:
+        model_info: The model_info dictionary from the deployment
+        access_group: The access group name to remove
+        
+    Returns:
+        Tuple[Dict[str, Any], bool]: (updated_model_info, was_modified)
+    """
+    access_groups = model_info.get("access_groups", [])
+    
+    # Check if access group exists
+    if access_group not in access_groups:
+        return model_info, False
+    
+    # Remove the access group
+    access_groups.remove(access_group)
+    model_info["access_groups"] = access_groups
+    
+    return model_info, True
+
+
+async def get_all_access_groups_from_db(
+    prisma_client: PrismaClient,
+) -> Dict[str, AccessGroupInfo]:
+    """
+    Get all access groups from the database.
+    
+    Returns:
+        Dict[str, AccessGroupInfo]: Dictionary mapping access_group name to info
+    """
+    # Get all deployments
+    deployments = await prisma_client.db.litellm_proxymodeltable.find_many()
+    
+    # Build access group map
+    access_group_map: Dict[str, Dict[str, Any]] = {}
+    
+    for deployment in deployments:
+        model_info = deployment.model_info or {}
+        access_groups = model_info.get("access_groups", [])
+        model_name = deployment.model_name
+        
+        for access_group in access_groups:
+            if access_group not in access_group_map:
+                access_group_map[access_group] = {
+                    "model_names": set(),
+                    "deployment_count": 0,
+                }
+            
+            access_group_map[access_group]["model_names"].add(model_name)
+            access_group_map[access_group]["deployment_count"] += 1
+    
+    # Convert to AccessGroupInfo objects
+    result = {}
+    for access_group, data in access_group_map.items():
+        result[access_group] = AccessGroupInfo(
+            access_group=access_group,
+            model_names=sorted(list(data["model_names"])),
+            deployment_count=data["deployment_count"],
+        )
+    
+    return result
+
+
 @router.post(
-    "/model_group/new",
+    "/access_group/new",
     tags=["model management"],
     dependencies=[Depends(user_api_key_auth)],
     response_model=NewModelGroupResponse,
@@ -139,7 +211,7 @@ async def create_model_group(
     
     Example:
     ```bash
-    curl -X POST 'http://localhost:4000/model_group/new' \\
+    curl -X POST 'http://localhost:4000/access_group/new' \\
       -H 'Authorization: Bearer sk-1234' \\
       -H 'Content-Type: application/json' \\
       -d '{
@@ -230,5 +302,351 @@ async def create_model_group(
         raise HTTPException(
             status_code=500,
             detail={"error": f"Failed to create access group: {str(e)}"},
+        )
+
+
+@router.get(
+    "/access_group/list",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=ListAccessGroupsResponse,
+)
+async def list_access_groups(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    List all access groups.
+    
+    Returns a list of all access groups with their model names and deployment counts.
+    
+    Example:
+    ```bash
+    curl -X GET 'http://localhost:4000/access_group/list' \\
+      -H 'Authorization: Bearer sk-1234'
+    ```
+    
+    Returns:
+    - ListAccessGroupsResponse with all access groups
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected."},
+        )
+    
+    try:
+        access_groups_map = await get_all_access_groups_from_db(
+            prisma_client=prisma_client
+        )
+        
+        # Sort by access group name
+        access_groups_list = sorted(
+            access_groups_map.values(),
+            key=lambda x: x.access_group,
+        )
+        
+        return ListAccessGroupsResponse(access_groups=access_groups_list)
+        
+    except Exception as e:
+        verbose_proxy_logger.exception(f"Error listing access groups: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to list access groups: {str(e)}"},
+        )
+
+
+@router.get(
+    "/access_group/{access_group}/info",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=AccessGroupInfo,
+)
+async def get_access_group_info(
+    access_group: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Get information about a specific access group.
+    
+    Example:
+    ```bash
+    curl -X GET 'http://localhost:4000/access_group/production-models/info' \\
+      -H 'Authorization: Bearer sk-1234'
+    ```
+    
+    Parameters:
+    - access_group: str - The access group name (URL path parameter)
+    
+    Returns:
+    - AccessGroupInfo with the access group details
+    
+    Raises:
+    - HTTPException 404: If access group not found
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected."},
+        )
+    
+    try:
+        access_groups_map = await get_all_access_groups_from_db(
+            prisma_client=prisma_client
+        )
+        
+        if access_group not in access_groups_map:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"Access group '{access_group}' not found"},
+            )
+        
+        return access_groups_map[access_group]
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error getting access group info for '{access_group}': {str(e)}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to get access group info: {str(e)}"},
+        )
+
+
+@router.put(
+    "/access_group/{access_group}/update",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=NewModelGroupResponse,
+)
+async def update_access_group(
+    access_group: str,
+    data: UpdateModelGroupRequest,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Update an access group's model names.
+    
+    This will:
+    1. Remove the access group from all current deployments
+    2. Add the access group to all deployments for the new model_names list
+    
+    Example:
+    ```bash
+    curl -X PUT 'http://localhost:4000/access_group/production-models/update' \\
+      -H 'Authorization: Bearer sk-1234' \\
+      -H 'Content-Type: application/json' \\
+      -d '{
+        "model_names": ["gpt-4", "claude-3-sonnet"]
+      }'
+    ```
+    
+    Parameters:
+    - access_group: str - The access group name (URL path parameter)
+    - model_names: List[str] - New list of model groups to include
+    
+    Returns:
+    - NewModelGroupResponse with the updated access group details
+    
+    Raises:
+    - HTTPException 400: If any model names don't exist
+    - HTTPException 404: If access group not found
+    """
+    from litellm.proxy.proxy_server import llm_router, prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected."},
+        )
+    
+    verbose_proxy_logger.debug(
+        f"Updating access group: {access_group} with models: {data.model_names}"
+    )
+    
+    # Validation: Check if model_names list is provided and not empty
+    if not data.model_names or len(data.model_names) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "model_names list is required and cannot be empty"},
+        )
+    
+    # Validation: Check if access group exists
+    try:
+        access_groups_map = await get_all_access_groups_from_db(
+            prisma_client=prisma_client
+        )
+        if access_group not in access_groups_map:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"Access group '{access_group}' not found"},
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to check access group existence: {str(e)}"},
+        )
+    
+    # Validation: Check if all new models exist
+    all_valid, missing_models = validate_models_exist(
+        model_names=data.model_names,
+        llm_router=llm_router,
+    )
+    
+    if not all_valid:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"Model(s) not found: {', '.join(missing_models)}"},
+        )
+    
+    try:
+        # Step 1: Remove access group from ALL deployments
+        all_deployments = await prisma_client.db.litellm_proxymodeltable.find_many()
+        
+        for deployment in all_deployments:
+            model_info = deployment.model_info or {}
+            updated_model_info, was_modified = remove_access_group_from_deployment(
+                model_info=model_info,
+                access_group=access_group,
+            )
+            
+            if was_modified:
+                await prisma_client.db.litellm_proxymodeltable.update(
+                    where={"model_id": deployment.model_id},
+                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                )
+        
+        # Step 2: Add access group to new model_names
+        models_updated = await update_deployments_with_access_group(
+            model_names=data.model_names,
+            access_group=access_group,
+            prisma_client=prisma_client,
+        )
+        
+        verbose_proxy_logger.info(
+            f"Successfully updated access group '{access_group}' with {models_updated} models updated"
+        )
+        
+        return NewModelGroupResponse(
+            access_group=access_group,
+            model_names=data.model_names,
+            models_updated=models_updated,
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error updating access group '{access_group}': {str(e)}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to update access group: {str(e)}"},
+        )
+
+
+@router.delete(
+    "/access_group/{access_group}/delete",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=DeleteModelGroupResponse,
+)
+async def delete_access_group(
+    access_group: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Delete an access group.
+    
+    Removes the access group from all deployments that have it.
+    
+    Example:
+    ```bash
+    curl -X DELETE 'http://localhost:4000/access_group/production-models/delete' \\
+      -H 'Authorization: Bearer sk-1234'
+    ```
+    
+    Parameters:
+    - access_group: str - The access group name (URL path parameter)
+    
+    Returns:
+    - DeleteModelGroupResponse with deletion details
+    
+    Raises:
+    - HTTPException 404: If access group not found
+    """
+    from litellm.proxy.proxy_server import prisma_client
+    
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected."},
+        )
+    
+    verbose_proxy_logger.debug(f"Deleting access group: {access_group}")
+    
+    # Validation: Check if access group exists
+    try:
+        access_groups_map = await get_all_access_groups_from_db(
+            prisma_client=prisma_client
+        )
+        if access_group not in access_groups_map:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"Access group '{access_group}' not found"},
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to check access group existence: {str(e)}"},
+        )
+    
+    try:
+        # Remove access group from all deployments
+        all_deployments = await prisma_client.db.litellm_proxymodeltable.find_many()
+        models_updated = 0
+        
+        for deployment in all_deployments:
+            model_info = deployment.model_info or {}
+            updated_model_info, was_modified = remove_access_group_from_deployment(
+                model_info=model_info,
+                access_group=access_group,
+            )
+            
+            if was_modified:
+                await prisma_client.db.litellm_proxymodeltable.update(
+                    where={"model_id": deployment.model_id},
+                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                )
+                models_updated += 1
+        
+        verbose_proxy_logger.info(
+            f"Successfully deleted access group '{access_group}' from {models_updated} deployments"
+        )
+        
+        return DeleteModelGroupResponse(
+            access_group=access_group,
+            models_updated=models_updated,
+            message=f"Access group '{access_group}' deleted successfully",
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            f"Error deleting access group '{access_group}': {str(e)}"
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={"error": f"Failed to delete access group: {str(e)}"},
         )
 

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -30,7 +30,7 @@ def validate_models_exist(
 ) -> Tuple[bool, List[str]]:
     """
     Validate that all requested model names exist in the router.
-    Uses router's get_model_list() which checks both exact matches and wildcard patterns.
+    Checks only exact model name matches.
     
     Returns:
         Tuple[bool, List[str]]: (all_valid, missing_models)
@@ -38,15 +38,8 @@ def validate_models_exist(
     if llm_router is None:
         return False, model_names
     
-    missing = []
-    
-    for model_name in model_names:
-        # Use router's built-in method that checks both exact and pattern matches
-        model_list = llm_router.get_model_list(model_name=model_name)
-        
-        if not model_list or len(model_list) == 0:
-            missing.append(model_name)
-    
+    router_model_names = set(llm_router.get_model_names())
+    missing = [m for m in model_names if m not in router_model_names]
     return (len(missing) == 0, missing)
 
 

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -30,6 +30,7 @@ def validate_models_exist(
 ) -> Tuple[bool, List[str]]:
     """
     Validate that all requested model names exist in the router.
+    Uses router's get_model_list() which checks both exact matches and wildcard patterns.
     
     Returns:
         Tuple[bool, List[str]]: (all_valid, missing_models)
@@ -37,8 +38,15 @@ def validate_models_exist(
     if llm_router is None:
         return False, model_names
     
-    router_model_names = set(llm_router.get_model_names())
-    missing = [m for m in model_names if m not in router_model_names]
+    missing = []
+    
+    for model_name in model_names:
+        # Use router's built-in method that checks both exact and pattern matches
+        model_list = llm_router.get_model_list(model_name=model_name)
+        
+        if not model_list or len(model_list) == 0:
+            missing.append(model_name)
+    
     return (len(missing) == 0, missing)
 
 

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -5,6 +5,7 @@ Endpoints here:
 - POST /model_group/new - Create a new access group with multiple model names
 """
 
+import json
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -115,7 +116,7 @@ async def update_deployments_with_access_group(
             if was_modified:
                 await prisma_client.db.litellm_proxymodeltable.update(
                     where={"model_id": deployment.model_id},
-                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                    data={"model_info": json.dumps(updated_model_info)},
                 )
                 
                 models_updated += 1
@@ -532,7 +533,7 @@ async def update_access_group(
             if was_modified:
                 await prisma_client.db.litellm_proxymodeltable.update(
                     where={"model_id": deployment.model_id},
-                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                    data={"model_info": json.dumps(updated_model_info)},
                 )
         
         # Step 2: Add access group to new model_names
@@ -637,7 +638,7 @@ async def delete_access_group(
             if was_modified:
                 await prisma_client.db.litellm_proxymodeltable.update(
                     where={"model_id": deployment.model_id},
-                    data={"model_info": prisma_client.jsonify_object(updated_model_info)},
+                    data={"model_info": json.dumps(updated_model_info)},
                 )
                 models_updated += 1
         

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -284,6 +284,17 @@ async def create_model_group(
         )
     
     try:
+        # Check if access group already exists
+        existing_access_groups = await get_all_access_groups_from_db(
+            prisma_client=prisma_client
+        )
+        
+        if data.access_group in existing_access_groups:
+            raise HTTPException(
+                status_code=409,
+                detail={"error": f"Access group '{data.access_group}' already exists. Use PUT /access_group/{data.access_group}/update to modify it."},
+            )
+        
         # Update deployments using helper function
         models_updated = await update_deployments_with_access_group(
             model_names=data.model_names,

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -13,6 +13,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+# Clear cache and reload models to pick up the access group changes
+from litellm.proxy.management_endpoints.model_management_endpoints import (
+    clear_cache,
+)
 from litellm.proxy.utils import PrismaClient
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     AccessGroupInfo,
@@ -296,6 +301,8 @@ async def create_model_group(
             prisma_client=prisma_client,
         )
         
+        await clear_cache()
+        
         verbose_proxy_logger.info(
             f"Successfully created access group '{data.access_group}' with {models_updated} models updated"
         )
@@ -543,6 +550,9 @@ async def update_access_group(
             prisma_client=prisma_client,
         )
         
+        # Clear cache and reload models to pick up the access group changes
+        await clear_cache()
+        
         verbose_proxy_logger.info(
             f"Successfully updated access group '{access_group}' with {models_updated} models updated"
         )
@@ -641,6 +651,9 @@ async def delete_access_group(
                     data={"model_info": json.dumps(updated_model_info)},
                 )
                 models_updated += 1
+        
+        # Clear cache and reload models to pick up the access group changes
+        await clear_cache()
         
         verbose_proxy_logger.info(
             f"Successfully deleted access group '{access_group}' from {models_updated} deployments"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -292,6 +292,9 @@ from litellm.proxy.management_endpoints.model_management_endpoints import (
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     router as model_management_router,
 )
+from litellm.proxy.management_endpoints.model_access_group_management_endpoints import (
+    router as model_access_group_management_router,
+)
 from litellm.proxy.management_endpoints.organization_endpoints import (
     router as organization_router,
 )
@@ -10086,6 +10089,7 @@ app.include_router(openai_files_router)
 app.include_router(team_callback_router)
 app.include_router(budget_management_router)
 app.include_router(model_management_router)
+app.include_router(model_access_group_management_router)
 app.include_router(tag_management_router)
 app.include_router(cost_tracking_settings_router)
 app.include_router(router_settings_router)

--- a/litellm/types/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/model_management_endpoints.py
@@ -17,7 +17,28 @@ class NewModelGroupRequest(BaseModel):
     access_group: str  # The access group name (e.g., "production-models")
     model_names: List[str]  # Existing model groups to include (e.g., ["gpt-4", "claude-3"])
 
+
 class NewModelGroupResponse(BaseModel):
     access_group: str
     model_names: List[str]
     models_updated: int  # Number of models updated
+
+
+class UpdateModelGroupRequest(BaseModel):
+    model_names: List[str]  # Updated list of model groups to include
+
+
+class DeleteModelGroupResponse(BaseModel):
+    access_group: str
+    models_updated: int  # Number of deployments where the access group was removed
+    message: str
+
+
+class AccessGroupInfo(BaseModel):
+    access_group: str
+    model_names: List[str]  # List of model names in this access group
+    deployment_count: int  # Total number of deployments with this access group
+
+
+class ListAccessGroupsResponse(BaseModel):
+    access_groups: List[AccessGroupInfo]

--- a/litellm/types/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/model_management_endpoints.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 from pydantic import BaseModel, Field
 
@@ -11,3 +11,13 @@ class ModelGroupInfoProxy(ModelGroupInfo):
 
 class UpdateUsefulLinksRequest(BaseModel):
     useful_links: Dict[str, str]
+
+
+class NewModelGroupRequest(BaseModel):
+    model_group_name: str  # The access group name (e.g., "production-models")
+    model_names: List[str]  # Existing model groups to include (e.g., ["gpt-4", "claude-3"])
+
+class NewModelGroupResponse(BaseModel):
+    model_group_name: str
+    model_names: List[str]
+    models_updated: int  # Number of models updated

--- a/litellm/types/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/model_management_endpoints.py
@@ -14,10 +14,10 @@ class UpdateUsefulLinksRequest(BaseModel):
 
 
 class NewModelGroupRequest(BaseModel):
-    model_group_name: str  # The access group name (e.g., "production-models")
+    access_group: str  # The access group name (e.g., "production-models")
     model_names: List[str]  # Existing model groups to include (e.g., ["gpt-4", "claude-3"])
 
 class NewModelGroupResponse(BaseModel):
-    model_group_name: str
+    access_group: str
     model_names: List[str]
     models_updated: int  # Number of models updated

--- a/tests/test_litellm/proxy/management_endpoints/test_access_group_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_access_group_management.py
@@ -1,0 +1,171 @@
+"""
+Test access group management endpoints with wildcard model support
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm import Router
+from litellm.proxy.management_endpoints.model_access_group_management_endpoints import (
+    validate_models_exist,
+)
+from litellm.router import Deployment, LiteLLM_Params
+from litellm.types.router import ModelInfo
+
+
+def test_validate_models_exist_with_wildcard():
+    """
+    Test that validate_models_exist correctly validates model names against wildcard patterns.
+    
+    Scenario: Router has openai/* wildcard configured, user tries to create access group
+    with openai/gpt-4 which should match the wildcard pattern.
+    """
+    # Create a router with a wildcard model
+    router = Router(
+        model_list=[
+            {
+                "model_name": "openai/*",  # Wildcard pattern
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "fake-key-for-test",
+                },
+            }
+        ]
+    )
+    
+    # Test 1: Model that matches wildcard pattern should be valid
+    model_names = ["openai/gpt-4"]
+    all_valid, missing = validate_models_exist(model_names, router)
+    
+    assert all_valid is True, f"Expected openai/gpt-4 to match openai/* pattern"
+    assert len(missing) == 0, f"Expected no missing models, got: {missing}"
+    
+    # Test 2: Model that doesn't match pattern should be invalid
+    model_names = ["anthropic/claude-3"]
+    all_valid, missing = validate_models_exist(model_names, router)
+    
+    assert all_valid is False, "Expected anthropic/claude-3 to not match"
+    assert "anthropic/claude-3" in missing, f"Expected anthropic/claude-3 in missing, got: {missing}"
+    
+    # Test 3: Mix of valid wildcard match and invalid model
+    model_names = ["openai/gpt-4", "nonexistent/model"]
+    all_valid, missing = validate_models_exist(model_names, router)
+    
+    assert all_valid is False, "Expected validation to fail with mixed models"
+    assert "openai/gpt-4" not in missing, "openai/gpt-4 should not be in missing"
+    assert "nonexistent/model" in missing, f"Expected nonexistent/model in missing, got: {missing}"
+
+
+def test_validate_models_exist_with_exact_and_wildcard():
+    """
+    Test validation with both exact model names and wildcard patterns.
+    """
+    # Create a router with both exact models and wildcard pattern
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",  # Exact model
+                "litellm_params": {
+                    "model": "gpt-4",
+                    "api_key": "fake-key-for-test",
+                },
+            },
+            {
+                "model_name": "openai/*",  # Wildcard pattern
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "fake-key-for-test",
+                },
+            },
+        ]
+    )
+    
+    # Test: Both exact and wildcard matches should be valid
+    model_names = ["gpt-4", "openai/gpt-3.5-turbo"]
+    all_valid, missing = validate_models_exist(model_names, router)
+    
+    assert all_valid is True, "Expected both exact and wildcard matches to be valid"
+    assert len(missing) == 0, f"Expected no missing models, got: {missing}"
+
+
+def test_validate_models_exist_no_router():
+    """
+    Test that validation fails gracefully when router is None.
+    """
+    model_names = ["gpt-4"]
+    all_valid, missing = validate_models_exist(model_names, llm_router=None)
+    
+    assert all_valid is False, "Expected validation to fail with no router"
+    assert missing == model_names, "Expected all models to be missing when router is None"
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_access_group_fails():
+    """
+    Test that creating an access group with a name that already exists returns 409 error.
+    
+    Scenario: User creates "production-models" access group, then tries to create it again.
+    Should fail with 409 Conflict.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.model_access_group_management_endpoints import (
+        create_model_group,
+    )
+    from litellm.types.proxy.management_endpoints.model_management_endpoints import (
+        NewModelGroupRequest,
+    )
+
+    # Mock dependencies
+    mock_router = Router(
+        model_list=[
+            {
+                "model_name": "openai/*",
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "fake-key",
+                },
+            }
+        ]
+    )
+    
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_proxymodeltable.find_many = AsyncMock(
+        return_value=[
+            MagicMock(
+                model_id="1",
+                model_name="openai/gpt-4",
+                model_info={"access_groups": ["production-models"]},  # Already exists
+            )
+        ]
+    )
+    
+    mock_user = UserAPIKeyAuth(
+        user_id="test_admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    
+    request_data = NewModelGroupRequest(
+        access_group="production-models",
+        model_names=["openai/gpt-4"],
+    )
+    
+    # Mock the imported dependencies from proxy_server (where they're actually imported from)
+    with patch("litellm.proxy.proxy_server.llm_router", mock_router), \
+         patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        
+        # Should raise 409 Conflict
+        with pytest.raises(HTTPException) as exc_info:
+            await create_model_group(data=request_data, user_api_key_dict=mock_user)
+        
+        assert exc_info.value.status_code == 409
+        assert "already exists" in str(exc_info.value.detail)
+

--- a/tests/test_litellm/proxy/management_endpoints/test_access_group_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_access_group_management.py
@@ -1,5 +1,5 @@
 """
-Test access group management endpoints with wildcard model support
+Test access group management endpoints
 """
 
 import os
@@ -13,97 +13,6 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm import Router
-from litellm.proxy.management_endpoints.model_access_group_management_endpoints import (
-    validate_models_exist,
-)
-from litellm.router import Deployment, LiteLLM_Params
-from litellm.types.router import ModelInfo
-
-
-def test_validate_models_exist_with_wildcard():
-    """
-    Test that validate_models_exist correctly validates model names against wildcard patterns.
-    
-    Scenario: Router has openai/* wildcard configured, user tries to create access group
-    with openai/gpt-4 which should match the wildcard pattern.
-    """
-    # Create a router with a wildcard model
-    router = Router(
-        model_list=[
-            {
-                "model_name": "openai/*",  # Wildcard pattern
-                "litellm_params": {
-                    "model": "gpt-3.5-turbo",
-                    "api_key": "fake-key-for-test",
-                },
-            }
-        ]
-    )
-    
-    # Test 1: Model that matches wildcard pattern should be valid
-    model_names = ["openai/gpt-4"]
-    all_valid, missing = validate_models_exist(model_names, router)
-    
-    assert all_valid is True, f"Expected openai/gpt-4 to match openai/* pattern"
-    assert len(missing) == 0, f"Expected no missing models, got: {missing}"
-    
-    # Test 2: Model that doesn't match pattern should be invalid
-    model_names = ["anthropic/claude-3"]
-    all_valid, missing = validate_models_exist(model_names, router)
-    
-    assert all_valid is False, "Expected anthropic/claude-3 to not match"
-    assert "anthropic/claude-3" in missing, f"Expected anthropic/claude-3 in missing, got: {missing}"
-    
-    # Test 3: Mix of valid wildcard match and invalid model
-    model_names = ["openai/gpt-4", "nonexistent/model"]
-    all_valid, missing = validate_models_exist(model_names, router)
-    
-    assert all_valid is False, "Expected validation to fail with mixed models"
-    assert "openai/gpt-4" not in missing, "openai/gpt-4 should not be in missing"
-    assert "nonexistent/model" in missing, f"Expected nonexistent/model in missing, got: {missing}"
-
-
-def test_validate_models_exist_with_exact_and_wildcard():
-    """
-    Test validation with both exact model names and wildcard patterns.
-    """
-    # Create a router with both exact models and wildcard pattern
-    router = Router(
-        model_list=[
-            {
-                "model_name": "gpt-4",  # Exact model
-                "litellm_params": {
-                    "model": "gpt-4",
-                    "api_key": "fake-key-for-test",
-                },
-            },
-            {
-                "model_name": "openai/*",  # Wildcard pattern
-                "litellm_params": {
-                    "model": "gpt-3.5-turbo",
-                    "api_key": "fake-key-for-test",
-                },
-            },
-        ]
-    )
-    
-    # Test: Both exact and wildcard matches should be valid
-    model_names = ["gpt-4", "openai/gpt-3.5-turbo"]
-    all_valid, missing = validate_models_exist(model_names, router)
-    
-    assert all_valid is True, "Expected both exact and wildcard matches to be valid"
-    assert len(missing) == 0, f"Expected no missing models, got: {missing}"
-
-
-def test_validate_models_exist_no_router():
-    """
-    Test that validation fails gracefully when router is None.
-    """
-    model_names = ["gpt-4"]
-    all_valid, missing = validate_models_exist(model_names, llm_router=None)
-    
-    assert all_valid is False, "Expected validation to fail with no router"
-    assert missing == model_names, "Expected all models to be missing when router is None"
 
 
 @pytest.mark.asyncio
@@ -124,48 +33,48 @@ async def test_create_duplicate_access_group_fails():
         NewModelGroupRequest,
     )
 
-    # Mock dependencies
+    # Mock dependencies - use exact model name (not wildcard)
     mock_router = Router(
         model_list=[
             {
-                "model_name": "openai/*",
+                "model_name": "gpt-4",  # Exact model name
                 "litellm_params": {
-                    "model": "gpt-3.5-turbo",
+                    "model": "gpt-4",
                     "api_key": "fake-key",
                 },
             }
         ]
     )
-    
+
     mock_prisma = MagicMock()
     mock_prisma.db.litellm_proxymodeltable.find_many = AsyncMock(
         return_value=[
             MagicMock(
                 model_id="1",
-                model_name="openai/gpt-4",
+                model_name="gpt-4",
                 model_info={"access_groups": ["production-models"]},  # Already exists
             )
         ]
     )
-    
+
     mock_user = UserAPIKeyAuth(
         user_id="test_admin",
         user_role=LitellmUserRoles.PROXY_ADMIN,
     )
-    
+
     request_data = NewModelGroupRequest(
         access_group="production-models",
-        model_names=["openai/gpt-4"],
+        model_names=["gpt-4"],
     )
-    
+
     # Mock the imported dependencies from proxy_server (where they're actually imported from)
     with patch("litellm.proxy.proxy_server.llm_router", mock_router), \
          patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
-        
+
         # Should raise 409 Conflict
         with pytest.raises(HTTPException) as exc_info:
             await create_model_group(data=request_data, user_api_key_dict=mock_user)
-        
+
         assert exc_info.value.status_code == 409
         assert "already exists" in str(exc_info.value.detail)
 


### PR DESCRIPTION
## [Feat] Model Management API - Add API Endpoints for creating, updating, deleting and viewing model access group 



### 1. Create an Access Group

**Request:**
```bash
curl -X POST 'http://localhost:4000/access_group/new' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{
    "access_group": "production-models",
    "model_names": ["gpt-4", "gpt-3.5-turbo"]
  }'
```

**Expected Response:**
```json
{
  "access_group": "production-models",
  "model_names": ["gpt-4", "gpt-3.5-turbo"],
  "models_updated": 2
}
```

---

### 2. Create Another Access Group

**Request:**
```bash
curl -X POST 'http://localhost:4000/access_group/new' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{
    "access_group": "staging-models",
    "model_names": ["gpt-3.5-turbo", "claude-3-opus"]
  }'
```

**Expected Response:**
```json
{
  "access_group": "staging-models",
  "model_names": ["gpt-3.5-turbo", "claude-3-opus"],
  "models_updated": 2
}
```

---

### 3. List All Access Groups

**Request:**
```bash
curl -X GET 'http://localhost:4000/access_group/list' \
  -H 'Authorization: Bearer sk-1234'
```

**Expected Response:**
```json
{
  "access_groups": [
    {
      "access_group": "production-models",
      "model_names": ["gpt-3.5-turbo", "gpt-4"],
      "deployment_count": 2
    },
    {
      "access_group": "staging-models",
      "model_names": ["claude-3-opus", "gpt-3.5-turbo"],
      "deployment_count": 2
    }
  ]
}
```

---

### 4. Get Specific Access Group Info

**Request:**
```bash
curl -X GET 'http://localhost:4000/access_group/production-models/info' \
  -H 'Authorization: Bearer sk-1234'
```

**Expected Response:**
```json
{
  "access_group": "production-models",
  "model_names": ["gpt-3.5-turbo", "gpt-4"],
  "deployment_count": 2
}
```

---

### 5. Update Access Group

**Request:**
```bash
curl -X PUT 'http://localhost:4000/access_group/production-models/update' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{
    "model_names": ["gpt-4", "claude-3-opus"]
  }'
```

**Expected Response:**
```json
{
  "access_group": "production-models",
  "model_names": ["gpt-4", "claude-3-opus"],
  "models_updated": 2
}
```

---

### 6. Verify Update

**Request:**
```bash
curl -X GET 'http://localhost:4000/access_group/production-models/info' \
  -H 'Authorization: Bearer sk-1234'
```

**Expected Response:**
```json
{
  "access_group": "production-models",
  "model_names": ["claude-3-opus", "gpt-4"],
  "deployment_count": 2
}
```

---

### 7. Delete Access Group

**Request:**
```bash
curl -X DELETE 'http://localhost:4000/access_group/staging-models/delete' \
  -H 'Authorization: Bearer sk-1234'
```

**Expected Response:**
```json
{
  "access_group": "staging-models",
  "models_updated": 2,
  "message": "Access group 'staging-models' deleted successfully"
}
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


