### PR TITLE
fix: cache SSL contexts to prevent excessive memory allocation

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -87,6 +87,60 @@ def _prepare_request_data_and_content(
     return request_data, request_content
 
 
+# Cache for SSL contexts to avoid creating duplicate contexts with the same configuration
+# Key: tuple of (cafile, ssl_security_level, ssl_ecdh_curve)
+# Value: ssl.SSLContext
+_ssl_context_cache: Dict[Tuple[Optional[str], Optional[str], Optional[str]], ssl.SSLContext] = {}
+
+
+def _create_ssl_context(
+    cafile: Optional[str],
+    ssl_security_level: Optional[str],
+    ssl_ecdh_curve: Optional[str],
+) -> ssl.SSLContext:
+    """
+    Create an SSL context with the given configuration.
+    This is separated from get_ssl_configuration to enable caching.
+    """
+    custom_ssl_context = ssl.create_default_context(cafile=cafile)
+
+    # Optimize SSL handshake performance
+    # Set minimum TLS version to 1.2 for better performance
+    custom_ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+
+    # Configure cipher suites for optimal performance
+    if ssl_security_level and isinstance(ssl_security_level, str):
+        # User provided custom cipher configuration (e.g., via SSL_SECURITY_LEVEL env var)
+        custom_ssl_context.set_ciphers(ssl_security_level)
+    else:
+        # Use optimized cipher list that strongly prefers fast ciphers
+        # but falls back to widely compatible ones
+        custom_ssl_context.set_ciphers(DEFAULT_SSL_CIPHERS)
+
+    # Configure ECDH curve for key exchange (e.g., to disable PQC and improve performance)
+    # Set SSL_ECDH_CURVE env var or litellm.ssl_ecdh_curve to 'X25519' to disable PQC
+    # Common valid curves: X25519, prime256v1, secp384r1, secp521r1
+    if ssl_ecdh_curve and isinstance(ssl_ecdh_curve, str):
+        try:
+            custom_ssl_context.set_ecdh_curve(ssl_ecdh_curve)
+            verbose_logger.debug(f"SSL ECDH curve set to: {ssl_ecdh_curve}")
+        except AttributeError:
+            verbose_logger.warning(
+                f"SSL ECDH curve configuration not supported. "
+                f"Python version: {sys.version.split()[0]}, OpenSSL version: {ssl.OPENSSL_VERSION}. "
+                f"Requested curve: {ssl_ecdh_curve}. Continuing with default curves."
+            )
+        except ValueError as e:
+            # Invalid curve name
+            verbose_logger.warning(
+                f"Invalid SSL ECDH curve name: '{ssl_ecdh_curve}'. {e}. "
+                f"Common valid curves: X25519, prime256v1, secp384r1, secp521r1. "
+                f"Continuing with default curves (including PQC)."
+            )
+
+    return custom_ssl_context
+
+
 def get_ssl_configuration(
     ssl_verify: Optional[VerifyTypes] = None,
 ) -> Union[bool, str, ssl.SSLContext]:
@@ -101,6 +155,9 @@ def get_ssl_configuration(
     5. Else will use default SSL context with certifi CA bundle
 
     If ssl_security_level is set, it will apply the security level to the SSL context.
+
+    SSL contexts are cached to avoid creating duplicate contexts with the same configuration,
+    which reduces memory allocation and improves performance.
 
     Args:
         ssl_verify: SSL verification setting. Can be:
@@ -128,6 +185,7 @@ def get_ssl_configuration(
             ssl_verify = ssl_verify_bool
 
     ssl_security_level = os.getenv("SSL_SECURITY_LEVEL", litellm.ssl_security_level)
+    ssl_ecdh_curve = os.getenv("SSL_ECDH_CURVE", litellm.ssl_ecdh_curve)
 
     cafile = None
     if isinstance(ssl_verify, str) and os.path.exists(ssl_verify):
@@ -140,45 +198,19 @@ def get_ssl_configuration(
             cafile = certifi.where()
 
     if ssl_verify is not False:
-        custom_ssl_context = ssl.create_default_context(cafile=cafile)
-
-        # Optimize SSL handshake performance
-        # Set minimum TLS version to 1.2 for better performance
-        custom_ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-
-        # Configure cipher suites for optimal performance
-        if ssl_security_level and isinstance(ssl_security_level, str):
-            # User provided custom cipher configuration (e.g., via SSL_SECURITY_LEVEL env var)
-            custom_ssl_context.set_ciphers(ssl_security_level)
-        else:
-            # Use optimized cipher list that strongly prefers fast ciphers
-            # but falls back to widely compatible ones
-            custom_ssl_context.set_ciphers(DEFAULT_SSL_CIPHERS)
-
-        # Configure ECDH curve for key exchange (e.g., to disable PQC and improve performance)
-        # Set SSL_ECDH_CURVE env var or litellm.ssl_ecdh_curve to 'X25519' to disable PQC
-        # Common valid curves: X25519, prime256v1, secp384r1, secp521r1
-        ssl_ecdh_curve = os.getenv("SSL_ECDH_CURVE", litellm.ssl_ecdh_curve)
-        if ssl_ecdh_curve and isinstance(ssl_ecdh_curve, str):
-            try:
-                custom_ssl_context.set_ecdh_curve(ssl_ecdh_curve)
-                verbose_logger.debug(f"SSL ECDH curve set to: {ssl_ecdh_curve}")
-            except AttributeError:
-                verbose_logger.warning(
-                    f"SSL ECDH curve configuration not supported. "
-                    f"Python version: {sys.version.split()[0]}, OpenSSL version: {ssl.OPENSSL_VERSION}. "
-                    f"Requested curve: {ssl_ecdh_curve}. Continuing with default curves."
-                )
-            except ValueError as e:
-                # Invalid curve name
-                verbose_logger.warning(
-                    f"Invalid SSL ECDH curve name: '{ssl_ecdh_curve}'. {e}. "
-                    f"Common valid curves: X25519, prime256v1, secp384r1, secp521r1. "
-                    f"Continuing with default curves (including PQC)."
-                )
-
-        # Use our custom SSL context instead of the original ssl_verify value
-        return custom_ssl_context
+        # Create cache key from configuration parameters
+        cache_key = (cafile, ssl_security_level, ssl_ecdh_curve)
+        
+        # Check if we have a cached SSL context for this configuration
+        if cache_key not in _ssl_context_cache:
+            _ssl_context_cache[cache_key] = _create_ssl_context(
+                cafile=cafile,
+                ssl_security_level=ssl_security_level,
+                ssl_ecdh_curve=ssl_ecdh_curve,
+            )
+        
+        # Return the cached SSL context
+        return _ssl_context_cache[cache_key]
 
     return ssl_verify
 


### PR DESCRIPTION
## Title

fix: cache SSL contexts to prevent excessive memory allocation

## Relevant issues

Fixes #16177

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

⚡️Performance Improvement

## Changes

Previously, get_ssl_configuration() created a new SSL context on every call, even when the configuration was identical. This caused continuous memory allocation from ssl.create_default_context(), especially during:
- Proxy server startup
- Background health checks
- HTTP client creation

Solution:
- Added _ssl_context_cache to cache SSL contexts by configuration parameters (cafile, ssl_security_level, ssl_ecdh_curve)
- Refactored SSL context creation into _create_ssl_context() helper
- Modified get_ssl_configuration() to reuse cached contexts when configuration matches

Fixes memory allocation issue where create_default_context was allocating 6.282MB+ continuously even without any requests.

## Performance Gains

> observe create_default_context

**Before**

<img width="1372" height="516" alt="Screenshot 2025-11-21 at 5 30 35 PM" src="https://github.com/user-attachments/assets/cc54a2a5-dbd2-4c0b-ae55-52ab5daab9f8" />


**After**

<img width="1349" height="499" alt="Screenshot 2025-11-21 at 5 34 00 PM" src="https://github.com/user-attachments/assets/4d94a5b0-cfd3-4aca-8d13-3be4eaadd39c" />

## Test Results

<img width="1389" height="231" alt="Screenshot 2025-11-21 at 5 48 15 PM" src="https://github.com/user-attachments/assets/d4a710e0-9288-494b-864b-ba7566efb820" />

- Failures seem unrelated.
