### PR TITLE
refactor: drop MCPClient.connect and use run_with_session lifecycle

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -385,12 +385,12 @@ class MCPServerManager:
                     )
 
                     # Update tool name to server name mapping (for both prefixed and base names)
-                    self.tool_name_to_mcp_server_name_mapping[base_tool_name] = (
-                        server_prefix
-                    )
-                    self.tool_name_to_mcp_server_name_mapping[prefixed_tool_name] = (
-                        server_prefix
-                    )
+                    self.tool_name_to_mcp_server_name_mapping[
+                        base_tool_name
+                    ] = server_prefix
+                    self.tool_name_to_mcp_server_name_mapping[
+                        prefixed_tool_name
+                    ] = server_prefix
 
                     registered_count += 1
                     verbose_logger.debug(
@@ -714,12 +714,6 @@ class MCPServerManager:
                 f"Failed to get tools from server {server.name}: {str(e)}"
             )
             return []
-        finally:
-            if client:
-                try:
-                    await client.disconnect()
-                except Exception:
-                    pass
 
     async def _descovery_metadata(
         self,
@@ -983,8 +977,6 @@ class MCPServerManager:
 
         async def _list_tools_task():
             try:
-                await client.connect()
-
                 tools = await client.list_tools()
                 verbose_logger.debug(f"Tools from {server_name}: {tools}")
                 return tools
@@ -1439,14 +1431,12 @@ class MCPServerManager:
         )
 
         async def _call_tool_via_client(client, params):
-            async with client:
-                return await client.call_tool(params)
+            return await client.call_tool(params)
 
         tasks.append(
             asyncio.create_task(_call_tool_via_client(client, call_tool_params))
         )
 
-        # IMPORTANT: Must await tasks INSIDE the context manager to keep connection alive
         try:
             mcp_responses = await asyncio.gather(*tasks)
         except (

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -84,8 +84,8 @@ class TestMCPClientUnitTests:
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.streamablehttp_client")
     @patch("litellm.experimental_mcp_client.client.ClientSession")
-    async def test_connect(self, mock_session_class, mock_transport):
-        """Test connecting to MCP server with authentication."""
+    async def test_run_with_session(self, mock_session_class, mock_transport):
+        """Test run_with_session establishes session with auth headers."""
         # Setup mocks
         mock_transport_ctx = AsyncMock()
         mock_transport.return_value = mock_transport_ctx
@@ -102,7 +102,11 @@ class TestMCPClientUnitTests:
             auth_type=MCPAuth.bearer_token,
             auth_value="test_token",
         )
-        await client.connect()
+
+        async def _operation(session):
+            return "ok"
+
+        await client.run_with_session(_operation)
 
         # Verify transport was created with auth headers
         call_args = mock_transport.call_args
@@ -112,7 +116,6 @@ class TestMCPClientUnitTests:
 
         # Verify session was initialized
         mock_session_instance.initialize.assert_called_once()
-        assert client._session == mock_session_instance
 
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.streamablehttp_client")

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -54,8 +54,6 @@ async def test_mcp_cost_tracking():
             inputSchema={"type": "object", "properties": {"test": {"type": "string"}}}
         )
     ])
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
     
     # Mock the MCPClient constructor
     def mock_client_constructor(*args, **kwargs):
@@ -118,7 +116,6 @@ async def test_mcp_cost_tracking():
             assert response_list[0].text == "Test response"
             
             # Verify client methods were called
-            mock_client.__aenter__.assert_called()
             mock_client.call_tool.assert_called_once()
 
             ######
@@ -153,9 +150,6 @@ async def test_mcp_cost_tracking_per_tool():
             inputSchema={"type": "object", "properties": {"data": {"type": "string"}}}
         )
     ])
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    mock_client.disconnect = AsyncMock(return_value=None)
     
     # Mock the MCPClient constructor
     def mock_client_constructor(*args, **kwargs):
@@ -297,9 +291,6 @@ async def test_mcp_tool_call_hook():
             inputSchema={"type": "object", "properties": {"test": {"type": "string"}}}
         )
     ])
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
-    mock_client.disconnect = AsyncMock(return_value=None)
     
     # Mock the MCPClient constructor
     def mock_client_constructor(*args, **kwargs):

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -68,8 +68,6 @@ async def test_mcp_server_manager_https_server():
     mock_client = AsyncMock()
     mock_client.list_tools = AsyncMock(return_value=mock_tools)
     mock_client.call_tool = AsyncMock(return_value=mock_result)
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=None)
 
     # Mock the MCPClient constructor
     def mock_client_constructor(*args, **kwargs):
@@ -132,7 +130,6 @@ async def test_mcp_server_manager_https_server():
         assert result.content[0].text == "Email sent successfully"
 
         # Verify client methods were called
-        mock_client.__aenter__.assert_called()
         mock_client.list_tools.assert_called()
         mock_client.call_tool.assert_called_once()
 
@@ -301,7 +298,6 @@ async def test_mcp_http_transport_call_tool_mock():
         assert result.content[0].text == "Email sent successfully to test@example.com"
 
         # Verify client methods were called
-        mock_client.__aenter__.assert_called()
         mock_client.call_tool.assert_called_once()
 
 
@@ -364,7 +360,6 @@ async def test_mcp_http_transport_call_tool_error_mock():
         assert "Error: Invalid email address" in result.content[0].text
 
         # Verify client methods were called
-        mock_client.__aenter__.assert_called()
         mock_client.call_tool.assert_called_once()
 
 

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -39,7 +39,10 @@ class TestMCPClient:
         with pytest.raises(
             ValueError, match="stdio_config is required for stdio transport"
         ):
-            await client.connect()
+            async def _noop(session):
+                return None
+
+            await client.run_with_session(_noop)
 
     @pytest.mark.asyncio
     @patch("litellm.experimental_mcp_client.client.stdio_client")
@@ -65,7 +68,10 @@ class TestMCPClient:
 
         client = MCPClient(transport_type=MCPTransport.stdio, stdio_config=stdio_config)
 
-        await client.connect()
+        async def _operation(session):
+            return "ok"
+
+        await client.run_with_session(_operation)
 
         # Verify stdio_client was called with correct parameters
         mock_stdio_client.assert_called_once()
@@ -109,7 +115,10 @@ class TestMCPClient:
                 transport_type=MCPTransport.http,
             )
 
-            await client.connect()
+            async def _operation(session):
+                return "ok"
+
+            await client.run_with_session(_operation)
 
             # Verify streamablehttp_client was called
             mock_streamablehttp_client.assert_called_once()
@@ -157,7 +166,10 @@ class TestMCPClient:
                 ssl_verify=False,
             )
 
-            await client.connect()
+            async def _operation(session):
+                return "ok"
+
+            await client.run_with_session(_operation)
 
             # Verify sse_client was called
             mock_sse_client.assert_called_once()
@@ -208,7 +220,10 @@ class TestMCPClient:
                 ssl_verify=custom_ca_path,
             )
 
-            await client.connect()
+            async def _operation(session):
+                return "ok"
+
+            await client.run_with_session(_operation)
 
             # Verify streamablehttp_client was called
             mock_streamablehttp_client.assert_called_once()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -540,7 +540,6 @@ async def test_oauth2_headers_passed_to_mcp_client():
         )
         # Return a mock client that doesn't actually connect
         mock_client = MagicMock()
-        mock_client.disconnect = AsyncMock()
         return mock_client
 
     # Mock _fetch_tools_with_timeout to avoid actual network calls


### PR DESCRIPTION
## Title

drop MCPClient.connect and use run_with_session lifecycle

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

- Replaced the __aenter__ lifecycle with the new run_with_session helper so we manage transport setup/teardown per call.
- While doing so, captured the detailed HTTP errors (status, URL, body) that occur during connection attempts, making MCP connection issues much easier to diagnose.

### Next steps
Use the surfaced 401 responses to move forward with the MCP OAuth UI flow.