### PR TITLE
fix: Get custom_llm_provider from query param

### DIFF
--- a/litellm/proxy/fine_tuning_endpoints/endpoints.py
+++ b/litellm/proxy/fine_tuning_endpoints/endpoints.py
@@ -281,7 +281,7 @@ async def retrieve_fine_tuning_job(
         except Exception:
             request_body = {}
 
-        custom_llm_provider = request_body.get("custom_llm_provider", None)
+        custom_llm_provider = request_body.get("custom_llm_provider", None) or custom_llm_provider
 
         ## CHECK IF MANAGED FILE ID
         unified_finetuning_job_id: Union[str, Literal[False]] = False


### PR DESCRIPTION
## Title

fix: Get custom_llm_provider from query param

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


In retrieve_fine_tuning_job function you can see that exist a parameter called custom_llm_provider. This parameter has not been used inside the function.

I don't know why, but using the OpenAI library, somehow the request are not treated as a json (Maybe as a form). So LiteLLM not recognizes (If you use a requests.get it works fine)
<img width="1257" height="167" alt="Screenshot 2025-11-17 at 12 38 10" src="https://github.com/user-attachments/assets/79b93194-6951-41d6-9728-21be5f3ede58" />

The exactly error is `BadRequestError: Error code: 400 - {'error': {'message': 'Invalid request, No litellm managed file id or custom_llm_provider provided.', 'type': 'internal_server_error', 'param': 'None', 'code': '400'}}
`
Since the parameter exists within the function but wasn't being used, I'm using it in the `or` clause so that it will be used if the user specifies it in the query parameters. This solves the access problem for the fine-tuning job via the OpenAI library.

<img width="1257" height="167" alt="Screenshot 2025-11-17 at 12 38 56" src="https://github.com/user-attachments/assets/00cbe206-1670-4176-941d-5ca99672e615" />

## Local Tests
<img width="1159" height="401" alt="Screenshot 2025-11-17 at 12 42 28" src="https://github.com/user-attachments/assets/0ce21d1e-a0a2-4407-ac70-62c9f1d89736" />

Note: I try to run the uv run pytest tests/batches_tests/test_fine_tuning_api.py::test_create_fine_tune_jobs_async but since it require a Datadog key, I can't test this function.