### PR TITLE
[Fix] Fix Watsonx Audio Transcription API

### DIFF
--- a/litellm/types/llms/watsonx.py
+++ b/litellm/types/llms/watsonx.py
@@ -1,9 +1,7 @@
-import json
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 
-from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class WatsonXAPIParams(TypedDict):
@@ -16,6 +14,36 @@ class WatsonXCredentials(TypedDict):
     api_key: str
     api_base: str
     token: Optional[str]
+
+
+class WatsonXAudioTranscriptionRequestBody(TypedDict):
+    """
+    WatsonX Audio Transcription API request body.
+    
+    Follows multipart/form-data format for WatsonX Whisper models.
+    See: https://cloud.ibm.com/apidocs/watsonx-ai
+    """
+
+    model: str
+    """Model name (e.g., 'whisper-large-v3-turbo')"""
+
+    project_id: str
+    """WatsonX project ID (required)"""
+
+    language: NotRequired[str]
+    """Language code (e.g., 'en', 'es')"""
+
+    prompt: NotRequired[str]
+    """Optional prompt to guide transcription"""
+
+    response_format: NotRequired[str]
+    """Response format: 'json', 'text', 'srt', 'verbose_json', 'vtt'"""
+
+    temperature: NotRequired[float]
+    """Sampling temperature (0-1)"""
+
+    timestamp_granularities: NotRequired[List[str]]
+    """Timestamp granularities: ['word', 'segment']"""
 
 
 class WatsonXAIEndpoint(str, Enum):

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -4,6 +4,7 @@ Tests for IBM WatsonX Audio Transcription.
 Validates that litellm.transcription transforms requests correctly for WatsonX.
 """
 
+import json
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -111,6 +112,9 @@ class TestWatsonXAudioTranscription:
 
         # Validate form data contains expected fields
         data = captured_request.get("data", {})
+
+        print("JSON DUMPS captured_request:")
+        print(json.dumps(captured_request, indent=4, default=str))
         
         # Model name should NOT have watsonx/ prefix
         assert data.get("model") == "whisper-large-v3-turbo"

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -29,6 +29,7 @@ class TestWatsonXAudioTranscription:
             captured_request["url"] = str(kwargs.get("url", args[0] if args else None))
             captured_request["headers"] = kwargs.get("headers", {})
             captured_request["data"] = kwargs.get("data", {})
+            captured_request["files"] = kwargs.get("files", {})
             
             mock_response = MagicMock()
             mock_response.json.return_value = {
@@ -54,16 +55,30 @@ class TestWatsonXAudioTranscription:
         # Validate URL contains WatsonX audio transcription endpoint
         assert "/ml/v1/audio/transcriptions" in captured_request["url"]
         assert "version=" in captured_request["url"]
-        assert "project_id=test-project-123" in captured_request["url"]
+        # project_id should NOT be in URL (it should be in form data instead)
+        assert "project_id=test-project-123" not in captured_request["url"]
 
         # Validate headers contain WatsonX auth
         assert "Authorization" in captured_request["headers"]
         assert "Bearer test-bearer-token" in captured_request["headers"]["Authorization"]
+        
+        # Validate project_id is in form data, not URL
+        assert captured_request["data"].get("project_id") == "test-project-123"
+        
+        # Validate file is in files dict
+        assert "file" in captured_request["files"]
 
     @pytest.mark.asyncio
     async def test_watsonx_transcription_request_body(self):
         """
         Test that litellm.transcription sends correct request body for WatsonX.
+        
+        Validates that:
+        - Request uses multipart/form-data (data + files)
+        - Model name has watsonx/ prefix removed
+        - project_id is in form data, not URL
+        - Audio file is in files dict
+        - OpenAI params are included in form data
         """
         captured_request = {}
 
@@ -94,9 +109,21 @@ class TestWatsonXAudioTranscription:
             except Exception:
                 pass  # We just want to capture the request
 
-        # Validate request body contains expected fields
+        # Validate form data contains expected fields
         data = captured_request.get("data", {})
+        
+        # Model name should NOT have watsonx/ prefix
         assert data.get("model") == "whisper-large-v3-turbo"
+        
+        # project_id should be in form data
+        assert data.get("project_id") == "test-project-123"
+        
+        # OpenAI params should be in form data
         assert data.get("language") == "en"
         assert data.get("temperature") == 0.5
         assert data.get("response_format") == "verbose_json"  # Default for cost calculation
+        
+        # Validate file is in files dict (multipart/form-data)
+        files = captured_request.get("files", {})
+        assert "file" in files
+        assert isinstance(files["file"], tuple)  # Should be (filename, content, content_type)


### PR DESCRIPTION
## [Fix] Fix Watsonx Audio Transcription API

Fixes WatsonX audio transcription by sending requests as multipart/form-data instead of JSON. The WatsonX API requires form-encoded requests with the audio file and parameters (model, project_id, etc.) sent as multipart form fields.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


