### PR TITLE
feat(provider): add Z.AI (Zhipu AI) as built-in provider

### DIFF
--- a/docs/my-website/docs/providers/zai.md
+++ b/docs/my-website/docs/providers/zai.md
@@ -1,0 +1,135 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Z.AI (Zhipu AI)
+https://z.ai/
+
+**We support Z.AI GLM text/chat models, just set `zai/` as a prefix when sending completion requests**
+
+## API Key
+```python
+# env variable
+os.environ['ZAI_API_KEY']
+```
+
+## Sample Usage
+```python
+from litellm import completion
+import os
+
+os.environ['ZAI_API_KEY'] = ""
+response = completion(
+    model="zai/glm-4.6",
+    messages=[
+       {"role": "user", "content": "hello from litellm"}
+   ],
+)
+print(response)
+```
+
+## Sample Usage - Streaming
+```python
+from litellm import completion
+import os
+
+os.environ['ZAI_API_KEY'] = ""
+response = completion(
+    model="zai/glm-4.6",
+    messages=[
+       {"role": "user", "content": "hello from litellm"}
+   ],
+    stream=True
+)
+
+for chunk in response:
+    print(chunk)
+```
+
+## Supported Models
+
+We support ALL Z.AI GLM models, just set `zai/` as a prefix when sending completion requests.
+
+| Model Name | Function Call | Notes |
+|------------|---------------|-------|
+| glm-4.6 | `completion(model="zai/glm-4.6", messages)` | Latest flagship model, 200K context |
+| glm-4.5 | `completion(model="zai/glm-4.5", messages)` | 128K context |
+| glm-4.5v | `completion(model="zai/glm-4.5v", messages)` | Vision model |
+| glm-4.5-x | `completion(model="zai/glm-4.5-x", messages)` | Premium tier |
+| glm-4.5-air | `completion(model="zai/glm-4.5-air", messages)` | Lightweight |
+| glm-4.5-airx | `completion(model="zai/glm-4.5-airx", messages)` | Fast lightweight |
+| glm-4-32b-0414-128k | `completion(model="zai/glm-4-32b-0414-128k", messages)` | 32B parameter model |
+| glm-4.5-flash | `completion(model="zai/glm-4.5-flash", messages)` | **FREE tier** |
+
+## Model Pricing
+
+| Model | Input ($/1M tokens) | Output ($/1M tokens) | Context Window |
+|-------|---------------------|----------------------|----------------|
+| glm-4.6 | $0.60 | $2.20 | 200K |
+| glm-4.5 | $0.60 | $2.20 | 128K |
+| glm-4.5v | $0.60 | $1.80 | 128K |
+| glm-4.5-x | $2.20 | $8.90 | 128K |
+| glm-4.5-air | $0.20 | $1.10 | 128K |
+| glm-4.5-airx | $1.10 | $4.50 | 128K |
+| glm-4-32b-0414-128k | $0.10 | $0.10 | 128K |
+| glm-4.5-flash | **FREE** | **FREE** | 128K |
+
+## Using with LiteLLM Proxy
+
+<Tabs>
+<TabItem value="sdk" label="SDK">
+
+```python
+from litellm import completion
+import os
+
+os.environ['ZAI_API_KEY'] = ""
+response = completion(
+    model="zai/glm-4.6",
+    messages=[{"role": "user", "content": "Hello, how are you?"}],
+)
+
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+<TabItem value="proxy" label="PROXY">
+
+1. Setup config.yaml
+
+```yaml
+model_list:
+  - model_name: glm-4.6
+    litellm_params:
+        model: zai/glm-4.6
+        api_key: os.environ/ZAI_API_KEY
+  - model_name: glm-4.5-flash  # Free tier
+    litellm_params:
+        model: zai/glm-4.5-flash
+        api_key: os.environ/ZAI_API_KEY
+```
+
+2. Run proxy
+
+```bash
+litellm --config config.yaml
+```
+
+3. Test it!
+
+```bash
+curl -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-d '{
+    "model": "glm-4.6",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello, how are you?"
+      }
+    ]
+}'
+```
+
+</TabItem>
+</Tabs>

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -655,6 +655,7 @@ const sidebars = {
         },
         "providers/xai",
         "providers/xinference",
+        "providers/zai",
       ],
     },
     {

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -554,6 +554,7 @@ openai_compatible_providers: List = [
     "perplexity",
     "xinference",
     "xai",
+    "zai",
     "together_ai",
     "fireworks_ai",
     "empower",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -662,6 +662,13 @@ def _get_openai_compatible_provider_info(  # noqa: PLR0915
         ) = litellm.XAIChatConfig()._get_openai_compatible_provider_info(
             api_base, api_key
         )
+    elif custom_llm_provider == "zai":
+        api_base = (
+            api_base
+            or get_secret_str("ZAI_API_BASE")
+            or "https://api.z.ai/api/paas/v4"
+        )
+        dynamic_api_key = api_key or get_secret_str("ZAI_API_KEY")
     elif custom_llm_provider == "together_ai":
         api_base = (
             api_base

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26842,6 +26842,95 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai/glm-4.6": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5v": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 1.8e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-x": {
+        "input_cost_per_token": 2.2e-06,
+        "output_cost_per_token": 8.9e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-air": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 1.1e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-airx": {
+        "input_cost_per_token": 1.1e-06,
+        "output_cost_per_token": 4.5e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4-32b-0414-128k": {
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-flash": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "vertex_ai/search_api": {
         "input_cost_per_query": 1.5e-03,
         "litellm_provider": "vertex_ai",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2553,6 +2553,7 @@ class LlmProviders(str, Enum):
     OPENAI_LIKE = "openai_like"  # embedding only
     JINA_AI = "jina_ai"
     XAI = "xai"
+    ZAI = "zai"
     CUSTOM_OPENAI = "custom_openai"
     TEXT_COMPLETION_OPENAI = "text-completion-openai"
     COHERE = "cohere"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26842,6 +26842,95 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "zai/glm-4.6": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5v": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 1.8e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-x": {
+        "input_cost_per_token": 2.2e-06,
+        "output_cost_per_token": 8.9e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-air": {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 1.1e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-airx": {
+        "input_cost_per_token": 1.1e-06,
+        "output_cost_per_token": 4.5e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4-32b-0414-128k": {
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.5-flash": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "zai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 32000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "vertex_ai/search_api": {
         "input_cost_per_query": 1.5e-03,
         "litellm_provider": "vertex_ai",

--- a/tests/test_litellm/llms/zai/test_zai_provider.py
+++ b/tests/test_litellm/llms/zai/test_zai_provider.py
@@ -1,0 +1,144 @@
+"""
+Tests for Z.AI (Zhipu AI) provider - GLM models
+"""
+import json
+import math
+
+import pytest
+import respx
+
+import litellm
+from litellm import completion
+from litellm.cost_calculator import cost_per_token
+
+
+@pytest.fixture
+def zai_response():
+    """Mock response from Z.AI API"""
+    return {
+        "id": "chatcmpl-zai-123",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "glm-4.6",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello! How can I help you today?"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25},
+    }
+
+
+def test_get_llm_provider_zai():
+    """Test that get_llm_provider correctly identifies zai provider"""
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, api_key, api_base = get_llm_provider("zai/glm-4.6")
+    assert model == "glm-4.6"
+    assert provider == "zai"
+    assert api_base == "https://api.z.ai/api/paas/v4"
+
+
+def test_zai_in_provider_lists():
+    """Test that zai is registered in all necessary provider lists"""
+    assert "zai" in litellm.openai_compatible_providers
+    assert "zai" in litellm.provider_list
+
+
+def test_zai_models_in_model_cost():
+    """Test that ZAI models are in the model cost map"""
+    import os
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    zai_models = [
+        "zai/glm-4.6",
+        "zai/glm-4.5",
+        "zai/glm-4.5v",
+        "zai/glm-4.5-x",
+        "zai/glm-4.5-air",
+        "zai/glm-4.5-airx",
+        "zai/glm-4-32b-0414-128k",
+        "zai/glm-4.5-flash",
+    ]
+
+    for model in zai_models:
+        assert model in litellm.model_cost, f"Model {model} not found in model_cost"
+        assert litellm.model_cost[model]["litellm_provider"] == "zai"
+
+
+def test_zai_glm46_cost_calculation():
+    """Test the cost calculation for glm-4.6"""
+    import os
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    key = "zai/glm-4.6"
+    info = litellm.model_cost[key]
+
+    prompt_cost, completion_cost = cost_per_token(
+        model="zai/glm-4.6",
+        prompt_tokens=1000000,  # 1M tokens
+        completion_tokens=1000000,
+    )
+
+    # GLM-4.6: $0.6/M input, $2.2/M output
+    assert math.isclose(prompt_cost, 0.6, rel_tol=1e-6)
+    assert math.isclose(completion_cost, 2.2, rel_tol=1e-6)
+
+
+def test_zai_flash_model_is_free():
+    """Test that glm-4.5-flash has zero cost"""
+    import os
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    key = "zai/glm-4.5-flash"
+    info = litellm.model_cost[key]
+
+    assert info["input_cost_per_token"] == 0
+    assert info["output_cost_per_token"] == 0
+
+
+@pytest.mark.asyncio
+async def test_zai_completion_call(respx_mock, zai_response, monkeypatch):
+    """Test completion call with zai provider using mocked response"""
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    litellm.disable_aiohttp_transport = True
+
+    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(json=zai_response)
+
+    response = await litellm.acompletion(
+        model="zai/glm-4.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=20,
+    )
+
+    assert response.choices[0].message.content == "Hello! How can I help you today?"
+    assert response.usage.total_tokens == 25
+
+    assert len(respx_mock.calls) == 1
+    request = respx_mock.calls[0].request
+    assert request.method == "POST"
+    assert "api.z.ai" in str(request.url)
+    assert "Authorization" in request.headers
+    assert request.headers["Authorization"] == "Bearer test-api-key"
+
+
+def test_zai_sync_completion(respx_mock, zai_response, monkeypatch):
+    """Test synchronous completion call"""
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    litellm.disable_aiohttp_transport = True
+
+    respx_mock.post("https://api.z.ai/api/paas/v4/chat/completions").respond(json=zai_response)
+
+    response = completion(
+        model="zai/glm-4.6",
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=20,
+    )
+
+    assert response.choices[0].message.content == "Hello! How can I help you today?"
+    assert response.usage.total_tokens == 25


### PR DESCRIPTION
## Title

  Add Z.AI (Zhipu AI) as built-in provider for GLM models

  ## Relevant issues

  Fixes #17289

  ## Pre-Submission checklist

  - [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory - Added
  `tests/test_litellm/llms/zai/test_zai_provider.py` with 7 tests
  - [ ] I have added a screenshot of my new test passing locally
  - [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
  - [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

  ## Type

  🆕 New Feature

  ## Changes

  Add Z.AI (Zhipu AI) as a native OpenAI-compatible provider for GLM models.

  **Files changed:**
  - `litellm/constants.py` - Add `zai` to `openai_compatible_providers`
  - `litellm/types/utils.py` - Add `ZAI` to `LlmProviders` enum
  - `litellm/litellm_core_utils/get_llm_provider_logic.py` - Add URL resolution for `https://api.z.ai/api/paas/v4`
  - `model_prices_and_context_window.json` - Add 8 GLM models with pricing
  - `litellm/model_prices_and_context_window_backup.json` - Same models

  **Models added:**
  | Model | Input $/1M | Output $/1M | Context |
  |-------|-----------|-------------|---------|
  | zai/glm-4.6 | $0.60 | $2.20 | 200K |
  | zai/glm-4.5 | $0.60 | $2.20 | 128K |
  | zai/glm-4.5v | $0.60 | $1.80 | 128K |
  | zai/glm-4.5-x | $2.20 | $8.90 | 128K |
  | zai/glm-4.5-air | $0.20 | $1.10 | 128K |
  | zai/glm-4.5-airx | $1.10 | $4.50 | 128K |
  | zai/glm-4-32b-0414-128k | $0.10 | $0.10 | 128K |
  | zai/glm-4.5-flash | **FREE** | **FREE** | 128K |

  **Usage:**
  ```python
  import litellm

  response = litellm.completion(
      model="zai/glm-4.6",
      messages=[{"role": "user", "content": "Hello"}],
      api_key="your-zai-api-key"  # or set ZAI_API_KEY env var
  )
```

## Documentation

 Docs Added

  - docs/my-website/docs/providers/zai.md - Full provider documentation with:
    - API key setup
    - Sample usage (sync and streaming)
    - Complete model list with pricing
    - LiteLLM Proxy configuration examples
  - docs/my-website/sidebars.js - Added to providers navigation