### PR TITLE
fix: handle None or empty contents in Gemini token counter

### DIFF
--- a/litellm/llms/gemini/count_tokens/handler.py
+++ b/litellm/llms/gemini/count_tokens/handler.py
@@ -30,6 +30,10 @@ class GoogleAIStudioTokenCounter:
 
         from google.genai.types import FunctionResponse
 
+        # Handle None or empty contents
+        if not contents:
+            return contents
+
         cleaned_contents = copy.deepcopy(contents)
 
         for content in cleaned_contents:


### PR DESCRIPTION
**Summary**
Prevents errors in the Gemini token counter by adding a null/empty check before processing contents.

**Key Changes**
- **Added null safety check**: Returns early if contents is None or empty in GoogleAIStudioTokenCounter (litellm/llms/gemini/count_tokens/handler.py)

**Impact**
- Prevents potential errors when token counting is called with None or empty contents
- Improves robustness of the Gemini integration

**Log**

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/anthropic_endpoints/endpoints.py", line 288, in count_tokens
    token_response = await internal_token_counter(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/proxy/proxy_server.py", line 6398, in token_counter
    result = await provider_counter.count_tokens(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/vertex_ai/common_utils.py", line 749, in count_tokens
    result = await VertexAITokenCounter().acount_tokens(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/gemini/count_tokens/handler.py", line 130, in acount_tokens
    cleaned_contents = self._clean_contents_for_gemini_api(contents)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/litellm/llms/gemini/count_tokens/handler.py", line 35, in _clean_contents_for_gemini_api
    for content in cleaned_contents:
TypeError: 'NoneType' object is not iterable
```