### PR TITLE
fix: add nodejs and npm to docker image for prisma generate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 # Install runtime dependencies
-RUN apk add --no-cache openssl tzdata
+RUN apk add --no-cache openssl tzdata nodejs npm
 
 # Upgrade pip to fix CVE-2025-8869
 RUN pip install --upgrade pip>=24.3.1


### PR DESCRIPTION
Fixes cross-platform Docker build issue where `prisma generate` fails when building for amd64 platform from macOS using OrbStack while attempting to install nodejs.

When python prisma attempts to bootstrap nodeenv to run `prisma generate` it seems to be failing in this image (chainguard) in this environment.


```bash
docker buildx build . -f Dockerfile -t litellm:mybuild --platform linux/amd64
```

Error log **before** the change (original state)

```bash
...
=> [runtime 11/16] RUN chmod +x docker/install_auto_router.sh && ./docker/install_auto_router.sh                                                                                                               3.7s 
 => ERROR [runtime 12/16] RUN prisma generate                                                                                                                                                                   9.4s 
------                                                                                                                                                                                                               
 > [runtime 12/16] RUN prisma generate:                                                                                                                                                                              
0.919 Installing Prisma CLI                                                                                                                                                                                          
1.381  * Install prebuilt node (25.2.1) ../usr/lib/python3.13/site-packages/nodeenv.py:639: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.                                                                                                                                                                  
3.723   archive.extractall(src_dir, extract_list)                                                                                                                                                                    
5.676 ... done.
8.438 An error ocurred while installing the Prisma CLI; npm install log: npm error cannot set sizeCalculation without setting maxSize or maxEntrySize
8.438 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-11-21T01_16_51_193Z-debug-0.log
8.438 
8.444 Traceback (most recent call last):
8.448   File "/usr/bin/prisma", line 7, in <module>
8.448     sys.exit(main())
8.448              ~~~~^^
8.448   File "/usr/lib/python3.13/site-packages/prisma/cli/cli.py", line 39, in main
8.448     sys.exit(prisma.run(args[1:]))
8.448              ~~~~~~~~~~^^^^^^^^^^
8.448   File "/usr/lib/python3.13/site-packages/prisma/cli/prisma.py", line 36, in run
8.448     entrypoint = ensure_cached().entrypoint
8.448                  ~~~~~~~~~~~~~^^
8.448   File "/usr/lib/python3.13/site-packages/prisma/cli/prisma.py", line 104, in ensure_cached
8.448     proc.check_returncode()
8.448     ~~~~~~~~~~~~~~~~~~~~~^^
8.448   File "/usr/lib/python3.13/subprocess.py", line 508, in check_returncode
8.448     raise CalledProcessError(self.returncode, self.args, self.stdout,
8.448                              self.stderr)
8.448 subprocess.CalledProcessError: Command '['/root/.cache/prisma-python/nodeenv/bin/npm', 'install', 'prisma@5.4.2']' returned non-zero exit status 1.
------
Dockerfile:76
--------------------
  74 |     
  75 |     # Generate prisma client
  76 | >>> RUN prisma generate
  77 |     RUN chmod +x docker/entrypoint.sh
  78 |     RUN chmod +x docker/prod_entrypoint.sh
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c prisma generate" did not complete successfully: exit code: 1

```

The same command succeeds after proposed change

## Pre-Submission checklist

- [N/A] I have Added testing in the [`tests/litellm/`]
- [N/A] I have added a screenshot of my new test passing locally 
- [N/A] My PR passes all unit tests on [`make test-unit`]
- [Y] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🚄 Infrastructure

## Changes

Adding nodejs npm to the image