### PR TITLE
fix(openai-video): use GET for /v1/videos/{video_id}/content

### DIFF
--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -178,10 +178,10 @@ class OpenAIVideoConfig(BaseVideoConfig):
         # Construct the URL for video content download
         url = f"{api_base.rstrip('/')}/{original_video_id}/content"
         
-        # Add video_id as query parameter
-        params = {"video_id": original_video_id}
-        
-        return url, params
+        # No additional data needed for GET content request
+        data: Dict[str, Any] = {}
+
+        return url, data
 
     def transform_video_remix_request(
         self,


### PR DESCRIPTION
## Title

fix(openai-video): use GET for /videos/{id}/content

## Relevant issues

 - Fixes incorrect HTTP method when downloading OpenAI video content.
  - Symptom: OpenAI returned invalid_request_error for POST to /v1/videos/{video_id}/content, leading to JSON error bytes being saved
    as .mp4

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
  - Update litellm/llms/openai/videos/transformation.py:transform_video_content_request to return an empty dict so the HTTP handler issues a GET (per OpenAI spec).
  - Impact scope: OpenAI video content download path only; other providers unaffected.
  - Behavior
      - Before: non-empty params triggered POST with JSON body → OpenAI error.
      - After: empty params triggers GET with query params → returns raw MP4 bytes as expected.
<img width="979" height="73" alt="Screenshot 2025-11-14 at 4 38 17 PM" src="https://github.com/user-attachments/assets/c504c0bb-a279-4987-a37b-01d1dbe4e078" />

## Actual Error
```
    {
      "error": {
        "message": "Invalid method for URL (POST /v1/videos/{video_id}/content)",
        "type": "invalid_request_error"
      }
    }
```

