### PR TITLE
fix: Extend message trimming to properly handle messages with list content

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -19,10 +19,13 @@ from litellm.types.utils import (
     StreamingChoices,
 )
 from litellm.utils import (
-    ProviderConfigManager,
     TextCompletionStreamWrapper,
-    get_llm_provider,
     get_optional_params_image_gen,
+    is_text_content,
+    shorten_message_to_fit_limit,
+    shorten_message_with_list_content,
+    trim_messages,
+    trim_text,
 )
 
 # Adds the parent directory to the system path
@@ -757,10 +760,10 @@ def test_get_model_info_gemini():
     for model, info in model_map.items():
         if (
             model.startswith("gemini/")
-            and not "gemma" in model
-            and not "learnlm" in model
-            and not "imagen" in model
-            and not "veo" in model
+            and "gemma" not in model
+            and "learnlm" not in model
+            and "imagen" not in model
+            and "veo" not in model
         ):
             assert info.get("tpm") is not None, f"{model} does not have tpm"
             assert info.get("rpm") is not None, f"{model} does not have rpm"
@@ -845,6 +848,7 @@ def test_check_provider_match():
     model_info = {"litellm_provider": "bedrock"}
     assert litellm.utils._check_provider_match(model_info, "openai") is False
 
+
 def test_get_provider_rerank_config():
     """
     Test the get_provider_rerank_config function for various providers
@@ -853,8 +857,11 @@ def test_get_provider_rerank_config():
     from litellm.utils import LlmProviders, ProviderConfigManager
 
     # Test for hosted_vllm provider
-    config = ProviderConfigManager.get_provider_rerank_config("my_model", LlmProviders.HOSTED_VLLM, 'http://localhost', [])
+    config = ProviderConfigManager.get_provider_rerank_config(
+        "my_model", LlmProviders.HOSTED_VLLM, "http://localhost", []
+    )
     assert isinstance(config, HostedVLLMRerankConfig)
+
 
 # Models that should be skipped during testing
 OLD_PROVIDERS = ["aleph_alpha", "palm"]
@@ -1366,7 +1373,7 @@ class TestProxyFunctionCalling:
         direct_result = supports_function_calling(model=direct_model)
         proxy_result = supports_function_calling(model=proxy_model)
 
-        print(f"\nDemonstration of proxy model resolution:")
+        print("\nDemonstration of proxy model resolution:")
         print(
             f"Direct model '{direct_model}' supports function calling: {direct_result}"
         )
@@ -2270,9 +2277,7 @@ def test_anthropic_claude_4_invoke_chat_provider_config():
 
 def test_bedrock_application_inference_profile():
     model = "arn:aws:bedrock:us-east-2:<AWS-ACCOUNT-ID>:inference-profile/us.anthropic.claude-3-5-haiku-20241022-v1:0"
-    from pydantic import BaseModel
 
-    from litellm import completion
     from litellm.utils import supports_tool_choice
 
     result = supports_tool_choice(model, custom_llm_provider="bedrock")
@@ -2339,7 +2344,6 @@ def test_block_key_hashing_logic():
     """
     Test that block_key() function only hashes keys that start with "sk-"
     """
-    import hashlib
 
     from litellm.proxy.utils import hash_token
 
@@ -2512,3 +2516,323 @@ class TestGetValidModelsWithCLI:
             assert "headers" in call_kwargs
             headers = call_kwargs["headers"]
             assert headers.get("Authorization") == "Bearer sk-test-cli-key-123"
+
+
+def test_trim_messages_with_list_content() -> None:
+    # This minimal case reproduces the bug
+    original_text = "First text, very long content that needs trimming." * 10
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": original_text},
+            ],
+        },
+    ]
+    result = trim_messages(messages, max_tokens=50)
+    assert result != messages
+    assert len(result[0]["content"][0]["text"]) < len(original_text)
+    assert ".." in result[0]["content"][0]["text"]
+
+
+def test_trim_text_basic() -> None:
+    """Test basic text trimming."""
+    text = "This is a long text that needs trimming" * 5
+    result = trim_text(text, tokens_needed=50, total_tokens=100)
+
+    assert len(result) < len(text)
+    assert ".." in result
+    assert result.startswith("This")
+    assert result.endswith("g")
+
+
+def test_trim_text_very_short() -> None:
+    """Test trimming to very short length."""
+    text = "This is a long text"
+    result = trim_text(text, tokens_needed=1, total_tokens=100)
+
+    assert result == ".."
+
+
+def test_string_content_no_trimming_needed() -> None:
+    """Test that short messages are not trimmed."""
+    message = {"role": "user", "content": "Short message"}
+    result = shorten_message_to_fit_limit(message, tokens_needed=1000, model="gpt-4")
+    assert result["content"] == "Short message"
+
+
+def test_string_content_with_trimming() -> None:
+    """Test that long string messages are trimmed."""
+    long_text = "This is a very long message that needs trimming. " * 50
+    message = {"role": "user", "content": long_text}
+    result = shorten_message_to_fit_limit(message, tokens_needed=50, model="gpt-4")
+    assert len(result["content"]) < len(long_text)
+    assert ".." in result["content"]
+
+
+def test_gpt_minimum_tokens_check() -> None:
+    """Test that GPT models don't trim if tokens_needed is too small."""
+    message = {"role": "user", "content": "Any message"}
+    result = shorten_message_to_fit_limit(message, tokens_needed=5, model="gpt-4")
+    # Should return unchanged due to minimum token check
+    assert result["content"] == "Any message"
+
+
+def test_list_no_trimming_needed() -> None:
+    """Test that messages within token limit are not modified."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Short text"},
+        ],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=1000, model="gpt-4"
+    )
+    assert len(result["content"]) == 1
+    item = result["content"][0]
+    assert is_text_content(item)
+    if is_text_content(item):
+        assert item["text"] == "Short text"
+
+
+def test_list_text_only_with_trimming() -> None:
+    """Test trimming of text-only multimodal message."""
+    long_text = "This is a very long text. " * 100
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": long_text},
+        ],
+    }
+    result = shorten_message_with_list_content(message, tokens_needed=50, model="gpt-4")
+    assert len(result["content"]) == 1
+    item = result["content"][0]
+    assert is_text_content(item)
+    if is_text_content(item):
+        assert len(item["text"]) < len(long_text)
+        assert ".." in item["text"]
+
+
+def test_list_multiple_text_items() -> None:
+    """Test trimming with multiple text items."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "First text. " * 50},
+            {"type": "text", "text": "Second text. " * 50},
+            {"type": "text", "text": "Third text. " * 50},
+        ],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=100, model="gpt-4"
+    )
+    # Should keep some items, possibly trim the last one
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) >= 1
+    max_items_in_result = 3
+    assert len(result["content"]) <= max_items_in_result
+
+
+def test_list_text_and_image() -> None:
+    """Test trimming with text and image items."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Look at this image:"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": (
+                        "data:image/png;base64,"
+                        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                    )
+                },
+            },
+            {"type": "text", "text": "Text after image"},
+        ],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=100, model="gpt-4"
+    )
+    # All items should fit
+    max_items_in_result = 3
+    assert len(result["content"]) == max_items_in_result
+
+
+def test_list_image_preservation() -> None:
+    """Test that images are preserved when possible."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Very long text. " * 100},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": (
+                        "data:image/png;base64,"
+                        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                    )
+                },
+            },
+        ],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=500, model="gpt-4"
+    )
+    # Should have text (possibly trimmed) and image
+    assert isinstance(result["content"], list)
+    # Check that we still have at least one item
+    assert len(result["content"]) >= 1
+
+
+def test_list_image_removal_when_oversized() -> None:
+    """Test that very large images are replaced with text placeholder."""
+    # Create a message with a very large base64 image (simulated)
+    large_image_url = "data:image/png;base64," + "A" * 100000  # Very long base64
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Check this huge image:"},
+            {"type": "image_url", "image_url": {"url": large_image_url}},
+        ],
+    }
+    result = shorten_message_with_list_content(message, tokens_needed=50, model="gpt-4")
+    # Image should be replaced with text
+    assert isinstance(result["content"], list)
+    # Check if the image was replaced
+    has_replacement_text = any(
+        is_text_content(item) and "[Multi-modal item removed:" in item.get("text", "")
+        for item in result["content"]
+    )
+    # Either replaced or removed
+    assert has_replacement_text or len(result["content"]) == 1
+
+
+def test_list_greedy_packing() -> None:
+    """Test that greedy packing keeps items in order."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "First. " * 10},
+            {"type": "text", "text": "Second. " * 10},
+            {"type": "text", "text": "Third. " * 10},
+            {"type": "text", "text": "Fourth. " * 10},
+        ],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=100, model="gpt-4"
+    )
+    # Should keep items from the beginning
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) >= 1
+    assert all(is_text_content(item) for item in result["content"])
+    first_item = result["content"][0]
+    assert "First" in first_item.get("text", "")
+
+
+def test_list_empty_content_list() -> None:
+    """Test handling of empty content list."""
+    message = {
+        "role": "user",
+        "content": [],
+    }
+    result = shorten_message_with_list_content(message, tokens_needed=50, model="gpt-4")
+    assert result["content"] == []
+
+
+def test_list_not_a_list_raises_error() -> None:
+    """Test that non-list content raises ValueError."""
+    message = {
+        "role": "user",
+        "content": "This is a string, not a list",
+    }
+    with pytest.raises(ValueError, match="Content is not a list"):
+        shorten_message_with_list_content(message, tokens_needed=50, model="gpt-4")
+
+
+def test_list_max_attempts_with_raise_error() -> None:
+    """Test that max attempts with raise_error_on_max_limit raises ValueError."""
+    # Create a scenario that's hard to trim (though in practice this is rare)
+    very_long_text_length = 10000
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "x" * very_long_text_length},  # Very long text
+        ],
+    }
+    # This should raise ValueError due to max attempts
+    with pytest.raises(ValueError, match="Failed to trim") as exc_info:
+        shorten_message_with_list_content(
+            message, tokens_needed=1, model="gpt-4", raise_error_on_max_limit=True
+        )
+    # Verify the error message
+    assert "Failed to trim" in str(exc_info.value)
+
+
+def test_dispatches_to_string_handler() -> None:
+    """Test that string content is handled by string logic."""
+    message = {"role": "user", "content": "String message " * 100}
+    result = shorten_message_to_fit_limit(message, tokens_needed=50, model="gpt-4")
+    assert isinstance(result["content"], str)
+    assert ".." in result["content"]
+
+
+def test_preserves_message_role() -> None:
+    """Test that message role is preserved after trimming."""
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Long assistant message " * 100},
+        ],
+    }
+    result = shorten_message_to_fit_limit(message, tokens_needed=50, model="gpt-4")
+    assert result["role"] == "assistant"
+
+
+def test_zero_tokens_needed() -> None:
+    """Test behavior when tokens_needed is 0."""
+    message = {
+        "role": "user",
+        "content": [{"type": "text", "text": "Any text"}],
+    }
+    result = shorten_message_with_list_content(message, tokens_needed=0, model="gpt-4")
+    # Should return empty or minimal content
+    assert isinstance(result["content"], list)
+
+
+def test_single_character_text() -> None:
+    """Test trimming of very short text."""
+    message = {
+        "role": "user",
+        "content": [{"type": "text", "text": "x"}],
+    }
+    result = shorten_message_with_list_content(
+        message, tokens_needed=1000, model="gpt-4"
+    )
+    item = result["content"][0]
+    assert is_text_content(item)
+    if is_text_content(item):
+        assert item["text"] == "x"
+
+
+def test_mixed_content_with_tight_budget() -> None:
+    """Test mixed content with very tight token budget."""
+    message = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Text before"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfF"
+                    "cSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                },
+            },
+            {"type": "text", "text": "Text after"},
+        ],
+    }
+    result = shorten_message_with_list_content(message, tokens_needed=50, model="gpt-4")
+    # With tight budget, should keep at least some content
+    assert isinstance(result["content"], list)
+    assert len(result["content"]) >= 1


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/16567

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) (it doesn't on main either, does it?)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem
Previously, `shorten_message_to_fit_limit()` only handled string content. When encountering multimodal messages (list of text/image objects), it would fail with a `TypeError` when trying to use string operations on a list.

### Solution
Implemented trimming for multimodal messages using a greedy packing algorithm:

1. **Detect content type**: Dispatch to appropriate handler based on whether content is string or list
2. **Replace oversized items**: Images that alone exceed the token limit are replaced with text placeholders
3. **Greedy packing**: Iterate through content items in order, adding each item if it fits within the remaining token budget
4. **Trim text when needed**: If a text item doesn't fit completely, trim it from the middle (preserving existing behavior)

### New Helper Functions
- `is_text_content()`: TypeGuard for detecting text content items
- `trim_text()`: Extracted text trimming logic for reusability  
- `shorten_message_with_list_content()`: Handles multimodal message trimming with greedy packing strategy

## Testing

I've added 21 unit tests covering:
- String content trimming
- Multimodal (list) content handling
- Image placeholder replacement
- Edge cases (empty content, single character, tight budgets)
- Preserving message roles and structure

All tests pass locally (see screenshot below).

### Note on test location

Tests added to `tests/test_litellm/test_utils.py` following the contributing guidelines.

Note: There are existing `trim_messages` tests in `tests/litellm_utils_tests/test_utils.py` 
that may not be running in CI (based on the "LiteLLM Mock Tests (folder - tests/test_litellm)" 
job name). These could potentially be migrated in a future PR if desired.

### Screenshot of test passing locally

<img width="726" height="394" alt="image" src="https://github.com/user-attachments/assets/18d3c9ca-a0d3-4675-963e-e186fce90839" />

## Formatting

`make format` leads to the formatting of many unrelated files, as it does on main. I manually formatted the files I changed using `poetry run black litellm/utils.py tests/test_litellm/test_utils.py`. This also reformatted locations of the code that I did not touch.

## Linting

`poetry run ruff check litellm/utils.py tests/test_litellm/test_utils.py` lead to many linting errors unrelated to my changes. I ran `poetry run ruff check --fix litellm/utils.py tests/test_litellm/test_utils.py` nonetheless. This also changed locations of the code that I did not touch.

## Unit tests

`make test-unit` failed on unrelated tests, as it does on main, even in dev-container.