### PR TITLE
Fix missing costs for gemini-2.5-flash-image

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24491,10 +24491,52 @@
         "supports_tool_choice": true
     },
     "vertex_ai/gemini-2.5-flash-image": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_audio_token": 1e-06,
+        "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-language-models",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "max_pdf_size_mb": 30,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-generation#edit-an-image"
+        "output_cost_per_reasoning_token": 2.5e-06,
+        "output_cost_per_token": 2.5e-06,
+        "rpm": 100000,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-generation#edit-an-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_audio_output": false,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": false,
+        "tpm": 8000000
     },
     "vertex_ai/imagegeneration@006": {
         "litellm_provider": "vertex_ai-image-models",


### PR DESCRIPTION
## Relevant issues

When fetching costs (through the `v1/model/info` endpoint), the Vertex AI Gemini models first try fetching the information using the model name with the `vertex_ai/` prefix, and after that fall back on other keys.

The `vertex_ai/gemini-2.5-flash-image` key was recently added in [this PR](https://github.com/BerriAI/litellm/pull/16828/files#diff-e79ee75335289e1292d021126866b66ac21ff2a828942aa5db68875f81b63e05), and it doesn't contain any information on input cost per token or such, which are very relevant for that model since it's a multimodal model that supports i.e. chat. As a result, our proxy cannot correctly attribute costs to the use of the model.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

<s>- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)</s>
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

