### PR TITLE
Fix bedrock passthrough auth issue

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -121,5 +121,16 @@ def get_litellm_params(
         "use_litellm_proxy": use_litellm_proxy,
         "litellm_request_debug": litellm_request_debug,
         "aws_region_name": kwargs.get("aws_region_name"),
+        # AWS credentials for Bedrock/Sagemaker
+        "aws_access_key_id": kwargs.get("aws_access_key_id"),
+        "aws_secret_access_key": kwargs.get("aws_secret_access_key"),
+        "aws_session_token": kwargs.get("aws_session_token"),
+        "aws_session_name": kwargs.get("aws_session_name"),
+        "aws_profile_name": kwargs.get("aws_profile_name"),
+        "aws_role_name": kwargs.get("aws_role_name"),
+        "aws_web_identity_token": kwargs.get("aws_web_identity_token"),
+        "aws_sts_endpoint": kwargs.get("aws_sts_endpoint"),
+        "aws_external_id": kwargs.get("aws_external_id"),
+        "aws_bedrock_runtime_endpoint": kwargs.get("aws_bedrock_runtime_endpoint"),
     }
     return litellm_params

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -258,7 +258,7 @@ def llm_passthrough_route(
         model=model,
         messages=[],
         optional_params={},
-        litellm_params={},
+        litellm_params=litellm_params_dict,
         api_key=provider_api_key,
         api_base=base_target_url,
     )


### PR DESCRIPTION
## Title

Fix bedrock passthrough auth issue

## Relevant issues

Fixes 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes
- Added aws params in litellm params
- Added litellm params in validate_env

**Before**
<img width="883" height="627" alt="Screenshot 2025-11-20 at 5 13 22 PM" src="https://github.com/user-attachments/assets/899947dd-e5c2-4e88-8988-5ae6b0522465" />

**After**
<img width="883" height="627" alt="image" src="https://github.com/user-attachments/assets/3546aaa6-2190-41f7-af52-65350cd9c230" />


