### PR TITLE
fix(gemini): preserve non-ASCII characters in thinking blocks

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1092,7 +1092,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 thinking_blocks.append(
                     ChatCompletionThinkingBlock(
                         type="thinking",
-                        thinking=json.dumps(part_copy),
+                        thinking=json.dumps(part_copy, ensure_ascii=False),
                         signature=part["thoughtSignature"],
                     )
                 )

--- a/tests/llm_translation/test_gemini.py
+++ b/tests/llm_translation/test_gemini.py
@@ -1223,3 +1223,57 @@ def test_gemini_function_args_preserve_unicode():
     assert parsed_args["recipient"] == "José"
     assert "\\u" not in arguments_str
     assert "José" in arguments_str
+
+
+def test_gemini_thinking_blocks_preserve_unicode():
+    """
+    Test that Gemini thinking blocks preserve non-ASCII characters.
+    Follow-up to Issue #16533: Same fix applied to thinking blocks.
+
+    Before fix: "や" becomes "\u3084"
+    After fix: "や" stays as "や"
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
+
+    # Test Japanese characters in thinking block
+    parts = [
+        {
+            "text": "これは日本語の思考です",  # Japanese thinking content
+            "thought": True,
+            "thoughtSignature": "test_signature_123"
+        }
+    ]
+
+    config = VertexGeminiConfig()
+    thinking_blocks = config._extract_thinking_blocks_from_parts(parts)
+
+    assert len(thinking_blocks) == 1
+    thinking_str = thinking_blocks[0]["thinking"]
+
+    # Verify no Unicode escape sequences in raw string
+    assert "\\u" not in thinking_str, "Should not contain Unicode escape sequences"
+    assert "これは日本語の思考です" in thinking_str, "Original Japanese characters should be in the string"
+
+    # Verify it's valid JSON and characters are preserved
+    parsed = json.loads(thinking_str)
+    assert parsed["text"] == "これは日本語の思考です"
+
+    # Test Spanish characters in thinking block
+    parts_spanish = [
+        {
+            "text": "¡Esto es un texto en español!",
+            "thought": True,
+            "thoughtSignature": "test_signature_456"
+        }
+    ]
+
+    thinking_blocks = config._extract_thinking_blocks_from_parts(parts_spanish)
+
+    assert len(thinking_blocks) == 1
+    thinking_str = thinking_blocks[0]["thinking"]
+
+    assert "\\u" not in thinking_str, "Should not contain Unicode escape sequences"
+    assert "¡Esto es un texto en español!" in thinking_str
+
+    parsed = json.loads(thinking_str)
+    assert parsed["text"] == "¡Esto es un texto en español!"


### PR DESCRIPTION
## Title

fix(gemini): preserve non-ASCII characters in thinking blocks

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/16533#issuecomment-3581886719

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Problem

Non-ASCII characters (Japanese, Chinese, Spanish, etc.) in Gemini thinking blocks are displayed as Unicode.

**Before:**
```json
{
  "thinking_blocks": [
    {
      "type": "thinking",
      "thinking": "{\"functionCall\": {\"name\": \"welcome_message\", \"args\": {\"nudge\": \"iPhone\\u3084MacBook\\u306b\\u3064\\u3044\\u3066\\u3001\\u30c6\\u30af\\u30cb\\u30ab\\u30eb\\u30b5\\u30dd\\u30fc\\u30c8\\u306b\\u4eca\\u3059\\u3050\\u76f8\\u8ac7\\u53ef\\u80fd\\u3067\\u3059\\u3002\"}}}",
      "signature": "CpYXAXL..."
    }
  ]
}
```

**After:**
```json
{
  "thinking_blocks": [
    {
      "type": "thinking",
      "thinking": "{\"functionCall\": {\"name\": \"welcome_message\", \"args\": {\"nudge\": \"iPhoneやMacBookについて、テクニカルサポートに今すぐ相談可能です。\"}}}",
      "signature": "CpYXAXL..."
    }
  ]
}
```

## Solution

Added `ensure_ascii=False` to `json.dumps()` in `_extract_thinking_blocks_from_parts()` (line 1095 of `vertex_and_google_ai_studio_gemini.py`).

Follow-up to #16550 which applied the same fix to function call arguments.

## Testing

Added `test_gemini_thinking_blocks_preserve_unicode()` verifying Japanese and Spanish character preservation.