### PR TITLE
[Fix] Change /public fields to honor server root path

### DIFF
--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -217,7 +217,7 @@ const handleError = async (errorData: string | any) => {
   if (currentTime - lastErrorTime > 60000) {
     // 60000 milliseconds = 60 seconds
     // Convert errorData to string if it isn't already
-    const errorString = typeof errorData === 'string' ? errorData : JSON.stringify(errorData);
+    const errorString = typeof errorData === "string" ? errorData : JSON.stringify(errorData);
     if (errorString.includes("Authentication Error - Expired Key")) {
       NotificationsManager.info("UI Session Expired. Logging out.");
       lastErrorTime = currentTime;
@@ -238,7 +238,7 @@ export const getProviderCreateMetadata = async (): Promise<ProviderCreateInfo[]>
    * Fetch provider credential field metadata from the proxy's public endpoint.
    * This is used by the UI to dynamically render provider-specific credential fields.
    */
-  const url = defaultProxyBaseUrl ? `${defaultProxyBaseUrl}/public/providers/fields` : `/public/providers/fields`;
+  const url = proxyBaseUrl ? `${proxyBaseUrl}/public/providers/fields` : `/public/providers/fields`;
   const response = await fetch(url, {
     method: "GET",
   });
@@ -295,7 +295,7 @@ export const getUiConfig = async () => {
 };
 
 export const getPublicModelHubInfo = async () => {
-  const url = defaultProxyBaseUrl ? `${defaultProxyBaseUrl}/public/model_hub/info` : `/public/model_hub/info`;
+  const url = proxyBaseUrl ? `${proxyBaseUrl}/public/model_hub/info` : `/public/model_hub/info`;
   const response = await fetch(url);
   const jsonData: PublicModelHubInfo = await response.json();
   return jsonData;
@@ -6749,7 +6749,6 @@ export const getGuardrailProviderSpecificParams = async (accessToken: string) =>
   }
 };
 
-
 export const getAgentsList = async (accessToken: string) => {
   try {
     const url = proxyBaseUrl ? `${proxyBaseUrl}/v1/agents` : `/v1/agents`;
@@ -6866,7 +6865,6 @@ export const patchAgentCall = async (
     throw error;
   }
 };
-
 
 export const updateGuardrailCall = async (
   accessToken: string,


### PR DESCRIPTION
## [Fix] Change /public fields to honor server root path

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Currently when the UI calls /public endpoints, it does not honor the server root path set in the environment variables. This changes all /public endpoints to honor the proxyBaseUrl and the server root path. 

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test


SERVER_ROOT_PATH="/litellmInstance"
<img width="1509" height="708" alt="image" src="https://github.com/user-attachments/assets/b1f6fbf6-f8a3-4c6a-beb5-cdba866a43cc" />
<img width="645" height="248" alt="image" src="https://github.com/user-attachments/assets/1c4ecc92-bb6a-450d-90ba-a0b43f80c211" />


