### PR TITLE
docs(openai): Add gpt-5.1-codex and gpt-5.1-codex-mini models to documentation

### DIFF
--- a/docs/my-website/docs/providers/openai.md
+++ b/docs/my-website/docs/providers/openai.md
@@ -176,6 +176,9 @@ os.environ["OPENAI_BASE_URL"] = "https://your_host/v1"     # OPTIONAL
 | gpt-5-mini-2025-08-07 | `response = completion(model="gpt-5-mini-2025-08-07", messages=messages)` |
 | gpt-5-nano-2025-08-07 | `response = completion(model="gpt-5-nano-2025-08-07", messages=messages)` |
 | gpt-5-pro | `response = completion(model="gpt-5-pro", messages=messages)` |
+| gpt-5.1 | `response = completion(model="gpt-5.1", messages=messages)` |
+| gpt-5.1-codex | `response = completion(model="gpt-5.1-codex", messages=messages)` |
+| gpt-5.1-codex-mini | `response = completion(model="gpt-5.1-codex-mini", messages=messages)` |
 | gpt-4.1 | `response = completion(model="gpt-4.1", messages=messages)` |
 | gpt-4.1-mini | `response = completion(model="gpt-4.1-mini", messages=messages)` |
 | gpt-4.1-nano | `response = completion(model="gpt-4.1-nano", messages=messages)` |
@@ -477,6 +480,8 @@ curl -X POST 'http://0.0.0.0:4000/chat/completions' \
 | `gpt-5-mini` | `medium` | `none`, `minimal`, `low`, `medium`, `high` |
 | `gpt-5-nano` | `none` | `none`, `low`, `medium`, `high` |
 | `gpt-5-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
+| `gpt-5.1-codex` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
+| `gpt-5.1-codex-mini` | `adaptive` | `low`, `medium`, `high` (no `minimal`) |
 | `gpt-5-pro` | `high` | `high` only |
 
 **Note:**
@@ -490,7 +495,9 @@ See [OpenAI Reasoning documentation](https://platform.openai.com/docs/guides/rea
 
 The `verbosity` parameter controls the length and detail of responses from GPT-5 family models. It accepts three values: `"low"`, `"medium"`, or `"high"`.
 
-**Supported models:** All GPT-5 family models (`gpt-5`, `gpt-5.1`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-codex`, `gpt-5-pro`)
+**Supported models:** `gpt-5`, `gpt-5.1`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`
+
+**Note:** GPT-5-Codex models (`gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`) do **not** support the `verbosity` parameter.
 
 **Use cases:**
 - **`"low"`**: Best for concise answers or simple code generation (e.g., SQL queries)


### PR DESCRIPTION
## Title

Add gpt-5.1-codex and gpt-5.1-codex-mini models to OpenAI documentation

## Relevant issues

N/A - Documentation update for new models already added to main

## Type

📖 Documentation

## Changes

### Summary
Updated OpenAI provider documentation to include the newly added `gpt-5.1`, `gpt-5.1-codex`, and `gpt-5.1-codex-mini` models. These models were already added to `model_prices_and_context_window.json` in the main branch but were missing from the documentation.

### Changes
1. **Added models to OpenAI Chat Completion Models table:**
   - `gpt-5.1`
   - `gpt-5.1-codex`
   - `gpt-5.1-codex-mini`

2. **Updated `reasoning_effort` table:**
   - Added `gpt-5.1-codex` and `gpt-5.1-codex-mini` with supported values: `low`, `medium`, `high` (no `minimal`)
   - Default value: `adaptive`

3. **Clarified `verbosity` parameter support:**
   - Removed GPT-5-Codex models from the list of models that support `verbosity`
   - Added explicit note that `gpt-5-codex`, `gpt-5.1-codex`, and `gpt-5.1-codex-mini` do NOT support the `verbosity` parameter
   - This aligns with [OpenAI's official documentation](https://platform.openai.com/docs/models/gpt-5-codex)

### References
- Model configs already exist in `model_prices_and_context_window.json:14557-14622`
- OpenAI official docs: https://platform.openai.com/docs/models/gpt-5.1-codex