### PR TITLE
Add managed files support for responses API

### DIFF
--- a/docs/my-website/docs/proxy/litellm_managed_files.md
+++ b/docs/my-website/docs/proxy/litellm_managed_files.md
@@ -21,7 +21,7 @@ Available via the `litellm[proxy]` package or any `litellm` docker image.
 | Proxy | ✅ |  |
 | SDK | ❌ | Requires postgres DB for storing file ids. |
 | Available across all providers | ✅ |  |
-| Supported endpoints | `/chat/completions`, `/batch`, `/fine_tuning` |  |
+| Supported endpoints | `/chat/completions`, `/batch`, `/fine_tuning`, `/responses` |  |
 
 ## Usage
 

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -475,7 +475,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
           - type: "input_file" with file_id
           - content: a list that can contain items with type: "input_file" and file_id
         """
-        file_ids = []
+        file_ids: List[str] = []
         
         if isinstance(input, str):
             return file_ids

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -297,6 +297,16 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     )
 
                     data["model_file_id_mapping"] = model_file_id_mapping
+        elif call_type == CallTypes.aresponses.value or call_type == CallTypes.responses.value:
+            # Handle managed files in responses API input
+            input_data = data.get("input")
+            if input_data:
+                file_ids = self.get_file_ids_from_responses_input(input_data)
+                if file_ids:
+                    model_file_id_mapping = await self.get_model_file_id_mapping(
+                        file_ids, user_api_key_dict.parent_otel_span
+                    )
+                    data["model_file_id_mapping"] = model_file_id_mapping
         elif call_type == CallTypes.afile_content.value:
             retrieve_file_id = cast(Optional[str], data.get("file_id"))
             potential_file_id = (
@@ -451,6 +461,47 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                             file_id = file_object_file_field.get("file_id")
                             if file_id:
                                 file_ids.append(file_id)
+        return file_ids
+
+    def get_file_ids_from_responses_input(
+        self, input: Union[str, List[Dict[str, Any]]]
+    ) -> List[str]:
+        """
+        Gets file ids from responses API input.
+        
+        The input can be:
+        - A string (no files)
+        - A list of input items, where each item can have:
+          - type: "input_file" with file_id
+          - content: a list that can contain items with type: "input_file" and file_id
+        """
+        file_ids = []
+        
+        if isinstance(input, str):
+            return file_ids
+        
+        if not isinstance(input, list):
+            return file_ids
+        
+        for item in input:
+            if not isinstance(item, dict):
+                continue
+            
+            # Check for direct input_file type
+            if item.get("type") == "input_file":
+                file_id = item.get("file_id")
+                if file_id:
+                    file_ids.append(file_id)
+            
+            # Check for input_file in content array
+            content = item.get("content")
+            if isinstance(content, list):
+                for content_item in content:
+                    if isinstance(content_item, dict) and content_item.get("type") == "input_file":
+                        file_id = content_item.get("file_id")
+                        if file_id:
+                            file_ids.append(file_id)
+        
         return file_ids
 
     async def get_model_file_id_mapping(

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -437,6 +437,66 @@ def update_messages_with_model_file_ids(
     return messages
 
 
+def update_responses_input_with_model_file_ids(
+    input: Union[str, List[Dict[str, Any]]],
+) -> Union[str, List[Dict[str, Any]]]:
+    """
+    Updates responses API input with provider-specific file IDs.
+    File IDs are always inside the content array, not as direct input_file items.
+    
+    For managed files (unified file IDs), decodes the base64-encoded unified file ID
+    and extracts the llm_output_file_id directly.
+    """
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        _is_base64_encoded_unified_file_id,
+        convert_b64_uid_to_unified_uid,
+    )
+    
+    if isinstance(input, str):
+        return input
+    
+    if not isinstance(input, list):
+        return input
+    
+    updated_input = []
+    for item in input:
+        if not isinstance(item, dict):
+            updated_input.append(item)
+            continue
+        
+        updated_item = item.copy()
+        content = item.get("content")
+        if isinstance(content, list):
+            updated_content = []
+            for content_item in content:
+                if isinstance(content_item, dict) and content_item.get("type") == "input_file":
+                    file_id = content_item.get("file_id")
+                    if file_id:
+                        # Check if this is a managed file ID (base64-encoded unified file ID)
+                        is_unified_file_id = _is_base64_encoded_unified_file_id(file_id)
+                        if is_unified_file_id:
+                            unified_file_id = convert_b64_uid_to_unified_uid(file_id)
+                            if "llm_output_file_id," in unified_file_id:
+                                provider_file_id = unified_file_id.split("llm_output_file_id,")[1].split(";")[0]
+                            else:
+                                # Fallback: keep original if we can't extract
+                                provider_file_id = file_id
+                            updated_content_item = content_item.copy()
+                            updated_content_item["file_id"] = provider_file_id
+                            updated_content.append(updated_content_item)
+                        else:
+                            updated_content.append(content_item)
+                    else:
+                        updated_content.append(content_item)
+                else:
+                    updated_content.append(content_item)
+            updated_item["content"] = updated_content
+        
+        updated_input.append(updated_item)
+    
+    return updated_input
+
+
 def extract_file_data(file_data: FileTypes) -> ExtractedFileData:
     """
     Extracts and processes file data from various input formats.

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -438,7 +438,7 @@ def update_messages_with_model_file_ids(
 
 
 def update_responses_input_with_model_file_ids(
-    input: Union[str, List[Dict[str, Any]]],
+    input: Any,
 ) -> Union[str, List[Dict[str, Any]]]:
     """
     Updates responses API input with provider-specific file IDs.

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1025,19 +1025,19 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         _tools: List[ChatCompletionToolCallChunk] = []
         for part in parts:
             if "functionCall" in part:
-                _function_chunk: ChatCompletionToolCallFunctionChunk = {
-                    "name": part["functionCall"]["name"],
-                    "arguments": json.dumps(part["functionCall"]["args"], ensure_ascii=False),
-                }
+                _function_chunk = ChatCompletionToolCallFunctionChunk(
+                    name=part["functionCall"]["name"],
+                    arguments=json.dumps(part["functionCall"]["args"], ensure_ascii=False),
+                )
                 if is_function_call is True:
                     function = _function_chunk
                 else:
-                    _tool_response_chunk: ChatCompletionToolCallChunk = {
-                        "id": f"call_{uuid.uuid4().hex[:28]}",
-                        "type": "function",
-                        "function": _function_chunk,
-                        "index": cumulative_tool_call_idx,
-                    }
+                    _tool_response_chunk = ChatCompletionToolCallChunk(
+                        id=f"call_{uuid.uuid4().hex[:28]}",
+                        type="function",
+                        function=_function_chunk,
+                        index=cumulative_tool_call_idx,
+                    )
                     _tools.append(_tool_response_chunk)
                 cumulative_tool_call_idx += 1
         if len(_tools) == 0:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1025,19 +1025,19 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         _tools: List[ChatCompletionToolCallChunk] = []
         for part in parts:
             if "functionCall" in part:
-                _function_chunk = ChatCompletionToolCallFunctionChunk(
-                    name=part["functionCall"]["name"],
-                    arguments=json.dumps(part["functionCall"]["args"], ensure_ascii=False),
-                )
+                _function_chunk: ChatCompletionToolCallFunctionChunk = {
+                    "name": part["functionCall"]["name"],
+                    "arguments": json.dumps(part["functionCall"]["args"], ensure_ascii=False),
+                }
                 if is_function_call is True:
                     function = _function_chunk
                 else:
-                    _tool_response_chunk = ChatCompletionToolCallChunk(
-                        id=f"call_{uuid.uuid4().hex[:28]}",
-                        type="function",
-                        function=_function_chunk,
-                        index=cumulative_tool_call_idx,
-                    )
+                    _tool_response_chunk: ChatCompletionToolCallChunk = {
+                        "id": f"call_{uuid.uuid4().hex[:28]}",
+                        "type": "function",
+                        "function": _function_chunk,
+                        "index": cumulative_tool_call_idx,
+                    }
                     _tools.append(_tool_response_chunk)
                 cumulative_tool_call_idx += 1
         if len(_tools) == 0:

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -37,6 +37,9 @@ from litellm.types.llms.openai import (
     ToolChoice,
     ToolParam,
 )
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    update_responses_input_with_model_file_ids,
+)
 
 # Handle ResponseText import with fallback
 if TYPE_CHECKING:
@@ -555,6 +558,13 @@ def responses(
             api_base=litellm_params.api_base,
             api_key=litellm_params.api_key,
         )
+        
+        #########################################################
+        # Update input with provider-specific file IDs if managed files are used
+        #########################################################
+        input = update_responses_input_with_model_file_ids(input=input)
+        local_vars["input"] = input
+        
         #########################################################
         # Native MCP Responses API
         #########################################################

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Type,
     Union,
+    cast,
 )
 
 import httpx
@@ -562,7 +563,7 @@ def responses(
         #########################################################
         # Update input with provider-specific file IDs if managed files are used
         #########################################################
-        input = update_responses_input_with_model_file_ids(input=input)
+        input = cast(Union[str, ResponseInputParam], update_responses_input_with_model_file_ids(input=input))
         local_vars["input"] = input
         
         #########################################################

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -390,6 +390,8 @@ CallTypesLiteral = Literal[
     "vector_store_file_delete",
     "avector_store_file_delete",
     "call_mcp_tool",
+    "aresponses",
+    "responses",
 ]
 
 


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🆕 New Feature
🐛 Bug Fix


## Changes
When using the responses API with managed files (unified file IDs created with `target_model_names`), the API would fail with an error: `Invalid 'input[0].content[0].file_id': string too long. Expected a string with maximum length 64, but got a string with length 320 instead.` This occurred because the base64-encoded unified file ID (320 characters) was being sent directly to the provider instead of being converted to the provider-specific file ID.

### Solution
1. **Added `update_responses_input_with_model_file_ids` function** in `common_utils.py`:
   - Decodes base64-encoded unified file IDs
   - Extracts `llm_output_file_id` directly from the unified file ID structure
   - Updates `input_file` items in the `content` array with provider-specific file IDs
   - Keeps regular OpenAI file IDs unchanged

2. **Updated `responses` function** in `responses/main.py`:
   - Calls `update_responses_input_with_model_file_ids` to transform input before making the API call
   - Follows the same pattern as `completion` function uses for `update_messages_with_model_file_ids`

3. **Updated `async_pre_call_hook`** in `managed_files.py`:
   - Added handling for `CallTypes.aresponses.value` and `CallTypes.responses.value`
   - Extracts file IDs from responses API input and gets `model_file_id_mapping` (for future use if needed)

<img width="1148" height="607" alt="image" src="https://github.com/user-attachments/assets/fdb8be83-46c7-4aa1-80e4-ecbbf77cbf8e" />
