### PR TITLE
fix: return response in bedrock guardrail post_call hook

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -808,6 +808,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             request_data=data, guardrail_name=self.guardrail_name
         )
 
+        return response
+
     ###########  HELPER FUNCTIONS for bedrock guardrails ############################
     ##############################################################################
     ##############################################################################

--- a/tests/guardrails_tests/test_bedrock_guardrails.py
+++ b/tests/guardrails_tests/test_bedrock_guardrails.py
@@ -732,6 +732,69 @@ async def test_bedrock_guardrail_response_pii_masking_non_streaming():
 
 
 @pytest.mark.asyncio
+async def test_bedrock_guardrail_post_call_returns_response():
+    """Test that async_post_call_success_hook returns the response object"""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from litellm.proxy._types import UserAPIKeyAuth
+    
+    mock_user_api_key_dict = UserAPIKeyAuth()
+    
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+    )
+
+    # Mock the Bedrock API response
+    mock_bedrock_response = MagicMock()
+    mock_bedrock_response.status_code = 200
+    mock_bedrock_response.json.return_value = {
+        "action": "NONE",
+        "outputs": [{"text": "Hello, how can I help?"}],
+        "assessments": []
+    }
+
+    # Create a mock response
+    mock_response = litellm.ModelResponse(
+        id="test-id",
+        choices=[
+            litellm.Choices(
+                index=0,
+                message=litellm.Message(
+                    role="assistant", 
+                    content="Hello, how can I help?"
+                ),
+                finish_reason="stop"
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion"
+    )
+
+    request_data = {
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Hi"},
+        ],
+    }
+
+    with patch.object(guardrail.async_handler, 'post', new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_bedrock_response
+        
+        # Call the post-call success hook and capture return value
+        result = await guardrail.async_post_call_success_hook(
+            data=request_data,
+            user_api_key_dict=mock_user_api_key_dict,
+            response=mock_response
+        )
+        
+        # Verify that the response is returned (not None)
+        assert result is not None, "async_post_call_success_hook should return the response object"
+        assert result == mock_response, "Returned response should be the same object passed in"
+        print("✓ Post-call hook returns response test passed")
+
+
+@pytest.mark.asyncio
 async def test_bedrock_guardrail_response_pii_masking_streaming():
     """Test that PII masking is applied to response content in streaming scenarios"""
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -1507,6 +1570,6 @@ async def test_bedrock_guardrail_post_call_success_hook_no_output_text():
         response=mock_response, 
         user_api_key_dict=mock_user_api_key_dict,
     )
-    # If no error is raised and result is None, then the test passes
+    # Should return None when there's no output text to process
     assert result is None
     print("✅ No output text in response test passed")


### PR DESCRIPTION
Previously, the async_post_call_success_hook method in BedrockGuardrail was modifying the response in-place but not returning it. This caused the response to be lost when using Bedrock guardrails in post_call mode, resulting in no response being sent back to the client.

This fix ensures the response object is properly returned after applying guardrail checks and masking, maintaining consistency with other guardrail implementations (AIM, Pangea, etc.) and the pre_call hook behavior.

Changes:
- Add return statement in async_post_call_success_hook
- Add test to verify response is returned correctly
- Update test comment for clarity

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


