### PR TITLE
fix google_genai streamGenerateContent endpoint got multiple stream flag error

### DIFF
--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -398,6 +398,7 @@ async def agenerate_content_stream(
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
             # Use the adapter to convert to completion format
+            kwargs.pop('stream', None)  # Remove the stream flag
             return (
                 await GenerateContentToCompletionHandler.async_generate_content_handler(
                     model=model,


### PR DESCRIPTION
## Title

fix google_genai streamGenerateContent endpoint got multiple stream flag error

## Relevant issues

 #15587 #16910 

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix

## Changes

remove stream flag from `kwargs` before calling `GenerateContentToCompletionHandler.async_generate_content_handler` to avoid `TypeError: litellm.google_genai.adapters.handler.GenerateContentToCompletionHandler.async_generate_content_handler() got multiple values for keyword argument 'stream'`

<img width="974" height="42" alt="image" src="https://github.com/user-attachments/assets/e6a50a7f-367f-4e92-9f65-7e543525206f" />
