### PR TITLE
fix(db): add mcp_namespaced_tool_name to daily spend sort key

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1054,6 +1054,7 @@ class DBSpendUpdateWriter:
                                 x[1].get("api_key") or "",
                                 x[1].get("model") or "",
                                 x[1].get("custom_llm_provider") or "",
+                                x[1].get("mcp_namespaced_tool_name") or "",
                             ),
                         )[:BATCH_SIZE]
                     )

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -306,6 +306,20 @@ async def test_update_daily_spend_with_none_values_in_sorting_fields():
             "successful_requests": 1,
             "failed_requests": 0,
         },
+        "key6": {
+            "user_id": "user6",
+            "date": "2024-01-01",
+            "api_key": "test-api-key",
+            "model": "gpt-4",
+            "custom_llm_provider": "openai",
+            "mcp_namespaced_tool_name": None,  # None mcp_namespaced_tool_name
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "spend": 0.1,
+            "api_requests": 1,
+            "successful_requests": 1,
+            "failed_requests": 0,
+        },
     }
 
     # Call the method - this should not raise TypeError
@@ -320,8 +334,8 @@ async def test_update_daily_spend_with_none_values_in_sorting_fields():
         unique_constraint_name="user_id_date_api_key_model_custom_llm_provider",
     )
 
-    # Verify that table.upsert was called (should be called 5 times, once for each transaction)
-    assert mock_table.upsert.call_count == 5
+    # Verify that table.upsert was called (should be called 6 times, once for each transaction)
+    assert mock_table.upsert.call_count == 6
 
 
 # Tag Spend Tracking Tests


### PR DESCRIPTION
## Title

fix(db): add mcp_namespaced_tool_name to daily spend sort key

## Relevant issues

<!-- Fixes potential deadlocks when sorting transactions with mcp_namespaced_tool_name field -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

### Screenshot of tests passing

<img width="2300" height="1288" alt="image" src="https://github.com/user-attachments/assets/ea9715e0-35eb-4383-aaa7-325ab8e2b733" />

All 12 tests in `test_db_spend_update_writer.py` pass ✅

## Type

🐛 Bug Fix

## Changes

### Problem

The `mcp_namespaced_tool_name` field is part of the unique constraint (e.g., `user_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name`) but was missing from the sort key in the `_update_daily_spend` method.

When transactions with different values for this field are processed in non-deterministic order, it can lead to database deadlocks during concurrent upsert operations.

### Solution

Add `mcp_namespaced_tool_name` to the sort key tuple in `_update_daily_spend`, using the same `x[1].get("mcp_namespaced_tool_name") or ""` pattern already used for other optional fields.

### Files Changed

- `litellm/proxy/db/db_spend_update_writer.py` - Added `mcp_namespaced_tool_name` to sort key
- `tests/test_litellm/proxy/db/test_db_spend_update_writer.py` - Added test case with `mcp_namespaced_tool_name: None`