### PR TITLE
[Fix] Prompt Management - UI, allow seeing model, prompt id for Prompt

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -19977,6 +19977,53 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "openrouter/google/gemini-3-pro-preview": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_200k_tokens": 4e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "openrouter",
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_images_per_prompt": 3000,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_pdf_size_mb": 30,
+        "max_tokens": 65535,
+        "max_video_length": 1,
+        "max_videos_per_prompt": 10,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_200k_tokens": 1.8e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "openrouter/google/gemini-pro-1.5": {
         "input_cost_per_image": 0.00265,
         "input_cost_per_token": 2.5e-06,

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -104,6 +104,45 @@ def construct_versioned_prompt_id(prompt_id: str, version: Optional[int] = None)
     return f"{base_id}.v{version}"
 
 
+def get_latest_version_prompt_id(prompt_id: str, all_prompt_ids: Dict[str, Any]) -> str:
+    """
+    Find the latest version of a prompt from available prompt IDs.
+    
+    Args:
+        prompt_id: Base prompt ID or versioned prompt ID (e.g., "jack_success" or "jack_success.v2")
+        all_prompt_ids: Dictionary of all available prompt IDs (keys are prompt IDs)
+    
+    Returns:
+        The prompt ID with the highest version number, or the original prompt_id if no versions exist
+    
+    Examples:
+        >>> all_ids = {"jack.v1": {}, "jack.v2": {}, "jack.v3": {}}
+        >>> get_latest_version_prompt_id("jack", all_ids)
+        "jack.v3"
+        >>> get_latest_version_prompt_id("jack.v1", all_ids)
+        "jack.v3"
+        >>> all_ids = {"simple": {}}
+        >>> get_latest_version_prompt_id("simple", all_ids)
+        "simple"
+    """
+    base_id = get_base_prompt_id(prompt_id=prompt_id)
+    
+    # Find all versions of this prompt
+    matching_versions = []
+    for stored_prompt_id in all_prompt_ids.keys():
+        if get_base_prompt_id(prompt_id=stored_prompt_id) == base_id:
+            version_num = get_version_number(prompt_id=stored_prompt_id)
+            matching_versions.append((version_num, stored_prompt_id))
+    
+    # Use the highest version number
+    if matching_versions:
+        matching_versions.sort(reverse=True)
+        return matching_versions[0][1]
+    else:
+        # No versioned prompts found, use the base ID as-is
+        return prompt_id
+
+
 def get_latest_prompt_versions(prompts: List[PromptSpec]) -> List[PromptSpec]:
     """
     Filter a list of prompts to return only the latest version of each unique prompt.

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -296,13 +296,20 @@ async def list_prompts(
     if key_metadata is not None:
         prompts = cast(Optional[List[str]], key_metadata.get("prompts", None))
         if prompts is not None:
-            return ListPromptsResponse(
-                prompts=[
-                    IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[prompt]
-                    for prompt in prompts
-                    if prompt in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS
-                ]
-            )
+            prompt_list = []
+            for prompt_id in prompts:
+                if prompt_id in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS:
+                    original_prompt = IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[prompt_id]
+                    # Create a copy with base prompt_id (without version suffix)
+                    prompt_copy = PromptSpec(
+                        prompt_id=get_base_prompt_id(prompt_id=original_prompt.prompt_id),
+                        litellm_params=original_prompt.litellm_params,
+                        prompt_info=original_prompt.prompt_info,
+                        created_at=original_prompt.created_at,
+                        updated_at=original_prompt.updated_at,
+                    )
+                    prompt_list.append(prompt_copy)
+            return ListPromptsResponse(prompts=prompt_list)
     # check if user is proxy admin - show all prompts
     if user_api_key_dict.user_role is not None and (
         user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
@@ -311,7 +318,18 @@ async def list_prompts(
         # Get all prompts and filter to show only the latest version of each
         all_prompts = list(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.values())
         latest_prompts = get_latest_prompt_versions(prompts=all_prompts)
-        return ListPromptsResponse(prompts=latest_prompts)
+        # Create copies with base prompt_id (without version suffix) for display
+        prompts_for_display = []
+        for original_prompt in latest_prompts:
+            prompt_copy = PromptSpec(
+                prompt_id=get_base_prompt_id(prompt_id=original_prompt.prompt_id),
+                litellm_params=original_prompt.litellm_params,
+                prompt_info=original_prompt.prompt_info,
+                created_at=original_prompt.created_at,
+                updated_at=original_prompt.updated_at,
+            )
+            prompts_for_display.append(prompt_copy)
+        return ListPromptsResponse(prompts=prompts_for_display)
     else:
         return ListPromptsResponse(prompts=[])
 
@@ -457,7 +475,17 @@ async def get_prompt_info(
             detail=f"You are not authorized to access this prompt. Your role - {user_api_key_dict.user_role}, Your key's prompts - {prompts}",
         )
 
+    # Try to get prompt directly first
     prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
+    
+    # If not found, try to find the latest version
+    if prompt_spec is None:
+        latest_prompt_id = get_latest_version_prompt_id(
+            prompt_id=prompt_id,
+            all_prompt_ids=IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS
+        )
+        prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(latest_prompt_id)
+    
     if prompt_spec is None:
         raise HTTPException(status_code=400, detail=f"Prompt {prompt_id} not found")
 
@@ -745,8 +773,19 @@ async def delete_prompt(
         )
 
     try:
-        # Check if prompt exists
+        # Try to get prompt directly first
         existing_prompt = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
+        
+        # If not found, try to find the latest version
+        if existing_prompt is None:
+            latest_prompt_id = get_latest_version_prompt_id(
+                prompt_id=prompt_id,
+                all_prompt_ids=IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS
+            )
+            existing_prompt = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(latest_prompt_id)
+            # Use the resolved prompt_id for deletion
+            prompt_id = latest_prompt_id
+        
         if existing_prompt is None:
             raise HTTPException(
                 status_code=404, detail=f"Prompt with ID {prompt_id} not found"

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -77,6 +77,33 @@ def get_version_number(prompt_id: str) -> int:
     return 1
 
 
+def construct_versioned_prompt_id(prompt_id: str, version: Optional[int] = None) -> str:
+    """
+    Construct a versioned prompt ID from a base prompt_id and version number.
+    
+    Args:
+        prompt_id: Base prompt ID (e.g., "jack_success")
+        version: Version number (if None, returns the base prompt_id unchanged)
+    
+    Returns:
+        Versioned prompt ID (e.g., "jack_success.v4")
+    
+    Examples:
+        >>> construct_versioned_prompt_id("jack_success", 4)
+        "jack_success.v4"
+        >>> construct_versioned_prompt_id("jack_success", None)
+        "jack_success"
+        >>> construct_versioned_prompt_id("jack_success.v2", 4)
+        "jack_success.v4"
+    """
+    if version is None:
+        return prompt_id
+    
+    # Strip any existing version suffix first
+    base_id = get_base_prompt_id(prompt_id)
+    return f"{base_id}.v{version}"
+
+
 def get_latest_prompt_versions(prompts: List[PromptSpec]) -> List[PromptSpec]:
     """
     Filter a list of prompts to return only the latest version of each unique prompt.

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -904,13 +904,21 @@ class ProxyLogging:
         ):
             from litellm.proxy.prompts.prompt_endpoints import (
                 construct_versioned_prompt_id,
+                get_latest_version_prompt_id,
             )
             from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
 
-            # Construct versioned prompt_id if prompt_version is provided
-            lookup_prompt_id = construct_versioned_prompt_id(
-                prompt_id=prompt_id, version=prompt_version
-            )
+            # If no version is specified, find the latest version
+            if prompt_version is None:
+                lookup_prompt_id = get_latest_version_prompt_id(
+                    prompt_id=prompt_id,
+                    all_prompt_ids=IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS,
+                )
+            else:
+                # Construct versioned prompt_id if prompt_version is provided
+                lookup_prompt_id = construct_versioned_prompt_id(
+                    prompt_id=prompt_id, version=prompt_version
+                )
 
             custom_logger = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id(
                 lookup_prompt_id

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -894,6 +894,7 @@ class ProxyLogging:
             Optional["LiteLLMLoggingObj"], data.get("litellm_logging_obj", None)
         )
         prompt_id = data.get("prompt_id", None)
+        prompt_version = data.get("prompt_version", None)
 
         ## PROMPT TEMPLATE CHECK ##
         if (
@@ -901,12 +902,20 @@ class ProxyLogging:
             and prompt_id is not None
             and (call_type == "completion" or call_type == "acompletion")
         ):
+            from litellm.proxy.prompts.prompt_endpoints import (
+                construct_versioned_prompt_id,
+            )
             from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
 
-            custom_logger = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id(
-                prompt_id
+            # Construct versioned prompt_id if prompt_version is provided
+            lookup_prompt_id = construct_versioned_prompt_id(
+                prompt_id=prompt_id, version=prompt_version
             )
-            prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(prompt_id)
+
+            custom_logger = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id(
+                lookup_prompt_id
+            )
+            prompt_spec = IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id(lookup_prompt_id)
             litellm_prompt_id: Optional[str] = None
             if prompt_spec is not None:
                 litellm_prompt_id = prompt_spec.litellm_params.prompt_id

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
@@ -104,6 +104,87 @@ class TestPromptVersioning:
         assert get_base_prompt_id(prompt_id="jack") == "jack"
         assert get_base_prompt_id(prompt_id="my_prompt.v10") == "my_prompt"
 
+    def test_get_latest_version_prompt_id(self):
+        """
+        Test that get_latest_version_prompt_id returns the highest version
+        """
+        from litellm.proxy.prompts.prompt_endpoints import get_latest_version_prompt_id
+
+        # Mock prompt IDs dictionary
+        all_prompt_ids = {
+            "jack.v1": {},
+            "jack.v2": {},
+            "jack.v3": {},
+            "jane.v1": {},
+            "simple_prompt": {},
+        }
+
+        # Test with base prompt ID - should return latest version
+        assert get_latest_version_prompt_id(
+            prompt_id="jack",
+            all_prompt_ids=all_prompt_ids
+        ) == "jack.v3"
+
+        # Test with versioned prompt ID - should still return latest version
+        assert get_latest_version_prompt_id(
+            prompt_id="jack.v1",
+            all_prompt_ids=all_prompt_ids
+        ) == "jack.v3"
+
+        # Test with single version
+        assert get_latest_version_prompt_id(
+            prompt_id="jane",
+            all_prompt_ids=all_prompt_ids
+        ) == "jane.v1"
+
+        # Test with non-versioned prompt
+        assert get_latest_version_prompt_id(
+            prompt_id="simple_prompt",
+            all_prompt_ids=all_prompt_ids
+        ) == "simple_prompt"
+
+        # Test with non-existent prompt
+        assert get_latest_version_prompt_id(
+            prompt_id="nonexistent",
+            all_prompt_ids=all_prompt_ids
+        ) == "nonexistent"
+
+    def test_construct_versioned_prompt_id(self):
+        """
+        Test that construct_versioned_prompt_id correctly builds versioned IDs
+        """
+        from litellm.proxy.prompts.prompt_endpoints import construct_versioned_prompt_id
+
+        # Test with base prompt ID and version
+        assert construct_versioned_prompt_id(
+            prompt_id="jack_success",
+            version=4
+        ) == "jack_success.v4"
+
+        # Test with None version - should return base ID unchanged
+        assert construct_versioned_prompt_id(
+            prompt_id="jack_success",
+            version=None
+        ) == "jack_success"
+
+        # Test with existing versioned ID - should replace version
+        assert construct_versioned_prompt_id(
+            prompt_id="jack_success.v2",
+            version=4
+        ) == "jack_success.v4"
+
+        # Test with hyphenated prompt ID
+        assert construct_versioned_prompt_id(
+            prompt_id="my-prompt",
+            version=1
+        ) == "my-prompt.v1"
+
+        # Test with double-digit version
+        assert construct_versioned_prompt_id(
+            prompt_id="test_prompt",
+            version=10
+        ) == "test_prompt.v10"
+
 
 class TestPromptVersionsEndpoint:
     """

--- a/ui/litellm-dashboard/src/components/prompts/prompt_utils.tsx
+++ b/ui/litellm-dashboard/src/components/prompts/prompt_utils.tsx
@@ -1,0 +1,56 @@
+import { PromptSpec } from "@/components/networking";
+
+interface ModelGroupInfo {
+  model_group: string;
+  providers: string[];
+  [key: string]: any;
+}
+
+/**
+ * Extract model from prompt litellm_params
+ */
+export const extractModel = (prompt: PromptSpec): string | null => {
+  try {
+    const params = prompt.litellm_params as any;
+    
+    // Try to extract from dotprompt_content
+    if (params?.dotprompt_content) {
+      const match = params.dotprompt_content.match(/model:\s*([^\n]+)/);
+      if (match) return match[1].trim();
+    }
+    
+    // Try to extract from prompt_data
+    if (params?.prompt_data?.model) {
+      return params.prompt_data.model;
+    }
+    
+    // Try to extract model from litellm_params directly
+    if (params?.model) {
+      return params.model;
+    }
+    
+    return null;
+  } catch (error) {
+    console.error("Error extracting model:", error);
+    return null;
+  }
+};
+
+/**
+ * Get provider from model hub data
+ */
+export const getProviderFromModelHub = (
+  modelName: string | null,
+  modelHubData: Map<string, ModelGroupInfo>
+): string | null => {
+  if (!modelName) return null;
+  
+  const modelInfo = modelHubData.get(modelName);
+  if (modelInfo && modelInfo.providers && modelInfo.providers.length > 0) {
+    // Return the first provider from the list
+    return modelInfo.providers[0];
+  }
+  
+  return null;
+};
+


### PR DESCRIPTION
## [Fix] Prompt Management - UI, allow seeing model, prompt id for Prompt

- show prompt_id and model associated with prompt 

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


