### PR TITLE
fix: respect guardrail mock_response during during_call to return blo…

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -536,7 +536,11 @@ class ProxyBaseLLMRequestProcessing:
 
         responses = await llm_responses
 
-        response = responses[1]
+        # Guardrails (pre/during-call) can inject a mock response to short-circuit the LLM call.
+        # Prefer it when present so blocked/filtered output is returned instead of the model response.
+        response = self.data.get("mock_response")
+        if response is None:
+            response = responses[1]
 
         hidden_params = getattr(response, "_hidden_params", {}) or {}
         model_id = hidden_params.get("model_id", None) or ""
@@ -804,7 +808,7 @@ class ProxyBaseLLMRequestProcessing:
             # This matches the original behavior before the refactor in commit 511d435f6f
             error_body = await e.response.aread()
             error_text = error_body.decode("utf-8")
-            
+
             raise HTTPException(
                 status_code=e.response.status_code,
                 detail={"error": error_text},
@@ -1072,9 +1076,9 @@ class ProxyBaseLLMRequestProcessing:
 
             # Add cache-related fields to **params (handled by Usage.__init__)
             if cache_creation_input_tokens is not None:
-                usage_kwargs["cache_creation_input_tokens"] = (
-                    cache_creation_input_tokens
-                )
+                usage_kwargs[
+                    "cache_creation_input_tokens"
+                ] = cache_creation_input_tokens
             if cache_read_input_tokens is not None:
                 usage_kwargs["cache_read_input_tokens"] = cache_read_input_tokens
 
@@ -1093,7 +1097,9 @@ class ProxyBaseLLMRequestProcessing:
                 return obj
         return None
 
-    def maybe_get_model_id(self, _logging_obj: Optional[LiteLLMLoggingObj]) -> Optional[str]:
+    def maybe_get_model_id(
+        self, _logging_obj: Optional[LiteLLMLoggingObj]
+    ) -> Optional[str]:
         """
         Get model_id from logging object or request metadata.
 
@@ -1103,10 +1109,7 @@ class ProxyBaseLLMRequestProcessing:
         model_id = None
         if _logging_obj:
             # 1. Try getting from litellm_params (updated during call)
-            if (
-                hasattr(_logging_obj, "litellm_params")
-                and _logging_obj.litellm_params
-            ):
+            if hasattr(_logging_obj, "litellm_params") and _logging_obj.litellm_params:
                 # First check direct model_info path (set by router.py with selected deployment)
                 model_info = _logging_obj.litellm_params.get("model_info") or {}
                 model_id = model_info.get("id", None)

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,11 +1,13 @@
 import copy
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastapi import Request, status
+from fastapi import Request, Response, status
 from fastapi.responses import StreamingResponse
 
 import litellm
+import litellm.proxy.common_request_processing as common_request_processing
 from litellm._uuid import uuid
 from litellm.integrations.opentelemetry import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import (
@@ -74,6 +76,101 @@ class TestProxyBaseLLMRequestProcessing:
         except ValueError:
             pytest.fail("litellm_call_id is not a valid UUID")
         assert data_passed["litellm_call_id"] == returned_data["litellm_call_id"]
+
+    @pytest.mark.asyncio
+    async def test_base_process_llm_request_prefers_guardrail_mock_response(
+        self, monkeypatch
+    ):
+        processing_obj = ProxyBaseLLMRequestProcessing(
+            data={
+                "messages": [],
+                "metadata": {},
+                "litellm_metadata": {"model_info": {"id": "fallback-model"}},
+            }
+        )
+
+        guardrail_response = litellm.ModelResponse(
+            model="bedrock-guardrail",
+            hidden_params={"model_id": "guardrail-model"},
+        )
+        llm_response = litellm.ModelResponse(
+            model="real-model",
+            hidden_params={"model_id": "real-model"},
+        )
+
+        async def mock_common_processing(self, *args, **kwargs):
+            logging_obj = SimpleNamespace(litellm_call_id="test-call-id")
+            self.data["litellm_call_id"] = "test-call-id"
+            self.data["litellm_logging_obj"] = logging_obj
+            return self.data, logging_obj
+
+        monkeypatch.setattr(
+            ProxyBaseLLMRequestProcessing,
+            "common_processing_pre_call_logic",
+            mock_common_processing,
+        )
+
+        async def mock_route_request(*args, **kwargs):
+            async def _inner():
+                return llm_response
+
+            return _inner()
+
+        monkeypatch.setattr(
+            common_request_processing,
+            "route_request",
+            mock_route_request,
+        )
+
+        check_response_size_is_safe_mock = AsyncMock()
+        monkeypatch.setattr(
+            common_request_processing,
+            "check_response_size_is_safe",
+            check_response_size_is_safe_mock,
+        )
+
+        async def mock_during_call_hook(*args, **kwargs):
+            kwargs["data"]["mock_response"] = guardrail_response
+
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.during_call_hook = AsyncMock(
+            side_effect=mock_during_call_hook
+        )
+        proxy_logging_obj.update_request_status = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_success_hook = AsyncMock(
+            return_value=guardrail_response
+        )
+
+        user_api_key_dict = MagicMock(spec=UserAPIKeyAuth)
+        user_api_key_dict.tpm_limit = None
+        user_api_key_dict.rpm_limit = None
+        user_api_key_dict.max_budget = None
+        user_api_key_dict.spend = 0
+        user_api_key_dict.allowed_model_region = None
+
+        fastapi_response = Response()
+        proxy_config = MagicMock(spec=ProxyConfig)
+
+        result = await processing_obj.base_process_llm_request(
+            request=MagicMock(spec=Request),
+            fastapi_response=fastapi_response,
+            user_api_key_dict=user_api_key_dict,
+            route_type="acompletion",
+            proxy_logging_obj=proxy_logging_obj,
+            general_settings={},
+            proxy_config=proxy_config,
+            select_data_generator=lambda **kwargs: None,
+        )
+
+        assert result is guardrail_response
+        assert (
+            proxy_logging_obj.post_call_success_hook.await_args.kwargs["response"]
+            is guardrail_response
+        )
+        assert (
+            check_response_size_is_safe_mock.await_args.kwargs["response"]
+            is guardrail_response
+        )
 
     @pytest.mark.asyncio
     async def test_stream_timeout_header_processing(self):


### PR DESCRIPTION

## Title

fix: respect guardrail mock_response during during_call to return blocked output

## Relevant issues

Fixes #15092

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

Example configuration:
```
  - guardrail_name: "bedrock-guard"
    litellm_params:
      guardrail: bedrock
      mode: "during_call"
      guardrailIdentifier: xxxxx
      guardrailVersion: "DRAFT"
      aws_region_name: us-east-1
      disable_exception_on_block: true
```

Example curl test:
```
curl -i  -X POST http://localhost:4001/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer sk-1234" \
-d '{
    "model": "gpt-4o",
    "messages": [
        {
            "role": "user",
            "content": "My name is Yuta. Say my name."
        }
    ], "guardrails": ["bedrock-guard"]
}'
HTTP/1.1 200 OK
date: Fri, 28 Nov 2025 05:17:54 GMT
server: uvicorn
content-length: 316
content-type: application/json
x-litellm-call-id: 0b9dc18c-87f0-4aeb-bf62-87f19c41668c
x-litellm-version: 1.80.0
x-litellm-response-cost-original: 0.00016250000000000002
x-litellm-response-cost-discount-amount: 0.0
x-litellm-key-spend: 0.0
x-litellm-applied-guardrails: bedrock-guard

{"id":"chatcmpl-6ffa39bd-c3f4-4932-a555-b6e6a63fed06","created":1764307087,"model":"bedrock-guardrail","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"The name cannot be returned.","role":"assistant"}}],"usage":{"completion_tokens":0,"prompt_tokens":0,"total_tokens":0}
```