### PR TITLE
Fix image edit endpoint

### DIFF
--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -235,6 +235,10 @@ async def image_edit_api(
         -F 'prompt=Create a studio ghibli image of this'
     ```
     """
+    if image is not None and image_array is not None:
+        raise HTTPException(status_code=422, detail="Cannot specify both 'image' and 'image[]'")
+    if mask is not None and mask_array is not None:
+        raise HTTPException(status_code=422, detail="Cannot specify both 'mask' and 'mask[]'")
     if image is None and image_array is not None:
         image = image_array
     if mask is None and mask_array is not None:

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -215,9 +215,11 @@ async def image_generation(
 async def image_edit_api(
     request: Request,
     fastapi_response: Response,
-    image: List[UploadFile] = File(...),
-    mask: Optional[List[UploadFile]] = File(None),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    image: Optional[List[UploadFile]] = File(None),
+    image_array: Optional[List[UploadFile]] = File(None, alias="image[]"),
+    mask: Optional[List[UploadFile]] = File(None),
+    mask_array: Optional[List[UploadFile]] = File(None, alias="mask[]"),
     model: Optional[str] = None,
 ):
     """
@@ -233,6 +235,14 @@ async def image_edit_api(
         -F 'prompt=Create a studio ghibli image of this'
     ```
     """
+    if image is None and image_array is not None:
+        image = image_array
+    if mask is None and mask_array is not None:
+        mask = mask_array
+
+    if image is None:
+        raise HTTPException(status_code=422, detail="Field required: image")
+
     from litellm.proxy.proxy_server import (
         _read_request_body,
         general_settings,


### PR DESCRIPTION
## Title
**Fix image edit with multiple image inputs**

Triggering the image edition endpoint with multiple input images causes a HTTP 422 error.
The UnprocessableEntityError with the message `Field required: image` was caused by a mismatch between how the OpenAI Python client formats  multipart requests for lists of files and how the LiteLLM FastAPI endpoint was expecting them.

When you pass a list of files to `client.images.edit(image=[...])`, the OpenAI Python client sends them as separate multipart form fields, but it names them image[] (with brackets) to indicate an array.

 The `image_edit_api` endpoint in LiteLLM was defined as image: `List[UploadFile] = File(...)`. FastAPI looks for form fields named exactly image (no brackets). Because it couldn't find image, it raised the validation error.

 I updated the endpoint to accept both image (standard single file or manually formatted list) and image[] (OpenAI client
      formatted list).

  Fix Applied:
  I modified `litellm/proxy/image_endpoints/endpoints.py` to:
   1. Add an optional image_array parameter with alias="image[]".
   2. Add an optional mask_array parameter with alias="mask[]" (for symmetry and future-proofing).
   3. Merge image_array into image (and mask_array into mask) at the start of the function.
   4. Manually check that image is present, raising a 422 error if not.

  This change ensures that requests from the OpenAI Python client with multiple images will now be correctly parsed by the LiteLLM proxy.



## Relevant issues

Fixes #16468

## Type
🐛 Bug Fix