### PR TITLE
[Feature] UI - Delete user and MCP Server Modal, MCP Table Tooltips

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_columns.tsx
@@ -154,13 +154,22 @@ export const mcpServerColumns = (
     header: "Actions",
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
-        <Icon
-          icon={PencilAltIcon}
-          size="sm"
-          onClick={() => onEdit(row.original.server_id)}
-          className="cursor-pointer"
-        />
-        <Icon icon={TrashIcon} size="sm" onClick={() => onDelete(row.original.server_id)} className="cursor-pointer" />
+        <Tooltip title="Edit MCP Server">
+          <Icon
+            icon={PencilAltIcon}
+            size="sm"
+            onClick={() => onEdit(row.original.server_id)}
+            className="cursor-pointer hover:text-blue-600"
+          />
+        </Tooltip>
+        <Tooltip title="Delete MCP Server">
+          <Icon
+            icon={TrashIcon}
+            size="sm"
+            onClick={() => onDelete(row.original.server_id)}
+            className="cursor-pointer hover:text-red-600"
+          />
+        </Tooltip>
       </div>
     ),
   },

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_servers.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import MCPServers from "./mcp_servers";
+import * as networking from "../networking";
+
+// Mock the networking module
+vi.mock("../networking", () => ({
+  fetchMCPServers: vi.fn(),
+  deleteMCPServer: vi.fn(),
+  getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost:4000"),
+}));
+
+// Mock NotificationsManager
+vi.mock("../molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+describe("MCPServers", () => {
+  const defaultProps = {
+    accessToken: "test-token",
+    userRole: "Admin",
+    userID: "admin-user-id",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the MCPServers component with title", async () => {
+    // Mock empty response for simple render test
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([]);
+
+    const queryClient = createQueryClient();
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <MCPServers {...defaultProps} />
+      </QueryClientProvider>,
+    );
+
+    // Wait for the component to load and check if title renders
+    await waitFor(() => {
+      expect(getByText("MCP Servers")).toBeInTheDocument();
+    });
+
+    // Verify the title is rendered
+    expect(getByText("MCP Servers")).toBeInTheDocument();
+  });
+
+  it("should render mocked MCP servers data in the table", async () => {
+    // Mock MCP servers data
+    const mockServers = [
+      {
+        server_id: "server-1",
+        server_name: "Test Server 1",
+        alias: "test-server-1",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "none",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+        teams: [],
+        mcp_access_groups: [],
+      },
+      {
+        server_id: "server-2",
+        server_name: "Test Server 2",
+        alias: "test-server-2",
+        url: "https://example2.com/mcp",
+        transport: "sse",
+        auth_type: "api_key",
+        created_at: "2024-01-02T00:00:00Z",
+        created_by: "user-2",
+        updated_at: "2024-01-02T00:00:00Z",
+        updated_by: "user-2",
+        teams: [],
+        mcp_access_groups: ["group-1"],
+      },
+    ];
+
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue(mockServers);
+
+    const queryClient = createQueryClient();
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <MCPServers {...defaultProps} />
+      </QueryClientProvider>,
+    );
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(getByText("MCP Servers")).toBeInTheDocument();
+    });
+
+    // Wait for the mocked data to render in the table
+    await waitFor(() => {
+      expect(getByText("Test Server 1")).toBeInTheDocument();
+    });
+
+    // Verify the mocked server data is rendered in the table
+    expect(getByText("Test Server 1")).toBeInTheDocument();
+    expect(getByText("Test Server 2")).toBeInTheDocument();
+    expect(getByText("test-server-1")).toBeInTheDocument();
+    expect(getByText("test-server-2")).toBeInTheDocument();
+
+    // Verify the API was called
+    expect(networking.fetchMCPServers).toHaveBeenCalledWith("test-token");
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_users.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ViewUserDashboard from "./view_users";
+
+// Mock the networking module
+vi.mock("./networking", () => ({
+  userListCall: vi.fn().mockResolvedValue({
+    users: [
+      {
+        user_id: "user-1",
+        user_email: "test@example.com",
+        user_role: "Admin",
+        spend: 100.5,
+        max_budget: null,
+        key_count: 2,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        sso_user_id: null,
+        budget_duration: null,
+      },
+    ],
+    total: 1,
+    page: 1,
+    page_size: 25,
+    total_pages: 1,
+  }),
+  userDeleteCall: vi.fn().mockResolvedValue({}),
+  getPossibleUserRoles: vi.fn().mockResolvedValue({
+    Admin: { ui_label: "Admin" },
+    User: { ui_label: "User" },
+  }),
+  modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+  invitationCreateCall: vi.fn().mockResolvedValue({}),
+  userUpdateUserCall: vi.fn().mockResolvedValue({}),
+  getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost:4000"),
+  getProxyUISettings: vi.fn().mockResolvedValue({
+    PROXY_BASE_URL: null,
+    PROXY_LOGOUT_URL: null,
+    DEFAULT_TEAM_DISABLED: false,
+    SSO_ENABLED: false,
+  }),
+  getInternalUserSettings: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock NotificationsManager
+vi.mock("./molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+describe("ViewUserDashboard", () => {
+  const defaultProps = {
+    accessToken: "test-token",
+    token: "test-token",
+    keys: null,
+    userRole: "Admin",
+    userID: "admin-user-id",
+    teams: [],
+    setKeys: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the ViewUserDashboard component", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ViewUserDashboard {...defaultProps} />
+      </QueryClientProvider>,
+    );
+
+    // Wait for the component to load (it shows "Loading..." initially)
+    await waitFor(() => {
+      expect(screen.getByText("Users")).toBeInTheDocument();
+    });
+
+    // Check if main elements are rendered
+    expect(screen.getByText("Users")).toBeInTheDocument();
+    // Use getAllByText since "Default User Settings" appears multiple times
+    const defaultUserSettingsTabs = screen.getAllByText("Default User Settings");
+    expect(defaultUserSettingsTabs.length).toBeGreaterThan(0);
+  });
+
+  it("should show delete modal after clicking delete user button", async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ViewUserDashboard {...defaultProps} />
+      </QueryClientProvider>,
+    );
+
+    // Wait for the component to load and the table to render
+    await waitFor(() => {
+      expect(screen.getByText("Users")).toBeInTheDocument();
+    });
+
+    // Wait for the user data to load
+    await waitFor(() => {
+      expect(screen.getAllByText("test@example.com").length).toBeGreaterThan(0);
+    });
+
+    // Initially, the delete modal should not be visible
+    expect(screen.queryByText("Delete User?")).not.toBeInTheDocument();
+
+    // Find the row containing the user email (use the first one which is in the table)
+    // The email appears in both the table and potentially in modals, so get the first one from the table
+    const userEmailCells = screen.getAllByText("test@example.com");
+    const userEmailCell = userEmailCells[0]; // First occurrence is in the table
+    const userRow = userEmailCell.closest("tr");
+    expect(userRow).toBeInTheDocument();
+
+    // Find clickable elements in the actions column (the last column)
+    const actionCells = userRow?.querySelectorAll("td");
+    const actionsCell = actionCells?.[actionCells.length - 1];
+    expect(actionsCell).toBeInTheDocument();
+
+    // Find the action container div with flex gap-2
+    const actionContainer =
+      actionsCell?.querySelector("div.flex.gap-2") ||
+      Array.from(actionsCell?.querySelectorAll("div") || []).find(
+        (div) => div.className.includes("flex") && div.className.includes("gap"),
+      );
+
+    expect(actionContainer).toBeInTheDocument();
+
+    // Get all direct children of the action container
+    // These should be Tooltip components wrapping Icon components
+    const tooltipWrappers = Array.from(actionContainer!.children);
+    expect(tooltipWrappers.length).toBeGreaterThanOrEqual(2);
+
+    // The delete icon is the second tooltip wrapper (index 1)
+    // Edit=0, Delete=1, Reset=2
+    const deleteTooltipWrapper = tooltipWrappers[1] as HTMLElement;
+    const clickableElement = deleteTooltipWrapper.querySelector("button, [role='button'], svg") as HTMLElement;
+
+    expect(clickableElement).toBeInTheDocument();
+
+    fireEvent.click(clickableElement);
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete User?")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Are you sure you want to delete this user? This action cannot be undone."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("user-1")).toBeInTheDocument();
+    const emailInstances = screen.getAllByText("test@example.com");
+    expect(emailInstances.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/columns.tsx
@@ -17,7 +17,7 @@ interface SelectionOptions {
 export const columns = (
   possibleUIRoles: Record<string, Record<string, string>>,
   handleEdit: (user: UserInfo) => void,
-  handleDelete: (userId: string) => void,
+  handleDelete: (user: UserInfo) => void,
   handleResetPassword: (userId: string) => void,
   handleUserClick: (userId: string, openInEditMode?: boolean) => void,
   selectionOptions?: SelectionOptions,
@@ -124,7 +124,7 @@ export const columns = (
             <Icon
               icon={TrashIcon}
               size="sm"
-              onClick={() => handleDelete(row.original.user_id)}
+              onClick={() => handleDelete(row.original)}
               className="cursor-pointer hover:text-red-600"
             />
           </Tooltip>

--- a/ui/litellm-dashboard/src/components/view_users/table.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/table.tsx
@@ -39,7 +39,7 @@ interface UserDataTableProps {
   userRole: string | null;
   possibleUIRoles: Record<string, Record<string, string>> | null;
   handleEdit: (user: UserInfo) => void;
-  handleDelete: (userId: string) => void;
+  handleDelete: (user: UserInfo) => void;
   handleResetPassword: (userId: string) => void;
   selectedUsers?: UserInfo[];
   onSelectionChange?: (selectedUsers: UserInfo[]) => void;


### PR DESCRIPTION
## [Feature] UI - Delete user and MCP Server Modal, MCP Table Tooltips

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR modernizes and adds more details to the delete modals for delete user and mcp flow. This PR is intended to set the design pattern for simpler resources. More critical resources, such as teams, keys, and organizations, will have a pattern with even more friction (most likely requiring input of the resource name).

As a quick fix, this implements tooltips for the buttons on the MCP server table.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="760" height="241" alt="image" src="https://github.com/user-attachments/assets/94d444fc-248e-4562-a427-f35bcd0edd54" />

<img width="218" height="141" alt="image" src="https://github.com/user-attachments/assets/730acbd1-20cf-43c4-ae15-3b926f3db35e" />
<img width="560" height="393" alt="image" src="https://github.com/user-attachments/assets/faafa2bf-793e-4e1c-92df-988a02138128" />

<img width="598" height="388" alt="image" src="https://github.com/user-attachments/assets/49da893f-4423-4f10-9293-c38365b42da1" />

