### PR TITLE
fix: handle None or empty contents in Gemini token counter

### DIFF
--- a/litellm/llms/gemini/count_tokens/handler.py
+++ b/litellm/llms/gemini/count_tokens/handler.py
@@ -30,6 +30,10 @@ class GoogleAIStudioTokenCounter:
 
         from google.genai.types import FunctionResponse
 
+        # Handle None or empty contents
+        if not contents:
+            return contents
+
         cleaned_contents = copy.deepcopy(contents)
 
         for content in cleaned_contents:


### PR DESCRIPTION
**Summary**
Prevents errors in the Gemini token counter by adding a null/empty check before processing contents.

**Key Changes**
- **Added null safety check**: Returns early if contents is None or empty in GoogleAIStudioTokenCounter (litellm/llms/gemini/count_tokens/handler.py)

**Impact**
- Prevents potential errors when token counting is called with None or empty contents
- Improves robustness of the Gemini integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)