### PR TITLE
[Feat] Prompt Management - Add support for versioning prompts 

### DIFF
--- a/litellm/integrations/dotprompt/dotprompt_manager.py
+++ b/litellm/integrations/dotprompt/dotprompt_manager.py
@@ -108,7 +108,7 @@ class DotpromptManager(CustomPromptManagement):
         Compile a .prompt file into a PromptManagementClient structure.
 
         This method:
-        1. Loads the prompt template from the .prompt file
+        1. Loads the prompt template from the .prompt file (with optional version)
         2. Renders it with the provided variables
         3. Converts the rendered text into chat messages
         4. Extracts model and optional parameters from metadata
@@ -116,13 +116,22 @@ class DotpromptManager(CustomPromptManagement):
 
         try:
 
-            # Get the prompt template
-            template = self.prompt_manager.get_prompt(prompt_id)
+            # Get the prompt template (versioned or base)
+            template = self.prompt_manager.get_prompt(
+                prompt_id=prompt_id, version=prompt_version
+            )
             if template is None:
-                raise ValueError(f"Prompt '{prompt_id}' not found in prompt directory")
+                version_str = f" (version {prompt_version})" if prompt_version else ""
+                raise ValueError(
+                    f"Prompt '{prompt_id}'{version_str} not found in prompt directory"
+                )
 
-            # Render the template with variables
-            rendered_content = self.prompt_manager.render(prompt_id, prompt_variables)
+            # Render the template with variables (pass version for proper lookup)
+            rendered_content = self.prompt_manager.render(
+                prompt_id=prompt_id,
+                prompt_variables=prompt_variables,
+                version=prompt_version,
+            )
 
             # Convert rendered content to chat messages
             messages = self._convert_to_messages(rendered_content)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -585,7 +585,10 @@ class Logging(LiteLLMLoggingBaseClass):
         custom_logger = (
             prompt_management_logger
             or self.get_custom_logger_for_prompt_management(
-                model=model, non_default_params=non_default_params
+                model=model,
+                non_default_params=non_default_params,
+                prompt_id=prompt_id,
+                dynamic_callback_params=self.standard_callback_dynamic_params,
             )
         )
 
@@ -622,7 +625,11 @@ class Logging(LiteLLMLoggingBaseClass):
         custom_logger = (
             prompt_management_logger
             or self.get_custom_logger_for_prompt_management(
-                model=model, tools=tools, non_default_params=non_default_params
+                model=model,
+                tools=tools,
+                non_default_params=non_default_params,
+                prompt_id=prompt_id,
+                dynamic_callback_params=self.standard_callback_dynamic_params,
             )
         )
 
@@ -646,19 +653,69 @@ class Logging(LiteLLMLoggingBaseClass):
         self.messages = messages
         return model, messages, non_default_params
 
+    def _auto_detect_prompt_management_logger(
+        self,
+        prompt_id: str,
+        dynamic_callback_params: StandardCallbackDynamicParams,
+    ) -> Optional[CustomLogger]:
+        """
+        Auto-detect which prompt management system owns the given prompt_id.
+
+        This allows  a user to just pass prompt_id in the completion call and it will be auto-detected which system owns this prompt.
+
+        Args:
+            prompt_id: The prompt ID to check
+            dynamic_callback_params: Dynamic callback parameters for should_run_prompt_management checks
+
+        Returns:
+            A CustomLogger instance if a matching prompt management system is found, None otherwise
+        """
+        prompt_management_loggers = (
+            litellm.logging_callback_manager.get_custom_loggers_for_type(
+                callback_type=CustomPromptManagement
+            )
+        )
+
+        for logger in prompt_management_loggers:
+            if isinstance(logger, CustomPromptManagement):
+                try:
+                    if logger.should_run_prompt_management(
+                        prompt_id=prompt_id,
+                        dynamic_callback_params=dynamic_callback_params,
+                    ):
+                        self.model_call_details["prompt_integration"] = (
+                            logger.__class__.__name__
+                        )
+                        return logger
+                except Exception:
+                    # If check fails, continue to next logger
+                    continue
+        
+        return None
+
     def get_custom_logger_for_prompt_management(
-        self, model: str, non_default_params: Dict, tools: Optional[List[Dict]] = None
+        self,
+        model: str,
+        non_default_params: Dict,
+        tools: Optional[List[Dict]] = None,
+        prompt_id: Optional[str] = None,
+        dynamic_callback_params: Optional[StandardCallbackDynamicParams] = None,
     ) -> Optional[CustomLogger]:
         """
         Get a custom logger for prompt management based on model name or available callbacks.
 
         Args:
             model: The model name to check for prompt management integration
+            non_default_params: Non-default parameters passed to the completion call
+            tools: Optional tools passed to the completion call
+            prompt_id: Optional prompt ID to auto-detect which system owns this prompt
+            dynamic_callback_params: Dynamic callback parameters for should_run_prompt_management checks
 
         Returns:
             A CustomLogger instance if one is found, None otherwise
         """
         # First check if model starts with a known custom logger compatible callback
+        # This takes precedence for backward compatibility
         for callback_name in litellm._known_custom_logger_compatible_callbacks:
             if model.startswith(callback_name):
                 custom_logger = _init_custom_logger_compatible_class(
@@ -670,7 +727,16 @@ class Logging(LiteLLMLoggingBaseClass):
                     self.model_call_details["prompt_integration"] = model.split("/")[0]
                     return custom_logger
 
-        # Then check for any registered CustomPromptManagement loggers
+        # If prompt_id is provided, try to auto-detect which system has this prompt
+        if prompt_id and dynamic_callback_params is not None:
+            auto_detected_logger = self._auto_detect_prompt_management_logger(
+                prompt_id=prompt_id,
+                dynamic_callback_params=dynamic_callback_params,
+            )
+            if auto_detected_logger is not None:
+                return auto_detected_logger
+
+        # Then check for any registered CustomPromptManagement loggers (fallback)
         prompt_management_loggers = (
             litellm.logging_callback_manager.get_custom_loggers_for_type(
                 callback_type=CustomPromptManagement

--- a/tests/test_litellm/integrations/dotprompt/chat_prompt.v1.prompt
+++ b/tests/test_litellm/integrations/dotprompt/chat_prompt.v1.prompt
@@ -1,0 +1,10 @@
+---
+model: gpt-3.5-turbo
+temperature: 0.5
+max_tokens: 100
+input:
+  schema:
+    user_message: string
+---
+
+Version 1: {{user_message}}

--- a/tests/test_litellm/integrations/dotprompt/chat_prompt.v2.prompt
+++ b/tests/test_litellm/integrations/dotprompt/chat_prompt.v2.prompt
@@ -1,0 +1,10 @@
+---
+model: gpt-4
+temperature: 0.9
+max_tokens: 200
+input:
+  schema:
+    user_message: string
+---
+
+Version 2: {{user_message}}

--- a/tests/test_litellm/integrations/dotprompt/test_prompt_manager.py
+++ b/tests/test_litellm/integrations/dotprompt/test_prompt_manager.py
@@ -195,6 +195,33 @@ def test_get_prompt_metadata():
     assert "output" in metadata
 
 
+def test_get_prompt_with_version():
+    """Test that get_prompt correctly retrieves versioned prompts."""
+    prompt_dir = Path(__file__).parent
+    manager = PromptManager(prompt_directory=str(prompt_dir))
+
+    # Get base prompt (no version)
+    base_prompt = manager.get_prompt(prompt_id="chat_prompt")
+    assert base_prompt is not None
+    assert "User: {{user_message}}" in base_prompt.content
+
+    # Get version 1
+    v1_prompt = manager.get_prompt(prompt_id="chat_prompt", version=1)
+    assert v1_prompt is not None
+    assert "Version 1:" in v1_prompt.content
+    assert v1_prompt.model == "gpt-3.5-turbo"
+
+    # Get version 2
+    v2_prompt = manager.get_prompt(prompt_id="chat_prompt", version=2)
+    assert v2_prompt is not None
+    assert "Version 2:" in v2_prompt.content
+    assert v2_prompt.model == "gpt-4"
+
+    # Get non-existent version (should return None)
+    non_existent = manager.get_prompt(prompt_id="chat_prompt", version=999)
+    assert non_existent is None
+
+
 def test_add_prompt_programmatically():
     """Test adding prompts programmatically."""
     prompt_dir = Path(


### PR DESCRIPTION
## [Feat] Prompt Management - Add support for versioning prompts 

The dotprompt integration now supports versioned prompts, allowing users to maintain and reference different versions of the same prompt using the prompt_version parameter.

Create versioned files like this 

Relevant issue: https://github.com/BerriAI/litellm/issues/16233 

```
prompts/
├── chat_prompt.prompt       # Base version
├── chat_prompt.v1.prompt    # Version 1
└── chat_prompt.v2.prompt    # Version 2
```

Usage 

```
# Use version 1
curl -X POST 'http://0.0.0.0:4000/chat/completions' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{
    "model": "gpt-4",
    "prompt_id": "chat_prompt",
    "prompt_version": 1,
    "prompt_variables": {"user_message": "Hello"}
  }'

# Use version 2
curl -X POST 'http://0.0.0.0:4000/chat/completions' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{
    "model": "gpt-4",
    "prompt_id": "chat_prompt",
    "prompt_version": 2,
    "prompt_variables": {"user_message": "Hello"}
  }'
```

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


