### PR TITLE
[Feature] UI - User Table Sort by All

### DIFF
--- a/ui/litellm-dashboard/src/components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/columns.tsx
@@ -22,10 +22,12 @@ export const columns = (
   handleUserClick: (userId: string, openInEditMode?: boolean) => void,
   selectionOptions?: SelectionOptions,
 ): ColumnDef<UserInfo>[] => {
+  // Backend sortable columns: user_id, user_email, created_at, spend, user_alias, user_role
   const baseColumns: ColumnDef<UserInfo>[] = [
     {
       header: "User ID",
       accessorKey: "user_id",
+      enableSorting: true,
       cell: ({ row }) => (
         <Tooltip title={row.original.user_id}>
           <span className="text-xs">{row.original.user_id ? `${row.original.user_id.slice(0, 7)}...` : "-"}</span>
@@ -35,16 +37,19 @@ export const columns = (
     {
       header: "Email",
       accessorKey: "user_email",
+      enableSorting: true,
       cell: ({ row }) => <span className="text-xs">{row.original.user_email || "-"}</span>,
     },
     {
       header: "Global Proxy Role",
       accessorKey: "user_role",
+      enableSorting: true,
       cell: ({ row }) => <span className="text-xs">{possibleUIRoles?.[row.original.user_role]?.ui_label || "-"}</span>,
     },
     {
       header: "Spend (USD)",
       accessorKey: "spend",
+      enableSorting: true,
       cell: ({ row }) => (
         <span className="text-xs">{row.original.spend ? formatNumberWithCommas(row.original.spend, 4) : "-"}</span>
       ),
@@ -52,6 +57,7 @@ export const columns = (
     {
       header: "Budget (USD)",
       accessorKey: "max_budget",
+      enableSorting: false,
       cell: ({ row }) => (
         <span className="text-xs">{row.original.max_budget !== null ? row.original.max_budget : "Unlimited"}</span>
       ),
@@ -66,6 +72,7 @@ export const columns = (
         </div>
       ),
       accessorKey: "sso_user_id",
+      enableSorting: false,
       cell: ({ row }) => (
         <span className="text-xs">{row.original.sso_user_id !== null ? row.original.sso_user_id : "-"}</span>
       ),
@@ -73,6 +80,7 @@ export const columns = (
     {
       header: "API Keys",
       accessorKey: "key_count",
+      enableSorting: false,
       cell: ({ row }) => (
         <Grid numItems={2}>
           {row.original.key_count > 0 ? (
@@ -90,7 +98,7 @@ export const columns = (
     {
       header: "Created At",
       accessorKey: "created_at",
-      sortingFn: "datetime",
+      enableSorting: true,
       cell: ({ row }) => (
         <span className="text-xs">
           {row.original.created_at ? new Date(row.original.created_at).toLocaleDateString() : "-"}
@@ -100,7 +108,7 @@ export const columns = (
     {
       header: "Updated At",
       accessorKey: "updated_at",
-      sortingFn: "datetime",
+      enableSorting: false,
       cell: ({ row }) => (
         <span className="text-xs">
           {row.original.updated_at ? new Date(row.original.updated_at).toLocaleDateString() : "-"}
@@ -110,6 +118,7 @@ export const columns = (
     {
       id: "actions",
       header: "Actions",
+      enableSorting: false,
       cell: ({ row }) => (
         <div className="flex gap-2">
           <Tooltip title="Edit user details">
@@ -148,6 +157,7 @@ export const columns = (
     return [
       {
         id: "select",
+        enableSorting: false,
         header: () => (
           <Checkbox
             indeterminate={isIndeterminate}

--- a/ui/litellm-dashboard/src/components/view_users/table.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/table.test.tsx
@@ -1,6 +1,5 @@
-import { render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import React from "react";
 
 import { UserDataTable } from "./table";
 
@@ -21,7 +20,7 @@ describe("UserDataTable", () => {
 
     const updateFilters = vi.fn();
 
-    const { getByText } = render(
+    render(
       <UserDataTable
         data={[]}
         columns={[]}
@@ -41,6 +40,58 @@ describe("UserDataTable", () => {
       />,
     );
 
-    expect(getByText("Filters")).toBeInTheDocument();
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+  });
+
+  it("should call onSortChange when clicking a sortable header", () => {
+    const filters = {
+      email: "",
+      user_id: "",
+      user_role: "",
+      sso_user_id: "",
+      team: "",
+      model: "",
+      min_spend: null,
+      max_spend: null,
+      sort_by: "created_at",
+      sort_order: "desc" as const,
+    };
+
+    const updateFilters = vi.fn();
+    const onSortChange = vi.fn();
+
+    const possibleUIRoles = {
+      admin: { ui_label: "Admin" },
+      user: { ui_label: "User" },
+    };
+
+    render(
+      <UserDataTable
+        data={[]}
+        columns={[]}
+        accessToken={null}
+        userRole={"Admin"}
+        possibleUIRoles={possibleUIRoles}
+        filters={filters}
+        updateFilters={updateFilters}
+        initialFilters={filters}
+        teams={[]}
+        handleEdit={vi.fn()}
+        handleDelete={vi.fn()}
+        handleResetPassword={vi.fn()}
+        userListResponse={{ users: [], total: 0, page: 1, page_size: 25, total_pages: 1 }}
+        currentPage={1}
+        handlePageChange={vi.fn()}
+        onSortChange={onSortChange}
+        currentSort={{ sortBy: filters.sort_by, sortOrder: filters.sort_order }}
+      />,
+    );
+
+    const emailHeader = screen.getByRole("columnheader", { name: /email/i });
+    act(() => {
+      fireEvent.click(emailHeader);
+    });
+
+    expect(onSortChange).toHaveBeenCalledWith("user_email", "desc");
   });
 });


### PR DESCRIPTION
## [Feature] UI - User Table Sort by All

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Currently when the user clicks on a sortable header, it will sort only by the values displayed in the table currently. There have been feature requests to sort by the entire set of users when clicking on a sortable header. This PR implements this feature. Sorting is dictated by what is supported on the backend, the current values are:
```
valid_columns = [
        "user_id",
        "user_email",
        "created_at",
        "spend",
        "user_alias",
        "user_role",
    ]
```

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="664" height="238" alt="image" src="https://github.com/user-attachments/assets/79e5947a-1b72-4498-bc15-d94c5ae6adab" />
<img width="515" height="576" alt="image" src="https://github.com/user-attachments/assets/aa943dfb-d4e2-4e57-9432-dd63ca177a39" />
<img width="683" height="395" alt="image" src="https://github.com/user-attachments/assets/397d3e01-60c5-4e72-a30d-75321ea83450" />

