### PR TITLE
[Feature] UI - Expose user_alias in view and update path

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1143,6 +1143,7 @@ class UpdateUserRequestNoUserIDorEmail(
     password: Optional[str] = None
     spend: Optional[float] = None
     metadata: Optional[dict] = None
+    user_alias: Optional[str] = None
     user_role: Optional[
         Literal[
             LitellmUserRoles.PROXY_ADMIN,

--- a/ui/litellm-dashboard/src/components/user_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/user_edit_view.tsx
@@ -40,6 +40,7 @@ export function UserEditView({
     form.setFieldsValue({
       user_id: userData.user_id,
       user_email: userData.user_info?.user_email,
+      user_alias: userData.user_info?.user_alias,
       user_role: userData.user_info?.user_role,
       models: userData.user_info?.models || [],
       max_budget: userData.user_info?.max_budget,
@@ -75,6 +76,10 @@ export function UserEditView({
           <TextInput />
         </Form.Item>
       )}
+
+      <Form.Item label="User Alias" name="user_alias">
+        <TextInput />
+      </Form.Item>
 
       <Form.Item
         label={

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.test.tsx
@@ -7,6 +7,7 @@ vi.mock("../networking", () => {
     user_id: "user-123",
     user_info: {
       user_email: "test@example.com",
+      user_alias: "Test Alias",
       user_role: "admin",
       teams: [],
       models: [],
@@ -40,12 +41,19 @@ describe("UserInfoView", () => {
     possibleUIRoles: null,
   };
 
-  it("renders loading state and then the user email", async () => {
+  it("should render the loading state and then the user email", async () => {
     const { getByText, findAllByText } = render(<UserInfoView {...defaultProps} />);
 
     expect(getByText("Loading user data...")).toBeInTheDocument();
 
     const emails = await findAllByText("test@example.com");
     expect(emails.length).toBeGreaterThan(0);
+  });
+
+  it("should render the user alias", async () => {
+    const { findAllByText } = render(<UserInfoView {...defaultProps} />);
+
+    const aliases = await findAllByText("Test Alias");
+    expect(aliases.length).toBeGreaterThan(0);
   });
 });

--- a/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/user_info_view.tsx
@@ -33,6 +33,7 @@ interface UserInfo {
   user_id: string;
   user_info: {
     user_email: string | null;
+    user_alias: string | null;
     user_role: string | null;
     teams: any[] | null;
     models: string[] | null;
@@ -138,6 +139,7 @@ export default function UserInfoView({
         user_info: {
           ...userData.user_info,
           user_email: formValues.user_email,
+          user_alias: formValues.user_alias,
           models: formValues.models,
           max_budget: formValues.max_budget,
           budget_duration: formValues.budget_duration,
@@ -382,6 +384,11 @@ export default function UserInfoView({
                   <div>
                     <Text className="font-medium">Email</Text>
                     <Text>{userData.user_info?.user_email || "Not Set"}</Text>
+                  </div>
+
+                  <div>
+                    <Text className="font-medium">User Alias</Text>
+                    <Text>{userData.user_info?.user_alias || "Not Set"}</Text>
                   </div>
 
                   <div>


### PR DESCRIPTION
## [Feature] UI - Expose user_alias in view and update path

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The user_alias was previously not displayed in the UI and it was not respected in the post body of the update call. This fixes the backend to respect the user_alias and adds rendering of the user_alias in the UI.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

## Screenshot
<img width="659" height="201" alt="image" src="https://github.com/user-attachments/assets/591a42e4-5c29-41bb-9e6f-ca60e01f8158" />

<img width="343" height="216" alt="image" src="https://github.com/user-attachments/assets/1ad2a79a-19c5-4823-b4e8-541ce8f5ca3e" />

<img width="208" height="320" alt="image" src="https://github.com/user-attachments/assets/b39f7624-8aae-456d-b379-748ee411e1fc" />


