### PR TITLE
chore: remove unused MCP_PROTOCOL_VERSION_HEADER_NAME constant

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -29,9 +29,6 @@ class MCPRequestHandler:
 
     LITELLM_MCP_ACCESS_GROUPS_HEADER_NAME = SpecialHeaders.mcp_access_groups.value
 
-    # MCP Protocol Version header
-    MCP_PROTOCOL_VERSION_HEADER_NAME = "MCP-Protocol-Version"
-
     @staticmethod
     async def process_mcp_request(
         scope: Scope,

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1712,7 +1712,6 @@ async def test_list_tool_rest_api_with_server_specific_auth():
         "authorization": "Bearer user_token",
         "x-mcp-zapier-authorization": "Bearer zapier_token",
         "x-mcp-slack-authorization": "Bearer slack_token",
-        "MCP-Protocol-Version": "2025-06-18",
     }
 
     # Create mock user_api_key_dict
@@ -1797,7 +1796,6 @@ async def test_list_tool_rest_api_with_default_auth():
     mock_request.headers = {
         "authorization": "Bearer user_token",
         "x-mcp-authorization": "Bearer default_token",
-        "MCP-Protocol-Version": "2025-06-18",
     }
 
     # Create mock user_api_key_dict
@@ -1880,7 +1878,6 @@ async def test_list_tool_rest_api_all_servers_with_auth():
         "authorization": "Bearer user_token",
         "x-mcp-zapier-authorization": "Bearer zapier_token",
         "x-mcp-slack-authorization": "Bearer slack_token",
-        "MCP-Protocol-Version": "2025-06-18",
     }
 
     # Create mock user_api_key_dict


### PR DESCRIPTION
## Title

chore: remove unused MCP_PROTOCOL_VERSION_HEADER_NAME constant

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes


