### PR TITLE
fix(openai-video): inherit BaseVideoConfig to enable async content response

### DIFF
--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -4,6 +4,7 @@ from typing import cast
 import httpx
 from httpx._types import RequestFiles
 
+from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
 from litellm.types.videos.main import VideoCreateOptionalRequestParams
 from litellm.types.llms.openai import CreateVideoRequest
 from litellm.types.router import GenericLiteLLMParams
@@ -15,15 +16,12 @@ from litellm.llms.openai.image_edit.transformation import ImageEditRequestUtils
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
 
-    from ...base_llm.videos.transformation import BaseVideoConfig as _BaseVideoConfig
     from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
-    BaseVideoConfig = _BaseVideoConfig
     BaseLLMException = _BaseLLMException
 else:
     LiteLLMLoggingObj = Any
-    BaseVideoConfig = Any
     BaseLLMException = Any
 
 

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -760,5 +760,10 @@ def test_video_content_handler_uses_get_for_openai():
     assert called_url == "https://api.openai.com/v1/videos/video_abc/content"
 
 
+def test_openai_video_config_has_async_transform():
+    """Ensure OpenAIVideoConfig exposes async_transform_video_content_response at runtime."""
+    cfg = OpenAIVideoConfig()
+    assert callable(getattr(cfg, "async_transform_video_content_response", None))
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Title

fix(openai-video): inherit BaseVideoConfig to enable async content response

## Relevant issues

- Resolves AttributeError when calling avideo_content for OpenAI:
    - "'OpenAIVideoConfig' object has no attribute 'async_transform_video_content_response'"

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes
  - Import and subclass the real base class at runtime in OpenAIVideoConfig:
      - from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
      - class OpenAIVideoConfig(BaseVideoConfig):
  - Remove TYPE_CHECKING aliasing of BaseVideoConfig to Any so the class inherits:
      - async_transform_video_content_response(...) default implementation
  - Scope: OpenAI videos only; no API changes; no behavior changes beyond fixing the AttributeError during async content downloads.
  
<img width="969" height="302" alt="Screenshot 2025-11-16 at 4 29 48 PM" src="https://github.com/user-attachments/assets/54ca36f0-cbca-42b5-8dbb-cc642a189e17" />


