### PR TITLE
feat: configurable exclude_none and exclude_unset fields for chat completion response

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -94,6 +94,8 @@ callback_settings:
 
 general_settings:
   completion_model: string
+  completion_exclude_none: boolean  # if false, includes None values in chat completion responses (default: true)
+  completion_exclude_unset: boolean  # if false, includes unset fields in chat completion responses (default: true)
   store_prompts_in_spend_logs: boolean
   forward_client_headers_to_llm_api: boolean
   disable_spend_logs: boolean  # turn off writing each transaction to the db
@@ -192,6 +194,8 @@ router_settings:
 | Name | Type | Description |
 |------|------|-------------|
 | completion_model | string | The default model to use for completions when `model` is not specified in the request |
+| completion_exclude_none | boolean | If false, includes fields with `None` values in chat completion responses. If true (default), excludes `None` values. Useful for OpenAI SDK strict compatibility or debugging when you need to see all response fields including null values. |
+| completion_exclude_unset | boolean | If false, includes all fields (even unset ones) in chat completion responses. If true (default), excludes unset fields. Set to false along with `completion_exclude_none: false` for full field visibility in responses. |
 | disable_spend_logs | boolean | If true, turns off writing each transaction to the database |
 | disable_spend_updates | boolean | If true, turns off all spend updates to the DB. Including key/user/team spend updates. |
 | disable_master_key_return | boolean | If true, turns off returning master key on UI. (checked on '/user/info' endpoint) |

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4798,7 +4798,18 @@ async def chat_completion(  # noqa: PLR0915
             version=version,
         )
         if isinstance(result, BaseModel):
-            return result.model_dump(exclude_none=True, exclude_unset=True)
+            # Check general_settings for response filtering configuration
+            # Default to True for backward compatibility
+            exclude_none_from_response = general_settings.get(
+                "completion_exclude_none", True
+            )
+            exclude_unset_from_response = general_settings.get(
+                "completion_exclude_unset", True
+            )
+            return result.model_dump(
+                exclude_none=exclude_none_from_response,
+                exclude_unset=exclude_unset_from_response,
+            )
         else:
             return result
     except RejectedRequestError as e:

--- a/tests/proxy_unit_tests/test_chat_completion_response_config.py
+++ b/tests/proxy_unit_tests/test_chat_completion_response_config.py
@@ -1,0 +1,98 @@
+"""
+Test chat completion response configuration for exclude_none and exclude_unset settings.
+"""
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from fastapi import Request, Response
+from pydantic import BaseModel
+from typing import Optional
+
+
+class MockModelResponse(BaseModel):
+    """Mock response model for testing"""
+    id: str
+    content: str
+    optional_field: Optional[str] = None
+    
+
+@pytest.mark.asyncio
+async def test_chat_completion_exclude_none_true():
+    """Test that None fields are excluded when completion_exclude_none is True"""
+    from litellm.proxy.proxy_server import general_settings
+    
+    # Mock general_settings
+    general_settings["completion_exclude_none"] = True
+    general_settings["completion_exclude_unset"] = True
+    
+    # Create a mock response
+    mock_response = MockModelResponse(id="test-1", content="Hello", optional_field=None)
+    
+    # The model_dump should exclude None values
+    result = mock_response.model_dump(exclude_none=True, exclude_unset=True)
+    
+    assert "id" in result
+    assert "content" in result
+    assert "optional_field" not in result  # Should be excluded because it's None
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_exclude_none_false():
+    """Test that None fields are included when completion_exclude_none is False"""
+    from litellm.proxy.proxy_server import general_settings
+    
+    # Mock general_settings
+    general_settings["completion_exclude_none"] = False
+    general_settings["completion_exclude_unset"] = False
+    
+    # Create a mock response
+    mock_response = MockModelResponse(id="test-1", content="Hello", optional_field=None)
+    
+    # The model_dump should include None values
+    result = mock_response.model_dump(exclude_none=False, exclude_unset=False)
+    
+    assert "id" in result
+    assert "content" in result
+    assert "optional_field" in result  # Should be included even though it's None
+    assert result["optional_field"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_default_behavior():
+    """Test that default behavior maintains backward compatibility (exclude_none=True, exclude_unset=True)"""
+    from litellm.proxy.proxy_server import general_settings
+    
+    # Clear these settings to test default behavior
+    general_settings.pop("completion_exclude_none", None)
+    general_settings.pop("completion_exclude_unset", None)
+    
+    # The default should be True for both settings
+    exclude_none_from_response = general_settings.get("completion_exclude_none", True)
+    exclude_unset_from_response = general_settings.get("completion_exclude_unset", True)
+    
+    assert exclude_none_from_response is True
+    assert exclude_unset_from_response is True
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_mixed_configuration():
+    """Test mixed configuration (exclude_none=False, exclude_unset=True)"""
+    from litellm.proxy.proxy_server import general_settings
+    
+    # Mock general_settings with mixed configuration
+    general_settings["completion_exclude_none"] = False
+    general_settings["completion_exclude_unset"] = True
+    
+    # Create a mock response
+    mock_response = MockModelResponse(id="test-1", content="Hello", optional_field=None)
+    
+    # The model_dump should include None values but exclude unset fields
+    result = mock_response.model_dump(exclude_none=False, exclude_unset=True)
+    
+    assert "id" in result
+    assert "content" in result
+    assert "optional_field" in result  # Should be included even though it's None
+    assert result["optional_field"] is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Title

This change introduces configurable control over how `None` and unset fields are handled in chat completion responses, addressing the need for flexibility in response formatting while maintaining backward compatibility.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

**Before**:
```python
if isinstance(result, BaseModel):
    return result.model_dump(exclude_none=True, exclude_unset=True)
```

**After**:
```python
if isinstance(result, BaseModel):
    # Check general_settings for response filtering configuration
    # Default to True for backward compatibility
    exclude_none_from_response = general_settings.get(
        "completion_exclude_none", True
    )
    exclude_unset_from_response = general_settings.get(
        "completion_exclude_unset", True
    )
    return result.model_dump(
        exclude_none=exclude_none_from_response,
        exclude_unset=exclude_unset_from_response,
    )
```
<img width="546" height="103" alt="image" src="https://github.com/user-attachments/assets/d185b822-b5dd-4fa3-a82f-c95918232ca4" />
