### PR TITLE
fix: Update broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
         <p align="center">Call all LLM APIs using the OpenAI format [Bedrock, Huggingface, VertexAI, TogetherAI, Azure, OpenAI, Groq etc.]
         <br>
     </p>
-<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (LLM Gateway)</a> | <a href="https://docs.litellm.ai/docs/hosted" target="_blank"> Hosted Proxy (Preview)</a> | <a href="https://docs.litellm.ai/docs/enterprise"target="_blank">Enterprise Tier</a></h4>
+<h4 align="center"><a href="https://docs.litellm.ai/docs/simple_proxy" target="_blank">LiteLLM Proxy Server (LLM Gateway)</a> | <a href="https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy" target="_blank"> Hosted Proxy</a> | <a href="https://docs.litellm.ai/docs/enterprise"target="_blank">Enterprise Tier</a></h4>
 <h4 align="center">
     <a href="https://pypi.org/project/litellm/" target="_blank">
         <img src="https://img.shields.io/pypi/v/litellm.svg" alt="PyPI Version">
@@ -40,7 +40,7 @@ LiteLLM manages:
 LiteLLM Performance: **8ms P95 latency** at 1k RPS (See benchmarks [here](https://docs.litellm.ai/docs/benchmarks))
 
 [**Jump to LiteLLM Proxy (LLM Gateway) Docs**](https://github.com/BerriAI/litellm?tab=readme-ov-file#litellm-proxy-server-llm-gateway---docs) <br>
-[**Jump to Supported LLM Providers**](https://github.com/BerriAI/litellm?tab=readme-ov-file#supported-providers-docs)
+[**Jump to Supported LLM Providers**](https://docs.litellm.ai/docs/providers)
 
 🚨 **Stable Release:** Use docker images with the `-stable` tag. These have undergone 12 hour load tests, before being published. [More information about the release cycle here](https://docs.litellm.ai/docs/proxy/release_cycle)
 
@@ -210,7 +210,7 @@ response = completion(model="openai/gpt-4o", messages=[{"role": "user", "content
 
 Track spend + Load Balance across multiple projects
 
-[Hosted Proxy (Preview)](https://docs.litellm.ai/docs/hosted)
+[Hosted Proxy](https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy)
 
 The proxy provides:
 


### PR DESCRIPTION
## Title

fix: Update broken documentation links in README

## Relevant issues

N/A - Documentation fix

## Pre-Submission checklist

- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] This is a documentation-only change, no code changes or tests required

## Type

📖 Documentation

## Changes

Fixed broken documentation links in README.md:

1. **Hosted Proxy links**: Updated from `https://docs.litellm.ai/docs/hosted` to `https://docs.litellm.ai/docs/enterprise#hosted-litellm-proxy` (2 occurrences)
   - Removed "(Preview)" label as the hosted proxy is now GA
   
2. **Supported LLM Providers link**: Updated from GitHub anchor `https://github.com/BerriAI/litellm?tab=readme-ov-file#supported-providers-docs` to direct docs link `https://docs.litellm.ai/docs/providers`

These links were returning 404 errors or pointing to non-existent anchors. All links now point to the correct documentation pages.