### PR TITLE
docs: add OpenAI Agents SDK to projects

### DIFF
--- a/docs/my-website/docs/projects/openai-agents.md
+++ b/docs/my-website/docs/projects/openai-agents.md
@@ -1,0 +1,22 @@
+
+# OpenAI Agents SDK
+
+The [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) is a lightweight framework for building multi-agent workflows.
+It includes an official LiteLLM extension that lets you use any of the 100+ supported providers (Anthropic, Gemini, Mistral, Bedrock, etc.) 
+
+```python
+from agents import Agent, Runner
+from agents.extensions.models.litellm_model import LitellmModel
+
+agent = Agent(
+    name="Assistant",
+    instructions="You are a helpful assistant.",
+    model=LitellmModel(model="provider/model-name")
+)
+
+result = Runner.run_sync(agent, "your_prompt_here")
+print("Result:", result.final_output)
+```
+
+- [GitHub](https://github.com/openai/openai-agents-python)
+- [LiteLLM Extension Docs](https://openai.github.io/openai-agents-python/ref/extensions/litellm/)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -797,10 +797,10 @@ const sidebars = {
               "Learn how to deploy + call models from different providers on LiteLLM",
             slug: "/project",
           },
-          items: [
-            "projects/openai-agents",
+          items: [        
             "projects/smolagents",
             "projects/mini-swe-agent",
+            "projects/openai-agents",
             "projects/Docq.AI",
             "projects/PDL",
             "projects/OpenInterpreter",

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -798,6 +798,7 @@ const sidebars = {
             slug: "/project",
           },
           items: [
+            "projects/openai-agents",
             "projects/smolagents",
             "projects/mini-swe-agent",
             "projects/Docq.AI",


### PR DESCRIPTION
## Title

  Add OpenAI Agents SDK to projects documentation

## Relevant issues

  N/A

##  Pre-Submission checklist

  - I have Added testing - N/A (documentation only)
  - I have added a screenshot - N/A (documentation only)
  - My PR passes all unit tests - N/A (documentation only)
  - My PR's scope is as isolated as possible, it only solves 1 specific problem

 ## Type

  📖 Documentation

 ## Changes

  - Added new project page for OpenAI Agents SDK (docs/my-website/docs/projects/openai-agents.md)
  - Updated sidebar to include the new project (sidebars.js)

  The OpenAI Agents SDK has an official LiteLLM extension that enables using any of the 100+ supported LLM providers in multi-agent workflows.