### PR TITLE
Fix Thinking may not be enabled when tool_choice forces tool use

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -580,6 +580,20 @@ class AmazonConverseConfig(BaseConfig):
                 non_default_params=non_default_params, optional_params=optional_params
             )
 
+        final_is_thinking_enabled = self.is_thinking_enabled(optional_params)
+        if (
+            final_is_thinking_enabled
+            and "tool_choice" in optional_params
+        ):
+            tool_choice_block = optional_params["tool_choice"]
+            if isinstance(tool_choice_block, dict):
+                if "any" in tool_choice_block or "tool" in tool_choice_block:
+                    verbose_logger.info(
+                        f"{model} does not support forced tool use (tool_choice='required' or specific tool) "
+                        f"when reasoning is enabled. Changing tool_choice to 'auto'."
+                    )
+                    optional_params["tool_choice"] = ToolChoiceValuesBlock(auto={})
+
         return optional_params
 
     def _translate_response_format_param(

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -238,6 +238,30 @@ def test_transform_tool_call_with_cache_control():
     assert "cachePoint" in transformed_cache_msg
     assert transformed_cache_msg["cachePoint"]["type"] == "default"
 
+
+def test_reasoning_with_forced_tool_choice_switches_to_auto():
+    config = AmazonConverseConfig()
+
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "get_current_weather", "parameters": {}},
+            }
+        ],
+        "tool_choice": "required",
+        "reasoning_effort": "low",
+    }
+
+    optional_params = config.map_openai_params(
+        model="bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        non_default_params=non_default_params,
+        optional_params={},
+        drop_params=False,
+    )
+
+    assert optional_params["tool_choice"] == {"auto": {}}
+
 def test_get_supported_openai_params():
     config = AmazonConverseConfig()
     supported_params = config.get_supported_openai_params(
@@ -2592,8 +2616,10 @@ def test_empty_assistant_message_handling():
     empty or whitespace-only content with a placeholder to prevent AWS Bedrock
     Converse API 400 Bad Request errors.
     """
-    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_converse_messages_pt
-    
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _bedrock_converse_messages_pt,
+    )
+
     # Test case 1: Empty string content - test with modify_params=True to prevent merging
     messages = [
         {"role": "user", "content": "Hello"},


### PR DESCRIPTION
## Title

Fix Thinking may not be enabled when tool_choice forces tool use

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
**Before**
<img width="1064" height="360" alt="image" src="https://github.com/user-attachments/assets/34595a55-fe6e-4986-8dbc-ac890a0d2ca1" />

**After**
<img width="1064" height="532" alt="image" src="https://github.com/user-attachments/assets/91447047-68fe-4eec-92f9-358005bc94f8" />


