### PR TITLE
Fix : acompletion throws error with SambaNova models

### DIFF
--- a/litellm/llms/sambanova/chat.py
+++ b/litellm/llms/sambanova/chat.py
@@ -121,5 +121,10 @@ class SambanovaConfig(OpenAIGPTConfig):
         SambaNova API doesn't support content as a list - only string content.
         This converts content lists like [{"type": "text", "text": "..."}] to strings.
         """
+        async def _async_transform():
+            return handle_messages_with_content_list_to_str_conversion(messages)
+
+        if is_async:
+            return _async_transform()
         messages = handle_messages_with_content_list_to_str_conversion(messages)
         return messages


### PR DESCRIPTION
## Title

Fixed the bug where for sambanova provider acompletion function was not returning a coroutine , but a list .

🐛 Bug Fix

## Changes
Fixed the bug where for sambanova provider acompletion function was not returning a coroutine , but a list , in litellm/llms/sambanova/chat.py

