### PR TITLE
Fix: MLflow streaming spans for Anthropic passthrough

### DIFF
--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -153,23 +153,12 @@ class MlflowLogger(CustomLogger):
 
         try:
             for choice in response_obj.choices:
-                payload = None
-                delta = getattr(choice, "delta", None)
-                if delta is not None:
-                    payload = delta.model_dump(exclude_none=True)
-                else:
-                    message = getattr(choice, "message", None)
-                    if message is not None and hasattr(message, "model_dump"):
-                        payload = message.model_dump(exclude_none=True)
-                    elif hasattr(choice, "model_dump"):
-                        payload = choice.model_dump(exclude_none=True)
-                    else:
-                        payload = choice
-
                 span.add_event(
                     SpanEvent(
                         name="streaming_chunk",
-                        attributes={"delta": json.dumps(payload, default=str)},
+                        attributes={
+                            "delta": json.dumps(choice.delta.model_dump, default=str)
+                        },
                     )
                 )
         except Exception:

--- a/tests/test_litellm/integrations/test_mlflow.py
+++ b/tests/test_litellm/integrations/test_mlflow.py
@@ -186,28 +186,3 @@ def test_mlflow_stream_handler_uses_async_complete_response():
             is final_response
         )
         assert "abc123" not in mlflow_logger._stream_id_to_span
-
-
-def test_mlflow_chunk_events_support_choices_without_delta():
-    modules = _mock_mlflow_modules()
-    with patch.dict("sys.modules", modules):
-        from litellm.integrations.mlflow import MlflowLogger
-
-        mlflow_logger = MlflowLogger()
-        span = MagicMock()
-
-        class DummyMessage:
-            def model_dump(self, exclude_none=True):
-                return {"content": "full"}
-
-        choice = MagicMock()
-        choice.delta = None
-        choice.message = DummyMessage()
-        response_obj = MagicMock()
-        response_obj.choices = [choice]
-
-        mlflow_logger._add_chunk_events(span=span, response_obj=response_obj)
-
-        span.add_event.assert_called_once()
-        event = span.add_event.call_args.args[0]
-        assert json.loads(event.attributes["delta"]) == {"content": "full"}

--- a/tests/test_litellm/integrations/test_mlflow.py
+++ b/tests/test_litellm/integrations/test_mlflow.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import os
 import sys
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 # Adds the grandparent directory to sys.path to allow importing project modules
@@ -125,3 +127,87 @@ def test_mlflow_token_usage_attribute_structure():
             "output_tokens": 7,
             "total_tokens": 12,
         }
+
+
+def _mock_mlflow_modules():
+    mock_tracking = MagicMock()
+    mock_tracking.MlflowClient = MagicMock()
+
+    class DummySpanEvent:
+        def __init__(self, name, attributes):
+            self.name = name
+            self.attributes = attributes
+
+    mock_entities = MagicMock()
+    mock_entities.SpanStatusCode.OK = "OK"
+    mock_entities.SpanEvent = DummySpanEvent
+
+    return {
+        "mlflow": MagicMock(),
+        "mlflow.tracking": mock_tracking,
+        "mlflow.entities": mock_entities,
+        "mlflow.tracing.utils": MagicMock(),
+    }
+
+
+def test_mlflow_stream_handler_uses_async_complete_response():
+    modules = _mock_mlflow_modules()
+    with patch.dict("sys.modules", modules):
+        from litellm.integrations.mlflow import MlflowLogger
+
+        mlflow_logger = MlflowLogger()
+        mlflow_logger._start_span_or_trace = MagicMock(return_value="mock_span")
+        mlflow_logger._end_span_or_trace = MagicMock()
+        mlflow_logger._extract_and_set_chat_attributes = MagicMock()
+
+        class DummyDelta:
+            def model_dump(self, exclude_none=True):
+                return {"content": "chunk"}
+
+        response_obj = MagicMock()
+        response_obj.choices = [MagicMock(delta=DummyDelta())]
+
+        final_response = MagicMock()
+        kwargs = {
+            "litellm_call_id": "abc123",
+            "async_complete_streaming_response": final_response,
+        }
+
+        mlflow_logger._handle_stream_event(
+            kwargs=kwargs,
+            response_obj=response_obj,
+            start_time=datetime.utcnow(),
+            end_time=datetime.utcnow(),
+        )
+
+        mlflow_logger._end_span_or_trace.assert_called_once()
+        assert (
+            mlflow_logger._end_span_or_trace.call_args.kwargs["outputs"]
+            is final_response
+        )
+        assert "abc123" not in mlflow_logger._stream_id_to_span
+
+
+def test_mlflow_chunk_events_support_choices_without_delta():
+    modules = _mock_mlflow_modules()
+    with patch.dict("sys.modules", modules):
+        from litellm.integrations.mlflow import MlflowLogger
+
+        mlflow_logger = MlflowLogger()
+        span = MagicMock()
+
+        class DummyMessage:
+            def model_dump(self, exclude_none=True):
+                return {"content": "full"}
+
+        choice = MagicMock()
+        choice.delta = None
+        choice.message = DummyMessage()
+        response_obj = MagicMock()
+        response_obj.choices = [choice]
+
+        mlflow_logger._add_chunk_events(span=span, response_obj=response_obj)
+
+        span.add_event.assert_called_once()
+        event = span.add_event.call_args.args[0]
+        assert json.loads(event.attributes["delta"]) == {"content": "full"}


### PR DESCRIPTION
## Title

Fix: MLflow streaming spans for Anthropic passthrough

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

https://www.loom.com/share/bfa28a2660a14fe7a4cd14ed840ea3fd
