### PR TITLE
fix: Cerebras GPT-OSS-120B model name

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5906,7 +5906,7 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
-    "cerebras/openai/gpt-oss-120b": {
+    "cerebras/gpt-oss-120b": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 131072,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5906,7 +5906,7 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
-    "cerebras/openai/gpt-oss-120b": {
+    "cerebras/gpt-oss-120b": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 131072,


### PR DESCRIPTION
 ## Title

  Fix Cerebras GPT-OSS-120B model name

  ## Relevant issues

  Fixes #16924

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


  ## Type

  🐛 Bug Fix

  ## Changes

  Changed model identifier from `cerebras/openai/gpt-oss-120b` to `cerebras/gpt-oss-120b` in both pricing JSON files.

  ### Summary
  The model was incorrectly listed as `cerebras/openai/gpt-oss-120b`, but the Cerebras API only accepts `gpt-oss-120b` as the model ID.

  ### Solution
  - Updated `model_prices_and_context_window.json`
  - Updated `litellm/model_prices_and_context_window_backup.json`

  According to [Cerebras documentation](https://inference-docs.cerebras.ai/models/overview), the official model ID is `gpt-oss-120b`.