### PR TITLE
fix redis event loop closed at first call

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -193,7 +193,7 @@ class RedisCache(BaseCache):
                 connection_pool=self.async_redis_conn_pool, **self.redis_kwargs
             )
             in_memory_llm_clients_cache.set_cache(
-                key="async-redis-client", value=self.redis_async_client
+                key="async-redis-client", value=redis_async_client
             )
 
         self.redis_async_client = redis_async_client  # type: ignore


### PR DESCRIPTION
## Title

fix redis event loop closed at first call

error is ：
LiteLLM:ERROR: redis_cache.py:470 - LiteLLM Redis Caching: async set() - Got exception from REDIS Event loop is closed, Writing value={'44afdf223ad6becc134b79dfe685b789a867426a9259cd0c2f084a6b16bcda44': 52}


## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix


## Changes
redis_cache.py

