### PR TITLE
[Fix]: (Vertex AI) handle global location in context caching

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -64,11 +64,17 @@ class ContextCachingEndpoints(VertexBase):
         elif custom_llm_provider == "vertex_ai":
             auth_header = vertex_auth_header
             endpoint = "cachedContents"
-            url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            if vertex_location == "global":
+                url = f"https://aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            else:
+                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
         else:
             auth_header = vertex_auth_header
             endpoint = "cachedContents"
-            url = f"https://{vertex_location}-aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            if vertex_location == "global":
+                url = f"https://aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
+            else:
+                url = f"https://{vertex_location}-aiplatform.googleapis.com/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
 
 
         return self._check_custom_proxy(


### PR DESCRIPTION
## Title

[Fix]: (Vertex AI) handle global location in context caching

<!-- e.g. "Implement user authentication feature" -->

## Relevant Issues

Fixes #16995 

Past issues related to global endpoint in vertex-ai #11190, #9234

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Fixes context caching (cachedContents API) to work with `vertex_location: "global"` by handling global location separately in URL construction.

## Problem

When using `vertex_location: "global"` with context caching, LiteLLM generates an incorrect URL:
- **Current (buggy)**: `https://global-aiplatform.googleapis.com/v1/...` → 404 Not Found
- **Fixed**: `https://aiplatform.googleapis.com/v1/...` → Works correctly

Regular completion calls already handle "global" correctly - this PR brings context caching in line with that behavior.

## Changes

**Modified**: `litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py`

- Added conditional check for `vertex_location == "global"`
- Global location: Uses `https://aiplatform.googleapis.com` (no location prefix)
- Regional locations: Uses `https://{location}-aiplatform.googleapis.com` (with prefix)
- Applied fix to both `vertex_ai` (v1) and `vertex_ai_beta` (v1beta1) branches

**Added**: `tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py:TestVertexAIGlobalLocation`

- Test global location URL construction (v1)
- Test regional location URL construction (v1)
- Test global location URL construction (v1beta1)
- All tests pass ✅

## Testing

```bash
# New tests added
pytest tests/test_litellm/llms/vertex_ai/test_context_caching_global.py -v
✅ All tests pass
```

<img width="2060" height="913" alt="image" src="https://github.com/user-attachments/assets/a506f3b0-8089-477f-b397-5302cbcc935b" />