### PR TITLE
[Feat] Add image_size support for Gemini image generation

### DIFF
--- a/litellm/llms/gemini/image_edit/transformation.py
+++ b/litellm/llms/gemini/image_edit/transformation.py
@@ -22,7 +22,7 @@ else:
 
 class GeminiImageEditConfig(BaseImageEditConfig):
     DEFAULT_BASE_URL: str = "https://generativelanguage.googleapis.com/v1beta"
-    SUPPORTED_PARAMS: List[str] = ["size"]
+    SUPPORTED_PARAMS: List[str] = ["size", "image_size"]
 
     def get_supported_openai_params(self, model: str) -> List[str]:
         return list(self.SUPPORTED_PARAMS)
@@ -46,6 +46,9 @@ class GeminiImageEditConfig(BaseImageEditConfig):
             mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(
                 filtered_params["size"]  # type: ignore[arg-type]
             )
+
+        if "image_size" in filtered_params:
+            mapped_params["imageSize"] = filtered_params["image_size"]
 
         return mapped_params
 
@@ -95,11 +98,18 @@ class GeminiImageEditConfig(BaseImageEditConfig):
         request_body: Dict[str, Any] = {"contents": contents}
 
         generation_config: Dict[str, Any] = {}
+        image_config: Dict[str, Any] = {}
 
         if "aspectRatio" in image_edit_optional_request_params:
-            generation_config["aspectRatio"] = image_edit_optional_request_params[
+            image_config["aspectRatio"] = image_edit_optional_request_params[
                 "aspectRatio"
             ]
+
+        if "imageSize" in image_edit_optional_request_params:
+            image_config["imageSize"] = image_edit_optional_request_params["imageSize"]
+
+        if image_config:
+            generation_config["imageConfig"] = image_config
 
         if generation_config:
             request_body["generationConfig"] = generation_config

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -182,9 +182,11 @@ class GeminiThinkingConfig(TypedDict, total=False):
 GeminiResponseModalities = Literal["TEXT", "IMAGE", "AUDIO", "VIDEO"]
 
 GeminiImageAspectRatio = Literal["1:1", "2:3", "3:2", "3:4", "4:3", "9:16", "16:9", "21:9"]
+GeminiImageSize = Literal["1K", "2K", "4K"]
 
 class GeminiImageConfig(TypedDict, total=False):
     aspectRatio: GeminiImageAspectRatio
+    imageSize: GeminiImageSize
 
 class PrebuiltVoiceConfig(TypedDict):
     voiceName: str


### PR DESCRIPTION
Add support for the image_size parameter in Gemini image generation API. This allows users to specify resolution (1K, 2K, 4K) for generated images. Also restructures the generationConfig to properly nest aspectRatio and imageSize within imageConfig as per Gemini API structure.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


