### PR TITLE
feat: allow custom violation message for tool-permission guardrail

### DIFF
--- a/litellm/proxy/example_config_yaml/tool_permission_example.yaml
+++ b/litellm/proxy/example_config_yaml/tool_permission_example.yaml
@@ -10,6 +10,7 @@ guardrails:
       guardrail: tool_permission
       mode: "post_call"
       default_on: true  # Apply to all requests by default
+      violation_message_template: "this violates our org policy, we don't support executing {tool_name} commands"
       rules:
         - id: "allow_bash"
           tool_name: "Bash"

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -135,6 +135,7 @@ def initialize_tool_permission(litellm_params: LitellmParams, guardrail: Guardra
         default_action=getattr(litellm_params, "default_action", "deny"),
         on_disallowed_action=getattr(litellm_params, "on_disallowed_action", "block"),
         default_on=litellm_params.default_on,
+        violation_message_template=litellm_params.violation_message_template,
     )
     litellm.logging_callback_manager.add_litellm_callback(_tool_permission_callback)
     return _tool_permission_callback
@@ -172,9 +173,12 @@ def initialize_panw_prisma_airs(litellm_params, guardrail):
         raise ValueError("PANW Prisma AIRS: profile_name is required")
 
     _panw_callback = PanwPrismaAirsHandler(
-        guardrail_name=guardrail.get("guardrail_name", "panw_prisma_airs"),  # Use .get() with default
+        guardrail_name=guardrail.get(
+            "guardrail_name", "panw_prisma_airs"
+        ),  # Use .get() with default
         api_key=litellm_params.api_key,
-        api_base=litellm_params.api_base or "https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request",
+        api_base=litellm_params.api_base
+        or "https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request",
         profile_name=litellm_params.profile_name,
         default_on=litellm_params.default_on,
     )

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -16,7 +16,6 @@ from litellm.types.proxy.guardrails.guardrail_hooks.ibm import (
 )
 
 
-
 """
 Pydantic object defining how to set guardrails on litellm proxy
 
@@ -51,7 +50,7 @@ class SupportedGuardrailIntegrations(Enum):
     OPENAI_MODERATION = "openai_moderation"
     NOMA = "noma"
     TOOL_PERMISSION = "tool_permission"
-    ZSCALER_AI_GUARD = "zscaler_ai_guard"    
+    ZSCALER_AI_GUARD = "zscaler_ai_guard"
     JAVELIN = "javelin"
     ENKRYPTAI = "enkryptai"
     IBM_GUARDRAILS = "ibm_guardrails"
@@ -432,7 +431,7 @@ class ZscalerAIGuardConfigModel(BaseModel):
 
     policy_id: Optional[int] = Field(
         default=None,
-        description="Policy ID for Zscaler AI Guard. Can also be set via ZSCALER_AI_GUARD_POLICY_ID environment variable"
+        description="Policy ID for Zscaler AI Guard. Can also be set via ZSCALER_AI_GUARD_POLICY_ID environment variable",
     )
     send_user_api_key_alias: Optional[bool] = Field(
         default=False, description="Whether to send user_API_key_alias in headers"
@@ -443,6 +442,7 @@ class ZscalerAIGuardConfigModel(BaseModel):
     send_user_api_key_team_id: Optional[bool] = Field(
         default=False, description="Whether to send user_API_key_team_id in headers"
     )
+
 
 class JavelinGuardrailConfigModel(BaseModel):
     """Configuration parameters for the Javelin guardrail"""
@@ -479,7 +479,8 @@ class BlockedWord(BaseModel):
         description="Action to take when keyword is detected (BLOCK or MASK)"
     )
     description: Optional[str] = Field(
-        default=None, description="Optional description explaining why this keyword is sensitive"
+        default=None,
+        description="Optional description explaining why this keyword is sensitive",
     )
 
 
@@ -491,15 +492,15 @@ class ContentFilterPattern(BaseModel):
     )
     pattern_name: Optional[str] = Field(
         default=None,
-        description="Name of prebuilt pattern (e.g., 'us_ssn', 'credit_card'). Required if pattern_type is 'prebuilt'"
+        description="Name of prebuilt pattern (e.g., 'us_ssn', 'credit_card'). Required if pattern_type is 'prebuilt'",
     )
     pattern: Optional[str] = Field(
         default=None,
-        description="Custom regex pattern. Required if pattern_type is 'regex'"
+        description="Custom regex pattern. Required if pattern_type is 'regex'",
     )
     name: Optional[str] = Field(
         default=None,
-        description="Name for this pattern (used in logging and error messages)"
+        description="Name for this pattern (used in logging and error messages)",
     )
     action: ContentFilterAction = Field(
         description="Action to take when pattern matches (BLOCK or MASK)"
@@ -511,15 +512,13 @@ class ContentFilterConfigModel(BaseModel):
 
     patterns: Optional[List[ContentFilterPattern]] = Field(
         default=None,
-        description="List of patterns (prebuilt or custom regex) to detect"
+        description="List of patterns (prebuilt or custom regex) to detect",
     )
     blocked_words: Optional[List[BlockedWord]] = Field(
-        default=None,
-        description="List of blocked words with individual actions"
+        default=None, description="List of blocked words with individual actions"
     )
     blocked_words_file: Optional[str] = Field(
-        default=None,
-        description="Path to YAML file containing blocked_words list"
+        default=None, description="Path to YAML file containing blocked_words list"
     )
 
 
@@ -575,6 +574,11 @@ class BaseLitellmParams(BaseModel):  # works for new and patch update guardrails
         description="Optional field if guardrail requires a 'model' parameter",
     )
 
+    violation_message_template: Optional[str] = Field(
+        default=None,
+        description="Custom message when a guardrail blocks an action. Supports placeholders like {tool_name}, {rule_id}, and {default_message}.",
+    )
+
     # Model Armor params
     template_id: Optional[str] = Field(
         default=None, description="The ID of your Model Armor template"
@@ -613,7 +617,7 @@ class LitellmParams(
     GraySwanGuardrailConfigModel,
     NomaGuardrailConfigModel,
     ToolPermissionGuardrailConfigModel,
-    ZscalerAIGuardConfigModel, 
+    ZscalerAIGuardConfigModel,
     JavelinGuardrailConfigModel,
     ContentFilterConfigModel,
     BaseLitellmParams,
@@ -671,9 +675,11 @@ class GuardrailEventHooks(str, Enum):
 class DynamicGuardrailParams(TypedDict):
     extra_body: Dict[str, Any]
 
+
 class GUARDRAIL_DEFINITION_LOCATION(str, Enum):
     DB = "db"
     CONFIG = "config"
+
 
 class GuardrailInfoResponse(BaseModel):
     guardrail_id: Optional[str] = None
@@ -682,7 +688,9 @@ class GuardrailInfoResponse(BaseModel):
     guardrail_info: Optional[Dict] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.CONFIG
+    guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = (
+        GUARDRAIL_DEFINITION_LOCATION.CONFIG
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Title

allow custom violation message for tool-permission guardrail

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

- allow custom violation message for tool-permission guardrail
- add details on how on disallowed action works

