### PR TITLE
Add missing standard logging object fields

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9522,6 +9522,15 @@
         "output_cost_per_token": 0.0,
         "supports_embedding_image_input": true
     },
+    "embed-multilingual-light-v3.0": {
+        "input_cost_per_token": 1e-04,
+        "litellm_provider": "cohere",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "supports_embedding_image_input": true
+    },
     "eu.amazon.nova-lite-v1:0": {
         "input_cost_per_token": 7.8e-08,
         "litellm_provider": "bedrock_converse",

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -148,6 +148,8 @@ class VertexPassthroughLoggingHandler:
 
             logging_obj.model = model
             logging_obj.model_call_details["model"] = logging_obj.model
+            logging_obj.model_call_details["custom_llm_provider"] = "vertex_ai"
+            logging_obj.custom_llm_provider = "vertex_ai"
             response_cost = litellm.completion_cost(
                 completion_response=litellm_prediction_response,
                 model=model,
@@ -156,6 +158,7 @@ class VertexPassthroughLoggingHandler:
 
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
+            kwargs["custom_llm_provider"] = "vertex_ai"
             logging_obj.model_call_details["response_cost"] = response_cost
 
             return {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1241,7 +1241,7 @@ def cost_tracking():
     global prisma_client
     if prisma_client is not None:
         litellm.logging_callback_manager.add_litellm_callback(_ProxyDBLogger())
-
+        litellm.logging_callback_manager.add_litellm_async_success_callback(_ProxyDBLogger())
 
 async def update_cache(  # noqa: PLR0915
     token: Optional[str],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9522,6 +9522,15 @@
         "output_cost_per_token": 0.0,
         "supports_embedding_image_input": true
     },
+    "embed-multilingual-light-v3.0": {
+        "input_cost_per_token": 1e-04,
+        "litellm_provider": "cohere",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "supports_embedding_image_input": true
+    },
     "eu.amazon.nova-lite-v1:0": {
         "input_cost_per_token": 7.8e-08,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Title

Add missing standard logging object fields

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
Fixed:
*Type:* embedding   |  *API:* vertex_ai
• vertex_ai/textembedding-gecko-multilingual@001
  – Issue: custom_llm_provider
• vertex_ai/textembedding-gecko-multilingual
  – Issue: custom_llm_provider
• vertex_ai/textembedding-gecko@003
  – Issue: custom_llm_provider
• vertex_ai/text-embedding-005
  – Issue: custom_llm_provider
• vertex_ai/textembedding-gecko
  – Issue: custom_llm_provider
• vertex_ai/text-embedding-004
  – Issue: custom_llm_provider
• vertex_ai/text-multilingual-embedding-002
  – Issue: custom_llm_provider


*Type:* embedding   |  *API:* openai
• vertex_ai/multimodalembedding@001
  – Issues: prompt_tokens, total_tokens
• cohere/embed-v4.0
  – Issue: response_cost
• cohere/embed-multilingual-light-v3.0
  – Issue: response_cost

*Type:* chat   |  *API:* openai
• cohere/command-nightly
  – Issue: response_cost


<img width="464" height="421" alt="image" src="https://github.com/user-attachments/assets/69156293-dcce-40a7-95e5-a88b6cd1ec84" />


