### PR TITLE
fix: add missing mock attributes in websocket and realtime tests

### DIFF
--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -827,6 +827,10 @@ async def test_user_api_key_auth_websocket():
     mock_websocket = MagicMock(spec=WebSocket)
     mock_websocket.query_params = {"model": "some_model"}
     mock_websocket.headers = {"authorization": "Bearer some_api_key"}
+    # Mock the scope attribute that user_api_key_auth_websocket accesses
+    mock_websocket.scope = {"headers": [(b"authorization", b"Bearer some_api_key")]}
+    # Mock the url attribute
+    mock_websocket.url = URL(url="/ws")
 
     # Mock the return value of `user_api_key_auth` when it's called within the `user_api_key_auth_websocket` function
     with patch(

--- a/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
+++ b/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
@@ -168,6 +168,7 @@ async def test_async_realtime_url_contains_model():
         async def __aexit__(self, exc_type, exc, tb):
             return None
 
+    shared_context = get_shared_realtime_ssl_context()
     with patch("websockets.connect", return_value=DummyAsyncContextManager(mock_backend_ws)) as mock_ws_connect, \
          patch("litellm.llms.openai.realtime.handler.RealTimeStreaming") as mock_realtime_streaming:
         


### PR DESCRIPTION
## Title

fix: add missing mock attributes in websocket and realtime tests

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

- Add scope and url attributes to WebSocket mock in test_user_api_key_auth_websocket
- Add shared_realtime_ssl_context initialization in realtime handler test

## Test Results
<img width="1422" height="424" alt="Screenshot 2025-11-22 at 10 31 03 AM" src="https://github.com/user-attachments/assets/88c403cf-2d0c-443c-a511-26d089f839a2" />


<img width="1415" height="350" alt="Screenshot 2025-11-22 at 10 29 39 AM" src="https://github.com/user-attachments/assets/99779247-76a7-46ac-987e-485555cb5ef8" />

