### PR TITLE
Remove cost tracking disabled tooltip in chat ui

### DIFF
--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ResponseMetrics.tsx
@@ -85,13 +85,7 @@ const ResponseMetrics: React.FC<ResponseMetricsProps> = ({ timeToFirstToken, tot
       )}
 
       {usage && (
-        <Tooltip
-          title={
-            usage.cost !== undefined
-              ? "Cost"
-              : "Cost tracking is disabled. Set include_cost_in_streaming_usage: true in your proxy config to enable cost tracking."
-          }
-        >
+        <Tooltip title="Cost">
           <div className="flex items-center">
             <DollarOutlined className="mr-1" />
             <span>{usage.cost !== undefined ? `$${usage.cost.toFixed(6)}` : "Not Tracked"}</span>

--- a/ui/litellm-dashboard/src/components/playground/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/playground/chat_ui/ResponseMetrics.tsx
@@ -84,11 +84,11 @@ const ResponseMetrics: React.FC<ResponseMetricsProps> = ({ timeToFirstToken, tot
         </Tooltip>
       )}
 
-      {usage && (
+      {usage?.cost !== undefined && (
         <Tooltip title="Cost">
           <div className="flex items-center">
             <DollarOutlined className="mr-1" />
-            <span>{usage.cost !== undefined ? `$${usage.cost.toFixed(6)}` : "Not Tracked"}</span>
+            <span>${usage.cost.toFixed(6)}</span>
           </div>
         </Tooltip>
       )}


### PR DESCRIPTION
## Title

Remove misleading cost tracking tooltip in chat UI

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

Simplified the tooltip for the cost metric in the chat UI (`ResponseMetrics.tsx`) to always display "Cost".

The previous tooltip incorrectly suggested that cost tracking was disabled when the cost was simply not included in the streaming response. Cost is tracked internally, but not always returned in the response object. This change prevents misleading users about the actual cost tracking behavior.

---
[Slack Thread](https://berriaillm.slack.com/archives/C09JWQ7PZ29/p1763773857029149?thread_ts=1763773857.029149&cid=C09JWQ7PZ29)

<a href="https://cursor.com/background-agent?bcId=bc-7f90db5d-3dff-44f0-afb5-4ca23745b5c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f90db5d-3dff-44f0-afb5-4ca23745b5c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies cost display in chat response metrics: show only when defined, always titled "Cost", and format to 6 decimals.
> 
> - **Frontend (chat UI)**:
>   - **Response metrics (`ui/litellm-dashboard/src/components/playground/chat_ui/ResponseMetrics.tsx`)**:
>     - Show `usage.cost` only when defined and always render tooltip title as "Cost".
>     - Remove conditional tooltip message and "Not Tracked" state.
>     - Display cost as `$<value.toFixed(6)>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 562bbcef87a9948a05ba9dd2224504d55fbda2ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->