### PR TITLE
Upgrade pydantic to version 2.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ jinja2==3.1.6 # for prompt templates
 aiohttp==3.12.14 # for network calls
 aioboto3==13.4.0 # for async sagemaker calls
 tenacity==8.5.0  # for retrying requests, when litellm.num_retries set
-pydantic==2.10.2 # proxy + openai req.
+pydantic==2.11.0 # proxy + openai req. + mcp
 jsonschema==4.22.0 # validating json schema
 websockets==13.1.0 # for realtime API
 soundfile==0.12.1 # for audio file processing


### PR DESCRIPTION
Updated pydantic version to 2.11.0 for compatibility.

## Title

pydantic >= 2.11.0 reuierd for mcp 
## Relevant issues

4.19 ERROR: Cannot install -r requirements.txt (line 15), -r requirements.txt (line 18), -r requirements.txt (line 20), -r requirements.txt (line 22), -r requirements.txt (line 4), -r requirements.txt (line 5), anthropic and pydantic==2.10.2 because these package versions have conflicting dependencies.
24.19
24.19 The conflict is caused by:
24.19     The user requested pydantic==2.10.2
24.19     openai 2.8.0 depends on pydantic<3 and >=1.9.0
24.19     fastapi 0.120.1 depends on pydantic!=1.8, !=1.8.1, !=2.0.0, !=2.0.1, !=2.1.0, <3.0.0 and >=1.7.4
24.19     prisma 0.11.0 depends on pydantic<3 and >=1.8.0
24.19     google-cloud-aiplatform 1.47.0 depends on pydantic<3
24.19     google-genai 1.22.0 depends on pydantic<3.0.0 and >=2.0.0
24.19     anthropic 0.54.0 depends on pydantic<3 and >=1.9.0
24.19     mcp 1.21.2 depends on pydantic<3.0.0 and >=2.11.0
24.19
24.19 Additionally, some packages in these conflicts have no matching distributions available for your environment:
24.19     pydantic

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

@ishaan-jaff @krrishdholakia 

