### PR TITLE
feat: show alias in customer usage

### DIFF
--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -843,6 +843,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ accessToken, token, userRole, use
                 <TableHead>
                   <TableRow>
                     <TableHeaderCell>Customer</TableHeaderCell>
+                    <TableHeaderCell>Alias</TableHeaderCell>
                     <TableHeaderCell>Spend</TableHeaderCell>
                     <TableHeaderCell>Total Events</TableHeaderCell>
                   </TableRow>
@@ -852,6 +853,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ accessToken, token, userRole, use
                   {topUsers?.map((user: any, index: number) => (
                     <TableRow key={index}>
                       <TableCell>{user.end_user}</TableCell>
+                      <TableCell>{user.alias || "-"}</TableCell>
                       <TableCell>{formatNumberWithCommas(user.total_spend, 2)}</TableCell>
                       <TableCell>{user.total_count}</TableCell>
                     </TableRow>


### PR DESCRIPTION
## Title

Show customer alias in customer usage (in old usage tab)

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- updated global spend api to return alias
- updated ui to show the alias