### PR TITLE
fix logfile and pidfile of supervisor for non root environment

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,6 +1,8 @@
 [supervisord]
 nodaemon=true
 loglevel=info
+logfile=/tmp/supervisord.log
+pidfile=/tmp/supervisord.pid
 
 [group:litellm]
 programs=main,health


### PR DESCRIPTION
## fix logfile and pidfile of supervisor for non root environment

## Relevant issues

Fixes #17264 

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ x ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ x ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

Use /tmp instead of the current workdir to put logfile and pidfile of supervisor


