### PR TITLE
[Feature] Deleting a User From Team Deletes key User Ceated for Team

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1878,6 +1878,15 @@ async def team_member_delete(
             where={"team_id": data.team_id, "user_id": _uid}
         )
 
+    ## DELETE KEYS CREATED BY USER FOR THIS TEAM
+    if user_ids_to_delete:
+        await prisma_client.db.litellm_verificationtoken.delete_many(
+            where={
+                "user_id": {"in": list(user_ids_to_delete)},
+                "team_id": data.team_id,
+            }
+        )
+
     return existing_team_row
 
 


### PR DESCRIPTION
## [Feature] Deleting a User From Team Deletes key User Ceated for Team

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Deleting a user from a team now deletes all the keys for the user in the team. These can either be created for the user by themselves or created by an admin for a user for the team.

Tested in UI using these steps:
1. Admin add user (not admin) into team, and give users permissions to /key/generate
2. Log into user to create a key for the team
3. Admin removes user from the team
4. Verify the key was deleted

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
<img width="691" height="250" alt="image" src="https://github.com/user-attachments/assets/6e858600-1c3b-4240-8a42-ffe0fec75aef" />


