### PR TITLE
Fix image edit with multiple image inputs

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -485,6 +485,7 @@ vertex_ai_ai21_models: Set = set()
 vertex_mistral_models: Set = set()
 vertex_openai_models: Set = set()
 vertex_minimax_models: Set = set()
+vertex_moonshot_models: Set = set()
 ai21_models: Set = set()
 ai21_chat_models: Set = set()
 nlp_cloud_models: Set = set()
@@ -649,6 +650,9 @@ def add_known_models():
         elif value.get("litellm_provider") == "vertex_ai-minimax_models":
             key = key.replace("vertex_ai/", "")
             vertex_minimax_models.add(key)
+        elif value.get("litellm_provider") == "vertex_ai-moonshot_models":
+            key = key.replace("vertex_ai/", "")
+            vertex_moonshot_models.add(key)
         elif value.get("litellm_provider") == "ai21":
             if value.get("mode") == "chat":
                 ai21_chat_models.add(key)
@@ -908,7 +912,8 @@ models_by_provider: dict = {
     | vertex_vision_models
     | vertex_language_models
     | vertex_deepseek_models
-    | vertex_minimax_models,
+    | vertex_minimax_models
+    | vertex_moonshot_models,
     "ai21": ai21_models,
     "bedrock": bedrock_models | bedrock_converse_models,
     "petals": petals_models,

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -39,6 +39,7 @@ class PartnerModelPrefixes(str, Enum):
     QWEN_PREFIX = "qwen"
     GPT_OSS_PREFIX = "openai/gpt-oss-"
     MINIMAX_PREFIX = "minimaxai/"
+    MOONSHOT_PREFIX = "moonshotai/"
 
 
 class VertexAIPartnerModels(VertexBase):
@@ -64,6 +65,7 @@ class VertexAIPartnerModels(VertexBase):
             or model.startswith(PartnerModelPrefixes.QWEN_PREFIX)
             or model.startswith(PartnerModelPrefixes.GPT_OSS_PREFIX)
             or model.startswith(PartnerModelPrefixes.MINIMAX_PREFIX)
+            or model.startswith(PartnerModelPrefixes.MOONSHOT_PREFIX)
         ):
             return True
         return False
@@ -76,6 +78,7 @@ class VertexAIPartnerModels(VertexBase):
             PartnerModelPrefixes.QWEN_PREFIX,
             PartnerModelPrefixes.GPT_OSS_PREFIX,
             PartnerModelPrefixes.MINIMAX_PREFIX,
+            PartnerModelPrefixes.MOONSHOT_PREFIX,
         ]
         if any(provider in model for provider in OPENAI_LIKE_VERTEX_PROVIDERS):
             return True

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23440,7 +23440,7 @@
         "max_tokens": 256000,
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23432,6 +23432,19 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "vertex_ai-moonshot_models",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "vertex_ai/mistral-medium-3": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -215,9 +215,11 @@ async def image_generation(
 async def image_edit_api(
     request: Request,
     fastapi_response: Response,
-    image: List[UploadFile] = File(...),
-    mask: Optional[List[UploadFile]] = File(None),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    image: Optional[List[UploadFile]] = File(None),
+    image_array: Optional[List[UploadFile]] = File(None, alias="image[]"),
+    mask: Optional[List[UploadFile]] = File(None),
+    mask_array: Optional[List[UploadFile]] = File(None, alias="mask[]"),
     model: Optional[str] = None,
 ):
     """
@@ -233,6 +235,14 @@ async def image_edit_api(
         -F 'prompt=Create a studio ghibli image of this'
     ```
     """
+    if image is None and image_array is not None:
+        image = image_array
+    if mask is None and mask_array is not None:
+        mask = mask_array
+
+    if image is None:
+        raise HTTPException(status_code=422, detail="Field required: image")
+
     from litellm.proxy.proxy_server import (
         _read_request_body,
         general_settings,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23440,7 +23440,7 @@
         "max_tokens": 256000,
         "mode": "chat",
         "output_cost_per_token": 2.5e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#partner-models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23432,6 +23432,19 @@
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
+    "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "vertex_ai-moonshot_models",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 256000,
+        "max_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "vertex_ai/mistral-medium-3": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -967,6 +967,10 @@ async def test_vertex_ai_partner_model_detection():
     assert VertexAIPartnerModels.is_vertex_partner_model("meta/llama-3.1-405b")
     # Test Minimax models
     assert VertexAIPartnerModels.is_vertex_partner_model("minimaxai/minimax-m2-maas")
+    # Test Moonshot models
+    assert VertexAIPartnerModels.is_vertex_partner_model(
+        "moonshotai/kimi-k2-thinking-maas"
+    )
 
     # Test Gemini models (should NOT be detected as partner model)
     assert not VertexAIPartnerModels.is_vertex_partner_model("gemini-1.5-pro")
@@ -988,4 +992,17 @@ def test_vertex_ai_minimax_uses_openai_handler():
 
     assert VertexAIPartnerModels.should_use_openai_handler(
         "minimaxai/minimax-m2-maas"
+    )
+
+
+def test_vertex_ai_moonshot_uses_openai_handler():
+    """
+    Ensure Moonshot partner models re-use the OpenAI-format handler.
+    """
+    from litellm.llms.vertex_ai.vertex_ai_partner_models.main import (
+        VertexAIPartnerModels,
+    )
+
+    assert VertexAIPartnerModels.should_use_openai_handler(
+        "moonshotai/kimi-k2-thinking-maas"
     )


### PR DESCRIPTION
## Title
**Fix image edit with multiple image inputs**

Triggering the image edition endpoint with multiple input images causes a HTTP 422 error.
The UnprocessableEntityError with the message `Field required: image` was caused by a mismatch between how the OpenAI Python client formats  multipart requests for lists of files and how the LiteLLM FastAPI endpoint was expecting them.

When you pass a list of files to `client.images.edit(image=[...])`, the OpenAI Python client sends them as separate multipart form fields, but it names them image[] (with brackets) to indicate an array.

 The image_edit_api endpoint in LiteLLM was defined as image: List[UploadFile] = File(...). FastAPI looks for form fields named exactly image (no brackets). Because it couldn't find image, it raised the validation error.

 I updated the endpoint to accept both image (standard single file or manually formatted list) and image[] (OpenAI client
      formatted list).

  Fix Applied:
  I modified `litellm/proxy/image_endpoints/endpoints.py` to:
   1. Add an optional image_array parameter with alias="image[]".
   2. Add an optional mask_array parameter with alias="mask[]" (for symmetry and future-proofing).
   3. Merge image_array into image (and mask_array into mask) at the start of the function.
   4. Manually check that image is present, raising a 422 error if not.

  This change ensures that requests from the OpenAI Python client with multiple images will now be correctly parsed by the LiteLLM proxy.



## Relevant issues

Fixes #16468

## Type
🐛 Bug Fix
