### PR TITLE
Allow wildcard routes for nonproxy admin (SCIM)

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -241,11 +241,11 @@ class RouteChecks:
                     route_allowed = True
                     break
 
-	    if RouteChecks._route_matches_wildcard_pattern(
-		route=route, pattern=allowed_route
-	    ):
-		route_allowed = True
-		break
+                if RouteChecks._route_matches_wildcard_pattern(
+                    route=route, pattern=allowed_route
+                ):
+                    route_allowed = True
+                    break
 
             if not route_allowed:
                 RouteChecks._raise_admin_only_route_exception(

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -241,6 +241,12 @@ class RouteChecks:
                     route_allowed = True
                     break
 
+	    if RouteChecks._route_matches_wildcard_pattern(
+		route=route, pattern=allowed_route
+	    ):
+		route_allowed = True
+		break
+
             if not route_allowed:
                 RouteChecks._raise_admin_only_route_exception(
                     user_obj=user_obj, route=route

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -732,3 +732,31 @@ def test_videos_route_with_virtual_key_llm_api_routes():
         assert (
             result is True
         ), f"Virtual key with llm_api_routes should be able to access {route}"
+
+def test_non_proxy_admin_wildcard_allowed_routes():
+    """Test that nonproxy admin users can still use wildcard routes"""
+
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=["/scim/*"],
+    )
+    
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER.value,
+        route="/scim/v2/Users",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+        


### PR DESCRIPTION
## Title

<!-- e.g. "Implement user authentication feature" -->
Allow wildcard routes for nonproxy admin (SCIM)

## Relevant issues

<!-- e.g. "Fixes #000" -->

fixes the issue where new keys w/ allowed route `scim/*` for nonproxy admin users failed

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="830" height="34" alt="Screenshot 2025-11-26 at 11 14 08 PM" src="https://github.com/user-attachments/assets/0466dd6f-bc3c-4b8c-9f1c-a72cc031eae3" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

Added a check for wildcard routes. Really straightforward.
