### PR TITLE
fix(bedrock): handle None value of "parameters" correctly

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4207,9 +4207,10 @@ def _bedrock_tools_pt(tools: List) -> List[BedrockToolBlock]:
 
     tool_block_list: List[BedrockToolBlock] = []
     for tool in tools:
-        parameters = tool.get("function", {}).get(
-            "parameters", {"type": "object", "properties": {}}
-        )
+        function = tool.get("function", {})
+        parameters = function.get("parameters", None)
+        if not parameters:
+            parameters = {"type": "object", "properties": {}}
         name = tool.get("function", {}).get("name", "")
 
         # related issue: https://github.com/BerriAI/litellm/issues/5007

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -569,26 +569,26 @@ def test_bedrock_tools_unpack_defs():
 
 def test_bedrock_image_processor_content_type_fallback_url_extension():
     """
-    Test that _post_call_image_processing falls back to URL extension 
+    Test that _post_call_image_processing falls back to URL extension
     when content-type is binary/octet-stream or application/octet-stream
     """
     import base64
-    
+
     # Create mock response with binary/octet-stream content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     # Create a simple PNG header (magic bytes)
     png_header = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
     png_content = png_header + b"\x00" * 100  # Add some padding
     mock_response.content = png_content
-    
+
     # Test with .png URL
     image_url = "https://example.com/test-image.png"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url
     )
-    
+
     assert content_type == "image/png"
     assert base64_bytes == base64.b64encode(png_content).decode("utf-8")
 
@@ -599,22 +599,22 @@ def test_bedrock_image_processor_content_type_fallback_binary_detection():
     when content-type is missing and URL extension is not recognized
     """
     import base64
-    
+
     # Create mock response with no content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = None
-    
+
     # Create a JPEG header (magic bytes)
     jpeg_header = b"\xff\xd8\xff"
     jpeg_content = jpeg_header + b"\x00" * 100  # Add some padding
     mock_response.content = jpeg_content
-    
+
     # Test with URL without extension
     image_url = "https://example.com/test-image-without-extension"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url
     )
-    
+
     assert content_type == "image/jpeg"
     assert base64_bytes == base64.b64encode(jpeg_content).decode("utf-8")
 
@@ -624,22 +624,22 @@ def test_bedrock_image_processor_content_type_fallback_application_octet_stream(
     Test that _post_call_image_processing handles application/octet-stream correctly
     """
     import base64
-    
+
     # Create mock response with application/octet-stream content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "application/octet-stream"
-    
+
     # Create a GIF header (magic bytes)
     gif_header = b"GIF8" + b"\x00" + b"a"
     gif_content = gif_header + b"\x00" * 100  # Add some padding
     mock_response.content = gif_content
-    
+
     # Test with .gif URL
     image_url = "https://s3.amazonaws.com/bucket/image.gif"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url
     )
-    
+
     assert content_type == "image/gif"
     assert base64_bytes == base64.b64encode(gif_content).decode("utf-8")
 
@@ -649,22 +649,22 @@ def test_bedrock_image_processor_content_type_with_query_params():
     Test that _post_call_image_processing correctly extracts extension from URL with query parameters
     """
     import base64
-    
+
     # Create mock response with binary/octet-stream content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     # Create a WebP header (magic bytes)
     webp_header = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP"
     webp_content = webp_header + b"\x00" * 100  # Add some padding
     mock_response.content = webp_content
-    
+
     # Test with URL containing query parameters (common in S3 signed URLs)
     image_url = "https://s3.amazonaws.com/bucket/image.webp?AWSAccessKeyId=123&Expires=456&Signature=789"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url
     )
-    
+
     assert content_type == "image/webp"
     assert base64_bytes == base64.b64encode(webp_content).decode("utf-8")
 
@@ -674,21 +674,21 @@ def test_bedrock_image_processor_content_type_normal_header():
     Test that _post_call_image_processing works normally when content-type is correctly set
     """
     import base64
-    
+
     # Create mock response with correct content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "image/png"
-    
+
     # Create a PNG header
     png_header = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
     png_content = png_header + b"\x00" * 100
     mock_response.content = png_content
-    
+
     image_url = "https://example.com/test-image.png"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url
     )
-    
+
     assert content_type == "image/png"
     assert base64_bytes == base64.b64encode(png_content).decode("utf-8")
 
@@ -700,16 +700,16 @@ def test_bedrock_image_processor_content_type_fallback_failure():
     # Create mock response with binary/octet-stream content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     # Create content with unrecognizable image format
     mock_response.content = b"\x00" * 100
-    
+
     # Test with URL without recognizable extension
     image_url = "https://example.com/unknown-file"
-    
+
     with pytest.raises(ValueError) as excinfo:
         BedrockImageProcessor._post_call_image_processing(mock_response, image_url)
-    
+
     assert "Unable to determine content type" in str(excinfo.value)
 
 
@@ -720,18 +720,18 @@ def test_bedrock_image_processor_content_type_jpeg_variants():
     # Create mock response with binary/octet-stream
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     jpeg_header = b"\xff\xd8\xff"
     jpeg_content = jpeg_header + b"\x00" * 100
     mock_response.content = jpeg_content
-    
+
     # Test with .jpg extension
     image_url_jpg = "https://example.com/photo.jpg"
     _, content_type_jpg = BedrockImageProcessor._post_call_image_processing(
         mock_response, image_url_jpg
     )
     assert content_type_jpg == "image/jpeg"
-    
+
     # Test with .jpeg extension
     image_url_jpeg = "https://example.com/photo.jpeg"
     _, content_type_jpeg = BedrockImageProcessor._post_call_image_processing(
@@ -746,22 +746,22 @@ def test_bedrock_image_processor_content_type_pdf_document():
     when content-type is binary/octet-stream
     """
     import base64
-    
+
     # Create mock response with binary/octet-stream content-type
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     # Create a PDF header (magic bytes: %PDF)
     pdf_header = b"%PDF-1.4"
     pdf_content = pdf_header + b"\x00" * 100
     mock_response.content = pdf_content
-    
+
     # Test with .pdf URL
     pdf_url = "https://s3.amazonaws.com/bucket/document.pdf"
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, pdf_url
     )
-    
+
     assert content_type == "application/pdf"
     assert base64_bytes == base64.b64encode(pdf_content).decode("utf-8")
 
@@ -771,27 +771,35 @@ def test_bedrock_image_processor_content_type_document_formats():
     Test that _post_call_image_processing handles various document formats
     """
     import base64
-    
+
     # Create mock response
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "application/octet-stream"
     mock_response.content = b"\x00" * 100
-    
+
     # Test various document formats
     test_cases = [
         ("https://example.com/doc.pdf", "application/pdf"),
         ("https://example.com/sheet.csv", "text/csv"),
-        ("https://example.com/doc.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
-        ("https://example.com/sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        (
+            "https://example.com/doc.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+        (
+            "https://example.com/sheet.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
         ("https://example.com/page.html", "text/html"),
         ("https://example.com/readme.txt", "text/plain"),
     ]
-    
+
     for url, expected_mime in test_cases:
         _, content_type = BedrockImageProcessor._post_call_image_processing(
             mock_response, url
         )
-        assert content_type == expected_mime, f"Expected {expected_mime} for {url}, got {content_type}"
+        assert (
+            content_type == expected_mime
+        ), f"Expected {expected_mime} for {url}, got {content_type}"
 
 
 def test_bedrock_image_processor_content_type_s3_pdf_with_query():
@@ -799,21 +807,21 @@ def test_bedrock_image_processor_content_type_s3_pdf_with_query():
     Test that _post_call_image_processing handles S3 PDF with query parameters
     """
     import base64
-    
+
     # Create mock response
     mock_response = MagicMock()
     mock_response.headers.get.return_value = "binary/octet-stream"
-    
+
     pdf_content = b"%PDF-1.4" + b"\x00" * 100
     mock_response.content = pdf_content
-    
+
     # S3 signed URL with query parameters
     s3_url = "https://my-bucket.s3.us-east-1.amazonaws.com/documents/report.pdf?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1234567890&Signature=abcdef123456"
-    
+
     base64_bytes, content_type = BedrockImageProcessor._post_call_image_processing(
         mock_response, s3_url
     )
-    
+
     assert content_type == "application/pdf"
     assert base64_bytes == base64.b64encode(pdf_content).decode("utf-8")
 
@@ -857,6 +865,45 @@ def test_bedrock_tools_pt_empty_description():
     assert tool_spec is not None
     assert tool_spec.get("name") == "get_weather"
     assert tool_spec.get("description") == "get_weather"
+
+
+def test_bedrock_tools_pt_none_parameters():
+    """
+    Test that _bedrock_tools_pt handles none value of the key "parameters" correctly.
+
+    Some agent frameworks may produce a tool having a None value of its "parameters" key.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather1",
+                "description": "Get current weather",
+                "parameters": None,
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather2",
+                "description": "Get current weather",
+            },
+        },
+    ]
+
+    result = _bedrock_tools_pt(tools=tools)
+
+    # Verify that the result is a list with two tools
+    assert len(result) == 2
+
+    # Verify that the description falls back to the function name
+    for r in result:
+        tool_spec = r.get("toolSpec")
+        assert tool_spec is not None
+        assert tool_spec.get("description") == "Get current weather"
+
 
 def test_bedrock_create_bedrock_block_deterministic_document_hash():
     """
@@ -1057,7 +1104,9 @@ def test_bedrock_create_bedrock_block_document_name_format():
 
     # Check format: DocumentPDFmessages_{16_hex_chars}_{format}
     pattern = r"^DocumentPDFmessages_[0-9a-f]{16}_pdf$"
-    assert re.match(pattern, document_name), f"Document name format mismatch: {document_name}"
+    assert re.match(
+        pattern, document_name
+    ), f"Document name format mismatch: {document_name}"
 
 
 def test_bedrock_create_bedrock_block_different_document_formats():


### PR DESCRIPTION
## Title

fix(bedrock): handle None value of "parameters" correctly

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes

Some agent frameworks provide a None value when a tool has no parameters. For example,
```json
{"type":"function","function":{"name":"weather","description":"Get current weather information","parameters":null}}
```

The bedrock function `_bedrock_tools_pt` is using `dict.get(key, default)` which provides a default value only when there is no such key. However, when the key is present and is `None`, the default value will not be used. In such case, litellm will raise a KeyError when trying to pop `$defs` from None. 

This PR changed the way of bedrock checking parameters, by adding a if-check on parameters and setting the default value


