### PR TITLE
fix(gemini): Add reasoning_content to streaming responses with tools enabled

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1673,6 +1673,19 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if thinking_blocks is not None:
                 chat_completion_message["thinking_blocks"] = thinking_blocks  # type: ignore
 
+                # Convert thinking_blocks to reasoning_content for streaming
+                # This ensures reasoning_content is available in streaming responses
+                if isinstance(model_response, ModelResponseStream) and reasoning_content is None:
+                    reasoning_content_parts = []
+                    for block in thinking_blocks:
+                        thinking_text = block.get("thinking")
+                        if thinking_text:
+                            reasoning_content_parts.append(thinking_text)
+
+                    if reasoning_content_parts:
+                        reasoning_content = "\n".join(reasoning_content_parts)
+                        chat_completion_message["reasoning_content"] = reasoning_content
+
             if isinstance(model_response, ModelResponseStream):
                 choice = VertexGeminiConfig._create_streaming_choice(
                     chat_completion_message=chat_completion_message,

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -390,6 +390,58 @@ def test_streaming_chunk_includes_reasoning_content():
     )
 
 
+def test_streaming_chunk_with_tool_calls_includes_reasoning_content():
+    """
+    Test for issue #16805: Ensure that when Gemini returns a streaming chunk with
+    tool calls AND thoughtSignature, the reasoning_content is included in the delta.
+
+    Previously, thinking_blocks were only added to non-streaming responses, causing
+    reasoning_content to be missing in streaming mode when tools were enabled.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    litellm_logging = MagicMock()
+
+    chunk = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_current_time",
+                                "args": {"timezone": "America/New_York"},
+                            },
+                            "thoughtSignature": "EsEDCr4DAdHtim...",  # Base64 signature
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 68,
+            "candidatesTokenCount": 120,
+            "totalTokenCount": 188,
+        },
+    }
+
+    iterator = ModelResponseIterator(
+        streaming_response=[], sync_stream=True, logging_obj=litellm_logging
+    )
+    streaming_chunk = iterator.chunk_parser(chunk)
+
+    # Verify that reasoning_content is present in the streaming delta
+    assert streaming_chunk.choices[0].delta.reasoning_content is not None
+
+    # Verify tool calls are also present
+    assert streaming_chunk.choices[0].delta.tool_calls is not None
+    assert len(streaming_chunk.choices[0].delta.tool_calls) == 1
+    assert streaming_chunk.choices[0].delta.tool_calls[0].function.name == "get_current_time"
+
+
 def test_check_finish_reason():
     finish_reason_mappings = VertexGeminiConfig.get_finish_reason_mapping()
     for k, v in finish_reason_mappings.items():


### PR DESCRIPTION
## Title

fix(gemini): Add reasoning_content to streaming responses with tools enabled

  ## Relevant issues

  Fixes #16805

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] I have added a screenshot of my new test passing locally 
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


  ## Type

  🐛 Bug Fix

  ## Changes

  ### Problem
  When using Gemini models (2.5 Flash, 2.0 Flash Thinking, 3.0 Pro Preview) with **streaming enabled + tools**, the `reasoning_content` field was missing from streaming response chunks, even though `thinking_blocks` were in non-streaming responses.

  This affected both direct library usage (`litellm.completion()`) and proxy usage.

  ### Details
  In `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`, the code was:
  1. ✅ Correctly extracting `thinking_blocks` from Google's API response
  2. ✅ Adding them to the message for non-streaming responses
  3. ❌ **NOT converting** `thinking_blocks` to `reasoning_content` for streaming deltas

  ### Solution
  Added logic (lines 1676-1687) to convert `thinking_blocks` to `reasoning_content` when creating streaming responses:

  **files:**
  - `litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`
  - `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`

  ### Testing
  Added `test_streaming_chunk_with_tool_calls_includes_reasoning_content()` to verify:
  - Reasoning content appears in streaming deltas when tool calls are present
  - Tool calls and reasoning_content coexist correctly
  - All 39 existing Gemini tests continue to pass

  **Test Results:**
  ✓ test_streaming_chunk_with_tool_calls_includes_reasoning_content PASSED
  ✓ All 39 Gemini tests PASSED

  - ✅ No breaking changes - only adds missing field