### PR TITLE
[Fix] UI - Fix flaky tests due to antd Notification Manager

### DIFF
--- a/ui/litellm-dashboard/src/components/molecules/notifications_manager.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/notifications_manager.test.tsx
@@ -1,6 +1,14 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
 import { notification } from "antd";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import NotificationManager from "./notifications_manager";
+
+vi.mock("@/components/molecules/notifications_manager", async () => {
+  const actual = await vi.importActual<typeof import("@/components/molecules/notifications_manager")>(
+    "@/components/molecules/notifications_manager",
+  );
+
+  return actual;
+});
 
 // Mock the antd notification module
 vi.mock("antd", () => ({

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -1,6 +1,20 @@
 import "@testing-library/jest-dom";
-import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+// Global mock for NotificationManager to prevent React rendering issues in tests
+// This avoids "window is not defined" errors when notifications try to render
+// after test environment is torn down
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    clear: vi.fn(),
+  },
+}));
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## [Fix] UI - Fix flaky tests due to antd Notification Manager

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Components that use antd's Notification Manager will occasionally throw an error after the test has finished. This is not an issue with the test itself, but with how Notification Manager relies on `window` which can be undefined in testing environments and it introduces flakiness to the UI test suite. This PR mocks the Notification Manager globally, so all and subsequent tests will not run into this issue. It imports the actual notification manager to test in the dedicated notification manager test file.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

## Screenshot 
<img width="777" height="255" alt="image" src="https://github.com/user-attachments/assets/87a87059-bec3-432e-8667-30a095a1353d" />

