### PR TITLE
Fix gpt-5.1 temperature support when reasoning_effort is "none" or not specified

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -25,6 +25,15 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     def is_model_gpt_5_codex_model(cls, model: str) -> bool:
         """Check if the model is specifically a GPT-5 Codex variant."""
         return "gpt-5-codex" in model
+    
+    @classmethod
+    def is_model_gpt_5_1_model(cls, model: str) -> bool:
+        """Check if the model is a gpt-5.1 variant.
+        
+        gpt-5.1 supports temperature when reasoning_effort="none",
+        unlike gpt-5 which only supports temperature=1.
+        """
+        return "gpt-5.1" in model
 
     def get_supported_openai_params(self, model: str) -> list:
         from litellm.utils import supports_tool_choice
@@ -69,14 +78,26 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         if "temperature" in non_default_params:
             temperature_value: Optional[float] = non_default_params.pop("temperature")
             if temperature_value is not None:
-                if temperature_value == 1:
+                is_gpt_5_1 = self.is_model_gpt_5_1_model(model)
+                reasoning_effort = (
+                    non_default_params.get("reasoning_effort") 
+                    or optional_params.get("reasoning_effort")
+                )
+                
+                # gpt-5.1 supports any temperature when reasoning_effort="none" (or not specified, as it defaults to "none")
+                if is_gpt_5_1 and (reasoning_effort == "none" or reasoning_effort is None):
+                    optional_params["temperature"] = temperature_value
+                elif temperature_value == 1:
                     optional_params["temperature"] = temperature_value
                 elif litellm.drop_params or drop_params:
                     pass
                 else:
                     raise litellm.utils.UnsupportedParamsError(
                         message=(
-                            "gpt-5 models (including gpt-5-codex) don't support temperature={}. Only temperature=1 is supported. To drop unsupported params set `litellm.drop_params = True`"
+                            "gpt-5 models (including gpt-5-codex) don't support temperature={}. "
+                            "Only temperature=1 is supported. "
+                            "For gpt-5.1, temperature is supported when reasoning_effort='none' (or not specified, as it defaults to 'none'). "
+                            "To drop unsupported params set `litellm.drop_params = True`"
                         ).format(temperature_value),
                         status_code=400,
                     )

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -101,3 +101,65 @@ def test_azure_gpt5_codex_series_transform_request(config: AzureOpenAIGPT5Config
     )
     assert request["model"] == "gpt-5-codex"
 
+
+# GPT-5.1 temperature handling tests for Azure
+def test_azure_gpt5_1_temperature_with_reasoning_effort_none(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort='none'."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.5, "reasoning_effort": "none"},
+        optional_params={},
+        model="azure/gpt-5.1",
+        drop_params=False,
+        api_version="2024-05-01-preview",
+    )
+    assert params["temperature"] == 0.5
+    assert params["reasoning_effort"] == "none"
+
+
+def test_azure_gpt5_1_temperature_without_reasoning_effort(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort is not specified."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.7},
+        optional_params={},
+        model="azure/gpt-5.1",
+        drop_params=False,
+        api_version="2024-05-01-preview",
+    )
+    assert params["temperature"] == 0.7
+
+
+def test_azure_gpt5_1_temperature_with_reasoning_effort_other_values(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 only allows temperature=1 when reasoning_effort is not 'none'."""
+    # Test that temperature != 1 raises error when reasoning_effort is set to other values
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.7, "reasoning_effort": "low"},
+            optional_params={},
+            model="azure/gpt-5.1",
+            drop_params=False,
+            api_version="2024-05-01-preview",
+        )
+    
+    # Test that temperature=1 is allowed with other reasoning_effort values
+    params = config.map_openai_params(
+        non_default_params={"temperature": 1.0, "reasoning_effort": "medium"},
+        optional_params={},
+        model="azure/gpt-5.1",
+        drop_params=False,
+        api_version="2024-05-01-preview",
+    )
+    assert params["temperature"] == 1.0
+    assert params["reasoning_effort"] == "medium"
+
+
+def test_azure_gpt5_1_series_temperature_handling(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 with gpt5_series prefix supports temperature with reasoning_effort='none'."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.6},
+        optional_params={},
+        model="gpt5_series/gpt-5.1",
+        drop_params=False,
+        api_version="2024-05-01-preview",
+    )
+    assert params["temperature"] == 0.6
+

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -209,3 +209,122 @@ def test_gpt5_1_reasoning_effort_none(config: OpenAIConfig):
             drop_params=False,
         )
         assert params["reasoning_effort"] == effort
+
+
+# GPT-5.1 temperature handling tests
+def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
+    """Test that GPT-5.1 models are correctly detected."""
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1")
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1-codex")
+    assert gpt5_config.is_model_gpt_5_1_model("gpt-5.1-chat")
+    assert not gpt5_config.is_model_gpt_5_1_model("gpt-5")
+    assert not gpt5_config.is_model_gpt_5_1_model("gpt-5-mini")
+    assert not gpt5_config.is_model_gpt_5_1_model("gpt-5-codex")
+
+
+def test_gpt5_1_temperature_with_reasoning_effort_none(config: OpenAIConfig):
+    """Test that GPT-5.1 supports any temperature when reasoning_effort='none'."""
+    # Test various temperature values with reasoning_effort="none"
+    for temp in [0.0, 0.2, 0.5, 0.7, 0.9, 1.0, 1.5, 2.0]:
+        params = config.map_openai_params(
+            non_default_params={"temperature": temp, "reasoning_effort": "none"},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+        assert params["temperature"] == temp
+        assert params["reasoning_effort"] == "none"
+
+
+def test_gpt5_1_temperature_without_reasoning_effort(config: OpenAIConfig):
+    """Test that GPT-5.1 supports any temperature when reasoning_effort is not specified.
+    
+    When reasoning_effort is not provided, it defaults to "none" for gpt-5.1,
+    so temperature should be allowed.
+    """
+    # Test various temperature values without reasoning_effort (defaults to "none")
+    for temp in [0.0, 0.2, 0.5, 0.7, 0.9, 1.0, 1.5, 2.0]:
+        params = config.map_openai_params(
+            non_default_params={"temperature": temp},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+        assert params["temperature"] == temp
+
+
+def test_gpt5_1_temperature_with_reasoning_effort_other_values(config: OpenAIConfig):
+    """Test that GPT-5.1 only allows temperature=1 when reasoning_effort is not 'none'."""
+    # Test that temperature != 1 raises error when reasoning_effort is set to other values
+    for effort in ["low", "medium", "high"]:
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            config.map_openai_params(
+                non_default_params={"temperature": 0.7, "reasoning_effort": effort},
+                optional_params={},
+                model="gpt-5.1",
+                drop_params=False,
+            )
+    
+    # Test that temperature=1 is allowed with other reasoning_effort values
+    for effort in ["low", "medium", "high"]:
+        params = config.map_openai_params(
+            non_default_params={"temperature": 1.0, "reasoning_effort": effort},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+        assert params["temperature"] == 1.0
+        assert params["reasoning_effort"] == effort
+
+
+def test_gpt5_1_temperature_with_reasoning_effort_in_optional_params(config: OpenAIConfig):
+    """Test that reasoning_effort can be in optional_params and still work correctly."""
+    # Test with reasoning_effort="none" in optional_params
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.5},
+        optional_params={"reasoning_effort": "none"},
+        model="gpt-5.1",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.5
+    
+    # Test with reasoning_effort="low" in optional_params (should only allow temp=1)
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.5},
+            optional_params={"reasoning_effort": "low"},
+            model="gpt-5.1",
+            drop_params=False,
+        )
+
+def test_gpt5_1_temperature_drop_when_not_none(config: OpenAIConfig):
+    """Test that GPT-5.1 drops temperature when reasoning_effort != 'none' and drop_params=True."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.7, "reasoning_effort": "low"},
+        optional_params={},
+        model="gpt-5.1",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+    assert params["reasoning_effort"] == "low"
+
+
+def test_gpt5_temperature_still_restricted(config: OpenAIConfig):
+    """Test that regular gpt-5 (not 5.1) still only allows temperature=1."""
+    # Regular gpt-5 should still only allow temperature=1
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.7},
+            optional_params={},
+            model="gpt-5",
+            drop_params=False,
+        )
+    
+    # temperature=1 should still work for gpt-5
+    params = config.map_openai_params(
+        non_default_params={"temperature": 1.0},
+        optional_params={},
+        model="gpt-5",
+        drop_params=False,
+    )
+    assert params["temperature"] == 1.0


### PR DESCRIPTION
## Title

Fix gpt-5.1 temperature support when reasoning_effort is "none" or not specified

## Relevant issues

Fixes #17005

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix


## Changes
### Problem
- `gpt-5.1` models were incorrectly rejecting temperature values other than 1
- The OpenAI API supports any temperature for `gpt-5.1` when `reasoning_effort="none"` or when `reasoning_effort` is not specified (defaults to "none")
- Only `gpt-5` (not 5.1) should be restricted to `temperature=1`

### Solution
1. **Added `is_model_gpt_5_1_model()` method** to distinguish `gpt-5.1` variants from `gpt-5` models
2. **Updated temperature handling logic** in `map_openai_params()`:
   - For `gpt-5.1` models: Allow any temperature when `reasoning_effort="none"` OR when `reasoning_effort` is not specified (None)
   - For `gpt-5.1` models with other `reasoning_effort` values: Only allow `temperature=1` (same as gpt-5)
   - For `gpt-5` models: Continue to only allow `temperature=1` (unchanged behavior)
3. **Updated error message** to clarify the behavior for `gpt-5.1` models



## Testing
1. Temp with reasoning None
<img width="921" height="403" alt="image" src="https://github.com/user-attachments/assets/5144f095-736d-42a7-8bc7-2d418cc81102" />
<img width="819" height="116" alt="image" src="https://github.com/user-attachments/assets/b942ef7c-41c1-499d-9d1b-e6a48612e346" />

2. Temp with no reasoning(defaults to resoning=None)
<img width="921" height="403" alt="image" src="https://github.com/user-attachments/assets/90ede9ab-805d-4b93-9229-1a94874357d1" />
<img width="817" height="104" alt="image" src="https://github.com/user-attachments/assets/4541704b-f53c-4894-8344-fcb4f1155d37" />


3. checking if gpt-5 request still removes temp:
<img width="901" height="459" alt="image" src="https://github.com/user-attachments/assets/bf22b20e-7951-4de7-a06a-05295622cba9" />
<img width="805" height="86" alt="image" src="https://github.com/user-attachments/assets/260bdfb5-d11c-443f-9ee1-1a3929f59e28" />

