### PR TITLE
[Feat] UI - Allow adding Bedrock API Key when adding models 

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -127,6 +127,16 @@
         "default_value": null
       },
       {
+        "key": "api_key",
+        "label": "AWS Bedrock API Key",
+        "placeholder": null,
+        "tooltip": "You can provide the API Key for accessing the Bedrock API.",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
         "key": "aws_session_token",
         "label": "AWS Session Token",
         "placeholder": null,


### PR DESCRIPTION
## [Feat] UI - Allow adding Bedrock API Key when adding models 

<img width="1524" height="355" alt="Screenshot 2025-11-26 at 11 14 06 AM" src="https://github.com/user-attachments/assets/d9eddec5-a19d-41b4-ab55-01035b911400" />


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes


