### PR TITLE
feat(bedrock): Add Claude 4.5 to US Gov Cloud

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5573,6 +5573,20 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock/us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5573,6 +5573,20 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock/us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5714,6 +5714,20 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock/us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": {
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock/us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",

--- a/tests/llm_translation/test_bedrock_govcloud.py
+++ b/tests/llm_translation/test_bedrock_govcloud.py
@@ -45,6 +45,8 @@ class TestBedrockGovCloudSupport:
         assert "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0" in model_cost
         assert "bedrock/us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0" in model_cost
         assert "bedrock/us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0" in model_cost
+        assert "bedrock/us-gov-east-1/claude-sonnet-4-5-20250929-v1:0" in model_cost
+        assert "bedrock/us-gov-west-1/claude-sonnet-4-5-20250929-v1:0" in model_cost
         
         # Test Llama models in GovCloud
         assert "bedrock/us-gov-east-1/meta.llama3-8b-instruct-v1:0" in model_cost


### PR DESCRIPTION
## feat(bedrock): Add Claude 4.5 for US Gov Cloud

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->
AWS GovCloud now supports Claude 4.5. The issue is since this is not in the cost map, there are failing api calls to set this model.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


