### PR TITLE
docs: fix anthropic pass-through endpoint

### DIFF
--- a/docs/my-website/docs/tutorials/claude_responses_api.md
+++ b/docs/my-website/docs/tutorials/claude_responses_api.md
@@ -105,7 +105,7 @@ LITELLM_MASTER_KEY gives claude access to all proxy models, whereas a virtual ke
 Alternatively, use the Anthropic pass-through endpoint:
 
 ```bash
-export ANTHROPIC_BASE_URL="http://0.0.0.0:4000"
+export ANTHROPIC_BASE_URL="http://0.0.0.0:4000/anthropic"
 export ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY"
 ```
 


### PR DESCRIPTION
## Title

in docs https://docs.litellm.ai/docs/tutorials/claude_responses_api#method-2-provider-specific-pass-through-endpoint
anthropic pass through url is not correct. This PR fixes that. 

## Relevant issues

NA

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

📖 Documentation

## Changes

updated `docs/my-website/docs/tutorials/claude_responses_api.md` 
