### PR TITLE
[Fix] Video download for veo3

### DIFF
--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -15,17 +15,16 @@ from litellm.images.utils import ImageEditRequestUtils
 import litellm
 from litellm.types.llms.gemini import GeminiLongRunningOperationResponse, GeminiVideoGenerationInstance, GeminiVideoGenerationParameters, GeminiVideoGenerationRequest
 from litellm.constants import DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS
+from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
+
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
-    from ...base_llm.videos.transformation import BaseVideoConfig as _BaseVideoConfig
     from ...base_llm.chat.transformation import BaseLLMException as _BaseLLMException
 
     LiteLLMLoggingObj = _LiteLLMLoggingObj
-    BaseVideoConfig = _BaseVideoConfig
     BaseLLMException = _BaseLLMException
 else:
     LiteLLMLoggingObj = Any
-    BaseVideoConfig = Any
     BaseLLMException = Any
 
 

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -14,6 +14,7 @@ import litellm
 from litellm.types.videos.main import VideoObject, VideoResponse
 from litellm.videos.main import video_generation, avideo_generation, video_status, avideo_status
 from litellm.llms.openai.videos.transformation import OpenAIVideoConfig
+from litellm.llms.gemini.videos.transformation import GeminiVideoConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.cost_calculator import default_video_cost_calculator
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
@@ -812,6 +813,13 @@ def test_openai_video_config_has_async_transform():
     """Ensure OpenAIVideoConfig exposes async_transform_video_content_response at runtime."""
     cfg = OpenAIVideoConfig()
     assert callable(getattr(cfg, "async_transform_video_content_response", None))
+
+
+def test_gemini_video_config_has_async_transform():
+    """Ensure GeminiVideoConfig exposes async_transform_video_content_response at runtime."""
+    cfg = GeminiVideoConfig()
+    assert callable(getattr(cfg, "async_transform_video_content_response", None))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION


## Fix video download for veo3 (Gemini)

Fixes video generation errors for Gemini Veo models: 'GeminiVideoConfig' object has no attribute 'async_transform_video_content_response'

The GeminiVideoConfig class was importing BaseVideoConfig only within TYPE_CHECKING, causing it to be 'Any' at runtime. This prevented the async_transform_video_content_response method from being available during video content downloads.

## Relevant issues

This fix addresses the same issue that was resolved for OpenAI video in PR #16708.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes
- Moved BaseVideoConfig import from TYPE_CHECKING to top-level imports
- Added test_gemini_video_config_has_async_transform() to verify the fix
- Ensures GeminiVideoConfig properly inherits BaseVideoConfig at runtime

