### PR TITLE
[Feature] UI - Deactivate delete button on model table for config models

### DIFF
--- a/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/models/columns.tsx
@@ -300,21 +300,28 @@ export const columns = (
     cell: ({ row }) => {
       const model = row.original;
       const canEditModel = userRole === "Admin" || model.model_info?.created_by === userID;
+      const isConfigModel = !model.model_info?.db_model;
       return (
         <div className="flex items-center justify-end gap-2 pr-4">
-          <Tooltip title="Delete model">
-            <Icon
-              icon={TrashIcon}
-              size="sm"
-              onClick={() => {
-                if (canEditModel) {
-                  setSelectedModelId(model.model_info.id);
-                  setEditModel(false);
-                }
-              }}
-              className={!canEditModel ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-red-600"}
-            />
-          </Tooltip>
+          {isConfigModel ? (
+            <Tooltip title="Config model cannot be deleted on the dashboard. Please delete it from the config file.">
+              <Icon icon={TrashIcon} size="sm" className="opacity-50 cursor-not-allowed" />
+            </Tooltip>
+          ) : (
+            <Tooltip title="Delete model">
+              <Icon
+                icon={TrashIcon}
+                size="sm"
+                onClick={() => {
+                  if (canEditModel) {
+                    setSelectedModelId(model.model_info.id);
+                    setEditModel(false);
+                  }
+                }}
+                className={!canEditModel ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:text-red-600"}
+              />
+            </Tooltip>
+          )}
         </div>
       );
     },


### PR DESCRIPTION
## [Feature] UI - Deactivate delete button on model table for config models

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Currently clicking on the delete icon button for config models will bring the user to the model info page, only for the delete button to be deactivated due to it being a config model. This PR will deactivate the icon button on the table, with a tooltip stating config models cannot be deleted on the dashboard.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="299" height="214" alt="image" src="https://github.com/user-attachments/assets/be446c76-ea0b-416e-8674-ba4e4f2aeb70" />
<img width="665" height="205" alt="image" src="https://github.com/user-attachments/assets/8386f477-b140-4610-b482-4a032e26e695" />

