### PR TITLE
[Fix] AI Gateway Auth - Ensure Team Tags works when using JWT Auth

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -584,6 +584,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                         if team_membership is not None
                         else None
                     ),
+                    team_metadata=team_object.metadata if team_object is not None else None,
                 )
                 # run through common checks
                 _ = await common_checks(


### PR DESCRIPTION
## [Fix] AI Gateway Auth - Ensure Team Tags works when using JWT Auth

This PR fixes a bug where team-level metadata (specifically tags) was not being applied when using JWT authentication. The team_metadata field from the team object was not being mapped to the UserAPIKeyAuth object during JWT token validation, causing tags to be lost in litellm_pre_call_utils.py.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix
✅ Test

## Changes


