### PR TITLE
[Feature] UI - Edit add callbacks route to use data from backend

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5,6 +5,36 @@ export const formatDate = (date: Date) => {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 };
+
+export const getCallbackConfigsCall = async (accessToken: string) => {
+  /**
+   * Get callback configuration metadata (logos, params, etc.)
+   */
+  try {
+    let url = proxyBaseUrl ? `${proxyBaseUrl}/callbacks/configs` : `/callbacks/configs`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to get callbacks:", error);
+    throw error;
+  }
+};
 /**
  * Helper file for calls being made to proxy
  */

--- a/ui/litellm-dashboard/src/components/settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/settings.test.tsx
@@ -1,10 +1,11 @@
 import { render, waitFor } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { alertingSettingsCall, getCallbacksCall } from "./networking";
+import { alertingSettingsCall, getCallbackConfigsCall, getCallbacksCall } from "./networking";
 import Settings from "./settings";
 
 vi.mock("./networking", () => ({
   getCallbacksCall: vi.fn(),
+  getCallbackConfigsCall: vi.fn(),
   setCallbacksCall: vi.fn(),
   serviceHealthCheck: vi.fn(),
   deleteCallback: vi.fn(),
@@ -65,6 +66,7 @@ describe("Settings", () => {
     premiumUser: false,
   };
   const mockGetCallbacksCall = vi.mocked(getCallbacksCall);
+  const mockGetCallbackConfigsCall = vi.mocked(getCallbackConfigsCall);
   const mockAlertingSettingsCall = vi.mocked(alertingSettingsCall);
 
   beforeEach(() => {
@@ -74,6 +76,7 @@ describe("Settings", () => {
       available_callbacks: [],
       alerts: [],
     });
+    mockGetCallbackConfigsCall.mockResolvedValue([]);
     mockAlertingSettingsCall.mockResolvedValue([]);
   });
 
@@ -92,6 +95,14 @@ describe("Settings", () => {
       expect(getByText("Alerting Types")).toBeInTheDocument();
       expect(getByText("Alerting Settings")).toBeInTheDocument();
       expect(getByText("Email Alerts")).toBeInTheDocument();
+    });
+  });
+
+  it("should load callback configs from the backend when access token is provided", async () => {
+    render(<Settings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockGetCallbackConfigsCall).toHaveBeenCalledWith(defaultProps.accessToken);
     });
   });
 });


### PR DESCRIPTION
## [Feature] UI - Edit add callbacks route to use data from backend

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

The current implementation of the add callbacks route uses hard coded variables in the front end. This results in significant drift between what users can enter in the UI vs the API. This PR edits the add callbacks route to use data from a new configs endpoint to allow users to enter all values supported on the backend

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


## Screenshots
<img width="678" height="216" alt="image" src="https://github.com/user-attachments/assets/9101b572-59f5-46d2-a3ae-44ee4e439261" />
<img width="1512" height="312" alt="image" src="https://github.com/user-attachments/assets/1043ea09-d722-4a01-856b-8f0149a77fe1" />
<img width="775" height="683" alt="image" src="https://github.com/user-attachments/assets/39707e6b-567a-4175-a972-cef4a1297047" />
