### PR TITLE
fix: custom pricing cache token billing

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -162,13 +162,20 @@ def _get_token_base_cost(
     prompt_base_cost = cast(float, _get_cost_per_unit(model_info, input_cost_key))
     completion_base_cost = cast(float, _get_cost_per_unit(model_info, output_cost_key))
     cache_creation_cost = cast(
-        float, _get_cost_per_unit(model_info, cache_creation_cost_key)
+        float,
+        _get_cost_per_unit(model_info, cache_creation_cost_key, prompt_base_cost),
     )
     cache_creation_cost_above_1hr = cast(
         float,
-        _get_cost_per_unit(model_info, "cache_creation_input_token_cost_above_1hr"),
+        _get_cost_per_unit(
+            model_info,
+            "cache_creation_input_token_cost_above_1hr",
+            cache_creation_cost,
+        ),
     )
-    cache_read_cost = cast(float, _get_cost_per_unit(model_info, cache_read_cost_key))
+    cache_read_cost = cast(
+        float, _get_cost_per_unit(model_info, cache_read_cost_key, prompt_base_cost)
+    )
 
     ## CHECK IF ABOVE THRESHOLD
     threshold: Optional[float] = None


### PR DESCRIPTION
fix:#17067

## Pre-Submission checklist
- [x] Added/updated tests in `tests/litellm/` (custom cache-pricing regression)
- [x] Scope is limited to this single bug

## Type
🐛 Bug Fix  
✅ Test

## Changes
- Ensure cache creation/read token prices fall back to `input_cost_per_token` when cache-specific costs aren’t supplied.
- Add a regression test covering custom-priced deployments with cached tokens.