### PR TITLE
Add support for `strict` parameter in Anthropic tool schemas

### DIFF
--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -25,6 +25,7 @@ AnthropicInputSchema = TypedDict(
         "additionalProperties": Optional[bool],
         "required": Optional[List[str]],
         "$defs": Optional[Dict],
+        "strict": Optional[bool],
     },
     total=False,
 )

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -1691,3 +1691,78 @@ def test_anthropic_via_responses_api():
 
     print(f"✓ All {len(events_seen)} events matched expected structure")
     print(f"✓ Received {text_delta_count} text delta chunks")
+
+def test_anthropic_strict_parameter_passthrough():
+    """Test that the strict parameter in tool parameters is passed through to Anthropic input_schema"""
+    args = {
+        "non_default_params": {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather information",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "location": {"type": "string"},
+                            },
+                            "required": ["location"],
+                            "strict": True,
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mapped_params = litellm.AnthropicConfig().map_openai_params(
+        non_default_params=args["non_default_params"],
+        optional_params={},
+        model="claude-sonnet-4-5-20250929",
+        drop_params=False,
+    )
+
+    # Verify the strict parameter is in the mapped tool's input_schema
+    assert "tools" in mapped_params
+    assert len(mapped_params["tools"]) == 1
+    tool = mapped_params["tools"][0]
+    assert "input_schema" in tool
+    assert tool["input_schema"]["strict"] is True
+
+def test_anthropic_strict_not_present():
+    """Test that the strict parameter in tool parameters is passed through to Anthropic input_schema"""
+    args = {
+        "non_default_params": {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather information",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "location": {"type": "string"},
+                            },
+                            "required": ["location"],
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mapped_params = litellm.AnthropicConfig().map_openai_params(
+        non_default_params=args["non_default_params"],
+        optional_params={},
+        model="claude-sonnet-4-5-20250929",
+        drop_params=False,
+    )
+
+    # Verify the strict parameter is in the mapped tool's input_schema
+    assert "tools" in mapped_params
+    assert len(mapped_params["tools"]) == 1
+    tool = mapped_params["tools"][0]
+    assert "input_schema" in tool
+    assert "strict" not in tool["input_schema"]

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -1760,7 +1760,7 @@ def test_anthropic_strict_not_present():
         drop_params=False,
     )
 
-    # Verify the strict parameter is in the mapped tool's input_schema
+    # Verify the strict parameter does not exist if it is not passed in
     assert "tools" in mapped_params
     assert len(mapped_params["tools"]) == 1
     tool = mapped_params["tools"][0]


### PR DESCRIPTION
## Add support for strict parameter in Anthropic tool schemas

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - existing tests are failing with default setup script. Can give details if required.
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="707" height="405" alt="image" src="https://github.com/user-attachments/assets/33c42766-b2dd-4520-a347-ee203a3d5e92" />


## Type

🆕 New Feature

## Changes

**Problem:**
  Anthropic's API now supports a `strict` parameter in tool input schemas with the beta header flag: `structured-outputs-2025-11-13` for structured outputs, but LiteLLM filters it out during the OpenAI → Anthropic parameter mapping. See https://docs.claude.com/en/docs/build-with-claude/structured-outputs#strict-tool-use for further details.

  **Solution:**
  - Added `"strict": Optional[bool]` to the `AnthropicInputSchema` TypedDict in `litellm/types/llms/anthropic.py` (line 28)
  - This allows the `strict` parameter to pass through the filter in `litellm/llms/anthropic/chat/transformation.py` (lines 206-212)
  - Added test `test_anthropic_strict_parameter_passthrough` to verify the parameter is correctly passed through

  **Impact:**
  Users can now use Anthropic's strict mode for tool calling by including `"strict": true` in their tool parameters

