### PR TITLE
Resolves multi-account file and batch routing without requiring a database

### DIFF
--- a/docs/my-website/docs/batches.md
+++ b/docs/my-website/docs/batches.md
@@ -174,6 +174,257 @@ print("list_batches_response=", list_batches_response)
 </Tabs>
 
 
+## Multi-Account / Model-Based Routing
+
+Route batch operations to different provider accounts using model-specific credentials from your `config.yaml`. This eliminates the need for environment variables and enables multi-tenant batch processing.
+
+### How It Works
+
+**Priority Order:**
+1. **Encoded Batch/File ID** (highest) - Model info embedded in the ID
+2. **Model Parameter** - Via header (`x-litellm-model`), query param, or request body
+3. **Custom Provider** (fallback) - Uses environment variables
+
+### Configuration
+
+```yaml
+model_list:
+  - model_name: gpt-4o-account-1
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: sk-account-1-key
+      api_base: https://api.openai.com/v1
+  
+  - model_name: gpt-4o-account-2
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: sk-account-2-key
+      api_base: https://api.openai.com/v1
+  
+  - model_name: azure-batches
+    litellm_params:
+      model: azure/gpt-4
+      api_key: azure-key-123
+      api_base: https://my-resource.openai.azure.com
+      api_version: "2024-02-01"
+```
+
+### Usage Examples
+
+#### Scenario 1: Encoded File ID with Model
+
+When you upload a file with a model parameter, LiteLLM encodes the model information in the file ID. All subsequent operations automatically use those credentials.
+
+```bash
+# Step 1: Upload file with model
+curl http://localhost:4000/v1/files \
+  -H "Authorization: Bearer sk-1234" \
+  -H "x-litellm-model: gpt-4o-account-1" \
+  -F purpose="batch" \
+  -F file="@batch.jsonl"
+
+# Response includes encoded file ID:
+# {
+#   "id": "file-bGl0ZWxsbTpmaWxlLUxkaUwzaVYxNGZRVlpYcU5KVEdkSjk7bW9kZWwsZ3B0LTRvLWFjY291bnQtMQ",
+#   ...
+# }
+
+# Step 2: Create batch - automatically routes to gpt-4o-account-1
+curl http://localhost:4000/v1/batches \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input_file_id": "file-bGl0ZWxsbTpmaWxlLUxkaUwzaVYxNGZRVlpYcU5KVEdkSjk7bW9kZWwsZ3B0LTRvLWFjY291bnQtMQ",
+    "endpoint": "/v1/chat/completions",
+    "completion_window": "24h"
+  }'
+
+# Batch ID is also encoded with model:
+# {
+#   "id": "batch_bGl0ZWxsbTpiYXRjaF82OTIwM2IzNjg0MDQ4MTkwYTA3ODQ5NDY3YTFjMDJkYTttb2RlbCxncHQtNG8tYWNjb3VudC0x",
+#   "input_file_id": "file-bGl0ZWxsbTpmaWxlLUxkaUwzaVYxNGZRVlpYcU5KVEdkSjk7bW9kZWwsZ3B0LTRvLWFjY291bnQtMQ",
+#   ...
+# }
+
+# Step 3: Retrieve batch - automatically routes to gpt-4o-account-1
+curl http://localhost:4000/v1/batches/batch_bGl0ZWxsbTpiYXRjaF82OTIwM2IzNjg0MDQ4MTkwYTA3ODQ5NDY3YTFjMDJkYTttb2RlbCxncHQtNG8tYWNjb3VudC0x \
+  -H "Authorization: Bearer sk-1234"
+```
+
+**✅ Benefits:**
+- No need to specify model on every request
+- File and batch IDs "remember" which account created them
+- Automatic routing for retrieve, cancel, and file content operations
+
+#### Scenario 2: Model via Header/Query Parameter
+
+Specify the model for each request without encoding it in the ID.
+
+```bash
+# Create batch with model header
+curl http://localhost:4000/v1/batches \
+  -H "Authorization: Bearer sk-1234" \
+  -H "x-litellm-model: gpt-4o-account-2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input_file_id": "file-abc123",
+    "endpoint": "/v1/chat/completions",
+    "completion_window": "24h"
+  }'
+
+# Or use query parameter
+curl "http://localhost:4000/v1/batches?model=gpt-4o-account-2" \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input_file_id": "file-abc123",
+    "endpoint": "/v1/chat/completions",
+    "completion_window": "24h"
+  }'
+
+# List batches for specific model
+curl "http://localhost:4000/v1/batches?model=gpt-4o-account-2" \
+  -H "Authorization: Bearer sk-1234"
+```
+
+**✅ Use Case:**
+- One-off batch operations
+- Different models for different operations
+- Explicit control over routing
+
+#### Scenario 3: Environment Variables (Fallback)
+
+Traditional approach using environment variables when no model is specified.
+
+```bash
+export OPENAI_API_KEY="sk-env-key"
+
+curl http://localhost:4000/v1/batches \
+  -H "Authorization: Bearer sk-1234" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input_file_id": "file-abc123",
+    "endpoint": "/v1/chat/completions",
+    "completion_window": "24h"
+  }'
+```
+
+**✅ Use Case:**
+- Backward compatibility
+- Simple single-account setups
+- Quick prototyping
+
+### Complete Multi-Account Example
+
+```bash
+# Upload file to Account 1
+FILE_1=$(curl -s http://localhost:4000/v1/files \
+  -H "x-litellm-model: gpt-4o-account-1" \
+  -F purpose="batch" \
+  -F file="@batch1.jsonl" | jq -r '.id')
+
+# Upload file to Account 2
+FILE_2=$(curl -s http://localhost:4000/v1/files \
+  -H "x-litellm-model: gpt-4o-account-2" \
+  -F purpose="batch" \
+  -F file="@batch2.jsonl" | jq -r '.id')
+
+# Create batch on Account 1 (auto-routed via encoded file ID)
+BATCH_1=$(curl -s http://localhost:4000/v1/batches \
+  -d "{\"input_file_id\": \"$FILE_1\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}" | jq -r '.id')
+
+# Create batch on Account 2 (auto-routed via encoded file ID)
+BATCH_2=$(curl -s http://localhost:4000/v1/batches \
+  -d "{\"input_file_id\": \"$FILE_2\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}" | jq -r '.id')
+
+# Retrieve both batches (auto-routed to correct accounts)
+curl http://localhost:4000/v1/batches/$BATCH_1
+curl http://localhost:4000/v1/batches/$BATCH_2
+
+# List batches per account
+curl "http://localhost:4000/v1/batches?model=gpt-4o-account-1"
+curl "http://localhost:4000/v1/batches?model=gpt-4o-account-2"
+```
+
+### SDK Usage with Model Routing
+
+```python
+import litellm
+import asyncio
+
+# Upload file with model routing
+file_obj = await litellm.acreate_file(
+    file=open("batch.jsonl", "rb"),
+    purpose="batch",
+    model="gpt-4o-account-1",  # Route to specific account
+)
+
+print(f"File ID: {file_obj.id}")
+# File ID is encoded with model info
+
+# Create batch - automatically uses gpt-4o-account-1 credentials
+batch = await litellm.acreate_batch(
+    completion_window="24h",
+    endpoint="/v1/chat/completions",
+    input_file_id=file_obj.id,  # Model info embedded in ID
+)
+
+print(f"Batch ID: {batch.id}")
+# Batch ID is also encoded
+
+# Retrieve batch - automatically routes to correct account
+retrieved = await litellm.aretrieve_batch(
+    batch_id=batch.id,  # Model info embedded in ID
+)
+
+print(f"Batch status: {retrieved.status}")
+
+# Or explicitly specify model
+batch2 = await litellm.acreate_batch(
+    completion_window="24h",
+    endpoint="/v1/chat/completions",
+    input_file_id="file-regular-id",
+    model="gpt-4o-account-2",  # Explicit routing
+)
+```
+
+### How ID Encoding Works
+
+LiteLLM encodes model information into file and batch IDs using base64:
+
+```
+Original:  file-abc123
+Encoded:   file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8tdGVzdA
+           └─┬─┘ └──────────────────┬──────────────────────┘
+          prefix      base64(litellm:file-abc123;model,gpt-4o-test)
+
+Original:  batch_xyz789
+Encoded:   batch_bGl0ZWxsbTpiYXRjaF94eXo3ODk7bW9kZWwsZ3B0LTRvLXRlc3Q
+           └──┬──┘ └──────────────────┬──────────────────────┘
+           prefix       base64(litellm:batch_xyz789;model,gpt-4o-test)
+```
+
+The encoding:
+- ✅ Preserves OpenAI-compatible prefixes (`file-`, `batch_`)
+- ✅ Is transparent to clients
+- ✅ Enables automatic routing without additional parameters
+- ✅ Works across all batch and file endpoints
+
+### Supported Endpoints
+
+All batch and file endpoints support model-based routing:
+
+| Endpoint | Method | Model Routing |
+|----------|--------|---------------|
+| `/v1/files` | POST | ✅ Via header/query/body |
+| `/v1/files/{file_id}` | GET | ✅ Auto from encoded ID + header/query |
+| `/v1/files/{file_id}/content` | GET | ✅ Auto from encoded ID + header/query |
+| `/v1/files/{file_id}` | DELETE | ✅ Auto from encoded ID |
+| `/v1/batches` | POST | ✅ Auto from file ID + header/query/body |
+| `/v1/batches` | GET | ✅ Via header/query |
+| `/v1/batches/{batch_id}` | GET | ✅ Auto from encoded ID |
+| `/v1/batches/{batch_id}/cancel` | POST | ✅ Auto from encoded ID |
+
 ## **Supported Providers**:
 ### [Azure OpenAI](./providers/azure#azure-batches-api)
 ### [OpenAI](#quick-start)

--- a/docs/my-website/docs/files_endpoints.md
+++ b/docs/my-website/docs/files_endpoints.md
@@ -32,17 +32,17 @@ Use different OpenAI API keys for files and batches by specifying a `model` para
 
 ```yaml
 model_list:
-  # iFood OpenAI Account
+  # litellm OpenAI Account
   - model_name: "gpt-4o-litellm"
     litellm_params:
       model: openai/gpt-4o
-      api_key: os.environ/OPENAI_IFOOD_KEY
+      api_key: os.environ/OPENAI_LITELLM_API_KEY
   
-  # Prosus OpenAI Account
+  # Free OpenAI Account
   - model_name: "gpt-4o-free"
     litellm_params:
       model: openai/gpt-4o
-      api_key: os.environ/OPENAI_PROSUS_KEY
+      api_key: os.environ/OPENAI_FREE_API_KEY
 ```
 
 ### Usage Example
@@ -55,7 +55,7 @@ client = OpenAI(
     base_url="http://0.0.0.0:4000"
 )
 
-# Create file using iFood account
+# Create file using litellm account
 file_response = client.files.create(
     file=open("batch_data.jsonl", "rb"),
     purpose="batch",

--- a/docs/my-website/docs/files_endpoints.md
+++ b/docs/my-website/docs/files_endpoints.md
@@ -16,7 +16,137 @@ Use this to call the provider's `/files` endpoints directly, in the OpenAI forma
 - Delete File
 - Get File Content
 
+## Multi-Account Support (Multiple OpenAI Keys)
 
+Use different OpenAI API keys for files and batches by specifying a `model` parameter that references entries in your `model_list`. This approach works **without requiring a database** and allows you to route files/batches to different OpenAI accounts.
+
+### How It Works
+
+1. Define models in `model_list` with different API keys
+2. Pass `model` parameter when creating files
+3. LiteLLM returns encoded IDs that contain routing information
+4. Use encoded IDs for all subsequent operations (retrieve, delete, batches)
+5. No need to specify model again - routing info is in the ID
+
+### Setup
+
+```yaml
+model_list:
+  # iFood OpenAI Account
+  - model_name: "gpt-4o-litellm"
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_IFOOD_KEY
+  
+  # Prosus OpenAI Account
+  - model_name: "gpt-4o-free"
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_PROSUS_KEY
+```
+
+### Usage Example
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="sk-1234",  # Your LiteLLM proxy key
+    base_url="http://0.0.0.0:4000"
+)
+
+# Create file using iFood account
+file_response = client.files.create(
+    file=open("batch_data.jsonl", "rb"),
+    purpose="batch",
+    extra_body={"model": "gpt-4o-litellm"}  # Routes to litellm key
+)
+print(f"File ID: {file_response.id}")
+# Returns encoded ID like: file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8taWZvb2Q
+
+# Create batch using the encoded file ID
+# No need to specify model again - it's embedded in the file ID
+batch_response = client.batches.create(
+    input_file_id=file_response.id,  # Encoded ID
+    endpoint="/v1/chat/completions",
+    completion_window="24h"
+)
+print(f"Batch ID: {batch_response.id}")
+# Returns encoded batch ID with routing info
+
+# Retrieve batch - routing happens automatically
+batch_status = client.batches.retrieve(batch_response.id)
+print(f"Status: {batch_status.status}")
+
+# List files for a specific account
+files = client.files.list(
+    extra_body={"model": "gpt-4o-free"}  # List free files
+)
+
+# List batches for a specific account
+batches = client.batches.list(
+    extra_query={"model": "gpt-4o-litellm"}  # List litellm batches
+)
+```
+
+### Parameter Options
+
+You can pass the `model` parameter via:
+- **Request body**: `extra_body={"model": "gpt-4o-litellm"}`
+- **Query parameter**: `?model=gpt-4o-litellm`
+- **Header**: `x-litellm-model: gpt-4o-litellm`
+
+### How Encoded IDs Work
+
+- When you create a file/batch with a `model` parameter, LiteLLM encodes the model name into the returned ID
+- The encoded ID is base64-encoded and looks like: `file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8taWZvb2Q`
+- When you use this ID in subsequent operations (retrieve, delete, batch create), LiteLLM automatically:
+  1. Decodes the ID
+  2. Extracts the model name
+  3. Looks up the credentials
+  4. Routes the request to the correct OpenAI account
+- The original provider file/batch ID is preserved internally
+
+### Benefits
+
+✅ **No Database Required** - All routing info stored in the ID  
+✅ **Stateless** - Works across proxy restarts  
+✅ **Simple** - Just pass the ID around like normal  
+✅ **Backward Compatible** - Existing `custom_llm_provider` and `files_settings` still work  
+✅ **Future-Proof** - Aligns with managed batches approach  
+
+### Migration from files_settings
+
+**Old approach (still works):**
+```yaml
+files_settings:
+  - custom_llm_provider: openai
+    api_key: os.environ/OPENAI_KEY
+```
+
+```python
+# Had to specify provider on every call
+client.files.create(..., extra_headers={"custom-llm-provider": "openai"})
+client.files.retrieve(file_id, extra_headers={"custom-llm-provider": "openai"})
+```
+
+**New approach (recommended):**
+```yaml
+model_list:
+  - model_name: "gpt-4o-account1"
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_KEY
+```
+
+```python
+# Specify model once on create
+file = client.files.create(..., extra_body={"model": "gpt-4o-account1"})
+
+# Then just use the ID - routing is automatic
+client.files.retrieve(file.id)  # No need to specify account
+client.batches.create(input_file_id=file.id)  # Routes correctly
+```
 
 <Tabs>
 <TabItem value="proxy" label="LiteLLM PROXY Server">

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -126,7 +126,7 @@ async def create_batch(
             unified_file_id = _is_base64_encoded_unified_file_id(input_file_id)
         
         # SCENARIO 1: File ID is encoded with model info
-        if model_from_file_id is not None:
+        if model_from_file_id is not None and input_file_id:
             credentials = get_credentials_for_model(
                 llm_router=llm_router,
                 model_id=model_from_file_id,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -23,10 +23,17 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _is_base64_encoded_unified_file_id,
     convert_b64_uid_to_unified_uid,
+    decode_model_from_file_id,
+    encode_file_id_with_model,
     get_batch_id_from_unified_batch_id,
+    get_credentials_for_model,
     get_model_id_from_unified_batch_id,
     get_models_from_unified_file_id,
+    get_original_file_id,
+    is_model_embedded_id,
+    prepare_data_with_credentials,
 )
+
 from litellm.proxy.utils import handle_exception_on_proxy, is_known_model
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
 
@@ -112,9 +119,59 @@ async def create_batch(
         _create_batch_data = LiteLLMBatchCreateRequest(**data)
         input_file_id = _create_batch_data.get("input_file_id", None)
         unified_file_id: Union[str, Literal[False]] = False
+        
+        model_from_file_id = None
         if input_file_id:
+            model_from_file_id = decode_model_from_file_id(input_file_id)
             unified_file_id = _is_base64_encoded_unified_file_id(input_file_id)
-        if (
+        
+        # SCENARIO 1: File ID is encoded with model info
+        if model_from_file_id is not None:
+            credentials = get_credentials_for_model(
+                llm_router=llm_router,
+                model_id=model_from_file_id,
+                operation_context="batch creation (file created with model)",
+            )
+            
+            original_file_id = get_original_file_id(input_file_id)
+            _create_batch_data["input_file_id"] = original_file_id
+            prepare_data_with_credentials(
+                data=_create_batch_data,  # type: ignore
+                credentials=credentials,
+            )
+            
+            # Create batch using model credentials
+            response = await litellm.acreate_batch(
+                custom_llm_provider=credentials["custom_llm_provider"],
+                **_create_batch_data  # type: ignore
+            )
+            
+            # Encode the batch ID and related file IDs with model information
+            if response and hasattr(response, "id") and response.id:
+                original_batch_id = response.id
+                encoded_batch_id = encode_file_id_with_model(
+                    file_id=original_batch_id, model=model_from_file_id
+                )
+                response.id = encoded_batch_id
+                
+                if hasattr(response, "output_file_id") and response.output_file_id:
+                    response.output_file_id = encode_file_id_with_model(
+                        file_id=response.output_file_id, model=model_from_file_id
+                    )
+                
+                if hasattr(response, "error_file_id") and response.error_file_id:
+                    response.error_file_id = encode_file_id_with_model(
+                        file_id=response.error_file_id, model=model_from_file_id
+                    )
+                
+                verbose_proxy_logger.debug(
+                    f"Created batch using model: {model_from_file_id}, "
+                    f"original_batch_id: {original_batch_id}, encoded: {encoded_batch_id}"
+                )
+            
+            response.input_file_id = input_file_id
+        
+        elif (
             litellm.enable_loadbalancing_on_batch_endpoints is True
             and is_router_model
             and router_model is not None
@@ -156,9 +213,39 @@ async def create_batch(
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id
         else:
-            response = await litellm.acreate_batch(
-                custom_llm_provider=custom_llm_provider, **_create_batch_data  # type: ignore
+            # Check if model specified via header/query/body param
+            model_param = (
+                data.get("model")
+                or request.query_params.get("model")
+                or request.headers.get("x-litellm-model")
             )
+            
+            # SCENARIO 2 & 3: Model from header/query OR custom_llm_provider fallback
+            if model_param:
+                # SCENARIO 2: Use model-based routing from header/query/body
+                credentials = get_credentials_for_model(
+                    llm_router=llm_router,
+                    model_id=model_param,
+                    operation_context="batch creation",
+                )
+                
+                prepare_data_with_credentials(
+                    data=_create_batch_data,  # type: ignore
+                    credentials=credentials,
+                )
+                
+                # Create batch using model credentials
+                response = await litellm.acreate_batch(
+                    custom_llm_provider=credentials["custom_llm_provider"],
+                    **_create_batch_data  # type: ignore
+                )
+                
+                verbose_proxy_logger.debug(f"Created batch using model: {model_param}")
+            else:
+                # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
+                response = await litellm.acreate_batch(
+                    custom_llm_provider=custom_llm_provider, **_create_batch_data  # type: ignore
+                )
 
         ### CALL HOOKS ### - modify outgoing data
         response = await proxy_logging_obj.post_call_success_hook(
@@ -250,7 +337,7 @@ async def retrieve_batch(
 
     data: Dict = {}
     try:
-        ## check if model is a loadbalanced model
+        model_from_id = decode_model_from_file_id(batch_id)
         _retrieve_batch_request = RetrieveBatchRequest(
             batch_id=batch_id,
         )
@@ -272,7 +359,54 @@ async def retrieve_batch(
             route_type="aretrieve_batch",
         )
 
-        if litellm.enable_loadbalancing_on_batch_endpoints is True or unified_batch_id:
+        # SCENARIO 1: Batch ID is encoded with model info
+        if model_from_id is not None:
+            credentials = get_credentials_for_model(
+                llm_router=llm_router,
+                model_id=model_from_id,
+                operation_context="batch retrieval (batch created with model)",
+            )
+            
+            original_batch_id = get_original_file_id(batch_id)
+            prepare_data_with_credentials(
+                data=data,
+                credentials=credentials,
+                file_id=original_batch_id,  # Sets data["batch_id"] = original_batch_id
+            )
+            # Fix: The helper sets "file_id" but we need "batch_id"
+            data["batch_id"] = data.pop("file_id", original_batch_id)
+            
+            # Retrieve batch using model credentials
+            response = await litellm.aretrieve_batch(
+                custom_llm_provider=credentials["custom_llm_provider"],
+                **data  # type: ignore
+            )
+            
+            # Re-encode all IDs in the response
+            if response:
+                if hasattr(response, "id") and response.id:
+                    response.id = batch_id  # Keep the encoded batch ID
+                
+                if hasattr(response, "input_file_id") and response.input_file_id:
+                    response.input_file_id = encode_file_id_with_model(
+                        file_id=response.input_file_id, model=model_from_id
+                    )
+                
+                if hasattr(response, "output_file_id") and response.output_file_id:
+                    response.output_file_id = encode_file_id_with_model(
+                        file_id=response.output_file_id, model=model_from_id
+                    )
+                
+                if hasattr(response, "error_file_id") and response.error_file_id:
+                    response.error_file_id = encode_file_id_with_model(
+                        file_id=response.error_file_id, model=model_from_id
+                    )
+            
+            verbose_proxy_logger.debug(
+                f"Retrieved batch using model: {model_from_id}, original_id: {original_batch_id}"
+            )
+        
+        elif litellm.enable_loadbalancing_on_batch_endpoints is True or unified_batch_id:
             if llm_router is None:
                 raise HTTPException(
                     status_code=500,
@@ -283,6 +417,8 @@ async def retrieve_batch(
 
             response = await llm_router.aretrieve_batch(**data)  # type: ignore
             response._hidden_params["unified_batch_id"] = unified_batch_id
+        
+        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:
             custom_llm_provider = (
                 provider
@@ -406,9 +542,34 @@ async def list_batches(
             route_type="alist_batches",
         )
 
-        ## check for target model names
-        target_model_names = target_model_names or data.get("target_model_names", None)
-        if target_model_names:
+        model_param = (
+            data.get("model")
+            or request.query_params.get("model")
+            or request.headers.get("x-litellm-model")
+        )
+        
+        # SCENARIO 2: Use model-based routing from header/query/body
+        if model_param:
+            credentials = get_credentials_for_model(
+                llm_router=llm_router,
+                model_id=model_param,
+                operation_context="batch listing",
+            )
+            
+            data.update(credentials)
+            
+            response = await litellm.alist_batches(
+                custom_llm_provider=credentials["custom_llm_provider"],
+                after=after,
+                limit=limit,
+                **data  # type: ignore
+            )
+            
+            verbose_proxy_logger.debug(f"Listed batches using model: {model_param}")
+        
+        # SCENARIO 2 (alternative): target_model_names based routing
+        elif target_model_names or data.get("target_model_names", None):
+            target_model_names = target_model_names or data.get("target_model_names", None)
             model = target_model_names.split(",")[0]
             response = await llm_router.alist_batches(
                 model=model,
@@ -416,6 +577,8 @@ async def list_batches(
                 limit=limit,
                 **data,
             )
+        
+        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:
             custom_llm_provider = (
                 provider
@@ -521,6 +684,9 @@ async def cancel_batch(
         verbose_proxy_logger.debug(
             "Request received by LiteLLM:\n{}".format(json.dumps(data, indent=4)),
         )
+        
+        # Check for encoded batch ID with model info
+        model_from_id = decode_model_from_file_id(batch_id)
         unified_batch_id = _is_base64_encoded_unified_file_id(batch_id)
 
         # Include original request and headers in the data
@@ -533,7 +699,35 @@ async def cancel_batch(
             proxy_config=proxy_config,
         )
 
-        if unified_batch_id:
+        # SCENARIO 1: Batch ID is encoded with model info
+        if model_from_id is not None:
+            credentials = get_credentials_for_model(
+                llm_router=llm_router,
+                model_id=model_from_id,
+                operation_context="batch cancellation (batch created with model)",
+            )
+            
+            original_batch_id = get_original_file_id(batch_id)
+            prepare_data_with_credentials(
+                data=data,
+                credentials=credentials,
+                file_id=original_batch_id,
+            )
+            # Fix: The helper sets "file_id" but we need "batch_id"
+            data["batch_id"] = data.pop("file_id", original_batch_id)
+            
+            # Cancel batch using model credentials
+            response = await litellm.acancel_batch(
+                custom_llm_provider=credentials["custom_llm_provider"],
+                **data  # type: ignore
+            )
+            
+            verbose_proxy_logger.debug(
+                f"Cancelled batch using model: {model_from_id}, original_id: {original_batch_id}"
+            )
+        
+        # SCENARIO 2: target_model_names based routing
+        elif unified_batch_id:
             if llm_router is None:
                 raise HTTPException(
                     status_code=500,
@@ -553,6 +747,8 @@ async def cancel_batch(
             data["batch_id"] = model_batch_id
 
             response = await llm_router.acancel_batch(model=model, **data)  # type: ignore
+        
+        # SCENARIO 3: Fallback to custom_llm_provider (uses env variables)
         else:
 
             custom_llm_provider = (

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -87,13 +87,13 @@ def encode_file_id_with_model(file_id: str, model: str) -> str:
     
     Args:
         file_id: Original file/batch ID from the provider (e.g., "file-abc123", "batch_xyz")
-        model: Model name from model_list (e.g., "gpt-4o-ifood")
+        model: Model name from model_list (e.g., "gpt-4o-litellm")
     
     Returns:
         Encoded ID starting with appropriate prefix and containing routing information
     
     Examples:
-        encode_file_id_with_model("file-abc123", "gpt-4o-ifood")
+        encode_file_id_with_model("file-abc123", "gpt-4o-litellm")
         -> "file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8taWZvb2Q"
         
         encode_file_id_with_model("batch_abc123", "gpt-4o-test")

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -76,3 +76,266 @@ def get_batch_id_from_unified_batch_id(file_id: str) -> str:
         return file_id.split("llm_batch_id:")[1].split(",")[0]
     else:
         return file_id.split("generic_response_id:")[1].split(",")[0]
+
+
+def encode_file_id_with_model(file_id: str, model: str) -> str:
+    """
+    Encode a file/batch ID with model routing information.
+    
+    Format: <prefix>-<base64(litellm:<original_id>;model,<model_name>)>
+    The result preserves the original prefix (file-, batch_, etc.) for OpenAI compliance.
+    
+    Args:
+        file_id: Original file/batch ID from the provider (e.g., "file-abc123", "batch_xyz")
+        model: Model name from model_list (e.g., "gpt-4o-ifood")
+    
+    Returns:
+        Encoded ID starting with appropriate prefix and containing routing information
+    
+    Examples:
+        encode_file_id_with_model("file-abc123", "gpt-4o-ifood")
+        -> "file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8taWZvb2Q"
+        
+        encode_file_id_with_model("batch_abc123", "gpt-4o-test")
+        -> "batch_bGl0ZWxsbTpiYXRjaF9hYmMxMjM7bW9kZWwsZ3B0LTRvLXRlc3Q"
+    """
+    encoded_str = f"litellm:{file_id};model,{model}"
+    encoded_bytes = base64.urlsafe_b64encode(encoded_str.encode())
+    encoded_b64 = encoded_bytes.decode().rstrip("=")
+    
+    # Detect the prefix from the original ID (file-, batch_, etc.)
+    # Default to "file-" if no recognizable prefix
+    if file_id.startswith("batch_"):
+        prefix = "batch_"
+    elif file_id.startswith("file-"):
+        prefix = "file-"
+    else:
+        # Default to file- for backward compatibility
+        prefix = "file-"
+    
+    return f"{prefix}{encoded_b64}"
+
+
+def decode_model_from_file_id(encoded_id: str) -> Optional[str]:
+    """
+    Extract model name from an encoded file/batch ID.
+    Handles IDs that start with "file-" or "batch_" prefix.
+    """
+    try:
+        if not isinstance(encoded_id, str):
+            return None
+        
+        # Remove prefix if present (file-, batch_, etc.)
+        if encoded_id.startswith("file-"):
+            b64_part = encoded_id[5:]  # Remove "file-"
+        elif encoded_id.startswith("batch_"):
+            b64_part = encoded_id[6:]  # Remove "batch_"
+        else:
+            b64_part = encoded_id
+        
+        padded = b64_part + "=" * (-len(b64_part) % 4)
+        decoded = base64.urlsafe_b64decode(padded).decode()   
+        if decoded.startswith("litellm:") and ";model," in decoded:
+            match = re.search(r";model,([^;]+)", decoded)
+            if match:
+                return match.group(1).strip()
+        
+        return None
+    except Exception:
+        return None
+
+
+def get_original_file_id(encoded_id: str) -> str:
+    """
+    Extract the original provider file/batch ID from an encoded ID.
+    Handles IDs that start with "file-" or "batch_" prefix.
+    """
+    try:
+        if not isinstance(encoded_id, str):
+            return encoded_id
+        
+        # Remove prefix if present (file-, batch_, etc.)
+        if encoded_id.startswith("file-"):
+            b64_part = encoded_id[5:]  # Remove "file-"
+        elif encoded_id.startswith("batch_"):
+            b64_part = encoded_id[6:]  # Remove "batch_"
+        else:
+            b64_part = encoded_id
+        
+        padded = b64_part + "=" * (-len(b64_part) % 4)
+        decoded = base64.urlsafe_b64decode(padded).decode()
+        
+        if decoded.startswith("litellm:") and ";model," in decoded:
+            match = re.search(r"litellm:([^;]+);model,", decoded)
+            if match:
+                return match.group(1)
+        
+        return encoded_id
+    except Exception:
+        return encoded_id
+
+
+def is_model_embedded_id(file_id: str) -> bool:
+    """
+    Check if a file/batch ID has model routing information embedded.
+    """
+    return decode_model_from_file_id(file_id) is not None
+
+
+# ============================================================================
+#                    MODEL-BASED CREDENTIAL ROUTING HELPERS
+# ============================================================================
+
+
+def extract_model_from_sources(
+    file_id: str,
+    request,  # FastAPI Request object
+    data: Optional[dict] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Extract model information from multiple sources in priority order:
+    1. Embedded in file_id (highest priority)
+    2. Request headers (x-litellm-model)
+    3. Query parameters (?model=)
+    4. Request body/data dict
+    
+    Args:
+        file_id: File ID that may contain embedded model info
+        request: FastAPI request object
+        data: Optional request data dictionary
+        
+    Returns:
+        Tuple of (model_from_id, model_from_param)
+        - model_from_id: Model decoded from file ID (if embedded)
+        - model_from_param: Model from header/query/body
+    """
+    if data is None:
+        data = {}
+    
+    # Check if file_id has embedded model info
+    model_from_id = decode_model_from_file_id(file_id)
+    
+    # Check other sources for model parameter
+    model_from_param = (
+        data.get("model")
+        or request.query_params.get("model")
+        or request.headers.get("x-litellm-model")
+    )
+    
+    return model_from_id, model_from_param
+
+
+def get_credentials_for_model(
+    llm_router,  # Router instance
+    model_id: str,
+    operation_context: str = "file operation",
+):
+    """
+    Retrieve API credentials for a model from the LLM Router.
+    
+    Args:
+        llm_router: LiteLLM Router instance
+        model_id: Model name or deployment ID
+        operation_context: Description for error messages (e.g., "file upload", "batch creation")
+        
+    Returns:
+        Dictionary with credentials (api_key, api_base, custom_llm_provider, etc.)
+        
+    Raises:
+        HTTPException: If router not initialized or model not found
+    """
+    from fastapi import HTTPException
+    
+    if llm_router is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Router not initialized. Cannot use model-based routing."},
+        )
+    
+    credentials = llm_router.get_deployment_credentials_with_provider(model_id=model_id)
+    
+    if credentials is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"Model '{model_id}' not found in model_list. Please check your config.yaml."
+            },
+        )
+    
+    return credentials
+
+
+def prepare_data_with_credentials(
+    data: dict,
+    credentials: dict,
+    file_id: Optional[str] = None,
+) -> None:
+    """
+    Update data dictionary with model credentials (in-place).
+    
+    Args:
+        data: Data dictionary to update
+        credentials: Credentials from router
+        file_id: Optional original file_id to set (for decoded file IDs)
+    """
+    data.update(credentials)
+    data.pop("custom_llm_provider", None)
+    
+    if file_id is not None:
+        data["file_id"] = file_id
+
+
+def handle_model_based_routing(
+    file_id: str,
+    request,  # FastAPI Request object
+    llm_router,  # Router instance
+    data: dict,
+    check_file_id_encoding: bool = True,
+) -> tuple[bool, Optional[str], Optional[str], Optional[dict]]:
+    """
+    Orchestrate model-based credential routing for file operations.
+    
+    Args:
+        file_id: File ID (may contain embedded model info)
+        request: FastAPI request object
+        llm_router: LiteLLM Router instance
+        data: Request data dictionary
+        check_file_id_encoding: Whether to check for embedded model in file_id
+        
+    Returns:
+        Tuple of (should_use_model_routing, model_used, original_file_id, credentials)
+        - should_use_model_routing: True if model-based routing should be used
+        - model_used: The model name being used
+        - original_file_id: Decoded file ID (if it was encoded)
+        - credentials: Model credentials dict
+        
+    Raises:
+        HTTPException: If router unavailable or model not found
+    """
+    model_from_id, model_from_param = extract_model_from_sources(
+        file_id=file_id,
+        request=request,
+        data=data,
+    )
+    
+    # Priority 1: Model embedded in file_id
+    if check_file_id_encoding and model_from_id is not None:
+        credentials = get_credentials_for_model(
+            llm_router=llm_router,
+            model_id=model_from_id,
+            operation_context=f"file operation (file created with model '{model_from_id}')",
+        )
+        original_file_id = get_original_file_id(file_id)
+        return True, model_from_id, original_file_id, credentials
+    
+    # Priority 2: Model from header/query/body
+    elif model_from_param is not None:
+        credentials = get_credentials_for_model(
+            llm_router=llm_router,
+            model_id=model_from_param,
+            operation_context="file operation",
+        )
+        return True, model_from_param, None, credentials
+    
+    # No model-based routing needed
+    return False, None, None, None

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -29,6 +29,7 @@ from litellm.llms.base_llm.files.transformation import BaseFileEndpoints
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_body,
     get_custom_llm_provider_from_request_headers,
@@ -42,7 +43,16 @@ from litellm.types.llms.openai import (
     OpenAIFilesPurpose,
 )
 
-from .common_utils import _is_base64_encoded_unified_file_id
+from .common_utils import (
+    _is_base64_encoded_unified_file_id,
+    decode_model_from_file_id,
+    encode_file_id_with_model,
+    get_credentials_for_model,
+    get_original_file_id,
+    handle_model_based_routing,
+    is_model_embedded_id,
+    prepare_data_with_credentials,
+)
 
 router = APIRouter()
 
@@ -127,7 +137,51 @@ async def route_create_file(
     is_router_model: bool,
     router_model: Optional[str],
     custom_llm_provider: str,
+    model: Optional[str] = None,
 ) -> OpenAIFileObject:
+    """
+    Route file creation request to the appropriate provider.
+    
+    Priority:
+    1. If model parameter provided -> use model credentials and encode ID
+    2. If enable_loadbalancing_on_batch_endpoints -> deprecated loadbalancing
+    3. If target_model_names_list -> managed files (requires DB)
+    4. Else -> use custom_llm_provider with files_settings
+    """
+    
+    # NEW: Handle model-based routing (no DB required)
+    if model is not None:
+        # Get credentials from model_list via router
+        credentials = get_credentials_for_model(
+            llm_router=llm_router,
+            model_id=model,
+            operation_context="file upload",
+        )
+        
+        # Merge credentials into the request
+        prepare_data_with_credentials(
+            data=_create_file_request,  # type: ignore
+            credentials=credentials,
+        )
+        
+        # Create the file with model credentials
+        response = await litellm.acreate_file(
+            **_create_file_request, 
+            custom_llm_provider=credentials["custom_llm_provider"]
+        )  # type: ignore
+        
+        # Encode the file ID with model information
+        if response and hasattr(response, "id") and response.id:
+            original_id = response.id
+            encoded_id = encode_file_id_with_model(file_id=original_id, model=model)
+            response.id = encoded_id
+            verbose_proxy_logger.debug(
+                f"Encoded file ID: {original_id} -> {encoded_id} (model: {model})"
+            )
+        
+        return response
+    
+    # EXISTING: Deprecated loadbalancing approach
     if (
         litellm.enable_loadbalancing_on_batch_endpoints is True
         and is_router_model
@@ -245,6 +299,14 @@ async def create_file(
             or "openai"
         )
 
+        # NEW: Extract model parameter for multi-account routing
+        request_body = await _read_request_body(request=request) or {}
+        model_param = (
+            request_body.get("model")
+            or request.query_params.get("model")
+            or request.headers.get("x-litellm-model")
+        )
+
         target_model_names_list = (
             target_model_names.split(",") if target_model_names else []
         )
@@ -303,6 +365,7 @@ async def create_file(
             is_router_model=is_router_model,
             router_model=router_model,
             custom_llm_provider=custom_llm_provider,
+            model=model_param,
         )
 
         if response is None:
@@ -480,13 +543,41 @@ async def get_file_content(
                     }
                 )
         else:
-            response = await litellm.afile_content(
-                **{
-                    "custom_llm_provider": custom_llm_provider,
-                    "file_id": file_id,
-                    **data,
-                }  # type: ignore
+            # Check for model-based credential routing
+            should_route, model_used, original_file_id, credentials = handle_model_based_routing(
+                file_id=file_id,
+                request=request,
+                llm_router=llm_router,
+                data=data,
+                check_file_id_encoding=True,
             )
+            
+            if should_route:
+                # Use model-based routing with credentials from config
+                prepare_data_with_credentials(
+                    data=data,
+                    credentials=credentials,  # type: ignore
+                    file_id=original_file_id,  # Use decoded file ID if from encoded ID
+                )
+                
+                response = await litellm.afile_content(
+                    custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                    **data
+                )  # type: ignore
+                
+                verbose_proxy_logger.debug(
+                    f"Retrieved file content using model: {model_used}"
+                    + (f", file_id: {file_id} -> {original_file_id}" if original_file_id else "")
+                )
+            else:
+                # Fallback to default behavior (uses env variables or provider-based routing)
+                response = await litellm.afile_content(
+                    **{
+                        "custom_llm_provider": custom_llm_provider,
+                        "file_id": file_id,
+                        **data,
+                    }  # type: ignore
+                )
 
         ### ALERTING ###
         asyncio.create_task(
@@ -618,10 +709,38 @@ async def get_file(
             route_type="afile_retrieve",
         )
 
-        ## check if file_id is a litellm managed file
-        is_base64_unified_file_id = _is_base64_encoded_unified_file_id(file_id)
+        ## Check for model-based credential routing
+        from litellm.proxy.proxy_server import llm_router
+        
+        should_route, model_used, original_file_id, credentials = handle_model_based_routing(
+            file_id=file_id,
+            request=request,
+            llm_router=llm_router,
+            data=data,
+            check_file_id_encoding=True,
+        )
+        
+        if should_route:
+            # Use model-based routing with credentials from config
+            prepare_data_with_credentials(
+                data=data,
+                credentials=credentials,  # type: ignore
+                file_id=original_file_id,
+            )
 
-        if is_base64_unified_file_id:
+            response = await litellm.afile_retrieve(**data)  # type: ignore
+            
+            # Keep the encoded ID in response if it was originally encoded
+            if original_file_id and response and hasattr(response, "id") and response.id:
+                response.id = file_id
+            
+            verbose_proxy_logger.debug(
+                f"Retrieved file using model: {model_used}"
+                + (f", original_id: {original_file_id}" if original_file_id else "")
+            )
+        
+        ## EXISTING: check if file_id is a litellm managed file
+        elif _is_base64_encoded_unified_file_id(file_id):
             managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
             if managed_files_obj is None:
                 raise ProxyException(
@@ -762,10 +881,32 @@ async def delete_file(
             proxy_config=proxy_config,
         )
 
-        ## check if file_id is a litellm managed file
-        is_base64_unified_file_id = _is_base64_encoded_unified_file_id(file_id)
-
-        if is_base64_unified_file_id:
+        # Check for model-based credential routing
+        should_route, model_used, original_file_id, credentials = handle_model_based_routing(
+            file_id=file_id,
+            request=request,
+            llm_router=llm_router,
+            data=data,
+            check_file_id_encoding=True,
+        )
+        
+        if should_route:
+            # Use model-based routing with credentials from config
+            prepare_data_with_credentials(
+                data=data,
+                credentials=credentials,  # type: ignore
+                file_id=original_file_id,
+            )
+            
+            response = await litellm.afile_delete(**data)  # type: ignore
+            
+            verbose_proxy_logger.debug(
+                f"Deleted file using model: {model_used}"
+                + (f", original_id: {original_file_id}" if original_file_id else "")
+            )
+        
+        ## EXISTING: check if file_id is a litellm managed file
+        elif _is_base64_encoded_unified_file_id(file_id):
             managed_files_obj = proxy_logging_obj.get_proxy_hook("managed_files")
             if managed_files_obj is None:
                 raise ProxyException(
@@ -913,7 +1054,28 @@ async def list_files(
         )
 
         response: Optional[Any] = None
-        if target_model_names and isinstance(target_model_names, str):
+        
+        # Check for model-based credential routing (no file_id encoding check for list)
+        should_route, model_used, _, credentials = handle_model_based_routing(
+            file_id="",  # No file_id for list endpoint
+            request=request,
+            llm_router=llm_router,
+            data=data,
+            check_file_id_encoding=False,
+        )
+        
+        if should_route:
+            # Use model-based routing with credentials from config
+            data.update(credentials)  # type: ignore
+            response = await litellm.afile_list(
+                custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                purpose=purpose,
+                **data  # type: ignore
+            )
+            
+            verbose_proxy_logger.debug(f"Listed files using model: {model_used}")
+        
+        elif target_model_names and isinstance(target_model_names, str):
             target_model_names_list = target_model_names.split(",")
             if len(target_model_names_list) != 1:
                 raise HTTPException(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5906,14 +5906,14 @@ class Router:
         it tries to find by model_group_name (model_name).
         
         Args:
-            model_id: Model ID or model name from model_list (e.g., "gpt-4o-ifood")
+            model_id: Model ID or model name from model_list (e.g., "gpt-4o-litellm")
         
         Returns:
             Dictionary containing api_key, api_base, custom_llm_provider, etc.
             Returns None if model not found.
         
         Example:
-            credentials = router.get_deployment_credentials_with_provider("gpt-4o-ifood")
+            credentials = router.get_deployment_credentials_with_provider("gpt-4o-litellm")
             # Returns: {"api_key": "sk-...", "custom_llm_provider": "openai", ...}
         """
         # Try to get deployment by model_id first

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5895,6 +5895,57 @@ class Router:
                     raise Exception("Model Name invalid - {}".format(type(model)))
         return None
 
+    def get_deployment_credentials_with_provider(
+        self, model_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get API credentials and provider info from a model name in model_list.
+        Useful for passthrough endpoints (files, batches, etc.) that need credentials.
+        
+        This method tries to find a deployment by model_id first, and if not found,
+        it tries to find by model_group_name (model_name).
+        
+        Args:
+            model_id: Model ID or model name from model_list (e.g., "gpt-4o-ifood")
+        
+        Returns:
+            Dictionary containing api_key, api_base, custom_llm_provider, etc.
+            Returns None if model not found.
+        
+        Example:
+            credentials = router.get_deployment_credentials_with_provider("gpt-4o-ifood")
+            # Returns: {"api_key": "sk-...", "custom_llm_provider": "openai", ...}
+        """
+        # Try to get deployment by model_id first
+        deployment = self.get_deployment(model_id=model_id)
+        
+        # If not found, try by model_group_name
+        if deployment is None:
+            deployment = self.get_deployment_by_model_group_name(model_group_name=model_id)
+        
+        if deployment is None:
+            return None
+        
+        # Get basic credentials
+        credentials = CredentialLiteLLMParams(
+            **deployment.litellm_params.model_dump(exclude_none=True)
+        ).model_dump(exclude_none=True)
+        
+        # Add custom_llm_provider
+        if deployment.litellm_params.custom_llm_provider:
+            credentials["custom_llm_provider"] = (
+                deployment.litellm_params.custom_llm_provider
+            )
+        elif "/" in deployment.litellm_params.model:
+            # Extract provider from "provider/model" format
+            credentials["custom_llm_provider"] = deployment.litellm_params.model.split(
+                "/"
+            )[0]
+        else:
+            credentials["custom_llm_provider"] = "openai"  # default
+        
+        return credentials
+
     @overload
     def get_router_model_info(
         self, deployment: dict, received_model_name: str, id: None = None

--- a/tests/openai_endpoints_tests/test_model_based_routing_files_batches.py
+++ b/tests/openai_endpoints_tests/test_model_based_routing_files_batches.py
@@ -1,0 +1,429 @@
+"""
+Test Model-Based Credential Routing for Files and Batches Endpoints
+
+This test suite validates that files and batches can be routed to different
+provider accounts based on model configuration in model_list.
+
+Tests cover 3 scenarios:
+1. Encoded file/batch ID with model (auto-routing)
+2. Model specified via header/query/body parameter
+3. Fallback to custom_llm_provider (environment variables)
+"""
+import pytest
+import asyncio
+import aiohttp
+import json
+import os
+from typing import Optional
+from openai import AsyncOpenAI
+
+# Test configuration
+BASE_URL = "http://localhost:4000"
+API_KEY = "sk-1234"
+
+# Mock model names configured in proxy config
+MODEL_ACCOUNT_1 = "gpt-4o-test-account-1"
+MODEL_ACCOUNT_2 = "gpt-4o-test-account-2"
+
+
+class TestFilesModelBasedRouting:
+    """Test model-based credential routing for files endpoints"""
+
+    @pytest.mark.asyncio
+    async def test_scenario_1_encoded_file_id_routing(self):
+        """
+        Scenario 1: File ID with embedded model info
+        - Upload file with model parameter
+        - Verify file ID is encoded with model info
+        - Retrieve file using encoded ID (no model param needed)
+        - Get file content using encoded ID
+        - Delete file using encoded ID
+        All operations should auto-route to the correct account
+        """
+        async with aiohttp.ClientSession() as session:
+            # Upload file with model header
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": MODEL_ACCOUNT_1,
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field(
+                "file",
+                b'{"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}}',
+                filename="batch.jsonl",
+            )
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                
+                # Verify file ID starts with "file-" and contains encoded data
+                assert file_id.startswith("file-"), f"File ID should start with 'file-', got: {file_id}"
+                assert len(file_id) > 10, "File ID should be encoded with model info"
+                
+                print(f"✅ Created file with encoded ID: {file_id}")
+
+            # Retrieve file without specifying model (should auto-route)
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+
+            async with session.get(url, headers=headers) as response:
+                assert response.status == 200
+                result = await response.json()
+                assert result["id"] == file_id
+                assert result["purpose"] == "batch"
+                print(f"✅ Retrieved file using auto-routing from encoded ID")
+
+            # Get file content without specifying model
+            url = f"{BASE_URL}/v1/files/{file_id}/content"
+            async with session.get(url, headers=headers) as response:
+                assert response.status == 200
+                content = await response.text()
+                assert len(content) > 0
+                print(f"✅ Got file content using auto-routing from encoded ID")
+
+            # Delete file without specifying model
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            async with session.delete(url, headers=headers) as response:
+                assert response.status == 200
+                result = await response.json()
+                assert result["deleted"] is True
+                print(f"✅ Deleted file using auto-routing from encoded ID")
+
+    @pytest.mark.asyncio
+    async def test_scenario_2_model_via_header(self):
+        """
+        Scenario 2: Model specified via header
+        - Upload file with model header
+        - Retrieve file with model header
+        - List files with model query param
+        All operations should use credentials from the specified model
+        """
+        async with aiohttp.ClientSession() as session:
+            # Upload file with model header
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": MODEL_ACCOUNT_2,
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "fine-tune")
+            data.add_field(
+                "file", b'{"prompt": "Hello", "completion": "Hi"}', filename="data.jsonl"
+            )
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                print(f"✅ Created file with model header: {file_id}")
+
+            # List files with model query parameter
+            url = f"{BASE_URL}/v1/files?model={MODEL_ACCOUNT_2}"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+
+            async with session.get(url, headers=headers) as response:
+                assert response.status == 200
+                result = await response.json()
+                assert "data" in result
+                print(f"✅ Listed files with model query param")
+
+            # Clean up
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            await session.delete(url, headers={"Authorization": f"Bearer {API_KEY}", "x-litellm-model": MODEL_ACCOUNT_2})
+
+    @pytest.mark.asyncio
+    async def test_scenario_2_model_via_query_param(self):
+        """
+        Scenario 2: Model specified via query parameter
+        - Upload file with model query param
+        - Operations should use credentials from the specified model
+        """
+        async with aiohttp.ClientSession() as session:
+            # Upload file with model query param
+            url = f"{BASE_URL}/v1/files?model={MODEL_ACCOUNT_1}"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field("file", b'{"test": "data"}', filename="test.jsonl")
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                print(f"✅ Created file with model query param: {file_id}")
+
+            # Clean up
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            await session.delete(url, headers={"Authorization": f"Bearer {API_KEY}"})
+
+    @pytest.mark.asyncio
+    async def test_scenario_3_fallback_to_provider(self):
+        """
+        Scenario 3: No model specified, fallback to environment variables
+        - Upload file without model parameter
+        - Should use credentials from OPENAI_API_KEY env var
+        """
+        # This test requires OPENAI_API_KEY to be set
+        if not os.getenv("OPENAI_API_KEY"):
+            pytest.skip("OPENAI_API_KEY not set, skipping fallback test")
+
+        async with aiohttp.ClientSession() as session:
+            url = f"{BASE_URL}/v1/files"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+            data = aiohttp.FormData()
+            data.add_field("purpose", "fine-tune")
+            data.add_field("file", b'{"prompt": "Test"}', filename="fallback.jsonl")
+
+            async with session.post(url, headers=headers, data=data) as response:
+                # Should succeed with environment credentials
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                # File ID should NOT be encoded (no model info)
+                assert not file_id.startswith("file-bGl0ZWxs")  # Not base64 encoded
+                print(f"✅ Created file with fallback credentials: {file_id}")
+
+                # Clean up
+                url = f"{BASE_URL}/v1/files/{file_id}"
+                await session.delete(url, headers=headers)
+
+
+class TestBatchesModelBasedRouting:
+    """Test model-based credential routing for batches endpoints"""
+
+    @pytest.mark.asyncio
+    async def test_scenario_1_encoded_batch_id_routing(self):
+        """
+        Scenario 1: Batch with encoded file ID (auto-routing)
+        - Create file with model parameter (gets encoded ID)
+        - Create batch using encoded file ID (no model param needed)
+        - Verify batch ID is also encoded
+        - Retrieve batch using encoded ID
+        - Cancel batch using encoded ID
+        All operations should auto-route to the correct account
+        """
+        async with aiohttp.ClientSession() as session:
+            # Step 1: Create file with model
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": MODEL_ACCOUNT_1,
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field(
+                "file",
+                b'{"custom_id": "request-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}}',
+                filename="batch_test.jsonl",
+            )
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                assert file_id.startswith("file-")
+                print(f"✅ Created file with encoded ID: {file_id}")
+
+            # Step 2: Create batch using encoded file ID (no model param)
+            url = f"{BASE_URL}/v1/batches"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            }
+            body = {
+                "input_file_id": file_id,
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            }
+
+            async with session.post(url, headers=headers, json=body) as response:
+                assert response.status == 200
+                result = await response.json()
+                batch_id = result["id"]
+                
+                # Verify batch ID starts with "batch_" and is encoded
+                assert batch_id.startswith("batch_"), f"Batch ID should start with 'batch_', got: {batch_id}"
+                assert len(batch_id) > 10, "Batch ID should be encoded with model info"
+                assert result["input_file_id"] == file_id
+                print(f"✅ Created batch with encoded ID: {batch_id}")
+
+            # Step 3: Retrieve batch without model param (auto-routing)
+            url = f"{BASE_URL}/v1/batches/{batch_id}"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+
+            async with session.get(url, headers=headers) as response:
+                assert response.status == 200
+                result = await response.json()
+                assert result["id"] == batch_id
+                assert result["input_file_id"] == file_id
+                print(f"✅ Retrieved batch using auto-routing from encoded ID")
+
+            # Step 4: Cancel batch without model param
+            url = f"{BASE_URL}/v1/batches/{batch_id}/cancel"
+            async with session.post(url, headers=headers) as response:
+                # Cancelling might fail if batch already completed, that's ok
+                print(f"✅ Attempted to cancel batch using auto-routing")
+
+            # Clean up file
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            await session.delete(url, headers=headers)
+
+    @pytest.mark.asyncio
+    async def test_scenario_2_batch_with_model_header(self):
+        """
+        Scenario 2: Batch with model specified via header
+        - Create batch with model header
+        - List batches with model query param
+        Operations should use credentials from the specified model
+        """
+        async with aiohttp.ClientSession() as session:
+            # First create a file
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": MODEL_ACCOUNT_2,
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field(
+                "file",
+                b'{"custom_id": "test-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o", "messages": [{"role": "user", "content": "Test"}]}}',
+                filename="test_batch.jsonl",
+            )
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+
+            # Create batch with model header
+            url = f"{BASE_URL}/v1/batches"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+                "x-litellm-model": MODEL_ACCOUNT_2,
+            }
+            body = {
+                "input_file_id": file_id,
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            }
+
+            async with session.post(url, headers=headers, json=body) as response:
+                assert response.status == 200
+                result = await response.json()
+                batch_id = result["id"]
+                print(f"✅ Created batch with model header: {batch_id}")
+
+            # List batches with model query param
+            url = f"{BASE_URL}/v1/batches?model={MODEL_ACCOUNT_2}"
+            headers = {"Authorization": f"Bearer {API_KEY}"}
+
+            async with session.get(url, headers=headers) as response:
+                assert response.status == 200
+                result = await response.json()
+                assert "data" in result
+                print(f"✅ Listed batches with model query param")
+
+            # Clean up
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            await session.delete(url, headers={"Authorization": f"Bearer {API_KEY}"})
+
+    @pytest.mark.asyncio
+    async def test_id_encoding_format(self):
+        """
+        Verify that file and batch IDs are correctly encoded with proper prefixes
+        - File IDs should start with "file-"
+        - Batch IDs should start with "batch_"
+        """
+        async with aiohttp.ClientSession() as session:
+            # Create file with model
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": MODEL_ACCOUNT_1,
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field("file", b'{"test": "data"}', filename="format_test.jsonl")
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 200
+                result = await response.json()
+                file_id = result["id"]
+                
+                # Verify file ID format
+                assert file_id.startswith("file-"), f"File ID must start with 'file-', got: {file_id}"
+                print(f"✅ File ID format correct: {file_id}")
+
+                # Extract base64 part (after "file-")
+                base64_part = file_id[5:]
+                assert len(base64_part) > 20, "Encoded data should be substantial"
+
+            # Create batch
+            url = f"{BASE_URL}/v1/batches"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            }
+            body = {
+                "input_file_id": file_id,
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            }
+
+            async with session.post(url, headers=headers, json=body) as response:
+                assert response.status == 200
+                result = await response.json()
+                batch_id = result["id"]
+                
+                # Verify batch ID format
+                assert batch_id.startswith("batch_"), f"Batch ID must start with 'batch_', got: {batch_id}"
+                print(f"✅ Batch ID format correct: {batch_id}")
+
+                # Verify input_file_id is preserved
+                assert result["input_file_id"] == file_id
+                
+                # Extract base64 part (after "batch_")
+                base64_part = batch_id[6:]
+                assert len(base64_part) > 20, "Encoded data should be substantial"
+
+            # Clean up
+            url = f"{BASE_URL}/v1/files/{file_id}"
+            await session.delete(url, headers={"Authorization": f"Bearer {API_KEY}"})
+
+
+class TestModelNotFound:
+    """Test error handling when model is not found in config"""
+
+    @pytest.mark.asyncio
+    async def test_invalid_model_name(self):
+        """
+        Test that using a non-existent model name returns proper error
+        """
+        async with aiohttp.ClientSession() as session:
+            url = f"{BASE_URL}/v1/files"
+            headers = {
+                "Authorization": f"Bearer {API_KEY}",
+                "x-litellm-model": "non-existent-model-12345",
+            }
+            data = aiohttp.FormData()
+            data.add_field("purpose", "batch")
+            data.add_field("file", b'{"test": "data"}', filename="error_test.jsonl")
+
+            async with session.post(url, headers=headers, data=data) as response:
+                assert response.status == 400
+                result = await response.json()
+                assert "error" in result
+                assert "not found in model_list" in result["error"]["message"]
+                print(f"✅ Correct error for invalid model name")
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v", "-s"])
+


### PR DESCRIPTION
## Title

Resolves multi-account file and batch routing without requiring a database

## Relevant issues

Resolves multi-account file and batch routing without requiring a database

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Overview
Added model-based credential routing for **Files API** and **Batches API**, enabling multi-account support without requiring a database. Users can now route file and batch operations to different provider accounts by specifying a model from their `model_list` configuration.

### Key Features

#### 1. **Three Routing Scenarios Supported**

**Scenario 1: Encoded IDs with Auto-Routing** (Recommended)
- File/batch IDs automatically encode model information
- Subsequent operations auto-route to the correct account
- No need to specify model on every request
```bash
# Upload with model
curl -H "x-litellm-model: gpt-4o-account-1" -F file=@batch.jsonl http://localhost:4000/v1/files
# Returns: "file-bGl0ZWxsbTpmaWxlLWFiYzEyMzttb2RlbCxncHQtNG8tYWNjb3VudC0x"

# Create batch - auto-routes to gpt-4o-account-1
curl -d '{"input_file_id": "file-bGl0ZWxs..."}' http://localhost:4000/v1/batches
```

**Scenario 2: Model via Header/Query/Body**
- Explicitly specify model for each request
```bash
curl -H "x-litellm-model: gpt-4o-account-2" ...
curl "http://localhost:4000/v1/files?model=gpt-4o-account-2"
```

**Scenario 3: Environment Variables (Fallback)**
- Backward compatible with existing setups
- Uses `OPENAI_API_KEY` when no model specified

#### 2. **OpenAI-Compliant ID Format**
- File IDs: `file-<base64_encoded_data>` ✅
- Batch IDs: `batch_<base64_encoded_data>` ✅
- Preserves OpenAI API compatibility

#### 3. **All Endpoints Supported**
✅ `POST /v1/files` - Upload file  
✅ `GET /v1/files` - List files  
✅ `GET /v1/files/{id}` - Get file metadata  
✅ `GET /v1/files/{id}/content` - Get file content  
✅ `DELETE /v1/files/{id}` - Delete file  
✅ `POST /v1/batches` - Create batch  
✅ `GET /v1/batches` - List batches  
✅ `GET /v1/batches/{id}` - Retrieve batch  
✅ `POST /v1/batches/{id}/cancel` - Cancel batch  

### Technical Implementation

#### Files Modified

1. **`litellm/router.py`**
   - Added `get_deployment_credentials_with_provider()` method
   - Retrieves API credentials by model name or ID
   - Supports fallback from model_id → model_group_name

2. **`litellm/proxy/openai_files_endpoints/common_utils.py`**
   - `encode_file_id_with_model()` - Encodes model info in IDs (preserves prefix)
   - `decode_model_from_file_id()` - Extracts model from encoded IDs
   - `get_original_file_id()` - Decodes to original provider ID
   - `get_credentials_for_model()` - Retrieves credentials with error handling
   - `prepare_data_with_credentials()` - Merges credentials into request data
   - `handle_model_based_routing()` - Orchestrates the routing logic

3. **`litellm/proxy/openai_files_endpoints/files_endpoints.py`**
   - Refactored all 5 endpoints to use helper methods
   - Removed duplicate credential routing code
   - Consistent error handling across endpoints

4. **`litellm/proxy/batches_endpoints/endpoints.py`**
   - Refactored all 4 endpoints to use helper methods
   - Added model-based routing to `cancel_batch`
   - Batch IDs now correctly start with `batch_` prefix

5. **Documentation**
   - `docs/my-website/docs/files_endpoints.md` - Updated with multi-account examples
   - `docs/my-website/docs/batches.md` - Added comprehensive routing documentation

### Configuration Example

```yaml
model_list:
  - model_name: gpt-4o-account-1
    litellm_params:
      model: openai/gpt-4o
      api_key: sk-account-1-key
      api_base: https://api.openai.com/v1
  
  - model_name: gpt-4o-account-2
    litellm_params:
      model: openai/gpt-4o
      api_key: sk-account-2-key
      api_base: https://api.openai.com/v1
  
  - model_name: azure-batches
    litellm_params:
      model: azure/gpt-4
      api_key: azure-key
      api_base: https://my-resource.openai.azure.com
      api_version: "2024-02-01"
```

### Testing
<img width="897" height="722" alt="image" src="https://github.com/user-attachments/assets/d9712b33-a4f6-49d8-8070-49248d873288" />
<img width="897" height="722" alt="image" src="https://github.com/user-attachments/assets/b290cd34-ca45-466d-b80d-9ec718f87253" />
