### PR TITLE
Refactor date filtering to use BETWEEN clause

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1427,7 +1427,7 @@ async def _get_spend_report_for_time_range(
         LEFT JOIN
             "LiteLLM_TeamTable" t ON s.team_id = t.team_id
         WHERE
-            s."startTime"::DATE >= $1::date AND s."startTime"::DATE <= $2::date
+            s."startTime" BETWEEN $1::date AND $2::date
         GROUP BY
             t.team_alias
         ORDER BY
@@ -1441,7 +1441,7 @@ async def _get_spend_report_for_time_range(
         jsonb_array_elements_text(request_tags) AS individual_request_tag,
         SUM(spend) AS total_spend
         FROM "LiteLLM_SpendLogs"
-        WHERE "startTime"::DATE >= $1::date AND "startTime"::DATE <= $2::date
+        WHERE "startTime" BETWEEN $1::date AND $2::date
         GROUP BY individual_request_tag
         ORDER BY total_spend DESC;
         """


### PR DESCRIPTION
These two queries are a major cause of latency when opening the "usage" page in the admin UI.

This should allow postgres to perform an index scan instead of a sequential scan, hopefully significantly reducing the query latency.

The BETWEEN idiom is already in use in multiple places in the same file.


