### PR TITLE
Fix bedrock claude opus 4.5 inference profile - only global currently

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23232,7 +23232,7 @@
         "supports_vision": true,
         "tool_use_system_prompt_tokens": 159
     },
-    "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "global.anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,


### PR DESCRIPTION
## Title

AWS Bedrock only supports global inference currently for Claude Opus 4.5. 

See: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

https://github.com/BerriAI/litellm/pull/17101 updated `litellm/model_prices_and_context_window_backup.json` which is auto generated. `model_prices_and_context_window.json` at repo root should be updated instead.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

