### PR TITLE
docs: Add mini-swe-agent to Projects built on LiteLLM

### DIFF
--- a/docs/my-website/docs/projects/mini-swe-agent.md
+++ b/docs/my-website/docs/projects/mini-swe-agent.md
@@ -1,0 +1,17 @@
+# mini-swe-agent
+
+**mini-swe-agent** The 100 line AI agent that solves GitHub issues & more.
+
+Key features:
+- Just 100 lines of Python - radically simple and hackable
+- Uses bash only (no custom tools) for maximum flexibility
+- Built on LiteLLM for model flexibility
+- Comes with CLI and Python bindings
+- Deployable anywhere: local, docker, podman, singularity
+
+Perfect for researchers, developers who want readable tools, and engineers who need easy deployment.
+
+- [Website](https://mini-swe-agent.com/latest/)
+- [GitHub](https://github.com/SWE-agent/mini-swe-agent)
+- [Quick Start](https://mini-swe-agent.com/latest/quickstart/)
+- [Documentation](https://mini-swe-agent.com/latest/)

--- a/docs/my-website/docs/projects/mini-swe-agent.md
+++ b/docs/my-website/docs/projects/mini-swe-agent.md
@@ -7,7 +7,7 @@ Key features:
 - Uses bash only (no custom tools) for maximum flexibility
 - Built on LiteLLM for model flexibility
 - Comes with CLI and Python bindings
-- Deployable anywhere: local, docker, podman, singularity
+- Deployable anywhere: local, docker, podman, apptainer
 
 Perfect for researchers, developers who want readable tools, and engineers who need easy deployment.
 

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -789,6 +789,7 @@ const sidebars = {
           },
           items: [
             "projects/smolagents",
+            "projects/mini-swe-agent",
             "projects/Docq.AI",
             "projects/PDL",
             "projects/OpenInterpreter",


### PR DESCRIPTION
  ## Title

docs: Add mini-swe-agent to Projects built on LiteLLM

  ## Relevant issues

  N/A - Documentation improvement

  ## Pre-Submission checklist

  - [ ] My PR's scope is as isolated as possible, it only solves 1 specific
  problem
  - [N/A] Tests not required for documentation changes
  - [N/A] Screenshot not required for documentation changes
  - [N/A] Unit tests not required for documentation changes

  ## Type

  📖 Documentation

  ## Summary

  Added mini-swe-agent to the "Projects built on LiteLLM" section in the
  documentation.

  **Changes made:**
  - Created `docs/my-website/docs/projects/mini-swe-agent.md` with project description and links
  - Updated `docs/my-website/sidebars.js` to include mini-swe-agent in the projects list