### PR TITLE
[Feature] Allow partial matches for user ID in User Table

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1462,13 +1462,19 @@ async def get_users(
     where_conditions: Dict[str, Any] = {}
 
     if role:
-        where_conditions["user_role"] = role  # Exact match instead of contains
+        where_conditions["user_role"] = role
 
     if user_ids and isinstance(user_ids, str):
         user_id_list = [uid.strip() for uid in user_ids.split(",") if uid.strip()]
-        where_conditions["user_id"] = {
-            "in": user_id_list,
-        }
+        if len(user_id_list) == 1:
+            where_conditions["user_id"] = {
+                "contains": user_id_list[0],
+                "mode": "insensitive",
+            }
+        else:
+            where_conditions["user_id"] = {
+                "in": user_id_list,
+            }
 
     if user_email is not None and isinstance(user_email, str):
         where_conditions["user_email"] = {


### PR DESCRIPTION
## [Feature] Allow partial matches for user ID in User Table

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The user table in the Internal User page has an input that allows for partial matches for the user's email, but there is an input for the user ID and that does not accept partial matches. To keep everything consistent, I am implementing partial match support in that input.

The input calls /user/list to filter the users on the table

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="1255" height="436" alt="image" src="https://github.com/user-attachments/assets/25f4ad98-4141-4685-a04d-ad712a98f238" />
<img width="678" height="170" alt="image" src="https://github.com/user-attachments/assets/eb818c2e-31b0-4889-bb0f-e528c73b67c0" />


