### PR TITLE
Fix: Allow reasoning_effort='none' for Azure gpt-5.1 models

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -40,7 +40,11 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             or optional_params.get("reasoning_effort")
         )
 
-        if reasoning_effort_value == "none":
+        # gpt-5.1 supports reasoning_effort='none', but other gpt-5 models don't
+        # See: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
+        is_gpt_5_1 = self.is_model_gpt_5_1_model(model)
+
+        if reasoning_effort_value == "none" and not is_gpt_5_1:
             if litellm.drop_params is True or (
                 drop_params is not None and drop_params is True
             ):
@@ -54,8 +58,9 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
                 raise UnsupportedParamsError(
                     status_code=400,
                     message=(
-                        "Azure OpenAI does not support reasoning_effort='none'. "
+                        "Azure OpenAI does not support reasoning_effort='none' for this model. "
                         "Supported values are: 'low', 'medium', and 'high'. "
+                        "Note: gpt-5.1 does support reasoning_effort='none'. "
                         "To drop this parameter, set `litellm.drop_params=True` or for proxy:\n\n"
                         "`litellm_settings:\n drop_params: true`\n"
                         "Issue: https://github.com/BerriAI/litellm/issues/16704"
@@ -70,7 +75,8 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             drop_params=drop_params,
         )
 
-        if result.get("reasoning_effort") == "none":
+        # Only drop reasoning_effort='none' for non-gpt-5.1 models
+        if result.get("reasoning_effort") == "none" and not is_gpt_5_1:
             result.pop("reasoning_effort")
 
         return result


### PR DESCRIPTION
## Relevant issues & PRs

Fixes #17309, #17071
https://github.com/BerriAI/litellm/pull/17071

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

 Allow reasoning_effort='none' for Azure gpt-5.1 models.

  Files Changed

  - litellm/llms/azure/chat/gpt_5_transformation.py
  - tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py

  Details

  Azure documentation confirms reasoning_effort='none' is supported for gpt-5.1:
  https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning

>  "none is only supported for gpt-5.1"

  Test

  - All 16 tests pass in test_azure_gpt5_transformation.py