### PR TITLE
[Feat] Add SSML Support for Azure Text-to-Speech (AVA)

### DIFF
--- a/litellm/llms/azure/text_to_speech/transformation.py
+++ b/litellm/llms/azure/text_to_speech/transformation.py
@@ -382,6 +382,13 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
             return f"https://{region}.{self.TTS_SPEECH_DOMAIN}{self.TTS_ENDPOINT_PATH}"
         return f"https://{self.TTS_SPEECH_DOMAIN}{self.TTS_ENDPOINT_PATH}"
 
+    
+    def is_ssml_input(self, input: str) -> bool:
+        """
+        Returns True if input is SSML, False otherwise
+        """
+        return "<speak>" in input or "<speak " in input
+
     def transform_text_to_speech_request(
         self,
         model: str,
@@ -402,6 +409,9 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
         - role: Voice role (e.g., "Girl", "Boy", "SeniorFemale", "SeniorMale")
         - lang: Language code for multilingual voices (e.g., "es-ES", "fr-FR")
         
+        Auto-detects SSML:
+        - If input contains <speak>, it's passed through as-is without transformation
+        
         Returns:
             TextToSpeechRequestData: Contains SSML body and Azure-specific headers
         """
@@ -414,7 +424,15 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
         )
         headers["X-Microsoft-OutputFormat"] = output_format
         
-        # Build SSML
+        # Auto-detect SSML: if input contains <speak>, pass it through as-is
+        # Similar to Vertex AI behavior - check if input looks like SSML
+        if self.is_ssml_input(input=input):
+            return TextToSpeechRequestData(
+                ssml_body=input,
+                headers=headers,
+            )
+        
+        # Build SSML from plain text
         rate = optional_params.get("rate", "0%")
         style = optional_params.get("style")
         styledegree = optional_params.get("styledegree")

--- a/litellm/llms/azure/text_to_speech/transformation.py
+++ b/litellm/llms/azure/text_to_speech/transformation.py
@@ -386,6 +386,8 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
     def is_ssml_input(self, input: str) -> bool:
         """
         Returns True if input is SSML, False otherwise
+
+        Based on https://www.w3.org/TR/speech-synthesis/ all SSML must start with <speak>
         """
         return "<speak>" in input or "<speak " in input
 

--- a/tests/test_litellm/llms/azure/text_to_speech/test_azure_tts_transformation.py
+++ b/tests/test_litellm/llms/azure/text_to_speech/test_azure_tts_transformation.py
@@ -1,8 +1,10 @@
-from unittest.mock import Mock
+import json
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
 
+import litellm
 from litellm.llms.azure.text_to_speech.transformation import AzureAVATextToSpeechConfig
 
 
@@ -650,4 +652,46 @@ def test_transform_text_to_speech_request_ssml_with_mstts_namespace(azure_tts_co
     assert "style='cheerful'" in ssml
     assert "styledegree='2'" in ssml
     assert "rate='+20%'" in ssml
+
+
+@patch("litellm.llms.custom_httpx.llm_http_handler.HTTPHandler.post")
+def test_litellm_speech_with_ssml_passthrough(mock_post):
+    """
+    Test that litellm.speech passes SSML through to Azure AVA without transformation
+    """
+    raw_ssml = """<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
+    <voice name='en-US-JennyNeural'>
+        <prosody rate='fast' pitch='high'>
+            Custom SSML content!
+        </prosody>
+    </voice>
+</speak>"""
+    
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.content = b"fake_audio_data"
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "audio/mpeg"}
+    mock_post.return_value = mock_response
+    
+    litellm.speech(
+        model="azure/speech/tts",
+        input=raw_ssml,
+        voice="en-US-AriaNeural",
+        api_key="test-key",
+        api_base="https://eastus.api.cognitive.microsoft.com"
+    )
+    
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args.kwargs
+    
+    # Verify the SSML was sent in the request body
+    assert "data" in call_kwargs
+    assert call_kwargs["data"] == raw_ssml
+    print("REQUEST BODY: ", json.dumps(call_kwargs["data"], indent=4))
+    
+    # Verify the SSML contains the original content
+    assert "en-US-JennyNeural" in call_kwargs["data"]
+    assert "fast" in call_kwargs["data"]
+    assert "high" in call_kwargs["data"]
+    assert "Custom SSML content!" in call_kwargs["data"]
 


### PR DESCRIPTION
## [Feat] Add SSML Support for Azure Text-to-Speech (AVA)

This PR adds automatic SSML passthrough support for Azure AI Speech (Cognitive Services). LiteLLM now detects when the input parameter contains SSML markup and passes it through to Azure without any transformation, giving users complete control over speech synthesis.


## Usage Examples

### LiteLLM SDK

**Basic SSML Passthrough**

```
from litellm import speech

ssml = """<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>
<voice name='en-US-JennyNeural'>
    <prosody rate='fast' pitch='high'>
        Custom SSML content!
    </prosody>
</voice>
</speak>"""
response = speech(
    model="azure/speech/tts",
    input=ssml,  # LiteLLM auto-detects SSML and sends as-is
    voice="en-US-JennyNeural",
    api_base="https://eastus.tts.speech.microsoft.com",
    api_key="your-key"
)
response.stream_to_file("speech.mp3")**Multilingual Translation (English text to Spanish speech)**
```


### LiteLLM Proxy (AI Gateway)
```
curl http://0.0.0.0:4000/v1/audio/speech \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "azure-speech",
    "voice": "en-US-AvaMultilingualNeural",
    "input": "<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xmlns:mstts=\"http://www.w3.org/2001/mstts\" xml:lang=\"es-ES\"><voice name=\"en-US-AvaMultilingualNeural\"><lang xml:lang=\"es-ES\">Hello, how are you today?</lang></voice></speak>"
  }' \
  --output speech.mp3## Implementation Details
```


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


