### PR TITLE
  fix: Responses API cost tracking with custom deployment names

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6680,7 +6680,13 @@ def _get_base_model_from_metadata(model_call_details=None):
             return _base_model
         metadata = litellm_params.get("metadata", {})
 
-        return _get_base_model_from_litellm_call_metadata(metadata=metadata)
+        base_model_from_metadata = _get_base_model_from_litellm_call_metadata(metadata=metadata)
+        if base_model_from_metadata is not None:
+            return base_model_from_metadata
+
+        # Also check litellm_metadata (used by Responses API and other generic API calls)
+        litellm_metadata = litellm_params.get("litellm_metadata", {})
+        return _get_base_model_from_litellm_call_metadata(metadata=litellm_metadata)
     return None
 
 


### PR DESCRIPTION
 ## Title

  fix: Responses API cost tracking with custom deployment names

  ## Relevant issues

  Fixes #16772

  ## Pre-Submission checklist

  - [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement**
  - [x] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on `make test-unit`
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🐛 Bug Fix

  ## Changes

  ### Details
  Cost tracking fails for Responses API when using custom Azure deployment names with `base_model` configuration.

  - Chat Completions API stores model info in `litellm_params["metadata"]` → cost tracking ✅
  - Responses API stores model info in `litellm_params["litellm_metadata"]` → cost tracking ❌
  - Cost calculator (`_get_base_model_from_metadata()`) only checked `metadata`

  ### Solution
  Modified `_get_base_model_from_metadata()` in `litellm/utils.py` to check both locations:
  1. First checks `metadata` (Chat Completions pattern)
  2. Falls back to `litellm_metadata` (Responses API pattern)

  ### Files Changed
  - **litellm/utils.py** (lines 6687-6689): Added fallback lookup for `litellm_metadata`
  - **tests/litellm_utils_tests/test_utils.py**: Added comprehensive unit test `test_get_base_model_from_metadata()`

  ### Test Coverage
  - ✅ base_model in litellm_params directly
  - ✅ base_model in metadata (Chat Completions)
  - ✅ base_model in litellm_metadata (Responses API) - **bug**
  - ✅ base_model in model_info.base_model