### PR TITLE
fix delete managed file method

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -811,9 +811,9 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 if deployment is not None:
                     custom_llm_provider = self._get_custom_llm_provider_from_deployment(deployment)
                     # Explicitly pass custom_llm_provider to ensure it's set
-                    data_with_provider = {**data, "custom_llm_provider": custom_llm_provider}
+                    data_with_provider: Dict[str, Any] = {**data, "custom_llm_provider": custom_llm_provider}
                 else:
-                    data_with_provider = data
+                    data_with_provider = dict(data)
                 await llm_router.afile_delete(model=model_id, file_id=model_file_id, **data_with_provider)  # type: ignore
 
         stored_file_object = await self.delete_unified_file_id(

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -566,7 +566,7 @@ def file_delete(
             )
         else:
             raise litellm.exceptions.BadRequestError(
-                message="LiteLLM doesn't support {} for 'create_batch'. Only 'openai' is supported.".format(
+                message="LiteLLM doesn't support {} for 'file_delete'. Only 'openai' and 'azure' are supported.".format(
                     custom_llm_provider
                 ),
                 model="n/a",
@@ -574,7 +574,7 @@ def file_delete(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="delete_file", url="https://github.com/BerriAI/litellm"),  # type: ignore
                 ),
             )
         return cast(FileDeleted, response)


### PR DESCRIPTION
## Title

Fix file deletion failure when custom_llm_provider is None in managed files

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type


🐛 Bug Fix
✅ Test

## Changes

### Problem
When deleting a unified file ID (created with `target_model_names`), the deletion would fail with two issues:
1. **"Not found" error**: The code was not using the original base64-encoded file ID for database lookups, causing the file to not be found in the database.
2. **`custom_llm_provider` is None error**: The deletion would fail with `LiteLLM doesn't support None for 'file_delete'. Only 'openai' and 'azure' are supported.` This occurred because `custom_llm_provider` was `None` in the deployment's `litellm_params`, and the code didn't extract it from the model name.

### Solution
1. **Fixed base64-encoded file ID handling** in `afile_delete` method:
   - Keep the original base64-encoded `file_id` for database/cache lookups
   - Use `original_file_id` when calling `get_model_file_id_mapping` and `delete_unified_file_id`
   - This ensures the file can be found in the database since it's stored with the base64-encoded ID

2. **Added `_get_custom_llm_provider_from_deployment` method** in `managed_files.py`:
   - Extracts `custom_llm_provider` from deployment's `litellm_params`
   - If `None`, falls back to extracting it from the model name using `get_llm_provider`
   - Defaults to `"openai"` if extraction fails

3. **Updated `afile_delete` method** in `managed_files.py`:
   - Uses the new `_get_custom_llm_provider_from_deployment` method to determine the provider
   - Explicitly passes `custom_llm_provider` to the router's `afile_delete` call
   - Ensures the provider is always set before calling the router

4. **Fixed error message** in `file_delete` function in `files/main.py`:
   - Corrected error message to refer to `'file_delete'` instead of `'create_batch'`

### Files Changed
- `litellm/enterprise/litellm_enterprise/proxy/hooks/managed_files.py`:
  - Fixed base64-encoded file ID handling in `afile_delete` (lines 800-802, 819-820)
  - Added `_get_custom_llm_provider_from_deployment` method (lines 644-675)
  - Updated `afile_delete` to use the new method and preserve original file ID (lines 800-825)

- `litellm/litellm/files/main.py`:
  - Fixed error message in `file_delete` (line 569)

