### PR TITLE
[Fix] UI - Fix Flaky Test

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.test.tsx
@@ -137,41 +137,30 @@ describe("TeamInfoView", () => {
       />,
     );
 
-    await waitFor(
-      () => {
-        expect(screen.getAllByText("Test Team")).not.toBeNull();
-      },
-      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
-      { timeout: 10000 },
-    );
+    await waitFor(() => {
+      expect(screen.getAllByText("Test Team")).not.toBeNull();
+    });
 
     const settingsTab = screen.getByRole("tab", { name: "Settings" });
     act(() => {
       fireEvent.click(settingsTab);
     });
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("Team Settings")).toBeInTheDocument();
-      },
-      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
-      { timeout: 10000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByText("Team Settings")).toBeInTheDocument();
+    });
 
     const editButton = screen.getByRole("button", { name: "Edit Settings" });
     act(() => {
       fireEvent.click(editButton);
     });
 
-    await waitFor(
-      () => {
-        expect(screen.getByLabelText("Models")).toBeInTheDocument();
-      },
-      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
-      { timeout: 10000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Models")).toBeInTheDocument();
+    });
 
     const allProxyModelsOption = screen.queryByText("All Proxy Models");
     expect(allProxyModelsOption).not.toBeInTheDocument();
-  });
+  }, // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+  10000);
 });

--- a/ui/litellm-dashboard/src/components/team/team_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.test.tsx
@@ -58,7 +58,7 @@ describe("TeamInfoView", () => {
       team_memberships: [],
     });
 
-    vi.mocked(networking.getGuardrailsList).mockResolvedValue([]);
+    vi.mocked(networking.getGuardrailsList).mockResolvedValue({ guardrails: [] });
     vi.mocked(networking.fetchMCPAccessGroups).mockResolvedValue([]);
 
     render(
@@ -74,9 +74,13 @@ describe("TeamInfoView", () => {
         premiumUser={false}
       />,
     );
-    await waitFor(() => {
-      expect(screen.queryByText("User ID")).not.toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByText("User ID")).not.toBeNull();
+      },
+      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+      { timeout: 10000 },
+    );
   });
 
   it("should not show all-proxy-models option when user has no access to it", async () => {
@@ -116,7 +120,7 @@ describe("TeamInfoView", () => {
       team_memberships: [],
     });
 
-    vi.mocked(networking.getGuardrailsList).mockResolvedValue([]);
+    vi.mocked(networking.getGuardrailsList).mockResolvedValue({ guardrails: [] });
     vi.mocked(networking.fetchMCPAccessGroups).mockResolvedValue([]);
 
     render(
@@ -133,27 +137,39 @@ describe("TeamInfoView", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByText("Test Team")).not.toBeNull();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getAllByText("Test Team")).not.toBeNull();
+      },
+      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+      { timeout: 10000 },
+    );
 
     const settingsTab = screen.getByRole("tab", { name: "Settings" });
     act(() => {
       fireEvent.click(settingsTab);
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Team Settings")).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByText("Team Settings")).toBeInTheDocument();
+      },
+      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+      { timeout: 10000 },
+    );
 
     const editButton = screen.getByRole("button", { name: "Edit Settings" });
     act(() => {
       fireEvent.click(editButton);
     });
 
-    await waitFor(() => {
-      expect(screen.getByLabelText("Models")).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Models")).toBeInTheDocument();
+      },
+      // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+      { timeout: 10000 },
+    );
 
     const allProxyModelsOption = screen.queryByText("All Proxy Models");
     expect(allProxyModelsOption).not.toBeInTheDocument();


### PR DESCRIPTION
## [Fix] UI - Fix Flaky Test

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

The tean_info test is flaky due to it being a "heavy" test. In CI/CD environments, the test can take longer than 5s to run, which is the default maximum, and will fail. This test does the following:
1. Renders the team info view (large component)
2. Finds the model dropdown
3. asserts a certain dropdown value does not exist

Changing the test time out to 10s in an effort to reduce flakiness.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

✅ Test

## Changes


