### PR TITLE
Additional cost mappings for gpt-5.1-chat

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14381,6 +14381,41 @@
         "supports_tool_choice": false,
         "supports_vision": true
     },
+    "gpt-5.1-chat": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": false,
+        "supports_vision": true
+    },
     "gpt-5-pro": {
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14394,6 +14394,41 @@
         "supports_tool_choice": false,
         "supports_vision": true
     },
+    "gpt-5.1-chat": {
+        "cache_read_input_token_cost": 1.25e-07,
+        "cache_read_input_token_cost_priority": 2.5e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_priority": 2.5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_priority": 2e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": false,
+        "supports_vision": true
+    },
     "gpt-5-pro": {
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,


### PR DESCRIPTION
## Relevant issues

Azure uses the base_model `gpt-5.1-chat` instead of `gpt-5.1-chat-latest`, which means we don't get any cost tracking on that model with the current version of the cost mapping. 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

<s>- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)</s>
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

Adde our key to the cost mapping

