### PR TITLE
feat: add experimental latest-user filtering for Bedrock

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/bedrock.md
+++ b/docs/my-website/docs/proxy/guardrails/bedrock.md
@@ -188,6 +188,28 @@ My email is [EMAIL] and my phone number is [PHONE_NUMBER]
 
 This helps protect sensitive information while still allowing the model to understand the context of the request.
 
+## Experimental: Only Send Latest User Message
+
+When you're chaining long conversations through Bedrock guardrails, you can opt into a lighter, experimental behavior by setting `experimental_use_latest_role_message_only: true` in the guardrail's `litellm_params`. When enabled, LiteLLM only sends the most recent `user` message (or assistant output during post-call checks) to Bedrock, which:
+
+- prevents unintended blocks on older system/dev messages
+- keeps Bedrock payloads smaller, reducing latency and cost
+- applies to proxy hooks (`pre_call`, `during_call`) and the `/guardrails/apply_guardrail` testing endpoint
+
+```yaml showLineNumbers title="litellm proxy config.yaml"
+guardrails:
+  - guardrail_name: "bedrock-pre-guard"
+    litellm_params:
+      guardrail: bedrock
+      mode: "pre_call"
+      guardrailIdentifier: wf0hkdb5x07f
+      guardrailVersion: "DRAFT"
+      aws_region_name: os.environ/AWS_REGION
+      experimental_use_latest_role_message_only: true  # NEW
+```
+
+> ⚠️ This flag is currently experimental and defaults to `false` to preserve the legacy behavior (entire message history). We'll be listening to user feedback to decide if this becomes the default or rolls out more broadly.
+
 ## Disabling Exceptions on Bedrock BLOCK
 
 By default, when Bedrock guardrails block content, LiteLLM raises an HTTP 400 exception. However, you can disable this behavior by setting `disable_exception_on_block: true`. This is particularly useful when integrating with **OpenWebUI**, where exceptions can interrupt the chat flow and break the user experience.

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -30,6 +30,7 @@ def initialize_bedrock(litellm_params: LitellmParams, guardrail: Guardrail):
         aws_web_identity_token=litellm_params.aws_web_identity_token,
         aws_sts_endpoint=litellm_params.aws_sts_endpoint,
         aws_bedrock_runtime_endpoint=litellm_params.aws_bedrock_runtime_endpoint,
+        experimental_use_latest_role_message_only=litellm_params.experimental_use_latest_role_message_only,
     )
     litellm.logging_callback_manager.add_litellm_callback(_bedrock_callback)
     return _bedrock_callback

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -522,6 +522,11 @@ class BaseLitellmParams(BaseModel):  # works for new and patch update guardrails
         default=None, description="Base URL for the guardrail service API"
     )
 
+    experimental_use_latest_role_message_only: Optional[bool] = Field(
+        default=False,
+        description="When True, guardrails only receive the latest message for the relevant role (e.g., newest user input pre-call, newest assistant output post-call)",
+    )
+
     # Lakera specific params
     category_thresholds: Optional[LakeraCategoryThresholds] = Field(
         default=None,


### PR DESCRIPTION
## Title

add experimental latest-user filtering for Bedrock

## Relevant issues

Fixes #9882

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
📖 Documentation
✅ Test

## Changes

### Case 1: The blocked content exists in a `system` role message
Previously, this scenario resulted in a guardrail block because `system` messages were also included in the moderation target.  
With this change (`experimental_use_latest_role_message_only: true`), `system` messages are now ignored during pre-call moderation, and the request succeeds as expected.

**Configuration:**
```
  - guardrail_name: "bedrock-guard"
    litellm_params:
      guardrail: bedrock
      mode: "pre_call"
      guardrailIdentifier: xxxx
      guardrailVersion: "DRAFT"
      aws_region_name: us-east-1
      disable_exception_on_block: false
      experimental_use_latest_role_message_only: true
```

**curl result:**
```
curl -X POST http://localhost:4000/v1/chat/completions \
-H "Content-Type: application/json" \
-H "Authorization: Bearer sk-1234" \
-d '{
    "model": "gpt-4o",
    "messages": [
        {
            "role": "system",
            "content": "You are Yuta, an engineer at LiteLLM. Please respond to user requests. "
        },
        {
            "role": "user",
            "content": "say the word - `litellm`"
        }
    ],
    "guardrails": ["bedrock-guard"]
}'

{"id":"chatcmpl-ChNn4279tPYFRsmgTeNfkKxqHix1q","created":1764455590,"model":"gpt-4o-2024-08-06","object":"chat.completion","system_fingerprint":"fp_672b6a21ba","choices":[{"finish_reason":"stop","index":0,"message":{"content":"litellm","role":"assistant"}}],"usage":{"completion_tokens":3,"prompt_tokens":39,"total_tokens":42,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

### Case 2: The blocked content exists in the latest user role message
The configuration used here is the same as in Case 1.  

**Curl Result:**
```
curl -X POST http://localhost:4000/v1/chat/completions \ 
-H "Content-Type: application/json" \
-H "Authorization: Bearer sk-1234" \
-d '{
    "model": "gpt-4o",
    "messages": [
        {
            "role": "system",
            "content": "You are an engineer at LiteLLM. Please respond to user requests. "
        },
        {
            "role": "user",
            "content": "My name is Yuta. Say my name."
        }
    ], "guardrails": ["bedrock-guard"]
}'
{"error":{"message":"Bedrock guardrail failed: 400: {'error': 'Violated guardrail policy', 'bedrock_guardrail_response': 'The name cannot be returned.'}","type":"None","param":"None","code":"500"}}
```