### PR TITLE
[Fix] UI - Add No Default Models for Team and User Settings

### DIFF
--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -1145,6 +1145,9 @@ const Teams: React.FC<TeamProps> = ({
                       <Select2.Option key="all-proxy-models" value="all-proxy-models">
                         All Proxy Models
                       </Select2.Option>
+                      <Select2.Option key="no-default-models" value="no-default-models">
+                        No Default Models
+                      </Select2.Option>
                       {modelsToPick.map((model) => (
                         <Select2.Option key={model} value={model}>
                           {getModelDisplayName(model)}

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -30,8 +30,7 @@ import {
   Text,
   TextInput,
 } from "@tremor/react";
-import { Button as Button2, Form, Input, Modal, Select as Select2, Tooltip, Typography } from "antd";
-import { AlertTriangleIcon, XIcon } from "lucide-react";
+import { Button as Button2, Form, Input, Modal, Select as Select2, Switch, Tooltip, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import { formatNumberWithCommas } from "../utils/dataUtils";
 import { fetchTeams } from "./common_components/fetch_teams";
@@ -77,6 +76,7 @@ interface EditTeamModalProps {
 }
 
 import { updateExistingKeys } from "@/utils/dataUtils";
+import DeleteResourceModal from "./common_components/DeleteResourceModal";
 import { Member, teamCreateCall, v2TeamListCall } from "./networking";
 
 interface TeamInfo {

--- a/ui/litellm-dashboard/src/components/SSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/SSOSettings.tsx
@@ -274,7 +274,9 @@ const SSOSettings: React.FC<SSOSettingsProps> = ({ accessToken, possibleUIRoles,
           onChange={(value) => handleTextInputChange(key, value)}
           className="mt-2"
         >
-          <Option value="no-default-models">No Default Models</Option>
+          <Option key="no-default-models" value="no-default-models">
+            No Default Models
+          </Option>
           {availableModels.map((model: string) => (
             <Option key={model} value={model}>
               {getModelDisplayName(model)}

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, waitFor } from "../../tests/test-utils";
+import { screen } from "@testing-library/react";
+import TeamSSOSettings from "./TeamSSOSettings";
+import * as networking from "./networking";
+
+// Mock the networking functions
+vi.mock("./networking");
+
+// Mock the budget duration dropdown
+vi.mock("./common_components/budget_duration_dropdown", () => ({
+  default: ({ value, onChange }: { value: string | null; onChange: (value: string) => void }) => (
+    <select data-testid="budget-duration-dropdown" value={value || ""} onChange={(e) => onChange(e.target.value)}>
+      <option value="">Select duration</option>
+      <option value="daily">Daily</option>
+      <option value="monthly">Monthly</option>
+    </select>
+  ),
+  getBudgetDurationLabel: vi.fn((value: string) => value),
+}));
+
+// Mock the model display name helper
+vi.mock("./key_team_helpers/fetch_available_models_team_key", () => ({
+  getModelDisplayName: vi.fn((model: string) => model),
+}));
+
+describe("TeamSSOSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the component", async () => {
+    // Mock successful API responses
+    vi.mocked(networking.getDefaultTeamSettings).mockResolvedValue({
+      values: {
+        budget_duration: "monthly",
+        max_budget: 1000,
+      },
+      field_schema: {
+        description: "Default team settings",
+        properties: {
+          budget_duration: {
+            type: "string",
+            description: "Budget duration",
+          },
+          max_budget: {
+            type: "number",
+            description: "Maximum budget",
+          },
+        },
+      },
+    });
+
+    vi.mocked(networking.modelAvailableCall).mockResolvedValue({
+      data: [{ id: "gpt-4" }, { id: "claude-3" }],
+    });
+
+    renderWithProviders(<TeamSSOSettings accessToken="test-token" userID="test-user" userRole="admin" />);
+
+    const container = await screen.findByText("Default Team Settings");
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
@@ -1,7 +1,6 @@
-import React from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, waitFor } from "../../tests/test-utils";
 import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../tests/test-utils";
 import TeamSSOSettings from "./TeamSSOSettings";
 import * as networking from "./networking";
 

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.tsx
@@ -123,6 +123,9 @@ const TeamSSOSettings: React.FC<TeamSSOSettingsProps> = ({ accessToken, userID, 
           onChange={(value) => handleTextInputChange(key, value)}
           className="mt-2"
         >
+          <Option key="no-default-models" value="no-default-models">
+            No Default Models
+          </Option>
           {availableModels.map((model: string) => (
             <Option key={model} value={model}>
               {getModelDisplayName(model)}

--- a/ui/litellm-dashboard/src/components/create_user_button.tsx
+++ b/ui/litellm-dashboard/src/components/create_user_button.tsx
@@ -299,6 +299,9 @@ const Createuser: React.FC<CreateuserProps> = ({
                   <Select2.Option key="all-proxy-models" value="all-proxy-models">
                     All Proxy Models
                   </Select2.Option>
+                  <Select2.Option key="no-default-models" value="no-default-models">
+                    No Default Models
+                  </Select2.Option>
                   {userModels.map((model) => (
                     <Select2.Option key={model} value={model}>
                       {getModelDisplayName(model)}

--- a/ui/litellm-dashboard/src/components/team/team_info.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.tsx
@@ -586,6 +586,9 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       <Select.Option key="all-proxy-models" value="all-proxy-models">
                         All Proxy Models
                       </Select.Option>
+                      <Select.Option key="no-default-models" value="no-default-models">
+                        No Default Models
+                      </Select.Option>
                       {Array.from(new Set(userModels)).map((model, idx) => (
                         <Select.Option key={idx} value={model}>
                           {getModelDisplayName(model)}


### PR DESCRIPTION
## [Fix] UI - Add No Default Models for Team and User Settings

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

Team and User settings were missing the option "No Default Models" in some places. This PR adds this option to all User and Team Settings.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="1224" height="485" alt="image" src="https://github.com/user-attachments/assets/5ba314f3-147a-480b-8e70-a6aa024778f7" />
<img width="1219" height="771" alt="image" src="https://github.com/user-attachments/assets/fa9dc48f-5195-491c-92c2-1d92347c4ae3" />
<img width="1249" height="703" alt="image" src="https://github.com/user-attachments/assets/23b8c5ef-9f03-42e2-b4d7-c9aacd9fc246" />
<img width="1238" height="586" alt="image" src="https://github.com/user-attachments/assets/71ea9add-c16a-42fa-affe-84ee38e4b073" />
<img width="1022" height="477" alt="image" src="https://github.com/user-attachments/assets/1a0e3514-3324-4d02-9d74-0fd6cf036c83" />
<img width="850" height="565" alt="image" src="https://github.com/user-attachments/assets/6d083011-c1f5-4c46-96b9-f4f573d337d0" />
<img width="848" height="231" alt="image" src="https://github.com/user-attachments/assets/43ec4ca8-7365-4656-9193-62d5503c061d" />

