### PR TITLE
fix(bedrock): handle cohere v4 embed response dictionary format

### DIFF
--- a/litellm/llms/cohere/embed/v1_transformation.py
+++ b/litellm/llms/cohere/embed/v1_transformation.py
@@ -1,5 +1,5 @@
 """
-Legacy /v1/embedding transformation logic for Bedrock Cohere. 
+Legacy /v1/embedding transformation logic for Bedrock Cohere.
 """
 
 from typing import Any, List, Optional, Union
@@ -123,7 +123,13 @@ class CohereEmbeddingConfig:
         """
         embeddings = response_json["embeddings"]
         output_data = []
-        is_embeddings_by_type = response_json.get("response_type") == "embeddings_by_type"
+        is_embeddings_by_type = (
+            response_json.get("response_type") == "embeddings_by_type"
+        )
+
+        if isinstance(embeddings, dict):
+            is_embeddings_by_type = True
+
         if is_embeddings_by_type:
             for embedding_type in embeddings:
                 for idx, embedding in enumerate(embeddings[embedding_type]):


### PR DESCRIPTION
## Title

Fix parsing of bedrock cohere embed v4 responses

## Relevant issues

This PR fixes an issue where `bedrock/cohere.embed-v4` models return a dictionary of embeddings (keyed by type, e.g., `float`, `int8`) instead of a flat list, causing LiteLLM to incorrectly parse the response.

Previously, LiteLLM would iterate over the dictionary keys (returning `["float", "int8"]`) instead of the actual embedding vectors. This change explicitly checks if the `embeddings` field in the response is a dictionary and handles it as `embeddings_by_type`.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

<img width="673" height="351" alt="litellm-tests-screenshot-bedrock-cohere-v4-fix" src="https://github.com/user-attachments/assets/1ff559a2-60a6-4cd8-9f5a-642be4da4285" />

I have also verified this in a live integration environment using `bedrock/cohere.embed-v4:0` as well as confirming other embedding models are not affected such as `bedrock/cohere.embed-multilingual-v3` and `bedrock/amazon.titan-embed-text-v2:0`.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

litellm/llms/cohere/embed/v1_transformation.py
Added new code here to check the returned data.

tests/test_litellm/llms/bedrock/embed/test_bedrock_cohere_v4.py
I have added a new unit test that mocks the Cohere v4 response structure.

