### PR TITLE
[Infra] Break e2e_ui_testing into build, unit, and e2e steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3339,7 +3339,7 @@ jobs:
             python -m build
             twine upload --verbose dist/*
 
-  e2e_ui_testing:
+  ui_build:
     machine:
       image: ubuntu-2204:2023.10.1
     resource_class: xlarge
@@ -3366,6 +3366,48 @@ jobs:
 
             # Now source the build script
             source ./build_ui.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+            - litellm/proxy/_experimental/out
+
+  ui_unit_tests:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_google_dns
+      - run:
+          name: Run UI unit tests (Vitest)
+          command: |
+            # Use Node 20 (several deps require >=20)
+            export NVM_DIR="/opt/circleci/.nvm"
+            source "$NVM_DIR/nvm.sh"
+            nvm install 20
+            nvm use 20
+
+            cd ui/litellm-dashboard
+            npm ci || npm install
+
+            # CI run, with both LCOV (Codecov) and HTML (artifact you can click)
+            CI=true npm run test -- --run --coverage \
+              --coverage.provider=v8 \
+              --coverage.reporter=lcov \
+              --coverage.reporter=html \
+              --coverage.reportsDirectory=coverage/html
+
+  e2e_ui_testing:
+    machine:
+      image: ubuntu-2204:2023.10.1
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_google_dns
+      - attach_workspace:
+          at: ~/project
       - run:
           name: Upgrade Docker to v24.x (API 1.44+)
           command: |
@@ -3411,24 +3453,6 @@ jobs:
           name: Install Playwright Browsers
           command: |
             npx playwright install
-      - run:
-          name: Run UI unit tests (Vitest)
-          command: |
-            # Use Node 20 (several deps require >=20)
-            export NVM_DIR="/opt/circleci/.nvm"
-            source "$NVM_DIR/nvm.sh"
-            nvm install 20
-            nvm use 20
-
-            cd ui/litellm-dashboard
-            npm ci || npm install
-
-            # CI run, with both LCOV (Codecov) and HTML (artifact you can click)
-            CI=true npm run test -- --run --coverage \
-              --coverage.provider=v8 \
-              --coverage.reporter=lcov \
-              --coverage.reporter=html \
-              --coverage.reportsDirectory=coverage/html
 
       - run:
           name: Build Docker image
@@ -3633,6 +3657,20 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
+      - ui_build:
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
+      - ui_unit_tests:
+          requires:
+            - ui_build
+          filters:
+            branches:
+              only:
+                - main
+                - /litellm_.*/
       - auth_ui_unit_tests:
           filters:
             branches:
@@ -3640,6 +3678,8 @@ workflows:
                 - main
                 - /litellm_.*/
       - e2e_ui_testing:
+          requires:
+            - ui_build
           filters:
             branches:
               only:


### PR DESCRIPTION
## [Infra] Break e2e_ui_testing into build, unit, and e2e steps

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The current `e2e_ui_testing` CI/CD step is bloated, leading to delayed signals for bad PRs. This change breaks up the `e2e_ui_testing` step into a `ui_build`, `ui_unit_testing`, and `ui_e2e_testing` step. The 2 latter steps depend on `ui_build` and uses the artifacts from the build.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🚄 Infrastructure

## Changes


