### PR TITLE
include `server_tool_use` in streaming usage

### DIFF
--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import TypedDict
 
-from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper
+from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper, ServerToolUse
 
 
 class UsagePerChunk(TypedDict):
@@ -10,6 +10,7 @@ class UsagePerChunk(TypedDict):
     completion_tokens: int
     cache_creation_input_tokens: Optional[int]
     cache_read_input_tokens: Optional[int]
+    server_tool_use: Optional[ServerToolUse]
     web_search_requests: Optional[int]
     completion_tokens_details: Optional[CompletionTokensDetails]
     prompt_tokens_details: Optional[PromptTokensDetailsWrapper]

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -16,6 +16,7 @@ from litellm.types.utils import (
     Function,
     ModelResponseStream,
     PromptTokensDetails,
+    ServerToolUse,
     StreamingChoices,
     Usage,
 )
@@ -325,3 +326,83 @@ def test_stream_chunk_builder_litellm_usage_chunks():
     assert usage.prompt_tokens == 50
     assert usage.completion_tokens == 27
     assert usage.total_tokens == 77
+
+
+def test_stream_chunk_builder_anthropic_web_search():
+    # Prepare two mocked streaming chunks with usage split across them
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-mocked-usage-1",
+        created=1745513206,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="",
+                    role=None,
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=0,
+            prompt_tokens=50,
+            total_tokens=50,
+            completion_tokens_details=None,
+            server_tool_use=ServerToolUse(web_search_requests=2),
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-mocked-usage-1",
+        created=1745513207,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content=None,
+                    role=None,
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields=None,
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=27,
+            prompt_tokens=0,
+            total_tokens=27,
+            completion_tokens_details=None,
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunks = [chunk1, chunk2]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks, model="claude-sonnet-4-5-20250929", completion_output=""
+    )
+
+    assert usage.prompt_tokens == 50
+    assert usage.completion_tokens == 27
+    assert usage.total_tokens == 77    
+    assert usage.server_tool_use['web_search_requests'] == 2


### PR DESCRIPTION
## Title

Currently anthropic `server_tool_use` is not included in usage metadata when `stream=True` and as a result not available in the `response_obj.usage` used by a custom logger. This PR adds `server_tool_use` to streaming usage.

<img width="999" height="222" alt="image" src="https://github.com/user-attachments/assets/9e2c6c38-3aba-428c-b7c3-50c7419a8d5a" />

## Relevant issues

Fixes: https://github.com/BerriAI/litellm/issues/16631

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes


## Notes

### Linting

Linting runs fine locally but for some reason failing in Github actions.

<img width="785" height="223" alt="image" src="https://github.com/user-attachments/assets/8adf92e7-6792-45e4-95a7-d8b32a370414" />


### Tests

Only 2 tests are failing and both appear to be related to missing dependencies, I've run `test-unit` which I was expecting to build the required environment using potery:

```
================================================================================================================================= short test summary info ==================================================================================================================================
FAILED tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py::TestVertexGemmaCompletion::test_acompletion_basic_request - litellm.exceptions.BadRequestError: litellm.BadRequestError: Vertex_aiException BadRequestError - vertexai import failed please run `pip install -U "google-cloud-aiplatform>=1.38"`. Got error: No module named 'vertexai'
FAILED tests/test_litellm/llms/gemini/test_gemini_common_utils.py::TestGoogleAIStudioTokenCounter::test_clean_contents_for_gemini_api_preserves_other_fields - ModuleNotFoundError: No module named 'google.genai'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 2 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================================ 2 failed, 892 passed, 11 skipped, 16 warnings in 205.77s (0:03:25) ============================================================================================================
make: *** [test-unit] Error 2
```

