### PR TITLE
fix: add mcp server ids

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1928,6 +1928,41 @@ class MCPServerManager:
             f"Registry now contains {len(self.get_registry())} servers"
         )
 
+    def get_mcp_servers_from_ids(
+        self, server_ids: List[str]
+    ) -> List[MCPServer]:
+        """Resolve a list of MCP server identifiers to in-memory MCPServer objects."""
+        if not server_ids:
+            return []
+
+        registry = self.get_registry()
+        resolved_servers: List[MCPServer] = []
+        seen_ids: Set[str] = set()
+
+        for identifier in server_ids:
+            server: Optional[MCPServer] = registry.get(identifier)
+
+            # Allow referencing servers by name or alias for backward compatibility
+            if server is None:
+                for candidate in registry.values():
+                    if candidate.server_name == identifier or candidate.alias == identifier:
+                        server = candidate
+                        break
+
+            if server is None:
+                verbose_logger.debug(
+                    "MCP server identifier '%s' not found in registry", identifier
+                )
+                continue
+
+            if server.server_id in seen_ids:
+                continue
+
+            seen_ids.add(server.server_id)
+            resolved_servers.append(server)
+
+        return resolved_servers
+
     def get_mcp_server_by_id(self, server_id: str) -> Optional[MCPServer]:
         """
         Get the MCP Server from the server id

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1928,40 +1928,13 @@ class MCPServerManager:
             f"Registry now contains {len(self.get_registry())} servers"
         )
 
-    def get_mcp_servers_from_ids(
-        self, server_ids: List[str]
-    ) -> List[MCPServer]:
-        """Resolve a list of MCP server identifiers to in-memory MCPServer objects."""
-        if not server_ids:
-            return []
-
+    def get_mcp_servers_from_ids(self, server_ids: List[str]) -> List[MCPServer]:
+        servers = []
         registry = self.get_registry()
-        resolved_servers: List[MCPServer] = []
-        seen_ids: Set[str] = set()
-
-        for identifier in server_ids:
-            server: Optional[MCPServer] = registry.get(identifier)
-
-            # Allow referencing servers by name or alias for backward compatibility
-            if server is None:
-                for candidate in registry.values():
-                    if candidate.server_name == identifier or candidate.alias == identifier:
-                        server = candidate
-                        break
-
-            if server is None:
-                verbose_logger.debug(
-                    "MCP server identifier '%s' not found in registry", identifier
-                )
-                continue
-
-            if server.server_id in seen_ids:
-                continue
-
-            seen_ids.add(server.server_id)
-            resolved_servers.append(server)
-
-        return resolved_servers
+        for server in registry.values():
+            if server.server_id in server_ids:
+                servers.append(server)
+        return servers
 
     def get_mcp_server_by_id(self, server_id: str) -> Optional[MCPServer]:
         """


### PR DESCRIPTION
## Title

this line returns an error bc of a missing function https://github.com/BerriAI/litellm/blob/main/litellm/proxy/_experimental/mcp_server/server.py#L650
mcp servers listed
<img width="1266" height="356" alt="Screenshot 2025-11-21 at 10 12 28 PM" src="https://github.com/user-attachments/assets/5369b980-b995-4804-bdb4-77d12115e33a" />
response
<img width="1266" height="618" alt="Screenshot 2025-11-21 at 10 10 41 PM" src="https://github.com/user-attachments/assets/7e409b92-608b-421a-8817-d7b75df1f0f4" />


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

cc @uc4w6c 