### PR TITLE
Fix AttributeError when metadata is null in request body

### DIFF
--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -309,7 +309,7 @@ def get_tags_from_request_body(request_body: dict) -> List[str]:
         List of tag names (strings), empty list if no valid tags found
     """
     metadata_variable_name = get_metadata_variable_name_from_kwargs(request_body)
-    metadata = request_body.get(metadata_variable_name, {})
+    metadata = request_body.get(metadata_variable_name) or {}
     tags_in_metadata: Any = metadata.get("tags", [])
     tags_in_request_body: Any = request_body.get("tags", [])
     combined_tags: List[str] = []

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -606,8 +606,27 @@ def test_get_tags_from_request_body_with_dict_tags():
             }
         }
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
+    assert result == []
+    assert isinstance(result, list)
+
+
+def test_get_tags_from_request_body_with_null_metadata():
+    """
+    Test that function handles null metadata gracefully without crashing.
+
+    This is a regression test for https://github.com/BerriAI/litellm/issues/17263
+    When metadata is explicitly set to null/None, the function should return
+    an empty list instead of raising AttributeError.
+    """
+    request_body = {
+        "model": "gpt-4",
+        "metadata": None  # OpenAI API accepts metadata: null
+    }
+
+    result = get_tags_from_request_body(request_body=request_body)
+
     assert result == []
     assert isinstance(result, list)


### PR DESCRIPTION
## Title

  Fix AttributeError when metadata is null in request body

  ## Relevant issues

  Fixes #17263

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard 
  requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
  - [ ] I have added a screenshot of my new test passing locally
  - [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🐛 Bug Fix

  ## Changes

  When sending a request to `/v1/batches` (or other endpoints) with `metadata: null`, the proxy returns a 401 error with:

  `AttributeError: 'NoneType' object has no attribute 'get'`

In `get_tags_from_request_body()`, the code uses `request_body.get("metadata", {})` which returns `None` (not `{}`) when the key exists with a `null` value. Then `metadata.get("tags", [])` fails.

  **Fix:** Changed to `request_body.get("metadata") or {}` which correctly handles both missing keys and explicit `null` values.

  **Files changed:**
  - `litellm/proxy/common_utils/http_parsing_utils.py` - Fix the null metadata handling
  - `tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py` - Add regression test
  
  No breaking changes