### PR TITLE
[Fix] UI - Change Public Model Hub to use proxyBaseUrl

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6720,7 +6720,6 @@ export const getGuardrailProviderSpecificParams = async (accessToken: string) =>
   }
 };
 
-
 export const getAgentsList = async (accessToken: string) => {
   try {
     const url = proxyBaseUrl ? `${proxyBaseUrl}/v1/agents` : `/v1/agents`;
@@ -6837,7 +6836,6 @@ export const patchAgentCall = async (
     throw error;
   }
 };
-
 
 export const updateGuardrailCall = async (
   accessToken: string,

--- a/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import PublicModelHub from "./public_model_hub";
+import { FeatureFlagsProvider } from "@/hooks/useFeatureFlags";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    replace: vi.fn(),
+    push: vi.fn(),
+    refresh: vi.fn(),
+  })),
+}));
+
+vi.mock("./networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./networking")>();
+  return {
+    ...actual,
+    modelHubPublicModelsCall: vi.fn().mockResolvedValue([]),
+    getPublicModelHubInfo: vi.fn().mockResolvedValue({
+      docs_title: "LiteLLM Gateway",
+      custom_docs_description: null,
+      litellm_version: "1.0.0",
+      useful_links: {},
+    }),
+    agentHubPublicModelsCall: vi.fn().mockResolvedValue([]),
+    mcpHubPublicServersCall: vi.fn().mockResolvedValue([]),
+    getUiConfig: vi.fn().mockResolvedValue({}),
+  };
+});
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+beforeEach(() => {
+  Storage.prototype.getItem = vi.fn(() => "false");
+  Storage.prototype.setItem = vi.fn();
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: {
+      pathname: "/",
+      origin: "http://localhost:3000",
+    },
+  });
+});
+
+describe("PublicModelHub", () => {
+  it("renders", () => {
+    const { container } = render(
+      <FeatureFlagsProvider>
+        <PublicModelHub />
+      </FeatureFlagsProvider>,
+    );
+    expect(container).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## [Fix] UI - Change Public Model Hub to use proxyBaseUrl

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The current implementation of the Public Model Hub always falls back to `/public/model_hub` due to not fetching the ui config first. This changes the behavior to fetch the ui config.


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="1511" height="298" alt="image" src="https://github.com/user-attachments/assets/f8ec9d9a-683d-4823-8ad3-d7047ecc7473" />
<img width="627" height="245" alt="image" src="https://github.com/user-attachments/assets/844afe91-c42b-4d7b-bd8d-d9700f559f11" />


