### PR TITLE
Fix: Distinguish permission errors from idempotent errors in Prisma migrations

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -131,6 +131,60 @@ class ProxyExtrasDBManager:
         )
 
     @staticmethod
+    def _is_permission_error(error_message: str) -> bool:
+        """
+        Check if the error message indicates a database permission error.
+
+        Permission errors should NOT be marked as applied, as the migration
+        did not actually execute successfully.
+
+        Args:
+            error_message: The error message from Prisma migrate
+
+        Returns:
+            bool: True if this is a permission error, False otherwise
+        """
+        permission_patterns = [
+            r"Database error code: 42501",  # PostgreSQL insufficient privilege
+            r"must be owner of table",
+            r"permission denied for schema",
+            r"permission denied for table",
+            r"must be owner of schema",
+        ]
+
+        for pattern in permission_patterns:
+            if re.search(pattern, error_message, re.IGNORECASE):
+                return True
+        return False
+
+    @staticmethod
+    def _is_idempotent_error(error_message: str) -> bool:
+        """
+        Check if the error message indicates an idempotent operation error.
+
+        Idempotent errors (like "column already exists") mean the migration
+        has effectively already been applied, so it's safe to mark as applied.
+
+        Args:
+            error_message: The error message from Prisma migrate
+
+        Returns:
+            bool: True if this is an idempotent error, False otherwise
+        """
+        idempotent_patterns = [
+            r"already exists",
+            r"column .* already exists",
+            r"duplicate key value violates",
+            r"relation .* already exists",
+            r"constraint .* already exists",
+        ]
+
+        for pattern in idempotent_patterns:
+            if re.search(pattern, error_message, re.IGNORECASE):
+                return True
+        return False
+
+    @staticmethod
     def _resolve_all_migrations(
         migrations_dir: str, schema_path: str, mark_all_applied: bool = True
     ):
@@ -320,29 +374,77 @@ class ProxyExtrasDBManager:
                             )
                             logger.info("✅ All migrations resolved.")
                             return True
-                        elif (
-                            "P3018" in e.stderr
-                        ):  # PostgreSQL error code for duplicate column
-                            logger.info(
-                                "Migration already exists, resolving specific migration"
-                            )
-                            # Extract the migration name from the error message
-                            migration_match = re.search(
-                                r"Migration name: (\d+_.*)", e.stderr
-                            )
-                            if migration_match:
-                                migration_name = migration_match.group(1)
-                                logger.info(f"Rolling back migration {migration_name}")
-                                ProxyExtrasDBManager._roll_back_migration(
-                                    migration_name
+                        elif "P3018" in e.stderr:
+                            # Check if this is a permission error or idempotent error
+                            if ProxyExtrasDBManager._is_permission_error(e.stderr):
+                                # Permission errors should NOT be marked as applied
+                                # Extract migration name for logging
+                                migration_match = re.search(
+                                    r"Migration name: (\d+_.*)", e.stderr
                                 )
+                                migration_name = (
+                                    migration_match.group(1)
+                                    if migration_match
+                                    else "unknown"
+                                )
+
+                                logger.error(
+                                    f"❌ Migration {migration_name} failed due to insufficient permissions. "
+                                    f"Please check database user privileges. Error: {e.stderr}"
+                                )
+
+                                # Mark as rolled back and exit with error
+                                if migration_match:
+                                    try:
+                                        ProxyExtrasDBManager._roll_back_migration(
+                                            migration_name
+                                        )
+                                        logger.info(
+                                            f"Migration {migration_name} marked as rolled back"
+                                        )
+                                    except Exception as rollback_error:
+                                        logger.warning(
+                                            f"Failed to mark migration as rolled back: {rollback_error}"
+                                        )
+
+                                # Re-raise the error to prevent silent failures
+                                raise RuntimeError(
+                                    f"Migration failed due to permission error. Migration {migration_name} "
+                                    f"was NOT applied. Please grant necessary database permissions and retry."
+                                ) from e
+
+                            elif ProxyExtrasDBManager._is_idempotent_error(e.stderr):
+                                # Idempotent errors mean the migration has effectively been applied
                                 logger.info(
-                                    f"Resolving migration {migration_name} that failed due to existing columns"
+                                    "Migration failed due to idempotent error (e.g., column already exists), "
+                                    "resolving as applied"
                                 )
-                                ProxyExtrasDBManager._resolve_specific_migration(
-                                    migration_name
+                                # Extract the migration name from the error message
+                                migration_match = re.search(
+                                    r"Migration name: (\d+_.*)", e.stderr
                                 )
-                                logger.info("✅ Migration resolved.")
+                                if migration_match:
+                                    migration_name = migration_match.group(1)
+                                    logger.info(
+                                        f"Rolling back migration {migration_name}"
+                                    )
+                                    ProxyExtrasDBManager._roll_back_migration(
+                                        migration_name
+                                    )
+                                    logger.info(
+                                        f"Resolving migration {migration_name} that failed due to existing schema objects"
+                                    )
+                                    ProxyExtrasDBManager._resolve_specific_migration(
+                                        migration_name
+                                    )
+                                    logger.info("✅ Migration resolved.")
+                            else:
+                                # Unknown P3018 error - log and re-raise for safety
+                                logger.warning(
+                                    f"P3018 error encountered but could not classify as permission or idempotent error. "
+                                    f"Error: {e.stderr}"
+                                )
+                                raise
                 else:
                     # Use prisma db push with increased timeout
                     subprocess.run(

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -432,7 +432,8 @@ class ProxyExtrasDBManager:
                                         migration_name
                                     )
                                     logger.info(
-                                        f"Resolving migration {migration_name} that failed due to existing schema objects"
+                                        f"Resolving migration {migration_name} that failed "
+                                        f"due to existing schema objects"
                                     )
                                     ProxyExtrasDBManager._resolve_specific_migration(
                                         migration_name
@@ -441,7 +442,8 @@ class ProxyExtrasDBManager:
                             else:
                                 # Unknown P3018 error - log and re-raise for safety
                                 logger.warning(
-                                    f"P3018 error encountered but could not classify as permission or idempotent error. "
+                                    f"P3018 error encountered but could not classify "
+                                    f"as permission or idempotent error. "
                                     f"Error: {e.stderr}"
                                 )
                                 raise

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -7,8 +7,10 @@ sys.path.insert(
 
 from litellm_proxy_extras.utils import ProxyExtrasDBManager
 
+
 def test_custom_prisma_dir(monkeypatch):
     import tempfile
+
     # create a temp directory
     temp_dir = tempfile.mkdtemp()
     monkeypatch.setenv("LITELLM_MIGRATION_DIR", temp_dir)
@@ -123,4 +125,3 @@ class TestErrorClassificationPriority:
         error_message = "connection timeout"
         assert ProxyExtrasDBManager._is_permission_error(error_message) is False
         assert ProxyExtrasDBManager._is_idempotent_error(error_message) is False
-

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -1,11 +1,5 @@
-import json
 import os
 import sys
-import httpx
-import pytest
-import respx
-
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -29,4 +23,104 @@ def test_custom_prisma_dir(monkeypatch):
     ## Check if the migrations dir is in the temp directory
     migrations_dir = os.path.join(temp_dir, "migrations")
     assert os.path.exists(migrations_dir)
+
+
+class TestPermissionErrorDetection:
+    """Test cases for permission error detection in Prisma migrations"""
+
+    def test_is_permission_error_postgres_42501(self):
+        """Test detection of PostgreSQL 42501 error code (insufficient privilege)"""
+        error_message = "Database error code: 42501 - permission denied for table users"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_must_be_owner(self):
+        """Test detection of 'must be owner of table' error"""
+        error_message = "ERROR: must be owner of table my_table"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_permission_denied_schema(self):
+        """Test detection of 'permission denied for schema' error"""
+        error_message = "permission denied for schema public"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_permission_denied_table(self):
+        """Test detection of 'permission denied for table' error"""
+        error_message = "permission denied for table my_table"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_must_be_owner_schema(self):
+        """Test detection of 'must be owner of schema' error"""
+        error_message = "must be owner of schema public"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_case_insensitive(self):
+        """Test that permission error detection is case insensitive"""
+        error_message = "PERMISSION DENIED FOR TABLE my_table"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+
+    def test_is_permission_error_negative(self):
+        """Test that non-permission errors are not detected as permission errors"""
+        error_message = "column 'id' already exists"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is False
+
+
+class TestIdempotentErrorDetection:
+    """Test cases for idempotent error detection in Prisma migrations"""
+
+    def test_is_idempotent_error_already_exists(self):
+        """Test detection of generic 'already exists' error"""
+        error_message = "object already exists"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_column_already_exists(self):
+        """Test detection of 'column already exists' error"""
+        error_message = "column 'email' already exists"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_duplicate_key(self):
+        """Test detection of duplicate key violation error"""
+        error_message = "duplicate key value violates unique constraint"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_relation_already_exists(self):
+        """Test detection of 'relation already exists' error"""
+        error_message = "relation 'users_pkey' already exists"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_constraint_already_exists(self):
+        """Test detection of 'constraint already exists' error"""
+        error_message = "constraint 'fk_user_id' already exists"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_case_insensitive(self):
+        """Test that idempotent error detection is case insensitive"""
+        error_message = "COLUMN 'ID' ALREADY EXISTS"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+
+    def test_is_idempotent_error_negative(self):
+        """Test that non-idempotent errors are not detected as idempotent errors"""
+        error_message = "Database error code: 42501 - permission denied"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is False
+
+
+class TestErrorClassificationPriority:
+    """Test cases to ensure errors are correctly classified"""
+
+    def test_permission_error_not_classified_as_idempotent(self):
+        """Ensure permission errors are not mistakenly classified as idempotent"""
+        error_message = "Database error code: 42501 - must be owner of table users"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is True
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is False
+
+    def test_idempotent_error_not_classified_as_permission(self):
+        """Ensure idempotent errors are not mistakenly classified as permission errors"""
+        error_message = "column 'created_at' already exists"
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is True
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is False
+
+    def test_unknown_error_classified_as_neither(self):
+        """Ensure unknown errors are classified as neither permission nor idempotent"""
+        error_message = "connection timeout"
+        assert ProxyExtrasDBManager._is_permission_error(error_message) is False
+        assert ProxyExtrasDBManager._is_idempotent_error(error_message) is False
 


### PR DESCRIPTION
## Title
Fix: Distinguish permission errors from idempotent errors in Prisma migrations

## Relevant issues
Fixes #14596

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

When LiteLLM runs database migrations with USE_PRISMA_MIGRATE=True, permission errors (PostgreSQL error
  code 42501) were being treated the same as idempotent conflicts. This caused migrations to be marked as
  "applied" even when DDL never executed, creating schema drift between metadata and actual database state.

  Root Cause

  The migration wrapper in litellm-proxy-extras/litellm_proxy_extras/utils.py treated all P3018 errors
  identically, executing migrate resolve --applied for both permission failures and genuine idempotent
  conflicts.

  Solution

  Added pattern-matching logic to distinguish permission errors from idempotent errors:

  Permission error patterns (NOT marked as applied):

  - Database error code: 42501 (PostgreSQL insufficient privilege)
  - must be owner of table
  - permission denied for schema
  - permission denied for table
  - must be owner of schema

  Idempotent error patterns (marked as applied):

  - already exists
  - column .* already exists
  - duplicate key value violates
  - relation .* already exists
  - constraint .* already exists

  Behavior changes:

  - Permission errors: Mark migration as rolled back and raise RuntimeError (migration NOT applied)
  - Idempotent errors: Continue with existing behavior (mark as applied)
  - Unknown P3018 errors: Log warning and re-raise for safety

  Code Changes

  File: litellm-proxy-extras/litellm_proxy_extras/utils.py

  1. Added _is_permission_error() static method (lines 133-158)
    - Detects database permission-related errors using regex patterns
  2. Added _is_idempotent_error() static method (lines 160-185)
    - Detects idempotent operation errors using regex patterns
  3. Updated P3018 error handling in setup_database() (lines 377-449)
    - Distinguishes between permission and idempotent errors
    - Permission errors trigger rollback and raise RuntimeError
    - Idempotent errors continue with existing resolve logic
    - Unknown errors are logged and re-raised

  File: tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py

  Added comprehensive test coverage (17 new tests):

  - TestPermissionErrorDetection (7 tests)
    - PostgreSQL 42501 error code detection
    - "must be owner" pattern detection
    - "permission denied" pattern detection
    - Case-insensitive matching
    - Negative case validation
  - TestIdempotentErrorDetection (7 tests)
    - "already exists" pattern detection
    - "duplicate key" pattern detection
    - "relation/constraint already exists" detection
    - Case-insensitive matching
    - Negative case validation
  - TestErrorClassificationPriority (3 tests)
    - Ensures correct mutual exclusivity
    - Validates unknown errors aren't misclassified

  Test Results

  All 18 tests pass (including 1 existing test):
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::test_custom_prisma_dir PASSED [  5%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_postgres_42501 PASSED [ 11%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_must_be_owner PASSED [ 16%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_permission_denied_schema PASSED [ 22%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_permission_denied_table PASSED [ 27%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_must_be_owner_schema PASSED [ 33%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_case_insensitive PASSED [ 38%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestPermissionErrorDetection::test_is_permission_error_negative PASSED [ 44%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_already_exists PASSED [ 50%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_column_already_exists PASSED [ 55%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_duplicate_key PASSED [ 61%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_relation_already_exists PASSED [ 66%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_constraint_already_exists PASSED [ 72%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_case_insensitive PASSED [ 77%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestIdempotentErrorDetection::test_is_idempotent_error_negative PASSED [ 83%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestErrorClassificationPriority::test_permission_error_not_classified_as_idempotent PASSED [ 88%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestErrorClassificationPriority::test_idempotent_error_not_classified_as_permission PASSED [ 94%]
tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestErrorClassificationPriority::test_unknown_error_classified_as_neither PASSED [100%]

## Impact

  This change prevents silent migration failures and ensures operators are immediately notified of
  permission issues, preventing schema drift and hard-to-trace runtime failures.

  Before: Permission errors silently marked migrations as "applied" despite DDL failures
  After: Permission errors explicitly fail with clear error messages, prompting operators to fix privileges


 