### PR TITLE
docs: enable automatic dark/light mode based on system preference

### DIFF
--- a/docs/my-website/docusaurus.config.js
+++ b/docs/my-website/docusaurus.config.js
@@ -231,6 +231,11 @@ const config = {
         ],
         copyright: `Copyright © ${new Date().getFullYear()} liteLLM`,
       },
+      colorMode: {
+        defaultMode: 'light',
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,


### PR DESCRIPTION
## Summary
- Configure Docusaurus to automatically respect user's system/browser color scheme preference (`prefers-color-scheme`)
- Improves UX by automatically matching documentation theme to OS-level dark/light mode setting
- Users can still manually override via the theme switcher

## Changes
- Added `colorMode` configuration to `docusaurus.config.js`
- Enabled `respectPrefersColorScheme: true` option

## Test Plan
- [x] Tested locally with `npm start`
- [x] Verified theme automatically switches based on system preference
- [x] Confirmed manual theme switcher still works

## References
- Docusaurus colorMode documentation: https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode