### PR TITLE
chore: add stack trace to mcp error message

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1,4 +1,5 @@
 import importlib
+import traceback
 from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -326,7 +327,12 @@ if MCP_AVAILABLE:
 
         except Exception as e:
             verbose_logger.error(f"Error in MCP operation: {e}", exc_info=True)
-            return {"status": "error", "message": "An internal error has occurred."}
+            stack_trace = traceback.format_exc()
+            return {
+                "status": "error",
+                "message": f"An internal error has occurred: {str(e)}",
+                "stack_trace": stack_trace,
+            }
 
     @router.post("/test/connection")
     async def test_connection(

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Button, Spin, Alert } from "antd";
+import { Button, Spin, Alert, Collapse } from "antd";
 import { CheckCircleOutlined, ExclamationCircleOutlined, ReloadOutlined, ToolOutlined } from "@ant-design/icons";
 import { Card, Title, Text } from "@tremor/react";
 import { useTestMCPConnection } from "../../hooks/useTestMCPConnection";
@@ -12,7 +12,7 @@ interface MCPConnectionStatusProps {
 }
 
 const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({ accessToken, oauthAccessToken, formValues, onToolsLoaded }) => {
-  const { tools, isLoadingTools, toolsError, canFetchTools, fetchTools } = useTestMCPConnection({
+  const { tools, isLoadingTools, toolsError, toolsErrorStackTrace, canFetchTools, fetchTools } = useTestMCPConnection({
     accessToken,
     oauthAccessToken,
     formValues, 
@@ -95,7 +95,38 @@ const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({ accessToken, 
             {toolsError && (
               <Alert
                 message="Connection Failed"
-                description={toolsError}
+                description={
+                  <div>
+                    <div>{toolsError}</div>
+                    {toolsErrorStackTrace && (
+                      <Collapse
+                        items={[
+                          {
+                            key: "stack-trace",
+                            label: "Stack Trace",
+                            children: (
+                              <pre style={{ 
+                                whiteSpace: "pre-wrap", 
+                                wordBreak: "break-word",
+                                fontSize: "12px",
+                                fontFamily: "monospace",
+                                margin: 0,
+                                padding: "8px",
+                                backgroundColor: "#f5f5f5",
+                                borderRadius: "4px",
+                                maxHeight: "400px",
+                                overflow: "auto"
+                              }}>
+                                {toolsErrorStackTrace}
+                              </pre>
+                            ),
+                          },
+                        ]}
+                        style={{ marginTop: "12px" }}
+                      />
+                    )}
+                  </div>
+                }
                 type="error"
                 showIcon
                 action={

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5963,7 +5963,7 @@ export const listMCPTools = async (accessToken: string, serverId: string) => {
       throw new Error("Failed to fetch MCP tools");
     }
 
-    // Return the full response object which includes tools, error, and message
+    // Return the full response object which includes tools, error, message, and stack_trace
     return data;
   } catch (error) {
     console.error("Failed to fetch MCP tools:", error);
@@ -5972,6 +5972,7 @@ export const listMCPTools = async (accessToken: string, serverId: string) => {
       tools: [],
       error: "network_error",
       message: error instanceof Error ? error.message : "Failed to fetch MCP tools",
+      stack_trace: null,
     };
   }
 };

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -29,6 +29,7 @@ interface UseTestMCPConnectionReturn {
   tools: any[];
   isLoadingTools: boolean;
   toolsError: string | null;
+  toolsErrorStackTrace: string | null;
   hasShownSuccessMessage: boolean;
   canFetchTools: boolean;
   fetchTools: () => Promise<void>;
@@ -44,6 +45,7 @@ export const useTestMCPConnection = ({
   const [tools, setTools] = useState<any[]>([]);
   const [isLoadingTools, setIsLoadingTools] = useState(false);
   const [toolsError, setToolsError] = useState<string | null>(null);
+  const [toolsErrorStackTrace, setToolsErrorStackTrace] = useState<string | null>(null);
   const [hasShownSuccessMessage, setHasShownSuccessMessage] = useState(false);
 
   // Check if we have the minimum required fields to fetch tools
@@ -137,18 +139,21 @@ export const useTestMCPConnection = ({
       if (toolsResponse.tools && !toolsResponse.error) {
         setTools(toolsResponse.tools);
         setToolsError(null);
+        setToolsErrorStackTrace(null);
         if (toolsResponse.tools.length > 0 && !hasShownSuccessMessage) {
           setHasShownSuccessMessage(true);
         }
       } else {
         const errorMessage = toolsResponse.message || "Failed to retrieve tools list";
         setToolsError(errorMessage);
+        setToolsErrorStackTrace(toolsResponse.stack_trace || null);
         setTools([]);
         setHasShownSuccessMessage(false);
       }
     } catch (error) {
       console.error("Tools fetch error:", error);
       setToolsError(error instanceof Error ? error.message : String(error));
+      setToolsErrorStackTrace(null);
       setTools([]);
       setHasShownSuccessMessage(false);
     } finally {
@@ -159,6 +164,7 @@ export const useTestMCPConnection = ({
   const clearTools = () => {
     setTools([]);
     setToolsError(null);
+    setToolsErrorStackTrace(null);
     setHasShownSuccessMessage(false);
   };
 
@@ -190,6 +196,7 @@ export const useTestMCPConnection = ({
     tools,
     isLoadingTools,
     toolsError,
+    toolsErrorStackTrace,
     hasShownSuccessMessage,
     canFetchTools,
     fetchTools,


### PR DESCRIPTION
## Title

chore: add stack trace to mcp error message

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🧹 Refactoring

## Changes

If an error occurs while fetching the tool list during MCP creation, the stack trace will now be dispalyed.

<img width="918" height="662" alt="image" src="https://github.com/user-attachments/assets/02f59d40-cbba-405e-b2f2-4f68a9963450" />

