### PR TITLE
feat: Add support for Gemini 3 Pro Image model

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11367,6 +11367,39 @@
         "supports_web_search": true,
         "tpm": 8000000
     },
+    "gemini-3-pro-image-preview": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 65536,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true
+    },
     "gemini-2.5-flash-lite": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
@@ -13070,6 +13103,39 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 8000000
+    },
+    "gemini/gemini-3-pro-image-preview": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 65536,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-lite": {
         "cache_read_input_token_cost": 2.5e-08,
@@ -24542,6 +24608,20 @@
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-generation#edit-an-image"
+    },
+    "vertex_ai/gemini-3-pro-image-preview": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 65536,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
     },
     "vertex_ai/imagegeneration@006": {
         "litellm_provider": "vertex_ai-image-models",


### PR DESCRIPTION
## Title

  Add support for Gemini 3 Pro Image model (Nano Banana Pro 🍌)

## Relevant issues

  Fixes #16925

## Pre-Submission checklist

  Please complete all items before asking a LiteLLM maintainer to review your PR

  - I have Added testing in the https://github.com/BerriAI/litellm/tree/main/tests/litellm directory, Adding at least 1 test is a hard requirement - 
  https://docs.litellm.ai/docs/extras/contributing_code
  - I have added a screenshot of my new test passing locally
  - My PR passes all unit tests on https://docs.litellm.ai/docs/extras/contributing_code
  - My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

  🆕 New Feature

## Changes

  Added support for Google's new Gemini 3 Pro Image model (gemini-3-pro-image-preview), also known as "Nano Banana Pro 🍌". This is Google's latest state-of-the-art image generation model released on November 20, 2025.

## Model Configuration

  Added three model variants to model_prices_and_context_window.json:

  1. gemini-3-pro-image-preview - Base model (uses Vertex AI provider)
  2. gemini/gemini-3-pro-image-preview - Gemini API variant
  3. vertex_ai/gemini-3-pro-image-preview - Vertex AI variant

##  Pricing (verified from official docs)

  - Input: $2.00 per 1M tokens (text), $0.0011 per image
  - Output: $12.00 per 1M tokens (text), $0.134 per image (1K/2K resolution), $0.24 per image (4K resolution)
  - Batch API: 50% discount on standard pricing
  - Context window: 65,536 input tokens / 32,768 output tokens

 ## Model Capabilities

  - ✅ Image generation (mode: image_generation)
  - ✅ Structured outputs (supports_response_schema)
  - ✅ Web search grounding (supports_web_search)
  - ✅ Prompt caching (supports_prompt_caching)
  - ✅ Thinking/reasoning
  - ❌ Function calling

##  Sources

  - Pricing: https://ai.google.dev/gemini-api/docs/pricing
  - Model docs: https://ai.google.dev/gemini-api/docs/models/gemini
  - Vertex AI docs: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image

##  Testing

  Verified model registration and API routing works correctly for all three variants. Model is in paid preview and requires appropriate API keys/credentials to use.
