### PR TITLE
Refactor Noma guardrail to use shared Responses transformation and include system instructions

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -148,7 +148,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             if role == "system":
                 # Extract system message as instructions
                 if isinstance(content, str):
-                    instructions = content
+                    if instructions:
+                        # Concatenate multiple system prompts with a space
+                        instructions = f"{instructions} {content}"
+                    else:
+                        instructions = content
                 else:
                     input_items.append(
                         {

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -28,6 +28,9 @@ from fastapi import HTTPException
 import litellm
 from litellm import DualCache, ModelResponse
 from litellm._logging import verbose_proxy_logger
+from litellm.completion_extras.litellm_responses_transformation.transformation import (
+    LiteLLMResponsesTransformationHandler,
+)
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
 from litellm.llms.custom_httpx.http_handler import (
@@ -111,6 +114,7 @@ class NomaGuardrail(CustomGuardrail):
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )
+        self._responses_transform_handler = LiteLLMResponsesTransformationHandler()
         self.api_key = api_key or os.environ.get("NOMA_API_KEY")
         self.api_base = api_base or os.environ.get(
             "NOMA_API_BASE", NomaGuardrail._DEFAULT_API_BASE
@@ -164,11 +168,28 @@ class NomaGuardrail(CustomGuardrail):
         start_time = datetime.now()
         extra_data = self.get_guardrail_dynamic_request_body_params(request_data)
 
-        messages_for_scan = await self._extract_messages_for_scan(request_data)
-        if not messages_for_scan:
+        messages = request_data.get("messages") or []
+        if not messages:
             return None
 
-        payload = {"input": messages_for_scan}
+        input_items, instructions = self._responses_transform_handler.convert_chat_completion_messages_to_responses_api(  # type: ignore[arg-type]
+            messages
+        )
+
+        if instructions:
+            system_message = {
+                "type": "message",
+                "role": "system",
+                "content": [
+                    {"type": "input_text", "text": instructions},
+                ],
+            }
+            input_items.insert(0, system_message)
+
+        if not input_items:
+            return None
+
+        payload = {"input": input_items}
         response_json = await self._call_noma_api(
             payload=payload,
             llm_request_id=None,
@@ -196,9 +217,9 @@ class NomaGuardrail(CustomGuardrail):
 
         if self.monitor_mode:
             await self._handle_verdict_background(
-                USER_ROLE, json.dumps(messages_for_scan), response_json
+                USER_ROLE, json.dumps(input_items), response_json
             )
-            return json.dumps(messages_for_scan)
+            return json.dumps(input_items)
 
         # Check if we should anonymize content
         if self._should_anonymize(response_json, USER_ROLE):
@@ -213,8 +234,8 @@ class NomaGuardrail(CustomGuardrail):
                 )
                 return anonymized_content
 
-        await self._check_verdict(USER_ROLE, json.dumps(messages_for_scan), response_json)
-        return json.dumps(messages_for_scan)
+        await self._check_verdict(USER_ROLE, json.dumps(input_items), response_json)
+        return json.dumps(input_items)
 
     async def _process_llm_response_check(
         self,
@@ -729,102 +750,6 @@ class NomaGuardrail(CustomGuardrail):
             return response
 
         return response
-
-    async def _extract_messages_for_scan(self, data: dict) -> Optional[List[dict]]:
-        """
-        Extract system and user messages from request data for scanning.
-
-        Multiple system prompts are combined into a single system message
-        with content joined by spaces.
-
-        Returns a list of message objects in the format:
-        [
-            {"type": "message", "role": "system", "content": [...]},
-            {"type": "message", "role": "user", "content": [...]}
-        ]
-        """
-        messages = data.get("messages", [])
-        if not messages:
-            return None
-
-        messages_for_scan = []
-
-        # Extract and combine all system messages into a single message
-        system_messages = [msg for msg in messages if msg.get("role") == "system"]
-        if system_messages:
-            system_contents = []
-            for msg in system_messages:
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    system_contents.append(content)
-                elif isinstance(content, list):
-                    # Handle multimodal content - extract text parts
-                    for item in content:
-                        if isinstance(item, dict) and item.get("type") == "text":
-                            system_contents.append(item.get("text", ""))
-                        elif isinstance(item, str):
-                            system_contents.append(item)
-
-            if system_contents:
-                # Combine all system prompts with spaces
-                combined_system_content = " ".join(system_contents)
-                messages_for_scan.append({
-                    "type": "message",
-                    "role": "system",
-                    "content": [{"type": "input_text", "text": combined_system_content}]
-                })
-
-        # Extract the last user message using existing method
-        user_message_content = await self._extract_user_message(data)
-        if user_message_content:
-            messages_for_scan.append({
-                "type": "message",
-                "role": "user",
-                "content": user_message_content
-            })
-
-        return messages_for_scan if messages_for_scan else None
-
-    async def _extract_user_message(self, data: dict) -> Optional[List[dict]]:
-        """Extract the last user message from request data"""
-        messages = data.get("messages", [])
-        if not messages:
-            return None
-
-        # Get the last user message
-        user_messages = [msg for msg in messages if msg.get("role") == USER_ROLE]
-        if not user_messages:
-            return None
-
-        last_user_message = user_messages[-1].get("content", "")
-        if isinstance(last_user_message, str):
-            return [{"type": "input_text", "text": last_user_message}]
-        elif isinstance(last_user_message, list):
-            converted_messages = []
-            for message in last_user_message:
-                converted_message = self._convert_single_user_message_to_payload(
-                    message
-                )
-                if converted_message is not None:
-                    converted_messages.append(converted_message)
-            return converted_messages
-        else:
-            return None
-
-    def _convert_single_user_message_to_payload(
-        self, user_message: Any
-    ) -> Optional[dict]:
-        if isinstance(user_message, str):
-            return {"type": "input_text", "text": user_message}
-        elif user_message.get("type", "") == "image_url":
-            return {
-                "type": "input_image",
-                "image_url": user_message.get("image_url", {}).get("url", ""),
-            }
-        elif user_message.get("type", "") == "text":
-            return {"type": "input_text", "text": user_message.get("text", "")}
-        else:
-            return None
 
     async def _call_noma_api(
         self,


### PR DESCRIPTION
## Title

Refactor Noma guardrail to use shared Responses transformation and include system instructions

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

<img width="811" height="83" alt="image" src="https://github.com/user-attachments/assets/38c249d0-725c-4ba3-b154-b6975e2e51ca" />


- [X] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] I have added a screenshot of my new test passing locally 
- [X] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature
🧹 Refactoring
✅ Test

## Changes
- Aggregate system prompts in the Responses transformer itself: `convert_chat_completion_messages_to_responses_api` no longer overwrites instructions on each string system message; it now concatenates multiple system prompts into a single string (`instructions = f"{instructions} {content}"` when instructions already exists), which is then surfaced through transform_request.
- Use shared Responses transformer in Noma guardrail: NomaGuardrail now uses `LiteLLMResponsesTransformationHandler.convert_chat_completion_messages_to_responses_api` instead of custom message-extraction helpers, and builds the Noma payload from input_items.
- Forward system prompts to Noma as a single instructions message: multiple string system messages are concatenated into instructions, then turned into a single system message prepended to input before calling the Noma API; tests for single and multiple system prompts were updated accordingly.
- Reuse transformer for image and mixed content tests: the `test_extract_user_message_*` and `test_image_with_base64_data` tests now call the transformer directly, asserting the same shapes as before (text + input_image blocks, including base64 URLs) using AllMessageValues and proper typing.
