### PR TITLE
Use LiteLLM key alias as fallback Noma applicationId in NomaGuardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -799,7 +799,7 @@ class NomaGuardrail(CustomGuardrail):
                     or request_data.get("metadata", {})
                     .get("headers", {})
                     .get("x-noma-application-id")
-                    or (user_auth.key_alias if user_auth.key_alias else (user_auth.key_name if user_auth.key_name else self.application_id)),
+                    or (user_auth.key_alias if user_auth.key_alias else self.application_id),
                     "ipAddress": request_data.get("metadata", {}).get(
                         "requester_ip_address", None
                     ),

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -116,8 +116,9 @@ class NomaGuardrail(CustomGuardrail):
             "NOMA_API_BASE", NomaGuardrail._DEFAULT_API_BASE
         )
         self.application_id = application_id or os.environ.get(
-            "NOMA_APPLICATION_ID", "litellm"
+            "NOMA_APPLICATION_ID"
         )
+        self.default_application_id = "litellm"
 
         if monitor_mode is None:
             self.monitor_mode = (
@@ -800,7 +801,8 @@ class NomaGuardrail(CustomGuardrail):
                     .get("headers", {})
                     .get("x-noma-application-id")
                     or self.application_id
-                    or user_auth.key_alias,
+                    or user_auth.key_alias
+                    or self.default_application_id,
                     "ipAddress": request_data.get("metadata", {}).get(
                         "requester_ip_address", None
                     ),

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -799,7 +799,8 @@ class NomaGuardrail(CustomGuardrail):
                     or request_data.get("metadata", {})
                     .get("headers", {})
                     .get("x-noma-application-id")
-                    or (user_auth.key_alias if user_auth.key_alias else self.application_id),
+                    or self.application_id
+                    or user_auth.key_alias,
                     "ipAddress": request_data.get("metadata", {}).get(
                         "requester_ip_address", None
                     ),

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -799,7 +799,7 @@ class NomaGuardrail(CustomGuardrail):
                     or request_data.get("metadata", {})
                     .get("headers", {})
                     .get("x-noma-application-id")
-                    or (user_auth.key_name if user_auth.key_name else self.application_id),
+                    or (user_auth.key_alias if user_auth.key_alias else (user_auth.key_name if user_auth.key_name else self.application_id)),
                     "ipAddress": request_data.get("metadata", {}).get(
                         "requester_ip_address", None
                     ),

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -799,7 +799,7 @@ class NomaGuardrail(CustomGuardrail):
                     or request_data.get("metadata", {})
                     .get("headers", {})
                     .get("x-noma-application-id")
-                    or self.application_id,
+                    or (user_auth.key_name if user_auth.key_name else self.application_id),
                     "ipAddress": request_data.get("metadata", {}).get(
                         "requester_ip_address", None
                     ),


### PR DESCRIPTION
## Title

Use LiteLLM key alias as fallback Noma applicationId in NomaGuardrail

## Relevant issues

N/A

## Pre-Submission checklist

<img width="797" height="176" alt="image" src="https://github.com/user-attachments/assets/3333da84-bc47-4d56-b34a-cd0db30baa6a" />

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Update Noma applicationId resolution in NomaGuardrail:
   - Stop defaulting NOMA_APPLICATION_ID to "litellm" inside __init__; instead, store a separate default_application_id =  "litellm" and keep self.application_id strictly to the explicit argument or environment value.
   - When building the Noma payload, expand the applicationId fallback chain to:
      - `extra_data.get("application_id")` (if set), then
      - `request_data["metadata"]["headers"]["x-noma-application-id"]` (if present), then
      - `self.application_id` (guardrail-level configuration), then
      - `user_auth.key_alias` (the LiteLLM key alias), then
      - `self.default_application_id` ("litellm").
- This allows each LiteLLM key alias to be used as a distinct Noma applicationId by default, while preserving "litellm" as a final fallback when no other identifier is available.