### PR TITLE
Fix metadata tags and model name display in UI for Azure passthrough + Add cost tracking for responses API

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -735,6 +735,12 @@ async def pass_through_request(  # noqa: PLR0915
             logging_obj=logging_obj,
         )
 
+        # Store custom_llm_provider in kwargs and logging object if provided
+        if custom_llm_provider:
+            kwargs["custom_llm_provider"] = custom_llm_provider
+            logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider
+            logging_obj.model_call_details["litellm_params"] = kwargs.get("litellm_params", {})
+
         # done for supporting 'parallel_request_limiter.py' with pass-through endpoints
         logging_obj.update_environment_variables(
             model="unknown",
@@ -923,6 +929,12 @@ async def pass_through_request(  # noqa: PLR0915
         if kwargs:
             for key, value in kwargs.items():
                 request_payload[key] = value
+        
+        if "model" not in request_payload and _parsed_body and isinstance(_parsed_body, dict):
+            request_payload["model"] = _parsed_body.get("model", "")
+        if "custom_llm_provider" not in request_payload and custom_llm_provider:
+            request_payload["custom_llm_provider"] = custom_llm_provider
+        
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
@@ -957,11 +969,21 @@ def _update_metadata_with_tags_in_header(request: Request, metadata: dict) -> di
     """
     If tags are in the request headers, add them to the metadata
 
-    Used for google and vertex JS SDKs
+    Used for google and vertex JS SDKs, and Azure passthrough
+    Checks both 'tags' and 'x-litellm-tags' headers
     """
+    # Initialize tags list if it doesn't exist
+    if "tags" not in metadata:
+        metadata["tags"] = []
+    
+    # Check for 'tags' header first
     _tags = request.headers.get("tags")
     if _tags:
-        metadata["tags"] = _tags.split(",")
+            metadata["tags"].extend([tag.strip() for tag in _tags.split(",")])
+
+    _tags = request.headers.get("x-litellm-tags")
+    if _tags:
+            metadata["tags"].extend([tag.strip() for tag in _tags.split(",")])
     return metadata
 
 


### PR DESCRIPTION
## Title

Fix metadata tags and model name display in UI for Azure passthrough + Add cost tracking for responses API

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🐛 Bug Fix

## Changes
- Preserved `custom_llm_provider` from kwargs instead of hardcoding "openai" in `OpenAIPassthroughLoggingHandler.openai_passthrough_handler()`
- Preserved existing `litellm_params` (including metadata tags) instead of overwriting them
- Ensured `custom_llm_provider` is correctly passed through the logging pipeline for both successful and failed requests
- Updated failure handler in `proxy_track_cost_callback.py` to preserve existing metadata tags from `litellm_params`



