### PR TITLE
fix(bedrock): Only forward anthropic_beta header to Claude models

### DIFF
--- a/litellm/llms/bedrock/messages/readme.md
+++ b/litellm/llms/bedrock/messages/readme.md
@@ -1,3 +1,10 @@
 # /v1/messages
 
 This folder contains transformation logic for calling bedrock models in the Anthropic /v1/messages API spec.
+
+## Important Notes
+
+- The `anthropic_beta` header is only forwarded to **Claude models** (models with provider "anthropic")
+- Non-Claude models (Qwen, Nova, etc.) will have this header stripped automatically
+- This prevents "unknown variant: anthropic_beta" errors on models that don't support Anthropic beta features
+- Provider detection is performed using `BedrockLLM.get_bedrock_invoke_provider()` for robust model identification


### PR DESCRIPTION
## Title

Fix issue where anthropic_beta header was being sent to all Bedrock models via the /v1/messages endpoint, causing "unknown variant: anthropic_beta" errors on non-Claude models like Qwen and Nova.

Changes:
- Use BedrockLLM.get_bedrock_invoke_provider() for robust model detection
- Only add anthropic_beta to request when provider is "anthropic"
- Add comprehensive tests for Claude and non-Claude models
- Update documentation explaining the filtering behavior

This ensures Claude Code works seamlessly with non-Claude Bedrock models while preserving full anthropic_beta support for Claude models.

## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/17133

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix


## Changes

- Use BedrockLLM.get_bedrock_invoke_provider() for robust model detection
- Only add anthropic_beta to request when provider is "anthropic"
- Add comprehensive tests for Claude and non-Claude models
- Update documentation explaining the filtering behavior

