### PR TITLE
feat: mcp tool param regex guardrail

### DIFF
--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -7,11 +7,13 @@ from litellm.proxy._types import MCPAuthType, MCPTransportType
 # MCPInfo now allows arbitrary additional fields for custom metadata
 MCPInfo = Dict[str, Any]
 
+
 class MCPOAuthMetadata(BaseModel):
     scopes: Optional[List[str]] = None
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+
 
 class MCPServer(BaseModel):
     server_id: str
@@ -32,6 +34,9 @@ class MCPServer(BaseModel):
     allowed_params: Optional[
         Dict[str, List[str]]
     ] = None  # map of tool names to allowed parameter lists
+    allowed_param_patterns: Optional[
+        Dict[str, Dict[str, str]]
+    ] = None  # map of tool names to nested param regex patterns
     static_headers: Optional[
         Dict[str, str]
     ] = None  # static headers to forward to the MCP server


### PR DESCRIPTION
## Title

mcp tool param regex guardrail

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

This PR adds support for `allowed_param_patterns` on MCP servers.
When `allowed_param_patterns` is configured, LiteLLM validates MCP tool arguments against the configured regular expressions before forwarding the request to the MCP server.

If any argument does not match the allowed pattern, LiteLLM returns an error and does not call the MCP server.

Example configuration:
```
mcp_servers:
  deepwiki3:
    url: "https://mcp.deepwiki.com/mcp"
    allowed_tools: ["read_wiki_structure"]
  structured_echo:
    url: "http://localhost:3001/mcp"
    allowed_param_patterns:
      structured_echo:
        payload.user.tags[]: "^.+@berri\\.ai$"
        payload.context.extra.score: "^([1-9]|10)$"
```

<img width="1306" height="533" alt="スクリーンショット 2025-11-22 14 07 07" src="https://github.com/user-attachments/assets/65b59d5f-5b94-4f3c-a0eb-9eb13fd7132f" />

