### PR TITLE
[Fix] UI - Mock Tremor's Tooltip to Fix Flaky UI Tests

### DIFF
--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { cleanup } from "@testing-library/react";
+import React from "react";
 import { afterEach, vi } from "vitest";
 
 // Global mock for NotificationManager to prevent React rendering issues in tests
@@ -15,6 +16,18 @@ vi.mock("@/components/molecules/notifications_manager", () => ({
     clear: vi.fn(),
   },
 }));
+
+vi.mock("@tremor/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tremor/react")>();
+  return {
+    ...actual,
+    Tooltip: ({ children, ..._props }: { children?: React.ReactNode; [key: string]: unknown }) => {
+      // Return children directly without tooltip functionality to prevent flaky tests
+      // This avoids issues with hover states, positioning, and DOM queries in tests
+      return React.createElement(React.Fragment, null, children);
+    },
+  };
+});
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## [Fix] UI - Mock Tremor's Tooltip to Fix Flaky UI Tests

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This PR attempts the address the flaky test issue due to Tremor's Tooltip (See screenshot for more details). This mock will simply return the children of the tooltip, and prevents the Tooltip from relying on window which is potentially undefined when test environments are torn down.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix

## Changes

<img width="1035" height="361" alt="image" src="https://github.com/user-attachments/assets/928ba83d-b36b-428c-aeb2-e7edc1b0b28a" />
<img width="660" height="212" alt="image" src="https://github.com/user-attachments/assets/3f26dd44-f700-4fb4-bd40-607914f4ffed" />


