### PR TITLE
fix: add None check for litellm_params

### DIFF
--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -33,6 +33,8 @@ class LowestTPMLoggingHandler(CustomLogger):
             """
             Update TPM/RPM usage on success
             """
+            if "litellm_params" not in kwargs or kwargs["litellm_params"] is None:
+                return
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
@@ -92,11 +94,11 @@ class LowestTPMLoggingHandler(CustomLogger):
             """
             Update TPM/RPM usage on success
             """
+            if "litellm_params" not in kwargs or kwargs["litellm_params"] is None:
+                return
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
             else:
-                if "litellm_params" not in kwargs:
-                    return
                 model_group = kwargs["litellm_params"]["metadata"].get(
                     "model_group", None
                 )


### PR DESCRIPTION
## Title

fix: add None check for litellm_params

## Relevant issues
<img width="1440" height="392" alt="Screenshot 2025-11-17 at 4 29 49 PM" src="https://github.com/user-attachments/assets/9dc43aab-ac96-4948-926c-98dc1861b53f" />

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- We already handled the case where litellm_params is missing from kwargs, but we didn’t handle the case where it exists but is None. This change adds a guard to cover both situations.

