### PR TITLE
Fix optional param mapping

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -198,9 +198,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 )
             elif key in ResponsesAPIOptionalRequestParams.__annotations__.keys():
                 responses_api_request[key] = value  # type: ignore
-            elif key in ("metadata"):
+            elif key == "metadata":
                 responses_api_request["metadata"] = value
-            elif key in ("previous_response_id"):
+            elif key == "previous_response_id":
                 responses_api_request["previous_response_id"] = value
             elif key == "reasoning_effort":
                 responses_api_request["reasoning"] = self._map_reasoning_effort(value)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -309,3 +309,71 @@ def test_extract_extra_body_params_reasoning_effort_override():
 
     # extra_body should no longer be in optional_params (it was popped)
     assert "extra_body" not in result
+
+
+def test_transform_request_single_char_keys_not_matched():
+    """Test that single-character keys are not incorrectly matched to 'metadata' or 'previous_response_id'
+
+    This is a regression test for a bug where:
+    - key in ("metadata") was used instead of key == "metadata"
+    - In Python, ("metadata") is a string, not a tuple
+    - So "m" in ("metadata") returns True (character in string)
+    - This caused single-char keys like "m", "e", "t", etc. to incorrectly match
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    # Create mock objects
+    logging_obj = Mock()
+
+    messages = [{"role": "user", "content": "test"}]
+
+    # Test with single-character keys that are in "metadata" string
+    # These should NOT be treated as metadata
+    optional_params = {
+        "m": "should_not_be_metadata",  # "m" is in "metadata"
+        "e": "should_not_be_metadata",  # "e" is in "metadata"
+        "t": "should_not_be_metadata",  # "t" is in "metadata"
+        "p": "should_not_be_previous_response_id",  # "p" is in "previous_response_id"
+        "r": "should_not_be_previous_response_id",  # "r" is in "previous_response_id"
+    }
+
+    litellm_params = {}
+    headers = {}
+
+    result = handler.transform_request(
+        model="gpt-4",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params=litellm_params,
+        headers=headers,
+        litellm_logging_obj=logging_obj,
+    )
+
+    # Verify that single-char keys were NOT mapped to metadata or previous_response_id
+    assert result.get("metadata") != "should_not_be_metadata"
+    assert result.get("previous_response_id") != "should_not_be_previous_response_id"
+
+    # Now test that the actual keys DO work correctly
+    optional_params_correct = {
+        "metadata": {"user_id": "123"},
+        "previous_response_id": "resp_abc",
+    }
+
+    result_correct = handler.transform_request(
+        model="gpt-4",
+        messages=messages,
+        optional_params=optional_params_correct,
+        litellm_params=litellm_params,
+        headers=headers,
+        litellm_logging_obj=logging_obj,
+    )
+
+    # Verify that the correct keys ARE mapped properly
+    assert result_correct.get("metadata") == {"user_id": "123"}
+    assert result_correct.get("previous_response_id") == "resp_abc"
+
+    print("✓ Single-character keys are not incorrectly matched to metadata/previous_response_id")


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

Fix tuple string check in optional param matching that caused single letter parameters to be incorrectly mapped. 

## Relevant issues

<!-- e.g. "Fixes #000" -->

Fixes #16809

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x]  My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

The code was using `key in ("metadata")` and `key in ("previous_response_id")` to check optional parameter keys. In Python, `("string")` is just a string in parentheses, not a tuple, so this performs a character membership check instead of equality.

```
>>> "n" in ("previous_response_id")
True
```

The PR just changes those to a simple string equality check.


<img width="1486" height="303" alt="image" src="https://github.com/user-attachments/assets/4d2ea0da-8318-4523-8074-2b57e785f953" />


