### PR TITLE
Metadata: fix 401 when audio/transcriptions

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -39,6 +39,8 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
 
         if "form" in content_type:
             parsed_body = dict(await request.form())
+            if "metadata" in parsed_body:
+                parsed_body["metadata"] = json.loads(parsed_body["metadata"])
         else:
             # Read the request body
             body = await request.body()

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -39,7 +39,7 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
 
         if "form" in content_type:
             parsed_body = dict(await request.form())
-            if "metadata" in parsed_body:
+            if "metadata" in parsed_body and isinstance(parsed_body["metadata"], str):
                 parsed_body["metadata"] = json.loads(parsed_body["metadata"])
         else:
             # Read the request body

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -94,6 +94,208 @@ async def test_form_data_parsing():
 
 
 @pytest.mark.asyncio
+async def test_form_data_with_json_metadata():
+    """
+    Test that form data with a JSON-encoded metadata field is correctly parsed.
+    
+    When form data includes a 'metadata' field, it comes as a JSON string that needs
+    to be parsed into a Python dictionary (lines 42-43 of http_parsing_utils.py).
+    """
+    # Create a mock request with form data containing JSON metadata
+    mock_request = MagicMock()
+    
+    # Metadata is sent as a JSON string in form data
+    metadata_json_string = json.dumps({
+        "user_id": "12345",
+        "request_type": "audio_transcription",
+        "tags": ["urgent", "production"],
+        "custom_field": {"nested": "value"}
+    })
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "metadata": metadata_json_string  # This is a JSON string, not a dict
+    }
+
+    # Mock the form method to return the test data as an awaitable
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+
+    # Parse the form data
+    result = await _read_request_body(mock_request)
+
+    # Verify the metadata was parsed from JSON string to dict
+    assert "metadata" in result
+    assert isinstance(result["metadata"], dict)
+    assert result["metadata"]["user_id"] == "12345"
+    assert result["metadata"]["request_type"] == "audio_transcription"
+    assert result["metadata"]["tags"] == ["urgent", "production"]
+    assert result["metadata"]["custom_field"] == {"nested": "value"}
+    
+    # Verify other fields remain unchanged
+    assert result["model"] == "whisper-1"
+    assert result["file"] == "audio.mp3"
+    
+    # Verify form() was called
+    mock_request.form.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_invalid_json_metadata():
+    """
+    Test that form data with invalid JSON in metadata field raises an exception.
+    
+    This tests error handling when the metadata field contains malformed JSON.
+    """
+    # Create a mock request with form data containing invalid JSON metadata
+    mock_request = MagicMock()
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "metadata": '{"invalid": json}'  # Invalid JSON - unquoted value
+    }
+
+    # Mock the form method to return the test data
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+
+    # Should raise JSONDecodeError when trying to parse invalid JSON metadata
+    with pytest.raises(json.JSONDecodeError):
+        await _read_request_body(mock_request)
+
+
+@pytest.mark.asyncio
+async def test_form_data_without_metadata():
+    """
+    Test that form data without metadata field works correctly.
+    
+    Ensures the metadata parsing logic doesn't break when metadata is absent.
+    """
+    # Create a mock request with form data without metadata
+    mock_request = MagicMock()
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "language": "en"
+    }
+
+    # Mock the form method to return the test data
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "application/x-www-form-urlencoded"}
+    mock_request.scope = {}
+
+    # Parse the form data
+    result = await _read_request_body(mock_request)
+
+    # Verify all fields are preserved as-is
+    assert result == test_data
+    assert "metadata" not in result
+    assert result["model"] == "whisper-1"
+    assert result["file"] == "audio.mp3"
+    assert result["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_empty_metadata():
+    """
+    Test that form data with empty JSON object in metadata field is parsed correctly.
+    """
+    # Create a mock request with form data containing empty metadata
+    mock_request = MagicMock()
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "metadata": "{}"  # Empty JSON object as string
+    }
+
+    # Mock the form method to return the test data
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+
+    # Parse the form data
+    result = await _read_request_body(mock_request)
+
+    # Verify the metadata was parsed to an empty dict
+    assert "metadata" in result
+    assert isinstance(result["metadata"], dict)
+    assert result["metadata"] == {}
+    assert result["model"] == "whisper-1"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_dict_metadata():
+    """
+    Test that form data with metadata already as a dict is not parsed again.
+    
+    This handles edge cases where metadata might already be a dictionary
+    (shouldn't happen in normal form data, but defensive coding).
+    """
+    # Create a mock request with form data where metadata is already a dict
+    mock_request = MagicMock()
+    
+    metadata_dict = {
+        "user_id": "12345",
+        "tags": ["test"]
+    }
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "metadata": metadata_dict  # Already a dict, not a string
+    }
+
+    # Mock the form method to return the test data
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+
+    # Parse the form data
+    result = await _read_request_body(mock_request)
+
+    # Verify the metadata remains as a dict and is not parsed
+    assert "metadata" in result
+    assert isinstance(result["metadata"], dict)
+    assert result["metadata"] == metadata_dict
+    assert result["metadata"]["user_id"] == "12345"
+    assert result["model"] == "whisper-1"
+
+
+@pytest.mark.asyncio
+async def test_form_data_with_none_metadata():
+    """
+    Test that form data with None metadata value is handled gracefully.
+    """
+    # Create a mock request with form data where metadata is None
+    mock_request = MagicMock()
+    
+    test_data = {
+        "model": "whisper-1",
+        "file": "audio.mp3",
+        "metadata": None  # None value
+    }
+
+    # Mock the form method to return the test data
+    mock_request.form = AsyncMock(return_value=test_data)
+    mock_request.headers = {"content-type": "multipart/form-data"}
+    mock_request.scope = {}
+
+    # Parse the form data
+    result = await _read_request_body(mock_request)
+
+    # Verify the metadata remains None (not parsed)
+    assert "metadata" in result
+    assert result["metadata"] is None
+    assert result["model"] == "whisper-1"
+
+
+@pytest.mark.asyncio
 async def test_empty_request_body():
     """
     Test handling of empty request bodies.


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](q)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

before the fix:
<img width="894" height="131" alt="Screenshot 2025-11-24 at 15 52 39" src="https://github.com/user-attachments/assets/3685fbb1-2c5b-40bf-abaf-f04e49b5a91f" />


after the fix:
<img width="732" height="733" alt="Screenshot 2025-11-24 at 15 09 50" src="https://github.com/user-attachments/assets/3b952daa-7237-4639-9e06-dca8f6c57e7a" />

<img width="1920" height="504" alt="Screenshot 2025-11-24 at 15 39 20" src="https://github.com/user-attachments/assets/c23cfaa6-e40b-4f1d-a9dd-950ed487001f" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

### Fix Description: Form Data Metadata JSON Parsing
Problem
When form data requests (e.g., multipart/form-data) were sent to the LiteLLM proxy with a metadata field, the metadata value remained as a JSON string instead of being parsed into a dictionary. This caused downstream code to fail when attempting to access metadata properties.
Error Example:
```
curl -X POST "localhost:4000/v1/audio/transcriptions" \
  -H "Authorization: Bearer sk-xxx" \
  -F "file=@audio.mp3" \
  -F "model=whisper-001" \
  -F 'metadata={"ss":"ss"}'
```
### Result:
```
{
  "error": {
    "message": "Authentication Error, 'str' object has no attribute 'get'",
    "type": "auth_error",
    "param": "None",
    "code": "401"
  }
}
```
The error occurred because authentication/authorization logic (and other downstream code) expected metadata to be a dictionary and tried to call `.get()` on it, but it was still a string.

###  Root Cause
When FastAPI parses form data, all fields come through as strings. Unlike JSON request bodies where nested objects are automatically parsed, form fields containing JSON remain as serialized strings. The metadata field was being left as `'{"ss":"ss"}'` (string) instead of being converted to `{"ss":"ss"}` (dict).

###  Solution
Added JSON parsing logic in `_read_request_body()` function (lines 42-44):
```
if "form" in content_type:
    parsed_body = dict(await request.form())
    if "metadata" in parsed_body:
        parsed_body["metadata"] = json.loads(parsed_body["metadata"])
```
This specifically checks if a metadata field exists in form data and parses it from a JSON string into a Python dictionary.

### Impact
Fixed: Audio transcription endpoints (`/v1/audio/transcriptions`) with metadata
Fixed: Any multipart/form-data requests that include metadata
Prevents: Authentication errors when metadata contains auth-related fields
Enables: Proper metadata tracking for file upload operations (user IDs, tags, custom parameters, etc.)

###  Test Coverage
Added comprehensive tests in `test_http_parsing_utils.py`:

- `test_form_data_with_json_metadata` - Valid JSON metadata parsing 
- `test_form_data_with_invalid_json_metadata` - Error handling for malformed JSON 
- `test_form_data_without_metadata` - No metadata field present 
- `test_form_data_with_empty_metadata` - Empty JSON object "{}" 
- `test_form_data_with_dict_metadata` - Metadata already a dict (defensive) 
- `test_form_data_with_none_metadata` - Metadata is None (defensive) 