### PR TITLE
Fix `reasoning_effort="none"` not working on Azure for GPT-5.1

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.types.llms.openai import AllMessageValues
 
@@ -33,13 +35,45 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         drop_params: bool,
         api_version: str = "",
     ) -> dict:
-        return OpenAIGPT5Config.map_openai_params(
+        reasoning_effort_value = (
+            non_default_params.get("reasoning_effort")
+            or optional_params.get("reasoning_effort")
+        )
+
+        if reasoning_effort_value == "none":
+            if litellm.drop_params is True or (
+                drop_params is not None and drop_params is True
+            ):
+                non_default_params = non_default_params.copy()
+                optional_params = optional_params.copy()
+                if non_default_params.get("reasoning_effort") == "none":
+                    non_default_params.pop("reasoning_effort")
+                if optional_params.get("reasoning_effort") == "none":
+                    optional_params.pop("reasoning_effort")
+            else:
+                raise UnsupportedParamsError(
+                    status_code=400,
+                    message=(
+                        "Azure OpenAI does not support reasoning_effort='none'. "
+                        "Supported values are: 'low', 'medium', and 'high'. "
+                        "To drop this parameter, set `litellm.drop_params=True` or for proxy:\n\n"
+                        "`litellm_settings:\n drop_params: true`\n"
+                        "Issue: https://github.com/BerriAI/litellm/issues/16704"
+                    ),
+                )
+
+        result = OpenAIGPT5Config.map_openai_params(
             self,
             non_default_params=non_default_params,
             optional_params=optional_params,
             model=model,
             drop_params=drop_params,
         )
+
+        if result.get("reasoning_effort") == "none":
+            result.pop("reasoning_effort")
+
+        return result
 
     def transform_request(
         self,

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -104,7 +104,12 @@ def test_azure_gpt5_codex_series_transform_request(config: AzureOpenAIGPT5Config
 
 # GPT-5.1 temperature handling tests for Azure
 def test_azure_gpt5_1_temperature_with_reasoning_effort_none(config: AzureOpenAIGPT5Config):
-    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort='none'."""
+    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort='none'.
+    
+    Note: Azure OpenAI doesn't support reasoning_effort='none', so it's dropped from the params.
+    However, the temperature logic still works correctly because the parent treats missing
+    reasoning_effort the same as 'none' for gpt-5.1.
+    """
     params = config.map_openai_params(
         non_default_params={"temperature": 0.5, "reasoning_effort": "none"},
         optional_params={},
@@ -113,7 +118,8 @@ def test_azure_gpt5_1_temperature_with_reasoning_effort_none(config: AzureOpenAI
         api_version="2024-05-01-preview",
     )
     assert params["temperature"] == 0.5
-    assert params["reasoning_effort"] == "none"
+    # Azure doesn't support reasoning_effort="none", so it should be dropped
+    assert "reasoning_effort" not in params or params.get("reasoning_effort") != "none"
 
 
 def test_azure_gpt5_1_temperature_without_reasoning_effort(config: AzureOpenAIGPT5Config):

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -104,22 +104,34 @@ def test_azure_gpt5_codex_series_transform_request(config: AzureOpenAIGPT5Config
 
 # GPT-5.1 temperature handling tests for Azure
 def test_azure_gpt5_1_temperature_with_reasoning_effort_none(config: AzureOpenAIGPT5Config):
-    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort='none'.
+    """Test that Azure GPT-5.1 supports any temperature when reasoning_effort='none' and drop_params=True.
     
-    Note: Azure OpenAI doesn't support reasoning_effort='none', so it's dropped from the params.
-    However, the temperature logic still works correctly because the parent treats missing
-    reasoning_effort the same as 'none' for gpt-5.1.
+    Note: Azure OpenAI doesn't support reasoning_effort='none', so it's dropped from the params
+    when drop_params=True. The temperature logic still works correctly because the parent treats
+    missing reasoning_effort the same as 'none' for gpt-5.1.
     """
     params = config.map_openai_params(
         non_default_params={"temperature": 0.5, "reasoning_effort": "none"},
         optional_params={},
         model="azure/gpt-5.1",
-        drop_params=False,
+        drop_params=True,
         api_version="2024-05-01-preview",
     )
     assert params["temperature"] == 0.5
     # Azure doesn't support reasoning_effort="none", so it should be dropped
     assert "reasoning_effort" not in params or params.get("reasoning_effort") != "none"
+
+
+def test_azure_gpt5_1_reasoning_effort_none_error_when_drop_params_false(config: AzureOpenAIGPT5Config):
+    """Test that Azure GPT-5.1 raises error for reasoning_effort='none' when drop_params=False."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": "none"},
+            optional_params={},
+            model="azure/gpt-5.1",
+            drop_params=False,
+            api_version="2024-05-01-preview",
+        )
 
 
 def test_azure_gpt5_1_temperature_without_reasoning_effort(config: AzureOpenAIGPT5Config):


### PR DESCRIPTION
## Title

Fix `reasoning_effort="none"` not working on Azure for GPT-5.1

## Relevant issues

Fixes #16704

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] I have added a screenshot of my new test passing locally 

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

**Problem:**
Azure OpenAI doesn't support `reasoning_effort="none"` (only supports `"low"`, `"medium"`, `"high"`), causing a 400 error when users pass `reasoning_effort="none"` for GPT-5.1 models on Azure.

**Solution:**
- Updated `AzureOpenAIGPT5Config.map_openai_params()` to handle `reasoning_effort="none"` following the same pattern as GPT-5 transformation
- When `drop_params=True` (or `litellm.drop_params=True`), the parameter is silently dropped since Azure's default behavior matches OpenAI's `"none"` behavior
- When `drop_params=False`, raises `UnsupportedParamsError` with a clear error message directing users to enable `drop_params`


## Testing
<img width="954" height="428" alt="image" src="https://github.com/user-attachments/assets/fceea857-3999-46c0-b22c-3b801604f670" />

<img width="803" height="105" alt="Screenshot 2025-11-25 at 1 49 55 PM" src="https://github.com/user-attachments/assets/71d708d5-e504-4a51-ae96-b9ce8eac44b9" />
