### PR TITLE
Remove location as editable param for vertex ai /videos api

### DIFF
--- a/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
@@ -86,7 +86,8 @@ class TestVertexAIVideoConfig:
 
         assert url.startswith("https://custom-endpoint.example.com")
         assert "test-project" in url
-        assert "us-west1" in url
+        # Location is always forced to us-central1 for video generation
+        assert "us-central1" in url
         assert "veo-002" in url
         # Should NOT include endpoint
         assert not url.endswith(":predictLongRunning")


### PR DESCRIPTION
## Title

Remove location as editable param for vertex ai /videos api

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
Only us-central1 is the supported location for videos api. Updated the code accordingly

