### PR TITLE
fix: Handle global location for Vertex AI image generation endpoint

### DIFF
--- a/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py
@@ -140,7 +140,11 @@ class VertexAIGeminiImageGenerationConfig(BaseImageGenerationConfig, VertexLLM):
         if not vertex_project or not vertex_location:
             raise ValueError("vertex_project and vertex_location are required for Vertex AI")
 
-        base_url = f"https://{vertex_location}-aiplatform.googleapis.com"
+        # Handle global location differently (no region prefix in URL)
+        if vertex_location == "global":
+            base_url = "https://aiplatform.googleapis.com"
+        else:
+            base_url = f"https://{vertex_location}-aiplatform.googleapis.com"
 
         return f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model_name}:generateContent"
 


### PR DESCRIPTION
# Fix: Handle global location for Vertex AI Gemini image generation

## Description
This PR fixes a bug in the Vertex AI Gemini image generation implementation that caused DNS resolution errors when using `vertex_location="global"`.

## Problem
When calling Vertex AI Gemini image generation models (e.g., `gemini-3-pro-image-preview`) with `vertex_location="global"`, the code constructs an invalid URL:
```
https://global-aiplatform.googleapis.com
```

This URL does not exist and causes a DNS resolution error.

## Root Cause
The current implementation in `vertex_gemini_transformation.py` always prefixes the location to the domain:
```python
base_url = f"https://{vertex_location}-aiplatform.googleapis.com"
```

However, the global endpoint should not have a region prefix.

## Solution
Added a conditional check to handle the global location correctly:
```python
if vertex_location == "global":
    base_url = "https://aiplatform.googleapis.com"
else:
    base_url = f"https://{vertex_location}-aiplatform.googleapis.com"
```

## Testing
Tested with `gemini-3-pro-image-preview` model using both global and regional locations:
- ✅ `vertex_location="global"` - now works correctly
- ✅ `vertex_location="us-central1"` - continues to work as before

## Files Changed
- `litellm/llms/vertex_ai/image_generation/vertex_gemini_transformation.py`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Impact
This fix enables users to use Vertex AI Gemini image generation models with the global endpoint, expanding deployment flexibility.
