### PR TITLE
[Feature] Add User Alias Column to Internal User Table

### DIFF
--- a/ui/litellm-dashboard/src/components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/columns.tsx
@@ -47,6 +47,12 @@ export const columns = (
       cell: ({ row }) => <span className="text-xs">{possibleUIRoles?.[row.original.user_role]?.ui_label || "-"}</span>,
     },
     {
+      header: "User Alias",
+      accessorKey: "user_alias",
+      enableSorting: false,
+      cell: ({ row }) => <span className="text-xs">{row.original.user_alias || "-"}</span>,
+    },
+    {
       header: "Spend (USD)",
       accessorKey: "spend",
       enableSorting: true,

--- a/ui/litellm-dashboard/src/components/view_users/table.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_users/table.test.tsx
@@ -1,63 +1,52 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-
 import { UserDataTable } from "./table";
+
+const defaultFilters = {
+  email: "",
+  user_id: "",
+  user_role: "",
+  sso_user_id: "",
+  team: "",
+  model: "",
+  min_spend: null,
+  max_spend: null,
+  sort_by: "",
+  sort_order: "asc" as const,
+};
+
+const getDefaultProps = () => ({
+  data: [] as any[],
+  columns: [] as any[],
+  accessToken: null,
+  userRole: "Admin",
+  possibleUIRoles: null as Record<string, Record<string, string>> | null,
+  filters: defaultFilters,
+  updateFilters: vi.fn(),
+  initialFilters: defaultFilters,
+  teams: [] as any[],
+  handleEdit: vi.fn(),
+  handleDelete: vi.fn(),
+  handleResetPassword: vi.fn(),
+  userListResponse: { users: [], total: 0, page: 1, page_size: 25, total_pages: 1 },
+  currentPage: 1,
+  handlePageChange: vi.fn(),
+});
 
 describe("UserDataTable", () => {
   it("should render the UserDataTable component", () => {
-    const filters = {
-      email: "",
-      user_id: "",
-      user_role: "",
-      sso_user_id: "",
-      team: "",
-      model: "",
-      min_spend: null,
-      max_spend: null,
-      sort_by: "",
-      sort_order: "asc" as const,
-    };
-
-    const updateFilters = vi.fn();
-
-    render(
-      <UserDataTable
-        data={[]}
-        columns={[]}
-        accessToken={null}
-        userRole={"Admin"}
-        possibleUIRoles={null}
-        filters={filters}
-        updateFilters={updateFilters}
-        initialFilters={filters}
-        teams={[]}
-        handleEdit={vi.fn()}
-        handleDelete={vi.fn()}
-        handleResetPassword={vi.fn()}
-        userListResponse={{ users: [], total: 0, page: 1, page_size: 25, total_pages: 1 }}
-        currentPage={1}
-        handlePageChange={vi.fn()}
-      />,
-    );
+    render(<UserDataTable {...getDefaultProps()} />);
 
     expect(screen.getByText("Filters")).toBeInTheDocument();
   });
 
   it("should call onSortChange when clicking a sortable header", () => {
     const filters = {
-      email: "",
-      user_id: "",
-      user_role: "",
-      sso_user_id: "",
-      team: "",
-      model: "",
-      min_spend: null,
-      max_spend: null,
+      ...defaultFilters,
       sort_by: "created_at",
       sort_order: "desc" as const,
     };
 
-    const updateFilters = vi.fn();
     const onSortChange = vi.fn();
 
     const possibleUIRoles = {
@@ -67,21 +56,10 @@ describe("UserDataTable", () => {
 
     render(
       <UserDataTable
-        data={[]}
-        columns={[]}
-        accessToken={null}
-        userRole={"Admin"}
+        {...getDefaultProps()}
         possibleUIRoles={possibleUIRoles}
         filters={filters}
-        updateFilters={updateFilters}
         initialFilters={filters}
-        teams={[]}
-        handleEdit={vi.fn()}
-        handleDelete={vi.fn()}
-        handleResetPassword={vi.fn()}
-        userListResponse={{ users: [], total: 0, page: 1, page_size: 25, total_pages: 1 }}
-        currentPage={1}
-        handlePageChange={vi.fn()}
         onSortChange={onSortChange}
         currentSort={{ sortBy: filters.sort_by, sortOrder: filters.sort_order }}
       />,
@@ -96,41 +74,7 @@ describe("UserDataTable", () => {
   });
 
   it("should show skeleton loaders when isLoading is true", () => {
-    const filters = {
-      email: "",
-      user_id: "",
-      user_role: "",
-      sso_user_id: "",
-      team: "",
-      model: "",
-      min_spend: null,
-      max_spend: null,
-      sort_by: "",
-      sort_order: "asc" as const,
-    };
-
-    const updateFilters = vi.fn();
-
-    render(
-      <UserDataTable
-        data={[]}
-        columns={[]}
-        accessToken={null}
-        userRole={"Admin"}
-        possibleUIRoles={null}
-        filters={filters}
-        updateFilters={updateFilters}
-        initialFilters={filters}
-        teams={[]}
-        handleEdit={vi.fn()}
-        handleDelete={vi.fn()}
-        handleResetPassword={vi.fn()}
-        userListResponse={{ users: [], total: 0, page: 1, page_size: 25, total_pages: 1 }}
-        currentPage={1}
-        handlePageChange={vi.fn()}
-        isLoading={true}
-      />,
-    );
+    render(<UserDataTable {...getDefaultProps()} isLoading={true} />);
 
     expect(screen.queryByText(/Showing/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Previous/i })).not.toBeInTheDocument();
@@ -138,44 +82,35 @@ describe("UserDataTable", () => {
   });
 
   it("should show actual content when isLoading is false", () => {
-    const filters = {
-      email: "",
-      user_id: "",
-      user_role: "",
-      sso_user_id: "",
-      team: "",
-      model: "",
-      min_spend: null,
-      max_spend: null,
-      sort_by: "",
-      sort_order: "asc" as const,
-    };
-
-    const updateFilters = vi.fn();
-
-    render(
-      <UserDataTable
-        data={[]}
-        columns={[]}
-        accessToken={null}
-        userRole={"Admin"}
-        possibleUIRoles={null}
-        filters={filters}
-        updateFilters={updateFilters}
-        initialFilters={filters}
-        teams={[]}
-        handleEdit={vi.fn()}
-        handleDelete={vi.fn()}
-        handleResetPassword={vi.fn()}
-        userListResponse={{ users: [], total: 0, page: 1, page_size: 25, total_pages: 1 }}
-        currentPage={1}
-        handlePageChange={vi.fn()}
-        isLoading={false}
-      />,
-    );
+    render(<UserDataTable {...getDefaultProps()} isLoading={false} />);
 
     expect(screen.getByText(/Showing/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Previous/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Next/i })).toBeInTheDocument();
+  });
+
+  it("should render all column headers", () => {
+    const possibleUIRoles = {
+      admin: { ui_label: "Admin" },
+      user: { ui_label: "User" },
+    };
+
+    render(<UserDataTable {...getDefaultProps()} possibleUIRoles={possibleUIRoles} />);
+
+    [
+      "User ID",
+      "Email",
+      "Global Proxy Role",
+      "User Alias",
+      "Spend (USD)",
+      "Budget (USD)",
+      "SSO ID",
+      "API Keys",
+      "Created At",
+      "Updated At",
+      "Actions",
+    ].forEach((header) => {
+      expect(screen.getByRole("columnheader", { name: header })).toBeInTheDocument();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/view_users/types.ts
+++ b/ui/litellm-dashboard/src/components/view_users/types.ts
@@ -1,6 +1,7 @@
 export interface UserInfo {
   user_id: string;
   user_email: string;
+  user_alias: string | null;
   user_role: string;
   spend: number;
   max_budget: number | null;


### PR DESCRIPTION
## [Feature] Add User Alias Column to Internal User Table

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
This adds the user alias to the internal user table, and adds a test to verify for table columns

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

<img width="648" height="232" alt="image" src="https://github.com/user-attachments/assets/e14c3bb5-231c-4780-a04b-cb178783485b" />
<img width="764" height="234" alt="image" src="https://github.com/user-attachments/assets/5e2df5bd-99c6-499e-b21d-24134f63cc98" />

