### PR TITLE
fix: correct wrong system message handling for gemma

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12995,7 +12995,7 @@
         "supports_audio_output": false,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_system_messages": true,
+        "supports_system_messages": false,
         "supports_tool_choice": true,
         "supports_vision": true
     },


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Fix BadRequestError for gemma

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #15765

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
fix wrong config of model_prices_and_context_window.json
```diff
    "gemini/gemma-3-27b-it": {
         ...
-        "supports_system_messages": true,
+        "supports_system_messages": false,
```

rationale: `the model(gemma) does not support a system role` from https://discuss.ai.google.dev/t/gemma-3-missing-features-despite-announcement/71692/22