### PR TITLE
Litellm anthropic image url support

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -6,7 +6,7 @@ import mimetypes
 import re
 import xml.etree.ElementTree as ET
 from enum import Enum
-from typing import Any, List, Optional, Tuple, cast, overload
+from typing import Any, List, Optional, Tuple, Union, cast, overload
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
@@ -906,6 +906,46 @@ def convert_to_anthropic_image_obj(
         )
 
 
+def create_anthropic_image_param(
+    image_url_input: Union[str, dict], format: Optional[str] = None
+) -> AnthropicMessagesImageParam:
+    """
+    Create an AnthropicMessagesImageParam from an image URL input.
+    
+    Supports both URL references (for HTTP/HTTPS URLs) and base64 encoding.
+    """
+    # Extract URL and format from input
+    if isinstance(image_url_input, str):
+        image_url = image_url_input
+    else:
+        image_url = image_url_input.get("url", "")
+        if format is None:
+            format = image_url_input.get("format")
+    
+    # Check if the image URL is an HTTP/HTTPS URL that should be passed directly
+    if image_url.startswith("http://") or image_url.startswith("https://"):
+        return AnthropicMessagesImageParam(
+            type="image",
+            source=AnthropicContentParamSourceUrl(
+                type="url",
+                url=image_url,
+            ),
+        )
+    else:
+        # Convert to base64 for data URIs or other formats
+        image_chunk = convert_to_anthropic_image_obj(
+            openai_image_url=image_url, format=format
+        )
+        return AnthropicMessagesImageParam(
+            type="image",
+            source=AnthropicContentParamSource(
+                type="base64",
+                media_type=image_chunk["media_type"],
+                data=image_chunk["data"],
+            ),
+        )
+
+
 # The following XML functions will be deprecated once JSON schema support is available on Bedrock and Vertex
 # ------------------------------------------------------------------------------
 def convert_to_anthropic_tool_result_xml(message: dict) -> str:
@@ -1008,15 +1048,31 @@ def anthropic_messages_pt_xml(messages: list):
             if isinstance(messages[msg_i]["content"], list):
                 for m in messages[msg_i]["content"]:
                     if m.get("type", "") == "image_url":
-                        format = m["image_url"].get("format")
-                        user_content.append(
-                            {
-                                "type": "image",
-                                "source": convert_to_anthropic_image_obj(
-                                    m["image_url"]["url"], format=format
-                                ),
-                            }
-                        )
+                        format = m["image_url"].get("format") if isinstance(m["image_url"], dict) else None
+                        image_param = create_anthropic_image_param(m["image_url"], format=format)
+                        # Convert to dict format for XML version
+                        source = image_param["source"]
+                        if source.get("type") == "url":
+                            user_content.append(
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "url",
+                                        "url": source["url"],
+                                    },
+                                }
+                            )
+                        else:
+                            user_content.append(
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": source["media_type"],
+                                        "data": source["data"],
+                                    },
+                                }
+                            )
                     elif m.get("type", "") == "text":
                         user_content.append({"type": "text", "text": m["text"]})
             else:
@@ -1389,24 +1445,9 @@ def convert_to_anthropic_tool_result(
                     )
                 )
             elif content["type"] == "image_url":
-                if isinstance(content["image_url"], str):
-                    image_chunk = convert_to_anthropic_image_obj(
-                        content["image_url"], format=None
-                    )
-                else:
-                    format = content["image_url"].get("format")
-                    image_chunk = convert_to_anthropic_image_obj(
-                        content["image_url"]["url"], format=format
-                    )
+                format = content["image_url"].get("format") if isinstance(content["image_url"], dict) else None
                 anthropic_content_list.append(
-                    AnthropicMessagesImageParam(
-                        type="image",
-                        source=AnthropicContentParamSource(
-                            type="base64",
-                            media_type=image_chunk["media_type"],
-                            data=image_chunk["data"],
-                        ),
-                    )
+                    create_anthropic_image_param(content["image_url"], format=format)
                 )
 
         anthropic_content = anthropic_content_list
@@ -1737,21 +1778,11 @@ def anthropic_messages_pt(  # noqa: PLR0915
                     for m in user_message_types_block["content"]:
                         if m.get("type", "") == "image_url":
                             m = cast(ChatCompletionImageObject, m)
-                            format: Optional[str] = None
-                            if isinstance(m["image_url"], str):
-                                image_chunk = convert_to_anthropic_image_obj(
-                                    openai_image_url=m["image_url"], format=None
-                                )
-                            else:
-                                format = m["image_url"].get("format")
-                                image_chunk = convert_to_anthropic_image_obj(
-                                    openai_image_url=m["image_url"]["url"],
-                                    format=format,
-                                )
-
-                            _anthropic_content_element = (
-                                _anthropic_content_element_factory(image_chunk)
+                            format = m["image_url"].get("format") if isinstance(m["image_url"], dict) else None
+                            _anthropic_content_element = create_anthropic_image_param(
+                                m["image_url"], format=format
                             )
+                            
                             _content_element = add_cache_control_to_content(
                                 anthropic_content_element=_anthropic_content_element,
                                 original_content_element=dict(m),

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -166,7 +166,11 @@ class AnthropicMessagesContainerUploadParam(TypedDict, total=False):
 class AnthropicMessagesImageParam(TypedDict, total=False):
     type: Required[Literal["image"]]
     source: Required[
-        Union[AnthropicContentParamSource, AnthropicContentParamSourceFileId]
+        Union[
+            AnthropicContentParamSource,
+            AnthropicContentParamSourceFileId,
+            AnthropicContentParamSourceUrl,
+        ]
     ]
     cache_control: Optional[Union[dict, ChatCompletionCachedContent]]
 

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -19,6 +19,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     claude_2_1_pt,
     convert_to_anthropic_image_obj,
     convert_url_to_base64,
+    create_anthropic_image_param,
     llama_2_chat_pt,
     prompt_factory,
 )
@@ -205,6 +206,125 @@ def test_base64_image_input(url, expected_media_type):
     response = convert_to_anthropic_image_obj(openai_image_url=url, format=None)
 
     assert response["media_type"] == expected_media_type
+
+
+def test_create_anthropic_image_param_with_http_url():
+    """Test that HTTP/HTTPS URLs are passed as URL references, not base64."""
+    image_param = create_anthropic_image_param(
+        "https://example.com/image.jpg", format=None
+    )
+    
+    assert image_param["type"] == "image"
+    assert image_param["source"]["type"] == "url"
+    assert image_param["source"]["url"] == "https://example.com/image.jpg"
+
+
+def test_create_anthropic_image_param_with_https_url():
+    """Test that HTTPS URLs are passed as URL references."""
+    image_param = create_anthropic_image_param(
+        "https://example.com/image.png", format=None
+    )
+    
+    assert image_param["type"] == "image"
+    assert image_param["source"]["type"] == "url"
+    assert image_param["source"]["url"] == "https://example.com/image.png"
+
+
+def test_create_anthropic_image_param_with_dict_input():
+    """Test that dict input with URL is handled correctly."""
+    image_param = create_anthropic_image_param(
+        {"url": "https://example.com/image.jpg", "format": "image/jpeg"}, format=None
+    )
+    
+    assert image_param["type"] == "image"
+    assert image_param["source"]["type"] == "url"
+    assert image_param["source"]["url"] == "https://example.com/image.jpg"
+
+
+def test_create_anthropic_image_param_with_base64_data_uri():
+    """Test that data URIs are converted to base64."""
+    image_param = create_anthropic_image_param(
+        "data:image/jpeg;base64,/9j/4AAQSkZJRg==", format=None
+    )
+    
+    assert image_param["type"] == "image"
+    assert image_param["source"]["type"] == "base64"
+    assert image_param["source"]["media_type"] == "image/jpeg"
+    assert image_param["source"]["data"] == "/9j/4AAQSkZJRg=="
+
+
+def test_create_anthropic_image_param_with_format_override():
+    """Test that format parameter can override media type."""
+    image_param = create_anthropic_image_param(
+        "data:image/jpeg;base64,1234", format="image/png"
+    )
+    
+    assert image_param["type"] == "image"
+    assert image_param["source"]["type"] == "base64"
+    assert image_param["source"]["media_type"] == "image/png"
+
+
+def test_anthropic_messages_pt_with_url_image():
+    """Test that anthropic_messages_pt correctly handles HTTP/HTTPS URLs as URL references."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": "https://example.com/image.jpg",
+                },
+            ],
+        }
+    ]
+    
+    result = anthropic_messages_pt(
+        messages=messages, model="claude-3-5-sonnet", llm_provider="anthropic"
+    )
+    
+    assert len(result) == 1
+    assert result[0]["role"] == "user"
+    assert isinstance(result[0]["content"], list)
+    assert len(result[0]["content"]) == 2
+    
+    # Check text content
+    assert result[0]["content"][0]["type"] == "text"
+    
+    # Check image content - should be URL reference, not base64
+    assert result[0]["content"][1]["type"] == "image"
+    assert result[0]["content"][1]["source"]["type"] == "url"
+    assert result[0]["content"][1]["source"]["url"] == "https://example.com/image.jpg"
+
+
+def test_anthropic_messages_pt_with_base64_image():
+    """Test that anthropic_messages_pt correctly handles data URIs as base64."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": "data:image/jpeg;base64,/9j/4AAQSkZJRg==",
+                },
+            ],
+        }
+    ]
+    
+    result = anthropic_messages_pt(
+        messages=messages, model="claude-3-5-sonnet", llm_provider="anthropic"
+    )
+    
+    assert len(result) == 1
+    assert result[0]["role"] == "user"
+    assert isinstance(result[0]["content"], list)
+    assert len(result[0]["content"]) == 2
+    
+    # Check image content - should be base64, not URL
+    assert result[0]["content"][1]["type"] == "image"
+    assert result[0]["content"][1]["source"]["type"] == "base64"
+    assert result[0]["content"][1]["source"]["media_type"] == "image/jpeg"
 
 
 def test_anthropic_messages_tool_call():

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -193,9 +193,21 @@ async def test_url_with_format_param(model, sync_mode, monkeypatch):
 
         print(f"type of json_str: {type(json_str)}")
         
-        # For Anthropic models, HTTP/HTTPS URLs should be passed as URL references
-        if "anthropic" in model or "claude" in model.lower():
-            # Check that URL is passed directly (not converted to base64)
+        # Bedrock models convert URLs to base64, while direct Anthropic models support URLs
+        # bedrock/invoke models use Anthropic messages API which supports URLs
+        if model.startswith("bedrock/invoke/"):
+            # bedrock/invoke uses Anthropic messages API format, which supports URLs
+            assert "https://upload.wikimedia.org" in json_str
+            # For Anthropic, URL references use "url" type, not base64
+            assert '"type":"url"' in json_str or '"type": "url"' in json_str
+        elif model.startswith("bedrock/"):
+            # Regular Bedrock models should convert URLs to base64 (uses "bytes" field)
+            # URL should NOT be in the JSON (it should be converted to base64)
+            assert "https://upload.wikimedia.org" not in json_str
+            # Should have "bytes" field (Bedrock uses "bytes" not "base64" in the field name)
+            assert '"bytes"' in json_str or '"bytes":' in json_str
+        elif model.startswith("anthropic/"):
+            # Direct Anthropic models should pass URLs directly
             assert "https://upload.wikimedia.org" in json_str
             # For Anthropic, URL references use "url" type, not base64
             assert '"type":"url"' in json_str or '"type": "url"' in json_str

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -192,8 +192,17 @@ async def test_url_with_format_param(model, sync_mode, monkeypatch):
             json_str = json_str.decode("utf-8")
 
         print(f"type of json_str: {type(json_str)}")
-        assert "png" in json_str
-        assert "jpeg" not in json_str
+        
+        # For Anthropic models, HTTP/HTTPS URLs should be passed as URL references
+        if "anthropic" in model or "claude" in model.lower():
+            # Check that URL is passed directly (not converted to base64)
+            assert "https://upload.wikimedia.org" in json_str
+            # For Anthropic, URL references use "url" type, not base64
+            assert '"type":"url"' in json_str or '"type": "url"' in json_str
+        else:
+            # For other models, check format parameter is respected
+            assert "png" in json_str
+            assert "jpeg" not in json_str
 
 
 @pytest.mark.parametrize("model", ["gpt-4o-mini"])


### PR DESCRIPTION
## Title

Litellm anthropic image url support

## Relevant issues

Fixes #12899
Fixes #16760

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🐛 Bug Fix


## Changes
Updated the code to handle image urls for anthropic

