### PR TITLE
[Feat] AI Gateway - Allow admins to disable, dynamic callback controls 

### DIFF
--- a/docs/my-website/docs/proxy/dynamic_logging.md
+++ b/docs/my-website/docs/proxy/dynamic_logging.md
@@ -211,4 +211,64 @@ x-litellm-disable-callbacks: LANGFUSE,datadog,PROMETHEUS
 x-litellm-disable-callbacks: langfuse,DATADOG,prometheus
 ```
 
+---
+
+## Disabling Dynamic Callback Management (Enterprise)
+
+Some organizations have compliance requirements where **all requests must be logged under all circumstances**. For these cases, you can disable dynamic callback management entirely to ensure users cannot disable any logging callbacks.
+
+### Use Case
+
+This is designed for enterprise scenarios where:
+- **Compliance requirements** mandate that all API requests must be logged
+- **Audit trails** must be complete with no gaps
+- **Security policies** require all traffic to be monitored
+- **No exceptions** can be made for callback disabling
+
+### How to Disable
+
+Set `allow_dynamic_callback_disabling` to `false` in your config.yaml:
+
+```yaml showLineNumbers title="config.yaml"
+litellm_settings:
+  allow_dynamic_callback_disabling: false
+```
+
+### Effect
+
+When disabled:
+- The `x-litellm-disable-callbacks` header will be **ignored**
+- All configured callbacks will **always execute** for every request
+- Users cannot bypass logging through headers or request metadata
+- All requests are guaranteed to be logged per your proxy configuration
+
+### Example: Compliance Logging Setup
+
+Here's a complete example for an organization requiring guaranteed logging:
+
+```yaml showLineNumbers title="config.yaml"
+# config.yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: openai/gpt-4
+      api_key: os.environ/OPENAI_API_KEY
+
+litellm_settings:
+  callbacks: ["langfuse", "datadog", "s3"]
+  # Disable dynamic callback disabling for compliance
+  allow_dynamic_callback_disabling: false
+```
+
+With this configuration:
+- All requests will be logged to Langfuse, Datadog, and S3
+- Users cannot disable any of these callbacks via headers
+- Complete audit trail is guaranteed for compliance requirements
+
+:::info
+
+**Default Behavior**: Dynamic callback disabling is **enabled by default** (`allow_dynamic_callback_disabling: true`). You must explicitly set it to `false` to enforce guaranteed logging.
+
+:::
+
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/callback_controls.py
@@ -40,7 +40,7 @@ class EnterpriseCallbackControls:
                     #########################################################
                     # premium user check
                     #########################################################
-                    if not EnterpriseCallbackControls._premium_user_check():
+                    if not EnterpriseCallbackControls._should_allow_dynamic_callback_disabling():
                         return False
                     #########################################################
                     if isinstance(callback, str):
@@ -84,8 +84,15 @@ class EnterpriseCallbackControls:
         return None
     
     @staticmethod
-    def _premium_user_check():
+    def _should_allow_dynamic_callback_disabling():
+        import litellm
         from litellm.proxy.proxy_server import premium_user
+
+        # Check if admin has disabled this feature
+        if litellm.allow_dynamic_callback_disabling is not True:
+            verbose_logger.debug("Dynamic callback disabling is disabled by admin via litellm.allow_dynamic_callback_disabling")
+            return False
+        
         if premium_user:
             return True
         verbose_logger.warning(f"Disabling callbacks using request headers is an enterprise feature. {CommonProxyErrors.not_premium_user.value}")

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -423,6 +423,7 @@ fallbacks: Optional[List] = None
 context_window_fallbacks: Optional[List] = None
 content_policy_fallbacks: Optional[List] = None
 allowed_fails: int = 3
+allow_dynamic_callback_disabling: bool = True
 num_retries_per_request: Optional[int] = (
     None  # for the request overall (incl. fallbacks + model retries)
 )


### PR DESCRIPTION
## [Feat] AI Gateway - Allow admins to disable, dynamic callback controls 

Fixes LIT-1502


## Disabling Dynamic Callback Management (Enterprise)

Some organizations have compliance requirements where **all requests must be logged under all circumstances**. For these cases, you can disable dynamic callback management entirely to ensure users cannot disable any logging callbacks.

### Use Case

This is designed for enterprise scenarios where:
- **Compliance requirements** mandate that all API requests must be logged
- **Audit trails** must be complete with no gaps
- **Security policies** require all traffic to be monitored
- **No exceptions** can be made for callback disabling

### How to Disable

Set `allow_dynamic_callback_disabling` to `false` in your config.yaml:

```yaml showLineNumbers title="config.yaml"
litellm_settings:
  allow_dynamic_callback_disabling: false
```

### Effect

When disabled:
- The `x-litellm-disable-callbacks` header will be **ignored**
- All configured callbacks will **always execute** for every request
- Users cannot bypass logging through headers or request metadata
- All requests are guaranteed to be logged per your proxy configuration

### Example: Compliance Logging Setup

Here's a complete example for an organization requiring guaranteed logging:

```yaml showLineNumbers title="config.yaml"
# config.yaml
model_list:
  - model_name: gpt-4
    litellm_params:
      model: openai/gpt-4
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["langfuse", "datadog", "s3"]
  # Disable dynamic callback disabling for compliance
  allow_dynamic_callback_disabling: false
```

With this configuration:
- All requests will be logged to Langfuse, Datadog, and S3
- Users cannot disable any of these callbacks via headers
- Complete audit trail is guaranteed for compliance requirements


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


