### PR TITLE
Add `model_info_fields` and `return_litellm_params` options in `/model/info` endpoint

### DIFF
--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -2,7 +2,7 @@
 Contains utils used by OpenAI compatible endpoints 
 """
 
-from typing import Optional
+from typing import Optional, List
 
 from fastapi import Request
 
@@ -29,6 +29,19 @@ def remove_sensitive_info_from_deployment(deployment_dict: dict) -> dict:
     deployment_dict["litellm_params"].pop("aws_secret_access_key", None)
 
     deployment_dict["litellm_params"] = SENSITIVE_DATA_MASKER.mask_dict(deployment_dict["litellm_params"])
+
+    return deployment_dict
+
+
+def process_model_info_fields_from_deployment(
+    deployment_dict: dict, model_info_fields: Optional[List[str]]) -> dict:
+    if model_info_fields is None:
+        return deployment_dict
+
+    # Remove fields that are not in the model_info_fields list
+    for field in model_info_fields:
+        if field not in deployment_dict:
+            del deployment_dict[field]
 
     return deployment_dict
 

--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -34,16 +34,33 @@ def remove_sensitive_info_from_deployment(deployment_dict: dict) -> dict:
 
 
 def process_model_info_fields_from_deployment(
-    deployment_dict: dict, model_info_fields: Optional[List[str]]) -> dict:
+    deployment_dict: dict, model_info_fields: Optional[List[str]]
+) -> dict:
+    """
+    Keeps only the specified fields in a deployment dictionary (whitelist approach).
+
+    This function filters the deployment dictionary to include only the fields
+    specified in model_info_fields. All other fields are removed.
+
+    Args:
+        deployment_dict (dict): The deployment dictionary to filter fields from.
+        model_info_fields (Optional[List[str]]): List of field names to keep in
+            the deployment dictionary. If None, all fields are kept.
+
+    Returns:
+        dict: The modified deployment dictionary with only specified fields kept.
+    """
     if model_info_fields is None:
         return deployment_dict
 
-    # Remove fields that are not in the model_info_fields list
-    for field in model_info_fields:
-        if field not in deployment_dict:
-            del deployment_dict[field]
+    # Keep only fields that are in the model_info_fields list
+    filtered_dict = {
+        key: value 
+        for key, value in deployment_dict.items() 
+        if key in model_info_fields
+    }
 
-    return deployment_dict
+    return filtered_dict
 
 
 async def get_custom_llm_provider_from_request_body(request: Request) -> Optional[str]:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7566,6 +7566,16 @@ async def model_info_v1(  # noqa: PLR0915
         - When litellm_model_id is passed, it will return the info for that specific model
         - When litellm_model_id is not passed, it will return the info for all models
 
+        model_info_fields: Optional[List[str]] = None (list of field names to include in the response)
+
+        - When model_info_fields is passed, only the specified fields will be included in each model's data
+        - When model_info_fields is not passed, all fields are included in the response
+
+        return_litellm_params: bool = True (controls whether to include litellm_params in the response)
+
+        - When return_litellm_params is True (default), litellm_params are included with sensitive data masked
+        - When return_litellm_params is False, litellm_params are completely removed from the response
+
     Returns:
         Returns a dictionary containing information about each model.
 


### PR DESCRIPTION
## Title

Add `model_info_fields` and `return_litellm_params` options in `/model/info` endpoint

## Relevant issues

Feature #16878 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1834" height="419" alt="image" src="https://github.com/user-attachments/assets/fbec9631-b955-43a0-b7bb-963b1d7f41d5" />

## Type

🆕 New Feature


## Changes

- Add `model_info_fields` parameter in `/model/info`
- Add `return_litellm_params` parameter in `/model/info`

