### PR TITLE
fix: sanity check for optional params

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -114,6 +114,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         self.guardrailVersion = guardrailVersion
         self.guardrail_provider = "bedrock"
 
+        # Ensure kwargs is always a dict to prevent AttributeError
+        # This defensive check handles edge cases where kwargs might be None or not a dict
+        kwargs = kwargs if kwargs is not None and isinstance(kwargs, dict) else {}
+
         # store kwargs as optional_params
         self.optional_params = kwargs
 


### PR DESCRIPTION
## Simple guard against invalid option access

Add sanity check on kwargs for optional params.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
> Test coverage exists already as this is a minor safeguard/sanity check edit to existing file. 

- [ ] I have added a screenshot of my new test passing locally 

>  unable to complete this step `make test-unit` fails [on my machine 🤷‍♂️ ]

- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

^^^ tests run from a fresh pull from `main` don't pass. ?
eg: 
```
FAILED tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py::TestVertexGemmaCompletion::test_acompletion_basic_request - litellm.exceptions.BadRequestError: litellm.BadRequestError: Vertex_aiException BadRequestError - vertexai import failed please run `pip install -U "google-cloud-aiplatform>=1.38"`. Got error: No module named 'vertexai'
FAILED tests/test_litellm/llms/gemini/test_gemini_common_utils.py::TestGoogleAIStudioTokenCounter::test_clean_contents_for_gemini_api_preserves_other_fields - ModuleNotFoundError: No module named 'google.genai'
!!!! stopping after 2 failures !!!!
xdist.dsession.Interrupted: stopping after 1 failures 
... 2 failed, 890 passed, 11 skipped, 15 warnings in 127.96s (0:02:07)
```
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Problems

`make test-unit` seems to fail - even on fresh repo init from `main` 

`make format` seems to change several hundred files! Again, even on fresh repo init from `main`. Is documentation up to date? 
```
All done! ✨ 🍰 ✨
550 files reformatted, 778 files left unchanged.
```
wut. 

## Type

🐛 Bug Fix

## Changes

Added simple sanity check to guard against access errors:

Adding bedrock guardrail results in an access error under some conditions, seems to be indeterminate as 3 out of 10 attempts _can_ result in the following:

```
File \"/app/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py\", line 1183, in apply_guardrail
    bedrock_response = await self.make_bedrock_api_request(`                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File \"/app/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py\", line 334, in make_bedrock_api_request
    credentials, aws_region_name = self._load_credentials()
                                   ~~~~~~~~~~~~~~~~~~~~~~^^
  File \"/app/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py\", line 224, in _load_credentials
    aws_secret_access_key = self.optional_params.get(\"aws_secret_access_key\", None)
```
