### PR TITLE
[Fix] UI - Change Bulk Invite User Roles to Match Backend

### DIFF
--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import BulkCreateUsersButton from "./bulk_create_users_button";
+
+vi.mock("./networking", () => ({
+  userCreateCall: vi.fn(),
+  invitationCreateCall: vi.fn(),
+  getProxyUISettings: vi.fn().mockResolvedValue({
+    PROXY_BASE_URL: null,
+    PROXY_LOGOUT_URL: null,
+    DEFAULT_TEAM_DISABLED: false,
+    SSO_ENABLED: false,
+  }),
+}));
+
+vi.mock("./molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
+describe("BulkCreateUsersButton", () => {
+  it("should render", () => {
+    const { getByText } = render(<BulkCreateUsersButton accessToken="test-token" teams={[]} possibleUIRoles={null} />);
+    expect(getByText("+ Bulk Invite Users")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -210,7 +210,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                 errors.push("Role is required");
               } else {
                 // Validate user role
-                const validRoles = ["proxy_admin", "proxy_admin_view_only", "internal_user", "internal_user_view_only"];
+                const validRoles = ["proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer"];
                 if (!validRoles.includes(user.user_role)) {
                   errors.push(`Invalid role "${user.user_role}". Must be one of: ${validRoles.join(", ")}`);
                 }
@@ -587,8 +587,8 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
                       <div>
                         <p className="font-medium">user_role</p>
                         <p className="text-sm text-gray-600">
-                          User&apos;s role (one of: &quot;proxy_admin&quot;, &quot;proxy_admin_view_only&quot;,
-                          &quot;internal_user&quot;, &quot;internal_user_view_only&quot;)
+                          User&apos;s role (one of: &quot;proxy_admin&quot;, &quot;proxy_admin_viewer&quot;,
+                          &quot;internal_user&quot;, &quot;internal_user_viewer&quot;)
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## [Fix] UI - Change Bulk Invite User Roles to Match Backend

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Fixes #16122

The frontend had user_roles that were different than the backend, and it performed validation on user_roles using the faulty user_role, causing the users to be unable to submit. I changed all the labeling in this workflow to match the backend

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

<img width="833" height="466" alt="image" src="https://github.com/user-attachments/assets/7eed90c0-00f3-44bf-9a2c-a1fbe0e590c1" />

<img width="752" height="231" alt="image" src="https://github.com/user-attachments/assets/c5aa2eff-8baf-4f41-9e44-80c87e1a7ae7" />

