### PR TITLE
[Fix] Add aws_bedrock_runtime_endpoint into Credential Types

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -159,6 +159,7 @@ class CredentialLiteLLMParams(BaseModel):
     aws_access_key_id: Optional[str] = None
     aws_secret_access_key: Optional[str] = None
     aws_region_name: Optional[str] = None
+    aws_bedrock_runtime_endpoint: Optional[str] = None
     ## IBM WATSONX ##
     watsonx_region_name: Optional[str] = None
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1692,3 +1692,35 @@ async def test_router_acompletion_with_unknown_model_and_no_fallback():
     # Check that the error message is correct.
     # The router returns 'no healthy deployments' because get_model_list returns [] not None.
     assert "no healthy deployments for this model" in str(excinfo.value)
+
+
+def test_get_deployment_credentials_with_provider_aws_bedrock_runtime_endpoint():
+    """
+    Test that get_deployment_credentials_with_provider correctly copies
+    aws_bedrock_runtime_endpoint from deployment litellm_params to credentials.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-claude-model",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "aws_access_key_id": "test-access-key",
+                    "aws_secret_access_key": "test-secret-key",
+                    "aws_region_name": "us-east-1",
+                    "aws_bedrock_runtime_endpoint": "https://bedrock-runtime.us-east-1.amazonaws.com",
+                },
+            }
+        ],
+    )
+
+    credentials = router.get_deployment_credentials_with_provider(
+        model_id="bedrock-claude-model"
+    )
+
+    assert credentials is not None
+    assert credentials["aws_bedrock_runtime_endpoint"] == "https://bedrock-runtime.us-east-1.amazonaws.com"
+    assert credentials["aws_access_key_id"] == "test-access-key"
+    assert credentials["aws_secret_access_key"] == "test-secret-key"
+    assert credentials["aws_region_name"] == "us-east-1"
+    assert credentials["custom_llm_provider"] == "bedrock"


### PR DESCRIPTION
## [Fix] Add aws_bedrock_runtime_endpoint into Credential Types

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Re-using credentials on a AWS bedrock model with aws_bedrock_runtime_endpoint defined in the credentials does not copy aws_bedrock_runtime_endpoint over into the new credentials. This PR fixes this issue.

This is a stop gap to immediate unblock customers who want to use the Reuse credential feature with AWS bedrock. A complete fix is tracked in LIT-1535

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="688" height="205" alt="image" src="https://github.com/user-attachments/assets/fef35100-c2b8-4f1a-89f7-d69d19fb6132" />

Reuse Cred from a test bedrock model with https://someEndpointForCredentialReuse.com as the aws_bedrock_runtime_endpoint
<img width="1177" height="98" alt="image" src="https://github.com/user-attachments/assets/6cda416f-c968-4236-9e6b-c31c5cc1c041" />

<img width="755" height="645" alt="image" src="https://github.com/user-attachments/assets/8e78c17e-2329-4f38-8d8b-7fb2ee0d855d" />


