### PR TITLE
Optimize date filtering for spend logs queries

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1423,7 +1423,7 @@ async def _get_spend_report_for_time_range(
         LEFT JOIN
             "LiteLLM_TeamTable" t ON s.team_id = t.team_id
         WHERE
-            s."startTime"::DATE >= $1::date AND s."startTime"::DATE <= $2::date
+            s."startTime" >= $1::date AND s."startTime" < ($2::date + INTERVAL '1 day')
         GROUP BY
             t.team_alias
         ORDER BY
@@ -1437,7 +1437,7 @@ async def _get_spend_report_for_time_range(
         jsonb_array_elements_text(request_tags) AS individual_request_tag,
         SUM(spend) AS total_spend
         FROM "LiteLLM_SpendLogs"
-        WHERE "startTime"::DATE >= $1::date AND "startTime"::DATE <= $2::date
+        WHERE "startTime" >= $1::date AND "startTime" < ($2::date + INTERVAL '1 day')
         GROUP BY individual_request_tag
         ORDER BY total_spend DESC;
         """


### PR DESCRIPTION
This should allow postgres to perform a more efficient index scan instead of a sequential table scan.

These two queries consistently show up in the longest-running ones in our instance.

The same pattern is already in use in the same file.