### PR TITLE
feat(pillar): add automatic LiteLLM context headers

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/pillar_security.md
+++ b/docs/my-website/docs/proxy/guardrails/pillar_security.md
@@ -60,6 +60,8 @@ litellm_settings:
   set_verbose: true                          # Enable detailed logging
 ```
 
+**Note:** Virtual key context is **automatically passed** as headers - no additional configuration needed!
+
 ### 3. Start the Proxy
 
 ```bash
@@ -210,7 +212,7 @@ export PILLAR_API_KEY="your_api_key_here"
 export PILLAR_API_BASE="https://api.pillar.security"
 export PILLAR_ON_FLAGGED_ACTION="monitor"
 export PILLAR_FALLBACK_ON_ERROR="allow"
-export PILLAR_TIMEOUT="30.0"
+export PILLAR_TIMEOUT="5.0"
 ```
 
 ### Session Tracking


### PR DESCRIPTION
## Title

feat(pillar): add automatic LiteLLM context headers to Pillar guardrail

## Relevant issues

<!-- Add issue number if applicable -->
N/A

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory, **Adding at least 1 test is a hard requirement**
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

![Test Results](screenshot.png)
<img width="1268" height="577" alt="image" src="https://github.com/user-attachments/assets/ae566e3e-6cff-4d27-a367-748c19555dc1" />


## Type

🆕 New Feature

## Changes

### Summary
Automatically passes LiteLLM virtual key context as `X-LiteLLM-*` headers to Pillar guardrail for application/user tracking. No configuration required - works out of the box.

### What Changed
- **Automatic header passing**: Extracts context from LiteLLM virtual keys and passes 7 standard headers
- **Headers sent**: `X-LiteLLM-Key-Name`, `X-LiteLLM-Key-Alias`, `X-LiteLLM-User-Id`, `X-LiteLLM-User-Email`, `X-LiteLLM-Team-Id`, `X-LiteLLM-Team-Name`, `X-LiteLLM-Org-Id`
- **Security**: Excludes sensitive data (metadata and API key tokens)
- **Zero config**: Always enabled - no additional setup needed

### Files Changed
- `litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py` - Added header extraction logic
- `tests/test_litellm/proxy/guardrails/test_pillar_guardrails.py` - Added 30 comprehensive tests (all passing)
- `docs/my-website/docs/proxy/guardrails/pillar_security.md` - Updated documentation

### Benefits
- Enables Pillar to track and analyze requests by application, user, team, and organization
- Engineers don't need to manually pass any headers
- Uses existing LiteLLM virtual key infrastructure