### PR TITLE
fix(proxy): Hash api_key in /spend/logs with date filters

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1973,8 +1973,6 @@ async def view_spend_logs(  # noqa: PLR0915
             }
 
             if api_key is not None and isinstance(api_key, str):
-                # Hash the API key before querying, consistent with other parts of the function.
-                # The database stores hashed keys, so the raw key must be transformed.
                 if api_key.startswith("sk-"):
                     hashed_token = prisma_client.hash_token(token=api_key)
                 else:


### PR DESCRIPTION
## Hash api_key in /spend/logs with date filters



## Relevant issues

Fixes #16481

## Pre-Submission checklist

**Please complete all items before asking a Lite-LLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) *(Please run `make test-unit` to confirm)*
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1670" height="851" alt="image" src="https://github.com/user-attachments/assets/ac528ad5-00e3-429c-a2d1-0398e232ad83" />



## Type

🐛 Bug Fix
✅ Test

## Changes

When a user called the `/spend/logs` endpoint with `api_key`, `start_date`, and `end_date` all specified, the `api_key` was not being hashed before being used in the database query. This caused the query to return an empty result, as the database stores hashed API keys.

This PR fixes the issue by adding the necessary hashing logic to this specific code path. The change ensures that the `api_key` is always hashed before filtering, making its behavior consistent with other parts of the endpoint. A new unit test has been added to replicate the bug and verify that the fix correctly solves the problem by checking that the endpoint now returns data as expected.