### PR TITLE
Fix IBM Guardrails optional params, add extra_headers field

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/ibm_guardrails.md
+++ b/docs/my-website/docs/proxy/guardrails/ibm_guardrails.md
@@ -95,6 +95,7 @@ curl -i http://localhost:4000/v1/chat/completions \
 These go under `optional_params`:
 
 - `detector_params` - dict - Parameters to pass to your detector
+- `extra_headers` - dict - Additional headers to inject into requests to IBM Guardrails, as a key-value dict.
 - `score_threshold` - float - Only count detections above this score (0.0 to 1.0)
 - `block_on_detection` - bool - Block the request when violations found. Default: `true`
 

--- a/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
+from litellm.types.proxy.guardrails.guardrail_hooks.ibm import IBMDetectorOptionalParams
 
 from .ibm_detector import IBMGuardrailDetector
 
@@ -22,11 +23,17 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
     if not guardrail_name:
         raise ValueError("IBM Guardrails: guardrail_name is required")
 
-    # Get optional params
-    detector_params = getattr(litellm_params, "detector_params", {})
-    score_threshold = getattr(litellm_params, "score_threshold", None)
-    block_on_detection = getattr(litellm_params, "block_on_detection", True)
     verify_ssl = getattr(litellm_params, "verify_ssl", True)
+
+    # Get optional params
+    optional_params = getattr(litellm_params, "optional_params", IBMDetectorOptionalParams())
+    detector_params = getattr(optional_params, "detector_params", {})
+    extra_headers = getattr(optional_params, "extra_headers", {})
+    score_threshold = getattr(optional_params, "score_threshold", None)
+    block_on_detection = getattr(optional_params, "block_on_detection", True)
+
+
+
     is_detector_server = litellm_params.is_detector_server
     if is_detector_server is None:
         is_detector_server = True
@@ -38,6 +45,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         detector_id=litellm_params.detector_id,
         is_detector_server=is_detector_server,
         detector_params=detector_params,
+        extra_headers=extra_headers,
         score_threshold=score_threshold,
         block_on_detection=block_on_detection,
         verify_ssl=verify_ssl,

--- a/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/ibm_guardrails/ibm_detector.py
@@ -39,6 +39,7 @@ class IBMGuardrailDetector(CustomGuardrail):
         detector_id: Optional[str] = None,
         is_detector_server: bool = True,
         detector_params: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         score_threshold: Optional[float] = None,
         block_on_detection: bool = True,
         verify_ssl: bool = True,
@@ -70,6 +71,7 @@ class IBMGuardrailDetector(CustomGuardrail):
 
         self.is_detector_server = is_detector_server
         self.detector_params = detector_params or {}
+        self.extra_headers = extra_headers or {}
         self.score_threshold = score_threshold
         self.block_on_detection = block_on_detection
         self.verify_ssl = verify_ssl
@@ -128,6 +130,10 @@ class IBMGuardrailDetector(CustomGuardrail):
             "content-type": "application/json",
             "detector-id": self.detector_id,
         }
+
+        # Add any extra headers to the request
+        for header, value in self.extra_headers.items():
+            headers[header] = value
 
         verbose_proxy_logger.debug(
             "IBM Detector Server request to %s with payload: %s",
@@ -216,6 +222,10 @@ class IBMGuardrailDetector(CustomGuardrail):
             "Authorization": f"Bearer {self.auth_token}",
             "content-type": "application/json",
         }
+
+        # Add any extra headers to the request
+        for header, value in self.extra_headers.items():
+            headers[header] = value
 
         verbose_proxy_logger.debug(
             "IBM Orchestrator request to %s with payload: %s",

--- a/litellm/types/proxy/guardrails/guardrail_hooks/ibm/ibm_detector.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/ibm/ibm_detector.py
@@ -57,7 +57,12 @@ class IBMDetectorOptionalParams(BaseModel):
 
     detector_params: Optional[Dict[str, Any]] = Field(
         default_factory=lambda: {},
-        description="Dictionary of arguments to pass to the detector. Can be set per-request or hard-coded at guardrail config time.",
+        description="Dictionary of arguments to pass to the detector.",
+    )
+
+    extra_headers: Optional[Dict[str, Any]] = Field(
+        default_factory=lambda: {},
+        description="Dictionary of extra headers to pass to the detector.",
     )
 
     score_threshold: Optional[float] = Field(


### PR DESCRIPTION
## Fixes `optional_params` usage of IBM Guardrails, adds `extra_headers` field.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues




## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix


## Changes
Currently, the `optional_params` field of the IBM Guardrails configuration is ignored- this PR fixes this. Additionally, this PR introduces an `extra_headers` field, which lets users pass custom headers to the IBM detector servers.

