### PR TITLE
[Refactor] Deprecate `spend/logs` & add `spend/logs/v2`

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1917,6 +1917,9 @@ async def view_spend_logs(  # noqa: PLR0915
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
+    [DEPRECATED] This endpoint is not paginated and can cause performance issues.
+    Please use `/spend/logs/v2` instead for paginated access to spend logs.
+
     View all spend logs, if request_id is provided, only logs for that request_id will be returned
 
     When start_date and end_date are provided:

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1,5 +1,6 @@
 #### SPEND MANAGEMENT #####
 import collections
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
@@ -1610,6 +1611,14 @@ async def calculate_spend(request: SpendCalculateRequest):
 
 
 @router.get(
+    "/spend/logs/v2",
+    tags=["Budget & Spend Tracking"],
+    dependencies=[Depends(user_api_key_auth)],
+    responses={
+        200: {"model": Dict[str, Any]},
+    },
+)
+@router.get(
     "/spend/logs/ui",
     tags=["Budget & Spend Tracking"],
     dependencies=[Depends(user_api_key_auth)],
@@ -1672,16 +1681,16 @@ async def ui_view_spend_logs(  # noqa: PLR0915
     ),
 ):
     """
-    View spend logs for UI with pagination support
+    View spend logs with pagination support.
+    Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
 
-    Returns:
-        {
-            "data": List[LiteLLM_SpendLogs],  # Paginated spend logs
-            "total": int,                      # Total number of records
-            "page": int,                       # Current page number
-            "page_size": int,                  # Number of items per page
-            "total_pages": int                 # Total number of pages
-        }
+    Returns paginated response with data, total, page, page_size, and total_pages.
+
+    Example:
+    ```
+    curl -X GET "http://0.0.0.0:8000/spend/logs/v2?start_date=2025-11-25%2000:00:00&end_date=2025-11-26%2023:59:59&page=1&page_size=50" \
+-H "Authorization: Bearer sk-1234"
+    ```
     """
     from litellm.proxy.proxy_server import prisma_client
 


### PR DESCRIPTION
## Title

[Refactor] Deprecate `spend/logs` & add `spend/logs/v2`

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🧹 Refactoring

## Changes

- Reused existing endpoint that contains pagination.
- Based on the url called parse the date accordingly.

## Manual Test Results
<img width="940" height="71" alt="Screenshot 2025-11-26 at 4 13 01 PM" src="https://github.com/user-attachments/assets/b9769324-92a4-482f-8cd9-af2920885ed7" />


<img width="935" height="148" alt="Screenshot 2025-11-26 at 4 13 18 PM" src="https://github.com/user-attachments/assets/7352e58d-4f76-4491-bec7-e884f1229db0" />
