### PR TITLE
Update Databricks model pricing and add new models (including databricks pricing test).

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7824,26 +7824,298 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
-        "input_cost_per_token": 2.5e-06,
-        "input_dbu_cost_per_token": 3.571e-05,
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
         "max_tokens": 200000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Claude 3.7 conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.7857e-05,
-        "output_db_cost_per_token": 0.000214286,
-        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-haiku-4-5": {
+        "input_cost_per_token": 1.00002e-06,
+        "input_dbu_cost_per_token": 1.4286e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.00003e-06,
+        "output_dbu_cost_per_token": 7.1429e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-opus-4": {
+        "input_cost_per_token": 1.5000020000000002e-05,
+        "input_dbu_cost_per_token": 0.000214286,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 7.500003000000001e-05,
+        "output_dbu_cost_per_token": 0.001071429,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-opus-4-1": {
+        "input_cost_per_token": 1.5000020000000002e-05,
+        "input_dbu_cost_per_token": 0.000214286,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 32000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 7.500003000000001e-05,
+        "output_dbu_cost_per_token": 0.001071429,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-opus-4-5": {
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-sonnet-4": {
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-sonnet-4-1": {
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-claude-sonnet-4-5": {
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-2-5-flash": {
+        "input_cost_per_token": 3.0001999999999996e-07,
+        "input_dbu_cost_per_token": 4.285999999999999e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 1048576,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.49998e-06,
+        "output_dbu_cost_per_token": 3.5714e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-2-5-pro": {
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 1048576,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemma-3-12b": {
+        "input_cost_per_token": 1.5000999999999998e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.0001e-07,
+        "output_dbu_cost_per_token": 7.143e-06,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5": {
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 400000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-1": {
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 400000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-mini": {
+        "input_cost_per_token": 2.4997000000000006e-07,
+        "input_dbu_cost_per_token": 3.571e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 400000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.9999700000000004e-06,
+        "output_dbu_cost_per_token": 2.8571e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-nano": {
+        "input_cost_per_token": 4.998e-08,
+        "input_dbu_cost_per_token": 7.14e-07,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 400000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.9998000000000007e-07,
+        "output_dbu_cost_per_token": 5.714000000000001e-06,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-oss-120b": {
+        "input_cost_per_token": 1.5000999999999998e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.9997e-07,
+        "output_dbu_cost_per_token": 8.571e-06,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
+    "databricks/databricks-gpt-oss-20b": {
+        "input_cost_per_token": 7e-08,
+        "input_dbu_cost_per_token": 1e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.0001999999999996e-07,
+        "output_dbu_cost_per_token": 4.285999999999999e-06,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
     "databricks/databricks-gte-large-en": {
-        "input_cost_per_token": 1.2999e-07,
+        "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 8192,
@@ -7868,14 +8140,14 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token": 1.5000300000000002e-06,
         "output_dbu_cost_per_token": 2.1429e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
     "databricks/databricks-llama-4-maverick": {
-        "input_cost_per_token": 5e-06,
-        "input_dbu_cost_per_token": 7.143e-05,
+        "input_cost_per_token": 5.0001e-07,
+        "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -7884,13 +8156,13 @@
             "notes": "Databricks documentation now provides both DBU costs (_dbu_cost_per_token) and dollar costs(_cost_per_token)."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "output_dbu_cost_per_token": 0.00021429,
+        "output_cost_per_token": 1.5000300000000002e-06,
+        "output_dbu_cost_per_token": 2.1429e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-405b-instruct": {
-        "input_cost_per_token": 5e-06,
+        "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 128000,
@@ -7900,14 +8172,29 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.500002e-05,
-        "output_db_cost_per_token": 0.000214286,
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
+    "databricks/databricks-meta-llama-3-1-8b-instruct": {
+        "input_cost_per_token": 1.5000999999999998e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 200000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 4.5003000000000007e-07,
+        "output_dbu_cost_per_token": 6.429000000000001e-06,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
     "databricks/databricks-meta-llama-3-3-70b-instruct": {
-        "input_cost_per_token": 1.00002e-06,
-        "input_dbu_cost_per_token": 1.4286e-05,
+        "input_cost_per_token": 5.0001e-07,
+        "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -7916,8 +8203,8 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.99999e-06,
-        "output_dbu_cost_per_token": 4.2857e-05,
+        "output_cost_per_token": 1.5000300000000002e-06,
+        "output_dbu_cost_per_token": 2.1429e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
@@ -7932,7 +8219,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.99999e-06,
+        "output_cost_per_token": 2.9999900000000002e-06,
         "output_dbu_cost_per_token": 4.2857e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
@@ -7948,13 +8235,13 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.9902e-07,
+        "output_cost_per_token": 1.00002e-06,
         "output_dbu_cost_per_token": 1.4286e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-30b-instruct": {
-        "input_cost_per_token": 9.9902e-07,
+        "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 8192,
@@ -7964,7 +8251,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.9902e-07,
+        "output_cost_per_token": 1.00002e-06,
         "output_dbu_cost_per_token": 1.4286e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supports_tool_choice": true

--- a/tests/test_litellm/llms/databricks/test_databricks_pricing.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_pricing.py
@@ -2,10 +2,6 @@ import json
 import os
 import sys
 
-# Add the project root to sys.path so we can import if needed,
-# though for this specific test we are just reading a JSON file.
-sys.path.insert(0, os.path.abspath("../../../../../../ সন"))
-
 
 def test_databricks_pricing_integrity():
     """
@@ -35,7 +31,7 @@ def test_databricks_pricing_integrity():
 
             if input_usd is not None and input_dbu is not None:
                 expected = input_dbu * conversion_rate
-                # Allow small floating point difference (e.g. 1e-9)
+                # Allow small floating point difference
                 if abs(input_usd - expected) > 1e-9:
                     errors.append(
                         f"{model} input mismatch: USD={input_usd}, DBU={input_dbu}, Expected={expected}"

--- a/tests/test_litellm/llms/databricks/test_databricks_pricing.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_pricing.py
@@ -1,0 +1,55 @@
+import json
+import os
+import sys
+
+# Add the project root to sys.path so we can import if needed,
+# though for this specific test we are just reading a JSON file.
+sys.path.insert(0, os.path.abspath("../../../../../../ সন"))
+
+
+def test_databricks_pricing_integrity():
+    """
+    Verifies that for all Databricks models in model_prices_and_context_window.json:
+    USD Price == DBU Price * 0.07
+    """
+    json_path = os.path.join(
+        os.path.dirname(__file__), "../../../../model_prices_and_context_window.json"
+    )
+
+    # Verify file exists
+    assert os.path.exists(
+        json_path
+    ), f"Could not find model_prices_and_context_window.json at {json_path}"
+
+    with open(json_path, "r") as f:
+        data = json.load(f)
+
+    conversion_rate = 0.07  # 1 DBU = 0.07 USD
+    errors = []
+
+    for model, info in data.items():
+        if info.get("litellm_provider") == "databricks":
+            # Check Input Cost
+            input_usd = info.get("input_cost_per_token")
+            input_dbu = info.get("input_dbu_cost_per_token")
+
+            if input_usd is not None and input_dbu is not None:
+                expected = input_dbu * conversion_rate
+                # Allow small floating point difference (e.g. 1e-9)
+                if abs(input_usd - expected) > 1e-9:
+                    errors.append(
+                        f"{model} input mismatch: USD={input_usd}, DBU={input_dbu}, Expected={expected}"
+                    )
+
+            # Check Output Cost
+            output_usd = info.get("output_cost_per_token")
+            output_dbu = info.get("output_dbu_cost_per_token")
+
+            if output_usd is not None and output_dbu is not None:
+                expected = output_dbu * conversion_rate
+                if abs(output_usd - expected) > 1e-9:
+                    errors.append(
+                        f"{model} output mismatch: USD={output_usd}, DBU={output_dbu}, Expected={expected}"
+                    )
+
+    assert not errors, "\n" + "\n".join(errors)


### PR DESCRIPTION
## Title

Update Databricks model pricing and add new models (including databricks pricing test).

## Relevant issues

Closes #17279 

The databricks model prices were outdated and/or incomplete.

The new prices are based on

https://www.databricks.com/product/pricing/foundation-model-serving

and

https://www.databricks.com/product/pricing/proprietary-foundation-model-serving

[NOTE] Some tests are failing (missing google ai library in poetry, etc.) but those have nothing to do with the .json file I edited. The newly added test in `tests/test_litellm/llms/databricks/` passes, as do all other test in that folder.

<img width="3447" height="1505" alt="Screenshot from 2025-11-29 15-17-04" src="https://github.com/user-attachments/assets/8d8faca0-3f4a-4250-8f16-ad297618af79" />


## Type

🐛 Bug Fix
✅ Test

## Changes

1.  **Pricing Correction:** Updated existing Databricks models in `model_prices_and_context_window.json`. The USD prices (`input_cost_per_token`, `output_cost_per_token`) were inconsistent with the DBU prices. They have been recalculated as `DBU * 0.07` as per Databricks pricing documentation.
2.  **New Models:** Added ~17 new models referenced in Databricks pricing tables but missing from the cost map, including GPT OSS series, Gemini models and Claude models.
3.  **Testing:** Added a new integrity test `tests/test_litellm/llms/databricks/test_databricks_pricing.py` which asserts that for all Databricks models, `USD_Cost == DBU_Cost * 0.07` (current DBU/Databricks Units to USD rate for foundation models).
