### PR TITLE
[Feature] UI - Organization Usage in Usage Tab (#16614)

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/page.tsx
@@ -15,6 +15,7 @@ const UsagePage = () => {
       userID={userId}
       teams={teams ?? []}
       premiumUser={premiumUser}
+      organizations={[]}
     />
   );
 };

--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -480,6 +480,7 @@ export default function CreateKeyPage() {
                     userRole={userRole}
                     accessToken={accessToken}
                     teams={(teams as Team[]) ?? []}
+                    organizations={(organizations as Organization[]) ?? []}
                     premiumUser={premiumUser}
                   />
                 ) : (

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/EntityUsageExportModal.tsx
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/EntityUsageExportModal.tsx
@@ -22,7 +22,7 @@ const EntityUsageExportModal: React.FC<EntityUsageExportModalProps> = ({
   const [exportScope, setExportScope] = useState<ExportScope>("daily");
   const [isExporting, setIsExporting] = useState(false);
 
-  const entityLabel = entityType === "tag" ? "Tag" : "Team";
+  const entityLabel = entityType.charAt(0).toUpperCase() + entityType.slice(1);
   const modalTitle = customTitle || `Export ${entityLabel} Usage`;
 
   const handleExportCSV = () => {

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/ExportTypeSelector.tsx
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/ExportTypeSelector.tsx
@@ -5,7 +5,7 @@ import type { ExportScope } from "./types";
 interface ExportTypeSelectorProps {
   value: ExportScope;
   onChange: (value: ExportScope) => void;
-  entityType: "tag" | "team";
+  entityType: "tag" | "team" | "organization";
 }
 
 const ExportTypeSelector: React.FC<ExportTypeSelectorProps> = ({ value, onChange, entityType }) => {
@@ -36,4 +36,3 @@ const ExportTypeSelector: React.FC<ExportTypeSelectorProps> = ({ value, onChange
 };
 
 export default ExportTypeSelector;
-

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/UsageExportHeader.tsx
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/UsageExportHeader.tsx
@@ -7,7 +7,7 @@ import type { EntitySpendData } from "./types";
 
 interface UsageExportHeaderProps {
   dateValue: DateRangePickerValue;
-  entityType: "tag" | "team";
+  entityType: "tag" | "team" | "organization";
   spendData: EntitySpendData;
   // Optional filter props
   showFilters?: boolean;

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/types.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/types.ts
@@ -17,7 +17,7 @@ export interface EntitySpendData {
 export interface EntityUsageExportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  entityType: "tag" | "team";
+  entityType: "tag" | "team" | "organization";
   spendData: EntitySpendData;
   dateRange: DateRangePickerValue;
   selectedFilters: string[];
@@ -59,4 +59,3 @@ export interface EntityBreakdown {
     id: string;
   };
 }
-

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -50,7 +50,7 @@ export const generateDailyData = (spendData: EntitySpendData, entityLabel: strin
         [entityLabel]: data.metadata?.team_alias || entity,
         [`${entityLabel} ID`]: entity,
         "Spend ($)": formatNumberWithCommas(data.metrics.spend, 4),
-        "Requests": data.metrics.api_requests,
+        Requests: data.metrics.api_requests,
         "Successful Requests": data.metrics.successful_requests,
         "Failed Requests": data.metrics.failed_requests,
         "Total Tokens": data.metrics.total_tokens,
@@ -109,9 +109,9 @@ export const generateDailyWithModelsData = (spendData: EntitySpendData, entityLa
           [`${entityLabel} ID`]: entity,
           Model: model,
           "Spend ($)": formatNumberWithCommas(metrics.spend, 4),
-          "Requests": metrics.requests,
-          "Successful": metrics.successful,
-          "Failed": metrics.failed,
+          Requests: metrics.requests,
+          Successful: metrics.successful,
+          Failed: metrics.failed,
           "Total Tokens": metrics.tokens,
         });
       });
@@ -137,7 +137,7 @@ export const generateExportData = (
 };
 
 export const generateMetadata = (
-  entityType: "tag" | "team",
+  entityType: "tag" | "team" | "organization",
   dateRange: { from?: Date; to?: Date },
   selectedFilters: string[],
   exportScope: ExportScope,
@@ -159,4 +159,3 @@ export const generateMetadata = (
     total_tokens: spendData.metadata.total_tokens,
   },
 });
-

--- a/ui/litellm-dashboard/src/components/common_components/default_org.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/default_org.tsx
@@ -1,6 +1,6 @@
 import { Organization } from "../networking";
 
 export const defaultOrg = {
-  organization_id: null,
+  organization_id: "default_organization",
   organization_alias: "Default Organization",
 } as Organization;

--- a/ui/litellm-dashboard/src/components/entity_usage.test.tsx
+++ b/ui/litellm-dashboard/src/components/entity_usage.test.tsx
@@ -3,7 +3,6 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import EntityUsage from "./entity_usage";
 import * as networking from "./networking";
 
-// Polyfill ResizeObserver for test environment
 beforeAll(() => {
   if (typeof window !== "undefined" && !window.ResizeObserver) {
     window.ResizeObserver = class ResizeObserver {
@@ -18,6 +17,7 @@ beforeAll(() => {
 vi.mock("./networking", () => ({
   tagDailyActivityCall: vi.fn(),
   teamDailyActivityCall: vi.fn(),
+  organizationDailyActivityCall: vi.fn(),
 }));
 
 // Mock the child components to simplify testing
@@ -41,6 +41,7 @@ vi.mock("./EntityUsageExport", () => ({
 describe("EntityUsage", () => {
   const mockTagDailyActivityCall = vi.mocked(networking.tagDailyActivityCall);
   const mockTeamDailyActivityCall = vi.mocked(networking.teamDailyActivityCall);
+  const mockOrganizationDailyActivityCall = vi.mocked(networking.organizationDailyActivityCall);
 
   const mockSpendData = {
     results: [
@@ -126,8 +127,10 @@ describe("EntityUsage", () => {
   beforeEach(() => {
     mockTagDailyActivityCall.mockClear();
     mockTeamDailyActivityCall.mockClear();
+    mockOrganizationDailyActivityCall.mockClear();
     mockTagDailyActivityCall.mockResolvedValue(mockSpendData);
     mockTeamDailyActivityCall.mockResolvedValue(mockSpendData);
+    mockOrganizationDailyActivityCall.mockResolvedValue(mockSpendData);
   });
 
   it("should render with tag entity type and display spend metrics", async () => {
@@ -162,6 +165,19 @@ describe("EntityUsage", () => {
       const spendElements = screen.getAllByText("$100.50");
       expect(spendElements.length).toBeGreaterThan(0);
     });
+  });
+
+  it("should render with organization entity type and call organization API", async () => {
+    const { getByText, getAllByText } = render(<EntityUsage {...defaultProps} entityType="organization" />);
+
+    await waitFor(() => {
+      expect(mockOrganizationDailyActivityCall).toHaveBeenCalled();
+    });
+
+    expect(getByText("Organization Spend Overview")).toBeInTheDocument();
+
+    const spendElements = getAllByText("$100.50");
+    expect(spendElements.length).toBeGreaterThan(0);
   });
 
   it("should switch between tabs", async () => {

--- a/ui/litellm-dashboard/src/components/new_usage.test.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
 import NewUsagePage from "./new_usage";
+import type { Organization } from "./networking";
 import * as networking from "./networking";
 
 // Polyfill ResizeObserver for test environment
@@ -153,6 +154,26 @@ describe("NewUsage", () => {
     },
   };
 
+  const mockOrganizations: Organization[] = [
+    {
+      organization_id: "org-123",
+      organization_alias: "Acme Org",
+      budget_id: "budget-1",
+      metadata: {},
+      models: [],
+      spend: 0,
+      model_spend: {},
+      created_at: "2025-01-01T00:00:00Z",
+      created_by: "user-123",
+      updated_at: "2025-01-02T00:00:00Z",
+      updated_by: "user-123",
+      litellm_budget_table: null,
+      teams: null,
+      users: null,
+      members: null,
+    },
+  ];
+
   const defaultProps = {
     accessToken: "test-token",
     userRole: "Admin",
@@ -175,6 +196,7 @@ describe("NewUsage", () => {
         members_with_roles: [],
       },
     ],
+    organizations: [],
     premiumUser: true,
   };
 
@@ -247,6 +269,23 @@ describe("NewUsage", () => {
     // Should still render EntityUsage component for tags
     await waitFor(() => {
       const entityUsageElements = screen.getAllByText("Entity Usage");
+      expect(entityUsageElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("should show organization usage banner and tab for admins", async () => {
+    const { getByText, getAllByText } = render(<NewUsagePage {...defaultProps} organizations={mockOrganizations} />);
+
+    await waitFor(() => {
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+    });
+
+    const organizationTab = getByText("Organization Usage");
+    fireEvent.click(organizationTab);
+
+    await waitFor(() => {
+      expect(getByText("Organization usage is a new feature.")).toBeInTheDocument();
+      const entityUsageElements = getAllByText("Entity Usage");
       expect(entityUsageElements.length).toBeGreaterThan(0);
     });
   });

--- a/ui/litellm-dashboard/src/components/new_usage.tsx
+++ b/ui/litellm-dashboard/src/components/new_usage.tsx
@@ -6,58 +6,66 @@
  * Works at 1m+ spend logs, by querying an aggregate table instead.
  */
 
-import React, { useState, useEffect, useMemo, useCallback } from "react";
 import {
   BarChart,
   Card,
-  Title,
-  Text,
-  Grid,
   Col,
-  TabGroup,
-  TabList,
-  Tab,
-  TabPanel,
-  TabPanels,
+  DateRangePickerValue,
   DonutChart,
+  Grid,
+  Tab,
+  TabGroup,
   Table,
-  TableHead,
-  TableRow,
-  TableHeaderCell,
   TableBody,
   TableCell,
-  DateRangePickerValue,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Text,
+  Title,
 } from "@tremor/react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert } from "antd";
 
-import { userDailyActivityCall, userDailyActivityAggregatedCall, tagListCall } from "./networking";
-import { Tag } from "./tag_management/types";
-import ViewUserSpend from "./view_user_spend";
-import TopKeyView from "./top_key_view";
-import { ActivityMetrics, processActivityData } from "./activity_metrics";
-import UserAgentActivity from "./user_agent_activity";
-import { DailyData, MetricWithMetadata, KeyMetricWithMetadata } from "./usage/types";
-import EntityUsage from "./entity_usage";
-import { all_admin_roles } from "../utils/roles";
-import { Team } from "./key_team_helpers/key_list";
-import { EntityList } from "./entity_usage";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
-import { valueFormatterSpend } from "./usage/utils/value_formatters";
-import CloudZeroExportModal from "./cloudzero_export_modal";
-import { ChartLoader } from "./shared/chart_loader";
-import { getProviderLogoAndName } from "./provider_info_helpers";
-import EntityUsageExportModal from "./EntityUsageExport";
-import AdvancedDatePicker from "./shared/advanced_date_picker";
 import { Button } from "@tremor/react";
+import { all_admin_roles } from "../utils/roles";
+import { ActivityMetrics, processActivityData } from "./activity_metrics";
+import CloudZeroExportModal from "./cloudzero_export_modal";
+import EntityUsage, { EntityList } from "./entity_usage";
+import EntityUsageExportModal from "./EntityUsageExport";
+import { Team } from "./key_team_helpers/key_list";
+import { Organization, tagListCall, userDailyActivityAggregatedCall, userDailyActivityCall } from "./networking";
+import { getProviderLogoAndName } from "./provider_info_helpers";
+import AdvancedDatePicker from "./shared/advanced_date_picker";
+import { ChartLoader } from "./shared/chart_loader";
+import { Tag } from "./tag_management/types";
+import TopKeyView from "./top_key_view";
+import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "./usage/types";
+import { valueFormatterSpend } from "./usage/utils/value_formatters";
+import UserAgentActivity from "./user_agent_activity";
+import ViewUserSpend from "./view_user_spend";
 
 interface NewUsagePageProps {
   accessToken: string | null;
   userRole: string | null;
   userID: string | null;
   teams: Team[];
+  organizations: Organization[];
   premiumUser: boolean;
 }
 
-const NewUsagePage: React.FC<NewUsagePageProps> = ({ accessToken, userRole, userID, teams, premiumUser }) => {
+const NewUsagePage: React.FC<NewUsagePageProps> = ({
+  accessToken,
+  userRole,
+  userID,
+  teams,
+  organizations,
+  premiumUser,
+}) => {
   const [userSpendData, setUserSpendData] = useState<{
     results: DailyData[];
     metadata: any;
@@ -81,6 +89,7 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({ accessToken, userRole, user
   const [modelViewType, setModelViewType] = useState<"groups" | "individual">("groups");
   const [isCloudZeroModalOpen, setIsCloudZeroModalOpen] = useState(false);
   const [isGlobalExportModalOpen, setIsGlobalExportModalOpen] = useState(false);
+  const [showOrganizationBanner, setShowOrganizationBanner] = useState(true);
 
   const getAllTags = async () => {
     if (!accessToken) {
@@ -415,6 +424,11 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({ accessToken, userRole, user
             <div className="flex items-end justify-start gap-6 mb-6">
               <TabList variant="solid">
                 {all_admin_roles.includes(userRole || "") ? <Tab>Global Usage</Tab> : <Tab>Your Usage</Tab>}
+                {all_admin_roles.includes(userRole || "") ? (
+                  <Tab>Organization Usage</Tab>
+                ) : (
+                  <Tab>Your Organization Usage</Tab>
+                )}
                 <Tab>Team Usage</Tab>
                 {all_admin_roles.includes(userRole || "") ? <Tab>Tag Usage</Tab> : <></>}
                 {all_admin_roles.includes(userRole || "") ? <Tab>User Agent Activity</Tab> : <></>}
@@ -735,6 +749,35 @@ const NewUsagePage: React.FC<NewUsagePageProps> = ({ accessToken, userRole, user
                     </TabPanel>
                   </TabPanels>
                 </TabGroup>
+              </TabPanel>
+
+              {/* Organization Usage Panel */}
+              <TabPanel>
+                {showOrganizationBanner && (
+                  <Alert
+                    banner
+                    type="info"
+                    message="Organization usage is a new feature."
+                    description="Spend is tracked from feature launch and previous data isn't backfilled, so only future usage appears here."
+                    closable
+                    onClose={() => setShowOrganizationBanner(false)}
+                    className="mb-5"
+                  />
+                )}
+                <EntityUsage
+                  accessToken={accessToken}
+                  entityType="organization"
+                  userID={userID}
+                  userRole={userRole}
+                  dateValue={dateValue}
+                  entityList={
+                    organizations?.map((organization) => ({
+                      label: organization.organization_alias,
+                      value: organization.organization_id,
+                    })) || null
+                  }
+                  premiumUser={premiumUser}
+                />
               </TabPanel>
 
               {/* Team Usage Panel */}


### PR DESCRIPTION
## [Feature] UI - Organization Usage in Usage Tab (#16614)

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
Re-adding the Organization Usage in UI now the backend has been merged
<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="1271" height="588" alt="image" src="https://github.com/user-attachments/assets/ad4f0a52-07b7-4147-b6cb-bb55887cfbe8" />
<img width="849" height="251" alt="image" src="https://github.com/user-attachments/assets/34451d53-ceee-4d5e-9a69-36fee1b0233d" />

