### PR TITLE
[Fix] Security - Filter secret fields form Langfuse

### DIFF
--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -208,7 +208,10 @@ def set_attributes(
     )
 
     try:
+        # Remove secret_fields to prevent leaking sensitive data (e.g., authorization headers)
         optional_params = kwargs.get("optional_params", {})
+        if isinstance(optional_params, dict):
+            optional_params.pop("secret_fields", None)
         litellm_params = kwargs.get("litellm_params", {})
         standard_logging_payload: Optional[StandardLoggingPayload] = kwargs.get(
             "standard_logging_object"

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -228,6 +228,8 @@ class LangFuseLogger:
 
             functions = optional_params.pop("functions", None)
             tools = optional_params.pop("tools", None)
+            # Remove secret_fields to prevent leaking sensitive data (e.g., authorization headers)
+            optional_params.pop("secret_fields", None)
             if functions is not None:
                 prompt["functions"] = functions
             if tools is not None:


### PR DESCRIPTION
## Title

[Fix] Security - Filter secret fields form Langfuse

## Relevant issues
> I am not leaking a real key.

**Before**
<img width="573" height="597" alt="Screenshot 2025-11-18 at 12 34 27 PM" src="https://github.com/user-attachments/assets/e2a1efaa-3c8d-4868-be77-0302e732a914" />

**After**
<img width="854" height="702" alt="Screenshot 2025-11-19 at 12 02 12 PM" src="https://github.com/user-attachments/assets/dc427e55-8cdd-473d-b503-78cee4768c93" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Filter `secret_fields` from optional params

