### PR TITLE
refactor: Remove legacy sys.path.insert() calls from test files

### DIFF
--- a/tests/code_coverage_tests/bedrock_pricing.py
+++ b/tests/code_coverage_tests/bedrock_pricing.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 import requests
 from bs4 import BeautifulSoup

--- a/tests/code_coverage_tests/check_spanattributes_value_usage.py
+++ b/tests/code_coverage_tests/check_spanattributes_value_usage.py
@@ -30,7 +30,6 @@ from typing import List, Tuple
 import sys
 
 # Add parent directory to path so we can import litellm
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 
 

--- a/tests/code_coverage_tests/enforce_llms_folder_style.py
+++ b/tests/code_coverage_tests/enforce_llms_folder_style.py
@@ -2,8 +2,6 @@ import ast
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 
 SEARCH_PROVIDERS = [

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from fastapi import HTTPException
 
 from litellm.integrations.custom_guardrail import CustomGuardrail

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from fastapi import HTTPException
 
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -2,7 +2,6 @@ import sys
 import os
 import io, asyncio
 import pytest
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import BedrockGuardrail
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/guardrails_tests/test_custom_guardrail.py
+++ b/tests/guardrails_tests/test_custom_guardrail.py
@@ -7,8 +7,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/guardrails_tests/test_dynamoai_guardrails.py
+++ b/tests/guardrails_tests/test_dynamoai_guardrails.py
@@ -5,8 +5,6 @@ import sys
 import os
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.proxy.guardrails.guardrail_hooks.dynamoai import DynamoAIGuardrails
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.caching.caching import DualCache

--- a/tests/guardrails_tests/test_guardrails_config.py
+++ b/tests/guardrails_tests/test_guardrails_config.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel
 import litellm.litellm_core_utils
 import litellm.litellm_core_utils.litellm_logging
 
-sys.path.insert(0, os.path.abspath("../.."))
 from typing import Any, List, Literal, Optional, Tuple, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/guardrails_tests/test_javelin_guardrails.py
+++ b/tests/guardrails_tests/test_javelin_guardrails.py
@@ -3,7 +3,6 @@ import os
 import pytest
 from unittest.mock import AsyncMock, patch
 from fastapi import HTTPException
-sys.path.insert(0, os.path.abspath("../.."))
 from litellm.proxy.guardrails.guardrail_hooks.javelin import JavelinGuardrail
 import litellm
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/guardrails_tests/test_lakera_v2.py
+++ b/tests/guardrails_tests/test_lakera_v2.py
@@ -5,7 +5,6 @@ import pytest
 import time
 from litellm import mock_completion
 from unittest.mock import MagicMock, AsyncMock, patch
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.proxy.guardrails.guardrail_hooks.lakera_ai_v2 import LakeraAIGuardrail
 from litellm.types.guardrails import PiiEntityType, PiiAction

--- a/tests/guardrails_tests/test_presidio_pii.py
+++ b/tests/guardrails_tests/test_presidio_pii.py
@@ -5,7 +5,6 @@ import pytest
 import time
 from litellm import mock_completion
 from unittest.mock import MagicMock, AsyncMock, patch
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking, PresidioPerRequestConfig
 from litellm.types.guardrails import PiiEntityType, PiiAction

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -6,7 +6,6 @@ import pytest
 import time
 from litellm import mock_completion
 from unittest.mock import MagicMock, AsyncMock, patch
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.proxy.guardrails.guardrail_hooks.presidio import _OPTIONAL_PresidioPIIMasking, PresidioPerRequestConfig
 from litellm.integrations.custom_logger import CustomLogger

--- a/tests/image_gen_tests/test_fal_ai_image_generation.py
+++ b/tests/image_gen_tests/test_fal_ai_image_generation.py
@@ -4,8 +4,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import aimage_generation
 

--- a/tests/litellm_utils_tests/test_cyberark.py
+++ b/tests/litellm_utils_tests/test_cyberark.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-sys.path.insert(0, os.path.abspath("../.."))
 from unittest.mock import AsyncMock, MagicMock, patch
 from litellm._uuid import uuid
 

--- a/tests/litellm_utils_tests/test_validate_tool_choice.py
+++ b/tests/litellm_utils_tests/test_validate_tool_choice.py
@@ -2,8 +2,6 @@ import pytest
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.utils import validate_chat_completion_tool_choice
 
 

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -9,7 +9,6 @@ from litellm.responses.litellm_completion_transformation.transformation import L
 from litellm.types.utils import ModelResponse
 
 
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
 import json

--- a/tests/llm_responses_api_testing/test_azure_responses_api.py
+++ b/tests/llm_responses_api_testing/test_azure_responses_api.py
@@ -5,7 +5,6 @@ import asyncio
 from typing import Optional
 from unittest.mock import patch, AsyncMock
 
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
 import json

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -21,8 +21,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.constants import STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig

--- a/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
+++ b/tests/llm_responses_api_testing/test_google_ai_studio_responses_api.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 from unittest.mock import patch, AsyncMock
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 import json
 from base_responses_api import BaseResponsesAPITest

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -10,7 +10,6 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 import time
 import json
 
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
 import json

--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -26,9 +26,7 @@ def event_loop():
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_teardown(event_loop):  # Add event_loop as a dependency
     curr_dir = os.getcwd()
-    sys.path.insert(0, os.path.abspath("../.."))
-
-    import litellm
+        import litellm
     from litellm import Router
 
     from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER

--- a/tests/llm_translation/test_bedrock_agentcore.py
+++ b/tests/llm_translation/test_bedrock_agentcore.py
@@ -7,10 +7,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)
-
 import litellm
 from unittest.mock import MagicMock, patch
 import pytest

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -9,7 +9,6 @@ import traceback
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
 from unittest.mock import MagicMock, patch
 
 import litellm

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -5,8 +5,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from typing import Union, List
 
 # from litellm.litellm_core_utils.prompt_templates.factory import prompt_factory

--- a/tests/llm_translation/test_unit_test_bedrock_invoke.py
+++ b/tests/llm_translation/test_unit_test_bedrock_invoke.py
@@ -11,7 +11,6 @@ load_dotenv()
 import io
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
 from unittest.mock import AsyncMock, Mock, patch
 
 

--- a/tests/load_tests/test_datadog_load_test.py
+++ b/tests/load_tests/test_datadog_load_test.py
@@ -1,8 +1,6 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import pytest

--- a/tests/load_tests/test_langsmith_load_test.py
+++ b/tests/load_tests/test_langsmith_load_test.py
@@ -2,8 +2,6 @@ import sys
 
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 from litellm._logging import verbose_logger

--- a/tests/load_tests/test_otel_load_test.py
+++ b/tests/load_tests/test_otel_load_test.py
@@ -2,8 +2,6 @@ import sys
 
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 from litellm._logging import verbose_logger

--- a/tests/load_tests/test_vertex_embeddings_load_test.py
+++ b/tests/load_tests/test_vertex_embeddings_load_test.py
@@ -6,8 +6,6 @@ Load test on vertex AI embeddings to ensure vertex median response time is less 
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import pytest

--- a/tests/load_tests/test_vertex_load_tests.py
+++ b/tests/load_tests/test_vertex_load_tests.py
@@ -1,8 +1,6 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import pytest

--- a/tests/local_testing/create_mock_standard_logging_payload.py
+++ b/tests/local_testing/create_mock_standard_logging_payload.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/local_testing/test_alangfuse.py
+++ b/tests/local_testing/test_alangfuse.py
@@ -8,8 +8,6 @@ from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import completion
 from litellm.caching import InMemoryCache

--- a/tests/local_testing/test_azure_perf.py
+++ b/tests/local_testing/test_azure_perf.py
@@ -4,8 +4,7 @@
 # from datetime import datetime
 # import pytest
 
-# sys.path.insert(0, os.path.abspath("../.."))
-# import openai, litellm, uuid
+# # import openai, litellm, uuid
 # from openai import AsyncAzureOpenAI
 
 # client = AsyncAzureOpenAI(

--- a/tests/local_testing/test_custom_api_logger.py
+++ b/tests/local_testing/test_custom_api_logger.py
@@ -4,7 +4,6 @@ import io, asyncio
 
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
 print("Modified sys.path:", sys.path)
 
 

--- a/tests/local_testing/test_custom_callback_input.py
+++ b/tests/local_testing/test_custom_callback_input.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import pytest
 from pydantic import BaseModel
 
-sys.path.insert(0, os.path.abspath("../.."))
 from typing import List, Literal, Optional, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/local_testing/test_custom_logger.py
+++ b/tests/local_testing/test_custom_logger.py
@@ -8,8 +8,6 @@ import traceback
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import completion, embedding
 from litellm.integrations.custom_logger import CustomLogger

--- a/tests/local_testing/test_dynamodb_logs.py
+++ b/tests/local_testing/test_dynamodb_logs.py
@@ -4,8 +4,6 @@ import io, asyncio
 
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import completion
 import litellm
 

--- a/tests/local_testing/test_gcs_bucket.py
+++ b/tests/local_testing/test_gcs_bucket.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import json
 import logging

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -8,8 +8,6 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import completion
 

--- a/tests/local_testing/test_langsmith.py
+++ b/tests/local_testing/test_langsmith.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import logging
 from litellm._uuid import uuid

--- a/tests/local_testing/test_literalai.py
+++ b/tests/local_testing/test_literalai.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import logging
 

--- a/tests/local_testing/test_logfire.py
+++ b/tests/local_testing/test_logfire.py
@@ -12,8 +12,6 @@ from litellm._logging import verbose_logger, verbose_proxy_logger
 
 verbose_logger.setLevel(logging.DEBUG)
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 # Testing scenarios for logfire logging:
 # 1. Test logfire logging for completion
 # 2. Test logfire logging for acompletion

--- a/tests/local_testing/test_lunary.py
+++ b/tests/local_testing/test_lunary.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import completion
 

--- a/tests/local_testing/test_mem_leak.py
+++ b/tests/local_testing/test_mem_leak.py
@@ -2,9 +2,7 @@
 # import os
 # import sys
 
-# sys.path.insert(0, os.path.abspath("../.."))
-
-# import litellm
+# # import litellm
 # from memory_profiler import profile
 # from litellm.utils import (
 #     ModelResponseIterator,

--- a/tests/local_testing/test_opik.py
+++ b/tests/local_testing/test_opik.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import logging
 

--- a/tests/local_testing/test_prometheus_service.py
+++ b/tests/local_testing/test_prometheus_service.py
@@ -6,7 +6,6 @@ import sys
 import os
 import io, asyncio
 
-sys.path.insert(0, os.path.abspath("../.."))
 import pytest
 from litellm import acompletion, Cache
 from litellm._service_logger import ServiceLogging

--- a/tests/local_testing/test_prompt_caching.py
+++ b/tests/local_testing/test_prompt_caching.py
@@ -4,8 +4,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 import pytest
 

--- a/tests/local_testing/test_promptlayer_integration.py
+++ b/tests/local_testing/test_promptlayer_integration.py
@@ -2,8 +2,6 @@ import sys
 import os
 import io
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import completion
 import litellm
 

--- a/tests/local_testing/test_redis_batch_optimizations.py
+++ b/tests/local_testing/test_redis_batch_optimizations.py
@@ -16,8 +16,6 @@ import pytest
 from dotenv import load_dotenv
 
 load_dotenv()
-sys.path.insert(0, os.path.abspath("../.."))
-
 import uuid
 from litellm.caching.dual_cache import DualCache
 from litellm.caching.in_memory_cache import InMemoryCache

--- a/tests/local_testing/test_router_fallback_handlers.py
+++ b/tests/local_testing/test_router_fallback_handlers.py
@@ -21,8 +21,6 @@ import sys
 import os
 from typing import List, Dict
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.router_utils.fallback_event_handlers import (
     run_async_fallback,
     log_success_fallback_event,

--- a/tests/local_testing/test_router_max_parallel_requests.py
+++ b/tests/local_testing/test_router_max_parallel_requests.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
 from typing import Optional
 
 import litellm

--- a/tests/local_testing/test_traceloop.py
+++ b/tests/local_testing/test_traceloop.py
@@ -7,9 +7,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 import litellm
 
-sys.path.insert(0, os.path.abspath("../.."))
-
-
 @pytest.fixture()
 @pytest.mark.skip(reason="Traceloop use `otel` integration instead")
 def exporter():

--- a/tests/local_testing/test_wandb.py
+++ b/tests/local_testing/test_wandb.py
@@ -4,8 +4,6 @@ import io, asyncio
 
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import completion
 import litellm
 

--- a/tests/logging_callback_tests/create_mock_standard_logging_payload.py
+++ b/tests/logging_callback_tests/create_mock_standard_logging_payload.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -18,7 +18,6 @@ from litellm.types.integrations.slack_alerting import AlertType
 
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
 import asyncio
 import os
 import unittest.mock

--- a/tests/logging_callback_tests/test_amazing_s3_logs.py
+++ b/tests/logging_callback_tests/test_amazing_s3_logs.py
@@ -4,8 +4,6 @@ import io, asyncio
 
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import completion
 import litellm
 

--- a/tests/logging_callback_tests/test_azure_blob_storage.py
+++ b/tests/logging_callback_tests/test_azure_blob_storage.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import litellm.vector_stores.main

--- a/tests/logging_callback_tests/test_custom_callback_router.py
+++ b/tests/logging_callback_tests/test_custom_callback_router.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
 from typing import List, Literal, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/logging_callback_tests/test_datadog.py
+++ b/tests/logging_callback_tests/test_datadog.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_datadog_llm_obs.py
+++ b/tests/logging_callback_tests/test_datadog_llm_obs.py
@@ -7,8 +7,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_gcs_pub_sub.py
+++ b/tests/logging_callback_tests/test_gcs_pub_sub.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import gzip

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import litellm
 import gzip

--- a/tests/logging_callback_tests/test_langfuse_e2e_test.py
+++ b/tests/logging_callback_tests/test_langfuse_e2e_test.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 import threading
 
 logging.basicConfig(level=logging.DEBUG)
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import completion
 from litellm.caching import InMemoryCache

--- a/tests/logging_callback_tests/test_langsmith_unit_test.py
+++ b/tests/logging_callback_tests/test_langsmith_unit_test.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_log_db_redis_services.py
+++ b/tests/logging_callback_tests/test_log_db_redis_services.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
+++ b/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
@@ -4,8 +4,6 @@ import sys
 
 from typing import Optional
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/logging_callback_tests/test_pagerduty_alerting.py
+++ b/tests/logging_callback_tests/test_pagerduty_alerting.py
@@ -5,7 +5,6 @@ import sys
 from datetime import datetime, timedelta
 from typing import Optional
 
-sys.path.insert(0, os.path.abspath("../.."))
 import pytest
 import litellm
 

--- a/tests/logging_callback_tests/test_posthog.py
+++ b/tests/logging_callback_tests/test_posthog.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import pytest
 
 from litellm.integrations.posthog import PostHogLogger

--- a/tests/logging_callback_tests/test_view_request_resp_logs.py
+++ b/tests/logging_callback_tests/test_view_request_resp_logs.py
@@ -2,8 +2,6 @@ import io
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import json
 import logging

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -3,8 +3,6 @@ import sys
 import pytest
 from typing import List, Any, cast
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 # Import required modules
 import litellm
 from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -8,8 +8,6 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Add the project root to the path
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.types.mcp import MCPAuth, MCPTransport
 from mcp.types import Tool as MCPTool, CallToolResult as MCPCallToolResult

--- a/tests/mcp_tests/test_mcp_guardrails.py
+++ b/tests/mcp_tests/test_mcp_guardrails.py
@@ -14,8 +14,6 @@ from typing import Optional, Dict, Any
 from unittest.mock import MagicMock, AsyncMock, patch
 
 # Add the project root to the path
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 from litellm.integrations.custom_guardrail import CustomGuardrail

--- a/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
+++ b/tests/pass_through_unit_tests/test_anthropic_messages_passthrough.py
@@ -41,9 +41,7 @@ def event_loop():
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_teardown(event_loop):  # Add event_loop as a dependency
     curr_dir = os.getcwd()
-    sys.path.insert(0, os.path.abspath("../.."))
-
-    import litellm
+        import litellm
     from litellm import Router
 
     importlib.reload(litellm)

--- a/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
+++ b/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
@@ -16,8 +16,6 @@ import pytest
 import httpx
 
 # Add the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_ai_live_passthrough_logging_handler import (
     VertexAILivePassthroughLoggingHandler,
 )

--- a/tests/proxy_unit_tests/test_custom_callback_input.py
+++ b/tests/proxy_unit_tests/test_custom_callback_input.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import pytest
 from pydantic import BaseModel
 
-sys.path.insert(0, os.path.abspath("../.."))
 from typing import List, Literal, Optional, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/proxy_unit_tests/test_default_end_user_budget_simple.py
+++ b/tests/proxy_unit_tests/test_default_end_user_budget_simple.py
@@ -12,8 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_EndUserTable
 from litellm.proxy.auth.auth_checks import get_end_user_object

--- a/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
+++ b/tests/proxy_unit_tests/test_google_gemini_proxy_request.py
@@ -18,8 +18,6 @@ import httpx
 import pytest
 
 # Add the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.google_endpoints.endpoints import google_generate_content

--- a/tests/proxy_unit_tests/test_prisma_client_backoff_retry.py
+++ b/tests/proxy_unit_tests/test_prisma_client_backoff_retry.py
@@ -14,8 +14,6 @@ import sys
 import os
 
 # Add project root to path
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.proxy.utils import PrismaClient, ProxyLogging
 from prisma.errors import PrismaError, ClientNotConnectedError
 import httpx

--- a/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
+++ b/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
@@ -7,7 +7,6 @@ from fastapi import Request
 from litellm.proxy.utils import _get_redoc_url, _get_docs_url
 from datetime import datetime
 
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 
 

--- a/tests/router_unit_tests/create_mock_standard_logging_payload.py
+++ b/tests/router_unit_tests/create_mock_standard_logging_payload.py
@@ -3,8 +3,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import gzip
 import json

--- a/tests/router_unit_tests/test_completion_no_copy.py
+++ b/tests/router_unit_tests/test_completion_no_copy.py
@@ -8,8 +8,6 @@ import sys
 import os
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import Router
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/router_unit_tests/test_default_deployment_copy.py
+++ b/tests/router_unit_tests/test_default_deployment_copy.py
@@ -7,8 +7,6 @@ doesn't corrupt the original default_deployment instance.
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import Router
 
 

--- a/tests/router_unit_tests/test_prompt_management_check.py
+++ b/tests/router_unit_tests/test_prompt_management_check.py
@@ -7,8 +7,6 @@ prompt management model detection.
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm import Router
 
 

--- a/tests/search_tests/test_google_pse_search.py
+++ b/tests/search_tests/test_google_pse_search.py
@@ -5,10 +5,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)
-
 from tests.search_tests.base_search_unit_tests import BaseSearchTest
 
 

--- a/tests/search_tests/test_perplexity_search.py
+++ b/tests/search_tests/test_perplexity_search.py
@@ -5,10 +5,6 @@ import os
 import sys
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)
-
 from tests.search_tests.base_search_unit_tests import BaseSearchTest
 
 

--- a/tests/search_tests/test_tavily_search.py
+++ b/tests/search_tests/test_tavily_search.py
@@ -6,10 +6,6 @@ import sys
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)
-
 import litellm
 
 

--- a/tests/test_litellm/caching/test_gcs_cache.py
+++ b/tests/test_litellm/caching/test_gcs_cache.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.caching.gcs_cache import GCSCache
 
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
@@ -11,7 +11,6 @@ from enterprise.litellm_enterprise.enterprise_callbacks.send_emails.base_email i
     BaseEmailLogger,
 )
 
-sys.path.insert(0, os.path.abspath("../../.."))
 from litellm_enterprise.types.enterprise_callbacks.send_emails import (
     EmailEvent,
     SendKeyCreatedEmailEvent,

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_endpoints.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_endpoints.py
@@ -7,8 +7,6 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm_enterprise.enterprise_callbacks.send_emails.endpoints import (
     _get_email_settings,
     _save_email_settings,

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_resend_email.py
@@ -5,8 +5,6 @@ import unittest.mock as mock
 import pytest
 from httpx import Response
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm_enterprise.enterprise_callbacks.send_emails.resend_email import (
     ResendEmailLogger,
 )

--- a/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.integrations.SlackAlerting.hanging_request_check import (
     AlertingHangingRequestCheck,
 )

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting_utils.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting_utils.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,

--- a/tests/test_litellm/integrations/arize/test_arize.py
+++ b/tests/test_litellm/integrations/arize/test_arize.py
@@ -5,8 +5,6 @@ from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 
 import pytest

--- a/tests/test_litellm/integrations/arize/test_arize_health_check.py
+++ b/tests/test_litellm/integrations/arize/test_arize_health_check.py
@@ -7,8 +7,6 @@ import sys
 from unittest.mock import patch, MagicMock
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 import pytest
 

--- a/tests/test_litellm/integrations/arize/test_arize_utils.py
+++ b/tests/test_litellm/integrations/arize/test_arize_utils.py
@@ -4,8 +4,6 @@ import sys
 from typing import Optional
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import asyncio
 
 import pytest

--- a/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
+++ b/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
@@ -8,8 +8,6 @@ import httpx
 import polars as pl
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.integrations.cloudzero.cz_stream_api import CloudZeroStreamer
 
 

--- a/tests/test_litellm/integrations/cloudzero/test_dry_run_endpoint.py
+++ b/tests/test_litellm/integrations/cloudzero/test_dry_run_endpoint.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import polars as pl
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.integrations.cloudzero.cloudzero import CloudZeroLogger
 
 

--- a/tests/test_litellm/integrations/cloudzero/test_transform.py
+++ b/tests/test_litellm/integrations/cloudzero/test_transform.py
@@ -6,8 +6,6 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.integrations.cloudzero.transform import CBFTransformer
 from litellm.types.integrations.cloudzero import CBFRecord
 

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -13,7 +13,6 @@ import litellm
 from litellm.integrations.langfuse import langfuse as langfuse_module
 from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
-sys.path.insert(0, os.path.abspath("../.."))
 from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 # Import LangfuseUsageDetails directly from the module where it's defined

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 from litellm.integrations.langsmith import LangsmithLogger
 
 

--- a/tests/test_litellm/integrations/test_mlflow.py
+++ b/tests/test_litellm/integrations/test_mlflow.py
@@ -4,8 +4,6 @@ import sys
 from unittest.mock import MagicMock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import pytest
 
 import litellm

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
 from opentelemetry.sdk._logs import LoggerProvider as OTLoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -8,8 +8,6 @@ import sys
 import pytest
 
 # Add the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3,9 +3,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
-
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     LiteLLMAnthropicMessagesAdapter,
 )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -4,8 +4,6 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from unittest.mock import MagicMock, patch
 
 from litellm.types.utils import Delta, ModelResponse, StreamingChoices

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_content_after_stop_reason.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_content_after_stop_reason.py
@@ -18,8 +18,6 @@ from typing import List
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
     AnthropicStreamWrapper,
 )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -3,8 +3,6 @@ import sys
 from typing import List
 
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
     AnthropicStreamWrapper,
 )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_sse_wrapper.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_sse_wrapper.py
@@ -4,8 +4,6 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
     AnthropicStreamWrapper,
 )

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_qwen3_transformation.py
@@ -8,8 +8,6 @@ import pytest
 
 # Ensure the project root is on the import path so `litellm` can be imported when
 # tests are executed from any working directory.
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from litellm.llms.bedrock.chat.invoke_transformations.amazon_qwen3_transformation import (
     AmazonQwen3Config,
 )

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -7,8 +7,6 @@ import pytest
 
 # Ensure the project root is on the import path so `litellm` can be imported when
 # tests are executed from any working directory.
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeConfig,
 )

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -8,8 +8,6 @@ import pytest
 
 # Ensure the project root is on the import path so `litellm` can be imported when
 # tests are executed from any working directory.
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeMessagesConfig,

--- a/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
+++ b/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.utils import _get_model_info_helper
 from litellm.cost_calculator import completion_cost
 from litellm.types.utils import ModelResponse, Usage, Choices, Message

--- a/tests/test_litellm/llms/bytez/chat/test_bytez_chat_transformation.py
+++ b/tests/test_litellm/llms/bytez/chat/test_bytez_chat_transformation.py
@@ -4,8 +4,6 @@ import pytest
 import json
 
 # Adds the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.llms.bytez.chat.transformation import BytezChatConfig, API_BASE, version
 
 TEST_API_KEY = "MOCK_BYTEZ_API_KEY"

--- a/tests/test_litellm/llms/cohere/rerank/test_rerank_guardrail_handler.py
+++ b/tests/test_litellm/llms/cohere/rerank/test_rerank_guardrail_handler.py
@@ -8,8 +8,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.cohere.rerank.guardrail_translation.handler import CohereRerankHandler

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -16,8 +16,6 @@ import sys
 import pytest
 
 # Add the project root to Python path
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 import litellm
 from litellm.llms.dashscope.cost_calculator import (
     cost_per_token as dashscope_cost_per_token,

--- a/tests/test_litellm/llms/deepinfra/test_deepinfra_chat_transformation.py
+++ b/tests/test_litellm/llms/deepinfra/test_deepinfra_chat_transformation.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Add litellm to path
-sys.path.insert(0, os.path.abspath("../../../.."))
 import litellm
 
 

--- a/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank.py
+++ b/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Add litellm to path
-sys.path.insert(0, os.path.abspath("../../../.."))
 import litellm
 
 

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -10,8 +10,6 @@ import sys
 import os
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 import pytest
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import httpx
 import pytest
 from respx import MockRouter

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -8,8 +8,6 @@ import json
 import litellm
 
 # Adds the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm import ModelResponse
 from litellm.llms.oci.chat.transformation import OCIChatConfig, OCIRequestWrapper, version
 

--- a/tests/test_litellm/llms/openai/completion/test_text_completion_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/completion/test_text_completion_guardrail_handler.py
@@ -8,8 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.openai.completion.guardrail_translation.handler import (

--- a/tests/test_litellm/llms/openai/image_generation/test_image_generation_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/image_generation/test_image_generation_guardrail_handler.py
@@ -7,8 +7,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.openai.image_generation.guardrail_translation.handler import (

--- a/tests/test_litellm/llms/openai/speech/test_text_to_speech_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/speech/test_text_to_speech_guardrail_handler.py
@@ -7,8 +7,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.openai.speech.guardrail_translation.handler import (

--- a/tests/test_litellm/llms/openai/transcriptions/test_audio_transcription_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_audio_transcription_guardrail_handler.py
@@ -7,8 +7,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.openai.transcriptions.guardrail_translation.handler import (

--- a/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
+++ b/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
@@ -12,8 +12,6 @@ from unittest.mock import Mock
 import pytest
 
 # Add the project root to Python path
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm import ModelResponse
 from litellm.llms.perplexity.chat.transformation import PerplexityChatConfig
 from litellm.types.utils import Usage

--- a/tests/test_litellm/llms/perplexity/test_perplexity.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 import pytest
 
 

--- a/tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity_cost_calculator.py
@@ -14,8 +14,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 # Add the project root to Python path
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 import litellm
 from litellm.cost_calculator import completion_cost, cost_per_token
 from litellm.llms.perplexity.cost_calculator import cost_per_token as perplexity_cost_per_token

--- a/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
+++ b/tests/test_litellm/llms/perplexity/test_perplexity_integration.py
@@ -14,8 +14,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 # Add the project root to Python path
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 import litellm
 from litellm import ModelResponse
 from litellm.cost_calculator import completion_cost, cost_per_token

--- a/tests/test_litellm/llms/runwayml/test_text_to_speech_transformation.py
+++ b/tests/test_litellm/llms/runwayml/test_text_to_speech_transformation.py
@@ -4,8 +4,6 @@ Test RunwayML text-to-speech transformation
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.llms.runwayml.text_to_speech.transformation import (
     RunwayMLTextToSpeechConfig,
 )

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_common_utils.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
 from litellm.llms.sagemaker.common_utils import AWSEventStreamDecoder
 from litellm.llms.sagemaker.completion.transformation import SagemakerConfig
 

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_embedding_voyage.py
@@ -14,8 +14,6 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from litellm import embedding
 from litellm.llms.sagemaker.embedding.transformation import SagemakerEmbeddingConfig
 from litellm.llms.voyage.embedding.transformation import VoyageEmbeddingConfig

--- a/tests/test_litellm/llms/volcengine/test_volcengine_embedding.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine_embedding.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Add parent directory to path for imports
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from tests.llm_translation.base_embedding_unit_tests import BaseLLMEmbeddingTest
 import litellm
 from litellm.types.utils import EmbeddingResponse

--- a/tests/test_litellm/llms/xai/responses/test_xai_responses_transformation.py
+++ b/tests/test_litellm/llms/xai/responses/test_xai_responses_transformation.py
@@ -9,8 +9,6 @@ Source: litellm/llms/xai/responses/transformation.py
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 import pytest
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager

--- a/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
+++ b/tests/test_litellm/proxy/common_utils/test_key_rotation_manager.py
@@ -8,8 +8,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 from litellm.proxy._types import (
     GenerateKeyResponse,
     LiteLLM_VerificationToken,

--- a/tests/test_litellm/proxy/google_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/google_endpoints/test_endpoints.py
@@ -12,10 +12,6 @@ from starlette.requests import Request
 
 load_dotenv()
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)
-
 @pytest.mark.asyncio
 async def test_proxy_gemini_to_openai_like_model_token_counting():
     """

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_patterns.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_patterns.py
@@ -7,10 +7,6 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../")
-)
-
 from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.patterns import (
     PATTERN_CATEGORIES,
     PATTERN_DESCRIPTIONS,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
@@ -5,8 +5,6 @@ Test OpenAI Moderation Guardrail
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 import asyncio
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -9,8 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockGuardrail,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
@@ -5,8 +5,6 @@ from unittest.mock import patch, MagicMock
 from httpx import Response, Request
 from fastapi import HTTPException
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm import DualCache
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -7,8 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))
-
 from fastapi import HTTPException
 
 import litellm

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -11,8 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from litellm.caching.caching import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.presidio import (

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -9,8 +9,6 @@ from unittest.mock import patch
 from litellm.caching.dual_cache import DualCache
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../../.."))
-
 from fastapi import HTTPException
 from litellm.exceptions import GuardrailRaisedException
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py
@@ -12,8 +12,6 @@ from typing import Dict
 from unittest.mock import Mock, patch
 
 # Add parent directory to path for imports
-sys.path.insert(0, os.path.abspath("../../.."))
-
 # Third-party imports
 import pytest
 from fastapi.exceptions import HTTPException

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -13,8 +13,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../.."))
-
 import litellm
 from litellm import DualCache, Router
 from litellm.proxy._types import UserAPIKeyAuth

--- a/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
+++ b/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
@@ -7,7 +7,6 @@ from unittest import mock
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.abspath("../../.."))
 import litellm
 from litellm.proxy.proxy_server import app, initialize
 

--- a/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
@@ -10,10 +10,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)
-
 import litellm
 from litellm.proxy.management_endpoints.cost_tracking_settings import router
 from litellm.proxy.proxy_server import app

--- a/tests/test_litellm/proxy/management_endpoints/test_delete_callbacks_endpoint.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_delete_callbacks_endpoint.py
@@ -5,10 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)
-
 from litellm.proxy._types import (
     CallbackDelete,
     ConfigYAML,

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -4,10 +4,6 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)
-
 from unittest.mock import AsyncMock, MagicMock
 
 from litellm.proxy.management_helpers.object_permission_utils import (

--- a/tests/test_litellm/proxy/public_endpoints/test_provider_create_metadata.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_provider_create_metadata.py
@@ -4,8 +4,6 @@ from copy import deepcopy
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 import litellm.proxy.public_endpoints.provider_create_metadata as pcm  # noqa: E402
 from litellm.proxy.public_endpoints.provider_create_metadata import (  # noqa: E402
     _normalize_field,

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -1,10 +1,6 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/test_litellm/proxy/test_health_check_functions.py
+++ b/tests/test_litellm/proxy/test_health_check_functions.py
@@ -4,8 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.proxy.utils import PrismaClient
 from litellm.proxy.health_endpoints._health_endpoints import _save_health_check_to_db
 

--- a/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_deployment_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_deployment_check.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
 import json
 
 import litellm

--- a/tests/test_litellm/router_utils/test_cooldown_cache.py
+++ b/tests/test_litellm/router_utils/test_cooldown_cache.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock
 import pytest
 
 # Add the parent directory to the system path
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.caching.dual_cache import DualCache
 from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker

--- a/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
+++ b/tests/test_litellm/secret_managers/test_get_azure_ad_token_provider.py
@@ -5,8 +5,6 @@ from typing import Optional
 from unittest.mock import MagicMock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
-sys.path.insert(0, os.path.abspath("../.."))
-
 import pytest
 
 from litellm.secret_managers.get_azure_ad_token_provider import (

--- a/tests/test_litellm/test_acompletion_session_reuse_e2e.py
+++ b/tests/test_litellm/test_acompletion_session_reuse_e2e.py
@@ -17,8 +17,6 @@ import inspect
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 import litellm
 
 

--- a/tests/test_litellm/test_add_deployment_no_master_key.py
+++ b/tests/test_litellm/test_add_deployment_no_master_key.py
@@ -11,8 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 import litellm
 from litellm.proxy.proxy_server import ProxyConfig
 from litellm.proxy.utils import PrismaClient, ProxyLogging

--- a/tests/test_litellm/test_aembedding_session_reuse_e2e.py
+++ b/tests/test_litellm/test_aembedding_session_reuse_e2e.py
@@ -8,8 +8,6 @@ import os
 import sys
 import inspect
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 from litellm.types.utils import all_litellm_params
 
 

--- a/tests/test_litellm/test_cost_calculation_log_level.py
+++ b/tests/test_litellm/test_cost_calculation_log_level.py
@@ -5,8 +5,6 @@ import sys
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
-
 import litellm
 from litellm import completion_cost
 

--- a/tests/test_litellm/test_shared_session_integration.py
+++ b/tests/test_litellm/test_shared_session_integration.py
@@ -8,8 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Add the litellm directory to the path
-sys.path.insert(0, os.path.abspath("../../.."))
-
 import litellm
 
 

--- a/tests/test_litellm/types/llms/test_types_llms_openai.py
+++ b/tests/test_litellm/types/llms/test_types_llms_openai.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../.."))
 import json
 
 import litellm

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../.."))
 import json
 
 from litellm.types.utils import HiddenParams


### PR DESCRIPTION
 ## Title

  Remove legacy sys.path.insert() calls from test files

  ## Relevant issues

  Fixes #16494

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🧹 Refactoring

  ## Changes

  ### Summary
  Removed 316 lines of legacy `sys.path.insert()` calls across 165 test files. These path manipulations are no longer necessary because LiteLLM now uses Poetry for package management.

  ### Details
  - **Poetry manages dependencies**: Running `poetry install` sets up the package in editable mode automatically
  - **Correct path configuration**: Test execution via `make test` or `poetry run pytest` correctly configures the Python path
  - **Legacy code removal**: These `sys.path.insert()` calls are remnants from before Poetry was adopted

  ### Changes Made
  - Removed `sys.path.insert(0, os.path.abspath("../.."))` and similar patterns from 165 test files
  - All imports now work correctly with Poetry's package installation
  - **Net reduction: 316 lines removed** (4 insertions, 320 deletions)

  ### Pattern Removed
  ```python
  # Before:
  import sys
  import os
  sys.path.insert(0, os.path.abspath("../.."))
  import litellm

  # After:
  import litellm  # Works directly with Poetry
```

 ##  Files Modified

  165 files across multiple test directories:
  - tests/logging_callback_tests/ - 7 files
  - tests/local_testing/ - 49 files
  - tests/test_litellm/ - 44 files
  - tests/llm_translation/ - 12 files
  - tests/guardrails_tests/ - 9 files
  - tests/proxy_unit_tests/ - 8 files
  - And 36 more files across other test directories

  Total: 165 files changed, 4 insertions(+), 320 deletions(-)