### PR TITLE
Passthrough in response

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -35,15 +35,15 @@ if TYPE_CHECKING:
 dc = DualCache()
 
 
-class GuardrailPassthroughException(Exception):
+class ModifyResponseException(Exception):
     """
-    Exception raised when a guardrail detects a violation in passthrough mode.
+    Exception raised when a guardrail wants to modify the response.
 
     This exception carries the synthetic response that should be returned
-    to the user instead of calling the LLM. It should be caught by the
-    proxy and returned with a 200 status code.
+    to the user instead of calling the LLM or instead of the LLM's response.
+    It should be caught by the proxy and returned with a 200 status code.
 
-    This is a base exception that all guardrails can use for passthrough mode,
+    This is a base exception that all guardrails can use to replace responses,
     allowing violation messages to be returned as successful responses
     rather than errors.
     """
@@ -57,7 +57,7 @@ class GuardrailPassthroughException(Exception):
         detection_info: Optional[Dict[str, Any]] = None,
     ):
         """
-        Initialize the passthrough exception.
+        Initialize the modify response exception.
 
         Args:
             message: The violation message to return to the user
@@ -157,8 +157,8 @@ class CustomGuardrail(CustomLogger):
             detection_info: Optional dictionary with detection metadata (scores, rules, etc.)
 
         Raises:
-            GuardrailPassthroughException: Always raises this exception to short-circuit
-                                          the LLM call and return the violation message
+            ModifyResponseException: Always raises this exception to short-circuit
+                                     the LLM call and return the violation message
 
         Example:
             if violation_detected and self.on_flagged_action == "passthrough":
@@ -171,7 +171,7 @@ class CustomGuardrail(CustomLogger):
         """
         model = request_data.get("model", "unknown")
 
-        raise GuardrailPassthroughException(
+        raise ModifyResponseException(
             message=violation_message,
             model=model,
             request_data=request_data,

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -35,6 +35,45 @@ if TYPE_CHECKING:
 dc = DualCache()
 
 
+class GuardrailPassthroughException(Exception):
+    """
+    Exception raised when a guardrail detects a violation in passthrough mode.
+
+    This exception carries the synthetic response that should be returned
+    to the user instead of calling the LLM. It should be caught by the
+    proxy and returned with a 200 status code.
+
+    This is a base exception that all guardrails can use for passthrough mode,
+    allowing violation messages to be returned as successful responses
+    rather than errors.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        model: str,
+        request_data: Dict[str, Any],
+        guardrail_name: Optional[str] = None,
+        detection_info: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Initialize the passthrough exception.
+
+        Args:
+            message: The violation message to return to the user
+            model: The model that was being called
+            request_data: The original request data
+            guardrail_name: Name of the guardrail that raised this exception
+            detection_info: Additional detection metadata (scores, rules, etc.)
+        """
+        self.message = message
+        self.model = model
+        self.request_data = request_data
+        self.guardrail_name = guardrail_name
+        self.detection_info = detection_info or {}
+        super().__init__(message)
+
+
 class CustomGuardrail(CustomLogger):
     def __init__(
         self,
@@ -95,6 +134,50 @@ class CustomGuardrail(CustomLogger):
                 e,
             )
             return default
+
+    def raise_passthrough_exception(
+        self,
+        violation_message: str,
+        request_data: Dict[str, Any],
+        detection_info: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Raise a passthrough exception for guardrail violations.
+
+        This helper method should be used by guardrails when they detect a violation
+        in passthrough mode.
+
+        The exception will be caught by the proxy endpoints and converted to a 200 response
+        with the violation message, preventing the LLM call from being made (pre_call/during_call)
+        or replacing the LLM response (post_call).
+
+        Args:
+            violation_message: The formatted violation message to return to the user
+            request_data: The original request data dictionary
+            detection_info: Optional dictionary with detection metadata (scores, rules, etc.)
+
+        Raises:
+            GuardrailPassthroughException: Always raises this exception to short-circuit
+                                          the LLM call and return the violation message
+
+        Example:
+            if violation_detected and self.on_flagged_action == "passthrough":
+                message = self._format_violation_message(detection_info)
+                self.raise_passthrough_exception(
+                    violation_message=message,
+                    request_data=data,
+                    detection_info=detection_info
+                )
+        """
+        model = request_data.get("model", "unknown")
+
+        raise GuardrailPassthroughException(
+            message=violation_message,
+            model=model,
+            request_data=request_data,
+            guardrail_name=self.guardrail_name,
+            detection_info=detection_info,
+        )
 
     @staticmethod
     def get_config_model() -> Optional[Type["GuardrailConfigModel"]]:

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -8,9 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import (
-    PassthroughResponseException,
-)
+from litellm.integrations.custom_guardrail import GuardrailPassthroughException
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
@@ -68,7 +66,7 @@ async def anthropic_response(  # noqa: PLR0915
             version=version,
         )
         return result
-    except PassthroughResponseException as e:
+    except GuardrailPassthroughException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -78,10 +78,11 @@ async def anthropic_response(  # noqa: PLR0915
         )
 
         # Create Anthropic-formatted response with violation message
+        import uuid
         from litellm.types.utils import AnthropicMessagesResponse
 
         _anthropic_response = AnthropicMessagesResponse(
-            id=f"msg_{litellm.utils.generate_random_id()}",
+            id=f"msg_{str(uuid.uuid4())}",
             type="message",
             role="assistant",
             content=[{"type": "text", "text": e.message}],

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.integrations.custom_guardrail import GuardrailPassthroughException
+from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
@@ -66,7 +66,7 @@ async def anthropic_response(  # noqa: PLR0915
             version=version,
         )
         return result
-    except GuardrailPassthroughException as e:
+    except ModifyResponseException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -480,18 +480,17 @@ class GraySwanGuardrail(CustomGuardrail):
         ipi = detection.get("ipi", False)
 
         message_parts = [
-            "Content was flagged by Gray Swan Guardrail",
-            f"Violation Score: {violation_score:.2f}",
+            f"Sorry I can't help with that. According to the Gray Swan Cygnal Guardrail, this request has a violation score of {violation_score:.2f}.",
         ]
 
         if violated_rules:
-            message_parts.append(f"Violated Rules: {', '.join(map(str, violated_rules))}")
+            message_parts.append(f"It was violating the rule(s): {', '.join(map(str, violated_rules))}.")
 
         if mutation:
-            message_parts.append("Mutation Detected: Yes")
+            message_parts.append("Mutation effort to make the harmful intention disguised was DETECTED.")
 
         if ipi:
-            message_parts.append("Indirect Prompt Injection Detected: Yes")
+            message_parts.append("Indirect Prompt Injection was DETECTED.")
 
         return "\n".join(message_parts)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -246,13 +246,19 @@ class GraySwanGuardrail(CustomGuardrail):
 
         # If passthrough mode and detection info exists, add it to response
         if self.on_flagged_action == "passthrough" and "metadata" in data:
-            guardrail_detections = data.get("metadata", {}).get("guardrail_detections", [])
+            guardrail_detections = data.get("metadata", {}).get(
+                "guardrail_detections", []
+            )
             if guardrail_detections:
                 # Add guardrail detections to response hidden params for client visibility
-                if hasattr(response, "_hidden_params"):
-                    if not response._hidden_params:
-                        response._hidden_params = {}
-                    response._hidden_params["guardrail_detections"] = guardrail_detections
+                hidden_params = getattr(response, "_hidden_params", None)
+                if hidden_params is not None:
+                    if not hidden_params:
+                        hidden_params = {}
+                        setattr(response, "_hidden_params", hidden_params)
+                    
+                    hidden_params["guardrail_detections"] = guardrail_detections
+                    setattr(response, "_hidden_params", hidden_params)
 
         add_guardrail_to_applied_guardrails_header(
             request_data=data, guardrail_name=self.guardrail_name
@@ -321,7 +327,9 @@ class GraySwanGuardrail(CustomGuardrail):
 
         return payload
 
-    def _process_grayswan_response(self, response_json: Dict[str, Any], data: Optional[dict] = None) -> None:
+    def _process_grayswan_response(
+        self, response_json: Dict[str, Any], data: Optional[dict] = None
+    ) -> None:
         violation_score = float(response_json.get("violation", 0.0) or 0.0)
         violated_rules = response_json.get("violated_rules", [])
         mutation_detected = response_json.get("mutation")
@@ -354,9 +362,13 @@ class GraySwanGuardrail(CustomGuardrail):
                 },
             )
         elif self.on_flagged_action == "monitor":
-            verbose_proxy_logger.info("Gray Swan Guardrail: Monitoring mode - allowing flagged content to proceed")
+            verbose_proxy_logger.info(
+                "Gray Swan Guardrail: Monitoring mode - allowing flagged content to proceed"
+            )
         elif self.on_flagged_action == "passthrough":
-            verbose_proxy_logger.info("Gray Swan Guardrail: Passthrough mode - storing detection info in metadata")
+            verbose_proxy_logger.info(
+                "Gray Swan Guardrail: Passthrough mode - storing detection info in metadata"
+            )
             if data is not None:
                 # Store guardrail detection info in metadata to be included in response
                 if "metadata" not in data:

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -216,7 +216,9 @@ class GraySwanGuardrail(CustomGuardrail):
             )
             return data
 
-        await self.run_grayswan_guardrail(payload, data, GuardrailEventHooks.during_call)
+        await self.run_grayswan_guardrail(
+            payload, data, GuardrailEventHooks.during_call
+        )
         add_guardrail_to_applied_guardrails_header(
             request_data=data, guardrail_name=self.guardrail_name
         )
@@ -281,7 +283,9 @@ class GraySwanGuardrail(CustomGuardrail):
                     )
                     for choice in response.choices:
                         # Handle chat completion format (message.content)
-                        if hasattr(choice, "message") and hasattr(choice.message, "content"):
+                        if hasattr(choice, "message") and hasattr(
+                            choice.message, "content"
+                        ):
                             choice.message.content = violation_message
                         # Handle text completion format (text)
                         elif hasattr(choice, "text"):
@@ -308,7 +312,7 @@ class GraySwanGuardrail(CustomGuardrail):
                     verbose_proxy_logger.warning(
                         "Gray Swan Guardrail: Passthrough mode enabled but response format not recognized. "
                         "Cannot replace content. Response type: %s",
-                        type(response).__name__
+                        type(response).__name__,
                     )
 
         add_guardrail_to_applied_guardrails_header(
@@ -434,7 +438,10 @@ class GraySwanGuardrail(CustomGuardrail):
             }
 
             # For pre_call and during_call, raise exception to short-circuit LLM call
-            if hook_type in (GuardrailEventHooks.pre_call, GuardrailEventHooks.during_call):
+            if hook_type in (
+                GuardrailEventHooks.pre_call,
+                GuardrailEventHooks.during_call,
+            ):
                 verbose_proxy_logger.info(
                     "Gray Swan Guardrail: Passthrough mode - raising exception to short-circuit LLM call"
                 )
@@ -484,10 +491,14 @@ class GraySwanGuardrail(CustomGuardrail):
         ]
 
         if violated_rules:
-            message_parts.append(f"It was violating the rule(s): {', '.join(map(str, violated_rules))}.")
+            message_parts.append(
+                f"It was violating the rule(s): {', '.join(map(str, violated_rules))}."
+            )
 
         if mutation:
-            message_parts.append("Mutation effort to make the harmful intention disguised was DETECTED.")
+            message_parts.append(
+                "Mutation effort to make the harmful intention disguised was DETECTED."
+            )
 
         if ipi:
             message_parts.append("Indirect Prompt Injection was DETECTED.")

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -31,29 +31,6 @@ class GraySwanGuardrailAPIError(Exception):
     """Raised when the Gray Swan API returns an error."""
 
 
-class PassthroughResponseException(Exception):
-    """
-    Raised when guardrail detects a violation in passthrough mode.
-
-    This exception carries the synthetic response that should be returned
-    to the user instead of calling the LLM. It should be caught by the
-    proxy and returned with a 200 status code.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        model: str,
-        request_data: Dict[str, Any],
-        detection_info: Optional[Dict[str, Any]] = None,
-    ):
-        self.message = message
-        self.model = model
-        self.request_data = request_data
-        self.detection_info = detection_info or {}
-        super().__init__(message)
-
-
 class GraySwanGuardrail(CustomGuardrail):
     """
     Guardrail that calls Gray Swan's Cygnal monitoring endpoint.
@@ -446,10 +423,8 @@ class GraySwanGuardrail(CustomGuardrail):
                     "Gray Swan Guardrail: Passthrough mode - raising exception to short-circuit LLM call"
                 )
                 violation_message = self._format_violation_message([detection_info])
-                model = data.get("model", "unknown") if data else "unknown"
-                raise PassthroughResponseException(
-                    message=violation_message,
-                    model=model,
+                self.raise_passthrough_exception(
+                    violation_message=violation_message,
                     request_data=data or {},
                     detection_info=detection_info,
                 )

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -256,7 +256,7 @@ class GraySwanGuardrail(CustomGuardrail):
                     if not hidden_params:
                         hidden_params = {}
                         setattr(response, "_hidden_params", hidden_params)
-                    
+
                     hidden_params["guardrail_detections"] = guardrail_detections
                     setattr(response, "_hidden_params", hidden_params)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -171,6 +171,9 @@ from litellm.constants import (
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import (
+    PassthroughResponseException,
+)
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
@@ -4945,6 +4948,43 @@ async def chat_completion(  # noqa: PLR0915
             return model_dump_with_preserved_fields(result, exclude_unset=True)
         else:
             return result
+    except PassthroughResponseException as e:
+        # Guardrail flagged content in passthrough mode - return 200 with violation message
+        _data = e.request_data
+        await proxy_logging_obj.post_call_failure_hook(
+            user_api_key_dict=user_api_key_dict,
+            original_exception=e,
+            request_data=_data,
+        )
+        _chat_response = litellm.ModelResponse()
+        _chat_response.model = e.model  # type: ignore
+        _chat_response.choices[0].message.content = e.message  # type: ignore
+        _chat_response.choices[0].finish_reason = "content_filter"  # type: ignore
+
+        if data.get("stream", None) is not None and data["stream"] is True:
+            _iterator = litellm.utils.ModelResponseIterator(
+                model_response=_chat_response, convert_to_delta=True
+            )
+            _streaming_response = litellm.CustomStreamWrapper(
+                completion_stream=_iterator,
+                model=e.model,
+                custom_llm_provider="cached_response",
+                logging_obj=data.get("litellm_logging_obj", None),
+            )
+            selected_data_generator = select_data_generator(
+                response=_streaming_response,
+                user_api_key_dict=user_api_key_dict,
+                request_data=_data,
+            )
+
+            return StreamingResponse(
+                selected_data_generator,
+                media_type="text/event-stream",
+                status_code=200,  # Return 200 for passthrough mode
+            )
+        _usage = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        _chat_response.usage = _usage  # type: ignore
+        return _chat_response
     except RejectedRequestError as e:
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -171,7 +171,7 @@ from litellm.constants import (
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.integrations.custom_guardrail import GuardrailPassthroughException
+from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
@@ -4946,7 +4946,7 @@ async def chat_completion(  # noqa: PLR0915
             return model_dump_with_preserved_fields(result, exclude_unset=True)
         else:
             return result
-    except GuardrailPassthroughException as e:
+    except ModifyResponseException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(
@@ -5092,7 +5092,7 @@ async def completion(  # noqa: PLR0915
             user_api_base=user_api_base,
             version=version,
         )
-    except GuardrailPassthroughException as e:
+    except ModifyResponseException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -171,9 +171,7 @@ from litellm.constants import (
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import (
-    PassthroughResponseException,
-)
+from litellm.integrations.custom_guardrail import GuardrailPassthroughException
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
@@ -4948,7 +4946,7 @@ async def chat_completion(  # noqa: PLR0915
             return model_dump_with_preserved_fields(result, exclude_unset=True)
         else:
             return result
-    except PassthroughResponseException as e:
+    except GuardrailPassthroughException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(
@@ -5094,7 +5092,7 @@ async def completion(  # noqa: PLR0915
             user_api_base=user_api_base,
             version=version,
         )
-    except PassthroughResponseException as e:
+    except GuardrailPassthroughException as e:
         # Guardrail flagged content in passthrough mode - return 200 with violation message
         _data = e.request_data
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/grayswan.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/grayswan.py
@@ -11,8 +11,8 @@ class GraySwanGuardrailConfigModelOptionalParams(BaseModel):
     """Optional parameters for the Gray Swan guardrail."""
 
     on_flagged_action: Optional[str] = Field(
-        default="monitor",
-        description="Action when a violation is detected: 'block' rejects the call, 'monitor' logs only, 'passthrough' includes detection info in response without blocking.",
+        default="passthrough",
+        description="Action when a violation is detected: 'block' rejects the call (400 error), 'monitor' logs only, 'passthrough' replaces response content with violation message (200 status).",
     )
     violation_threshold: Optional[float] = Field(
         default=0.5,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -81,7 +81,7 @@ def test_process_response_blocks_when_threshold_exceeded() -> None:
 
     assert exc.value.status_code == 400
     assert exc.value.detail["violation"] == 0.5
-    assert exc.value.detail["detected_in"] == "input"
+    assert exc.value.detail["violation_location"] == "input"
 
     # Test block mode with output violation (post_call)
     with pytest.raises(HTTPException) as exc:
@@ -92,7 +92,7 @@ def test_process_response_blocks_when_threshold_exceeded() -> None:
 
     assert exc.value.status_code == 400
     assert exc.value.detail["violation"] == 0.5
-    assert exc.value.detail["detected_in"] == "output"
+    assert exc.value.detail["violation_location"] == "output"
 
 
 class _DummyResponse:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -111,7 +111,11 @@ async def test_run_guardrail_posts_payload(
 
     captured = {}
 
-    def fake_process(response_json: dict, data: Optional[dict] = None) -> None:
+    def fake_process(
+        response_json: dict,
+        data: Optional[dict] = None,
+        hook_type: Optional[GuardrailEventHooks] = None,
+    ) -> None:
         captured["response"] = response_json
 
     monkeypatch.setattr(grayswan_guardrail, "_process_grayswan_response", fake_process)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -3,10 +3,10 @@ from typing import Optional
 import pytest
 from fastapi import HTTPException
 
+from litellm.integrations.custom_guardrail import GuardrailPassthroughException
 from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import (
     GraySwanGuardrail,
     GraySwanGuardrailAPIError,
-    PassthroughResponseException,
 )
 from litellm.types.guardrails import GuardrailEventHooks
 
@@ -145,7 +145,7 @@ async def test_run_guardrail_raises_api_error(
 
 
 def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
-    """Test that passthrough mode raises PassthroughResponseException in pre_call hook."""
+    """Test that passthrough mode raises GuardrailPassthroughException in pre_call hook."""
     guardrail = GraySwanGuardrail(
         guardrail_name="grayswan-passthrough",
         api_key="test-key",
@@ -162,8 +162,8 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
         "ipi": False,
     }
 
-    # Should raise PassthroughResponseException
-    with pytest.raises(PassthroughResponseException) as exc:
+    # Should raise GuardrailPassthroughException
+    with pytest.raises(GuardrailPassthroughException) as exc:
         guardrail._process_grayswan_response(
             response_json, data, GuardrailEventHooks.pre_call
         )
@@ -175,7 +175,7 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
 
 
 def test_process_response_passthrough_raises_exception_in_during_call() -> None:
-    """Test that passthrough mode raises PassthroughResponseException in during_call hook."""
+    """Test that passthrough mode raises GuardrailPassthroughException in during_call hook."""
     guardrail = GraySwanGuardrail(
         guardrail_name="grayswan-passthrough",
         api_key="test-key",
@@ -192,8 +192,8 @@ def test_process_response_passthrough_raises_exception_in_during_call() -> None:
         "ipi": False,
     }
 
-    # Should raise PassthroughResponseException
-    with pytest.raises(PassthroughResponseException) as exc:
+    # Should raise GuardrailPassthroughException
+    with pytest.raises(GuardrailPassthroughException) as exc:
         guardrail._process_grayswan_response(
             response_json, data, GuardrailEventHooks.during_call
         )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 from fastapi import HTTPException
 
-from litellm.integrations.custom_guardrail import GuardrailPassthroughException
+from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import (
     GraySwanGuardrail,
     GraySwanGuardrailAPIError,
@@ -161,7 +161,7 @@ async def test_run_guardrail_raises_api_error(
 
 
 def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
-    """Test that passthrough mode raises GuardrailPassthroughException in pre_call hook."""
+    """Test that passthrough mode raises ModifyResponseException in pre_call hook."""
     guardrail = GraySwanGuardrail(
         guardrail_name="grayswan-passthrough",
         api_key="test-key",
@@ -178,8 +178,8 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
         "ipi": False,
     }
 
-    # Should raise GuardrailPassthroughException
-    with pytest.raises(GuardrailPassthroughException) as exc:
+    # Should raise ModifyResponseException
+    with pytest.raises(ModifyResponseException) as exc:
         guardrail._process_grayswan_response(
             response_json, data, GuardrailEventHooks.pre_call
         )
@@ -191,7 +191,7 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
 
 
 def test_process_response_passthrough_raises_exception_in_during_call() -> None:
-    """Test that passthrough mode raises GuardrailPassthroughException in during_call hook."""
+    """Test that passthrough mode raises ModifyResponseException in during_call hook."""
     guardrail = GraySwanGuardrail(
         guardrail_name="grayswan-passthrough",
         api_key="test-key",
@@ -208,8 +208,8 @@ def test_process_response_passthrough_raises_exception_in_during_call() -> None:
         "ipi": False,
     }
 
-    # Should raise GuardrailPassthroughException
-    with pytest.raises(GuardrailPassthroughException) as exc:
+    # Should raise ModifyResponseException
+    with pytest.raises(ModifyResponseException) as exc:
         guardrail._process_grayswan_response(
             response_json, data, GuardrailEventHooks.during_call
         )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -168,7 +168,7 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
             response_json, data, GuardrailEventHooks.pre_call
         )
 
-    assert "Content was flagged by Gray Swan Guardrail" in exc.value.message
+    assert "Gray Swan Cygnal Guardrail" in exc.value.message
     assert exc.value.model == "gpt-4"
     assert exc.value.detection_info["violation_score"] == 0.8
     assert exc.value.detection_info["violated_rules"] == [1, 2]
@@ -198,7 +198,7 @@ def test_process_response_passthrough_raises_exception_in_during_call() -> None:
             response_json, data, GuardrailEventHooks.during_call
         )
 
-    assert "Content was flagged by Gray Swan Guardrail" in exc.value.message
+    assert "Gray Swan Cygnal Guardrail" in exc.value.message
     assert exc.value.model == "gpt-4"
 
 
@@ -287,8 +287,11 @@ def test_format_violation_message() -> None:
 
     message = guardrail._format_violation_message(detections)
 
-    assert "Content was flagged by Gray Swan Guardrail" in message
-    assert "Violation Score: 0.85" in message
-    assert "Violated Rules: 1, 3, 5" in message
-    assert "Mutation Detected: Yes" in message
-    assert "Indirect Prompt Injection" not in message or "No" not in message
+    # Check new message format
+    assert "Sorry I can't help with that" in message
+    assert "Gray Swan Cygnal Guardrail" in message
+    assert "violation score of 0.85" in message
+    assert "violating the rule(s): 1, 3, 5" in message
+    assert "Mutation effort to make the harmful intention disguised was DETECTED" in message
+    # IPI should not be in message since it's False
+    assert "Indirect Prompt Injection was DETECTED" not in message


### PR DESCRIPTION
## Gray Swan Guardrail Passthrough Mode Model Response

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="720" height="271" alt="image" src="https://github.com/user-attachments/assets/16f03a99-2aa0-47fc-97f5-d476284473f3" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
📖 Documentation

## Changes
When Gray Swan guardrail is set to passthrough mode the model response content is replaced with a detailed violation message when flagged

