### PR TITLE
fix(image-gen): include thoughtSignature in Gemini image generation response

### DIFF
--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -232,6 +232,7 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
                             model_response.data.append(ImageObject(
                                 b64_json=inline_data["data"],
                                 url=None,
+                                thought_signature=part.get("thoughtSignature"),
                             ))
         else:
             # Original Imagen format - predictions with generated images

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -229,10 +229,11 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
                     if "inlineData" in part:
                         inline_data = part["inlineData"]
                         if "data" in inline_data:
+                            thought_sig = part.get("thoughtSignature")
                             model_response.data.append(ImageObject(
                                 b64_json=inline_data["data"],
                                 url=None,
-                                thought_signature=part.get("thoughtSignature"),
+                                provider_specific_fields={"thought_signature": thought_sig} if thought_sig else None,
                             ))
         else:
             # Original Imagen format - predictions with generated images

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -258,6 +258,7 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                         model_response.data.append(ImageObject(
                             b64_json=inline_data["data"],
                             url=None,
+                            thought_signature=part.get("thoughtSignature"),
                         ))
         
         return model_response

--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -255,10 +255,11 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
                 if "inlineData" in part:
                     inline_data = part["inlineData"]
                     if "data" in inline_data:
+                        thought_sig = part.get("thoughtSignature")
                         model_response.data.append(ImageObject(
                             b64_json=inline_data["data"],
                             url=None,
-                            thought_signature=part.get("thoughtSignature"),
+                            provider_specific_fields={"thought_signature": thought_sig} if thought_sig else None,
                         ))
         
         return model_response

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1708,6 +1708,7 @@ class ImageObject(OpenAIImage):
     b64_json: The base64-encoded JSON of the generated image, if response_format is b64_json.
     url: The URL of the generated image, if response_format is url (default).
     revised_prompt: The prompt that was used to generate the image, if there was any revision to the prompt.
+    thought_signature: The thought signature returned by Gemini image generation models (used for interactive image editing).
 
     https://platform.openai.com/docs/api-reference/images/object
     """
@@ -1715,9 +1716,11 @@ class ImageObject(OpenAIImage):
     b64_json: Optional[str] = None
     url: Optional[str] = None
     revised_prompt: Optional[str] = None
+    thought_signature: Optional[str] = None
 
-    def __init__(self, b64_json=None, url=None, revised_prompt=None, **kwargs):
+    def __init__(self, b64_json=None, url=None, revised_prompt=None, thought_signature=None, **kwargs):
         super().__init__(b64_json=b64_json, url=url, revised_prompt=revised_prompt)  # type: ignore
+        self.thought_signature = thought_signature
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1708,7 +1708,7 @@ class ImageObject(OpenAIImage):
     b64_json: The base64-encoded JSON of the generated image, if response_format is b64_json.
     url: The URL of the generated image, if response_format is url (default).
     revised_prompt: The prompt that was used to generate the image, if there was any revision to the prompt.
-    thought_signature: The thought signature returned by Gemini image generation models (used for interactive image editing).
+    provider_specific_fields: Provider-specific fields not part of OpenAI spec.
 
     https://platform.openai.com/docs/api-reference/images/object
     """
@@ -1716,11 +1716,12 @@ class ImageObject(OpenAIImage):
     b64_json: Optional[str] = None
     url: Optional[str] = None
     revised_prompt: Optional[str] = None
-    thought_signature: Optional[str] = None
+    provider_specific_fields: Optional[Dict[str, Any]] = None
 
-    def __init__(self, b64_json=None, url=None, revised_prompt=None, thought_signature=None, **kwargs):
+    def __init__(self, b64_json=None, url=None, revised_prompt=None, provider_specific_fields=None, **kwargs):
         super().__init__(b64_json=b64_json, url=url, revised_prompt=revised_prompt)  # type: ignore
-        self.thought_signature = thought_signature
+        if provider_specific_fields:
+            self.provider_specific_fields = provider_specific_fields
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -248,7 +248,7 @@ class TestVertexAIGeminiImageGenerationConfig:
 
         assert len(result.data) == 1
         assert result.data[0].b64_json == "base64_encoded_image_data"
-        assert result.data[0].thought_signature == "test_signature_abc123"
+        assert result.data[0].provider_specific_fields["thought_signature"] == "test_signature_abc123"
 
 
 class TestVertexAIImagenImageGenerationConfig:

--- a/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/image_generation/test_vertex_ai_image_generation_transformation.py
@@ -209,6 +209,47 @@ class TestVertexAIGeminiImageGenerationConfig:
         assert result.data[0].b64_json == "image1"
         assert result.data[1].b64_json == "image2"
 
+    def test_transform_image_generation_response_signature(self):
+        """Test response transformation includes thoughtSignature for Gemini 3 Pro"""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "base64_encoded_image_data",
+                                },
+                                "thoughtSignature": "test_signature_abc123",
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        mock_response.headers = {}
+
+        from litellm.types.utils import ImageResponse
+
+        model_response = ImageResponse()
+        result = self.config.transform_image_generation_response(
+            model="gemini-3-pro-image-preview",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=MagicMock(),
+            request_data={},
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+        assert len(result.data) == 1
+        assert result.data[0].b64_json == "base64_encoded_image_data"
+        assert result.data[0].thought_signature == "test_signature_abc123"
+
 
 class TestVertexAIImagenImageGenerationConfig:
     def setup_method(self):


### PR DESCRIPTION
fix(image-gen): include thoughtSignature in Gemini image generation response

  ## Relevant issues

  Fixes #17184

  ## Pre-Submission checklist

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory
  - [ ] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🐛 Bug Fix

  ## Changes

  ### Summary

  Gemini 3 Pro image preview model returns a `thoughtSignature` field in the response that is required for interactive image editing workflows. This field was being discarded during response transformation.

  ### Solution

  - Added optional `thought_signature` field to `ImageObject` class
  - Updated response transformation in both `gemini/` and `vertex_ai/` providers to extract and include `thoughtSignature` from the API response
  - Added unit test to verify `thought_signature` is correctly extracted
  
  ### Backward Compatibility

  This change is fully backward compatible - the new field is optional