### PR TITLE
Fix missing max_budget type cast

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2236,6 +2236,8 @@ class ProxyConfig:
                         litellm.max_internal_user_budget = (
                             litellm.default_max_internal_user_budget
                         )
+                elif key == "max_budget":
+                    litellm.max_budget = float(value)
                 elif key == "custom_provider_map":
                     from litellm.utils import custom_llm_setup
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2494,3 +2494,29 @@ def test_get_prompt_spec_for_db_prompt_with_versions():
     prompt_spec_v2 = proxy_config._get_prompt_spec_for_db_prompt(db_prompt=mock_prompt_v2)
     assert prompt_spec_v2.prompt_id == "chat_prompt.v2"
 
+async def test_max_budget_type_casting_on_config_load(monkeypatch):
+    """
+    Test that litellm.max_budget is cast to float when loaded, even from an environment variable.
+    """
+    import tempfile
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    mock_router = MagicMock()
+
+    test_config = {
+        "litellm_settings": {
+            "max_budget": "os.environ/MAX_BUDGET",
+            "budget_duration": "1d"
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+        yaml.dump(test_config, f)
+        config_file_path = f.name
+
+        monkeypatch.setenv('MAX_BUDGET', '5.0')
+        await proxy_config.load_config(router=mock_router, config_file_path=config_file_path)
+        assert isinstance(litellm.max_budget, float)
+        assert litellm.max_budget == 5.0
+


### PR DESCRIPTION
## Title
Fix missing `litellm.max_budget` type cast on proxy server config load

## Relevant issues
The `litellm.max_budget` field is loaded as a `str` when set via an environment variable. The minimum required `config.yaml` to reproduce the issue:

```yaml
litellm_settings:
    max_budget: os.environ/MAX_BUDGET
    budget_duration: 1d
```

Then start the proxy server:
```
python litellm/proxy/proxy_cli.py --config config.yaml
```

`max_budget` is expected to be a `float`, but is loaded as a `str`, which throws the following exception:
```
  File "/Users/dylan/litellm-fork/litellm/proxy/proxy_server.py", line 738, in proxy_startup_event
    if prisma_client is not None and litellm.max_budget > 0:
                                     ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'
```


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="1352" height="480" alt="image" src="https://github.com/user-attachments/assets/b57a767f-5449-4af5-be0a-7dc5419c971f" />


## Type
🐛 Bug Fix
✅ Test

## Changes
When loading the config file, `max_budget` is now cast to a float automatically. It looks like this is also how `max_internal_user_budget` and `default_max_internal_user_budget` are loaded.

