### PR TITLE
feat(model_cost): add display_name, model_vendor, and model_version metadata to model entries

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4,6 +4,7 @@
         "computer_use_input_cost_per_1k_tokens": 0.0,
         "computer_use_output_cost_per_1k_tokens": 0.0,
         "deprecation_date": "date when the model becomes deprecated in the format YYYY-MM-DD",
+        "display_name": "human readable model name e.g. 'Llama 3.2 3B Instruct', 'GPT-4o', 'Grok 2', etc.",
         "file_search_cost_per_1k_calls": 0.0,
         "file_search_cost_per_gb_per_day": 0.0,
         "input_cost_per_audio_token": 0.0,
@@ -13,6 +14,8 @@
         "max_output_tokens": "max output tokens, if the provider specifies it. if not default to max_tokens",
         "max_tokens": "LEGACY parameter. set to max_output_tokens if provider specifies it. IF not set to max_input_tokens, if provider specifies it.",
         "mode": "one of: chat, embedding, completion, image_generation, audio_transcription, audio_speech, image_generation, moderation, rerank, search",
+        "model_vendor": "used to group models by vendor e.g. openai, google, etc.",
+        "model_version": "used to group models by version e.g. v1, v2, etc.",
         "output_cost_per_reasoning_token": 0.0,
         "output_cost_per_token": 0.0,
         "search_context_cost_per_query": {
@@ -40,104 +43,142 @@
         "vector_store_cost_per_gb_per_day": 0.0
     },
     "1024-x-1024/50-steps/bedrock/amazon.nova-canvas-v1:0": {
+        "display_name": "Nova Canvas",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_image": 0.06
     },
     "1024-x-1024/50-steps/stability.stable-diffusion-xl-v1": {
+        "display_name": "Stable Diffusion XL",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "image_generation",
+        "model_vendor": "stability",
+        "model_version": "v1",
         "output_cost_per_image": 0.04
     },
     "1024-x-1024/dall-e-2": {
+        "display_name": "DALL-E 2",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.9e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "1024-x-1024/max-steps/stability.stable-diffusion-xl-v1": {
+        "display_name": "Stable Diffusion XL",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "image_generation",
+        "model_vendor": "stability",
+        "model_version": "v1",
         "output_cost_per_image": 0.08
     },
     "256-x-256/dall-e-2": {
+        "display_name": "DALL-E 2",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 2.4414e-07,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "512-x-512/50-steps/stability.stable-diffusion-xl-v0": {
+        "display_name": "Stable Diffusion XL",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "image_generation",
+        "model_vendor": "stability",
+        "model_version": "v0",
         "output_cost_per_image": 0.018
     },
     "512-x-512/dall-e-2": {
+        "display_name": "DALL-E 2",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 6.86e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "512-x-512/max-steps/stability.stable-diffusion-xl-v0": {
+        "display_name": "Stable Diffusion XL",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "image_generation",
+        "model_vendor": "stability",
+        "model_version": "v0",
         "output_cost_per_image": 0.036
     },
     "ai21.j2-mid-v1": {
+        "display_name": "Jurassic-2 Mid",
         "input_cost_per_token": 1.25e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8191,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "ai21",
+        "model_version": "v1",
         "output_cost_per_token": 1.25e-05
     },
     "ai21.j2-ultra-v1": {
+        "display_name": "Jurassic-2 Ultra",
         "input_cost_per_token": 1.88e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8191,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "ai21",
+        "model_version": "v1",
         "output_cost_per_token": 1.88e-05
     },
     "ai21.jamba-1-5-large-v1:0": {
+        "display_name": "Jamba 1.5 Large",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "model_vendor": "ai21",
+        "model_version": "1.5-large-v1:0",
         "output_cost_per_token": 8e-06
     },
     "ai21.jamba-1-5-mini-v1:0": {
+        "display_name": "Jamba 1.5 Mini",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
         "mode": "chat",
+        "model_vendor": "ai21",
+        "model_version": "1.5-mini-v1:0",
         "output_cost_per_token": 4e-07
     },
     "ai21.jamba-instruct-v1:0": {
+        "display_name": "Jamba Instruct",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 70000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "ai21",
+        "model_version": "instruct-v1:0",
         "output_cost_per_token": 7e-07,
         "supports_system_messages": true
     },
     "aiml/dall-e-2": {
+        "display_name": "DALL-E 2",
+        "model_vendor": "openai",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "DALL-E 2 via AI/ML API - Reliable text-to-image generation"
@@ -150,6 +191,8 @@
         ]
     },
     "aiml/dall-e-3": {
+        "display_name": "DALL-E 3",
+        "model_vendor": "openai",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "DALL-E 3 via AI/ML API - High-quality text-to-image generation"
@@ -162,11 +205,13 @@
         ]
     },
     "aiml/flux-pro": {
+        "display_name": "FLUX Pro",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Dev - Development version optimized for experimentation"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.053,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
@@ -174,27 +219,35 @@
         ]
     },
     "aiml/flux-pro/v1.1": {
+        "display_name": "FLUX Pro",
         "litellm_provider": "aiml",
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
+        "model_version": "v1.1",
         "output_cost_per_image": 0.042,
         "supported_endpoints": [
             "/v1/images/generations"
         ]
     },
     "aiml/flux-pro/v1.1-ultra": {
+        "display_name": "FLUX Pro Ultra",
         "litellm_provider": "aiml",
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
+        "model_version": "v1.1-ultra",
         "output_cost_per_image": 0.063,
         "supported_endpoints": [
             "/v1/images/generations"
         ]
     },
     "aiml/flux-realism": {
+        "display_name": "FLUX Realism",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Pro - Professional-grade image generation model"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.037,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
@@ -202,11 +255,13 @@
         ]
     },
     "aiml/flux/dev": {
+        "display_name": "FLUX Dev",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Dev - Development version optimized for experimentation"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.026,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
@@ -214,11 +269,13 @@
         ]
     },
     "aiml/flux/kontext-max/text-to-image": {
+        "display_name": "FLUX Kontext Max",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Pro v1.1 - Enhanced version with improved capabilities and 6x faster inference speed"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.084,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
@@ -226,11 +283,13 @@
         ]
     },
     "aiml/flux/kontext-pro/text-to-image": {
+        "display_name": "FLUX Kontext Pro",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Pro v1.1 - Enhanced version with improved capabilities and 6x faster inference speed"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.042,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
@@ -238,48 +297,32 @@
         ]
     },
     "aiml/flux/schnell": {
+        "display_name": "FLUX Schnell",
         "litellm_provider": "aiml",
         "metadata": {
             "notes": "Flux Schnell - Fast generation model optimized for speed"
         },
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.003,
         "source": "https://docs.aimlapi.com/",
         "supported_endpoints": [
             "/v1/images/generations"
         ]
     },
-    "aiml/google/imagen-4.0-ultra-generate-001": {
-        "litellm_provider": "aiml",
-        "metadata": {
-            "notes": "Imagen 4.0 Ultra Generate API - Photorealistic image generation with precise text rendering"
-        },
-        "mode": "image_generation",
-        "output_cost_per_image": 0.063,
-        "source": "https://docs.aimlapi.com/api-references/image-models/google/imagen-4-ultra-generate",
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ]
-    },
-    "aiml/google/nano-banana-pro": {
-        "litellm_provider": "aiml",
-        "metadata": {
-            "notes": "Gemini 3 Pro Image (Nano Banana Pro) - Advanced text-to-image generation with reasoning and 4K resolution support"
-        },
-        "mode": "image_generation",
-        "output_cost_per_image": 0.1575,
-        "source": "https://docs.aimlapi.com/api-references/image-models/google/gemini-3-pro-image-preview",
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ]
-    },
     "amazon.nova-canvas-v1:0": {
+        "display_name": "Nova Canvas",
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
         "mode": "image_generation",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_image": 0.06
     },
     "us.writer.palmyra-x4-v1:0": {
+        "display_name": "Writer.palmyra X4 V1:0",
+        "model_vendor": "google",
+        "model_version": "0",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -291,6 +334,9 @@
         "supports_pdf_input": true
     },
     "us.writer.palmyra-x5-v1:0": {
+        "display_name": "Writer.palmyra X5 V1:0",
+        "model_vendor": "google",
+        "model_version": "0",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -302,6 +348,9 @@
         "supports_pdf_input": true
     },
     "writer.palmyra-x4-v1:0": {
+        "display_name": "Palmyra X4 V1:0",
+        "model_vendor": "google",
+        "model_version": "0",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -313,6 +362,9 @@
         "supports_pdf_input": true
     },
     "writer.palmyra-x5-v1:0": {
+        "display_name": "Palmyra X5 V1:0",
+        "model_vendor": "google",
+        "model_version": "0",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -324,12 +376,15 @@
         "supports_pdf_input": true
     },
     "amazon.nova-lite-v1:0": {
+        "display_name": "Nova Lite",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 2.4e-07,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -338,6 +393,8 @@
         "supports_vision": true
     },
     "amazon.nova-2-lite-v1:0": {
+        "display_name": "Nova 2 Lite",
+        "model_vendor": "amazon",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
@@ -355,6 +412,8 @@
         "supports_vision": true
     },
     "apac.amazon.nova-2-lite-v1:0": {
+        "display_name": "Nova 2 Lite",
+        "model_vendor": "amazon",
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
@@ -372,6 +431,8 @@
         "supports_vision": true
     },
     "eu.amazon.nova-2-lite-v1:0": {
+        "display_name": "Nova 2 Lite",
+        "model_vendor": "amazon",
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
@@ -389,6 +450,8 @@
         "supports_vision": true
     },
     "us.amazon.nova-2-lite-v1:0": {
+        "display_name": "Nova 2 Lite",
+        "model_vendor": "amazon",
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",
@@ -405,26 +468,31 @@
         "supports_video_input": true,
         "supports_vision": true
     },
-
     "amazon.nova-micro-v1:0": {
+        "display_name": "Nova Micro",
         "input_cost_per_token": 3.5e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.4e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true
     },
     "amazon.nova-pro-v1:0": {
+        "display_name": "Nova Pro",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.2e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -433,6 +501,7 @@
         "supports_vision": true
     },
     "amazon.rerank-v1:0": {
+        "display_name": "Amazon Rerank",
         "input_cost_per_query": 0.001,
         "input_cost_per_token": 0.0,
         "litellm_provider": "bedrock",
@@ -443,9 +512,12 @@
         "max_tokens": 32000,
         "max_tokens_per_document_chunk": 512,
         "mode": "rerank",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 0.0
     },
     "amazon.titan-embed-image-v1": {
+        "display_name": "Titan Embed Image",
         "input_cost_per_image": 6e-05,
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
@@ -455,6 +527,8 @@
             "notes": "'supports_image_input' is a deprecated field. Use 'supports_embedding_image_input' instead."
         },
         "mode": "embedding",
+        "model_vendor": "amazon",
+        "model_version": "v1",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "source": "https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/providers?model=amazon.titan-image-generator-v1",
@@ -462,42 +536,57 @@
         "supports_image_input": true
     },
     "amazon.titan-embed-text-v1": {
+        "display_name": "Titan Embed Text",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
+        "model_version": "v1",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1536
     },
     "amazon.titan-embed-text-v2:0": {
+        "display_name": "Titan Embed Text",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
+        "model_version": "v2:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024
     },
     "amazon.titan-image-generator-v1": {
+        "display_name": "Titan Image Generator",
         "input_cost_per_image": 0.0,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation",
+        "model_vendor": "amazon",
+        "model_version": "v1",
         "output_cost_per_image": 0.008,
-        "output_cost_per_image_premium_image": 0.01,
         "output_cost_per_image_above_512_and_512_pixels": 0.01,
         "output_cost_per_image_above_512_and_512_pixels_and_premium_image": 0.012,
-        "litellm_provider": "bedrock",
-        "mode": "image_generation"
+        "output_cost_per_image_premium_image": 0.01
     },
     "amazon.titan-image-generator-v2": {
+        "display_name": "Titan Image Generator",
         "input_cost_per_image": 0.0,
+        "litellm_provider": "bedrock",
+        "mode": "image_generation",
+        "model_vendor": "amazon",
+        "model_version": "v2",
         "output_cost_per_image": 0.008,
-        "output_cost_per_image_premium_image": 0.01,
         "output_cost_per_image_above_1024_and_1024_pixels": 0.01,
         "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image": 0.012,
-        "litellm_provider": "bedrock",
-        "mode": "image_generation"
+        "output_cost_per_image_premium_image": 0.01
     },
     "amazon.titan-image-generator-v2:0": {
+        "display_name": "Titan Image Generator V2:0",
+        "model_vendor": "amazon",
+        "model_version": "0",
         "input_cost_per_image": 0.0,
         "output_cost_per_image": 0.008,
         "output_cost_per_image_premium_image": 0.01,
@@ -507,101 +596,131 @@
         "mode": "image_generation"
     },
     "twelvelabs.marengo-embed-2-7-v1:0": {
+        "display_name": "Marengo Embed",
         "input_cost_per_token": 7e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "embedding",
+        "model_vendor": "twelve-labs",
+        "model_version": "2.7-v1:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "supports_embedding_image_input": true,
         "supports_image_input": true
     },
     "us.twelvelabs.marengo-embed-2-7-v1:0": {
-        "input_cost_per_token": 7e-05,
-        "input_cost_per_video_per_second": 0.0007,
+        "display_name": "Marengo Embed",
         "input_cost_per_audio_per_second": 0.00014,
         "input_cost_per_image": 0.0001,
+        "input_cost_per_token": 7e-05,
+        "input_cost_per_video_per_second": 0.0007,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "embedding",
+        "model_vendor": "twelve-labs",
+        "model_version": "2.7-v1:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "supports_embedding_image_input": true,
         "supports_image_input": true
     },
     "eu.twelvelabs.marengo-embed-2-7-v1:0": {
-        "input_cost_per_token": 7e-05,
-        "input_cost_per_video_per_second": 0.0007,
+        "display_name": "Marengo Embed",
         "input_cost_per_audio_per_second": 0.00014,
         "input_cost_per_image": 0.0001,
+        "input_cost_per_token": 7e-05,
+        "input_cost_per_video_per_second": 0.0007,
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "embedding",
+        "model_vendor": "twelve-labs",
+        "model_version": "2.7-v1:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "supports_embedding_image_input": true,
         "supports_image_input": true
     },
     "twelvelabs.pegasus-1-2-v1:0": {
+        "display_name": "Pegasus",
         "input_cost_per_video_per_second": 0.00049,
-        "output_cost_per_token": 7.5e-06,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "model_vendor": "twelve-labs",
+        "model_version": "1.2-v1:0",
+        "output_cost_per_token": 7.5e-06,
         "supports_video_input": true
     },
     "us.twelvelabs.pegasus-1-2-v1:0": {
+        "display_name": "Pegasus",
         "input_cost_per_video_per_second": 0.00049,
-        "output_cost_per_token": 7.5e-06,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "model_vendor": "twelve-labs",
+        "model_version": "1.2-v1:0",
+        "output_cost_per_token": 7.5e-06,
         "supports_video_input": true
     },
     "eu.twelvelabs.pegasus-1-2-v1:0": {
+        "display_name": "Pegasus",
         "input_cost_per_video_per_second": 0.00049,
-        "output_cost_per_token": 7.5e-06,
         "litellm_provider": "bedrock",
         "mode": "chat",
+        "model_vendor": "twelve-labs",
+        "model_version": "1.2-v1:0",
+        "output_cost_per_token": 7.5e-06,
         "supports_video_input": true
     },
     "amazon.titan-text-express-v1": {
+        "display_name": "Titan Text Express",
         "input_cost_per_token": 1.3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 8000,
         "max_tokens": 8000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1",
         "output_cost_per_token": 1.7e-06
     },
     "amazon.titan-text-lite-v1": {
+        "display_name": "Titan Text Lite",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 4000,
         "max_tokens": 4000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1",
         "output_cost_per_token": 4e-07
     },
     "amazon.titan-text-premier-v1:0": {
+        "display_name": "Titan Text Premier",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.5e-06
     },
     "anthropic.claude-3-5-haiku-20241022-v1:0": {
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 8e-08,
+        "display_name": "Claude 3.5 Haiku",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022-v1:0",
         "output_cost_per_token": 4e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -613,12 +732,15 @@
     "anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
+        "display_name": "Claude 4.5 Haiku",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251001-v1:0",
         "output_cost_per_token": 5e-06,
         "source": "https://aws.amazon.com/about-aws/whats-new/2025/10/claude-4-5-haiku-anthropic-amazon-bedrock",
         "supports_assistant_prefill": true,
@@ -635,12 +757,15 @@
     "anthropic.claude-haiku-4-5@20251001": {
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
+        "display_name": "Claude 4.5 Haiku",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "output_cost_per_token": 5e-06,
         "source": "https://aws.amazon.com/about-aws/whats-new/2025/10/claude-4-5-haiku-anthropic-amazon-bedrock",
         "supports_assistant_prefill": true,
@@ -655,12 +780,15 @@
         "tool_use_system_prompt_tokens": 346
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude 3.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -671,12 +799,15 @@
     "anthropic.claude-3-5-sonnet-20241022-v2:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "Claude 3.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022-v2:0",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -690,12 +821,15 @@
     "anthropic.claude-3-7-sonnet-20240620-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,
         "cache_read_input_token_cost": 3.6e-07,
+        "display_name": "Claude 3.7 Sonnet",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.8e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -710,12 +844,15 @@
     "anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "Claude 3.7 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250219-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -728,12 +865,15 @@
         "supports_vision": true
     },
     "anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude 3 Haiku",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240307-v1:0",
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -742,12 +882,15 @@
         "supports_vision": true
     },
     "anthropic.claude-3-opus-20240229-v1:0": {
+        "display_name": "Claude 3 Opus",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240229-v1:0",
         "output_cost_per_token": 7.5e-05,
         "supports_function_calling": true,
         "supports_response_schema": true,
@@ -755,12 +898,15 @@
         "supports_vision": true
     },
     "anthropic.claude-3-sonnet-20240229-v1:0": {
+        "display_name": "Claude 3 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240229-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -769,24 +915,30 @@
         "supports_vision": true
     },
     "anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v1",
         "output_cost_per_token": 2.4e-06,
         "supports_tool_choice": true
     },
     "anthropic.claude-opus-4-1-20250805-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "display_name": "Claude 4.1 Opus",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250805-v1:0",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -807,12 +959,15 @@
     "anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "display_name": "Claude 4 Opus",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514-v1:0",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -833,12 +988,15 @@
     "anthropic.claude-opus-4-5-20251101-v1:0": {
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "Claude 4.5 Opus",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251101-v1:0",
         "output_cost_per_token": 2.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -858,18 +1016,21 @@
     },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "display_name": "Claude 4 Sonnet",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514-v1:0",
         "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
@@ -888,18 +1049,21 @@
     },
     "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "display_name": "Claude 4.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250929-v1:0",
         "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
@@ -917,149 +1081,185 @@
         "tool_use_system_prompt_tokens": 159
     },
     "anthropic.claude-v1": {
+        "display_name": "Claude",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v1",
         "output_cost_per_token": 2.4e-05
     },
     "anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v2:1",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "anyscale/HuggingFaceH4/zephyr-7b-beta": {
+        "display_name": "Zephyr 7B Beta",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "huggingface",
         "output_cost_per_token": 1.5e-07
     },
     "anyscale/codellama/CodeLlama-34b-Instruct-hf": {
+        "display_name": "CodeLlama 34B Instruct",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anyscale",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1e-06
     },
     "anyscale/codellama/CodeLlama-70b-Instruct-hf": {
+        "display_name": "CodeLlama 70B Instruct",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anyscale",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1e-06,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/codellama-CodeLlama-70b-Instruct-hf"
     },
     "anyscale/google/gemma-7b-it": {
+        "display_name": "Gemma 7B IT",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "google",
         "output_cost_per_token": 1.5e-07,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/google-gemma-7b-it"
     },
     "anyscale/meta-llama/Llama-2-13b-chat-hf": {
+        "display_name": "Llama 2 13B Chat",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 2.5e-07
     },
     "anyscale/meta-llama/Llama-2-70b-chat-hf": {
+        "display_name": "Llama 2 70B Chat",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anyscale",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1e-06
     },
     "anyscale/meta-llama/Llama-2-7b-chat-hf": {
+        "display_name": "Llama 2 7B Chat",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1.5e-07
     },
     "anyscale/meta-llama/Meta-Llama-3-70B-Instruct": {
+        "display_name": "Llama 3 70B Instruct",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anyscale",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1e-06,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/meta-llama-Meta-Llama-3-70B-Instruct"
     },
     "anyscale/meta-llama/Meta-Llama-3-8B-Instruct": {
+        "display_name": "Llama 3 8B Instruct",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1.5e-07,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/meta-llama-Meta-Llama-3-8B-Instruct"
     },
     "anyscale/mistralai/Mistral-7B-Instruct-v0.1": {
+        "display_name": "Mistral 7B Instruct",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0.1",
         "output_cost_per_token": 1.5e-07,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/mistralai-Mistral-7B-Instruct-v0.1",
         "supports_function_calling": true
     },
     "anyscale/mistralai/Mixtral-8x22B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x22B Instruct",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0.1",
         "output_cost_per_token": 9e-07,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/mistralai-Mixtral-8x22B-Instruct-v0.1",
         "supports_function_calling": true
     },
     "anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "anyscale",
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0.1",
         "output_cost_per_token": 1.5e-07,
         "source": "https://docs.anyscale.com/preview/endpoints/text-generation/supported-models/mistralai-Mixtral-8x7B-Instruct-v0.1",
         "supports_function_calling": true
     },
     "apac.amazon.nova-lite-v1:0": {
+        "display_name": "Nova Lite",
         "input_cost_per_token": 6.3e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 2.52e-07,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -1068,24 +1268,30 @@
         "supports_vision": true
     },
     "apac.amazon.nova-micro-v1:0": {
+        "display_name": "Nova Micro",
         "input_cost_per_token": 3.7e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.48e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true
     },
     "apac.amazon.nova-pro-v1:0": {
+        "display_name": "Nova Pro",
         "input_cost_per_token": 8.4e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.36e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -1094,12 +1300,15 @@
         "supports_vision": true
     },
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude 3.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -1110,12 +1319,15 @@
     "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "Claude 3.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022-v2:0",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -1127,12 +1339,15 @@
         "supports_vision": true
     },
     "apac.anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude 3 Haiku",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240307-v1:0",
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -1143,12 +1358,15 @@
     "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
+        "display_name": "Claude 4.5 Haiku",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251001-v1:0",
         "output_cost_per_token": 5.5e-06,
         "source": "https://aws.amazon.com/about-aws/whats-new/2025/10/claude-4-5-haiku-anthropic-amazon-bedrock",
         "supports_assistant_prefill": true,
@@ -1163,12 +1381,15 @@
         "tool_use_system_prompt_tokens": 346
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "display_name": "Claude 3 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240229-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -1178,18 +1399,21 @@
     },
     "apac.anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "display_name": "Claude 4 Sonnet",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.25e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514-v1:0",
         "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
@@ -1207,31 +1431,38 @@
         "tool_use_system_prompt_tokens": 159
     },
     "assemblyai/best": {
+        "display_name": "AssemblyAI Best",
         "input_cost_per_second": 3.333e-05,
         "litellm_provider": "assemblyai",
         "mode": "audio_transcription",
+        "model_vendor": "assemblyai",
         "output_cost_per_second": 0.0
     },
     "assemblyai/nano": {
+        "display_name": "AssemblyAI Nano",
         "input_cost_per_second": 0.00010278,
         "litellm_provider": "assemblyai",
         "mode": "audio_transcription",
+        "model_vendor": "assemblyai",
         "output_cost_per_second": 0.0
     },
     "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,
+        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
         "cache_read_input_token_cost": 3.3e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
+        "display_name": "Claude 4.5 Sonnet",
         "input_cost_per_token": 3.3e-06,
         "input_cost_per_token_above_200k_tokens": 6.6e-06,
-        "output_cost_per_token_above_200k_tokens": 2.475e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 8.25e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6.6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250929-v1:0",
         "output_cost_per_token": 1.65e-05,
+        "output_cost_per_token_above_200k_tokens": 2.475e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
             "search_context_size_low": 0.01,
@@ -1249,21 +1480,25 @@
         "tool_use_system_prompt_tokens": 346
     },
     "azure/ada": {
+        "display_name": "Ada",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
         "mode": "embedding",
+        "model_vendor": "openai",
         "output_cost_per_token": 0.0
     },
     "azure/codex-mini": {
         "cache_read_input_token_cost": 3.75e-07,
+        "display_name": "Codex Mini",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 6e-06,
         "supported_endpoints": [
             "/v1/responses"
@@ -1286,22 +1521,26 @@
         "supports_vision": true
     },
     "azure/command-r-plus": {
+        "display_name": "Command R+",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "cohere",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true
     },
     "azure_ai/claude-haiku-4-5": {
+        "display_name": "Claude 4.5 Haiku",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 5e-06,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -1314,12 +1553,14 @@
         "supports_vision": true
     },
     "azure_ai/claude-opus-4-1": {
+        "display_name": "Claude 4.1 Opus",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 7.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -1332,12 +1573,14 @@
         "supports_vision": true
     },
     "azure_ai/claude-sonnet-4-5": {
+        "display_name": "Claude 4.5 Sonnet",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -1350,12 +1593,14 @@
         "supports_vision": true
     },
     "azure/computer-use-preview": {
+        "display_name": "Computer Use Preview",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 8192,
         "max_output_tokens": 1024,
         "max_tokens": 1024,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.2e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -1378,32 +1623,23 @@
     },
     "azure/container": {
         "code_interpreter_cost_per_session": 0.03,
+        "display_name": "Container",
         "litellm_provider": "azure",
-        "mode": "chat"
-    },
-    "azure_ai/gpt-oss-120b": {
-        "input_cost_per_token": 1.5e-7,
-        "output_cost_per_token": 6e-7,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
         "mode": "chat",
-        "source": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
+        "model_vendor": "openai"
     },
     "azure/eu/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
         "cache_read_input_token_cost": 1.375e-06,
+        "deprecation_date": "2026-02-27",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "output_cost_per_token": 1.1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1413,14 +1649,17 @@
         "supports_vision": true
     },
     "azure/eu/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
         "cache_creation_input_token_cost": 1.38e-06,
+        "deprecation_date": "2026-03-01",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "output_cost_per_token": 1.1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1430,12 +1669,15 @@
     },
     "azure/eu/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 8.3e-08,
+        "display_name": "GPT-4o Mini",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-07-18",
         "output_cost_per_token": 6.6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1447,6 +1689,7 @@
     "azure/eu/gpt-4o-mini-realtime-preview-2024-12-17": {
         "cache_creation_input_audio_token_cost": 3.3e-07,
         "cache_read_input_token_cost": 3.3e-07,
+        "display_name": "GPT-4o Mini Realtime",
         "input_cost_per_audio_token": 1.1e-05,
         "input_cost_per_token": 6.6e-07,
         "litellm_provider": "azure",
@@ -1454,6 +1697,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-2024-12-17",
         "output_cost_per_audio_token": 2.2e-05,
         "output_cost_per_token": 2.64e-06,
         "supports_audio_input": true,
@@ -1466,6 +1711,7 @@
     "azure/eu/gpt-4o-realtime-preview-2024-10-01": {
         "cache_creation_input_audio_token_cost": 2.2e-05,
         "cache_read_input_token_cost": 2.75e-06,
+        "display_name": "GPT-4o Realtime",
         "input_cost_per_audio_token": 0.00011,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "azure",
@@ -1473,6 +1719,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-2024-10-01",
         "output_cost_per_audio_token": 0.00022,
         "output_cost_per_token": 2.2e-05,
         "supports_audio_input": true,
@@ -1485,6 +1733,7 @@
     "azure/eu/gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_audio_token_cost": 2.5e-06,
         "cache_read_input_token_cost": 2.75e-06,
+        "display_name": "GPT-4o Realtime",
         "input_cost_per_audio_token": 4.4e-05,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "azure",
@@ -1492,6 +1741,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-2024-12-17",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 2.2e-05,
         "supported_modalities": [
@@ -1511,12 +1762,15 @@
     },
     "azure/eu/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.375e-07,
+        "display_name": "GPT-5",
         "input_cost_per_token": 1.375e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1543,12 +1797,15 @@
     },
     "azure/eu/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.75e-08,
+        "display_name": "GPT-5 Mini",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 2.2e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1575,12 +1832,14 @@
     },
     "azure/eu/gpt-5.1": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1608,12 +1867,14 @@
     },
     "azure/eu/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1 Chat",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1641,12 +1902,14 @@
     },
     "azure/eu/gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1 Codex",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -1671,12 +1934,14 @@
     },
     "azure/eu/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.8e-08,
+        "display_name": "GPT-5.1 Codex Mini",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 2.2e-06,
         "supported_endpoints": [
             "/v1/responses"
@@ -1701,12 +1966,15 @@
     },
     "azure/eu/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5.5e-09,
+        "display_name": "GPT-5 Nano",
         "input_cost_per_token": 5.5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 4.4e-07,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1733,12 +2001,15 @@
     },
     "azure/eu/o1-2024-12-17": {
         "cache_read_input_token_cost": 8.25e-06,
+        "display_name": "o1",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "output_cost_per_token": 6.6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1748,6 +2019,7 @@
     },
     "azure/eu/o1-mini-2024-09-12": {
         "cache_read_input_token_cost": 6.05e-07,
+        "display_name": "o1 Mini",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -1755,6 +2027,8 @@
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "output_cost_per_token": 4.84e-06,
         "output_cost_per_token_batches": 2.42e-06,
         "supports_function_calling": true,
@@ -1764,12 +2038,15 @@
     },
     "azure/eu/o1-preview-2024-09-12": {
         "cache_read_input_token_cost": 8.25e-06,
+        "display_name": "o1 Preview",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "preview-2024-09-12",
         "output_cost_per_token": 6.6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1778,6 +2055,7 @@
     },
     "azure/eu/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 6.05e-07,
+        "display_name": "o3 Mini",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -1785,6 +2063,8 @@
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-01-31",
         "output_cost_per_token": 4.84e-06,
         "output_cost_per_token_batches": 2.42e-06,
         "supports_prompt_caching": true,
@@ -1795,12 +2075,15 @@
     "azure/global-standard/gpt-4o-2024-08-06": {
         "cache_read_input_token_cost": 1.25e-06,
         "deprecation_date": "2026-02-27",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1812,12 +2095,15 @@
     "azure/global-standard/gpt-4o-2024-11-20": {
         "cache_read_input_token_cost": 1.25e-06,
         "deprecation_date": "2026-03-01",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1826,12 +2112,14 @@
         "supports_vision": true
     },
     "azure/global-standard/gpt-4o-mini": {
+        "display_name": "GPT-4o Mini",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1840,14 +2128,17 @@
         "supports_vision": true
     },
     "azure/global/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-02-27",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1857,14 +2148,17 @@
         "supports_vision": true
     },
     "azure/global/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-03-01",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -1875,12 +2169,14 @@
     },
     "azure/global/gpt-5.1": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1908,12 +2204,14 @@
     },
     "azure/global/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1 Chat",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -1941,12 +2239,14 @@
     },
     "azure/global/gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1 Codex",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -1971,12 +2271,14 @@
     },
     "azure/global/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-5.1 Codex Mini",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 2e-06,
         "supported_endpoints": [
             "/v1/responses"
@@ -2000,56 +2302,69 @@
         "supports_vision": true
     },
     "azure/gpt-3.5-turbo": {
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 4097,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-3.5-turbo-0125": {
         "deprecation_date": "2025-03-31",
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0125",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-3.5-turbo-instruct-0914": {
+        "display_name": "GPT-3.5 Turbo Instruct",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure_text",
         "max_input_tokens": 4097,
         "max_tokens": 4097,
         "mode": "completion",
+        "model_vendor": "openai",
+        "model_version": "instruct-0914",
         "output_cost_per_token": 2e-06
     },
     "azure/gpt-35-turbo": {
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 4097,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-35-turbo-0125": {
         "deprecation_date": "2025-05-31",
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0125",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2057,12 +2372,15 @@
     },
     "azure/gpt-35-turbo-0301": {
         "deprecation_date": "2025-02-13",
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 4097,
         "max_output_tokens": 4096,
         "max_tokens": 4097,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0301",
         "output_cost_per_token": 2e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2070,12 +2388,15 @@
     },
     "azure/gpt-35-turbo-0613": {
         "deprecation_date": "2025-02-13",
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 4097,
         "max_output_tokens": 4096,
         "max_tokens": 4097,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "output_cost_per_token": 2e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2083,139 +2404,173 @@
     },
     "azure/gpt-35-turbo-1106": {
         "deprecation_date": "2025-03-31",
+        "display_name": "GPT-3.5 Turbo",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "1106",
         "output_cost_per_token": 2e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-35-turbo-16k": {
+        "display_name": "GPT-3.5 Turbo 16K",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16385,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4e-06,
         "supports_tool_choice": true
     },
     "azure/gpt-35-turbo-16k-0613": {
+        "display_name": "GPT-3.5 Turbo 16K",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16385,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "16k-0613",
         "output_cost_per_token": 4e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-35-turbo-instruct": {
+        "display_name": "GPT-3.5 Turbo Instruct",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure_text",
         "max_input_tokens": 4097,
         "max_tokens": 4097,
         "mode": "completion",
+        "model_vendor": "openai",
         "output_cost_per_token": 2e-06
     },
     "azure/gpt-35-turbo-instruct-0914": {
+        "display_name": "GPT-3.5 Turbo Instruct",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "azure_text",
         "max_input_tokens": 4097,
         "max_tokens": 4097,
         "mode": "completion",
+        "model_vendor": "openai",
+        "model_version": "instruct-0914",
         "output_cost_per_token": 2e-06
     },
     "azure/gpt-4": {
+        "display_name": "GPT-4",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 8192,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-4-0125-preview": {
+        "display_name": "GPT-4 Turbo Preview",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0125-preview",
         "output_cost_per_token": 3e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-4-0613": {
+        "display_name": "GPT-4",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 8192,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-4-1106-preview": {
+        "display_name": "GPT-4 Turbo Preview",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "1106-preview",
         "output_cost_per_token": 3e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-4-32k": {
+        "display_name": "GPT-4 32K",
         "input_cost_per_token": 6e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 0.00012,
         "supports_tool_choice": true
     },
     "azure/gpt-4-32k-0613": {
+        "display_name": "GPT-4 32K",
         "input_cost_per_token": 6e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "32k-0613",
         "output_cost_per_token": 0.00012,
         "supports_tool_choice": true
     },
     "azure/gpt-4-turbo": {
+        "display_name": "GPT-4 Turbo",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 3e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true
     },
     "azure/gpt-4-turbo-2024-04-09": {
+        "display_name": "GPT-4 Turbo",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-04-09",
         "output_cost_per_token": 3e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2223,18 +2578,22 @@
         "supports_vision": true
     },
     "azure/gpt-4-turbo-vision-preview": {
+        "display_name": "GPT-4 Turbo Vision",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "vision-preview",
         "output_cost_per_token": 3e-05,
         "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure/gpt-4.1": {
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "GPT-4.1",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "azure",
@@ -2242,6 +2601,7 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
         "supported_endpoints": [
@@ -2267,8 +2627,9 @@
         "supports_web_search": false
     },
     "azure/gpt-4.1-2025-04-14": {
-        "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 5e-07,
+        "deprecation_date": "2026-11-04",
+        "display_name": "GPT-4.1",
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "azure",
@@ -2276,6 +2637,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "output_cost_per_token": 8e-06,
         "output_cost_per_token_batches": 4e-06,
         "supported_endpoints": [
@@ -2302,6 +2665,7 @@
     },
     "azure/gpt-4.1-mini": {
         "cache_read_input_token_cost": 1e-07,
+        "display_name": "GPT-4.1 Mini",
         "input_cost_per_token": 4e-07,
         "input_cost_per_token_batches": 2e-07,
         "litellm_provider": "azure",
@@ -2309,6 +2673,7 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.6e-06,
         "output_cost_per_token_batches": 8e-07,
         "supported_endpoints": [
@@ -2334,8 +2699,9 @@
         "supports_web_search": false
     },
     "azure/gpt-4.1-mini-2025-04-14": {
-        "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 1e-07,
+        "deprecation_date": "2026-11-04",
+        "display_name": "GPT-4.1 Mini",
         "input_cost_per_token": 4e-07,
         "input_cost_per_token_batches": 2e-07,
         "litellm_provider": "azure",
@@ -2343,6 +2709,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "mini-2025-04-14",
         "output_cost_per_token": 1.6e-06,
         "output_cost_per_token_batches": 8e-07,
         "supported_endpoints": [
@@ -2369,6 +2737,7 @@
     },
     "azure/gpt-4.1-nano": {
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-4.1 Nano",
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
         "litellm_provider": "azure",
@@ -2376,6 +2745,7 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4e-07,
         "output_cost_per_token_batches": 2e-07,
         "supported_endpoints": [
@@ -2400,8 +2770,9 @@
         "supports_vision": true
     },
     "azure/gpt-4.1-nano-2025-04-14": {
-        "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 2.5e-08,
+        "deprecation_date": "2026-11-04",
+        "display_name": "GPT-4.1 Nano",
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
         "litellm_provider": "azure",
@@ -2409,6 +2780,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "nano-2025-04-14",
         "output_cost_per_token": 4e-07,
         "output_cost_per_token_batches": 2e-07,
         "supported_endpoints": [
@@ -2434,6 +2807,7 @@
     },
     "azure/gpt-4.5-preview": {
         "cache_read_input_token_cost": 3.75e-05,
+        "display_name": "GPT-4.5 Preview",
         "input_cost_per_token": 7.5e-05,
         "input_cost_per_token_batches": 3.75e-05,
         "litellm_provider": "azure",
@@ -2441,6 +2815,7 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 0.00015,
         "output_cost_per_token_batches": 7.5e-05,
         "supports_function_calling": true,
@@ -2453,12 +2828,14 @@
     },
     "azure/gpt-4o": {
         "cache_read_input_token_cost": 1.25e-06,
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2468,12 +2845,15 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-05-13": {
+        "display_name": "GPT-4o",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-05-13",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2482,14 +2862,17 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-08-06": {
-        "deprecation_date": "2026-02-27",
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-02-27",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "output_cost_per_token": 1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2499,14 +2882,17 @@
         "supports_vision": true
     },
     "azure/gpt-4o-2024-11-20": {
-        "deprecation_date": "2026-03-01",
         "cache_read_input_token_cost": 1.25e-06,
+        "deprecation_date": "2026-03-01",
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "output_cost_per_token": 1.1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2516,6 +2902,7 @@
         "supports_vision": true
     },
     "azure/gpt-audio-2025-08-28": {
+        "display_name": "GPT Audio",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -2523,6 +2910,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-28",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
@@ -2547,6 +2936,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini-2025-10-06": {
+        "display_name": "GPT Audio Mini",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",
@@ -2554,6 +2944,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "mini-2025-10-06",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
@@ -2578,6 +2970,7 @@
         "supports_vision": false
     },
     "azure/gpt-4o-audio-preview-2024-12-17": {
+        "display_name": "GPT-4o Audio Preview",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -2585,6 +2978,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "audio-preview-2024-12-17",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
@@ -2610,12 +3005,14 @@
     },
     "azure/gpt-4o-mini": {
         "cache_read_input_token_cost": 7.5e-08,
+        "display_name": "GPT-4o Mini",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6.6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2626,12 +3023,15 @@
     },
     "azure/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 7.5e-08,
+        "display_name": "GPT-4o Mini",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-07-18",
         "output_cost_per_token": 6.6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -2641,6 +3041,7 @@
         "supports_vision": true
     },
     "azure/gpt-4o-mini-audio-preview-2024-12-17": {
+        "display_name": "GPT-4o Mini Audio Preview",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
@@ -2648,6 +3049,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "audio-preview-2024-12-17",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
@@ -2674,6 +3077,7 @@
     "azure/gpt-4o-mini-realtime-preview-2024-12-17": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "GPT-4o Mini Realtime Preview",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",
@@ -2681,6 +3085,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-preview-2024-12-17",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supports_audio_input": true,
@@ -2693,6 +3099,7 @@
     "azure/gpt-realtime-2025-08-28": {
         "cache_creation_input_audio_token_cost": 4e-06,
         "cache_read_input_token_cost": 4e-06,
+        "display_name": "GPT Realtime",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 4e-06,
@@ -2701,6 +3108,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-28",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
         "supported_endpoints": [
@@ -2725,6 +3134,7 @@
     "azure/gpt-realtime-mini-2025-10-06": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 6e-08,
+        "display_name": "GPT Realtime Mini",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_image": 8e-07,
         "input_cost_per_token": 6e-07,
@@ -2733,6 +3143,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "mini-2025-10-06",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
@@ -2755,21 +3167,25 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-mini-transcribe": {
+        "display_name": "GPT-4o Mini Transcribe",
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
         "max_output_tokens": 2000,
         "mode": "audio_transcription",
+        "model_vendor": "openai",
         "output_cost_per_token": 5e-06,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
     },
     "azure/gpt-4o-mini-tts": {
+        "display_name": "GPT-4o Mini TTS",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "mode": "audio_speech",
+        "model_vendor": "openai",
         "output_cost_per_audio_token": 1.2e-05,
         "output_cost_per_second": 0.00025,
         "output_cost_per_token": 1e-05,
@@ -2787,6 +3203,7 @@
     "azure/gpt-4o-realtime-preview-2024-10-01": {
         "cache_creation_input_audio_token_cost": 2e-05,
         "cache_read_input_token_cost": 2.5e-06,
+        "display_name": "GPT-4o Realtime Preview",
         "input_cost_per_audio_token": 0.0001,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
@@ -2794,6 +3211,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-preview-2024-10-01",
         "output_cost_per_audio_token": 0.0002,
         "output_cost_per_token": 2e-05,
         "supports_audio_input": true,
@@ -2805,6 +3224,7 @@
     },
     "azure/gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_token_cost": 2.5e-06,
+        "display_name": "GPT-4o Realtime Preview",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure",
@@ -2812,6 +3232,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "realtime-preview-2024-12-17",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 2e-05,
         "supported_modalities": [
@@ -2830,32 +3252,37 @@
         "supports_tool_choice": true
     },
     "azure/gpt-4o-transcribe": {
+        "display_name": "GPT-4o Transcribe",
         "input_cost_per_audio_token": 6e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
         "max_output_tokens": 2000,
         "mode": "audio_transcription",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
     },
     "azure/gpt-4o-transcribe-diarize": {
+        "display_name": "GPT-4o Transcribe Diarize",
         "input_cost_per_audio_token": 6e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 16000,
         "max_output_tokens": 2000,
         "mode": "audio_transcription",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
     },
-   "azure/gpt-5.1-2025-11-13": {
+    "azure/gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "display_name": "GPT-5.1",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -2863,6 +3290,8 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-11-13",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
         "supported_endpoints": [
@@ -2884,14 +3313,15 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_service_tier": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
-        "supports_service_tier": true,
         "supports_vision": true
     },
-   "azure/gpt-5.1-chat-2025-11-13": {
+    "azure/gpt-5.1-chat-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "display_name": "GPT-5.1 Chat",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -2899,6 +3329,8 @@
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "chat-2025-11-13",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
         "supported_endpoints": [
@@ -2924,9 +3356,10 @@
         "supports_tool_choice": false,
         "supports_vision": true
     },
-   "azure/gpt-5.1-codex-2025-11-13": {
+    "azure/gpt-5.1-codex-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
+        "display_name": "GPT-5.1 Codex",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_priority": 2.5e-06,
         "litellm_provider": "azure",
@@ -2934,6 +3367,8 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
+        "model_version": "codex-2025-11-13",
         "output_cost_per_token": 1e-05,
         "output_cost_per_token_priority": 2e-05,
         "supported_endpoints": [
@@ -2960,6 +3395,7 @@
     "azure/gpt-5.1-codex-mini-2025-11-13": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
+        "display_name": "GPT-5.1 Codex Mini",
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_priority": 4.5e-07,
         "litellm_provider": "azure",
@@ -2967,6 +3403,8 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
+        "model_version": "codex-mini-2025-11-13",
         "output_cost_per_token": 2e-06,
         "output_cost_per_token_priority": 3.6e-06,
         "supported_endpoints": [
@@ -2992,12 +3430,14 @@
     },
     "azure/gpt-5": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3024,12 +3464,15 @@
     },
     "azure/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3056,12 +3499,14 @@
     },
     "azure/gpt-5-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5 Chat",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "source": "https://azure.microsoft.com/en-us/blog/gpt-5-in-azure-ai-foundry-the-future-of-ai-apps-and-agents-starts-here/",
         "supported_endpoints": [
@@ -3089,12 +3534,14 @@
     },
     "azure/gpt-5-chat-latest": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5 Chat",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3121,12 +3568,14 @@
     },
     "azure/gpt-5-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5 Codex",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -3151,12 +3600,14 @@
     },
     "azure/gpt-5-mini": {
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-5 Mini",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 2e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3183,12 +3634,15 @@
     },
     "azure/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-5 Mini",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 2e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3215,12 +3669,14 @@
     },
     "azure/gpt-5-nano": {
         "cache_read_input_token_cost": 5e-09,
+        "display_name": "GPT-5 Nano",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4e-07,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3247,12 +3703,15 @@
     },
     "azure/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5e-09,
+        "display_name": "GPT-5 Nano",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 4e-07,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3278,12 +3737,14 @@
         "supports_vision": true
     },
     "azure/gpt-5-pro": {
+        "display_name": "GPT-5 Pro",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 400000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 0.00012,
         "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?pivots=azure-openai&tabs=global-standard-aoai%2Cstandard-chat-completions%2Cglobal-standard#gpt-5",
         "supported_endpoints": [
@@ -3308,12 +3769,14 @@
     },
     "azure/gpt-5.1": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3341,12 +3804,14 @@
     },
     "azure/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1 Chat",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -3374,12 +3839,14 @@
     },
     "azure/gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.25e-07,
+        "display_name": "GPT-5.1 Codex",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 1e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -3403,6 +3870,9 @@
         "supports_vision": true
     },
     "azure/gpt-5.1-codex-max": {
+        "display_name": "GPT 5.1 Codex Max",
+        "model_vendor": "openai",
+        "model_version": "5.1",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "azure",
@@ -3434,12 +3904,14 @@
     },
     "azure/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-5.1 Codex Mini",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 2e-06,
         "supported_endpoints": [
             "/v1/responses"
@@ -3463,6 +3935,9 @@
         "supports_vision": true
     },
     "azure/gpt-5.2": {
+        "display_name": "GPT 5.2",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "litellm_provider": "azure",
@@ -3496,6 +3971,9 @@
         "supports_vision": true
     },
     "azure/gpt-5.2-2025-12-11": {
+        "display_name": "GPT 5.2 2025 12 11",
+        "model_vendor": "openai",
+        "model_version": "2025-12-11",
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
@@ -3532,41 +4010,10 @@
         "supports_service_tier": true,
         "supports_vision": true
     },
-    "azure/gpt-5.2-chat": {
-        "cache_read_input_token_cost": 1.75e-07,
-        "cache_read_input_token_cost_priority": 3.5e-07,
-        "input_cost_per_token": 1.75e-06,
-        "input_cost_per_token_priority": 3.5e-06,
-        "litellm_provider": "azure",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 1.4e-05,
-        "output_cost_per_token_priority": 2.8e-05,
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure/gpt-5.2-chat-2025-12-11": {
+        "display_name": "GPT 5.2 Chat 2025 12 11",
+        "model_vendor": "openai",
+        "model_version": "2025-12-11",
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
@@ -3601,13 +4048,16 @@
         "supports_vision": true
     },
     "azure/gpt-5.2-pro": {
+        "display_name": "GPT 5.2 Pro",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
-        "output_cost_per_token": 1.68e-04,
+        "output_cost_per_token": 0.000168,
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -3632,13 +4082,16 @@
         "supports_web_search": true
     },
     "azure/gpt-5.2-pro-2025-12-11": {
+        "display_name": "GPT 5.2 Pro 2025 12 11",
+        "model_vendor": "openai",
+        "model_version": "2025-12-11",
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
-        "output_cost_per_token": 1.68e-04,
+        "output_cost_per_token": 0.000168,
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -3663,37 +4116,43 @@
         "supports_web_search": true
     },
     "azure/gpt-image-1": {
-        "cache_read_input_image_token_cost": 2.5e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_image_token": 1e-05,
-        "input_cost_per_token": 5e-06,
+        "display_name": "GPT Image 1",
+        "model_vendor": "openai",
+        "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_image_token": 4e-05,
+        "output_cost_per_pixel": 0.0,
         "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
+            "/v1/images/generations"
         ]
     },
     "azure/hd/1024-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 HD",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 7.629e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/hd/1024-x-1792/dall-e-3": {
+        "display_name": "DALL-E 3 HD",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 6.539e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/hd/1792-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 HD",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 6.539e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/high/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.59263611e-07,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3703,6 +4162,8 @@
         ]
     },
     "azure/high/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.58945719e-07,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3712,6 +4173,8 @@
         ]
     },
     "azure/high/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.58945719e-07,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3721,6 +4184,8 @@
         ]
     },
     "azure/low/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.0490417e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3730,6 +4195,8 @@
         ]
     },
     "azure/low/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.0172526e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3739,6 +4206,8 @@
         ]
     },
     "azure/low/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 1.0172526e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3748,6 +4217,8 @@
         ]
     },
     "azure/medium/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3757,6 +4228,8 @@
         ]
     },
     "azure/medium/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3766,6 +4239,8 @@
         ]
     },
     "azure/medium/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3775,45 +4250,19 @@
         ]
     },
     "azure/gpt-image-1-mini": {
-        "cache_read_input_image_token_cost": 2.5e-07,
-        "cache_read_input_token_cost": 2e-07,
-        "input_cost_per_image_token": 2.5e-06,
-        "input_cost_per_token": 2e-06,
+        "display_name": "GPT Image 1 Mini",
+        "model_vendor": "openai",
+        "input_cost_per_pixel": 8.0566406e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
-        "output_cost_per_image_token": 8e-06,
+        "output_cost_per_pixel": 0.0,
         "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ]
-    },
-    "azure/gpt-image-1.5": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "input_cost_per_image_token": 8e-06,
-        "litellm_provider": "azure",
-        "mode": "image_generation",
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ]
-    },
-    "azure/gpt-image-1.5-2025-12-16": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "input_cost_per_image_token": 8e-06,
-        "litellm_provider": "azure",
-        "mode": "image_generation",
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
+            "/v1/images/generations"
         ]
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 2.0751953125e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3823,6 +4272,8 @@
         ]
     },
     "azure/low/1024-x-1536/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 2.0751953125e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3832,6 +4283,8 @@
         ]
     },
     "azure/low/1536-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 2.0345052083e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3841,6 +4294,8 @@
         ]
     },
     "azure/medium/1024-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 8.056640625e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3850,6 +4305,8 @@
         ]
     },
     "azure/medium/1024-x-1536/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 8.056640625e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3859,6 +4316,8 @@
         ]
     },
     "azure/medium/1536-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 7.9752604167e-09,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3868,6 +4327,8 @@
         ]
     },
     "azure/high/1024-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 3.173828125e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3877,6 +4338,8 @@
         ]
     },
     "azure/high/1024-x-1536/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 3.173828125e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3886,6 +4349,8 @@
         ]
     },
     "azure/high/1536-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini High",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 3.1575520833e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
@@ -3895,31 +4360,38 @@
         ]
     },
     "azure/mistral-large-2402": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2402",
         "output_cost_per_token": 2.4e-05,
         "supports_function_calling": true
     },
     "azure/mistral-large-latest": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 2.4e-05,
         "supports_function_calling": true
     },
     "azure/o1": {
         "cache_read_input_token_cost": 7.5e-06,
+        "display_name": "o1",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -3930,12 +4402,15 @@
     },
     "azure/o1-2024-12-17": {
         "cache_read_input_token_cost": 7.5e-06,
+        "display_name": "o1",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -3946,12 +4421,14 @@
     },
     "azure/o1-mini": {
         "cache_read_input_token_cost": 6.05e-07,
+        "display_name": "o1 Mini",
         "input_cost_per_token": 1.21e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4.84e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -3961,12 +4438,15 @@
     },
     "azure/o1-mini-2024-09-12": {
         "cache_read_input_token_cost": 5.5e-07,
+        "display_name": "o1 Mini",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "output_cost_per_token": 4.4e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -3976,12 +4456,14 @@
     },
     "azure/o1-preview": {
         "cache_read_input_token_cost": 7.5e-06,
+        "display_name": "o1 Preview",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -3991,12 +4473,15 @@
     },
     "azure/o1-preview-2024-09-12": {
         "cache_read_input_token_cost": 7.5e-06,
+        "display_name": "o1 Preview",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "output_cost_per_token": 6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4007,12 +4492,14 @@
     },
     "azure/o3": {
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "o3",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 8e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4037,12 +4524,15 @@
     "azure/o3-2025-04-16": {
         "deprecation_date": "2026-04-16",
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "o3",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "output_cost_per_token": 8e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4066,12 +4556,14 @@
     },
     "azure/o3-deep-research": {
         "cache_read_input_token_cost": 2.5e-06,
+        "display_name": "o3 Deep Research",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 4e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4098,12 +4590,14 @@
     },
     "azure/o3-mini": {
         "cache_read_input_token_cost": 5.5e-07,
+        "display_name": "o3 Mini",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4.4e-06,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -4113,12 +4607,15 @@
     },
     "azure/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 5.5e-07,
+        "display_name": "o3 Mini",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-01-31",
         "output_cost_per_token": 4.4e-06,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
@@ -4126,6 +4623,7 @@
         "supports_vision": false
     },
     "azure/o3-pro": {
+        "display_name": "o3 Pro",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "azure",
@@ -4133,6 +4631,7 @@
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 8e-05,
         "output_cost_per_token_batches": 4e-05,
         "supported_endpoints": [
@@ -4156,6 +4655,7 @@
         "supports_vision": true
     },
     "azure/o3-pro-2025-06-10": {
+        "display_name": "o3 Pro",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "azure",
@@ -4163,6 +4663,8 @@
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "responses",
+        "model_vendor": "openai",
+        "model_version": "2025-06-10",
         "output_cost_per_token": 8e-05,
         "output_cost_per_token_batches": 4e-05,
         "supported_endpoints": [
@@ -4187,12 +4689,14 @@
     },
     "azure/o4-mini": {
         "cache_read_input_token_cost": 2.75e-07,
+        "display_name": "o4 Mini",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 4.4e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4216,12 +4720,15 @@
     },
     "azure/o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 2.75e-07,
+        "display_name": "o4 Mini",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "output_cost_per_token": 4.4e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": false,
@@ -4232,30 +4739,40 @@
         "supports_vision": true
     },
     "azure/standard/1024-x-1024/dall-e-2": {
+        "display_name": "DALL-E 2",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 0.0,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/standard/1024-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 3.81469e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/standard/1024-x-1792/dall-e-3": {
+        "display_name": "DALL-E 3",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.359e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/standard/1792-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.359e-08,
         "litellm_provider": "azure",
         "mode": "image_generation",
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-3-large": {
+        "display_name": "Text Embedding 3 Large",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
@@ -4264,6 +4781,8 @@
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-3-small": {
+        "display_name": "Text Embedding 3 Small",
+        "model_vendor": "openai",
         "deprecation_date": "2026-04-30",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "azure",
@@ -4273,6 +4792,9 @@
         "output_cost_per_token": 0.0
     },
     "azure/text-embedding-ada-002": {
+        "display_name": "Text Embedding Ada 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 8191,
@@ -4281,30 +4803,39 @@
         "output_cost_per_token": 0.0
     },
     "azure/speech/azure-tts": {
-        "input_cost_per_character": 15e-06,
+        "display_name": "Azure TTS",
+        "input_cost_per_character": 1.5e-05,
         "litellm_provider": "azure",
         "mode": "audio_speech",
+        "model_vendor": "microsoft",
         "source": "https://azure.microsoft.com/en-us/pricing/calculator/"
     },
     "azure/speech/azure-tts-hd": {
-        "input_cost_per_character": 30e-06,
+        "display_name": "Azure TTS HD",
+        "input_cost_per_character": 3e-05,
         "litellm_provider": "azure",
         "mode": "audio_speech",
+        "model_vendor": "microsoft",
         "source": "https://azure.microsoft.com/en-us/pricing/calculator/"
     },
     "azure/tts-1": {
+        "display_name": "TTS 1",
         "input_cost_per_character": 1.5e-05,
         "litellm_provider": "azure",
-        "mode": "audio_speech"
+        "mode": "audio_speech",
+        "model_vendor": "openai"
     },
     "azure/tts-1-hd": {
+        "display_name": "TTS 1 HD",
         "input_cost_per_character": 3e-05,
         "litellm_provider": "azure",
-        "mode": "audio_speech"
+        "mode": "audio_speech",
+        "model_vendor": "openai"
     },
     "azure/us/gpt-4.1-2025-04-14": {
         "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 5.5e-07,
+        "display_name": "GPT-4.1",
         "input_cost_per_token": 2.2e-06,
         "input_cost_per_token_batches": 1.1e-06,
         "litellm_provider": "azure",
@@ -4312,6 +4843,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "output_cost_per_token": 8.8e-06,
         "output_cost_per_token_batches": 4.4e-06,
         "supported_endpoints": [
@@ -4339,6 +4872,7 @@
     "azure/us/gpt-4.1-mini-2025-04-14": {
         "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 1.1e-07,
+        "display_name": "GPT-4.1 Mini",
         "input_cost_per_token": 4.4e-07,
         "input_cost_per_token_batches": 2.2e-07,
         "litellm_provider": "azure",
@@ -4346,6 +4880,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "output_cost_per_token": 1.76e-06,
         "output_cost_per_token_batches": 8.8e-07,
         "supported_endpoints": [
@@ -4373,6 +4909,7 @@
     "azure/us/gpt-4.1-nano-2025-04-14": {
         "deprecation_date": "2026-11-04",
         "cache_read_input_token_cost": 2.5e-08,
+        "display_name": "GPT-4.1 Nano",
         "input_cost_per_token": 1.1e-07,
         "input_cost_per_token_batches": 6e-08,
         "litellm_provider": "azure",
@@ -4380,6 +4917,8 @@
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "output_cost_per_token": 4.4e-07,
         "output_cost_per_token_batches": 2.2e-07,
         "supported_endpoints": [
@@ -4406,12 +4945,15 @@
     "azure/us/gpt-4o-2024-08-06": {
         "deprecation_date": "2026-02-27",
         "cache_read_input_token_cost": 1.375e-06,
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "output_cost_per_token": 1.1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4423,12 +4965,15 @@
     "azure/us/gpt-4o-2024-11-20": {
         "deprecation_date": "2026-03-01",
         "cache_creation_input_token_cost": 1.38e-06,
+        "display_name": "GPT-4o",
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "output_cost_per_token": 1.1e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4438,12 +4983,15 @@
     },
     "azure/us/gpt-4o-mini-2024-07-18": {
         "cache_read_input_token_cost": 8.3e-08,
+        "display_name": "GPT-4o Mini",
         "input_cost_per_token": 1.65e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-07-18",
         "output_cost_per_token": 6.6e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4455,6 +5003,7 @@
     "azure/us/gpt-4o-mini-realtime-preview-2024-12-17": {
         "cache_creation_input_audio_token_cost": 3.3e-07,
         "cache_read_input_token_cost": 3.3e-07,
+        "display_name": "GPT-4o Mini Realtime Preview",
         "input_cost_per_audio_token": 1.1e-05,
         "input_cost_per_token": 6.6e-07,
         "litellm_provider": "azure",
@@ -4462,6 +5011,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "output_cost_per_audio_token": 2.2e-05,
         "output_cost_per_token": 2.64e-06,
         "supports_audio_input": true,
@@ -4474,6 +5025,7 @@
     "azure/us/gpt-4o-realtime-preview-2024-10-01": {
         "cache_creation_input_audio_token_cost": 2.2e-05,
         "cache_read_input_token_cost": 2.75e-06,
+        "display_name": "GPT-4o Realtime Preview",
         "input_cost_per_audio_token": 0.00011,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "azure",
@@ -4481,6 +5033,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-10-01",
         "output_cost_per_audio_token": 0.00022,
         "output_cost_per_token": 2.2e-05,
         "supports_audio_input": true,
@@ -4493,6 +5047,7 @@
     "azure/us/gpt-4o-realtime-preview-2024-12-17": {
         "cache_read_input_audio_token_cost": 2.5e-06,
         "cache_read_input_token_cost": 2.75e-06,
+        "display_name": "GPT-4o Realtime Preview",
         "input_cost_per_audio_token": 4.4e-05,
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "azure",
@@ -4500,6 +5055,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "output_cost_per_audio_token": 8e-05,
         "output_cost_per_token": 2.2e-05,
         "supported_modalities": [
@@ -4519,12 +5076,15 @@
     },
     "azure/us/gpt-5-2025-08-07": {
         "cache_read_input_token_cost": 1.375e-07,
+        "display_name": "GPT-5",
         "input_cost_per_token": 1.375e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4551,12 +5111,15 @@
     },
     "azure/us/gpt-5-mini-2025-08-07": {
         "cache_read_input_token_cost": 2.75e-08,
+        "display_name": "GPT-5 Mini",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 2.2e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4583,12 +5146,15 @@
     },
     "azure/us/gpt-5-nano-2025-08-07": {
         "cache_read_input_token_cost": 5.5e-09,
+        "display_name": "GPT-5 Nano",
         "input_cost_per_token": 5.5e-08,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "output_cost_per_token": 4.4e-07,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4615,12 +5181,14 @@
     },
     "azure/us/gpt-5.1": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4648,12 +5216,14 @@
     },
     "azure/us/gpt-5.1-chat": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1 Chat",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4681,12 +5251,14 @@
     },
     "azure/us/gpt-5.1-codex": {
         "cache_read_input_token_cost": 1.4e-07,
+        "display_name": "GPT-5.1 Codex",
         "input_cost_per_token": 1.38e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.1e-05,
         "supported_endpoints": [
             "/v1/responses"
@@ -4711,12 +5283,14 @@
     },
     "azure/us/gpt-5.1-codex-mini": {
         "cache_read_input_token_cost": 2.8e-08,
+        "display_name": "GPT-5.1 Codex Mini",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure",
         "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
+        "model_vendor": "openai",
         "output_cost_per_token": 2.2e-06,
         "supported_endpoints": [
             "/v1/responses"
@@ -4741,12 +5315,15 @@
     },
     "azure/us/o1-2024-12-17": {
         "cache_read_input_token_cost": 8.25e-06,
+        "display_name": "o1",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "output_cost_per_token": 6.6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4756,6 +5333,7 @@
     },
     "azure/us/o1-mini-2024-09-12": {
         "cache_read_input_token_cost": 6.05e-07,
+        "display_name": "o1 Mini",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -4763,6 +5341,8 @@
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "output_cost_per_token": 4.84e-06,
         "output_cost_per_token_batches": 2.42e-06,
         "supports_function_calling": true,
@@ -4772,12 +5352,15 @@
     },
     "azure/us/o1-preview-2024-09-12": {
         "cache_read_input_token_cost": 8.25e-06,
+        "display_name": "o1 Preview",
         "input_cost_per_token": 1.65e-05,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "output_cost_per_token": 6.6e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -4787,12 +5370,15 @@
     "azure/us/o3-2025-04-16": {
         "deprecation_date": "2026-04-16",
         "cache_read_input_token_cost": 5.5e-07,
+        "display_name": "o3",
         "input_cost_per_token": 2.2e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "output_cost_per_token": 8.8e-06,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -4816,6 +5402,7 @@
     },
     "azure/us/o3-mini-2025-01-31": {
         "cache_read_input_token_cost": 6.05e-07,
+        "display_name": "o3 Mini",
         "input_cost_per_token": 1.21e-06,
         "input_cost_per_token_batches": 6.05e-07,
         "litellm_provider": "azure",
@@ -4823,6 +5410,8 @@
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-01-31",
         "output_cost_per_token": 4.84e-06,
         "output_cost_per_token_batches": 2.42e-06,
         "supports_prompt_caching": true,
@@ -4832,12 +5421,15 @@
     },
     "azure/us/o4-mini-2025-04-16": {
         "cache_read_input_token_cost": 3.1e-07,
+        "display_name": "o4 Mini",
         "input_cost_per_token": 1.21e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 200000,
         "max_output_tokens": 100000,
         "max_tokens": 100000,
         "mode": "chat",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "output_cost_per_token": 4.84e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": false,
@@ -4848,36 +5440,44 @@
         "supports_vision": true
     },
     "azure/whisper-1": {
+        "display_name": "Whisper",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "azure",
         "mode": "audio_transcription",
+        "model_vendor": "openai",
         "output_cost_per_second": 0.0001
     },
     "azure_ai/Cohere-embed-v3-english": {
+        "display_name": "Cohere Embed v3 English",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 512,
         "max_tokens": 512,
         "mode": "embedding",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
     "azure_ai/Cohere-embed-v3-multilingual": {
+        "display_name": "Cohere Embed v3 Multilingual",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 512,
         "max_tokens": 512,
         "mode": "embedding",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
     "azure_ai/FLUX-1.1-pro": {
+        "display_name": "FLUX 1.1 Pro",
         "litellm_provider": "azure_ai",
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.04,
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/black-forest-labs-flux-1-kontext-pro-and-flux1-1-pro-now-available-in-azure-ai-f/4434659",
         "supported_endpoints": [
@@ -4885,8 +5485,10 @@
         ]
     },
     "azure_ai/FLUX.1-Kontext-pro": {
+        "display_name": "FLUX 1 Kontext Pro",
         "litellm_provider": "azure_ai",
         "mode": "image_generation",
+        "model_vendor": "black-forest-labs",
         "output_cost_per_image": 0.04,
         "source": "https://azuremarketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
         "supported_endpoints": [
@@ -4894,12 +5496,14 @@
         ]
     },
     "azure_ai/Llama-3.2-11B-Vision-Instruct": {
+        "display_name": "Llama 3.2 11B Vision",
         "input_cost_per_token": 3.7e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 3.7e-07,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-11b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
@@ -4907,12 +5511,14 @@
         "supports_vision": true
     },
     "azure_ai/Llama-3.2-90B-Vision-Instruct": {
+        "display_name": "Llama 3.2 90B Vision",
         "input_cost_per_token": 2.04e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 2.04e-06,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.meta-llama-3-2-90b-vision-instruct-offer?tab=Overview",
         "supports_function_calling": true,
@@ -4920,24 +5526,28 @@
         "supports_vision": true
     },
     "azure_ai/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B",
         "input_cost_per_token": 7.1e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 7.1e-07,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/metagenai.llama-3-3-70b-instruct-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "display_name": "Llama 4 Maverick 17B",
         "input_cost_per_token": 1.41e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 1000000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 3.5e-07,
         "source": "https://azure.microsoft.com/en-us/blog/introducing-the-llama-4-herd-in-azure-ai-foundry-and-azure-databricks/",
         "supports_function_calling": true,
@@ -4945,12 +5555,14 @@
         "supports_vision": true
     },
     "azure_ai/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 10000000,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 7.8e-07,
         "source": "https://azure.microsoft.com/en-us/blog/introducing-the-llama-4-herd-in-azure-ai-foundry-and-azure-databricks/",
         "supports_function_calling": true,
@@ -4958,163 +5570,191 @@
         "supports_vision": true
     },
     "azure_ai/Meta-Llama-3-70B-Instruct": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 8192,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 3.7e-07,
         "supports_tool_choice": true
     },
     "azure_ai/Meta-Llama-3.1-405B-Instruct": {
+        "display_name": "Llama 3.1 405B",
         "input_cost_per_token": 5.33e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1.6e-05,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-405b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Meta-Llama-3.1-70B-Instruct": {
+        "display_name": "Llama 3.1 70B",
         "input_cost_per_token": 2.68e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 3.54e-06,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-70b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Meta-Llama-3.1-8B-Instruct": {
+        "display_name": "Llama 3.1 8B",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 6.1e-07,
         "source": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/metagenai.meta-llama-3-1-8b-instruct-offer?tab=PlansAndPrice",
         "supports_tool_choice": true
     },
     "azure_ai/Phi-3-medium-128k-instruct": {
+        "display_name": "Phi 3 Medium 128K",
         "input_cost_per_token": 1.7e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 6.8e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3-medium-4k-instruct": {
+        "display_name": "Phi 3 Medium 4K",
         "input_cost_per_token": 1.7e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 6.8e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3-mini-128k-instruct": {
+        "display_name": "Phi 3 Mini 128K",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3-mini-4k-instruct": {
+        "display_name": "Phi 3 Mini 4K",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3-small-128k-instruct": {
+        "display_name": "Phi 3 Small 128K",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 6e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3-small-8k-instruct": {
+        "display_name": "Phi 3 Small 8K",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 8192,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 6e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3.5-MoE-instruct": {
+        "display_name": "Phi 3.5 MoE",
         "input_cost_per_token": 1.6e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 6.4e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3.5-mini-instruct": {
+        "display_name": "Phi 3.5 Mini",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": false
     },
     "azure_ai/Phi-3.5-vision-instruct": {
+        "display_name": "Phi 3.5 Vision",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/phi-3/",
         "supports_tool_choice": true,
         "supports_vision": true
     },
     "azure_ai/Phi-4": {
+        "display_name": "Phi 4",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5e-07,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/affordable-innovation-unveiling-the-pricing-of-phi-3-slms-on-models-as-a-service/4156495",
         "supports_function_calling": true,
@@ -5122,17 +5762,20 @@
         "supports_vision": false
     },
     "azure_ai/Phi-4-mini-instruct": {
+        "display_name": "Phi 4 Mini",
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 3e-07,
         "source": "https://techcommunity.microsoft.com/blog/Azure-AI-Services-blog/announcing-new-phi-pricing-empowering-your-business-with-small-language-models/4395112",
         "supports_function_calling": true
     },
     "azure_ai/Phi-4-multimodal-instruct": {
+        "display_name": "Phi 4 Multimodal",
         "input_cost_per_audio_token": 4e-06,
         "input_cost_per_token": 8e-08,
         "litellm_provider": "azure_ai",
@@ -5140,6 +5783,7 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 3.2e-07,
         "source": "https://techcommunity.microsoft.com/blog/Azure-AI-Services-blog/announcing-new-phi-pricing-empowering-your-business-with-small-language-models/4395112",
         "supports_audio_input": true,
@@ -5147,23 +5791,27 @@
         "supports_vision": true
     },
     "azure_ai/Phi-4-mini-reasoning": {
+        "display_name": "Phi 4 Mini Reasoning",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 3.2e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
         "supports_function_calling": true
     },
     "azure_ai/Phi-4-reasoning": {
+        "display_name": "Phi 4 Reasoning",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
         "supports_function_calling": true,
@@ -5171,54 +5819,66 @@
         "supports_reasoning": true
     },
     "azure_ai/mistral-document-ai-2505": {
+        "display_name": "Mistral Document AI",
         "litellm_provider": "azure_ai",
-        "ocr_cost_per_page": 3e-3,
         "mode": "ocr",
+        "model_vendor": "mistral",
+        "model_version": "2505",
+        "ocr_cost_per_page": 0.003,
+        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry",
         "supported_endpoints": [
             "/v1/ocr"
-        ],
-        "source": "https://devblogs.microsoft.com/foundry/whats-new-in-azure-ai-foundry-august-2025/#mistral-document-ai-(ocr)-%E2%80%94-serverless-in-foundry"
+        ]
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
+        "display_name": "Document Intelligence Read",
         "litellm_provider": "azure_ai",
-        "ocr_cost_per_page": 1.5e-3,
         "mode": "ocr",
+        "model_vendor": "microsoft",
+        "ocr_cost_per_page": 0.0015,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/",
         "supported_endpoints": [
             "/v1/ocr"
-        ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/"
+        ]
     },
     "azure_ai/doc-intelligence/prebuilt-layout": {
+        "display_name": "Document Intelligence Layout",
         "litellm_provider": "azure_ai",
-        "ocr_cost_per_page": 1e-2,
         "mode": "ocr",
+        "model_vendor": "microsoft",
+        "ocr_cost_per_page": 0.01,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/",
         "supported_endpoints": [
             "/v1/ocr"
-        ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/"
+        ]
     },
     "azure_ai/doc-intelligence/prebuilt-document": {
+        "display_name": "Document Intelligence Document",
         "litellm_provider": "azure_ai",
-        "ocr_cost_per_page": 1e-2,
         "mode": "ocr",
+        "model_vendor": "microsoft",
+        "ocr_cost_per_page": 0.01,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/",
         "supported_endpoints": [
             "/v1/ocr"
-        ],
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-document-intelligence/"
+        ]
     },
     "azure_ai/MAI-DS-R1": {
+        "display_name": "MAI DeepSeek R1",
         "input_cost_per_token": 1.35e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "microsoft",
         "output_cost_per_token": 5.4e-06,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "azure_ai/cohere-rerank-v3-english": {
+        "display_name": "Cohere Rerank v3 English",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "azure_ai",
@@ -5227,9 +5887,11 @@
         "max_query_tokens": 2048,
         "max_tokens": 4096,
         "mode": "rerank",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0
     },
     "azure_ai/cohere-rerank-v3-multilingual": {
+        "display_name": "Cohere Rerank v3 Multilingual",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "azure_ai",
@@ -5238,9 +5900,11 @@
         "max_query_tokens": 2048,
         "max_tokens": 4096,
         "mode": "rerank",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0
     },
     "azure_ai/cohere-rerank-v3.5": {
+        "display_name": "Cohere Rerank v3.5",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "azure_ai",
@@ -5249,9 +5913,13 @@
         "max_query_tokens": 2048,
         "max_tokens": 4096,
         "mode": "rerank",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0
     },
     "azure_ai/cohere-rerank-v4.0-pro": {
+        "display_name": "Cohere Rerank V4.0 Pro",
+        "model_vendor": "cohere",
+        "model_version": "4.0",
         "input_cost_per_query": 0.0025,
         "input_cost_per_token": 0.0,
         "litellm_provider": "azure_ai",
@@ -5263,6 +5931,9 @@
         "output_cost_per_token": 0.0
     },
     "azure_ai/cohere-rerank-v4.0-fast": {
+        "display_name": "Cohere Rerank V4.0 Fast",
+        "model_vendor": "cohere",
+        "model_version": "4.0",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "azure_ai",
@@ -5273,7 +5944,10 @@
         "mode": "rerank",
         "output_cost_per_token": 0.0
     },
-        "azure_ai/deepseek-v3.2": {
+    "azure_ai/deepseek-v3.2": {
+        "display_name": "Deepseek V3.2",
+        "model_vendor": "deepseek",
+        "model_version": "3.2",
         "input_cost_per_token": 5.8e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 163840,
@@ -5288,6 +5962,9 @@
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v3.2-speciale": {
+        "display_name": "Deepseek V3.2 Speciale",
+        "model_vendor": "deepseek",
+        "model_version": "3.2",
         "input_cost_per_token": 5.8e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 163840,
@@ -5302,46 +5979,55 @@
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-r1": {
+        "display_name": "DeepSeek R1",
         "input_cost_per_token": 1.35e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "deepseek",
         "output_cost_per_token": 5.4e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/deepseek-r1-improved-performance-higher-limits-and-transparent-pricing/4386367",
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v3": {
+        "display_name": "DeepSeek V3",
         "input_cost_per_token": 1.14e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "deepseek",
         "output_cost_per_token": 4.56e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v3-0324": {
+        "display_name": "DeepSeek V3",
         "input_cost_per_token": 1.14e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "output_cost_per_token": 4.56e-06,
         "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/embed-v-4-0": {
+        "display_name": "Cohere Embed v4",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_tokens": 128000,
         "mode": "embedding",
+        "model_vendor": "cohere",
         "output_cost_per_token": 0.0,
         "output_vector_size": 3072,
         "source": "https://azuremarketplace.microsoft.com/pt-br/marketplace/apps/cohere.cohere-embed-4-offer?tab=PlansAndPrice",
@@ -5355,12 +6041,14 @@
         "supports_embedding_image_input": true
     },
     "azure_ai/global/grok-3": {
+        "display_name": "Grok 3",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 1.5e-05,
         "source": "https://devblogs.microsoft.com/foundry/announcing-grok-3-and-grok-3-mini-on-azure-ai-foundry/",
         "supports_function_calling": true,
@@ -5369,12 +6057,14 @@
         "supports_web_search": true
     },
     "azure_ai/global/grok-3-mini": {
+        "display_name": "Grok 3 Mini",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 1.27e-06,
         "source": "https://devblogs.microsoft.com/foundry/announcing-grok-3-and-grok-3-mini-on-azure-ai-foundry/",
         "supports_function_calling": true,
@@ -5384,12 +6074,14 @@
         "supports_web_search": true
     },
     "azure_ai/grok-3": {
+        "display_name": "Grok 3",
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 1.65e-05,
         "source": "https://devblogs.microsoft.com/foundry/announcing-grok-3-and-grok-3-mini-on-azure-ai-foundry/",
         "supports_function_calling": true,
@@ -5398,12 +6090,14 @@
         "supports_web_search": true
     },
     "azure_ai/grok-3-mini": {
+        "display_name": "Grok 3 Mini",
         "input_cost_per_token": 2.75e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 1.38e-06,
         "source": "https://devblogs.microsoft.com/foundry/announcing-grok-3-and-grok-3-mini-on-azure-ai-foundry/",
         "supports_function_calling": true,
@@ -5413,12 +6107,14 @@
         "supports_web_search": true
     },
     "azure_ai/grok-4": {
+        "display_name": "Grok 4",
         "input_cost_per_token": 5.5e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 2.75e-05,
         "source": "https://azure.microsoft.com/en-us/blog/grok-4-is-now-available-in-azure-ai-foundry-unlock-frontier-intelligence-and-business-ready-capabilities/",
         "supports_function_calling": true,
@@ -5427,26 +6123,30 @@
         "supports_web_search": true
     },
     "azure_ai/grok-4-fast-non-reasoning": {
-        "input_cost_per_token": 0.43e-06,
-        "output_cost_per_token": 1.73e-06,
+        "display_name": "Grok 4 Fast Non-Reasoning",
+        "input_cost_per_token": 4.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
+        "output_cost_per_token": 1.73e-06,
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "azure_ai/grok-4-fast-reasoning": {
-        "input_cost_per_token": 0.43e-06,
-        "output_cost_per_token": 1.73e-06,
+        "display_name": "Grok 4 Fast Reasoning",
+        "input_cost_per_token": 4.3e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
+        "output_cost_per_token": 1.73e-06,
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/announcing-the-grok-4-fast-models-from-xai-now-available-in-azure-ai-foundry/4456701",
         "supports_function_calling": true,
         "supports_response_schema": true,
@@ -5454,12 +6154,14 @@
         "supports_web_search": true
     },
     "azure_ai/grok-code-fast-1": {
+        "display_name": "Grok Code Fast 1",
         "input_cost_per_token": 3.5e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "model_vendor": "xai",
         "output_cost_per_token": 1.75e-05,
         "source": "https://azure.microsoft.com/en-us/blog/grok-4-is-now-available-in-azure-ai-foundry-unlock-frontier-intelligence-and-business-ready-capabilities/",
         "supports_function_calling": true,
@@ -5468,73 +6170,88 @@
         "supports_web_search": true
     },
     "azure_ai/jais-30b-chat": {
+        "display_name": "JAIS 30B Chat",
         "input_cost_per_token": 0.0032,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "g42",
         "output_cost_per_token": 0.00971,
         "source": "https://azure.microsoft.com/en-us/products/ai-services/ai-foundry/models/jais-30b-chat"
     },
     "azure_ai/jamba-instruct": {
+        "display_name": "Jamba Instruct",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 70000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "ai21",
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
     },
     "azure_ai/ministral-3b": {
+        "display_name": "Ministral 3B",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 4e-08,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.ministral-3b-2410-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-large": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 4e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 1.2e-05,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-large-2407": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2407",
         "output_cost_per_token": 6e-06,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-large-latest": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 6e-06,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-ai-large-2407-offer?tab=Overview",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-large-3": {
+        "display_name": "Mistral Large 3",
+        "model_vendor": "mistral",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 256000,
@@ -5548,52 +6265,65 @@
         "supports_vision": true
     },
     "azure_ai/mistral-medium-2505": {
+        "display_name": "Mistral Medium",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2505",
         "output_cost_per_token": 2e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-nemo": {
+        "display_name": "Mistral Nemo",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 131072,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 1.5e-07,
         "source": "https://azuremarketplace.microsoft.com/en/marketplace/apps/000-000.mistral-nemo-12b-2407?tab=PlansAndPrice",
         "supports_function_calling": true
     },
     "azure_ai/mistral-small": {
+        "display_name": "Mistral Small",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
         "output_cost_per_token": 3e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "azure_ai/mistral-small-2503": {
+        "display_name": "Mistral Small",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2503",
         "output_cost_per_token": 3e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },
     "babbage-002": {
+        "display_name": "Babbage 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -5603,323 +6333,401 @@
         "output_cost_per_token": 4e-07
     },
     "bedrock/*/1-month-commitment/cohere.command-light-text-v14": {
+        "display_name": "Command Light",
         "input_cost_per_second": 0.001902,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "cohere",
         "output_cost_per_second": 0.001902,
         "supports_tool_choice": true
     },
     "bedrock/*/1-month-commitment/cohere.command-text-v14": {
+        "display_name": "Command",
         "input_cost_per_second": 0.011,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "cohere",
         "output_cost_per_second": 0.011,
         "supports_tool_choice": true
     },
     "bedrock/*/6-month-commitment/cohere.command-light-text-v14": {
+        "display_name": "Command Light",
         "input_cost_per_second": 0.0011416,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "cohere",
         "output_cost_per_second": 0.0011416,
         "supports_tool_choice": true
     },
     "bedrock/*/6-month-commitment/cohere.command-text-v14": {
+        "display_name": "Command",
         "input_cost_per_second": 0.0066027,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "cohere",
         "output_cost_per_second": 0.0066027,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.01475,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.01475,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.0455,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0455
     },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.0455,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0455,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/6-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.008194,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.008194,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/6-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.02527,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.02527
     },
     "bedrock/ap-northeast-1/6-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.02527,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.02527,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_token": 2.23e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 7.55e-06,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/ap-northeast-1/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/ap-south-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 3.18e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 4.2e-06
     },
     "bedrock/ap-south-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3.6e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 7.2e-07
     },
     "bedrock/ca-central-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 3.05e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 4.03e-06
     },
     "bedrock/ca-central-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 6.9e-07
     },
     "bedrock/eu-central-1/1-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.01635,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.01635,
         "supports_tool_choice": true
     },
     "bedrock/eu-central-1/1-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.0415,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0415
     },
     "bedrock/eu-central-1/1-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.0415,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0415,
         "supports_tool_choice": true
     },
     "bedrock/eu-central-1/6-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.009083,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
+        "model_vendor": "anthropic",
         "mode": "chat",
         "output_cost_per_second": 0.009083,
         "supports_tool_choice": true
     },
     "bedrock/eu-central-1/6-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.02305,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.02305
     },
     "bedrock/eu-central-1/6-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.02305,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.02305,
         "supports_tool_choice": true
     },
     "bedrock/eu-central-1/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_token": 2.48e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 8.38e-06,
         "supports_tool_choice": true
     },
     "bedrock/eu-central-1/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05
     },
     "bedrock/eu-central-1/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/eu-west-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 2.86e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.78e-06
     },
     "bedrock/eu-west-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3.2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 6.5e-07
     },
     "bedrock/eu-west-2/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 3.45e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 4.55e-06
     },
     "bedrock/eu-west-2/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3.9e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 7.8e-07
     },
     "bedrock/eu-west-3/mistral.mistral-7b-instruct-v0:2": {
+        "display_name": "Mistral 7B",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:2",
         "output_cost_per_token": 2.6e-07,
         "supports_tool_choice": true
     },
     "bedrock/eu-west-3/mistral.mistral-large-2402-v1:0": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 1.04e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2402-v1:0",
         "output_cost_per_token": 3.12e-05,
         "supports_function_calling": true
     },
     "bedrock/eu-west-3/mistral.mixtral-8x7b-instruct-v0:1": {
+        "display_name": "Mixtral 8x7B",
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:1",
         "output_cost_per_token": 9.1e-07,
         "supports_tool_choice": true
     },
     "bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -5929,6 +6737,8 @@
             "notes": "Anthropic via Invoke route does not currently support pdf input."
         },
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_response_schema": true,
@@ -5936,121 +6746,151 @@
         "supports_vision": true
     },
     "bedrock/sa-east-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 4.45e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 5.88e-06
     },
     "bedrock/sa-east-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.01e-06
     },
     "bedrock/us-east-1/1-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.011,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.011,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/1-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.0175,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0175
     },
     "bedrock/us-east-1/1-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.0175,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0175,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/6-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.00611,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.00611,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/6-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.00972,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.00972
     },
     "bedrock/us-east-1/6-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_second": 0.00972,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.00972,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-06,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/anthropic.claude-v2:1": {
+        "display_name": "Claude 2.1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.5e-06
     },
     "bedrock/us-east-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
@@ -6060,42 +6900,54 @@
         "output_cost_per_token": 6e-07
     },
     "bedrock/us-east-1/mistral.mistral-7b-instruct-v0:2": {
+        "display_name": "Mistral 7B",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:2",
         "output_cost_per_token": 2e-07,
         "supports_tool_choice": true
     },
     "bedrock/us-east-1/mistral.mistral-large-2402-v1:0": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2402-v1:0",
         "output_cost_per_token": 2.4e-05,
         "supports_function_calling": true
     },
     "bedrock/us-east-1/mistral.mixtral-8x7b-instruct-v0:1": {
+        "display_name": "Mixtral 8x7B",
         "input_cost_per_token": 4.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:1",
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
     },
     "bedrock/us-gov-east-1/amazon.nova-pro-v1:0": {
+        "display_name": "Nova Pro",
         "input_cost_per_token": 9.6e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.84e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6104,57 +6956,72 @@
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/amazon.titan-embed-text-v1": {
+        "display_name": "Titan Embed Text",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1536
     },
     "bedrock/us-gov-east-1/amazon.titan-embed-text-v2:0": {
+        "display_name": "Titan Embed Text v2",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
+        "model_version": "v2:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024
     },
     "bedrock/us-gov-east-1/amazon.titan-text-express-v1": {
+        "display_name": "Titan Text Express",
         "input_cost_per_token": 1.3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 8000,
         "max_tokens": 8000,
         "mode": "chat",
+        "model_vendor": "amazon",
         "output_cost_per_token": 1.7e-06
     },
     "bedrock/us-gov-east-1/amazon.titan-text-lite-v1": {
+        "display_name": "Titan Text Lite",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 4000,
         "max_tokens": 4000,
         "mode": "chat",
+        "model_vendor": "amazon",
         "output_cost_per_token": 4e-07
     },
     "bedrock/us-gov-east-1/amazon.titan-text-premier-v1:0": {
+        "display_name": "Titan Text Premier",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.5e-06
     },
     "bedrock/us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.8e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6163,12 +7030,15 @@
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude Haiku 3",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240307-v1:0",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6177,12 +7047,15 @@
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250929-v1:0",
         "output_cost_per_token": 1.65e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -6195,32 +7068,41 @@
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true
     },
     "bedrock/us-gov-east-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 2.65e-06,
         "supports_pdf_input": true
     },
     "bedrock/us-gov-west-1/amazon.nova-pro-v1:0": {
+        "display_name": "Nova Pro",
         "input_cost_per_token": 9.6e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 300000,
         "max_output_tokens": 10000,
         "max_tokens": 10000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.84e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6229,59 +7111,74 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/amazon.titan-embed-text-v1": {
+        "display_name": "Titan Embed Text",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1536
     },
     "bedrock/us-gov-west-1/amazon.titan-embed-text-v2:0": {
+        "display_name": "Titan Embed Text v2",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding",
+        "model_vendor": "amazon",
+        "model_version": "v2:0",
         "output_cost_per_token": 0.0,
         "output_vector_size": 1024
     },
     "bedrock/us-gov-west-1/amazon.titan-text-express-v1": {
+        "display_name": "Titan Text Express",
         "input_cost_per_token": 1.3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 8000,
         "max_tokens": 8000,
         "mode": "chat",
+        "model_vendor": "amazon",
         "output_cost_per_token": 1.7e-06
     },
     "bedrock/us-gov-west-1/amazon.titan-text-lite-v1": {
+        "display_name": "Titan Text Lite",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 4000,
         "max_tokens": 4000,
         "mode": "chat",
+        "model_vendor": "amazon",
         "output_cost_per_token": 4e-07
     },
     "bedrock/us-gov-west-1/amazon.titan-text-premier-v1:0": {
+        "display_name": "Titan Text Premier",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 42000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "amazon",
+        "model_version": "v1:0",
         "output_cost_per_token": 1.5e-06
     },
     "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,
         "cache_read_input_token_cost": 3.6e-07,
+        "display_name": "Claude Sonnet 3.7",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250219-v1:0",
         "output_cost_per_token": 1.8e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -6294,12 +7191,15 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3.6e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620-v1:0",
         "output_cost_per_token": 1.8e-05,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6308,12 +7208,15 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude Haiku 3",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240307-v1:0",
         "output_cost_per_token": 1.5e-06,
         "supports_function_calling": true,
         "supports_pdf_input": true,
@@ -6322,12 +7225,15 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
         "input_cost_per_token": 3.3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250929-v1:0",
         "output_cost_per_token": 1.65e-05,
         "supports_assistant_prefill": true,
         "supports_computer_use": true,
@@ -6340,170 +7246,215 @@
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true
     },
     "bedrock/us-gov-west-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8000,
         "max_output_tokens": 2048,
         "max_tokens": 2048,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 2.65e-06,
         "supports_pdf_input": true
     },
     "bedrock/us-west-1/meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B",
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 3.5e-06
     },
     "bedrock/us-west-1/meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "meta",
+        "model_version": "v1:0",
         "output_cost_per_token": 6e-07
     },
     "bedrock/us-west-2/1-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.011,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.011,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/1-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.0175,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.0175
     },
     "bedrock/us-west-2/1-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2",
         "input_cost_per_second": 0.0175,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v2:1",
         "output_cost_per_second": 0.0175,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/6-month-commitment/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_second": 0.00611,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.00611,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/6-month-commitment/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_second": 0.00972,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_second": 0.00972
     },
     "bedrock/us-west-2/6-month-commitment/anthropic.claude-v2:1": {
+        "display_name": "Claude 2",
         "input_cost_per_second": 0.00972,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v2:1",
         "output_cost_per_second": 0.00972,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/anthropic.claude-instant-v1": {
+        "display_name": "Claude Instant",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-06,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/anthropic.claude-v1": {
+        "display_name": "Claude 1",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/anthropic.claude-v2:1": {
+        "display_name": "Claude 2",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 100000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "v2:1",
         "output_cost_per_token": 2.4e-05,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/mistral.mistral-7b-instruct-v0:2": {
+        "display_name": "Mistral 7B",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:2",
         "output_cost_per_token": 2e-07,
         "supports_tool_choice": true
     },
     "bedrock/us-west-2/mistral.mistral-large-2402-v1:0": {
+        "display_name": "Mistral Large",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "2402-v1:0",
         "output_cost_per_token": 2.4e-05,
         "supports_function_calling": true
     },
     "bedrock/us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
+        "display_name": "Mixtral 8x7B",
         "input_cost_per_token": 4.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
         "mode": "chat",
+        "model_vendor": "mistral",
+        "model_version": "v0:1",
         "output_cost_per_token": 7e-07,
         "supports_tool_choice": true
     },
     "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0": {
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 8e-08,
+        "display_name": "Claude Haiku 3.5",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022-v1:0",
         "output_cost_per_token": 4e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6513,45 +7464,53 @@
         "supports_tool_choice": true
     },
     "cerebras/llama-3.3-70b": {
+        "display_name": "Llama 3.3 70B",
         "input_cost_per_token": 8.5e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1.2e-06,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "cerebras/llama3.1-70b": {
+        "display_name": "Llama 3.1 70B",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "cerebras/llama3.1-8b": {
+        "display_name": "Llama 3.1 8B",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1e-07,
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "cerebras/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 131072,
         "max_output_tokens": 32768,
         "max_tokens": 32768,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 6.9e-07,
         "source": "https://www.cerebras.ai/blog/openai-gpt-oss-120b-runs-fastest-on-cerebras",
         "supports_function_calling": true,
@@ -6561,18 +7520,23 @@
         "supports_tool_choice": true
     },
     "cerebras/qwen-3-32b": {
+        "display_name": "Qwen 3 32B",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
+        "model_vendor": "alibaba",
         "output_cost_per_token": 8e-07,
         "source": "https://inference-docs.cerebras.ai/support/pricing",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
     "cerebras/zai-glm-4.6": {
+        "display_name": "Zai Glm 4.6",
+        "model_vendor": "zhipu",
+        "model_version": "4.6",
         "input_cost_per_token": 2.25e-06,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,
@@ -6586,6 +7550,7 @@
         "supports_tool_choice": true
     },
     "chat-bison": {
+        "display_name": "Chat Bison",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-chat-models",
@@ -6593,12 +7558,14 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "google",
         "output_cost_per_character": 5e-07,
         "output_cost_per_token": 1.25e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
         "supports_tool_choice": true
     },
     "chat-bison-32k": {
+        "display_name": "Chat Bison 32K",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-chat-models",
@@ -6606,12 +7573,14 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "google",
         "output_cost_per_character": 5e-07,
         "output_cost_per_token": 1.25e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
         "supports_tool_choice": true
     },
     "chat-bison-32k@002": {
+        "display_name": "Chat Bison 32K",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-chat-models",
@@ -6619,12 +7588,15 @@
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "google",
+        "model_version": "002",
         "output_cost_per_character": 5e-07,
         "output_cost_per_token": 1.25e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
         "supports_tool_choice": true
     },
     "chat-bison@001": {
+        "display_name": "Chat Bison",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-chat-models",
@@ -6632,6 +7604,8 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "google",
+        "model_version": "001",
         "output_cost_per_character": 5e-07,
         "output_cost_per_token": 1.25e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
@@ -6639,6 +7613,7 @@
     },
     "chat-bison@002": {
         "deprecation_date": "2025-04-09",
+        "display_name": "Chat Bison",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-chat-models",
@@ -6646,27 +7621,33 @@
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "google",
+        "model_version": "002",
         "output_cost_per_character": 5e-07,
         "output_cost_per_token": 1.25e-07,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models",
         "supports_tool_choice": true
     },
     "chatdolphin": {
+        "display_name": "Chat Dolphin",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "nlp_cloud",
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
         "max_tokens": 16384,
         "mode": "chat",
+        "model_vendor": "nlp_cloud",
         "output_cost_per_token": 5e-07
     },
     "chatgpt-4o-latest": {
+        "display_name": "ChatGPT-4o",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "openai",
         "output_cost_per_token": 1.5e-05,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -6676,29 +7657,20 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "gpt-4o-transcribe-diarize": {
-        "input_cost_per_audio_token": 6e-06,
-        "input_cost_per_token": 2.5e-06,
-        "litellm_provider": "openai",
-        "max_input_tokens": 16000,
-        "max_output_tokens": 2000,
-        "mode": "audio_transcription",
-        "output_cost_per_token": 1e-05,
-        "supported_endpoints": [
-            "/v1/audio/transcriptions"
-        ]
-    },
     "claude-3-5-haiku-20241022": {
         "cache_creation_input_token_cost": 1e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 8e-08,
         "deprecation_date": "2025-10-01",
+        "display_name": "Claude Haiku 3.5",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "output_cost_per_token": 4e-06,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6720,12 +7692,14 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 1e-07,
         "deprecation_date": "2025-10-01",
+        "display_name": "Claude Haiku 3.5",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 5e-06,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6746,12 +7720,15 @@
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
+        "display_name": "Claude Haiku 4.5",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "output_cost_per_token": 5e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6767,12 +7744,14 @@
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
+        "display_name": "Claude Haiku 4.5",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 5e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6789,12 +7768,15 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2025-06-01",
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240620",
         "output_cost_per_token": 1.5e-05,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6810,12 +7792,15 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2025-10-01",
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6838,12 +7823,14 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2025-06-01",
+        "display_name": "Claude Sonnet 3.5",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6866,12 +7853,15 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2026-02-19",
+        "display_name": "Claude Sonnet 3.7",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250219",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6895,12 +7885,14 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2025-06-01",
+        "display_name": "Claude Sonnet 3.7",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -6922,12 +7914,15 @@
         "cache_creation_input_token_cost": 3e-07,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-08,
+        "display_name": "Claude Haiku 3",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240307",
         "output_cost_per_token": 1.25e-06,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6942,12 +7937,15 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 1.5e-06,
         "deprecation_date": "2026-05-01",
+        "display_name": "Claude Opus 3",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "output_cost_per_token": 7.5e-05,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6962,12 +7960,14 @@
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 1.5e-06,
         "deprecation_date": "2025-03-01",
+        "display_name": "Claude Opus 3",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 7.5e-05,
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
@@ -6980,12 +7980,15 @@
     "claude-4-opus-20250514": {
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "display_name": "Claude Opus 4",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7008,6 +8011,7 @@
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
         "cache_read_input_token_cost_above_200k_tokens": 6e-07,
+        "display_name": "Claude Sonnet 4",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "litellm_provider": "anthropic",
@@ -7015,6 +8019,8 @@
         "max_output_tokens": 64000,
         "max_tokens": 1000000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "output_cost_per_token": 1.5e-05,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
         "search_context_cost_per_query": {
@@ -7036,6 +8042,7 @@
     "claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "Claude Sonnet 4.5",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -7046,6 +8053,7 @@
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7066,6 +8074,7 @@
     "claude-sonnet-4-5-20250929": {
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
+        "display_name": "Claude Sonnet 4.5",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_200k_tokens": 6e-06,
         "output_cost_per_token_above_200k_tokens": 2.25e-05,
@@ -7076,6 +8085,8 @@
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "output_cost_per_token": 1.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7095,6 +8106,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -7123,12 +8137,14 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
+        "display_name": "Claude Opus 4.1",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7150,13 +8166,16 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
         "deprecation_date": "2026-08-05",
+        "display_name": "Claude Opus 4.1",
+        "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250805",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7178,13 +8197,16 @@
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
-        "input_cost_per_token": 1.5e-05,
         "deprecation_date": "2026-05-14",
+        "display_name": "Claude Opus 4",
+        "input_cost_per_token": 1.5e-05,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 32000,
         "max_tokens": 32000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "output_cost_per_token": 7.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7206,12 +8228,15 @@
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "Claude Opus 4.5",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
+        "model_version": "20251101",
         "output_cost_per_token": 2.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7233,12 +8258,14 @@
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
+        "display_name": "Claude Opus 4.5",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "anthropic",
         "max_input_tokens": 200000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
+        "model_vendor": "anthropic",
         "output_cost_per_token": 2.5e-05,
         "search_context_cost_per_query": {
             "search_context_size_high": 0.01,
@@ -7257,6 +8284,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "claude-sonnet-4-20250514": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "deprecation_date": "2026-05-14",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -7289,15 +8319,19 @@
         "tool_use_system_prompt_tokens": 159
     },
     "cloudflare/@cf/meta/llama-2-7b-chat-fp16": {
+        "display_name": "Llama 2 7B Chat",
         "input_cost_per_token": 1.923e-06,
         "litellm_provider": "cloudflare",
         "max_input_tokens": 3072,
         "max_output_tokens": 3072,
         "max_tokens": 3072,
         "mode": "chat",
+        "model_vendor": "meta",
         "output_cost_per_token": 1.923e-06
     },
     "cloudflare/@cf/meta/llama-2-7b-chat-int8": {
+        "display_name": "Llama 2 7B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.923e-06,
         "litellm_provider": "cloudflare",
         "max_input_tokens": 2048,
@@ -7307,6 +8341,9 @@
         "output_cost_per_token": 1.923e-06
     },
     "cloudflare/@cf/mistral/mistral-7b-instruct-v0.1": {
+        "display_name": "Mistral 7B Instruct v0.1",
+        "model_vendor": "mistral",
+        "model_version": "v0.1",
         "input_cost_per_token": 1.923e-06,
         "litellm_provider": "cloudflare",
         "max_input_tokens": 8192,
@@ -7316,6 +8353,8 @@
         "output_cost_per_token": 1.923e-06
     },
     "cloudflare/@hf/thebloke/codellama-7b-instruct-awq": {
+        "display_name": "CodeLlama 7B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.923e-06,
         "litellm_provider": "cloudflare",
         "max_input_tokens": 4096,
@@ -7325,6 +8364,8 @@
         "output_cost_per_token": 1.923e-06
     },
     "code-bison": {
+        "display_name": "Code Bison",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
@@ -7338,6 +8379,9 @@
         "supports_tool_choice": true
     },
     "code-bison-32k@002": {
+        "display_name": "Code Bison 32K",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
@@ -7350,6 +8394,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-bison32k": {
+        "display_name": "Code Bison 32K",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
@@ -7362,6 +8408,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-bison@001": {
+        "display_name": "Code Bison",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
@@ -7374,6 +8423,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-bison@002": {
+        "display_name": "Code Bison",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
@@ -7386,6 +8438,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-gecko": {
+        "display_name": "Code Gecko",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
         "max_input_tokens": 2048,
@@ -7396,6 +8450,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-gecko-latest": {
+        "display_name": "Code Gecko",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
         "max_input_tokens": 2048,
@@ -7406,6 +8462,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-gecko@001": {
+        "display_name": "Code Gecko",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
         "max_input_tokens": 2048,
@@ -7416,6 +8475,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "code-gecko@002": {
+        "display_name": "Code Gecko",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-text-models",
         "max_input_tokens": 2048,
@@ -7426,6 +8488,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "codechat-bison": {
+        "display_name": "CodeChat Bison",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7439,6 +8503,8 @@
         "supports_tool_choice": true
     },
     "codechat-bison-32k": {
+        "display_name": "CodeChat Bison 32K",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7452,6 +8518,9 @@
         "supports_tool_choice": true
     },
     "codechat-bison-32k@002": {
+        "display_name": "CodeChat Bison 32K",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7465,6 +8534,9 @@
         "supports_tool_choice": true
     },
     "codechat-bison@001": {
+        "display_name": "CodeChat Bison",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7478,6 +8550,9 @@
         "supports_tool_choice": true
     },
     "codechat-bison@002": {
+        "display_name": "CodeChat Bison",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7491,6 +8566,8 @@
         "supports_tool_choice": true
     },
     "codechat-bison@latest": {
+        "display_name": "CodeChat Bison",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-code-chat-models",
@@ -7504,6 +8581,9 @@
         "supports_tool_choice": true
     },
     "codestral/codestral-2405": {
+        "display_name": "Codestral",
+        "model_vendor": "mistral",
+        "model_version": "2405",
         "input_cost_per_token": 0.0,
         "litellm_provider": "codestral",
         "max_input_tokens": 32000,
@@ -7516,6 +8596,8 @@
         "supports_tool_choice": true
     },
     "codestral/codestral-latest": {
+        "display_name": "Codestral",
+        "model_vendor": "mistral",
         "input_cost_per_token": 0.0,
         "litellm_provider": "codestral",
         "max_input_tokens": 32000,
@@ -7528,6 +8610,8 @@
         "supports_tool_choice": true
     },
     "codex-mini-latest": {
+        "display_name": "Codex Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 3.75e-07,
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openai",
@@ -7557,6 +8641,9 @@
         "supports_vision": true
     },
     "cohere.command-light-text-v14": {
+        "display_name": "Command Light",
+        "model_vendor": "cohere",
+        "model_version": "v14",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
@@ -7567,6 +8654,9 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-plus-v1:0": {
+        "display_name": "Command R+",
+        "model_vendor": "cohere",
+        "model_version": "v1:0",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -7577,6 +8667,9 @@
         "supports_tool_choice": true
     },
     "cohere.command-r-v1:0": {
+        "display_name": "Command R",
+        "model_vendor": "cohere",
+        "model_version": "v1:0",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -7587,6 +8680,9 @@
         "supports_tool_choice": true
     },
     "cohere.command-text-v14": {
+        "display_name": "Command",
+        "model_vendor": "cohere",
+        "model_version": "v14",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
@@ -7597,6 +8693,9 @@
         "supports_tool_choice": true
     },
     "cohere.embed-english-v3": {
+        "display_name": "Embed English v3",
+        "model_vendor": "cohere",
+        "model_version": "v3",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 512,
@@ -7606,6 +8705,9 @@
         "supports_embedding_image_input": true
     },
     "cohere.embed-multilingual-v3": {
+        "display_name": "Embed Multilingual v3",
+        "model_vendor": "cohere",
+        "model_version": "v3",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 512,
@@ -7615,6 +8717,9 @@
         "supports_embedding_image_input": true
     },
     "cohere.embed-v4:0": {
+        "display_name": "Embed v4",
+        "model_vendor": "cohere",
+        "model_version": "v4:0",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -7625,6 +8730,9 @@
         "supports_embedding_image_input": true
     },
     "cohere/embed-v4.0": {
+        "display_name": "Embed v4",
+        "model_vendor": "cohere",
+        "model_version": "v4.0",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 128000,
@@ -7635,6 +8743,9 @@
         "supports_embedding_image_input": true
     },
     "cohere.rerank-v3-5:0": {
+        "display_name": "Rerank v3.5",
+        "model_vendor": "cohere",
+        "model_version": "v3-5:0",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "bedrock",
@@ -7648,6 +8759,8 @@
         "output_cost_per_token": 0.0
     },
     "command": {
+        "display_name": "Command",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -7657,6 +8770,9 @@
         "output_cost_per_token": 2e-06
     },
     "command-a-03-2025": {
+        "display_name": "Command A",
+        "model_vendor": "cohere",
+        "model_version": "03-2025",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 256000,
@@ -7668,6 +8784,8 @@
         "supports_tool_choice": true
     },
     "command-light": {
+        "display_name": "Command Light",
+        "model_vendor": "cohere",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 4096,
@@ -7678,6 +8796,8 @@
         "supports_tool_choice": true
     },
     "command-nightly": {
+        "display_name": "Command Nightly",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -7687,6 +8807,8 @@
         "output_cost_per_token": 2e-06
     },
     "command-r": {
+        "display_name": "Command R",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
@@ -7698,6 +8820,9 @@
         "supports_tool_choice": true
     },
     "command-r-08-2024": {
+        "display_name": "Command R",
+        "model_vendor": "cohere",
+        "model_version": "08-2024",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
@@ -7709,6 +8834,8 @@
         "supports_tool_choice": true
     },
     "command-r-plus": {
+        "display_name": "Command R+",
+        "model_vendor": "cohere",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
@@ -7720,6 +8847,9 @@
         "supports_tool_choice": true
     },
     "command-r-plus-08-2024": {
+        "display_name": "Command R+",
+        "model_vendor": "cohere",
+        "model_version": "08-2024",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
@@ -7731,6 +8861,9 @@
         "supports_tool_choice": true
     },
     "command-r7b-12-2024": {
+        "display_name": "Command R 7B",
+        "model_vendor": "cohere",
+        "model_version": "12-2024",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "cohere_chat",
         "max_input_tokens": 128000,
@@ -7743,6 +8876,8 @@
         "supports_tool_choice": true
     },
     "computer-use-preview": {
+        "display_name": "Computer Use Preview",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 8192,
@@ -7770,6 +8905,8 @@
         "supports_vision": true
     },
     "deepseek-chat": {
+        "display_name": "DeepSeek Chat",
+        "model_vendor": "deepseek",
         "cache_read_input_token_cost": 6e-08,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "deepseek",
@@ -7791,6 +8928,8 @@
         "supports_tool_choice": true
     },
     "deepseek-reasoner": {
+        "display_name": "DeepSeek Reasoner",
+        "model_vendor": "deepseek",
         "cache_read_input_token_cost": 6e-08,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "deepseek",
@@ -7813,6 +8952,8 @@
         "supports_tool_choice": false
     },
     "dashscope/qwen-coder": {
+        "display_name": "Qwen Coder",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 1000000,
@@ -7826,6 +8967,8 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-flash": {
+        "display_name": "Qwen Flash",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 32768,
@@ -7855,6 +8998,9 @@
         ]
     },
     "dashscope/qwen-flash-2025-07-28": {
+        "display_name": "Qwen Flash",
+        "model_vendor": "alibaba",
+        "model_version": "2025-07-28",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 32768,
@@ -7884,6 +9030,8 @@
         ]
     },
     "dashscope/qwen-max": {
+        "display_name": "Qwen Max",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.6e-06,
         "litellm_provider": "dashscope",
         "max_input_tokens": 30720,
@@ -7897,6 +9045,8 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-plus": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
@@ -7910,6 +9060,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-01-25": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-01-25",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
@@ -7923,6 +9076,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-04-28": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-04-28",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
@@ -7937,6 +9093,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-07-14": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-07-14",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
@@ -7951,6 +9110,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-plus-2025-07-28": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-07-28",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 32768,
@@ -7982,6 +9144,9 @@
         ]
     },
     "dashscope/qwen-plus-2025-09-11": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-09-11",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 32768,
@@ -8013,6 +9178,8 @@
         ]
     },
     "dashscope/qwen-plus-latest": {
+        "display_name": "Qwen Plus",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 32768,
@@ -8044,6 +9211,8 @@
         ]
     },
     "dashscope/qwen-turbo": {
+        "display_name": "Qwen Turbo",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
@@ -8058,6 +9227,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-turbo-2024-11-01": {
+        "display_name": "Qwen Turbo",
+        "model_vendor": "alibaba",
+        "model_version": "2024-11-01",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "dashscope",
         "max_input_tokens": 1000000,
@@ -8071,6 +9243,9 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-turbo-2025-04-28": {
+        "display_name": "Qwen Turbo",
+        "model_vendor": "alibaba",
+        "model_version": "2025-04-28",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "dashscope",
         "max_input_tokens": 1000000,
@@ -8085,6 +9260,8 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen-turbo-latest": {
+        "display_name": "Qwen Turbo",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "dashscope",
         "max_input_tokens": 1000000,
@@ -8099,6 +9276,8 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen3-30b-a3b": {
+        "display_name": "Qwen3 30B A3B",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 129024,
         "max_output_tokens": 16384,
@@ -8110,6 +9289,8 @@
         "supports_tool_choice": true
     },
     "dashscope/qwen3-coder-flash": {
+        "display_name": "Qwen3 Coder Flash",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 65536,
@@ -8159,6 +9340,9 @@
         ]
     },
     "dashscope/qwen3-coder-flash-2025-07-28": {
+        "display_name": "Qwen3 Coder Flash",
+        "model_vendor": "alibaba",
+        "model_version": "2025-07-28",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 65536,
@@ -8204,6 +9388,8 @@
         ]
     },
     "dashscope/qwen3-coder-plus": {
+        "display_name": "Qwen3 Coder Plus",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 65536,
@@ -8253,6 +9439,9 @@
         ]
     },
     "dashscope/qwen3-coder-plus-2025-07-22": {
+        "display_name": "Qwen3 Coder Plus",
+        "model_vendor": "alibaba",
+        "model_version": "2025-07-22",
         "litellm_provider": "dashscope",
         "max_input_tokens": 997952,
         "max_output_tokens": 65536,
@@ -8298,6 +9487,8 @@
         ]
     },
     "dashscope/qwen3-max-preview": {
+        "display_name": "Qwen3 Max Preview",
+        "model_vendor": "alibaba",
         "litellm_provider": "dashscope",
         "max_input_tokens": 258048,
         "max_output_tokens": 65536,
@@ -8335,6 +9526,8 @@
         ]
     },
     "dashscope/qwq-plus": {
+        "display_name": "QWQ Plus",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "dashscope",
         "max_input_tokens": 98304,
@@ -8348,6 +9541,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-bge-large-en": {
+        "display_name": "BGE Large EN",
+        "model_vendor": "baai",
         "input_cost_per_token": 1.0003e-07,
         "input_dbu_cost_per_token": 1.429e-06,
         "litellm_provider": "databricks",
@@ -8363,6 +9558,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
+        "display_name": "Claude Sonnet 3.7",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -8382,6 +9579,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-haiku-4-5": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -8401,6 +9600,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -8420,6 +9621,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -8439,6 +9642,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -8458,6 +9663,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -8477,6 +9684,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
+        "display_name": "Claude Sonnet 4.1",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -8496,6 +9705,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -8515,6 +9726,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
         "litellm_provider": "databricks",
@@ -8532,6 +9745,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -8549,6 +9764,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
+        "display_name": "Gemma 3 12B",
+        "model_vendor": "google",
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -8564,6 +9781,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-5": {
+        "display_name": "GPT-5",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -8579,6 +9798,8 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-5-1": {
+        "display_name": "GPT-5.1",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -8594,6 +9815,8 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-5-mini": {
+        "display_name": "GPT-5 Mini",
+        "model_vendor": "openai",
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -8609,6 +9832,8 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-5-nano": {
+        "display_name": "GPT-5 Nano",
+        "model_vendor": "openai",
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",
@@ -8624,6 +9849,8 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-oss-120b": {
+        "display_name": "GPT OSS 120B",
+        "model_vendor": "databricks",
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -8639,6 +9866,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-oss-20b": {
+        "display_name": "GPT OSS 20B",
+        "model_vendor": "databricks",
         "input_cost_per_token": 7e-08,
         "input_dbu_cost_per_token": 1e-06,
         "litellm_provider": "databricks",
@@ -8654,6 +9883,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gte-large-en": {
+        "display_name": "GTE Large EN",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
@@ -8669,6 +9900,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-llama-2-70b-chat": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -8685,6 +9918,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-llama-4-maverick": {
+        "display_name": "Llama 4 Maverick",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -8701,6 +9936,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-405b-instruct": {
+        "display_name": "Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -8717,6 +9954,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-8b-instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -8732,6 +9971,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-meta-llama-3-3-70b-instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -8748,6 +9989,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-70b-instruct": {
+        "display_name": "Llama 3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -8764,6 +10007,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mixtral-8x7b-instruct": {
+        "display_name": "Mixtral 8x7B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -8780,6 +10025,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-30b-instruct": {
+        "display_name": "MPT 30B Instruct",
+        "model_vendor": "databricks",
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -8796,6 +10043,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-7b-instruct": {
+        "display_name": "MPT 7B Instruct",
+        "model_vendor": "databricks",
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -8812,11 +10061,16 @@
         "supports_tool_choice": true
     },
     "dataforseo/search": {
+        "display_name": "DataForSEO Search",
+        "model_vendor": "dataforseo",
         "input_cost_per_query": 0.003,
         "litellm_provider": "dataforseo",
         "mode": "search"
     },
     "davinci-002": {
+        "display_name": "Davinci 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 16384,
@@ -8826,6 +10080,8 @@
         "output_cost_per_token": 2e-06
     },
     "deepgram/base": {
+        "display_name": "Deepgram Base",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8840,6 +10096,8 @@
         ]
     },
     "deepgram/base-conversationalai": {
+        "display_name": "Deepgram Base Conversational AI",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8854,6 +10112,8 @@
         ]
     },
     "deepgram/base-finance": {
+        "display_name": "Deepgram Base Finance",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8868,6 +10128,8 @@
         ]
     },
     "deepgram/base-general": {
+        "display_name": "Deepgram Base General",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8882,6 +10144,8 @@
         ]
     },
     "deepgram/base-meeting": {
+        "display_name": "Deepgram Base Meeting",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8896,6 +10160,8 @@
         ]
     },
     "deepgram/base-phonecall": {
+        "display_name": "Deepgram Base Phone Call",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8910,6 +10176,8 @@
         ]
     },
     "deepgram/base-video": {
+        "display_name": "Deepgram Base Video",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8924,6 +10192,8 @@
         ]
     },
     "deepgram/base-voicemail": {
+        "display_name": "Deepgram Base Voicemail",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00020833,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8938,6 +10208,8 @@
         ]
     },
     "deepgram/enhanced": {
+        "display_name": "Deepgram Enhanced",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00024167,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8952,6 +10224,8 @@
         ]
     },
     "deepgram/enhanced-finance": {
+        "display_name": "Deepgram Enhanced Finance",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00024167,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8966,6 +10240,8 @@
         ]
     },
     "deepgram/enhanced-general": {
+        "display_name": "Deepgram Enhanced General",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00024167,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8980,6 +10256,8 @@
         ]
     },
     "deepgram/enhanced-meeting": {
+        "display_name": "Deepgram Enhanced Meeting",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00024167,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -8994,6 +10272,8 @@
         ]
     },
     "deepgram/enhanced-phonecall": {
+        "display_name": "Deepgram Enhanced Phone Call",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.00024167,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9008,6 +10288,8 @@
         ]
     },
     "deepgram/nova": {
+        "display_name": "Deepgram Nova",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9022,6 +10304,8 @@
         ]
     },
     "deepgram/nova-2": {
+        "display_name": "Deepgram Nova 2",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9036,6 +10320,8 @@
         ]
     },
     "deepgram/nova-2-atc": {
+        "display_name": "Deepgram Nova 2 ATC",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9050,6 +10336,8 @@
         ]
     },
     "deepgram/nova-2-automotive": {
+        "display_name": "Deepgram Nova 2 Automotive",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9064,6 +10352,8 @@
         ]
     },
     "deepgram/nova-2-conversationalai": {
+        "display_name": "Deepgram Nova 2 Conversational AI",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9078,6 +10368,8 @@
         ]
     },
     "deepgram/nova-2-drivethru": {
+        "display_name": "Deepgram Nova 2 Drive-Thru",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9092,6 +10384,8 @@
         ]
     },
     "deepgram/nova-2-finance": {
+        "display_name": "Deepgram Nova 2 Finance",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9106,6 +10400,8 @@
         ]
     },
     "deepgram/nova-2-general": {
+        "display_name": "Deepgram Nova 2 General",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9120,6 +10416,8 @@
         ]
     },
     "deepgram/nova-2-meeting": {
+        "display_name": "Deepgram Nova 2 Meeting",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9134,6 +10432,8 @@
         ]
     },
     "deepgram/nova-2-phonecall": {
+        "display_name": "Deepgram Nova 2 Phone Call",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9148,6 +10448,8 @@
         ]
     },
     "deepgram/nova-2-video": {
+        "display_name": "Deepgram Nova 2 Video",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9162,6 +10464,8 @@
         ]
     },
     "deepgram/nova-2-voicemail": {
+        "display_name": "Deepgram Nova 2 Voicemail",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9176,6 +10480,8 @@
         ]
     },
     "deepgram/nova-3": {
+        "display_name": "Deepgram Nova 3",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9190,6 +10496,8 @@
         ]
     },
     "deepgram/nova-3-general": {
+        "display_name": "Deepgram Nova 3 General",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9204,6 +10512,8 @@
         ]
     },
     "deepgram/nova-3-medical": {
+        "display_name": "Deepgram Nova 3 Medical",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 8.667e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9218,6 +10528,8 @@
         ]
     },
     "deepgram/nova-general": {
+        "display_name": "Deepgram Nova General",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9232,6 +10544,8 @@
         ]
     },
     "deepgram/nova-phonecall": {
+        "display_name": "Deepgram Nova Phone Call",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 7.167e-05,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9246,6 +10560,8 @@
         ]
     },
     "deepgram/whisper": {
+        "display_name": "Deepgram Whisper",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9259,6 +10575,8 @@
         ]
     },
     "deepgram/whisper-base": {
+        "display_name": "Deepgram Whisper Base",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9272,6 +10590,8 @@
         ]
     },
     "deepgram/whisper-large": {
+        "display_name": "Deepgram Whisper Large",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9285,6 +10605,8 @@
         ]
     },
     "deepgram/whisper-medium": {
+        "display_name": "Deepgram Whisper Medium",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9298,6 +10620,8 @@
         ]
     },
     "deepgram/whisper-small": {
+        "display_name": "Deepgram Whisper Small",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9311,6 +10635,8 @@
         ]
     },
     "deepgram/whisper-tiny": {
+        "display_name": "Deepgram Whisper Tiny",
+        "model_vendor": "deepgram",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "deepgram",
         "metadata": {
@@ -9324,6 +10650,8 @@
         ]
     },
     "deepinfra/Gryphe/MythoMax-L2-13b": {
+        "display_name": "MythoMax L2 13B",
+        "model_vendor": "gryphe",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -9334,6 +10662,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/NousResearch/Hermes-3-Llama-3.1-405B": {
+        "display_name": "Hermes 3 Llama 3.1 405B",
+        "model_vendor": "nousresearch",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9344,6 +10674,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/NousResearch/Hermes-3-Llama-3.1-70B": {
+        "display_name": "Hermes 3 Llama 3.1 70B",
+        "model_vendor": "nousresearch",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9354,6 +10686,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/Qwen/QwQ-32B": {
+        "display_name": "QwQ 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9364,6 +10698,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen2.5-72B-Instruct": {
+        "display_name": "Qwen 2.5 72B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -9374,6 +10710,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen2.5-7B-Instruct": {
+        "display_name": "Qwen 2.5 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -9384,6 +10722,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/Qwen/Qwen2.5-VL-32B-Instruct": {
+        "display_name": "Qwen 2.5 VL 32B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -9395,6 +10735,8 @@
         "supports_vision": true
     },
     "deepinfra/Qwen/Qwen3-14B": {
+        "display_name": "Qwen 3 14B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -9405,6 +10747,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-235B-A22B": {
+        "display_name": "Qwen 3 235B A22B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -9415,6 +10759,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "display_name": "Qwen 3 235B A22B Instruct",
+        "model_vendor": "alibaba",
+        "model_version": "2507",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9425,6 +10772,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "display_name": "Qwen 3 235B A22B Thinking",
+        "model_vendor": "alibaba",
+        "model_version": "2507",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9435,6 +10785,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-30B-A3B": {
+        "display_name": "Qwen 3 30B A3B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -9445,6 +10797,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-32B": {
+        "display_name": "Qwen 3 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -9455,6 +10809,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "display_name": "Qwen 3 Coder 480B A35B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9465,6 +10821,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": {
+        "display_name": "Qwen 3 Coder 480B A35B Instruct Turbo",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9475,6 +10833,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "display_name": "Qwen 3 Next 80B A3B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9485,6 +10845,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "display_name": "Qwen 3 Next 80B A3B Thinking",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9495,6 +10857,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/Sao10K/L3-8B-Lunaris-v1-Turbo": {
+        "display_name": "L3 8B Lunaris v1 Turbo",
+        "model_vendor": "sao10k",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -9505,6 +10869,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/Sao10K/L3.1-70B-Euryale-v2.2": {
+        "display_name": "L3.1 70B Euryale v2.2",
+        "model_vendor": "sao10k",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9515,6 +10881,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/Sao10K/L3.3-70B-Euryale-v2.3": {
+        "display_name": "L3.3 70B Euryale v2.3",
+        "model_vendor": "sao10k",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9525,6 +10893,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/allenai/olmOCR-7B-0725-FP8": {
+        "display_name": "OLMoCR 7B",
+        "model_vendor": "allenai",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -9535,6 +10905,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/anthropic/claude-3-7-sonnet-latest": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
         "max_tokens": 200000,
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
@@ -9546,6 +10918,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/anthropic/claude-4-opus": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
         "max_tokens": 200000,
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
@@ -9556,6 +10930,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/anthropic/claude-4-sonnet": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "max_tokens": 200000,
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
@@ -9566,6 +10942,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9576,6 +10954,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9587,6 +10968,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-0528-Turbo": {
+        "display_name": "DeepSeek R1 0528 Turbo",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -9597,6 +10981,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9607,6 +10993,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+        "display_name": "DeepSeek R1 Distill Qwen 32B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9617,6 +11005,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-R1-Turbo": {
+        "display_name": "DeepSeek R1 Turbo",
+        "model_vendor": "deepseek",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -9627,6 +11017,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9637,6 +11029,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9647,6 +11042,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3.1": {
+        "display_name": "DeepSeek V3.1",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9659,6 +11056,8 @@
         "supports_reasoning": true
     },
     "deepinfra/deepseek-ai/DeepSeek-V3.1-Terminus": {
+        "display_name": "DeepSeek V3.1 Terminus",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9670,6 +11069,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemini-2.0-flash-001": {
+        "display_name": "Gemini 2.0 Flash",
+        "model_vendor": "google",
         "max_tokens": 1000000,
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
@@ -9680,6 +11081,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemini-2.5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "max_tokens": 1000000,
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
@@ -9690,6 +11093,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "max_tokens": 1000000,
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
@@ -9700,6 +11105,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemma-3-12b-it": {
+        "display_name": "Gemma 3 12B IT",
+        "model_vendor": "google",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9710,6 +11117,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemma-3-27b-it": {
+        "display_name": "Gemma 3 27B IT",
+        "model_vendor": "google",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9720,6 +11129,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/google/gemma-3-4b-it": {
+        "display_name": "Gemma 3 4B IT",
+        "model_vendor": "google",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9730,6 +11141,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-3.2-11B-Vision-Instruct": {
+        "display_name": "Llama 3.2 11B Vision Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9740,6 +11153,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/meta-llama/Llama-3.2-3B-Instruct": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9750,6 +11165,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9760,6 +11177,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+        "display_name": "Llama 3.3 70B Instruct Turbo",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9770,6 +11189,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct",
+        "model_vendor": "meta",
         "max_tokens": 1048576,
         "max_input_tokens": 1048576,
         "max_output_tokens": 1048576,
@@ -9780,6 +11201,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "max_tokens": 327680,
         "max_input_tokens": 327680,
         "max_output_tokens": 327680,
@@ -9790,6 +11213,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Llama-Guard-3-8B": {
+        "display_name": "Llama Guard 3 8B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9800,6 +11225,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/meta-llama/Llama-Guard-4-12B": {
+        "display_name": "Llama Guard 4 12B",
+        "model_vendor": "meta",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -9810,6 +11237,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/meta-llama/Meta-Llama-3-8B-Instruct": {
+        "display_name": "Meta Llama 3 8B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -9820,6 +11249,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct": {
+        "display_name": "Meta Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9830,6 +11261,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+        "display_name": "Meta Llama 3.1 70B Instruct Turbo",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9840,6 +11273,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct": {
+        "display_name": "Meta Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9850,6 +11285,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+        "display_name": "Meta Llama 3.1 8B Instruct Turbo",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9860,6 +11297,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/microsoft/WizardLM-2-8x22B": {
+        "display_name": "WizardLM 2 8x22B",
+        "model_vendor": "microsoft",
         "max_tokens": 65536,
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
@@ -9870,6 +11309,8 @@
         "supports_tool_choice": false
     },
     "deepinfra/microsoft/phi-4": {
+        "display_name": "Phi 4",
+        "model_vendor": "microsoft",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -9880,6 +11321,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/mistralai/Mistral-Nemo-Instruct-2407": {
+        "display_name": "Mistral Nemo Instruct",
+        "model_vendor": "mistral",
+        "model_version": "2407",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9890,6 +11334,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/mistralai/Mistral-Small-24B-Instruct-2501": {
+        "display_name": "Mistral Small 24B Instruct",
+        "model_vendor": "mistral",
+        "model_version": "2501",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -9900,6 +11347,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
+        "display_name": "Mistral Small 3.2 24B Instruct",
+        "model_vendor": "mistral",
+        "model_version": "2506",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -9910,6 +11360,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct v0.1",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -9920,6 +11372,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/moonshotai/Kimi-K2-Instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9930,6 +11384,9 @@
         "supports_tool_choice": true
     },
     "deepinfra/moonshotai/Kimi-K2-Instruct-0905": {
+        "display_name": "Kimi K2 Instruct 0905",
+        "model_vendor": "moonshot",
+        "model_version": "0905",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -9941,6 +11398,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/nvidia/Llama-3.1-Nemotron-70B-Instruct": {
+        "display_name": "Llama 3.1 Nemotron 70B Instruct",
+        "model_vendor": "nvidia",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9951,6 +11410,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/nvidia/Llama-3.3-Nemotron-Super-49B-v1.5": {
+        "display_name": "Llama 3.3 Nemotron Super 49B v1.5",
+        "model_vendor": "nvidia",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9961,6 +11422,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {
+        "display_name": "NVIDIA Nemotron Nano 9B v2",
+        "model_vendor": "nvidia",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9971,6 +11434,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/openai/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9981,6 +11446,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/openai/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -9991,6 +11458,8 @@
         "supports_tool_choice": true
     },
     "deepinfra/zai-org/GLM-4.5": {
+        "display_name": "GLM 4.5",
+        "model_vendor": "zhipu",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -10001,6 +11470,8 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-chat": {
+        "display_name": "DeepSeek Chat",
+        "model_vendor": "deepseek",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 7e-08,
         "input_cost_per_token": 2.7e-07,
@@ -10017,6 +11488,8 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-coder": {
+        "display_name": "DeepSeek Coder",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.4e-07,
         "input_cost_per_token_cache_hit": 1.4e-08,
         "litellm_provider": "deepseek",
@@ -10031,6 +11504,8 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-r1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "deepseek",
@@ -10046,6 +11521,8 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-reasoner": {
+        "display_name": "DeepSeek Reasoner",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "deepseek",
@@ -10061,6 +11538,8 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-v3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 7e-08,
         "input_cost_per_token": 2.7e-07,
@@ -10077,6 +11556,9 @@
         "supports_tool_choice": true
     },
     "deepseek/deepseek-v3.2": {
+        "display_name": "DeepSeek V3.2",
+        "model_vendor": "deepseek",
+        "model_version": "v3.2",
         "input_cost_per_token": 2.8e-07,
         "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "deepseek",
@@ -10092,6 +11574,8 @@
         "supports_tool_choice": true
     },
     "deepseek.v3-v1:0": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.8e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 163840,
@@ -10104,6 +11588,8 @@
         "supports_tool_choice": true
     },
     "dolphin": {
+        "display_name": "Dolphin",
+        "model_vendor": "nlp_cloud",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "nlp_cloud",
         "max_input_tokens": 16384,
@@ -10113,6 +11599,8 @@
         "output_cost_per_token": 5e-07
     },
     "doubao-embedding": {
+        "display_name": "Doubao Embedding",
+        "model_vendor": "volcengine",
         "input_cost_per_token": 0.0,
         "litellm_provider": "volcengine",
         "max_input_tokens": 4096,
@@ -10125,6 +11613,8 @@
         "output_vector_size": 2560
     },
     "doubao-embedding-large": {
+        "display_name": "Doubao Embedding Large",
+        "model_vendor": "volcengine",
         "input_cost_per_token": 0.0,
         "litellm_provider": "volcengine",
         "max_input_tokens": 4096,
@@ -10137,6 +11627,9 @@
         "output_vector_size": 2048
     },
     "doubao-embedding-large-text-240915": {
+        "display_name": "Doubao Embedding Large Text 240915",
+        "model_vendor": "volcengine",
+        "model_version": "240915",
         "input_cost_per_token": 0.0,
         "litellm_provider": "volcengine",
         "max_input_tokens": 4096,
@@ -10149,6 +11642,9 @@
         "output_vector_size": 4096
     },
     "doubao-embedding-large-text-250515": {
+        "display_name": "Doubao Embedding Large Text 250515",
+        "model_vendor": "volcengine",
+        "model_version": "250515",
         "input_cost_per_token": 0.0,
         "litellm_provider": "volcengine",
         "max_input_tokens": 4096,
@@ -10161,6 +11657,9 @@
         "output_vector_size": 2048
     },
     "doubao-embedding-text-240715": {
+        "display_name": "Doubao Embedding Text 240715",
+        "model_vendor": "volcengine",
+        "model_version": "240715",
         "input_cost_per_token": 0.0,
         "litellm_provider": "volcengine",
         "max_input_tokens": 4096,
@@ -10173,18 +11672,20 @@
         "output_vector_size": 2560
     },
     "exa_ai/search": {
+        "display_name": "Exa AI Search",
+        "model_vendor": "exa_ai",
         "litellm_provider": "exa_ai",
         "mode": "search",
         "tiered_pricing": [
             {
-                "input_cost_per_query": 5e-03,
+                "input_cost_per_query": 0.005,
                 "max_results_range": [
                     0,
                     25
                 ]
             },
             {
-                "input_cost_per_query": 25e-03,
+                "input_cost_per_query": 0.025,
                 "max_results_range": [
                     26,
                     100
@@ -10193,74 +11694,76 @@
         ]
     },
     "firecrawl/search": {
+        "display_name": "Firecrawl Search",
+        "model_vendor": "firecrawl",
         "litellm_provider": "firecrawl",
         "mode": "search",
         "tiered_pricing": [
             {
-                "input_cost_per_query": 1.66e-03,
+                "input_cost_per_query": 0.00166,
                 "max_results_range": [
                     1,
                     10
                 ]
             },
             {
-                "input_cost_per_query": 3.32e-03,
+                "input_cost_per_query": 0.00332,
                 "max_results_range": [
                     11,
                     20
                 ]
             },
             {
-                "input_cost_per_query": 4.98e-03,
+                "input_cost_per_query": 0.00498,
                 "max_results_range": [
                     21,
                     30
                 ]
             },
             {
-                "input_cost_per_query": 6.64e-03,
+                "input_cost_per_query": 0.00664,
                 "max_results_range": [
                     31,
                     40
                 ]
             },
             {
-                "input_cost_per_query": 8.3e-03,
+                "input_cost_per_query": 0.0083,
                 "max_results_range": [
                     41,
                     50
                 ]
             },
             {
-                "input_cost_per_query": 9.96e-03,
+                "input_cost_per_query": 0.00996,
                 "max_results_range": [
                     51,
                     60
                 ]
             },
             {
-                "input_cost_per_query": 11.62e-03,
+                "input_cost_per_query": 0.01162,
                 "max_results_range": [
                     61,
                     70
                 ]
             },
             {
-                "input_cost_per_query": 13.28e-03,
+                "input_cost_per_query": 0.01328,
                 "max_results_range": [
                     71,
                     80
                 ]
             },
             {
-                "input_cost_per_query": 14.94e-03,
+                "input_cost_per_query": 0.01494,
                 "max_results_range": [
                     81,
                     90
                 ]
             },
             {
-                "input_cost_per_query": 16.6e-03,
+                "input_cost_per_query": 0.0166,
                 "max_results_range": [
                     91,
                     100
@@ -10272,11 +11775,15 @@
         }
     },
     "perplexity/search": {
-        "input_cost_per_query": 5e-03,
+        "display_name": "Perplexity Search",
+        "model_vendor": "perplexity",
+        "input_cost_per_query": 0.005,
         "litellm_provider": "perplexity",
         "mode": "search"
     },
     "searxng/search": {
+        "display_name": "SearXNG Search",
+        "model_vendor": "searxng",
         "litellm_provider": "searxng",
         "mode": "search",
         "input_cost_per_query": 0.0,
@@ -10285,6 +11792,8 @@
         }
     },
     "elevenlabs/scribe_v1": {
+        "display_name": "ElevenLabs Scribe v1",
+        "model_vendor": "elevenlabs",
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",
         "metadata": {
@@ -10300,6 +11809,8 @@
         ]
     },
     "elevenlabs/scribe_v1_experimental": {
+        "display_name": "ElevenLabs Scribe v1 Experimental",
+        "model_vendor": "elevenlabs",
         "input_cost_per_second": 6.11e-05,
         "litellm_provider": "elevenlabs",
         "metadata": {
@@ -10315,6 +11826,8 @@
         ]
     },
     "embed-english-light-v2.0": {
+        "display_name": "Embed English Light v2.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -10323,6 +11836,8 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-light-v3.0": {
+        "display_name": "Embed English Light v3.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -10331,6 +11846,8 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-v2.0": {
+        "display_name": "Embed English v2.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 4096,
@@ -10339,6 +11856,8 @@
         "output_cost_per_token": 0.0
     },
     "embed-english-v3.0": {
+        "display_name": "Embed English v3.0",
+        "model_vendor": "cohere",
         "input_cost_per_image": 0.0001,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
@@ -10353,6 +11872,8 @@
         "supports_image_input": true
     },
     "embed-multilingual-v2.0": {
+        "display_name": "Embed Multilingual v2.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 768,
@@ -10361,6 +11882,8 @@
         "output_cost_per_token": 0.0
     },
     "embed-multilingual-v3.0": {
+        "display_name": "Embed Multilingual v3.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
@@ -10370,7 +11893,9 @@
         "supports_embedding_image_input": true
     },
     "embed-multilingual-light-v3.0": {
-        "input_cost_per_token": 1e-04,
+        "display_name": "Embed Multilingual Light v3.0",
+        "model_vendor": "cohere",
+        "input_cost_per_token": 0.0001,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -10379,6 +11904,8 @@
         "supports_embedding_image_input": true
     },
     "eu.amazon.nova-lite-v1:0": {
+        "display_name": "Amazon Nova Lite",
+        "model_vendor": "amazon",
         "input_cost_per_token": 7.8e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
@@ -10393,6 +11920,8 @@
         "supports_vision": true
     },
     "eu.amazon.nova-micro-v1:0": {
+        "display_name": "Amazon Nova Micro",
+        "model_vendor": "amazon",
         "input_cost_per_token": 4.6e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -10405,6 +11934,8 @@
         "supports_response_schema": true
     },
     "eu.amazon.nova-pro-v1:0": {
+        "display_name": "Amazon Nova Pro",
+        "model_vendor": "amazon",
         "input_cost_per_token": 1.05e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
@@ -10420,6 +11951,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10435,6 +11969,9 @@
         "supports_tool_choice": true
     },
     "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -10458,6 +11995,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240620",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10472,6 +12012,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+        "display_name": "Claude 3.5 Sonnet v2",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10489,6 +12032,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20250219",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10507,6 +12053,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20240307",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10521,6 +12070,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-opus-20240229-v1:0": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10534,6 +12086,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "display_name": "Claude 3 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -10548,6 +12103,9 @@
         "supports_vision": true
     },
     "eu.anthropic.claude-opus-4-1-20250805-v1:0": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
+        "model_version": "20250805",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -10574,6 +12132,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "eu.anthropic.claude-opus-4-20250514-v1:0": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -10600,6 +12161,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "eu.anthropic.claude-sonnet-4-20250514-v1:0": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -10630,6 +12194,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
@@ -10660,6 +12227,8 @@
         "tool_use_system_prompt_tokens": 346
     },
     "eu.meta.llama3-2-1b-instruct-v1:0": {
+        "display_name": "Llama 3.2 1B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -10671,6 +12240,8 @@
         "supports_tool_choice": false
     },
     "eu.meta.llama3-2-3b-instruct-v1:0": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.9e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -10682,6 +12253,9 @@
         "supports_tool_choice": false
     },
     "eu.mistral.pixtral-large-2502-v1:0": {
+        "display_name": "Pixtral Large",
+        "model_vendor": "mistral",
+        "model_version": "2502",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -10693,6 +12267,8 @@
         "supports_tool_choice": false
     },
     "fal_ai/bria/text-to-image/3.2": {
+        "display_name": "Bria Text-to-Image 3.2",
+        "model_vendor": "bria",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.0398,
@@ -10701,6 +12277,9 @@
         ]
     },
     "fal_ai/fal-ai/flux-pro/v1.1": {
+        "display_name": "Flux Pro v1.1",
+        "model_vendor": "fal_ai",
+        "model_version": "1.1",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -10709,6 +12288,9 @@
         ]
     },
     "fal_ai/fal-ai/flux-pro/v1.1-ultra": {
+        "display_name": "Flux Pro v1.1 Ultra",
+        "model_vendor": "fal_ai",
+        "model_version": "1.1-ultra",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
@@ -10717,6 +12299,8 @@
         ]
     },
     "fal_ai/fal-ai/flux/schnell": {
+        "display_name": "Flux Schnell",
+        "model_vendor": "black_forest_labs",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.003,
@@ -10725,6 +12309,8 @@
         ]
     },
     "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image": {
+        "display_name": "SeedReam v3",
+        "model_vendor": "bytedance",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.03,
@@ -10733,6 +12319,8 @@
         ]
     },
     "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image": {
+        "display_name": "Dreamina v3.1",
+        "model_vendor": "bytedance",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.03,
@@ -10741,6 +12329,8 @@
         ]
     },
     "fal_ai/fal-ai/ideogram/v3": {
+        "display_name": "Ideogram v3",
+        "model_vendor": "ideogram",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
@@ -10749,6 +12339,9 @@
         ]
     },
     "fal_ai/fal-ai/imagen4/preview": {
+        "display_name": "Imagen 4 Preview",
+        "model_vendor": "google",
+        "model_version": "4-preview",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.0398,
@@ -10757,6 +12350,9 @@
         ]
     },
     "fal_ai/fal-ai/imagen4/preview/fast": {
+        "display_name": "Imagen 4 Preview Fast",
+        "model_vendor": "google",
+        "model_version": "4-preview-fast",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
@@ -10765,6 +12361,9 @@
         ]
     },
     "fal_ai/fal-ai/imagen4/preview/ultra": {
+        "display_name": "Imagen 4 Preview Ultra",
+        "model_vendor": "google",
+        "model_version": "4-preview-ultra",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
@@ -10773,6 +12372,8 @@
         ]
     },
     "fal_ai/fal-ai/recraft/v3/text-to-image": {
+        "display_name": "Recraft v3",
+        "model_vendor": "recraft",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.0398,
@@ -10781,6 +12382,9 @@
         ]
     },
     "fal_ai/fal-ai/stable-diffusion-v35-medium": {
+        "display_name": "Stable Diffusion v3.5 Medium",
+        "model_vendor": "stability_ai",
+        "model_version": "3.5-medium",
         "litellm_provider": "fal_ai",
         "mode": "image_generation",
         "output_cost_per_image": 0.0398,
@@ -10789,6 +12393,8 @@
         ]
     },
     "featherless_ai/featherless-ai/Qwerky-72B": {
+        "display_name": "Qwerky 72B",
+        "model_vendor": "featherless_ai",
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
@@ -10796,6 +12402,8 @@
         "mode": "chat"
     },
     "featherless_ai/featherless-ai/Qwerky-QwQ-32B": {
+        "display_name": "Qwerky QwQ 32B",
+        "model_vendor": "featherless_ai",
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
@@ -10803,46 +12411,64 @@
         "mode": "chat"
     },
     "fireworks-ai-4.1b-to-16b": {
+        "display_name": "Fireworks AI 4.1B-16B Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 2e-07
     },
     "fireworks-ai-56b-to-176b": {
+        "display_name": "Fireworks AI 56B-176B Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 1.2e-06
     },
     "fireworks-ai-above-16b": {
+        "display_name": "Fireworks AI Above 16B Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 9e-07
     },
     "fireworks-ai-default": {
+        "display_name": "Fireworks AI Default Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 0.0
     },
     "fireworks-ai-embedding-150m-to-350m": {
+        "display_name": "Fireworks AI Embedding 150M-350M Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 1.6e-08,
         "litellm_provider": "fireworks_ai-embedding-models",
         "output_cost_per_token": 0.0
     },
     "fireworks-ai-embedding-up-to-150m": {
+        "display_name": "Fireworks AI Embedding Up to 150M Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "fireworks_ai-embedding-models",
         "output_cost_per_token": 0.0
     },
     "fireworks-ai-moe-up-to-56b": {
+        "display_name": "Fireworks AI MoE Up to 56B Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 5e-07
     },
     "fireworks-ai-up-to-4b": {
+        "display_name": "Fireworks AI Up to 4B Tier",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "fireworks_ai",
         "output_cost_per_token": 2e-07
     },
     "fireworks_ai/WhereIsAI/UAE-Large-V1": {
+        "display_name": "UAE Large V1",
+        "model_vendor": "whereisai",
         "input_cost_per_token": 1.6e-08,
         "litellm_provider": "fireworks_ai-embedding-models",
         "max_input_tokens": 512,
@@ -10852,6 +12478,8 @@
         "source": "https://fireworks.ai/pricing"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-instruct": {
+        "display_name": "DeepSeek Coder V2 Instruct",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 65536,
@@ -10865,6 +12493,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10877,6 +12507,9 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 160000,
@@ -10889,6 +12522,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-basic": {
+        "display_name": "DeepSeek R1 Basic",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10901,6 +12536,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10913,6 +12550,9 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 163840,
@@ -10925,6 +12565,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p1": {
+        "display_name": "DeepSeek V3 Plus",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10938,6 +12580,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p1-terminus": {
+        "display_name": "DeepSeek V3 Plus Terminus",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10951,13 +12595,15 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v3p2": {
-        "input_cost_per_token": 5.6e-07,
+        "display_name": "DeepSeek V3p2",
+        "model_vendor": "deepseek",
+        "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
         "max_tokens": 163840,
         "mode": "chat",
-        "output_cost_per_token": 1.68e-06,
+        "output_cost_per_token": 1.2e-06,
         "source": "https://fireworks.ai/models/fireworks/deepseek-v3p2",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -10965,6 +12611,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/firefunction-v2": {
+        "display_name": "FireFunction V2",
+        "model_vendor": "fireworks_ai",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 8192,
@@ -10978,6 +12626,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/glm-4p5": {
+        "display_name": "GLM-4 Plus",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -10992,6 +12642,9 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/glm-4p5-air": {
+        "display_name": "GLM-4 Plus Air",
+        "model_vendor": "zhipu",
+        "model_version": "4.5-air",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -11006,7 +12659,9 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/glm-4p6": {
-        "input_cost_per_token": 0.55e-06,
+        "display_name": "GLM-4.6",
+        "model_vendor": "zhipu",
+        "input_cost_per_token": 5.5e-07,
         "output_cost_per_token": 2.19e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 202800,
@@ -11020,6 +12675,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 131072,
@@ -11034,6 +12691,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 131072,
@@ -11048,6 +12707,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 131072,
@@ -11061,6 +12722,9 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct-0905": {
+        "display_name": "Kimi K2 Instruct 0905",
+        "model_vendor": "moonshot",
+        "model_version": "0905",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
@@ -11074,6 +12738,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/kimi-k2-thinking": {
+        "display_name": "Kimi K2 Thinking",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 262144,
@@ -11088,6 +12754,8 @@
         "supports_web_search": true
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
+        "display_name": "Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 128000,
@@ -11101,6 +12769,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-8b-instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 16384,
@@ -11114,6 +12784,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
+        "display_name": "Llama 3.2 11B Vision Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 16384,
@@ -11128,6 +12800,8 @@
         "supports_vision": true
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-1b-instruct": {
+        "display_name": "Llama 3.2 1B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 16384,
@@ -11141,6 +12815,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-3b-instruct": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 16384,
@@ -11154,6 +12830,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
+        "display_name": "Llama 3.2 90B Vision Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 16384,
@@ -11167,6 +12845,8 @@
         "supports_vision": true
     },
     "fireworks_ai/accounts/fireworks/models/llama4-maverick-instruct-basic": {
+        "display_name": "Llama 4 Maverick Instruct Basic",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 131072,
@@ -11179,6 +12859,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/llama4-scout-instruct-basic": {
+        "display_name": "Llama 4 Scout Instruct Basic",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 131072,
@@ -11191,6 +12873,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
+        "display_name": "Mixtral 8x22B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 65536,
@@ -11204,6 +12888,8 @@
         "supports_tool_choice": true
     },
     "fireworks_ai/accounts/fireworks/models/qwen2-72b-instruct": {
+        "display_name": "Qwen 2 72B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 32768,
@@ -11217,6 +12903,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 4096,
@@ -11230,6 +12918,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/accounts/fireworks/models/yi-large": {
+        "display_name": "Yi Large",
+        "model_vendor": "01_ai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 32768,
@@ -11243,6 +12933,8 @@
         "supports_tool_choice": false
     },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
+        "display_name": "Nomic Embed Text V1",
+        "model_vendor": "nomic",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "fireworks_ai-embedding-models",
         "max_input_tokens": 8192,
@@ -11252,6 +12944,8 @@
         "source": "https://fireworks.ai/pricing"
     },
     "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
+        "display_name": "Nomic Embed Text V1.5",
+        "model_vendor": "nomic",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "fireworks_ai-embedding-models",
         "max_input_tokens": 8192,
@@ -11261,6 +12955,8 @@
         "source": "https://fireworks.ai/pricing"
     },
     "fireworks_ai/thenlper/gte-base": {
+        "display_name": "GTE Base",
+        "model_vendor": "thenlper",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "fireworks_ai-embedding-models",
         "max_input_tokens": 512,
@@ -11270,6 +12966,8 @@
         "source": "https://fireworks.ai/pricing"
     },
     "fireworks_ai/thenlper/gte-large": {
+        "display_name": "GTE Large",
+        "model_vendor": "thenlper",
         "input_cost_per_token": 1.6e-08,
         "litellm_provider": "fireworks_ai-embedding-models",
         "max_input_tokens": 512,
@@ -11279,6 +12977,8 @@
         "source": "https://fireworks.ai/pricing"
     },
     "friendliai/meta-llama-3.1-70b-instruct": {
+        "display_name": "Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "friendliai",
         "max_input_tokens": 8192,
@@ -11293,6 +12993,8 @@
         "supports_tool_choice": true
     },
     "friendliai/meta-llama-3.1-8b-instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "friendliai",
         "max_input_tokens": 8192,
@@ -11307,6 +13009,9 @@
         "supports_tool_choice": true
     },
     "ft:babbage-002": {
+        "display_name": "Babbage 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 1.6e-06,
         "input_cost_per_token_batches": 2e-07,
         "litellm_provider": "text-completion-openai",
@@ -11318,6 +13023,9 @@
         "output_cost_per_token_batches": 2e-07
     },
     "ft:davinci-002": {
+        "display_name": "Davinci 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 1.2e-05,
         "input_cost_per_token_batches": 1e-06,
         "litellm_provider": "text-completion-openai",
@@ -11329,6 +13037,8 @@
         "output_cost_per_token_batches": 1e-06
     },
     "ft:gpt-3.5-turbo": {
+        "display_name": "GPT-3.5 Turbo Fine-tuned",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_batches": 1.5e-06,
         "litellm_provider": "openai",
@@ -11342,6 +13052,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-0125": {
+        "display_name": "GPT-3.5 Turbo 0125 Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "0125",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -11353,6 +13066,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-0613": {
+        "display_name": "GPT-3.5 Turbo 0613 Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 4096,
@@ -11364,6 +13080,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-3.5-turbo-1106": {
+        "display_name": "GPT-3.5 Turbo 1106 Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "1106",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -11375,6 +13094,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4-0613": {
+        "display_name": "GPT-4 0613 Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -11388,6 +13110,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4o-2024-08-06": {
+        "display_name": "GPT-4o Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "cache_read_input_token_cost": 1.875e-06,
         "input_cost_per_token": 3.75e-06,
         "input_cost_per_token_batches": 1.875e-06,
@@ -11408,6 +13133,9 @@
         "supports_vision": true
     },
     "ft:gpt-4o-2024-11-20": {
+        "display_name": "GPT-4o Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "cache_creation_input_token_cost": 1.875e-06,
         "input_cost_per_token": 3.75e-06,
         "litellm_provider": "openai",
@@ -11425,6 +13153,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4o-mini-2024-07-18": {
+        "display_name": "GPT-4o Mini Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2024-07-18",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,
@@ -11444,6 +13175,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4.1-2025-04-14": {
+        "display_name": "GPT-4.1 Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_batches": 1.5e-06,
@@ -11462,6 +13196,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4.1-mini-2025-04-14": {
+        "display_name": "GPT-4.1 Mini Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 2e-07,
         "input_cost_per_token": 8e-07,
         "input_cost_per_token_batches": 4e-07,
@@ -11480,6 +13217,9 @@
         "supports_tool_choice": true
     },
     "ft:gpt-4.1-nano-2025-04-14": {
+        "display_name": "GPT-4.1 Nano Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 5e-08,
         "input_cost_per_token": 2e-07,
         "input_cost_per_token_batches": 1e-07,
@@ -11498,6 +13238,9 @@
         "supports_tool_choice": true
     },
     "ft:o4-mini-2025-04-16": {
+        "display_name": "O4 Mini Fine-tuned",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "cache_read_input_token_cost": 1e-06,
         "input_cost_per_token": 4e-06,
         "input_cost_per_token_batches": 2e-06,
@@ -11516,6 +13259,8 @@
         "supports_tool_choice": true
     },
     "gemini-1.0-pro": {
+        "display_name": "Gemini 1.0 Pro",
+        "model_vendor": "google",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
@@ -11533,6 +13278,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.0-pro-001": {
+        "display_name": "Gemini 1.0 Pro 001",
+        "model_vendor": "google",
+        "model_version": "1.0-001",
         "deprecation_date": "2025-04-09",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
@@ -11551,6 +13299,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.0-pro-002": {
+        "display_name": "Gemini 1.0 Pro 002",
+        "model_vendor": "google",
+        "model_version": "1.0-002",
         "deprecation_date": "2025-04-09",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
@@ -11569,6 +13320,8 @@
         "supports_tool_choice": true
     },
     "gemini-1.0-pro-vision": {
+        "display_name": "Gemini 1.0 Pro Vision",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-vision-models",
@@ -11587,6 +13340,9 @@
         "supports_vision": true
     },
     "gemini-1.0-pro-vision-001": {
+        "display_name": "Gemini 1.0 Pro Vision 001",
+        "model_vendor": "google",
+        "model_version": "1.0-001",
         "deprecation_date": "2025-04-09",
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
@@ -11606,6 +13362,9 @@
         "supports_vision": true
     },
     "gemini-1.0-ultra": {
+        "display_name": "Gemini 1.0 Ultra",
+        "model_vendor": "google",
+        "model_version": "1.0-ultra",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
@@ -11623,6 +13382,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.0-ultra-001": {
+        "display_name": "Gemini 1.0 Ultra 001",
+        "model_vendor": "google",
+        "model_version": "1.0-ultra-001",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
@@ -11640,7 +13402,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-flash": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash",
+        "model_vendor": "google",
+        "model_version": "1.5-flash",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11675,6 +13439,9 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-001": {
+        "display_name": "Gemini 1.5 Flash 001",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-001",
         "deprecation_date": "2025-05-24",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
@@ -11710,6 +13477,9 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-002": {
+        "display_name": "Gemini 1.5 Flash 002",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-002",
         "deprecation_date": "2025-09-24",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
@@ -11745,7 +13515,9 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-exp-0827": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash Exp 0827",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-exp-0827",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11780,7 +13552,9 @@
         "supports_vision": true
     },
     "gemini-1.5-flash-preview-0514": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash Preview 0514",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-preview-0514",
         "input_cost_per_audio_per_second": 2e-06,
         "input_cost_per_audio_per_second_above_128k_tokens": 4e-06,
         "input_cost_per_character": 1.875e-08,
@@ -11814,7 +13588,9 @@
         "supports_vision": true
     },
     "gemini-1.5-pro": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro",
+        "model_vendor": "google",
+        "model_version": "1.5-pro",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11844,6 +13620,9 @@
         "supports_vision": true
     },
     "gemini-1.5-pro-001": {
+        "display_name": "Gemini 1.5 Pro 001",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-001",
         "deprecation_date": "2025-05-24",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
@@ -11873,6 +13652,9 @@
         "supports_vision": true
     },
     "gemini-1.5-pro-002": {
+        "display_name": "Gemini 1.5 Pro 002",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-002",
         "deprecation_date": "2025-09-24",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
@@ -11902,7 +13684,9 @@
         "supports_vision": true
     },
     "gemini-1.5-pro-preview-0215": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Preview 0215",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-preview-0215",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11930,7 +13714,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0409": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Preview 0409",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-preview-0409",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11957,7 +13743,9 @@
         "supports_tool_choice": true
     },
     "gemini-1.5-pro-preview-0514": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Preview 0514",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-preview-0514",
         "input_cost_per_audio_per_second": 3.125e-05,
         "input_cost_per_audio_per_second_above_128k_tokens": 6.25e-05,
         "input_cost_per_character": 3.125e-07,
@@ -11985,6 +13773,9 @@
         "supports_tool_choice": true
     },
     "gemini-2.0-flash": {
+        "display_name": "Gemini 2.0 Flash",
+        "model_vendor": "google",
+        "model_version": "2.0-flash",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -12024,6 +13815,9 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-001": {
+        "display_name": "Gemini 2.0 Flash 001",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-001",
         "cache_read_input_token_cost": 3.75e-08,
         "deprecation_date": "2026-02-05",
         "input_cost_per_audio_token": 1e-06,
@@ -12062,6 +13856,8 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-exp": {
+        "display_name": "Gemini 2.0 Flash Experimental",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3.75e-08,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12110,6 +13906,8 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-lite": {
+        "display_name": "Gemini 2.0 Flash Lite",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
@@ -12145,6 +13943,9 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-lite-001": {
+        "display_name": "Gemini 2.0 Flash Lite 001",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-lite-001",
         "cache_read_input_token_cost": 1.875e-08,
         "deprecation_date": "2026-02-25",
         "input_cost_per_audio_token": 7.5e-08,
@@ -12181,6 +13982,9 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-live-preview-04-09": {
+        "display_name": "Gemini 2.0 Flash Live Preview 04-09",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-live-preview-04-09",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_image": 3e-06,
@@ -12229,7 +14033,8 @@
         "tpm": 250000
     },
     "gemini-2.0-flash-preview-image-generation": {
-        "deprecation_date": "2025-11-14",
+        "display_name": "Gemini 2.0 Flash Preview Image Generation",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -12268,7 +14073,8 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.0 Flash Thinking Experimental",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12317,7 +14123,9 @@
         "supports_web_search": true
     },
     "gemini-2.0-flash-thinking-exp-01-21": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.0 Flash Thinking Experimental 01-21",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-thinking-exp-01-21",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -12367,6 +14175,9 @@
         "supports_web_search": true
     },
     "gemini-2.0-pro-exp-02-05": {
+        "display_name": "Gemini 2.0 Pro Experimental 02-05",
+        "model_vendor": "google",
+        "model_version": "2.0-pro-exp-02-05",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
@@ -12410,6 +14221,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12455,6 +14268,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-image": {
+        "display_name": "Gemini 2.5 Flash Image",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12470,7 +14285,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -12504,7 +14318,8 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-image-preview": {
-        "deprecation_date": "2026-01-15",
+        "display_name": "Gemini 2.5 Flash Image Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12520,7 +14335,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 3e-05,
         "output_cost_per_token": 3e-05,
         "rpm": 100000,
@@ -12554,6 +14368,8 @@
         "tpm": 8000000
     },
     "gemini-3-pro-image-preview": {
+        "display_name": "Gemini 3 Pro Image Preview",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -12563,7 +14379,7 @@
         "max_tokens": 65536,
         "mode": "image_generation",
         "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 1.2e-04,
+        "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
@@ -12588,6 +14404,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite": {
+        "display_name": "Gemini 2.5 Flash Lite",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -12633,6 +14451,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-lite-preview-09-2025": {
+        "display_name": "Gemini 2.5 Flash Lite Preview 09-2025",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-lite-preview-09-2025",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
@@ -12678,6 +14499,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-preview-09-2025": {
+        "display_name": "Gemini 2.5 Flash Preview 09-2025",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-09-2025",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12723,6 +14547,9 @@
         "supports_web_search": true
     },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
+        "display_name": "Gemini Live 2.5 Flash Preview Native Audio 09-2025",
+        "model_vendor": "google",
+        "model_version": "live-2.5-flash-preview-native-audio-09-2025",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_token": 3e-07,
@@ -12768,6 +14595,9 @@
         "supports_web_search": true
     },
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
+        "display_name": "Gemini Live 2.5 Flash Preview Native Audio 09-2025",
+        "model_vendor": "google",
+        "model_version": "live-2.5-flash-preview-native-audio-09-2025",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_token": 3e-07,
@@ -12815,7 +14645,9 @@
         "tpm": 8000000
     },
     "gemini-2.5-flash-lite-preview-06-17": {
-        "deprecation_date": "2025-11-18",
+        "display_name": "Gemini 2.5 Flash Lite Preview 06-17",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-lite-preview-06-17",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -12861,6 +14693,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-preview-04-17": {
+        "display_name": "Gemini 2.5 Flash Preview 04-17",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-04-17",
         "cache_read_input_token_cost": 3.75e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 1.5e-07,
@@ -12905,7 +14740,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-flash-preview-05-20": {
-        "deprecation_date": "2025-11-18",
+        "display_name": "Gemini 2.5 Flash Preview 05-20",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-05-20",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -12951,6 +14788,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
@@ -12995,6 +14834,8 @@
         "supports_web_search": true
     },
     "gemini-3-pro-preview": {
+        "display_name": "Gemini 3 Pro Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -13043,6 +14884,8 @@
         "supports_web_search": true
     },
     "vertex_ai/gemini-3-pro-preview": {
+        "display_name": "Gemini 3 Pro Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -13090,50 +14933,10 @@
         "supports_vision": true,
         "supports_web_search": true
     },
-    "vertex_ai/gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 5e-08,
-        "input_cost_per_token": 5e-07,
-        "input_cost_per_audio_token": 1e-06,
-        "litellm_provider": "vertex_ai",
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image",
-            "audio",
-            "video"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_audio_input": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_video_input": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "gemini-2.5-pro-exp-03-25": {
+        "display_name": "Gemini 2.5 Pro Experimental 03-25",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-exp-03-25",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
@@ -13177,7 +14980,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-03-25": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.5 Pro Preview 03-25",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-03-25",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13223,7 +15028,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-05-06": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.5 Pro Preview 05-06",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-05-06",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13272,6 +15079,9 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-06-05": {
+        "display_name": "Gemini 2.5 Pro Preview 06-05",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-06-05",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 1.25e-06,
         "input_cost_per_token": 1.25e-06,
@@ -13317,6 +15127,8 @@
         "supports_web_search": true
     },
     "gemini-2.5-pro-preview-tts": {
+        "display_name": "Gemini 2.5 Pro Preview TTS",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -13352,6 +15164,9 @@
         "supports_web_search": true
     },
     "gemini-embedding-001": {
+        "display_name": "Gemini Embedding 001",
+        "model_vendor": "google",
+        "model_version": "embedding-001",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-embedding-models",
         "max_input_tokens": 2048,
@@ -13362,6 +15177,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models"
     },
     "gemini-flash-experimental": {
+        "display_name": "Gemini Flash Experimental",
+        "model_vendor": "google",
         "input_cost_per_character": 0,
         "input_cost_per_token": 0,
         "litellm_provider": "vertex_ai-language-models",
@@ -13377,6 +15194,8 @@
         "supports_tool_choice": true
     },
     "gemini-pro": {
+        "display_name": "Gemini Pro",
+        "model_vendor": "google",
         "input_cost_per_character": 1.25e-07,
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
@@ -13394,6 +15213,8 @@
         "supports_tool_choice": true
     },
     "gemini-pro-experimental": {
+        "display_name": "Gemini Pro Experimental",
+        "model_vendor": "google",
         "input_cost_per_character": 0,
         "input_cost_per_token": 0,
         "litellm_provider": "vertex_ai-language-models",
@@ -13409,6 +15230,8 @@
         "supports_tool_choice": true
     },
     "gemini-pro-vision": {
+        "display_name": "Gemini Pro Vision",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-vision-models",
@@ -13427,6 +15250,9 @@
         "supports_vision": true
     },
     "gemini/gemini-embedding-001": {
+        "display_name": "Gemini Embedding 001",
+        "model_vendor": "google",
+        "model_version": "embedding-001",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 2048,
@@ -13439,7 +15265,8 @@
         "tpm": 10000000
     },
     "gemini/gemini-1.5-flash": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash",
+        "model_vendor": "google",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13465,6 +15292,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-001": {
+        "display_name": "Gemini 1.5 Flash 001",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-001",
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 1.875e-08,
         "deprecation_date": "2025-05-24",
@@ -13494,6 +15324,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-002": {
+        "display_name": "Gemini 1.5 Flash 002",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-002",
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 1.875e-08,
         "deprecation_date": "2025-09-24",
@@ -13523,7 +15356,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash 8B",
+        "model_vendor": "google",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13550,7 +15384,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0827": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash 8B Experimental 0827",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-8b-exp-0827",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13576,7 +15412,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-8b-exp-0924": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash 8B Experimental 0924",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-8b-exp-0924",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13603,7 +15441,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-exp-0827": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash Experimental 0827",
+        "model_vendor": "google",
+        "model_version": "1.5-flash-exp-0827",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13629,7 +15469,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-flash-latest": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Flash Latest",
+        "model_vendor": "google",
         "input_cost_per_token": 7.5e-08,
         "input_cost_per_token_above_128k_tokens": 1.5e-07,
         "litellm_provider": "gemini",
@@ -13656,7 +15497,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13676,6 +15518,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-001": {
+        "display_name": "Gemini 1.5 Pro 001",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-001",
         "deprecation_date": "2025-05-24",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
@@ -13697,6 +15542,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-002": {
+        "display_name": "Gemini 1.5 Pro 002",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-002",
         "deprecation_date": "2025-09-24",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
@@ -13718,7 +15566,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0801": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Experimental 0801",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-exp-0801",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13738,7 +15588,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-exp-0827": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Experimental 0827",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-exp-0827",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -13758,7 +15610,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-1.5-pro-latest": {
-        "deprecation_date": "2025-09-29",
+        "display_name": "Gemini 1.5 Pro Latest",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-06,
         "input_cost_per_token_above_128k_tokens": 7e-06,
         "litellm_provider": "gemini",
@@ -13778,6 +15631,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash": {
+        "display_name": "Gemini 2.0 Flash",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -13818,6 +15673,9 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-001": {
+        "display_name": "Gemini 2.0 Flash 001",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-001",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -13856,6 +15714,8 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-exp": {
+        "display_name": "Gemini 2.0 Flash Experimental",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -13905,6 +15765,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-lite": {
+        "display_name": "Gemini 2.0 Flash Lite",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
@@ -13941,7 +15803,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-lite-preview-02-05": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.0 Flash Lite Preview 02-05",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-lite-preview-02-05",
         "cache_read_input_token_cost": 1.875e-08,
         "input_cost_per_audio_token": 7.5e-08,
         "input_cost_per_token": 7.5e-08,
@@ -13979,7 +15843,9 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-live-001": {
-        "deprecation_date": "2025-12-09",
+        "display_name": "Gemini 2.0 Flash Live 001",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-live-001",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 2.1e-06,
         "input_cost_per_image": 2.1e-06,
@@ -14028,7 +15894,8 @@
         "tpm": 250000
     },
     "gemini/gemini-2.0-flash-preview-image-generation": {
-        "deprecation_date": "2025-11-14",
+        "display_name": "Gemini 2.0 Flash Preview Image Generation",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
@@ -14068,7 +15935,8 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.0-flash-thinking-exp": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.0 Flash Thinking Experimental",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14118,7 +15986,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-flash-thinking-exp-01-21": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.0 Flash Thinking Experimental 01-21",
+        "model_vendor": "google",
+        "model_version": "2.0-flash-thinking-exp-01-21",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14169,6 +16039,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-2.0-pro-exp-02-05": {
+        "display_name": "Gemini 2.0 Pro Experimental 02-05",
+        "model_vendor": "google",
+        "model_version": "2.0-pro-exp-02-05",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
@@ -14210,6 +16083,8 @@
         "tpm": 1000000
     },
     "gemini/gemini-2.5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14257,6 +16132,8 @@
         "tpm": 8000000
     },
     "gemini/gemini-2.5-flash-image": {
+        "display_name": "Gemini 2.5 Flash Image",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14273,7 +16150,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -14307,7 +16183,8 @@
         "tpm": 8000000
     },
     "gemini/gemini-2.5-flash-image-preview": {
-        "deprecation_date": "2026-01-15",
+        "display_name": "Gemini 2.5 Flash Image Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14323,7 +16200,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 3e-05,
         "output_cost_per_token": 3e-05,
         "rpm": 100000,
@@ -14357,6 +16233,8 @@
         "tpm": 8000000
     },
     "gemini/gemini-3-pro-image-preview": {
+        "display_name": "Gemini 3 Pro Image Preview",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -14366,7 +16244,7 @@
         "max_tokens": 65536,
         "mode": "image_generation",
         "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 1.2e-04,
+        "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "rpm": 1000,
         "tpm": 4000000,
@@ -14393,6 +16271,8 @@
         "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-lite": {
+        "display_name": "Gemini 2.5 Flash Lite",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -14440,6 +16320,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-09-2025": {
+        "display_name": "Gemini 2.5 Flash Lite Preview 09-2025",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-lite-preview-09-2025",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
@@ -14487,6 +16370,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
+        "display_name": "Gemini 2.5 Flash Preview 09-2025",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-09-2025",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14534,6 +16420,8 @@
         "tpm": 250000
     },
     "gemini/gemini-flash-latest": {
+        "display_name": "Gemini Flash Latest",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14581,6 +16469,8 @@
         "tpm": 250000
     },
     "gemini/gemini-flash-lite-latest": {
+        "display_name": "Gemini Flash Lite Latest",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
@@ -14628,7 +16518,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
-        "deprecation_date": "2025-11-18",
+        "display_name": "Gemini 2.5 Flash Lite Preview 06-17",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-lite-preview-06-17",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
@@ -14676,6 +16568,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-04-17": {
+        "display_name": "Gemini 2.5 Flash Preview 04-17",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-04-17",
         "cache_read_input_token_cost": 3.75e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 1.5e-07,
@@ -14720,7 +16615,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-05-20": {
-        "deprecation_date": "2025-11-18",
+        "display_name": "Gemini 2.5 Flash Preview 05-20",
+        "model_vendor": "google",
+        "model_version": "2.5-flash-preview-05-20",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -14766,6 +16663,8 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-flash-preview-tts": {
+        "display_name": "Gemini 2.5 Flash Preview TTS",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3.75e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 1.5e-07,
@@ -14806,6 +16705,8 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
@@ -14851,6 +16752,9 @@
         "tpm": 800000
     },
     "gemini/gemini-2.5-computer-use-preview-10-2025": {
+        "display_name": "Gemini 2.5 Computer Use Preview 10 2025",
+        "model_vendor": "google",
+        "model_version": "2.5",
         "input_cost_per_token": 1.25e-06,
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
         "litellm_provider": "gemini",
@@ -14882,6 +16786,8 @@
         "tpm": 800000
     },
     "gemini/gemini-3-pro-preview": {
+        "display_name": "Gemini 3 Pro Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "input_cost_per_token": 2e-06,
@@ -14930,99 +16836,10 @@
         "supports_web_search": true,
         "tpm": 800000
     },
-    "gemini/gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 5e-08,
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "gemini",
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "mode": "chat",
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 3e-06,
-        "rpm": 2000,
-        "source": "https://ai.google.dev/pricing/gemini-3",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image",
-            "audio",
-            "video"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_audio_output": false,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_url_context": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "tpm": 800000
-    },
-    "gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 5e-08,
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "vertex_ai-language-models",
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "mode": "chat",
-        "output_cost_per_reasoning_token": 3e-06,
-        "output_cost_per_token": 3e-06,
-        "source": "https://ai.google.dev/pricing/gemini-3",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image",
-            "audio",
-            "video"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_audio_output": false,
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_url_context": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "gemini/gemini-2.5-pro-exp-03-25": {
+        "display_name": "Gemini 2.5 Pro Experimental 03-25",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-exp-03-25",
         "cache_read_input_token_cost": 0.0,
         "input_cost_per_token": 0.0,
         "input_cost_per_token_above_200k_tokens": 0.0,
@@ -15067,7 +16884,9 @@
         "tpm": 250000
     },
     "gemini/gemini-2.5-pro-preview-03-25": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.5 Pro Preview 03-25",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-03-25",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15108,7 +16927,9 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.5-pro-preview-05-06": {
-        "deprecation_date": "2025-12-02",
+        "display_name": "Gemini 2.5 Pro Preview 05-06",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-05-06",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15150,6 +16971,9 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.5-pro-preview-06-05": {
+        "display_name": "Gemini 2.5 Pro Preview 06-05",
+        "model_vendor": "google",
+        "model_version": "2.5-pro-preview-06-05",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15191,6 +17015,8 @@
         "tpm": 10000000
     },
     "gemini/gemini-2.5-pro-preview-tts": {
+        "display_name": "Gemini 2.5 Pro Preview TTS",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3.125e-07,
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
@@ -15227,6 +17053,9 @@
         "tpm": 10000000
     },
     "gemini/gemini-exp-1114": {
+        "display_name": "Gemini Experimental 1114",
+        "model_vendor": "google",
+        "model_version": "exp-1114",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -15256,6 +17085,9 @@
         "tpm": 4000000
     },
     "gemini/gemini-exp-1206": {
+        "display_name": "Gemini Experimental 1206",
+        "model_vendor": "google",
+        "model_version": "exp-1206",
         "input_cost_per_token": 0,
         "input_cost_per_token_above_128k_tokens": 0,
         "litellm_provider": "gemini",
@@ -15285,6 +17117,8 @@
         "tpm": 4000000
     },
     "gemini/gemini-gemma-2-27b-it": {
+        "display_name": "Gemma 2 27B IT",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "gemini",
         "max_output_tokens": 8192,
@@ -15297,6 +17131,8 @@
         "supports_vision": true
     },
     "gemini/gemini-gemma-2-9b-it": {
+        "display_name": "Gemma 2 9B IT",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "gemini",
         "max_output_tokens": 8192,
@@ -15309,6 +17145,8 @@
         "supports_vision": true
     },
     "gemini/gemini-pro": {
+        "display_name": "Gemini Pro",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-07,
         "input_cost_per_token_above_128k_tokens": 7e-07,
         "litellm_provider": "gemini",
@@ -15326,6 +17164,8 @@
         "tpm": 120000
     },
     "gemini/gemini-pro-vision": {
+        "display_name": "Gemini Pro Vision",
+        "model_vendor": "google",
         "input_cost_per_token": 3.5e-07,
         "input_cost_per_token_above_128k_tokens": 7e-07,
         "litellm_provider": "gemini",
@@ -15344,6 +17184,8 @@
         "tpm": 120000
     },
     "gemini/gemma-3-27b-it": {
+        "display_name": "Gemma 3 27B IT",
+        "model_vendor": "google",
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
         "input_cost_per_character": 0,
@@ -15372,43 +17214,63 @@
         "supports_vision": true
     },
     "gemini/imagen-3.0-fast-generate-001": {
+        "display_name": "Imagen 3.0 Fast Generate 001",
+        "model_vendor": "google",
+        "model_version": "3.0-fast-generate-001",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-3.0-generate-001": {
+        "display_name": "Imagen 3.0 Generate 001",
+        "model_vendor": "google",
+        "model_version": "3.0-generate-001",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-3.0-generate-002": {
-        "deprecation_date": "2025-11-10",
+        "display_name": "Imagen 3.0 Generate 002",
+        "model_vendor": "google",
+        "model_version": "3.0-generate-002",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-fast-generate-001": {
+        "display_name": "Imagen 4.0 Fast Generate 001",
+        "model_vendor": "google",
+        "model_version": "4.0-fast-generate-001",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-generate-001": {
+        "display_name": "Imagen 4.0 Generate 001",
+        "model_vendor": "google",
+        "model_version": "4.0-generate-001",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/imagen-4.0-ultra-generate-001": {
+        "display_name": "Imagen 4.0 Ultra Generate 001",
+        "model_vendor": "google",
+        "model_version": "4.0-ultra-generate-001",
         "litellm_provider": "gemini",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "gemini/learnlm-1.5-pro-experimental": {
+        "display_name": "LearnLM 1.5 Pro Experimental",
+        "model_vendor": "google",
+        "model_version": "1.5-pro-experimental",
         "input_cost_per_audio_per_second": 0,
         "input_cost_per_audio_per_second_above_128k_tokens": 0,
         "input_cost_per_character": 0,
@@ -15437,6 +17299,9 @@
         "supports_vision": true
     },
     "gemini/veo-2.0-generate-001": {
+        "display_name": "Veo 2.0 Generate 001",
+        "model_vendor": "google",
+        "model_version": "2.0-generate-001",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15451,7 +17316,9 @@
         ]
     },
     "gemini/veo-3.0-fast-generate-preview": {
-        "deprecation_date": "2025-11-12",
+        "display_name": "Veo 3.0 Fast Generate Preview",
+        "model_vendor": "google",
+        "model_version": "3.0-fast-generate-preview",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15466,7 +17333,9 @@
         ]
     },
     "gemini/veo-3.0-generate-preview": {
-        "deprecation_date": "2025-11-12",
+        "display_name": "Veo 3.0 Generate Preview",
+        "model_vendor": "google",
+        "model_version": "3.0-generate-preview",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15481,6 +17350,9 @@
         ]
     },
     "gemini/veo-3.1-fast-generate-preview": {
+        "display_name": "Veo 3.1 Fast Generate Preview",
+        "model_vendor": "google",
+        "model_version": "3.1-fast-generate-preview",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -15495,39 +17367,14 @@
         ]
     },
     "gemini/veo-3.1-generate-preview": {
+        "display_name": "Veo 3.1 Generate Preview",
+        "model_vendor": "google",
+        "model_version": "3.1-generate-preview",
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
         "mode": "video_generation",
-        "output_cost_per_second": 0.40,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "gemini/veo-3.1-fast-generate-001": {
-        "litellm_provider": "gemini",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "gemini/veo-3.1-generate-001": {
-        "litellm_provider": "gemini",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.40,
+        "output_cost_per_second": 0.4,
         "source": "https://ai.google.dev/gemini-api/docs/video",
         "supported_modalities": [
             "text"
@@ -15537,69 +17384,81 @@
         ]
     },
     "github_copilot/claude-haiku-4.5": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
     "github_copilot/claude-opus-4.5": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
     "github_copilot/claude-opus-41": {
+        "display_name": "Claude Opus 41",
+        "model_vendor": "anthropic",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 80000,
         "max_output_tokens": 16000,
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_vision": true
     },
     "github_copilot/claude-sonnet-4": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
     "github_copilot/claude-sonnet-4.5": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true
     },
     "github_copilot/gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -15610,6 +17469,8 @@
         "supports_vision": true
     },
     "github_copilot/gemini-3-pro-preview": {
+        "display_name": "Gemini 3 Pro Preview",
+        "model_vendor": "google",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -15620,6 +17481,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-3.5-turbo": {
+        "display_name": "GPT 3.5 Turbo",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
@@ -15628,6 +17491,8 @@
         "supports_function_calling": true
     },
     "github_copilot/gpt-3.5-turbo-0613": {
+        "display_name": "GPT 3.5 Turbo 0613",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 16384,
         "max_output_tokens": 4096,
@@ -15636,6 +17501,8 @@
         "supports_function_calling": true
     },
     "github_copilot/gpt-4": {
+        "display_name": "GPT 4",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
@@ -15644,6 +17511,8 @@
         "supports_function_calling": true
     },
     "github_copilot/gpt-4-0613": {
+        "display_name": "GPT 4 0613",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 32768,
         "max_output_tokens": 4096,
@@ -15652,6 +17521,8 @@
         "supports_function_calling": true
     },
     "github_copilot/gpt-4-o-preview": {
+        "display_name": "GPT 4 o Preview",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 4096,
@@ -15661,6 +17532,8 @@
         "supports_parallel_function_calling": true
     },
     "github_copilot/gpt-4.1": {
+        "display_name": "GPT 4.1",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
@@ -15672,6 +17545,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-4.1-2025-04-14": {
+        "display_name": "GPT 4.1 2025 04 14",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16384,
@@ -15683,10 +17558,14 @@
         "supports_vision": true
     },
     "github_copilot/gpt-41-copilot": {
+        "display_name": "GPT 41 Copilot",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "mode": "completion"
     },
     "github_copilot/gpt-4o": {
+        "display_name": "GPT 4o",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 4096,
@@ -15697,6 +17576,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-4o-2024-05-13": {
+        "display_name": "GPT 4o 2024 05 13",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 4096,
@@ -15707,6 +17588,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-4o-2024-08-06": {
+        "display_name": "GPT 4o 2024 08 06",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 16384,
@@ -15716,6 +17599,8 @@
         "supports_parallel_function_calling": true
     },
     "github_copilot/gpt-4o-2024-11-20": {
+        "display_name": "GPT 4o 2024 11 20",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 16384,
@@ -15726,6 +17611,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-4o-mini": {
+        "display_name": "GPT 4o Mini",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 4096,
@@ -15735,6 +17622,8 @@
         "supports_parallel_function_calling": true
     },
     "github_copilot/gpt-4o-mini-2024-07-18": {
+        "display_name": "GPT 4o Mini 2024 07 18",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 64000,
         "max_output_tokens": 4096,
@@ -15744,14 +17633,16 @@
         "supports_parallel_function_calling": true
     },
     "github_copilot/gpt-5": {
+        "display_name": "GPT 5",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15759,6 +17650,8 @@
         "supports_vision": true
     },
     "github_copilot/gpt-5-mini": {
+        "display_name": "GPT 5 Mini",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -15770,14 +17663,16 @@
         "supports_vision": true
     },
     "github_copilot/gpt-5.1": {
+        "display_name": "GPT 5.1",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15785,13 +17680,15 @@
         "supports_vision": true
     },
     "github_copilot/gpt-5.1-codex-max": {
+        "display_name": "GPT 5.1 Codex Max",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "supported_endpoints": [
-            "/v1/responses"
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15799,14 +17696,16 @@
         "supports_vision": true
     },
     "github_copilot/gpt-5.2": {
+        "display_name": "GPT 5.2",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15814,24 +17713,32 @@
         "supports_vision": true
     },
     "github_copilot/text-embedding-3-small": {
+        "display_name": "Text Embedding 3 Small",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
         "mode": "embedding"
     },
     "github_copilot/text-embedding-3-small-inference": {
+        "display_name": "Text Embedding 3 Small Inference",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
         "mode": "embedding"
     },
     "github_copilot/text-embedding-ada-002": {
+        "display_name": "Text Embedding Ada 002",
+        "model_vendor": "openai",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 8191,
         "max_tokens": 8191,
         "mode": "embedding"
     },
     "google.gemma-3-12b-it": {
+        "display_name": "Gemma 3 12B It",
+        "model_vendor": "google",
         "input_cost_per_token": 9e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -15843,6 +17750,8 @@
         "supports_vision": true
     },
     "google.gemma-3-27b-it": {
+        "display_name": "Gemma 3 27B It",
+        "model_vendor": "google",
         "input_cost_per_token": 2.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -15854,6 +17763,8 @@
         "supports_vision": true
     },
     "google.gemma-3-4b-it": {
+        "display_name": "Gemma 3 4B It",
+        "model_vendor": "google",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -15865,11 +17776,16 @@
         "supports_vision": true
     },
     "google_pse/search": {
+        "display_name": "Google PSE Search",
+        "model_vendor": "google",
         "input_cost_per_query": 0.005,
         "litellm_provider": "google_pse",
         "mode": "search"
     },
     "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -15900,6 +17816,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "global.anthropic.claude-sonnet-4-20250514-v1:0": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -15930,6 +17849,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
@@ -15952,6 +17874,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "global.amazon.nova-2-lite-v1:0": {
+        "display_name": "Amazon.nova 2 Lite V1:0",
+        "model_vendor": "amazon",
+        "model_version": "0",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
@@ -15969,7 +17894,9 @@
         "supports_vision": true
     },
     "gpt-3.5-turbo": {
-        "input_cost_per_token": 0.5e-06,
+        "display_name": "GPT-3.5 Turbo",
+        "model_vendor": "openai",
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
         "max_output_tokens": 4096,
@@ -15982,6 +17909,9 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0125": {
+        "display_name": "GPT-3.5 Turbo 0125",
+        "model_vendor": "openai",
+        "model_version": "0125",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -15996,6 +17926,9 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0301": {
+        "display_name": "GPT-3.5 Turbo 0301",
+        "model_vendor": "openai",
+        "model_version": "0301",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 4097,
@@ -16008,6 +17941,9 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-0613": {
+        "display_name": "GPT-3.5 Turbo 0613",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 4097,
@@ -16021,6 +17957,9 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-1106": {
+        "display_name": "GPT-3.5 Turbo 1106",
+        "model_vendor": "openai",
+        "model_version": "1106",
         "deprecation_date": "2026-09-28",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "openai",
@@ -16036,6 +17975,8 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-16k": {
+        "display_name": "GPT-3.5 Turbo 16K",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -16048,6 +17989,9 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-16k-0613": {
+        "display_name": "GPT-3.5 Turbo 16K 0613",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 16385,
@@ -16060,6 +18004,8 @@
         "supports_tool_choice": true
     },
     "gpt-3.5-turbo-instruct": {
+        "display_name": "GPT-3.5 Turbo Instruct",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 8192,
@@ -16069,6 +18015,9 @@
         "output_cost_per_token": 2e-06
     },
     "gpt-3.5-turbo-instruct-0914": {
+        "display_name": "GPT-3.5 Turbo Instruct 0914",
+        "model_vendor": "openai",
+        "model_version": "0914",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "text-completion-openai",
         "max_input_tokens": 8192,
@@ -16078,6 +18027,8 @@
         "output_cost_per_token": 2e-06
     },
     "gpt-4": {
+        "display_name": "GPT-4",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -16091,6 +18042,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-0125-preview": {
+        "display_name": "GPT-4 0125 Preview",
+        "model_vendor": "openai",
+        "model_version": "0125-preview",
         "deprecation_date": "2026-03-26",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
@@ -16106,6 +18060,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-0314": {
+        "display_name": "GPT-4 0314",
+        "model_vendor": "openai",
+        "model_version": "0314",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 8192,
@@ -16118,6 +18075,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-0613": {
+        "display_name": "GPT-4 0613",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "deprecation_date": "2025-06-06",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openai",
@@ -16132,6 +18092,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-1106-preview": {
+        "display_name": "GPT-4 1106 Preview",
+        "model_vendor": "openai",
+        "model_version": "1106-preview",
         "deprecation_date": "2026-03-26",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
@@ -16147,6 +18110,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-1106-vision-preview": {
+        "display_name": "GPT-4 1106 Vision Preview",
+        "model_vendor": "openai",
+        "model_version": "1106-vision-preview",
         "deprecation_date": "2024-12-06",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
@@ -16162,6 +18128,8 @@
         "supports_vision": true
     },
     "gpt-4-32k": {
+        "display_name": "GPT-4 32K",
+        "model_vendor": "openai",
         "input_cost_per_token": 6e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -16174,6 +18142,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-32k-0314": {
+        "display_name": "GPT-4 32K 0314",
+        "model_vendor": "openai",
+        "model_version": "0314",
         "input_cost_per_token": 6e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -16186,6 +18157,9 @@
         "supports_tool_choice": true
     },
     "gpt-4-32k-0613": {
+        "display_name": "GPT-4 32K 0613",
+        "model_vendor": "openai",
+        "model_version": "0613",
         "input_cost_per_token": 6e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -16198,6 +18172,8 @@
         "supports_tool_choice": true
     },
     "gpt-4-turbo": {
+        "display_name": "GPT-4 Turbo",
+        "model_vendor": "openai",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -16214,6 +18190,9 @@
         "supports_vision": true
     },
     "gpt-4-turbo-2024-04-09": {
+        "display_name": "GPT-4 Turbo",
+        "model_vendor": "openai",
+        "model_version": "2024-04-09",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -16230,6 +18209,8 @@
         "supports_vision": true
     },
     "gpt-4-turbo-preview": {
+        "display_name": "GPT-4 Turbo Preview",
+        "model_vendor": "openai",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 128000,
@@ -16245,6 +18226,8 @@
         "supports_tool_choice": true
     },
     "gpt-4-vision-preview": {
+        "display_name": "GPT-4 Vision Preview",
+        "model_vendor": "openai",
         "deprecation_date": "2024-12-06",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openai",
@@ -16260,6 +18243,8 @@
         "supports_vision": true
     },
     "gpt-4.1": {
+        "display_name": "GPT-4.1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_priority": 8.75e-07,
         "input_cost_per_token": 2e-06,
@@ -16297,6 +18282,9 @@
         "supports_vision": true
     },
     "gpt-4.1-2025-04-14": {
+        "display_name": "GPT-4.1",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -16331,6 +18319,8 @@
         "supports_vision": true
     },
     "gpt-4.1-mini": {
+        "display_name": "GPT-4.1 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1e-07,
         "cache_read_input_token_cost_priority": 1.75e-07,
         "input_cost_per_token": 4e-07,
@@ -16368,6 +18358,9 @@
         "supports_vision": true
     },
     "gpt-4.1-mini-2025-04-14": {
+        "display_name": "GPT-4.1 Mini",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 4e-07,
         "input_cost_per_token_batches": 2e-07,
@@ -16402,6 +18395,8 @@
         "supports_vision": true
     },
     "gpt-4.1-nano": {
+        "display_name": "GPT-4.1 Nano",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 1e-07,
@@ -16439,6 +18434,9 @@
         "supports_vision": true
     },
     "gpt-4.1-nano-2025-04-14": {
+        "display_name": "GPT-4.1 Nano",
+        "model_vendor": "openai",
+        "model_version": "2025-04-14",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
@@ -16473,6 +18471,8 @@
         "supports_vision": true
     },
     "gpt-4.5-preview": {
+        "display_name": "GPT-4.5 Preview",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 3.75e-05,
         "input_cost_per_token": 7.5e-05,
         "input_cost_per_token_batches": 3.75e-05,
@@ -16493,6 +18493,9 @@
         "supports_vision": true
     },
     "gpt-4.5-preview-2025-02-27": {
+        "display_name": "GPT-4.5 Preview",
+        "model_vendor": "openai",
+        "model_version": "2025-02-27",
         "cache_read_input_token_cost": 3.75e-05,
         "deprecation_date": "2025-07-14",
         "input_cost_per_token": 7.5e-05,
@@ -16514,6 +18517,8 @@
         "supports_vision": true
     },
     "gpt-4o": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost_priority": 2.125e-06,
         "input_cost_per_token": 2.5e-06,
@@ -16538,6 +18543,9 @@
         "supports_vision": true
     },
     "gpt-4o-2024-05-13": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
+        "model_version": "2024-05-13",
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_batches": 2.5e-06,
         "input_cost_per_token_priority": 8.75e-06,
@@ -16558,6 +18566,9 @@
         "supports_vision": true
     },
     "gpt-4o-2024-08-06": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
+        "model_version": "2024-08-06",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
@@ -16579,6 +18590,9 @@
         "supports_vision": true
     },
     "gpt-4o-2024-11-20": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
+        "model_version": "2024-11-20",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
@@ -16600,6 +18614,8 @@
         "supports_vision": true
     },
     "gpt-4o-audio-preview": {
+        "display_name": "GPT-4o Audio Preview",
+        "model_vendor": "openai",
         "input_cost_per_audio_token": 0.0001,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -16617,6 +18633,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2024-10-01": {
+        "display_name": "GPT-4o Audio Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-10-01",
         "input_cost_per_audio_token": 0.0001,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -16634,6 +18653,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2024-12-17": {
+        "display_name": "GPT-4o Audio Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -16651,6 +18673,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-audio-preview-2025-06-03": {
+        "display_name": "GPT-4o Audio Preview",
+        "model_vendor": "openai",
+        "model_version": "2025-06-03",
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -16668,6 +18693,8 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini": {
+        "display_name": "GPT-4o Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 7.5e-08,
         "cache_read_input_token_cost_priority": 1.25e-07,
         "input_cost_per_token": 1.5e-07,
@@ -16692,6 +18719,9 @@
         "supports_vision": true
     },
     "gpt-4o-mini-2024-07-18": {
+        "display_name": "GPT-4o Mini",
+        "model_vendor": "openai",
+        "model_version": "2024-07-18",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
@@ -16718,6 +18748,8 @@
         "supports_vision": true
     },
     "gpt-4o-mini-audio-preview": {
+        "display_name": "GPT-4o Mini Audio Preview",
+        "model_vendor": "openai",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -16735,6 +18767,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini-audio-preview-2024-12-17": {
+        "display_name": "GPT-4o Mini Audio Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openai",
@@ -16752,6 +18787,8 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini-realtime-preview": {
+        "display_name": "GPT-4o Mini Realtime Preview",
+        "model_vendor": "openai",
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_audio_token": 1e-05,
@@ -16771,6 +18808,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini-realtime-preview-2024-12-17": {
+        "display_name": "GPT-4o Mini Realtime Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_audio_token": 1e-05,
@@ -16790,6 +18830,8 @@
         "supports_tool_choice": true
     },
     "gpt-4o-mini-search-preview": {
+        "display_name": "GPT-4o Mini Search Preview",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
@@ -16816,6 +18858,9 @@
         "supports_web_search": true
     },
     "gpt-4o-mini-search-preview-2025-03-11": {
+        "display_name": "GPT-4o Mini Search Preview",
+        "model_vendor": "openai",
+        "model_version": "2025-03-11",
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
         "input_cost_per_token_batches": 7.5e-08,
@@ -16836,6 +18881,8 @@
         "supports_vision": true
     },
     "gpt-4o-mini-transcribe": {
+        "display_name": "GPT-4o Mini Transcribe",
+        "model_vendor": "openai",
         "input_cost_per_audio_token": 3e-06,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -16848,6 +18895,8 @@
         ]
     },
     "gpt-4o-mini-tts": {
+        "display_name": "GPT-4o Mini TTS",
+        "model_vendor": "openai",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
         "mode": "audio_speech",
@@ -16866,6 +18915,8 @@
         ]
     },
     "gpt-4o-realtime-preview": {
+        "display_name": "GPT-4o Realtime Preview",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
@@ -16884,6 +18935,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-realtime-preview-2024-10-01": {
+        "display_name": "GPT-4o Realtime Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-10-01",
         "cache_creation_input_audio_token_cost": 2e-05,
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_audio_token": 0.0001,
@@ -16903,6 +18957,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-realtime-preview-2024-12-17": {
+        "display_name": "GPT-4o Realtime Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
@@ -16921,6 +18978,9 @@
         "supports_tool_choice": true
     },
     "gpt-4o-realtime-preview-2025-06-03": {
+        "display_name": "GPT-4o Realtime Preview",
+        "model_vendor": "openai",
+        "model_version": "2025-06-03",
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_audio_token": 4e-05,
         "input_cost_per_token": 5e-06,
@@ -16939,6 +18999,8 @@
         "supports_tool_choice": true
     },
     "gpt-4o-search-preview": {
+        "display_name": "GPT-4o Search Preview",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
@@ -16965,6 +19027,9 @@
         "supports_web_search": true
     },
     "gpt-4o-search-preview-2025-03-11": {
+        "display_name": "GPT-4o Search Preview",
+        "model_vendor": "openai",
+        "model_version": "2025-03-11",
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
         "input_cost_per_token_batches": 1.25e-06,
@@ -16985,6 +19050,8 @@
         "supports_vision": true
     },
     "gpt-4o-transcribe": {
+        "display_name": "GPT-4o Transcribe",
+        "model_vendor": "openai",
         "input_cost_per_audio_token": 6e-06,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openai",
@@ -16996,367 +19063,9 @@
             "/v1/audio/transcriptions"
         ]
     },
-    "gpt-image-1.5": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "output_cost_per_token": 1e-05,
-        "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "gpt-image-1.5-2025-12-16": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "output_cost_per_token": 1e-05,
-        "input_cost_per_image_token": 8e-06,
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1024-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1024-x-1536/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1536-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1024-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.034,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1024-x-1536/gpt-image-1.5": {
-        "input_cost_per_image": 0.05,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1536-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.05,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1024-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.133,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1024-x-1536/gpt-image-1.5": {
-        "input_cost_per_image": 0.20,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1536-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.20,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1024-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1024-x-1536/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1536-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1024-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1024-x-1536/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1536-x-1024/gpt-image-1.5": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1024-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1024-x-1536/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "low/1536-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1024-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.034,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1024-x-1536/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.05,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "medium/1536-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.05,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1024-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.133,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1024-x-1536/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.20,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "high/1536-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.20,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1024-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1024-x-1536/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "standard/1536-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1024-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.009,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1024-x-1536/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
-    "1536-x-1024/gpt-image-1.5-2025-12-16": {
-        "input_cost_per_image": 0.013,
-        "litellm_provider": "openai",
-        "mode": "image_generation",
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ],
-        "supports_vision": true,
-        "supports_pdf_input": true
-    },
     "gpt-5": {
+        "display_name": "GPT-5",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_flex": 6.25e-08,
         "cache_read_input_token_cost_priority": 2.5e-07,
@@ -17396,6 +19105,8 @@
         "supports_vision": true
     },
     "gpt-5.1": {
+        "display_name": "GPT-5.1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
@@ -17432,6 +19143,9 @@
         "supports_vision": true
     },
     "gpt-5.1-2025-11-13": {
+        "display_name": "GPT-5.1",
+        "model_vendor": "openai",
+        "model_version": "2025-11-13",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
@@ -17468,6 +19182,8 @@
         "supports_vision": true
     },
     "gpt-5.1-chat-latest": {
+        "display_name": "GPT-5.1 Chat Latest",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
@@ -17503,6 +19219,9 @@
         "supports_vision": true
     },
     "gpt-5.2": {
+        "display_name": "GPT 5.2",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
@@ -17540,6 +19259,9 @@
         "supports_vision": true
     },
     "gpt-5.2-2025-12-11": {
+        "display_name": "GPT 5.2 2025 12 11",
+        "model_vendor": "openai",
+        "model_version": "2025-12-11",
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
@@ -17577,6 +19299,9 @@
         "supports_vision": true
     },
     "gpt-5.2-chat-latest": {
+        "display_name": "GPT 5.2 Chat Latest",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
         "input_cost_per_token": 1.75e-06,
@@ -17611,13 +19336,16 @@
         "supports_vision": true
     },
     "gpt-5.2-pro": {
+        "display_name": "GPT 5.2 Pro",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
-        "output_cost_per_token": 1.68e-04,
+        "output_cost_per_token": 0.000168,
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -17642,13 +19370,16 @@
         "supports_web_search": true
     },
     "gpt-5.2-pro-2025-12-11": {
+        "display_name": "GPT 5.2 Pro 2025 12 11",
+        "model_vendor": "openai",
+        "model_version": "2025-12-11",
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "openai",
         "max_input_tokens": 400000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
-        "output_cost_per_token": 1.68e-04,
+        "output_cost_per_token": 0.000168,
         "supported_endpoints": [
             "/v1/batch",
             "/v1/responses"
@@ -17673,6 +19404,8 @@
         "supports_web_search": true
     },
     "gpt-5-pro": {
+        "display_name": "GPT-5 Pro",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
@@ -17680,7 +19413,7 @@
         "max_output_tokens": 272000,
         "max_tokens": 272000,
         "mode": "responses",
-        "output_cost_per_token": 1.2e-04,
+        "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
         "supported_endpoints": [
             "/v1/batch",
@@ -17706,6 +19439,9 @@
         "supports_web_search": true
     },
     "gpt-5-pro-2025-10-06": {
+        "display_name": "GPT-5 Pro",
+        "model_vendor": "openai",
+        "model_version": "2025-10-06",
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
@@ -17713,7 +19449,7 @@
         "max_output_tokens": 272000,
         "max_tokens": 272000,
         "mode": "responses",
-        "output_cost_per_token": 1.2e-04,
+        "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
         "supported_endpoints": [
             "/v1/batch",
@@ -17739,6 +19475,9 @@
         "supports_web_search": true
     },
     "gpt-5-2025-08-07": {
+        "display_name": "GPT-5",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_flex": 6.25e-08,
         "cache_read_input_token_cost_priority": 2.5e-07,
@@ -17778,6 +19517,8 @@
         "supports_vision": true
     },
     "gpt-5-chat": {
+        "display_name": "GPT-5 Chat",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -17810,6 +19551,8 @@
         "supports_vision": true
     },
     "gpt-5-chat-latest": {
+        "display_name": "GPT-5 Chat Latest",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -17842,6 +19585,8 @@
         "supports_vision": true
     },
     "gpt-5-codex": {
+        "display_name": "GPT-5 Codex",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -17872,6 +19617,8 @@
         "supports_vision": true
     },
     "gpt-5.1-codex": {
+        "display_name": "GPT-5.1 Codex",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_priority": 2.5e-07,
         "input_cost_per_token": 1.25e-06,
@@ -17905,6 +19652,9 @@
         "supports_vision": true
     },
     "gpt-5.1-codex-max": {
+        "display_name": "GPT 5.1 Codex Max",
+        "model_vendor": "openai",
+        "model_version": "5.1",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openai",
@@ -17935,6 +19685,8 @@
         "supports_vision": true
     },
     "gpt-5.1-codex-mini": {
+        "display_name": "GPT-5.1 Codex Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
         "input_cost_per_token": 2.5e-07,
@@ -17968,6 +19720,8 @@
         "supports_vision": true
     },
     "gpt-5-mini": {
+        "display_name": "GPT-5 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
@@ -18007,6 +19761,9 @@
         "supports_vision": true
     },
     "gpt-5-mini-2025-08-07": {
+        "display_name": "GPT-5 Mini",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
         "cache_read_input_token_cost_priority": 4.5e-08,
@@ -18046,6 +19803,8 @@
         "supports_vision": true
     },
     "gpt-5-nano": {
+        "display_name": "GPT-5 Nano",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-09,
         "cache_read_input_token_cost_flex": 2.5e-09,
         "input_cost_per_token": 5e-08,
@@ -18082,6 +19841,9 @@
         "supports_vision": true
     },
     "gpt-5-nano-2025-08-07": {
+        "display_name": "GPT-5 Nano",
+        "model_vendor": "openai",
+        "model_version": "2025-08-07",
         "cache_read_input_token_cost": 5e-09,
         "cache_read_input_token_cost_flex": 2.5e-09,
         "input_cost_per_token": 5e-08,
@@ -18117,19 +19879,23 @@
         "supports_vision": true
     },
     "gpt-image-1": {
-        "cache_read_input_image_token_cost": 2.5e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_image_token": 1e-05,
+        "display_name": "GPT Image 1",
+        "model_vendor": "openai",
+        "input_cost_per_image": 0.042,
+        "input_cost_per_pixel": 4.0054321e-08,
         "input_cost_per_token": 5e-06,
+        "input_cost_per_image_token": 1e-05,
         "litellm_provider": "openai",
         "mode": "image_generation",
-        "output_cost_per_image_token": 4e-05,
+        "output_cost_per_pixel": 0.0,
+        "output_cost_per_token": 4e-05,
         "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
+            "/v1/images/generations"
         ]
     },
     "gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini",
+        "model_vendor": "openai",
         "cache_read_input_image_token_cost": 2.5e-07,
         "cache_read_input_token_cost": 2e-07,
         "input_cost_per_image_token": 2.5e-06,
@@ -18143,6 +19909,8 @@
         ]
     },
     "gpt-realtime": {
+        "display_name": "GPT Realtime",
+        "model_vendor": "openai",
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
         "input_cost_per_audio_token": 3.2e-05,
@@ -18175,6 +19943,8 @@
         "supports_tool_choice": true
     },
     "gpt-realtime-mini": {
+        "display_name": "GPT Realtime Mini",
+        "model_vendor": "openai",
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
         "input_cost_per_audio_token": 1e-05,
@@ -18206,6 +19976,9 @@
         "supports_tool_choice": true
     },
     "gpt-realtime-2025-08-28": {
+        "display_name": "GPT Realtime",
+        "model_vendor": "openai",
+        "model_version": "2025-08-28",
         "cache_creation_input_audio_token_cost": 4e-07,
         "cache_read_input_token_cost": 4e-07,
         "input_cost_per_audio_token": 3.2e-05,
@@ -18238,6 +20011,8 @@
         "supports_tool_choice": true
     },
     "gradient_ai/alibaba-qwen3-32b": {
+        "display_name": "Qwen3 32B",
+        "model_vendor": "alibaba",
         "litellm_provider": "gradient_ai",
         "max_tokens": 2048,
         "mode": "chat",
@@ -18250,6 +20025,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/anthropic-claude-3-opus": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "gradient_ai",
         "max_tokens": 1024,
@@ -18264,6 +20041,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/anthropic-claude-3.5-haiku": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "gradient_ai",
         "max_tokens": 1024,
@@ -18278,6 +20057,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/anthropic-claude-3.5-sonnet": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "gradient_ai",
         "max_tokens": 1024,
@@ -18292,6 +20073,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/anthropic-claude-3.7-sonnet": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "gradient_ai",
         "max_tokens": 1024,
@@ -18306,6 +20089,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/deepseek-r1-distill-llama-70b": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 9.9e-07,
         "litellm_provider": "gradient_ai",
         "max_tokens": 8000,
@@ -18320,6 +20105,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/llama3-8b-instruct": {
+        "display_name": "Llama 3 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "gradient_ai",
         "max_tokens": 512,
@@ -18334,6 +20121,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/llama3.3-70b-instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "gradient_ai",
         "max_tokens": 2048,
@@ -18348,6 +20137,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/mistral-nemo-instruct-2407": {
+        "display_name": "Mistral Nemo Instruct 2407",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "gradient_ai",
         "max_tokens": 512,
@@ -18362,6 +20153,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/openai-gpt-4o": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
         "litellm_provider": "gradient_ai",
         "max_tokens": 16384,
         "mode": "chat",
@@ -18374,6 +20167,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/openai-gpt-4o-mini": {
+        "display_name": "GPT-4o Mini",
+        "model_vendor": "openai",
         "litellm_provider": "gradient_ai",
         "max_tokens": 16384,
         "mode": "chat",
@@ -18386,6 +20181,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/openai-o3": {
+        "display_name": "o3",
+        "model_vendor": "openai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "gradient_ai",
         "max_tokens": 100000,
@@ -18400,6 +20197,8 @@
         "supports_tool_choice": false
     },
     "gradient_ai/openai-o3-mini": {
+        "display_name": "o3 Mini",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "gradient_ai",
         "max_tokens": 100000,
@@ -18414,6 +20213,8 @@
         "supports_tool_choice": false
     },
     "lemonade/Qwen3-Coder-30B-A3B-Instruct-GGUF": {
+        "display_name": "Qwen3 Coder 30B A3B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 0,
         "litellm_provider": "lemonade",
         "max_tokens": 262144,
@@ -18426,6 +20227,8 @@
         "supports_tool_choice": true
     },
     "lemonade/gpt-oss-20b-mxfp4-GGUF": {
+        "display_name": "GPT OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 0,
         "litellm_provider": "lemonade",
         "max_tokens": 131072,
@@ -18438,6 +20241,8 @@
         "supports_tool_choice": true
     },
     "lemonade/gpt-oss-120b-mxfp-GGUF": {
+        "display_name": "GPT OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 0,
         "litellm_provider": "lemonade",
         "max_tokens": 131072,
@@ -18450,6 +20255,8 @@
         "supports_tool_choice": true
     },
     "lemonade/Gemma-3-4b-it-GGUF": {
+        "display_name": "Gemma 3 4B IT",
+        "model_vendor": "google",
         "input_cost_per_token": 0,
         "litellm_provider": "lemonade",
         "max_tokens": 128000,
@@ -18462,6 +20269,8 @@
         "supports_tool_choice": true
     },
     "lemonade/Qwen3-4B-Instruct-2507-GGUF": {
+        "display_name": "Qwen3 4B Instruct 2507",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 0,
         "litellm_provider": "lemonade",
         "max_tokens": 262144,
@@ -18474,6 +20283,8 @@
         "supports_tool_choice": true
     },
     "amazon-nova/nova-micro-v1": {
+        "display_name": "Nova Micro V1",
+        "model_vendor": "amazon",
         "input_cost_per_token": 3.5e-08,
         "litellm_provider": "amazon_nova",
         "max_input_tokens": 128000,
@@ -18486,6 +20297,8 @@
         "supports_response_schema": true
     },
     "amazon-nova/nova-lite-v1": {
+        "display_name": "Nova Lite V1",
+        "model_vendor": "amazon",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "amazon_nova",
         "max_input_tokens": 300000,
@@ -18500,6 +20313,8 @@
         "supports_vision": true
     },
     "amazon-nova/nova-premier-v1": {
+        "display_name": "Nova Premier V1",
+        "model_vendor": "amazon",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "amazon_nova",
         "max_input_tokens": 1000000,
@@ -18514,6 +20329,8 @@
         "supports_vision": true
     },
     "amazon-nova/nova-pro-v1": {
+        "display_name": "Nova Pro V1",
+        "model_vendor": "amazon",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "amazon_nova",
         "max_input_tokens": 300000,
@@ -18527,7 +20344,90 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "groq/deepseek-r1-distill-llama-70b": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 9.9e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/distil-whisper-large-v3-en": {
+        "display_name": "Distil Whisper Large V3 EN",
+        "model_vendor": "openai",
+        "input_cost_per_second": 5.56e-06,
+        "litellm_provider": "groq",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0
+    },
+    "groq/gemma-7b-it": {
+        "display_name": "Gemma 7B IT",
+        "model_vendor": "google",
+        "deprecation_date": "2024-12-18",
+        "input_cost_per_token": 7e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/gemma2-9b-it": {
+        "display_name": "Gemma 2 9B IT",
+        "model_vendor": "google",
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_function_calling": false,
+        "supports_response_schema": false,
+        "supports_tool_choice": false
+    },
+    "groq/llama-3.1-405b-reasoning": {
+        "display_name": "Llama 3.1 405B Reasoning",
+        "model_vendor": "meta",
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.1-70b-versatile": {
+        "display_name": "Llama 3.1 70B Versatile",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-01-24",
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
     "groq/llama-3.1-8b-instant": {
+        "display_name": "Llama 3.1 8B Instant",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "groq",
         "max_input_tokens": 128000,
@@ -18539,7 +20439,114 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/llama-3.2-11b-text-preview": {
+        "display_name": "Llama 3.2 11B Text Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2024-10-28",
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-11b-vision-preview": {
+        "display_name": "Llama 3.2 11B Vision Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "groq/llama-3.2-1b-preview": {
+        "display_name": "Llama 3.2 1B Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-3b-preview": {
+        "display_name": "Llama 3.2 3B Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-90b-text-preview": {
+        "display_name": "Llama 3.2 90B Text Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2024-11-25",
+        "input_cost_per_token": 9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-90b-vision-preview": {
+        "display_name": "Llama 3.2 90B Vision Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "groq/llama-3.3-70b-specdec": {
+        "display_name": "Llama 3.3 70B SpecDec",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9.9e-07,
+        "supports_tool_choice": true
+    },
     "groq/llama-3.3-70b-versatile": {
+        "display_name": "Llama 3.3 70B Versatile",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 128000,
@@ -18551,19 +20558,9 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
-    "groq/gemma-7b-it": {
-        "input_cost_per_token": 5e-08,
-        "litellm_provider": "groq",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 8e-08,
-        "supports_function_calling": true,
-        "supports_response_schema": false,
-        "supports_tool_choice": true
-    },
-    "groq/meta-llama/llama-guard-4-12b": {
+    "groq/llama-guard-3-8b": {
+        "display_name": "Llama Guard 3 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 8192,
@@ -18572,7 +20569,53 @@
         "mode": "chat",
         "output_cost_per_token": 2e-07
     },
+    "groq/llama2-70b-4096": {
+        "display_name": "Llama 2 70B",
+        "model_vendor": "meta",
+        "input_cost_per_token": 7e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama3-groq-70b-8192-tool-use-preview": {
+        "display_name": "Llama 3 Groq 70B Tool Use Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-01-06",
+        "input_cost_per_token": 8.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama3-groq-8b-8192-tool-use-preview": {
+        "display_name": "Llama 3 Groq 8B Tool Use Preview",
+        "model_vendor": "meta",
+        "deprecation_date": "2025-01-06",
+        "input_cost_per_token": 1.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
     "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -18582,10 +20625,11 @@
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.1e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -18595,13 +20639,55 @@
         "output_cost_per_token": 3.4e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
+    },
+    "groq/mistral-saba-24b": {
+        "display_name": "Mistral Saba 24B",
+        "model_vendor": "mistralai",
+        "input_cost_per_token": 7.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07
+    },
+    "groq/mixtral-8x7b-32768": {
+        "display_name": "Mixtral 8x7B",
+        "model_vendor": "mistralai",
+        "deprecation_date": "2025-03-20",
+        "input_cost_per_token": 2.4e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/moonshotai/kimi-k2-instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "groq/moonshotai/kimi-k2-instruct-0905": {
+        "display_name": "Kimi K2 Instruct 0905",
+        "model_vendor": "moonshot",
+        "model_version": "0905",
         "input_cost_per_token": 1e-06,
         "output_cost_per_token": 3e-06,
-        "cache_read_input_token_cost": 0.5e-06,
+        "cache_read_input_token_cost": 5e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 262144,
         "max_output_tokens": 16384,
@@ -18612,6 +20698,8 @@
         "supports_tool_choice": true
     },
     "groq/openai/gpt-oss-120b": {
+        "display_name": "GPT OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -18627,6 +20715,8 @@
         "supports_web_search": true
     },
     "groq/openai/gpt-oss-20b": {
+        "display_name": "GPT OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131072,
@@ -18642,6 +20732,8 @@
         "supports_web_search": true
     },
     "groq/playai-tts": {
+        "display_name": "PlayAI TTS",
+        "model_vendor": "playai",
         "input_cost_per_character": 5e-05,
         "litellm_provider": "groq",
         "max_input_tokens": 10000,
@@ -18650,6 +20742,8 @@
         "mode": "audio_speech"
     },
     "groq/qwen/qwen3-32b": {
+        "display_name": "Qwen 3 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2.9e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 131000,
@@ -18663,36 +20757,50 @@
         "supports_tool_choice": true
     },
     "groq/whisper-large-v3": {
+        "display_name": "Whisper Large V3",
+        "model_vendor": "openai",
+        "model_version": "large-v3",
         "input_cost_per_second": 3.083e-05,
         "litellm_provider": "groq",
         "mode": "audio_transcription",
         "output_cost_per_second": 0.0
     },
     "groq/whisper-large-v3-turbo": {
+        "display_name": "Whisper Large V3 Turbo",
+        "model_vendor": "openai",
+        "model_version": "large-v3-turbo",
         "input_cost_per_second": 1.111e-05,
         "litellm_provider": "groq",
         "mode": "audio_transcription",
         "output_cost_per_second": 0.0
     },
     "hd/1024-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 HD 1024x1024",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 7.629e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "hd/1024-x-1792/dall-e-3": {
+        "display_name": "DALL-E 3 HD 1024x1792",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 6.539e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "hd/1792-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 HD 1792x1024",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 6.539e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "heroku/claude-3-5-haiku": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
         "litellm_provider": "heroku",
         "max_tokens": 4096,
         "mode": "chat",
@@ -18701,6 +20809,8 @@
         "supports_tool_choice": true
     },
     "heroku/claude-3-5-sonnet-latest": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "litellm_provider": "heroku",
         "max_tokens": 8192,
         "mode": "chat",
@@ -18709,6 +20819,8 @@
         "supports_tool_choice": true
     },
     "heroku/claude-3-7-sonnet": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
         "litellm_provider": "heroku",
         "max_tokens": 8192,
         "mode": "chat",
@@ -18717,6 +20829,8 @@
         "supports_tool_choice": true
     },
     "heroku/claude-4-sonnet": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "litellm_provider": "heroku",
         "max_tokens": 8192,
         "mode": "chat",
@@ -18725,6 +20839,8 @@
         "supports_tool_choice": true
     },
     "high/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 High 1024x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.167,
         "input_cost_per_pixel": 1.59263611e-07,
         "litellm_provider": "openai",
@@ -18735,6 +20851,8 @@
         ]
     },
     "high/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 High 1024x1536",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.25,
         "input_cost_per_pixel": 1.58945719e-07,
         "litellm_provider": "openai",
@@ -18745,6 +20863,8 @@
         ]
     },
     "high/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 High 1536x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.25,
         "input_cost_per_pixel": 1.58945719e-07,
         "litellm_provider": "openai",
@@ -18755,6 +20875,8 @@
         ]
     },
     "hyperbolic/NousResearch/Hermes-3-Llama-3.1-70B": {
+        "display_name": "Hermes 3 Llama 3.1 70B",
+        "model_vendor": "nousresearch",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18768,6 +20890,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/Qwen/QwQ-32B": {
+        "display_name": "QwQ 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18781,6 +20905,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/Qwen/Qwen2.5-72B-Instruct": {
+        "display_name": "Qwen 2.5 72B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18794,6 +20920,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/Qwen/Qwen2.5-Coder-32B-Instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18807,6 +20935,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/Qwen/Qwen3-235B-A22B": {
+        "display_name": "Qwen 3 235B A22B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18820,6 +20950,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/deepseek-ai/DeepSeek-R1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18833,6 +20965,9 @@
         "supports_tool_choice": true
     },
     "hyperbolic/deepseek-ai/DeepSeek-R1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18846,6 +20981,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/deepseek-ai/DeepSeek-V3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18859,6 +20996,9 @@
         "supports_tool_choice": true
     },
     "hyperbolic/deepseek-ai/DeepSeek-V3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18872,6 +21012,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Llama-3.2-3B-Instruct": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18885,6 +21027,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18898,6 +21042,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Meta-Llama-3-70B-Instruct": {
+        "display_name": "Meta Llama 3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18911,6 +21057,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Meta-Llama-3.1-405B-Instruct": {
+        "display_name": "Meta Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18924,6 +21072,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct": {
+        "display_name": "Meta Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18937,6 +21087,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/meta-llama/Meta-Llama-3.1-8B-Instruct": {
+        "display_name": "Meta Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 32768,
@@ -18950,6 +21102,8 @@
         "supports_tool_choice": true
     },
     "hyperbolic/moonshotai/Kimi-K2-Instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "hyperbolic",
         "max_input_tokens": 131072,
@@ -18963,6 +21117,8 @@
         "supports_tool_choice": true
     },
     "j2-light": {
+        "display_name": "J2 Light",
+        "model_vendor": "ai21",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "ai21",
         "max_input_tokens": 8192,
@@ -18972,6 +21128,8 @@
         "output_cost_per_token": 3e-06
     },
     "j2-mid": {
+        "display_name": "J2 Mid",
+        "model_vendor": "ai21",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "ai21",
         "max_input_tokens": 8192,
@@ -18981,6 +21139,8 @@
         "output_cost_per_token": 1e-05
     },
     "j2-ultra": {
+        "display_name": "J2 Ultra",
+        "model_vendor": "ai21",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "ai21",
         "max_input_tokens": 8192,
@@ -18990,6 +21150,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "jamba-1.5": {
+        "display_name": "Jamba 1.5",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19000,6 +21162,8 @@
         "supports_tool_choice": true
     },
     "jamba-1.5-large": {
+        "display_name": "Jamba 1.5 Large",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19010,6 +21174,8 @@
         "supports_tool_choice": true
     },
     "jamba-1.5-large@001": {
+        "display_name": "Jamba 1.5 Large @001",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19020,6 +21186,8 @@
         "supports_tool_choice": true
     },
     "jamba-1.5-mini": {
+        "display_name": "Jamba 1.5 Mini",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19030,6 +21198,8 @@
         "supports_tool_choice": true
     },
     "jamba-1.5-mini@001": {
+        "display_name": "Jamba 1.5 Mini @001",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19040,6 +21210,9 @@
         "supports_tool_choice": true
     },
     "jamba-large-1.6": {
+        "display_name": "Jamba Large 1.6",
+        "model_vendor": "ai21",
+        "model_version": "1.6",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19050,6 +21223,9 @@
         "supports_tool_choice": true
     },
     "jamba-large-1.7": {
+        "display_name": "Jamba Large 1.7",
+        "model_vendor": "ai21",
+        "model_version": "1.7",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19060,6 +21236,9 @@
         "supports_tool_choice": true
     },
     "jamba-mini-1.6": {
+        "display_name": "Jamba Mini 1.6",
+        "model_vendor": "ai21",
+        "model_version": "1.6",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19070,6 +21249,9 @@
         "supports_tool_choice": true
     },
     "jamba-mini-1.7": {
+        "display_name": "Jamba Mini 1.7",
+        "model_vendor": "ai21",
+        "model_version": "1.7",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "ai21",
         "max_input_tokens": 256000,
@@ -19080,6 +21262,8 @@
         "supports_tool_choice": true
     },
     "jina-reranker-v2-base-multilingual": {
+        "display_name": "Jina Reranker V2 Base Multilingual",
+        "model_vendor": "jina",
         "input_cost_per_token": 1.8e-08,
         "litellm_provider": "jina_ai",
         "max_document_chunks_per_query": 2048,
@@ -19090,6 +21274,9 @@
         "output_cost_per_token": 1.8e-08
     },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
@@ -19120,6 +21307,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -19142,6 +21332,8 @@
         "tool_use_system_prompt_tokens": 346
     },
     "lambda_ai/deepseek-llama3.3-70b": {
+        "display_name": "DeepSeek Llama 3.3 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19156,6 +21348,9 @@
         "supports_tool_choice": true
     },
     "lambda_ai/deepseek-r1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19170,6 +21365,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/deepseek-r1-671b": {
+        "display_name": "DeepSeek R1 671B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19184,6 +21381,9 @@
         "supports_tool_choice": true
     },
     "lambda_ai/deepseek-v3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19197,6 +21397,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/hermes3-405b": {
+        "display_name": "Hermes 3 405B",
+        "model_vendor": "nousresearch",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19210,6 +21412,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/hermes3-70b": {
+        "display_name": "Hermes 3 70B",
+        "model_vendor": "nousresearch",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19223,6 +21427,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/hermes3-8b": {
+        "display_name": "Hermes 3 8B",
+        "model_vendor": "nousresearch",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19236,6 +21442,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/lfm-40b": {
+        "display_name": "LFM 40B",
+        "model_vendor": "lambda",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19249,6 +21457,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/lfm-7b": {
+        "display_name": "LFM 7B",
+        "model_vendor": "lambda",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19262,6 +21472,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama-4-maverick-17b-128e-instruct-fp8": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19275,6 +21487,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama-4-scout-17b-16e-instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 16384,
@@ -19288,6 +21502,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.1-405b-instruct-fp8": {
+        "display_name": "Llama 3.1 405B Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19301,6 +21517,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.1-70b-instruct-fp8": {
+        "display_name": "Llama 3.1 70B Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19314,6 +21532,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.1-8b-instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19327,6 +21547,9 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.1-nemotron-70b-instruct-fp8": {
+        "display_name": "Llama 3.1 Nemotron 70B Instruct FP8",
+        "model_vendor": "nvidia",
+        "model_version": "3.1-nemotron",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19340,6 +21563,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.2-11b-vision-instruct": {
+        "display_name": "Llama 3.2 11B Vision Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19354,6 +21579,8 @@
         "supports_vision": true
     },
     "lambda_ai/llama3.2-3b-instruct": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19367,6 +21594,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/llama3.3-70b-instruct-fp8": {
+        "display_name": "Llama 3.3 70B Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19380,6 +21609,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/qwen25-coder-32b-instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19393,6 +21624,8 @@
         "supports_tool_choice": true
     },
     "lambda_ai/qwen3-32b-fp8": {
+        "display_name": "Qwen 3 32B FP8",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "lambda_ai",
         "max_input_tokens": 131072,
@@ -19407,6 +21640,8 @@
         "supports_tool_choice": true
     },
     "low/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Low 1024x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.011,
         "input_cost_per_pixel": 1.0490417e-08,
         "litellm_provider": "openai",
@@ -19417,6 +21652,8 @@
         ]
     },
     "low/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 Low 1024x1536",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.016,
         "input_cost_per_pixel": 1.0172526e-08,
         "litellm_provider": "openai",
@@ -19427,6 +21664,8 @@
         ]
     },
     "low/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Low 1536x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.016,
         "input_cost_per_pixel": 1.0172526e-08,
         "litellm_provider": "openai",
@@ -19437,6 +21676,8 @@
         ]
     },
     "luminous-base": {
+        "display_name": "Luminous Base",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19444,6 +21685,8 @@
         "output_cost_per_token": 3.3e-05
     },
     "luminous-base-control": {
+        "display_name": "Luminous Base Control",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 3.75e-05,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19451,6 +21694,8 @@
         "output_cost_per_token": 4.125e-05
     },
     "luminous-extended": {
+        "display_name": "Luminous Extended",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 4.5e-05,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19458,6 +21703,8 @@
         "output_cost_per_token": 4.95e-05
     },
     "luminous-extended-control": {
+        "display_name": "Luminous Extended Control",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 5.625e-05,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19465,6 +21712,8 @@
         "output_cost_per_token": 6.1875e-05
     },
     "luminous-supreme": {
+        "display_name": "Luminous Supreme",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 0.000175,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19472,6 +21721,8 @@
         "output_cost_per_token": 0.0001925
     },
     "luminous-supreme-control": {
+        "display_name": "Luminous Supreme Control",
+        "model_vendor": "aleph_alpha",
         "input_cost_per_token": 0.00021875,
         "litellm_provider": "aleph_alpha",
         "max_tokens": 2048,
@@ -19479,6 +21730,9 @@
         "output_cost_per_token": 0.000240625
     },
     "max-x-max/50-steps/stability.stable-diffusion-xl-v0": {
+        "display_name": "Stable Diffusion XL V0 50 Steps",
+        "model_vendor": "stability",
+        "model_version": "xl-v0",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -19486,6 +21740,9 @@
         "output_cost_per_image": 0.036
     },
     "max-x-max/max-steps/stability.stable-diffusion-xl-v0": {
+        "display_name": "Stable Diffusion XL V0 Max Steps",
+        "model_vendor": "stability",
+        "model_version": "xl-v0",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -19493,6 +21750,8 @@
         "output_cost_per_image": 0.072
     },
     "medium/1024-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium 1024x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.042,
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "openai",
@@ -19503,6 +21762,8 @@
         ]
     },
     "medium/1024-x-1536/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium 1024x1536",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.063,
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "openai",
@@ -19513,6 +21774,8 @@
         ]
     },
     "medium/1536-x-1024/gpt-image-1": {
+        "display_name": "GPT Image 1 Medium 1536x1024",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.063,
         "input_cost_per_pixel": 4.0054321e-08,
         "litellm_provider": "openai",
@@ -19523,6 +21786,9 @@
         ]
     },
     "low/1024-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low 1024x1024",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.005,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19531,6 +21797,9 @@
         ]
     },
     "low/1024-x-1536/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low 1024x1536",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.006,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19539,6 +21808,9 @@
         ]
     },
     "low/1536-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Low 1536x1024",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.006,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19547,6 +21819,9 @@
         ]
     },
     "medium/1024-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium 1024x1024",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.011,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19555,6 +21830,9 @@
         ]
     },
     "medium/1024-x-1536/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium 1024x1536",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.015,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19563,6 +21841,9 @@
         ]
     },
     "medium/1536-x-1024/gpt-image-1-mini": {
+        "display_name": "GPT Image 1 Mini Medium 1536x1024",
+        "model_vendor": "openai",
+        "model_version": "1-mini",
         "input_cost_per_image": 0.015,
         "litellm_provider": "openai",
         "mode": "image_generation",
@@ -19571,6 +21852,8 @@
         ]
     },
     "medlm-large": {
+        "display_name": "MedLM Large",
+        "model_vendor": "google",
         "input_cost_per_character": 5e-06,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 8192,
@@ -19582,6 +21865,8 @@
         "supports_tool_choice": true
     },
     "medlm-medium": {
+        "display_name": "MedLM Medium",
+        "model_vendor": "google",
         "input_cost_per_character": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 32768,
@@ -19593,6 +21878,8 @@
         "supports_tool_choice": true
     },
     "meta.llama2-13b-chat-v1": {
+        "display_name": "Llama 2 13B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
@@ -19602,6 +21889,8 @@
         "output_cost_per_token": 1e-06
     },
     "meta.llama2-70b-chat-v1": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.95e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 4096,
@@ -19611,6 +21900,8 @@
         "output_cost_per_token": 2.56e-06
     },
     "meta.llama3-1-405b-instruct-v1:0": {
+        "display_name": "Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.32e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19622,6 +21913,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-1-70b-instruct-v1:0": {
+        "display_name": "Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 9.9e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19633,6 +21926,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-1-8b-instruct-v1:0": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19644,6 +21939,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-2-11b-instruct-v1:0": {
+        "display_name": "Llama 3.2 11B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19656,6 +21953,8 @@
         "supports_vision": true
     },
     "meta.llama3-2-1b-instruct-v1:0": {
+        "display_name": "Llama 3.2 1B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19667,6 +21966,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-2-3b-instruct-v1:0": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19678,6 +21979,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-2-90b-instruct-v1:0": {
+        "display_name": "Llama 3.2 90B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19690,6 +21993,8 @@
         "supports_vision": true
     },
     "meta.llama3-3-70b-instruct-v1:0": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19701,6 +22006,8 @@
         "supports_tool_choice": false
     },
     "meta.llama3-70b-instruct-v1:0": {
+        "display_name": "Llama 3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
@@ -19710,6 +22017,8 @@
         "output_cost_per_token": 3.5e-06
     },
     "meta.llama3-8b-instruct-v1:0": {
+        "display_name": "Llama 3 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
@@ -19719,6 +22028,8 @@
         "output_cost_per_token": 6e-07
     },
     "meta.llama4-maverick-17b-instruct-v1:0": {
+        "display_name": "Llama 4 Maverick 17B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.4e-07,
         "input_cost_per_token_batches": 1.2e-07,
         "litellm_provider": "bedrock_converse",
@@ -19740,6 +22051,8 @@
         "supports_tool_choice": false
     },
     "meta.llama4-scout-17b-instruct-v1:0": {
+        "display_name": "Llama 4 Scout 17B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.7e-07,
         "input_cost_per_token_batches": 8.5e-08,
         "litellm_provider": "bedrock_converse",
@@ -19761,6 +22074,8 @@
         "supports_tool_choice": false
     },
     "meta_llama/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "litellm_provider": "meta_llama",
         "max_input_tokens": 128000,
         "max_output_tokens": 4028,
@@ -19777,6 +22092,8 @@
         "supports_tool_choice": true
     },
     "meta_llama/Llama-3.3-8B-Instruct": {
+        "display_name": "Llama 3.3 8B Instruct",
+        "model_vendor": "meta",
         "litellm_provider": "meta_llama",
         "max_input_tokens": 128000,
         "max_output_tokens": 4028,
@@ -19793,6 +22110,8 @@
         "supports_tool_choice": true
     },
     "meta_llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct FP8",
+        "model_vendor": "meta",
         "litellm_provider": "meta_llama",
         "max_input_tokens": 1000000,
         "max_output_tokens": 4028,
@@ -19810,6 +22129,8 @@
         "supports_tool_choice": true
     },
     "meta_llama/Llama-4-Scout-17B-16E-Instruct-FP8": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct FP8",
+        "model_vendor": "meta",
         "litellm_provider": "meta_llama",
         "max_input_tokens": 10000000,
         "max_output_tokens": 4028,
@@ -19827,6 +22148,8 @@
         "supports_tool_choice": true
     },
     "minimax.minimax-m2": {
+        "display_name": "Minimax M2",
+        "model_vendor": "minimax",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19836,81 +22159,9 @@
         "output_cost_per_token": 1.2e-06,
         "supports_system_messages": true
     },
-    "minimax/speech-02-hd": {
-        "input_cost_per_character": 0.0001,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-02-turbo": {
-        "input_cost_per_character": 0.00006,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-2.6-hd": {
-        "input_cost_per_character": 0.0001,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-2.6-turbo": {
-        "input_cost_per_character": 0.00006,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/MiniMax-M2.1": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2.1-lightning": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192
-    },
     "mistral.magistral-small-2509": {
+        "display_name": "Magistral Small 2509",
+        "model_vendor": "mistral",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19923,6 +22174,8 @@
         "supports_system_messages": true
     },
     "mistral.ministral-3-14b-instruct": {
+        "display_name": "Ministral 3 14B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19934,6 +22187,8 @@
         "supports_system_messages": true
     },
     "mistral.ministral-3-3b-instruct": {
+        "display_name": "Ministral 3 3B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19945,6 +22200,8 @@
         "supports_system_messages": true
     },
     "mistral.ministral-3-8b-instruct": {
+        "display_name": "Ministral 3 8B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19956,6 +22213,9 @@
         "supports_system_messages": true
     },
     "mistral.mistral-7b-instruct-v0:2": {
+        "display_name": "Mistral 7B Instruct V0.2",
+        "model_vendor": "mistralai",
+        "model_version": "0.2",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
@@ -19966,6 +22226,9 @@
         "supports_tool_choice": true
     },
     "mistral.mistral-large-2402-v1:0": {
+        "display_name": "Mistral Large 2402",
+        "model_vendor": "mistralai",
+        "model_version": "2402",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
@@ -19976,6 +22239,9 @@
         "supports_function_calling": true
     },
     "mistral.mistral-large-2407-v1:0": {
+        "display_name": "Mistral Large 2407",
+        "model_vendor": "mistralai",
+        "model_version": "2407",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -19987,6 +22253,8 @@
         "supports_tool_choice": true
     },
     "mistral.mistral-large-3-675b-instruct": {
+        "display_name": "Mistral Large 3 675B Instruct",
+        "model_vendor": "mistral",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -19998,6 +22266,9 @@
         "supports_system_messages": true
     },
     "mistral.mistral-small-2402-v1:0": {
+        "display_name": "Mistral Small 2402",
+        "model_vendor": "mistralai",
+        "model_version": "2402",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
@@ -20008,6 +22279,8 @@
         "supports_function_calling": true
     },
     "mistral.mixtral-8x7b-instruct-v0:1": {
+        "display_name": "Mixtral 8x7B Instruct V0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 32000,
@@ -20018,6 +22291,8 @@
         "supports_tool_choice": true
     },
     "mistral.voxtral-mini-3b-2507": {
+        "display_name": "Voxtral Mini 3B 2507",
+        "model_vendor": "mistral",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -20029,6 +22304,8 @@
         "supports_system_messages": true
     },
     "mistral.voxtral-small-24b-2507": {
+        "display_name": "Voxtral Small 24B 2507",
+        "model_vendor": "mistral",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -20040,6 +22317,9 @@
         "supports_system_messages": true
     },
     "mistral/codestral-2405": {
+        "display_name": "Codestral 2405",
+        "model_vendor": "mistralai",
+        "model_version": "2405",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20052,6 +22332,8 @@
         "supports_tool_choice": true
     },
     "mistral/codestral-2508": {
+        "display_name": "Mistral Codestral 2508",
+        "model_vendor": "mistral",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20066,6 +22348,8 @@
         "supports_tool_choice": true
     },
     "mistral/codestral-latest": {
+        "display_name": "Codestral Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20078,6 +22362,8 @@
         "supports_tool_choice": true
     },
     "mistral/codestral-mamba-latest": {
+        "display_name": "Codestral Mamba Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20090,6 +22376,9 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-medium-2507": {
+        "display_name": "Devstral Medium 2507",
+        "model_vendor": "mistralai",
+        "model_version": "2507",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20104,6 +22393,9 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-small-2505": {
+        "display_name": "Devstral Small 2505",
+        "model_vendor": "mistralai",
+        "model_version": "2505",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20118,6 +22410,9 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-small-2507": {
+        "display_name": "Devstral Small 2507",
+        "model_vendor": "mistralai",
+        "model_version": "2507",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20132,6 +22427,8 @@
         "supports_tool_choice": true
     },
     "mistral/labs-devstral-small-2512": {
+        "display_name": "Mistral Labs Devstral Small 2512",
+        "model_vendor": "mistral",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20146,6 +22443,8 @@
         "supports_tool_choice": true
     },
     "mistral/devstral-2512": {
+        "display_name": "Mistral Devstral 2512",
+        "model_vendor": "mistral",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20160,6 +22459,9 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-medium-2506": {
+        "display_name": "Magistral Medium 2506",
+        "model_vendor": "mistralai",
+        "model_version": "2506",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -20175,6 +22477,9 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-medium-2509": {
+        "display_name": "Magistral Medium 2509",
+        "model_vendor": "mistralai",
+        "model_version": "2509",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -20190,9 +22495,11 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-ocr-latest": {
+        "display_name": "Mistral OCR Latest",
+        "model_vendor": "mistralai",
         "litellm_provider": "mistral",
-        "ocr_cost_per_page": 1e-3,
-        "annotation_cost_per_page": 3e-3,
+        "ocr_cost_per_page": 0.001,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -20200,9 +22507,12 @@
         "source": "https://mistral.ai/pricing#api-pricing"
     },
     "mistral/mistral-ocr-2505-completion": {
+        "display_name": "Mistral OCR 2505 Completion",
+        "model_vendor": "mistralai",
+        "model_version": "2505",
         "litellm_provider": "mistral",
-        "ocr_cost_per_page": 1e-3,
-        "annotation_cost_per_page": 3e-3,
+        "ocr_cost_per_page": 0.001,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -20210,6 +22520,8 @@
         "source": "https://mistral.ai/pricing#api-pricing"
     },
     "mistral/magistral-medium-latest": {
+        "display_name": "Magistral Medium Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -20225,6 +22537,9 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-small-2506": {
+        "display_name": "Magistral Small 2506",
+        "model_vendor": "mistralai",
+        "model_version": "2506",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -20240,6 +22555,8 @@
         "supports_tool_choice": true
     },
     "mistral/magistral-small-latest": {
+        "display_name": "Magistral Small Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 40000,
@@ -20255,6 +22572,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-embed": {
+        "display_name": "Mistral Embed",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 8192,
@@ -20262,20 +22581,28 @@
         "mode": "embedding"
     },
     "mistral/codestral-embed": {
-        "input_cost_per_token": 0.15e-06,
+        "display_name": "Codestral Embed",
+        "model_vendor": "mistralai",
+        "input_cost_per_token": 1.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding"
     },
     "mistral/codestral-embed-2505": {
-        "input_cost_per_token": 0.15e-06,
+        "display_name": "Codestral Embed 2505",
+        "model_vendor": "mistralai",
+        "model_version": "2505",
+        "input_cost_per_token": 1.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 8192,
         "max_tokens": 8192,
         "mode": "embedding"
     },
     "mistral/mistral-large-2402": {
+        "display_name": "Mistral Large 2402",
+        "model_vendor": "mistralai",
+        "model_version": "2402",
         "input_cost_per_token": 4e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20289,6 +22616,9 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-2407": {
+        "display_name": "Mistral Large 2407",
+        "model_vendor": "mistralai",
+        "model_version": "2407",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20302,6 +22632,9 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-2411": {
+        "display_name": "Mistral Large 2411",
+        "model_vendor": "mistralai",
+        "model_version": "2411",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20315,6 +22648,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-latest": {
+        "display_name": "Mistral Large Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20328,6 +22663,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-large-3": {
+        "display_name": "Mistral Mistral Large 3",
+        "model_vendor": "mistral",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20343,6 +22680,8 @@
         "supports_vision": true
     },
     "mistral/mistral-medium": {
+        "display_name": "Mistral Medium",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2.7e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20355,6 +22694,9 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-2312": {
+        "display_name": "Mistral Medium 2312",
+        "model_vendor": "mistralai",
+        "model_version": "2312",
         "input_cost_per_token": 2.7e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20367,6 +22709,9 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-2505": {
+        "display_name": "Mistral Medium 2505",
+        "model_vendor": "mistralai",
+        "model_version": "2505",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -20380,6 +22725,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-medium-latest": {
+        "display_name": "Mistral Medium Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -20393,6 +22740,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-small": {
+        "display_name": "Mistral Small",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20406,6 +22755,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-small-latest": {
+        "display_name": "Mistral Small Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20419,6 +22770,8 @@
         "supports_tool_choice": true
     },
     "mistral/mistral-tiny": {
+        "display_name": "Mistral Tiny",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20431,6 +22784,8 @@
         "supports_tool_choice": true
     },
     "mistral/open-codestral-mamba": {
+        "display_name": "Open Codestral Mamba",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 256000,
@@ -20443,6 +22798,8 @@
         "supports_tool_choice": true
     },
     "mistral/open-mistral-7b": {
+        "display_name": "Open Mistral 7B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20455,6 +22812,8 @@
         "supports_tool_choice": true
     },
     "mistral/open-mistral-nemo": {
+        "display_name": "Open Mistral Nemo",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20468,6 +22827,9 @@
         "supports_tool_choice": true
     },
     "mistral/open-mistral-nemo-2407": {
+        "display_name": "Open Mistral Nemo 2407",
+        "model_vendor": "mistralai",
+        "model_version": "2407",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20481,6 +22843,8 @@
         "supports_tool_choice": true
     },
     "mistral/open-mixtral-8x22b": {
+        "display_name": "Open Mixtral 8x22B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 65336,
@@ -20494,6 +22858,8 @@
         "supports_tool_choice": true
     },
     "mistral/open-mixtral-8x7b": {
+        "display_name": "Open Mixtral 8x7B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 32000,
@@ -20507,6 +22873,9 @@
         "supports_tool_choice": true
     },
     "mistral/pixtral-12b-2409": {
+        "display_name": "Pixtral 12B 2409",
+        "model_vendor": "mistralai",
+        "model_version": "2409",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20521,6 +22890,9 @@
         "supports_vision": true
     },
     "mistral/pixtral-large-2411": {
+        "display_name": "Pixtral Large 2411",
+        "model_vendor": "mistralai",
+        "model_version": "2411",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20535,6 +22907,8 @@
         "supports_vision": true
     },
     "mistral/pixtral-large-latest": {
+        "display_name": "Pixtral Large Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",
         "max_input_tokens": 128000,
@@ -20549,6 +22923,8 @@
         "supports_vision": true
     },
     "moonshot.kimi-k2-thinking": {
+        "display_name": "Kimi K2 Thinking",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -20560,6 +22936,9 @@
         "supports_system_messages": true
     },
     "moonshot/kimi-k2-0711-preview": {
+        "display_name": "Kimi K2 0711 Preview",
+        "model_vendor": "moonshot",
+        "model_version": "k2-0711",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
@@ -20574,6 +22953,9 @@
         "supports_web_search": true
     },
     "moonshot/kimi-k2-0905-preview": {
+        "display_name": "Kimi K2 0905 Preview",
+        "model_vendor": "moonshot",
+        "model_version": "0905-preview",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
@@ -20588,6 +22970,9 @@
         "supports_web_search": true
     },
     "moonshot/kimi-k2-turbo-preview": {
+        "display_name": "Kimi K2 Turbo Preview",
+        "model_vendor": "moonshot",
+        "model_version": "turbo-preview",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
@@ -20602,6 +22987,8 @@
         "supports_web_search": true
     },
     "moonshot/kimi-latest": {
+        "display_name": "Kimi Latest",
+        "model_vendor": "moonshot",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
@@ -20616,6 +23003,8 @@
         "supports_vision": true
     },
     "moonshot/kimi-latest-128k": {
+        "display_name": "Kimi Latest 128K",
+        "model_vendor": "moonshot",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
@@ -20630,6 +23019,8 @@
         "supports_vision": true
     },
     "moonshot/kimi-latest-32k": {
+        "display_name": "Kimi Latest 32K",
+        "model_vendor": "moonshot",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
@@ -20644,6 +23035,8 @@
         "supports_vision": true
     },
     "moonshot/kimi-latest-8k": {
+        "display_name": "Kimi Latest 8K",
+        "model_vendor": "moonshot",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
@@ -20658,6 +23051,8 @@
         "supports_vision": true
     },
     "moonshot/kimi-thinking-preview": {
+        "display_name": "Kimi Thinking Preview",
+        "model_vendor": "moonshot",
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
@@ -20670,34 +23065,41 @@
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
-        "cache_read_input_token_cost": 1.5e-7,
-        "input_cost_per_token": 6e-7,
+        "display_name": "Kimi K2 Thinking",
+        "model_vendor": "moonshot",
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-6,
+        "output_cost_per_token": 2.5e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "moonshot/kimi-k2-thinking-turbo": {
-        "cache_read_input_token_cost": 1.5e-7,
-        "input_cost_per_token": 1.15e-6,
+        "display_name": "Kimi K2 Thinking Turbo",
+        "model_vendor": "moonshot",
+        "model_version": "thinking-turbo",
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.15e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 8e-6,
+        "output_cost_per_token": 8e-06,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "moonshot/moonshot-v1-128k": {
+        "display_name": "Moonshot V1 128K",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -20710,6 +23112,9 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-0430": {
+        "display_name": "Moonshot V1 128K 0430",
+        "model_vendor": "moonshot",
+        "model_version": "0430",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -20722,6 +23127,8 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-128k-vision-preview": {
+        "display_name": "Moonshot V1 128K Vision Preview",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -20735,6 +23142,8 @@
         "supports_vision": true
     },
     "moonshot/moonshot-v1-32k": {
+        "display_name": "Moonshot V1 32K",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -20747,6 +23156,9 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-0430": {
+        "display_name": "Moonshot V1 32K 0430",
+        "model_vendor": "moonshot",
+        "model_version": "0430",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -20759,6 +23171,8 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-32k-vision-preview": {
+        "display_name": "Moonshot V1 32K Vision Preview",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 32768,
@@ -20772,6 +23186,8 @@
         "supports_vision": true
     },
     "moonshot/moonshot-v1-8k": {
+        "display_name": "Moonshot V1 8K",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,
@@ -20784,6 +23200,9 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-0430": {
+        "display_name": "Moonshot V1 8K 0430",
+        "model_vendor": "moonshot",
+        "model_version": "0430",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,
@@ -20796,6 +23215,8 @@
         "supports_tool_choice": true
     },
     "moonshot/moonshot-v1-8k-vision-preview": {
+        "display_name": "Moonshot V1 8K Vision Preview",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 8192,
@@ -20809,6 +23230,8 @@
         "supports_vision": true
     },
     "moonshot/moonshot-v1-auto": {
+        "display_name": "Moonshot V1 Auto",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
@@ -20821,6 +23244,8 @@
         "supports_tool_choice": true
     },
     "morph/morph-v3-fast": {
+        "display_name": "Morph V3 Fast",
+        "model_vendor": "morph",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "morph",
         "max_input_tokens": 16000,
@@ -20835,6 +23260,8 @@
         "supports_vision": false
     },
     "morph/morph-v3-large": {
+        "display_name": "Morph V3 Large",
+        "model_vendor": "morph",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "morph",
         "max_input_tokens": 16000,
@@ -20849,6 +23276,8 @@
         "supports_vision": false
     },
     "multimodalembedding": {
+        "display_name": "Multimodal Embedding",
+        "model_vendor": "google",
         "input_cost_per_character": 2e-07,
         "input_cost_per_image": 0.0001,
         "input_cost_per_token": 8e-07,
@@ -20872,6 +23301,9 @@
         ]
     },
     "multimodalembedding@001": {
+        "display_name": "Multimodal Embedding 001",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_character": 2e-07,
         "input_cost_per_image": 0.0001,
         "input_cost_per_token": 8e-07,
@@ -20895,6 +23327,8 @@
         ]
     },
     "nscale/Qwen/QwQ-32B": {
+        "display_name": "QwQ 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "nscale",
         "mode": "chat",
@@ -20902,6 +23336,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/Qwen/Qwen2.5-Coder-32B-Instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "nscale",
         "mode": "chat",
@@ -20909,6 +23345,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/Qwen/Qwen2.5-Coder-3B-Instruct": {
+        "display_name": "Qwen 2.5 Coder 3B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1e-08,
         "litellm_provider": "nscale",
         "mode": "chat",
@@ -20916,6 +23354,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/Qwen/Qwen2.5-Coder-7B-Instruct": {
+        "display_name": "Qwen 2.5 Coder 7B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1e-08,
         "litellm_provider": "nscale",
         "mode": "chat",
@@ -20923,6 +23363,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/black-forest-labs/FLUX.1-schnell": {
+        "display_name": "FLUX.1 Schnell",
+        "model_vendor": "black_forest_labs",
         "input_cost_per_pixel": 1.3e-09,
         "litellm_provider": "nscale",
         "mode": "image_generation",
@@ -20933,6 +23375,8 @@
         ]
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 3.75e-07,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20943,6 +23387,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Llama-8B": {
+        "display_name": "DeepSeek R1 Distill Llama 8B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20953,6 +23399,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
+        "display_name": "DeepSeek R1 Distill Qwen 1.5B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 9e-08,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20963,6 +23411,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": {
+        "display_name": "DeepSeek R1 Distill Qwen 14B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20973,6 +23423,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": {
+        "display_name": "DeepSeek R1 Distill Qwen 32B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20983,6 +23435,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B": {
+        "display_name": "DeepSeek R1 Distill Qwen 7B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "nscale",
         "metadata": {
@@ -20993,6 +23447,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/meta-llama/Llama-3.1-8B-Instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 3e-08,
         "litellm_provider": "nscale",
         "metadata": {
@@ -21003,6 +23459,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/meta-llama/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "nscale",
         "metadata": {
@@ -21013,6 +23471,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 9e-08,
         "litellm_provider": "nscale",
         "mode": "chat",
@@ -21020,6 +23480,8 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/mistralai/mixtral-8x22b-instruct-v0.1": {
+        "display_name": "Mixtral 8x22B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "nscale",
         "metadata": {
@@ -21030,6 +23492,9 @@
         "source": "https://docs.nscale.com/docs/inference/serverless-models/current#chat-models"
     },
     "nscale/stabilityai/stable-diffusion-xl-base-1.0": {
+        "display_name": "Stable Diffusion XL Base 1.0",
+        "model_vendor": "stability",
+        "model_version": "xl-1.0",
         "input_cost_per_pixel": 3e-09,
         "litellm_provider": "nscale",
         "mode": "image_generation",
@@ -21040,6 +23505,8 @@
         ]
     },
     "nvidia.nemotron-nano-12b-v2": {
+        "display_name": "Nemotron Nano 12B V2",
+        "model_vendor": "nvidia",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -21051,6 +23518,8 @@
         "supports_vision": true
     },
     "nvidia.nemotron-nano-9b-v2": {
+        "display_name": "Nemotron Nano 9B V2",
+        "model_vendor": "nvidia",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -21061,6 +23530,8 @@
         "supports_system_messages": true
     },
     "o1": {
+        "display_name": "o1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
@@ -21080,6 +23551,9 @@
         "supports_vision": true
     },
     "o1-2024-12-17": {
+        "display_name": "o1",
+        "model_vendor": "openai",
+        "model_version": "2024-12-17",
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
@@ -21099,6 +23573,8 @@
         "supports_vision": true
     },
     "o1-mini": {
+        "display_name": "o1 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
@@ -21112,6 +23588,9 @@
         "supports_vision": true
     },
     "o1-mini-2024-09-12": {
+        "display_name": "o1 Mini",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "deprecation_date": "2025-10-27",
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 3e-06,
@@ -21127,6 +23606,8 @@
         "supports_vision": true
     },
     "o1-preview": {
+        "display_name": "o1 Preview",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
@@ -21141,6 +23622,9 @@
         "supports_vision": true
     },
     "o1-preview-2024-09-12": {
+        "display_name": "o1 Preview",
+        "model_vendor": "openai",
+        "model_version": "2024-09-12",
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openai",
@@ -21155,6 +23639,8 @@
         "supports_vision": true
     },
     "o1-pro": {
+        "display_name": "o1 Pro",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -21187,6 +23673,9 @@
         "supports_vision": true
     },
     "o1-pro-2025-03-19": {
+        "display_name": "o1 Pro",
+        "model_vendor": "openai",
+        "model_version": "2025-03-19",
         "input_cost_per_token": 0.00015,
         "input_cost_per_token_batches": 7.5e-05,
         "litellm_provider": "openai",
@@ -21219,6 +23708,8 @@
         "supports_vision": true
     },
     "o3": {
+        "display_name": "o3",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_flex": 2.5e-07,
         "cache_read_input_token_cost_priority": 8.75e-07,
@@ -21257,6 +23748,9 @@
         "supports_vision": true
     },
     "o3-2025-04-16": {
+        "display_name": "o3",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openai",
@@ -21289,6 +23783,8 @@
         "supports_vision": true
     },
     "o3-deep-research": {
+        "display_name": "o3 Deep Research",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_token": 1e-05,
         "input_cost_per_token_batches": 5e-06,
@@ -21322,6 +23818,9 @@
         "supports_vision": true
     },
     "o3-deep-research-2025-06-26": {
+        "display_name": "o3 Deep Research",
+        "model_vendor": "openai",
+        "model_version": "2025-06-26",
         "cache_read_input_token_cost": 2.5e-06,
         "input_cost_per_token": 1e-05,
         "input_cost_per_token_batches": 5e-06,
@@ -21355,6 +23854,8 @@
         "supports_vision": true
     },
     "o3-mini": {
+        "display_name": "o3 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
@@ -21372,6 +23873,9 @@
         "supports_vision": false
     },
     "o3-mini-2025-01-31": {
+        "display_name": "o3 Mini",
+        "model_vendor": "openai",
+        "model_version": "2025-01-31",
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
@@ -21389,6 +23893,8 @@
         "supports_vision": false
     },
     "o3-pro": {
+        "display_name": "o3 Pro",
+        "model_vendor": "openai",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "openai",
@@ -21419,6 +23925,9 @@
         "supports_vision": true
     },
     "o3-pro-2025-06-10": {
+        "display_name": "o3 Pro",
+        "model_vendor": "openai",
+        "model_version": "2025-06-10",
         "input_cost_per_token": 2e-05,
         "input_cost_per_token_batches": 1e-05,
         "litellm_provider": "openai",
@@ -21449,6 +23958,8 @@
         "supports_vision": true
     },
     "o4-mini": {
+        "display_name": "o4 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.75e-07,
         "cache_read_input_token_cost_flex": 1.375e-07,
         "cache_read_input_token_cost_priority": 5e-07,
@@ -21474,6 +23985,9 @@
         "supports_vision": true
     },
     "o4-mini-2025-04-16": {
+        "display_name": "o4 Mini",
+        "model_vendor": "openai",
+        "model_version": "2025-04-16",
         "cache_read_input_token_cost": 2.75e-07,
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openai",
@@ -21493,6 +24007,8 @@
         "supports_vision": true
     },
     "o4-mini-deep-research": {
+        "display_name": "o4 Mini Deep Research",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -21526,6 +24042,9 @@
         "supports_vision": true
     },
     "o4-mini-deep-research-2025-06-26": {
+        "display_name": "o4 Mini Deep Research",
+        "model_vendor": "openai",
+        "model_version": "2025-06-26",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -21559,6 +24078,8 @@
         "supports_vision": true
     },
     "oci/meta.llama-3.1-405b-instruct": {
+        "display_name": "Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.068e-05,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21571,6 +24092,8 @@
         "supports_response_schema": false
     },
     "oci/meta.llama-3.2-90b-vision-instruct": {
+        "display_name": "Llama 3.2 90B Vision Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21583,6 +24106,8 @@
         "supports_response_schema": false
     },
     "oci/meta.llama-3.3-70b-instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21595,6 +24120,8 @@
         "supports_response_schema": false
     },
     "oci/meta.llama-4-maverick-17b-128e-instruct-fp8": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "oci",
         "max_input_tokens": 512000,
@@ -21607,6 +24134,8 @@
         "supports_response_schema": false
     },
     "oci/meta.llama-4-scout-17b-16e-instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "oci",
         "max_input_tokens": 192000,
@@ -21619,6 +24148,8 @@
         "supports_response_schema": false
     },
     "oci/xai.grok-3": {
+        "display_name": "Grok 3",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 131072,
@@ -21631,6 +24162,8 @@
         "supports_response_schema": false
     },
     "oci/xai.grok-3-fast": {
+        "display_name": "Grok 3 Fast",
+        "model_vendor": "xai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 131072,
@@ -21643,6 +24176,8 @@
         "supports_response_schema": false
     },
     "oci/xai.grok-3-mini": {
+        "display_name": "Grok 3 Mini",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "oci",
         "max_input_tokens": 131072,
@@ -21655,6 +24190,8 @@
         "supports_response_schema": false
     },
     "oci/xai.grok-3-mini-fast": {
+        "display_name": "Grok 3 Mini Fast",
+        "model_vendor": "xai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "oci",
         "max_input_tokens": 131072,
@@ -21667,6 +24204,8 @@
         "supports_response_schema": false
     },
     "oci/xai.grok-4": {
+        "display_name": "Grok 4",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21679,6 +24218,8 @@
         "supports_response_schema": false
     },
     "oci/cohere.command-latest": {
+        "display_name": "Command Latest",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1.56e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21691,6 +24232,9 @@
         "supports_response_schema": false
     },
     "oci/cohere.command-a-03-2025": {
+        "display_name": "Command A 03-2025",
+        "model_vendor": "cohere",
+        "model_version": "03-2025",
         "input_cost_per_token": 1.56e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 256000,
@@ -21703,6 +24247,8 @@
         "supports_response_schema": false
     },
     "oci/cohere.command-plus-latest": {
+        "display_name": "Command Plus Latest",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1.56e-06,
         "litellm_provider": "oci",
         "max_input_tokens": 128000,
@@ -21715,6 +24261,8 @@
         "supports_response_schema": false
     },
     "ollama/codegeex4": {
+        "display_name": "CodeGeeX4",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21725,6 +24273,8 @@
         "supports_function_calling": false
     },
     "ollama/codegemma": {
+        "display_name": "CodeGemma",
+        "model_vendor": "google",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21734,6 +24284,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/codellama": {
+        "display_name": "Code Llama",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21743,6 +24295,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/deepseek-coder-v2-base": {
+        "display_name": "DeepSeek Coder V2 Base",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21753,6 +24307,8 @@
         "supports_function_calling": true
     },
     "ollama/deepseek-coder-v2-instruct": {
+        "display_name": "DeepSeek Coder V2 Instruct",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21763,6 +24319,8 @@
         "supports_function_calling": true
     },
     "ollama/deepseek-coder-v2-lite-base": {
+        "display_name": "DeepSeek Coder V2 Lite Base",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21773,6 +24331,8 @@
         "supports_function_calling": true
     },
     "ollama/deepseek-coder-v2-lite-instruct": {
+        "display_name": "DeepSeek Coder V2 Lite Instruct",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21782,7 +24342,9 @@
         "output_cost_per_token": 0.0,
         "supports_function_calling": true
     },
-    "ollama/deepseek-v3.1:671b-cloud" : {
+    "ollama/deepseek-v3.1:671b-cloud": {
+        "display_name": "DeepSeek V3.1 671B Cloud",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 163840,
@@ -21792,7 +24354,9 @@
         "output_cost_per_token": 0.0,
         "supports_function_calling": true
     },
-    "ollama/gpt-oss:120b-cloud" : {
+    "ollama/gpt-oss:120b-cloud": {
+        "display_name": "GPT-OSS 120B Cloud",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 131072,
@@ -21802,7 +24366,9 @@
         "output_cost_per_token": 0.0,
         "supports_function_calling": true
     },
-    "ollama/gpt-oss:20b-cloud" : {
+    "ollama/gpt-oss:20b-cloud": {
+        "display_name": "GPT-OSS 20B Cloud",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 131072,
@@ -21813,6 +24379,8 @@
         "supports_function_calling": true
     },
     "ollama/internlm2_5-20b-chat": {
+        "display_name": "InternLM 2.5 20B Chat",
+        "model_vendor": "shanghai_ai_lab",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21823,6 +24391,8 @@
         "supports_function_calling": true
     },
     "ollama/llama2": {
+        "display_name": "Llama 2",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21832,6 +24402,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama2-uncensored": {
+        "display_name": "Llama 2 Uncensored",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21841,6 +24413,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama2:13b": {
+        "display_name": "Llama 2 13B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21850,6 +24424,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama2:70b": {
+        "display_name": "Llama 2 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21859,6 +24435,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama2:7b": {
+        "display_name": "Llama 2 7B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21868,6 +24446,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama3": {
+        "display_name": "Llama 3",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21877,6 +24457,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama3.1": {
+        "display_name": "Llama 3.1",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21887,6 +24469,8 @@
         "supports_function_calling": true
     },
     "ollama/llama3:70b": {
+        "display_name": "Llama 3 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21896,6 +24480,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/llama3:8b": {
+        "display_name": "Llama 3 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21905,6 +24491,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/mistral": {
+        "display_name": "Mistral",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21915,6 +24503,8 @@
         "supports_function_calling": true
     },
     "ollama/mistral-7B-Instruct-v0.1": {
+        "display_name": "Mistral 7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 8192,
@@ -21925,6 +24515,9 @@
         "supports_function_calling": true
     },
     "ollama/mistral-7B-Instruct-v0.2": {
+        "display_name": "Mistral 7B Instruct v0.2",
+        "model_vendor": "mistralai",
+        "model_version": "0.2",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21935,6 +24528,9 @@
         "supports_function_calling": true
     },
     "ollama/mistral-large-instruct-2407": {
+        "display_name": "Mistral Large Instruct 2407",
+        "model_vendor": "mistralai",
+        "model_version": "2407",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 65536,
@@ -21945,6 +24541,8 @@
         "supports_function_calling": true
     },
     "ollama/mixtral-8x22B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x22B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 65536,
@@ -21955,6 +24553,8 @@
         "supports_function_calling": true
     },
     "ollama/mixtral-8x7B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 32768,
@@ -21965,6 +24565,8 @@
         "supports_function_calling": true
     },
     "ollama/orca-mini": {
+        "display_name": "Orca Mini",
+        "model_vendor": "microsoft",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 4096,
@@ -21974,6 +24576,8 @@
         "output_cost_per_token": 0.0
     },
     "ollama/qwen3-coder:480b-cloud": {
+        "display_name": "Qwen 3 Coder 480B Cloud",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 262144,
@@ -21984,6 +24588,8 @@
         "supports_function_calling": true
     },
     "ollama/vicuna": {
+        "display_name": "Vicuna",
+        "model_vendor": "lmsys",
         "input_cost_per_token": 0.0,
         "litellm_provider": "ollama",
         "max_input_tokens": 2048,
@@ -21993,6 +24599,9 @@
         "output_cost_per_token": 0.0
     },
     "omni-moderation-2024-09-26": {
+        "display_name": "Omni Moderation",
+        "model_vendor": "openai",
+        "model_version": "2024-09-26",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -22002,6 +24611,8 @@
         "output_cost_per_token": 0.0
     },
     "omni-moderation-latest": {
+        "display_name": "Omni Moderation Latest",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -22011,6 +24622,8 @@
         "output_cost_per_token": 0.0
     },
     "omni-moderation-latest-intents": {
+        "display_name": "Omni Moderation Latest Intents",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -22020,6 +24633,8 @@
         "output_cost_per_token": 0.0
     },
     "openai.gpt-oss-120b-1:0": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -22033,6 +24648,8 @@
         "supports_tool_choice": true
     },
     "openai.gpt-oss-20b-1:0": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -22046,6 +24663,8 @@
         "supports_tool_choice": true
     },
     "openai.gpt-oss-safeguard-120b": {
+        "display_name": "GPT Oss Safeguard 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -22056,6 +24675,8 @@
         "supports_system_messages": true
     },
     "openai.gpt-oss-safeguard-20b": {
+        "display_name": "GPT Oss Safeguard 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -22066,6 +24687,8 @@
         "supports_system_messages": true
     },
     "openrouter/anthropic/claude-2": {
+        "display_name": "Claude 2",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.102e-05,
         "litellm_provider": "openrouter",
         "max_output_tokens": 8191,
@@ -22075,6 +24698,8 @@
         "supports_tool_choice": true
     },
     "openrouter/anthropic/claude-3-5-haiku": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 200000,
@@ -22084,6 +24709,9 @@
         "supports_tool_choice": true
     },
     "openrouter/anthropic/claude-3-5-haiku-20241022": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 200000,
@@ -22096,6 +24724,8 @@
         "tool_use_system_prompt_tokens": 264
     },
     "openrouter/anthropic/claude-3-haiku": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0004,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",
@@ -22107,6 +24737,9 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-3-haiku-20240307": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20240307",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 200000,
@@ -22120,6 +24753,8 @@
         "tool_use_system_prompt_tokens": 264
     },
     "openrouter/anthropic/claude-3-opus": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openrouter",
         "max_input_tokens": 200000,
@@ -22133,6 +24768,8 @@
         "tool_use_system_prompt_tokens": 395
     },
     "openrouter/anthropic/claude-3-sonnet": {
+        "display_name": "Claude 3 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
@@ -22144,6 +24781,8 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-3.5-sonnet": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 200000,
@@ -22159,6 +24798,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-3.5-sonnet:beta": {
+        "display_name": "Claude 3.5 Sonnet Beta",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 200000,
@@ -22173,6 +24814,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-3.7-sonnet": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
@@ -22190,6 +24833,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-3.7-sonnet:beta": {
+        "display_name": "Claude 3.7 Sonnet Beta",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
@@ -22206,6 +24851,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-instant-v1": {
+        "display_name": "Claude Instant v1",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.63e-06,
         "litellm_provider": "openrouter",
         "max_output_tokens": 8191,
@@ -22215,6 +24862,8 @@
         "supports_tool_choice": true
     },
     "openrouter/anthropic/claude-opus-4": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
@@ -22235,6 +24884,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-opus-4.1": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_creation_input_token_cost_above_1hr": 3e-05,
@@ -22256,6 +24907,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-sonnet-4": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
@@ -22280,6 +24933,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-opus-4.5": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -22299,6 +24954,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-sonnet-4.5": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
         "input_cost_per_image": 0.0048,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -22323,6 +24980,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "openrouter/anthropic/claude-haiku-4.5": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
@@ -22342,6 +25001,8 @@
         "tool_use_system_prompt_tokens": 346
     },
     "openrouter/bytedance/ui-tars-1.5-7b": {
+        "display_name": "UI-TARS 1.5 7B",
+        "model_vendor": "bytedance",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
@@ -22353,6 +25014,8 @@
         "supports_tool_choice": true
     },
     "openrouter/cognitivecomputations/dolphin-mixtral-8x7b": {
+        "display_name": "Dolphin Mixtral 8x7B",
+        "model_vendor": "cognitivecomputations",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 32769,
@@ -22361,6 +25024,8 @@
         "supports_tool_choice": true
     },
     "openrouter/cohere/command-r-plus": {
+        "display_name": "Command R Plus",
+        "model_vendor": "cohere",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 128000,
@@ -22369,6 +25034,8 @@
         "supports_tool_choice": true
     },
     "openrouter/databricks/dbrx-instruct": {
+        "display_name": "DBRX Instruct",
+        "model_vendor": "databricks",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 32768,
@@ -22377,6 +25044,8 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-chat": {
+        "display_name": "DeepSeek Chat",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 65536,
@@ -22388,6 +25057,9 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-chat-v3-0324": {
+        "display_name": "DeepSeek Chat V3 0324",
+        "model_vendor": "deepseek",
+        "model_version": "0324",
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 65536,
@@ -22399,6 +25071,8 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-chat-v3.1": {
+        "display_name": "DeepSeek Chat V3.1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2e-07,
         "input_cost_per_token_cache_hit": 2e-08,
         "litellm_provider": "openrouter",
@@ -22414,6 +25088,9 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-v3.2": {
+        "display_name": "DeepSeek V3.2",
+        "model_vendor": "deepseek",
+        "model_version": "v3.2",
         "input_cost_per_token": 2.8e-07,
         "input_cost_per_token_cache_hit": 2.8e-08,
         "litellm_provider": "openrouter",
@@ -22429,6 +25106,8 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-v3.2-exp": {
+        "display_name": "DeepSeek V3.2 Experimental",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 2e-07,
         "input_cost_per_token_cache_hit": 2e-08,
         "litellm_provider": "openrouter",
@@ -22444,6 +25123,8 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-coder": {
+        "display_name": "DeepSeek Coder",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 66000,
@@ -22455,6 +25136,8 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-r1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "openrouter",
@@ -22470,6 +25153,9 @@
         "supports_tool_choice": true
     },
     "openrouter/deepseek/deepseek-r1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "input_cost_per_token": 5e-07,
         "input_cost_per_token_cache_hit": 1.4e-07,
         "litellm_provider": "openrouter",
@@ -22485,6 +25171,8 @@
         "supports_tool_choice": true
     },
     "openrouter/fireworks/firellava-13b": {
+        "display_name": "FireLLaVA 13B",
+        "model_vendor": "fireworks",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -22493,6 +25181,8 @@
         "supports_tool_choice": true
     },
     "openrouter/google/gemini-2.0-flash-001": {
+        "display_name": "Gemini 2.0 Flash 001",
+        "model_vendor": "google",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -22515,6 +25205,8 @@
         "supports_vision": true
     },
     "openrouter/google/gemini-2.5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "openrouter",
@@ -22537,6 +25229,8 @@
         "supports_vision": true
     },
     "openrouter/google/gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "input_cost_per_audio_token": 7e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openrouter",
@@ -22559,6 +25253,8 @@
         "supports_vision": true
     },
     "openrouter/google/gemini-3-pro-preview": {
+        "display_name": "Gemini 3 Pro Preview",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
         "cache_creation_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -22605,54 +25301,9 @@
         "supports_vision": true,
         "supports_web_search": true
     },
-    "openrouter/google/gemini-3-flash-preview": {
-      "cache_read_input_token_cost": 5e-08,
-      "input_cost_per_audio_token": 1e-06,
-      "input_cost_per_token": 5e-07,
-      "litellm_provider": "openrouter",
-      "max_audio_length_hours": 8.4,
-      "max_audio_per_prompt": 1,
-      "max_images_per_prompt": 3000,
-      "max_input_tokens": 1048576,
-      "max_output_tokens": 65535,
-      "max_pdf_size_mb": 30,
-      "max_tokens": 65535,
-      "max_video_length": 1,
-      "max_videos_per_prompt": 10,
-      "mode": "chat",
-      "output_cost_per_reasoning_token": 3e-06,
-      "output_cost_per_token": 3e-06,
-      "rpm": 2000,
-      "source": "https://ai.google.dev/pricing/gemini-3",
-      "supported_endpoints": [
-        "/v1/chat/completions",
-        "/v1/completions",
-        "/v1/batch"
-      ],
-      "supported_modalities": [
-        "text",
-        "image",
-        "audio",
-        "video"
-      ],
-      "supported_output_modalities": [
-        "text"
-      ],
-      "supports_audio_output": false,
-      "supports_function_calling": true,
-      "supports_parallel_function_calling": true,
-      "supports_pdf_input": true,
-      "supports_prompt_caching": true,
-      "supports_reasoning": true,
-      "supports_response_schema": true,
-      "supports_system_messages": true,
-      "supports_tool_choice": true,
-      "supports_url_context": true,
-      "supports_vision": true,
-      "supports_web_search": true,
-      "tpm": 800000
-    },
     "openrouter/google/gemini-pro-1.5": {
+        "display_name": "Gemini Pro 1.5",
+        "model_vendor": "google",
         "input_cost_per_image": 0.00265,
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openrouter",
@@ -22666,6 +25317,8 @@
         "supports_vision": true
     },
     "openrouter/google/gemini-pro-vision": {
+        "display_name": "Gemini Pro Vision",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0025,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "openrouter",
@@ -22677,6 +25330,8 @@
         "supports_vision": true
     },
     "openrouter/google/palm-2-chat-bison": {
+        "display_name": "PaLM 2 Chat Bison",
+        "model_vendor": "google",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 25804,
@@ -22685,6 +25340,8 @@
         "supports_tool_choice": true
     },
     "openrouter/google/palm-2-codechat-bison": {
+        "display_name": "PaLM 2 Codechat Bison",
+        "model_vendor": "google",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 20070,
@@ -22693,6 +25350,8 @@
         "supports_tool_choice": true
     },
     "openrouter/gryphe/mythomax-l2-13b": {
+        "display_name": "MythoMax L2 13B",
+        "model_vendor": "gryphe",
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22701,6 +25360,9 @@
         "supports_tool_choice": true
     },
     "openrouter/jondurbin/airoboros-l2-70b-2.1": {
+        "display_name": "Airoboros L2 70B 2.1",
+        "model_vendor": "jondurbin",
+        "model_version": "2.1",
         "input_cost_per_token": 1.3875e-05,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -22709,6 +25371,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mancer/weaver": {
+        "display_name": "Weaver",
+        "model_vendor": "mancer",
         "input_cost_per_token": 5.625e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 8000,
@@ -22717,6 +25381,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/codellama-34b-instruct": {
+        "display_name": "Code Llama 34B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22725,6 +25391,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-2-13b-chat": {
+        "display_name": "Llama 2 13B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -22733,6 +25401,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-2-70b-chat": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -22741,6 +25411,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-3-70b-instruct": {
+        "display_name": "Llama 3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22749,6 +25421,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-3-70b-instruct:nitro": {
+        "display_name": "Llama 3 70B Instruct Nitro",
+        "model_vendor": "meta",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22757,6 +25431,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-3-8b-instruct:extended": {
+        "display_name": "Llama 3 8B Instruct Extended",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.25e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 16384,
@@ -22765,6 +25441,8 @@
         "supports_tool_choice": true
     },
     "openrouter/meta-llama/llama-3-8b-instruct:free": {
+        "display_name": "Llama 3 8B Instruct Free",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22773,6 +25451,8 @@
         "supports_tool_choice": true
     },
     "openrouter/microsoft/wizardlm-2-8x22b:nitro": {
+        "display_name": "WizardLM 2 8x22B Nitro",
+        "model_vendor": "microsoft",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 65536,
@@ -22781,24 +25461,27 @@
         "supports_tool_choice": true
     },
     "openrouter/minimax/minimax-m2": {
-        "input_cost_per_token": 2.55e-7,
+        "display_name": "MiniMax M2",
+        "model_vendor": "minimax",
+        "input_cost_per_token": 2.55e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 204800,
         "max_output_tokens": 204800,
         "max_tokens": 32768,
         "mode": "chat",
-        "output_cost_per_token": 1.02e-6,
+        "output_cost_per_token": 1.02e-06,
         "supports_function_calling": true,
         "supports_prompt_caching": false,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "openrouter/mistralai/devstral-2512:free": {
+        "display_name": "Mistralai Devstral 2512:free",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 0,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 0,
@@ -22808,6 +25491,8 @@
         "supports_vision": false
     },
     "openrouter/mistralai/devstral-2512": {
+        "display_name": "Mistralai Devstral 2512",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openrouter",
@@ -22822,11 +25507,12 @@
         "supports_vision": false
     },
     "openrouter/mistralai/ministral-3b-2512": {
+        "display_name": "Mistralai Ministral 3B 2512",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1e-07,
@@ -22836,11 +25522,12 @@
         "supports_vision": true
     },
     "openrouter/mistralai/ministral-8b-2512": {
+        "display_name": "Mistralai Ministral 8B 2512",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 1.5e-07,
@@ -22850,11 +25537,12 @@
         "supports_vision": true
     },
     "openrouter/mistralai/ministral-14b-2512": {
+        "display_name": "Mistralai Ministral 14B 2512",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 2e-07,
@@ -22864,11 +25552,12 @@
         "supports_vision": true
     },
     "openrouter/mistralai/mistral-large-2512": {
+        "display_name": "Mistralai Mistral Large 2512",
+        "model_vendor": "mistral",
         "input_cost_per_image": 0,
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
@@ -22878,6 +25567,8 @@
         "supports_vision": true
     },
     "openrouter/mistralai/mistral-7b-instruct": {
+        "display_name": "Mistral 7B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22886,6 +25577,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mistralai/mistral-7b-instruct:free": {
+        "display_name": "Mistral 7B Instruct Free",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22894,6 +25587,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mistralai/mistral-large": {
+        "display_name": "Mistral Large",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 8e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 32000,
@@ -22902,6 +25597,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mistralai/mistral-small-3.1-24b-instruct": {
+        "display_name": "Mistral Small 3.1 24B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 32000,
@@ -22910,6 +25607,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mistralai/mistral-small-3.2-24b-instruct": {
+        "display_name": "Mistral Small 3.2 24B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 32000,
@@ -22918,6 +25617,8 @@
         "supports_tool_choice": true
     },
     "openrouter/mistralai/mixtral-8x22b-instruct": {
+        "display_name": "Mixtral 8x22B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 65536,
@@ -22926,6 +25627,8 @@
         "supports_tool_choice": true
     },
     "openrouter/nousresearch/nous-hermes-llama2-13b": {
+        "display_name": "Nous Hermes Llama2 13B",
+        "model_vendor": "nousresearch",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -22934,6 +25637,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-3.5-turbo": {
+        "display_name": "GPT-3.5 Turbo",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 4095,
@@ -22942,6 +25647,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-3.5-turbo-16k": {
+        "display_name": "GPT-3.5 Turbo 16K",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 16383,
@@ -22950,6 +25657,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-4": {
+        "display_name": "GPT-4",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-05,
         "litellm_provider": "openrouter",
         "max_tokens": 8192,
@@ -22958,6 +25667,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-4-vision-preview": {
+        "display_name": "GPT-4 Vision Preview",
+        "model_vendor": "openai",
         "input_cost_per_image": 0.01445,
         "input_cost_per_token": 1e-05,
         "litellm_provider": "openrouter",
@@ -22969,6 +25680,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1": {
+        "display_name": "GPT-4.1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openrouter",
@@ -22986,6 +25699,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1-2025-04-14": {
+        "display_name": "GPT-4.1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "openrouter",
@@ -23003,6 +25718,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1-mini": {
+        "display_name": "GPT-4.1 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 4e-07,
         "litellm_provider": "openrouter",
@@ -23020,6 +25737,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1-mini-2025-04-14": {
+        "display_name": "GPT-4.1 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 4e-07,
         "litellm_provider": "openrouter",
@@ -23037,6 +25756,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1-nano": {
+        "display_name": "GPT-4.1 Nano",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -23054,6 +25775,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4.1-nano-2025-04-14": {
+        "display_name": "GPT-4.1 Nano",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
@@ -23071,6 +25794,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4o": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23084,6 +25809,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-4o-2024-05-13": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23097,6 +25824,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-5-chat": {
+        "display_name": "GPT-5 Chat",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openrouter",
@@ -23116,6 +25845,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-5-codex": {
+        "display_name": "GPT-5 Codex",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openrouter",
@@ -23135,6 +25866,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-5": {
+        "display_name": "GPT-5",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 1.25e-07,
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "openrouter",
@@ -23154,6 +25887,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-5-mini": {
+        "display_name": "GPT-5 Mini",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "openrouter",
@@ -23173,6 +25908,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-5-nano": {
+        "display_name": "GPT-5 Nano",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 5e-09,
         "input_cost_per_token": 5e-08,
         "litellm_provider": "openrouter",
@@ -23192,6 +25929,9 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-5.2": {
+        "display_name": "Openai GPT 5.2",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "input_cost_per_image": 0,
         "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
@@ -23208,6 +25948,9 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-5.2-chat": {
+        "display_name": "Openai GPT 5.2 Chat",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "input_cost_per_image": 0,
         "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
@@ -23223,6 +25966,9 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-5.2-pro": {
+        "display_name": "Openai GPT 5.2 Pro",
+        "model_vendor": "openai",
+        "model_version": "5.2",
         "input_cost_per_image": 0,
         "input_cost_per_token": 2.1e-05,
         "litellm_provider": "openrouter",
@@ -23230,7 +25976,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 400000,
         "mode": "chat",
-        "output_cost_per_token": 1.68e-04,
+        "output_cost_per_token": 0.000168,
         "supports_function_calling": true,
         "supports_prompt_caching": false,
         "supports_reasoning": true,
@@ -23238,6 +25984,8 @@
         "supports_vision": true
     },
     "openrouter/openai/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
@@ -23253,6 +26001,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
@@ -23268,6 +26018,8 @@
         "supports_tool_choice": true
     },
     "openrouter/openai/o1": {
+        "display_name": "o1",
+        "model_vendor": "openai",
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openrouter",
@@ -23285,6 +26037,8 @@
         "supports_vision": true
     },
     "openrouter/openai/o1-mini": {
+        "display_name": "o1 Mini",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23298,6 +26052,8 @@
         "supports_vision": false
     },
     "openrouter/openai/o1-mini-2024-09-12": {
+        "display_name": "o1 Mini",
+        "model_vendor": "openai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23311,6 +26067,8 @@
         "supports_vision": false
     },
     "openrouter/openai/o1-preview": {
+        "display_name": "o1 Preview",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23324,6 +26082,8 @@
         "supports_vision": false
     },
     "openrouter/openai/o1-preview-2024-09-12": {
+        "display_name": "o1 Preview",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23337,6 +26097,8 @@
         "supports_vision": false
     },
     "openrouter/openai/o3-mini": {
+        "display_name": "o3 Mini",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23351,6 +26113,8 @@
         "supports_vision": false
     },
     "openrouter/openai/o3-mini-high": {
+        "display_name": "o3 Mini High",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.1e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 128000,
@@ -23365,6 +26129,8 @@
         "supports_vision": false
     },
     "openrouter/pygmalionai/mythalion-13b": {
+        "display_name": "Mythalion 13B",
+        "model_vendor": "pygmalionai",
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 4096,
@@ -23373,6 +26139,8 @@
         "supports_tool_choice": true
     },
     "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 33792,
@@ -23383,6 +26151,8 @@
         "supports_tool_choice": true
     },
     "openrouter/qwen/qwen-vl-plus": {
+        "display_name": "Qwen VL Plus",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2.1e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 8192,
@@ -23394,18 +26164,22 @@
         "supports_vision": true
     },
     "openrouter/qwen/qwen3-coder": {
-        "input_cost_per_token": 2.2e-7,
+        "display_name": "Qwen3 Coder",
+        "model_vendor": "alibaba",
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262100,
         "max_output_tokens": 262100,
         "max_tokens": 262100,
         "mode": "chat",
-        "output_cost_per_token": 9.5e-7,
+        "output_cost_per_token": 9.5e-07,
         "source": "https://openrouter.ai/qwen/qwen3-coder",
         "supports_tool_choice": true,
         "supports_function_calling": true
     },
     "openrouter/switchpoint/router": {
+        "display_name": "Switchpoint Router",
+        "model_vendor": "switchpoint",
         "input_cost_per_token": 8.5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
@@ -23417,6 +26191,8 @@
         "supports_tool_choice": true
     },
     "openrouter/undi95/remm-slerp-l2-13b": {
+        "display_name": "ReMM SLERP L2 13B",
+        "model_vendor": "undi95",
         "input_cost_per_token": 1.875e-06,
         "litellm_provider": "openrouter",
         "max_tokens": 6144,
@@ -23425,6 +26201,8 @@
         "supports_tool_choice": true
     },
     "openrouter/x-ai/grok-4": {
+        "display_name": "Grok 4",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "openrouter",
         "max_input_tokens": 256000,
@@ -23439,6 +26217,8 @@
         "supports_web_search": true
     },
     "openrouter/x-ai/grok-4-fast:free": {
+        "display_name": "Grok 4 Fast Free",
+        "model_vendor": "xai",
         "input_cost_per_token": 0,
         "litellm_provider": "openrouter",
         "max_input_tokens": 2000000,
@@ -23453,32 +26233,38 @@
         "supports_web_search": false
     },
     "openrouter/z-ai/glm-4.6": {
-        "input_cost_per_token": 4.0e-7,
+        "display_name": "GLM 4.6",
+        "model_vendor": "zhipu",
+        "input_cost_per_token": 4e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 202800,
         "max_output_tokens": 131000,
         "max_tokens": 202800,
         "mode": "chat",
-        "output_cost_per_token": 1.75e-6,
+        "output_cost_per_token": 1.75e-06,
         "source": "https://openrouter.ai/z-ai/glm-4.6",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "openrouter/z-ai/glm-4.6:exacto": {
-        "input_cost_per_token": 4.5e-7,
+        "display_name": "GLM 4.6 Exacto",
+        "model_vendor": "zhipu",
+        "input_cost_per_token": 4.5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 202800,
         "max_output_tokens": 131000,
         "max_tokens": 202800,
         "mode": "chat",
-        "output_cost_per_token": 1.9e-6,
+        "output_cost_per_token": 1.9e-06,
         "source": "https://openrouter.ai/z-ai/glm-4.6:exacto",
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "ovhcloud/DeepSeek-R1-Distill-Llama-70B": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23493,6 +26279,8 @@
         "supports_tool_choice": true
     },
     "ovhcloud/Llama-3.1-8B-Instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23506,6 +26294,8 @@
         "supports_tool_choice": true
     },
     "ovhcloud/Meta-Llama-3_1-70B-Instruct": {
+        "display_name": "Meta Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23519,6 +26309,8 @@
         "supports_tool_choice": false
     },
     "ovhcloud/Meta-Llama-3_3-70B-Instruct": {
+        "display_name": "Meta Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.7e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23532,6 +26324,9 @@
         "supports_tool_choice": true
     },
     "ovhcloud/Mistral-7B-Instruct-v0.3": {
+        "display_name": "Mistral 7B Instruct v0.3",
+        "model_vendor": "mistralai",
+        "model_version": "0.3",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 127000,
@@ -23545,6 +26340,9 @@
         "supports_tool_choice": true
     },
     "ovhcloud/Mistral-Nemo-Instruct-2407": {
+        "display_name": "Mistral Nemo Instruct 2407",
+        "model_vendor": "mistralai",
+        "model_version": "2407",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 118000,
@@ -23558,6 +26356,8 @@
         "supports_tool_choice": true
     },
     "ovhcloud/Mistral-Small-3.2-24B-Instruct-2506": {
+        "display_name": "Mistral Small 3.2 24B Instruct 2506",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 9e-08,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 128000,
@@ -23572,6 +26372,8 @@
         "supports_vision": true
     },
     "ovhcloud/Mixtral-8x7B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 6.3e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 32000,
@@ -23585,6 +26387,8 @@
         "supports_tool_choice": false
     },
     "ovhcloud/Qwen2.5-Coder-32B-Instruct": {
+        "display_name": "Qwen 2.5 Coder 32B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 8.7e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 32000,
@@ -23598,6 +26402,8 @@
         "supports_tool_choice": false
     },
     "ovhcloud/Qwen2.5-VL-72B-Instruct": {
+        "display_name": "Qwen 2.5 VL 72B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 9.1e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 32000,
@@ -23612,6 +26418,8 @@
         "supports_vision": true
     },
     "ovhcloud/Qwen3-32B": {
+        "display_name": "Qwen3 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 32000,
@@ -23626,6 +26434,8 @@
         "supports_tool_choice": true
     },
     "ovhcloud/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23640,6 +26450,8 @@
         "supports_tool_choice": false
     },
     "ovhcloud/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 131000,
@@ -23654,6 +26466,9 @@
         "supports_tool_choice": false
     },
     "ovhcloud/llava-v1.6-mistral-7b-hf": {
+        "display_name": "LLaVA v1.6 Mistral 7B",
+        "model_vendor": "liuhaotian",
+        "model_version": "1.6",
         "input_cost_per_token": 2.9e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 32000,
@@ -23668,6 +26483,8 @@
         "supports_vision": true
     },
     "ovhcloud/mamba-codestral-7B-v0.1": {
+        "display_name": "Mamba Codestral 7B v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.9e-07,
         "litellm_provider": "ovhcloud",
         "max_input_tokens": 256000,
@@ -23681,6 +26498,8 @@
         "supports_tool_choice": false
     },
     "palm/chat-bison": {
+        "display_name": "PaLM Chat Bison",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23691,6 +26510,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "palm/chat-bison-001": {
+        "display_name": "PaLM Chat Bison 001",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23701,6 +26522,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "palm/text-bison": {
+        "display_name": "PaLM Text Bison",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23711,6 +26534,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "palm/text-bison-001": {
+        "display_name": "PaLM Text Bison 001",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23721,6 +26546,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "palm/text-bison-safety-off": {
+        "display_name": "PaLM Text Bison Safety Off",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23731,6 +26558,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "palm/text-bison-safety-recitation-off": {
+        "display_name": "PaLM Text Bison Safety Recitation Off",
+        "model_vendor": "google",
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "palm",
         "max_input_tokens": 8192,
@@ -23741,16 +26570,22 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "parallel_ai/search": {
+        "display_name": "Parallel AI Search",
+        "model_vendor": "parallel_ai",
         "input_cost_per_query": 0.004,
         "litellm_provider": "parallel_ai",
         "mode": "search"
     },
     "parallel_ai/search-pro": {
+        "display_name": "Parallel AI Search Pro",
+        "model_vendor": "parallel_ai",
         "input_cost_per_query": 0.009,
         "litellm_provider": "parallel_ai",
         "mode": "search"
     },
     "perplexity/codellama-34b-instruct": {
+        "display_name": "Code Llama 34B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 16384,
@@ -23760,6 +26595,8 @@
         "output_cost_per_token": 1.4e-06
     },
     "perplexity/codellama-70b-instruct": {
+        "display_name": "Code Llama 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 16384,
@@ -23769,6 +26606,8 @@
         "output_cost_per_token": 2.8e-06
     },
     "perplexity/llama-2-70b-chat": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 4096,
@@ -23778,6 +26617,8 @@
         "output_cost_per_token": 2.8e-06
     },
     "perplexity/llama-3.1-70b-instruct": {
+        "display_name": "Llama 3.1 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "perplexity",
         "max_input_tokens": 131072,
@@ -23787,6 +26628,8 @@
         "output_cost_per_token": 1e-06
     },
     "perplexity/llama-3.1-8b-instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 131072,
@@ -23796,6 +26639,8 @@
         "output_cost_per_token": 2e-07
     },
     "perplexity/llama-3.1-sonar-huge-128k-online": {
+        "display_name": "Llama 3.1 Sonar Huge 128K Online",
+        "model_vendor": "perplexity",
         "deprecation_date": "2025-02-22",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "perplexity",
@@ -23806,6 +26651,8 @@
         "output_cost_per_token": 5e-06
     },
     "perplexity/llama-3.1-sonar-large-128k-chat": {
+        "display_name": "Llama 3.1 Sonar Large 128K Chat",
+        "model_vendor": "perplexity",
         "deprecation_date": "2025-02-22",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "perplexity",
@@ -23816,6 +26663,8 @@
         "output_cost_per_token": 1e-06
     },
     "perplexity/llama-3.1-sonar-large-128k-online": {
+        "display_name": "Llama 3.1 Sonar Large 128K Online",
+        "model_vendor": "perplexity",
         "deprecation_date": "2025-02-22",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "perplexity",
@@ -23826,6 +26675,8 @@
         "output_cost_per_token": 1e-06
     },
     "perplexity/llama-3.1-sonar-small-128k-chat": {
+        "display_name": "Llama 3.1 Sonar Small 128K Chat",
+        "model_vendor": "perplexity",
         "deprecation_date": "2025-02-22",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "perplexity",
@@ -23836,6 +26687,8 @@
         "output_cost_per_token": 2e-07
     },
     "perplexity/llama-3.1-sonar-small-128k-online": {
+        "display_name": "Llama 3.1 Sonar Small 128K Online",
+        "model_vendor": "perplexity",
         "deprecation_date": "2025-02-22",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "perplexity",
@@ -23846,6 +26699,8 @@
         "output_cost_per_token": 2e-07
     },
     "perplexity/mistral-7b-instruct": {
+        "display_name": "Mistral 7B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "perplexity",
         "max_input_tokens": 4096,
@@ -23855,6 +26710,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "perplexity/mixtral-8x7b-instruct": {
+        "display_name": "Mixtral 8x7B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "perplexity",
         "max_input_tokens": 4096,
@@ -23864,6 +26721,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "perplexity/pplx-70b-chat": {
+        "display_name": "PPLX 70B Chat",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 4096,
@@ -23873,6 +26732,8 @@
         "output_cost_per_token": 2.8e-06
     },
     "perplexity/pplx-70b-online": {
+        "display_name": "PPLX 70B Online",
+        "model_vendor": "perplexity",
         "input_cost_per_request": 0.005,
         "input_cost_per_token": 0.0,
         "litellm_provider": "perplexity",
@@ -23883,6 +26744,8 @@
         "output_cost_per_token": 2.8e-06
     },
     "perplexity/pplx-7b-chat": {
+        "display_name": "PPLX 7B Chat",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "perplexity",
         "max_input_tokens": 8192,
@@ -23892,6 +26755,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "perplexity/pplx-7b-online": {
+        "display_name": "PPLX 7B Online",
+        "model_vendor": "perplexity",
         "input_cost_per_request": 0.005,
         "input_cost_per_token": 0.0,
         "litellm_provider": "perplexity",
@@ -23902,6 +26767,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "perplexity/sonar": {
+        "display_name": "Sonar",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "perplexity",
         "max_input_tokens": 128000,
@@ -23916,6 +26783,8 @@
         "supports_web_search": true
     },
     "perplexity/sonar-deep-research": {
+        "display_name": "Sonar Deep Research",
+        "model_vendor": "perplexity",
         "citation_cost_per_token": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "perplexity",
@@ -23933,6 +26802,8 @@
         "supports_web_search": true
     },
     "perplexity/sonar-medium-chat": {
+        "display_name": "Sonar Medium Chat",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "perplexity",
         "max_input_tokens": 16384,
@@ -23942,6 +26813,8 @@
         "output_cost_per_token": 1.8e-06
     },
     "perplexity/sonar-medium-online": {
+        "display_name": "Sonar Medium Online",
+        "model_vendor": "perplexity",
         "input_cost_per_request": 0.005,
         "input_cost_per_token": 0,
         "litellm_provider": "perplexity",
@@ -23952,6 +26825,8 @@
         "output_cost_per_token": 1.8e-06
     },
     "perplexity/sonar-pro": {
+        "display_name": "Sonar Pro",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "perplexity",
         "max_input_tokens": 200000,
@@ -23967,6 +26842,8 @@
         "supports_web_search": true
     },
     "perplexity/sonar-reasoning": {
+        "display_name": "Sonar Reasoning",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "perplexity",
         "max_input_tokens": 128000,
@@ -23982,6 +26859,8 @@
         "supports_web_search": true
     },
     "perplexity/sonar-reasoning-pro": {
+        "display_name": "Sonar Reasoning Pro",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "perplexity",
         "max_input_tokens": 128000,
@@ -23997,6 +26876,8 @@
         "supports_web_search": true
     },
     "perplexity/sonar-small-chat": {
+        "display_name": "Sonar Small Chat",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "perplexity",
         "max_input_tokens": 16384,
@@ -24006,6 +26887,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "perplexity/sonar-small-online": {
+        "display_name": "Sonar Small Online",
+        "model_vendor": "perplexity",
         "input_cost_per_request": 0.005,
         "input_cost_per_token": 0,
         "litellm_provider": "perplexity",
@@ -24016,6 +26899,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "publicai/swiss-ai/apertus-8b-instruct": {
+        "display_name": "Apertus 8B Instruct",
+        "model_vendor": "swiss_ai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 8192,
@@ -24028,6 +26913,8 @@
         "supports_tool_choice": true
     },
     "publicai/swiss-ai/apertus-70b-instruct": {
+        "display_name": "Apertus 70B Instruct",
+        "model_vendor": "swiss_ai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 8192,
@@ -24040,6 +26927,8 @@
         "supports_tool_choice": true
     },
     "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
+        "display_name": "Gemma SEA-LION v4 27B IT",
+        "model_vendor": "aisingapore",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 8192,
@@ -24052,6 +26941,8 @@
         "supports_tool_choice": true
     },
     "publicai/BSC-LT/salamandra-7b-instruct-tools-16k": {
+        "display_name": "Salamandra 7B Instruct Tools 16K",
+        "model_vendor": "bsc_lt",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 16384,
@@ -24064,6 +26955,8 @@
         "supports_tool_choice": true
     },
     "publicai/BSC-LT/ALIA-40b-instruct_Q8_0": {
+        "display_name": "ALIA 40B Instruct Q8",
+        "model_vendor": "bsc_lt",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 8192,
@@ -24076,6 +26969,8 @@
         "supports_tool_choice": true
     },
     "publicai/allenai/Olmo-3-7B-Instruct": {
+        "display_name": "Olmo 3 7B Instruct",
+        "model_vendor": "allenai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 32768,
@@ -24088,6 +26983,8 @@
         "supports_tool_choice": true
     },
     "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
+        "display_name": "Qwen SEA-LION v4 32B IT",
+        "model_vendor": "aisingapore",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 32768,
@@ -24100,6 +26997,8 @@
         "supports_tool_choice": true
     },
     "publicai/allenai/Olmo-3-7B-Think": {
+        "display_name": "Olmo 3 7B Think",
+        "model_vendor": "allenai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 32768,
@@ -24113,6 +27012,8 @@
         "supports_reasoning": true
     },
     "publicai/allenai/Olmo-3-32B-Think": {
+        "display_name": "Olmo 3 32B Think",
+        "model_vendor": "allenai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "publicai",
         "max_input_tokens": 32768,
@@ -24126,6 +27027,8 @@
         "supports_reasoning": true
     },
     "qwen.qwen3-coder-480b-a35b-v1:0": {
+        "display_name": "Qwen3 Coder 480B A35B v1",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 262000,
@@ -24138,6 +27041,8 @@
         "supports_tool_choice": true
     },
     "qwen.qwen3-235b-a22b-2507-v1:0": {
+        "display_name": "Qwen3 235B A22B 2507 v1",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 262144,
@@ -24150,30 +27055,36 @@
         "supports_tool_choice": true
     },
     "qwen.qwen3-coder-30b-a3b-v1:0": {
+        "display_name": "Qwen3 Coder 30B A3B v1",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 262144,
         "max_output_tokens": 131072,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 6.0e-07,
+        "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "qwen.qwen3-32b-v1:0": {
+        "display_name": "Qwen3 32B v1",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 131072,
         "max_output_tokens": 16384,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 6.0e-07,
+        "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "qwen.qwen3-next-80b-a3b": {
+        "display_name": "Qwen3 Next 80B A3b",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -24185,6 +27096,8 @@
         "supports_system_messages": true
     },
     "qwen.qwen3-vl-235b-a22b": {
+        "display_name": "Qwen3 VL 235B A22b",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5.3e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -24197,6 +27110,8 @@
         "supports_vision": true
     },
     "recraft/recraftv2": {
+        "display_name": "Recraft v2",
+        "model_vendor": "recraft",
         "litellm_provider": "recraft",
         "mode": "image_generation",
         "output_cost_per_image": 0.022,
@@ -24206,6 +27121,8 @@
         ]
     },
     "recraft/recraftv3": {
+        "display_name": "Recraft v3",
+        "model_vendor": "recraft",
         "litellm_provider": "recraft",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
@@ -24215,6 +27132,8 @@
         ]
     },
     "replicate/meta/llama-2-13b": {
+        "display_name": "Llama 2 13B",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24225,6 +27144,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-2-13b-chat": {
+        "display_name": "Llama 2 13B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24235,6 +27156,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-2-70b": {
+        "display_name": "Llama 2 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24245,6 +27168,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-2-70b-chat": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24255,6 +27180,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-2-7b": {
+        "display_name": "Llama 2 7B",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24265,6 +27192,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-2-7b-chat": {
+        "display_name": "Llama 2 7B Chat",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24275,6 +27204,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-3-70b": {
+        "display_name": "Llama 3 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 8192,
@@ -24285,6 +27216,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-3-70b-instruct": {
+        "display_name": "Llama 3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 8192,
@@ -24295,6 +27228,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-3-8b": {
+        "display_name": "Llama 3 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 8086,
@@ -24305,6 +27240,8 @@
         "supports_tool_choice": true
     },
     "replicate/meta/llama-3-8b-instruct": {
+        "display_name": "Llama 3 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 8086,
@@ -24315,6 +27252,9 @@
         "supports_tool_choice": true
     },
     "replicate/mistralai/mistral-7b-instruct-v0.2": {
+        "display_name": "Mistral 7B Instruct v0.2",
+        "model_vendor": "mistralai",
+        "model_version": "0.2",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24325,6 +27265,8 @@
         "supports_tool_choice": true
     },
     "replicate/mistralai/mistral-7b-v0.1": {
+        "display_name": "Mistral 7B v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24335,6 +27277,8 @@
         "supports_tool_choice": true
     },
     "replicate/mistralai/mixtral-8x7b-instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "replicate",
         "max_input_tokens": 4096,
@@ -24345,6 +27289,8 @@
         "supports_tool_choice": true
     },
     "rerank-english-v2.0": {
+        "display_name": "Rerank English v2.0",
+        "model_vendor": "cohere",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -24356,6 +27302,8 @@
         "output_cost_per_token": 0.0
     },
     "rerank-english-v3.0": {
+        "display_name": "Rerank English v3.0",
+        "model_vendor": "cohere",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -24367,6 +27315,8 @@
         "output_cost_per_token": 0.0
     },
     "rerank-multilingual-v2.0": {
+        "display_name": "Rerank Multilingual v2.0",
+        "model_vendor": "cohere",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -24378,6 +27328,8 @@
         "output_cost_per_token": 0.0
     },
     "rerank-multilingual-v3.0": {
+        "display_name": "Rerank Multilingual v3.0",
+        "model_vendor": "cohere",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -24389,6 +27341,8 @@
         "output_cost_per_token": 0.0
     },
     "rerank-v3.5": {
+        "display_name": "Rerank v3.5",
+        "model_vendor": "cohere",
         "input_cost_per_query": 0.002,
         "input_cost_per_token": 0.0,
         "litellm_provider": "cohere",
@@ -24400,6 +27354,8 @@
         "output_cost_per_token": 0.0
     },
     "nvidia_nim/nvidia/nv-rerankqa-mistral-4b-v3": {
+        "display_name": "NV RerankQA Mistral 4B v3",
+        "model_vendor": "nvidia",
         "input_cost_per_query": 0.0,
         "input_cost_per_token": 0.0,
         "litellm_provider": "nvidia_nim",
@@ -24407,6 +27363,8 @@
         "output_cost_per_token": 0.0
     },
     "nvidia_nim/nvidia/llama-3_2-nv-rerankqa-1b-v2": {
+        "display_name": "Llama 3.2 NV RerankQA 1B v2",
+        "model_vendor": "nvidia",
         "input_cost_per_query": 0.0,
         "input_cost_per_token": 0.0,
         "litellm_provider": "nvidia_nim",
@@ -24414,6 +27372,9 @@
         "output_cost_per_token": 0.0
     },
     "nvidia_nim/ranking/nvidia/llama-3.2-nv-rerankqa-1b-v2": {
+        "display_name": "Llama 3.2 Nv Rerankqa 1B V2",
+        "model_vendor": "meta",
+        "model_version": "3.2",
         "input_cost_per_query": 0.0,
         "input_cost_per_token": 0.0,
         "litellm_provider": "nvidia_nim",
@@ -24421,6 +27382,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-13b": {
+        "display_name": "Llama 2 13B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24430,6 +27393,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-13b-f": {
+        "display_name": "Llama 2 13B F",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24439,6 +27404,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-70b": {
+        "display_name": "Llama 2 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24448,6 +27415,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-70b-b-f": {
+        "display_name": "Llama 2 70B B F",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24457,6 +27426,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-7b": {
+        "display_name": "Llama 2 7B",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24466,6 +27437,8 @@
         "output_cost_per_token": 0.0
     },
     "sagemaker/meta-textgeneration-llama-2-7b-f": {
+        "display_name": "Llama 2 7B F",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "sagemaker",
         "max_input_tokens": 4096,
@@ -24475,6 +27448,8 @@
         "output_cost_per_token": 0.0
     },
     "sambanova/DeepSeek-R1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "sambanova",
         "max_input_tokens": 32768,
@@ -24485,6 +27460,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/DeepSeek-R1-Distill-Llama-70B": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 131072,
@@ -24495,6 +27472,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/DeepSeek-V3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "sambanova",
         "max_input_tokens": 32768,
@@ -24508,6 +27487,8 @@
         "supports_tool_choice": true
     },
     "sambanova/Llama-4-Maverick-17B-128E-Instruct": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6.3e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 131072,
@@ -24525,6 +27506,8 @@
         "supports_vision": true
     },
     "sambanova/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 8192,
@@ -24541,6 +27524,8 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.1-405B-Instruct": {
+        "display_name": "Meta Llama 3.1 405B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -24554,6 +27539,8 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.1-8B-Instruct": {
+        "display_name": "Meta Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -24567,6 +27554,8 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.2-1B-Instruct": {
+        "display_name": "Meta Llama 3.2 1B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -24577,6 +27566,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/Meta-Llama-3.2-3B-Instruct": {
+        "display_name": "Meta Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "sambanova",
         "max_input_tokens": 4096,
@@ -24587,6 +27578,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/Meta-Llama-3.3-70B-Instruct": {
+        "display_name": "Meta Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 131072,
@@ -24600,6 +27593,8 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-Guard-3-8B": {
+        "display_name": "Meta Llama Guard 3 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -24610,6 +27605,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/QwQ-32B": {
+        "display_name": "QwQ 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -24620,6 +27617,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/Qwen2-Audio-7B-Instruct": {
+        "display_name": "Qwen2 Audio 7B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 4096,
@@ -24631,6 +27630,8 @@
         "supports_audio_input": true
     },
     "sambanova/Qwen3-32B": {
+        "display_name": "Qwen3 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 8192,
@@ -24644,6 +27645,8 @@
         "supports_tool_choice": true
     },
     "sambanova/DeepSeek-V3.1": {
+        "display_name": "DeepSeek V3.1",
+        "model_vendor": "deepseek",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -24657,6 +27660,8 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -24669,8 +27674,9 @@
         "supports_reasoning": true,
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
-
     "snowflake/claude-3-5-sonnet": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "litellm_provider": "snowflake",
         "max_input_tokens": 18000,
         "max_output_tokens": 8192,
@@ -24679,6 +27685,8 @@
         "supports_computer_use": true
     },
     "snowflake/deepseek-r1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "litellm_provider": "snowflake",
         "max_input_tokens": 32768,
         "max_output_tokens": 8192,
@@ -24687,6 +27695,8 @@
         "supports_reasoning": true
     },
     "snowflake/gemma-7b": {
+        "display_name": "Gemma 7B",
+        "model_vendor": "google",
         "litellm_provider": "snowflake",
         "max_input_tokens": 8000,
         "max_output_tokens": 8192,
@@ -24694,6 +27704,8 @@
         "mode": "chat"
     },
     "snowflake/jamba-1.5-large": {
+        "display_name": "Jamba 1.5 Large",
+        "model_vendor": "ai21",
         "litellm_provider": "snowflake",
         "max_input_tokens": 256000,
         "max_output_tokens": 8192,
@@ -24701,6 +27713,8 @@
         "mode": "chat"
     },
     "snowflake/jamba-1.5-mini": {
+        "display_name": "Jamba 1.5 Mini",
+        "model_vendor": "ai21",
         "litellm_provider": "snowflake",
         "max_input_tokens": 256000,
         "max_output_tokens": 8192,
@@ -24708,6 +27722,8 @@
         "mode": "chat"
     },
     "snowflake/jamba-instruct": {
+        "display_name": "Jamba Instruct",
+        "model_vendor": "ai21",
         "litellm_provider": "snowflake",
         "max_input_tokens": 256000,
         "max_output_tokens": 8192,
@@ -24715,6 +27731,8 @@
         "mode": "chat"
     },
     "snowflake/llama2-70b-chat": {
+        "display_name": "Llama 2 70B Chat",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 4096,
         "max_output_tokens": 8192,
@@ -24722,6 +27740,8 @@
         "mode": "chat"
     },
     "snowflake/llama3-70b": {
+        "display_name": "Llama 3 70B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 8000,
         "max_output_tokens": 8192,
@@ -24729,6 +27749,8 @@
         "mode": "chat"
     },
     "snowflake/llama3-8b": {
+        "display_name": "Llama 3 8B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 8000,
         "max_output_tokens": 8192,
@@ -24736,6 +27758,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.1-405b": {
+        "display_name": "Llama 3.1 405B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24743,6 +27767,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.1-70b": {
+        "display_name": "Llama 3.1 70B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24750,6 +27776,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.1-8b": {
+        "display_name": "Llama 3.1 8B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24757,6 +27785,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.2-1b": {
+        "display_name": "Llama 3.2 1B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24764,6 +27794,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.2-3b": {
+        "display_name": "Llama 3.2 3B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24771,6 +27803,8 @@
         "mode": "chat"
     },
     "snowflake/llama3.3-70b": {
+        "display_name": "Llama 3.3 70B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24778,6 +27812,8 @@
         "mode": "chat"
     },
     "snowflake/mistral-7b": {
+        "display_name": "Mistral 7B",
+        "model_vendor": "mistralai",
         "litellm_provider": "snowflake",
         "max_input_tokens": 32000,
         "max_output_tokens": 8192,
@@ -24785,6 +27821,8 @@
         "mode": "chat"
     },
     "snowflake/mistral-large": {
+        "display_name": "Mistral Large",
+        "model_vendor": "mistralai",
         "litellm_provider": "snowflake",
         "max_input_tokens": 32000,
         "max_output_tokens": 8192,
@@ -24792,6 +27830,8 @@
         "mode": "chat"
     },
     "snowflake/mistral-large2": {
+        "display_name": "Mistral Large 2",
+        "model_vendor": "mistralai",
         "litellm_provider": "snowflake",
         "max_input_tokens": 128000,
         "max_output_tokens": 8192,
@@ -24799,6 +27839,8 @@
         "mode": "chat"
     },
     "snowflake/mixtral-8x7b": {
+        "display_name": "Mixtral 8x7B",
+        "model_vendor": "mistralai",
         "litellm_provider": "snowflake",
         "max_input_tokens": 32000,
         "max_output_tokens": 8192,
@@ -24806,6 +27848,8 @@
         "mode": "chat"
     },
     "snowflake/reka-core": {
+        "display_name": "Reka Core",
+        "model_vendor": "reka",
         "litellm_provider": "snowflake",
         "max_input_tokens": 32000,
         "max_output_tokens": 8192,
@@ -24813,6 +27857,8 @@
         "mode": "chat"
     },
     "snowflake/reka-flash": {
+        "display_name": "Reka Flash",
+        "model_vendor": "reka",
         "litellm_provider": "snowflake",
         "max_input_tokens": 100000,
         "max_output_tokens": 8192,
@@ -24820,6 +27866,8 @@
         "mode": "chat"
     },
     "snowflake/snowflake-arctic": {
+        "display_name": "Snowflake Arctic",
+        "model_vendor": "snowflake",
         "litellm_provider": "snowflake",
         "max_input_tokens": 4096,
         "max_output_tokens": 8192,
@@ -24827,6 +27875,8 @@
         "mode": "chat"
     },
     "snowflake/snowflake-llama-3.1-405b": {
+        "display_name": "Snowflake Llama 3.1 405B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 8000,
         "max_output_tokens": 8192,
@@ -24834,6 +27884,8 @@
         "mode": "chat"
     },
     "snowflake/snowflake-llama-3.3-70b": {
+        "display_name": "Snowflake Llama 3.3 70B",
+        "model_vendor": "meta",
         "litellm_provider": "snowflake",
         "max_input_tokens": 8000,
         "max_output_tokens": 8192,
@@ -24841,144 +27893,98 @@
         "mode": "chat"
     },
     "stability/sd3": {
+        "display_name": "SD3",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.065,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3-large": {
+        "display_name": "SD3 Large",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.065,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3-large-turbo": {
+        "display_name": "SD3 Large Turbo",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3-medium": {
+        "display_name": "SD3 Medium",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.035,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3.5-large": {
+        "display_name": "Sd3.5 Large",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.065,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3.5-large-turbo": {
+        "display_name": "Sd3.5 Large Turbo",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/sd3.5-medium": {
+        "display_name": "Sd3.5 Medium",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.035,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/stable-image-ultra": {
+        "display_name": "Stable Image Ultra",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.08,
-        "supported_endpoints": ["/v1/images/generations"]
-    },
-    "stability/inpaint": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/outpaint": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.004,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/erase": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/search-and-replace": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/search-and-recolor": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/remove-background": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/replace-background-and-relight": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.008,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/sketch": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/structure": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/style": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/style-transfer": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.008,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/fast": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.002,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/conservative": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.04,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/creative": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.06,
-        "supported_endpoints": ["/v1/images/edits"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability/stable-image-core": {
+        "display_name": "Stable Image Core",
+        "model_vendor": "stability",
         "litellm_provider": "stability",
         "mode": "image_generation",
         "output_cost_per_image": 0.03,
-        "supported_endpoints": ["/v1/images/generations"]
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ]
     },
     "stability.sd3-5-large-v1:0": {
+        "display_name": "Stable Diffusion 3.5 Large v1",
+        "model_vendor": "stability_ai",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -24986,6 +27992,8 @@
         "output_cost_per_image": 0.08
     },
     "stability.sd3-large-v1:0": {
+        "display_name": "Stable Diffusion 3 Large v1",
+        "model_vendor": "stability_ai",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -24993,91 +28001,18 @@
         "output_cost_per_image": 0.08
     },
     "stability.stable-image-core-v1:0": {
+        "display_name": "Stable Image Core v1.0",
+        "model_vendor": "stability_ai",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
         "mode": "image_generation",
         "output_cost_per_image": 0.04
     },
-    "stability.stable-conservative-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.40
-    },
-    "stability.stable-creative-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.60
-    },
-    "stability.stable-fast-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.03
-    },
-    "stability.stable-outpaint-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.06
-    },
-    "stability.stable-image-control-sketch-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-control-structure-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-erase-object-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-inpaint-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-remove-background-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-search-recolor-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-search-replace-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-style-guide-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-style-transfer-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.08
-    },
     "stability.stable-image-core-v1:1": {
+        "display_name": "Stable Image Core v1.1",
+        "model_vendor": "stability_ai",
+        "model_version": "1.1",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -25085,6 +28020,8 @@
         "output_cost_per_image": 0.04
     },
     "stability.stable-image-ultra-v1:0": {
+        "display_name": "Stable Image Ultra v1.0",
+        "model_vendor": "stability_ai",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -25092,6 +28029,9 @@
         "output_cost_per_image": 0.14
     },
     "stability.stable-image-ultra-v1:1": {
+        "display_name": "Stable Image Ultra v1.1",
+        "model_vendor": "stability_ai",
+        "model_version": "1.1",
         "litellm_provider": "bedrock",
         "max_input_tokens": 77,
         "max_tokens": 77,
@@ -25099,44 +28039,46 @@
         "output_cost_per_image": 0.14
     },
     "standard/1024-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 Standard 1024x1024",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 3.81469e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "standard/1024-x-1792/dall-e-3": {
+        "display_name": "DALL-E 3 Standard 1024x1792",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.359e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
     "standard/1792-x-1024/dall-e-3": {
+        "display_name": "DALL-E 3 Standard 1792x1024",
+        "model_vendor": "openai",
         "input_cost_per_pixel": 4.359e-08,
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
     },
-    "linkup/search": {
-        "input_cost_per_query": 5.87e-03,
-        "litellm_provider": "linkup",
-        "mode": "search"
-    },
-    "linkup/search-deep": {
-        "input_cost_per_query": 58.67e-03,
-        "litellm_provider": "linkup",
-        "mode": "search"
-    },
     "tavily/search": {
+        "display_name": "Tavily Search",
+        "model_vendor": "tavily",
         "input_cost_per_query": 0.008,
         "litellm_provider": "tavily",
         "mode": "search"
     },
     "tavily/search-advanced": {
+        "display_name": "Tavily Search Advanced",
+        "model_vendor": "tavily",
         "input_cost_per_query": 0.016,
         "litellm_provider": "tavily",
         "mode": "search"
     },
     "text-bison": {
+        "display_name": "Text Bison",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "litellm_provider": "vertex_ai-text-models",
         "max_input_tokens": 8192,
@@ -25147,6 +28089,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-bison32k": {
+        "display_name": "Text Bison 32K",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-text-models",
@@ -25159,6 +28103,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-bison32k@002": {
+        "display_name": "Text Bison 32K @002",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "input_cost_per_token": 1.25e-07,
         "litellm_provider": "vertex_ai-text-models",
@@ -25171,6 +28117,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-bison@001": {
+        "display_name": "Text Bison @001",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "litellm_provider": "vertex_ai-text-models",
         "max_input_tokens": 8192,
@@ -25181,6 +28129,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-bison@002": {
+        "display_name": "Text Bison @002",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-07,
         "litellm_provider": "vertex_ai-text-models",
         "max_input_tokens": 8192,
@@ -25191,6 +28141,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-completion-codestral/codestral-2405": {
+        "display_name": "Codestral 2405",
+        "model_vendor": "mistralai",
+        "model_version": "2405",
         "input_cost_per_token": 0.0,
         "litellm_provider": "text-completion-codestral",
         "max_input_tokens": 32000,
@@ -25201,6 +28154,8 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "text-completion-codestral/codestral-latest": {
+        "display_name": "Codestral Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "text-completion-codestral",
         "max_input_tokens": 32000,
@@ -25211,7 +28166,8 @@
         "source": "https://docs.mistral.ai/capabilities/code_generation/"
     },
     "text-embedding-004": {
-        "deprecation_date": "2026-01-14",
+        "display_name": "Text Embedding 004",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25223,6 +28179,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models"
     },
     "text-embedding-005": {
+        "display_name": "Text Embedding 005",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25234,6 +28192,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models"
     },
     "text-embedding-3-large": {
+        "display_name": "Text Embedding 3 Large",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.3e-07,
         "input_cost_per_token_batches": 6.5e-08,
         "litellm_provider": "openai",
@@ -25245,6 +28205,8 @@
         "output_vector_size": 3072
     },
     "text-embedding-3-small": {
+        "display_name": "Text Embedding 3 Small",
+        "model_vendor": "openai",
         "input_cost_per_token": 2e-08,
         "input_cost_per_token_batches": 1e-08,
         "litellm_provider": "openai",
@@ -25256,6 +28218,9 @@
         "output_vector_size": 1536
     },
     "text-embedding-ada-002": {
+        "display_name": "Text Embedding Ada 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openai",
         "max_input_tokens": 8191,
@@ -25265,6 +28230,9 @@
         "output_vector_size": 1536
     },
     "text-embedding-ada-002-v2": {
+        "display_name": "Text Embedding Ada 002 v2",
+        "model_vendor": "openai",
+        "model_version": "002-v2",
         "input_cost_per_token": 1e-07,
         "input_cost_per_token_batches": 5e-08,
         "litellm_provider": "openai",
@@ -25275,6 +28243,8 @@
         "output_cost_per_token_batches": 0.0
     },
     "text-embedding-large-exp-03-07": {
+        "display_name": "Text Embedding Large Exp 03-07",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25286,6 +28256,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models"
     },
     "text-embedding-preview-0409": {
+        "display_name": "Text Embedding Preview 0409",
+        "model_vendor": "google",
         "input_cost_per_token": 6.25e-09,
         "input_cost_per_token_batch_requests": 5e-09,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25297,6 +28269,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "text-moderation-007": {
+        "display_name": "Text Moderation 007",
+        "model_vendor": "openai",
+        "model_version": "007",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -25306,6 +28281,8 @@
         "output_cost_per_token": 0.0
     },
     "text-moderation-latest": {
+        "display_name": "Text Moderation Latest",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -25315,6 +28292,8 @@
         "output_cost_per_token": 0.0
     },
     "text-moderation-stable": {
+        "display_name": "Text Moderation Stable",
+        "model_vendor": "openai",
         "input_cost_per_token": 0.0,
         "litellm_provider": "openai",
         "max_input_tokens": 32768,
@@ -25324,6 +28303,9 @@
         "output_cost_per_token": 0.0
     },
     "text-multilingual-embedding-002": {
+        "display_name": "Text Multilingual Embedding 002",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25335,6 +28317,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models"
     },
     "text-multilingual-embedding-preview-0409": {
+        "display_name": "Text Multilingual Embedding Preview 0409",
+        "model_vendor": "google",
         "input_cost_per_token": 6.25e-09,
         "litellm_provider": "vertex_ai-embedding-models",
         "max_input_tokens": 3072,
@@ -25345,6 +28329,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-unicorn": {
+        "display_name": "Text Unicorn",
+        "model_vendor": "google",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "vertex_ai-text-models",
         "max_input_tokens": 8192,
@@ -25355,6 +28341,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "text-unicorn@001": {
+        "display_name": "Text Unicorn 001",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "vertex_ai-text-models",
         "max_input_tokens": 8192,
@@ -25365,6 +28354,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "textembedding-gecko": {
+        "display_name": "Text Embedding Gecko",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25376,6 +28367,8 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "textembedding-gecko-multilingual": {
+        "display_name": "Text Embedding Gecko Multilingual",
+        "model_vendor": "google",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25387,6 +28380,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "textembedding-gecko-multilingual@001": {
+        "display_name": "Text Embedding Gecko Multilingual 001",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25398,6 +28394,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "textembedding-gecko@001": {
+        "display_name": "Text Embedding Gecko 001",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25409,6 +28408,9 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "textembedding-gecko@003": {
+        "display_name": "Text Embedding Gecko 003",
+        "model_vendor": "google",
+        "model_version": "003",
         "input_cost_per_character": 2.5e-08,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-embedding-models",
@@ -25420,24 +28422,32 @@
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#foundation_models"
     },
     "together-ai-21.1b-41b": {
+        "display_name": "Together AI 21.1B-41B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 8e-07
     },
     "together-ai-4.1b-8b": {
+        "display_name": "Together AI 4.1B-8B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 2e-07
     },
     "together-ai-41.1b-80b": {
+        "display_name": "Together AI 41.1B-80B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 9e-07
     },
     "together-ai-8.1b-21b": {
+        "display_name": "Together AI 8.1B-21B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "together_ai",
         "max_tokens": 1000,
@@ -25445,24 +28455,32 @@
         "output_cost_per_token": 3e-07
     },
     "together-ai-81.1b-110b": {
+        "display_name": "Together AI 81.1B-110B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 1.8e-06,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 1.8e-06
     },
     "together-ai-embedding-151m-to-350m": {
+        "display_name": "Together AI Embedding 151M-350M",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 1.6e-08,
         "litellm_provider": "together_ai",
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "together-ai-embedding-up-to-150m": {
+        "display_name": "Together AI Embedding Up to 150M",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "together_ai",
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "together_ai/baai/bge-base-en-v1.5": {
+        "display_name": "BGE Base EN v1.5",
+        "model_vendor": "baai",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "together_ai",
         "max_input_tokens": 512,
@@ -25471,6 +28489,8 @@
         "output_vector_size": 768
     },
     "together_ai/BAAI/bge-base-en-v1.5": {
+        "display_name": "BGE Base EN v1.5",
+        "model_vendor": "baai",
         "input_cost_per_token": 8e-09,
         "litellm_provider": "together_ai",
         "max_input_tokens": 512,
@@ -25479,28 +28499,34 @@
         "output_vector_size": 768
     },
     "together-ai-up-to-4b": {
+        "display_name": "Together AI Up to 4B",
+        "model_vendor": "together_ai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 1e-07
     },
     "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo": {
+        "display_name": "Qwen 2.5 72B Instruct Turbo",
+        "model_vendor": "alibaba",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo": {
+        "display_name": "Qwen 2.5 7B Instruct Turbo",
+        "model_vendor": "alibaba",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+        "display_name": "Qwen 3 235B A22B Instruct 2507",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262000,
@@ -25509,10 +28535,11 @@
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "display_name": "Qwen 3 235B A22B Thinking 2507",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -25521,10 +28548,11 @@
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+        "display_name": "Qwen 3 235B A22B FP8",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 40000,
@@ -25536,6 +28564,8 @@
         "supports_tool_choice": false
     },
     "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+        "display_name": "Qwen 3 Coder 480B A35B Instruct FP8",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -25544,10 +28574,11 @@
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -25557,10 +28588,12 @@
         "output_cost_per_token": 7e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
+        "model_version": "0528",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -25569,10 +28602,11 @@
         "source": "https://www.together.ai/models/deepseek-r1-0528-throughput",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.25e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 65536,
@@ -25582,10 +28616,11 @@
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3.1": {
+        "display_name": "DeepSeek V3.1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_tokens": 128000,
@@ -25598,14 +28633,17 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+        "display_name": "Llama 3.2 3B Instruct Turbo",
+        "model_vendor": "meta",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+        "display_name": "Llama 3.3 70B Instruct Turbo",
+        "model_vendor": "meta",
         "input_cost_per_token": 8.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25616,6 +28654,8 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+        "display_name": "Llama 3.3 70B Instruct Turbo Free",
+        "model_vendor": "meta",
         "input_cost_per_token": 0,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25626,36 +28666,41 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct FP8",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.7e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 8.5e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 5.9e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+        "display_name": "Meta Llama 3.1 405B Instruct Turbo",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-06,
         "litellm_provider": "together_ai",
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+        "display_name": "Meta Llama 3.1 70B Instruct Turbo",
+        "model_vendor": "meta",
         "input_cost_per_token": 8.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25666,6 +28711,8 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+        "display_name": "Meta Llama 3.1 8B Instruct Turbo",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25676,6 +28723,8 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-7B-Instruct-v0.1": {
+        "display_name": "Mistral 7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -25684,6 +28733,9 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {
+        "display_name": "Mistral Small 24B Instruct 2501",
+        "model_vendor": "mistralai",
+        "model_version": "2501",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -25691,6 +28743,8 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "display_name": "Mixtral 8x7B Instruct v0.1",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25701,6 +28755,9 @@
         "supports_tool_choice": true
     },
     "together_ai/moonshotai/Kimi-K2-Instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
+        "model_version": "k2",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -25708,10 +28765,11 @@
         "source": "https://www.together.ai/models/kimi-k2-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/openai/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -25720,10 +28778,11 @@
         "source": "https://www.together.ai/models/gpt-oss-120b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/openai/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -25732,10 +28791,11 @@
         "source": "https://www.together.ai/models/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/togethercomputer/CodeLlama-34b-Instruct": {
+        "display_name": "CodeLlama 34B Instruct",
+        "model_vendor": "meta",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -25743,6 +28803,8 @@
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.5-Air-FP8": {
+        "display_name": "GLM 4.5 Air FP8",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -25751,11 +28813,12 @@
         "source": "https://www.together.ai/models/glm-4-5-air",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.6": {
-        "input_cost_per_token": 0.6e-06,
+        "display_name": "GLM 4.6",
+        "model_vendor": "zhipu",
+        "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
@@ -25769,6 +28832,9 @@
         "supports_tool_choice": true
     },
     "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
+        "display_name": "Kimi K2 Instruct 0905",
+        "model_vendor": "moonshot",
+        "model_version": "k2-0905",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
@@ -25780,6 +28846,8 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "display_name": "Qwen 3 Next 80B A3B Instruct",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
@@ -25788,10 +28856,11 @@
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "display_name": "Qwen 3 Next 80B A3B Thinking",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
@@ -25800,10 +28869,11 @@
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-thinking",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "tts-1": {
+        "display_name": "TTS 1",
+        "model_vendor": "openai",
         "input_cost_per_character": 1.5e-05,
         "litellm_provider": "openai",
         "mode": "audio_speech",
@@ -25812,6 +28882,9 @@
         ]
     },
     "tts-1-hd": {
+        "display_name": "TTS 1 HD",
+        "model_vendor": "openai",
+        "model_version": "1-hd",
         "input_cost_per_character": 3e-05,
         "litellm_provider": "openai",
         "mode": "audio_speech",
@@ -25819,43 +28892,9 @@
             "/v1/audio/speech"
         ]
     },
-    "aws_polly/standard": {
-        "input_cost_per_character": 4e-06,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/neural": {
-        "input_cost_per_character": 1.6e-05,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/long-form": {
-        "input_cost_per_character": 1e-04,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/generative": {
-        "input_cost_per_character": 3e-05,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
     "us.amazon.nova-lite-v1:0": {
+        "display_name": "Amazon Nova Lite v1 US",
+        "model_vendor": "amazon",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
@@ -25870,6 +28909,8 @@
         "supports_vision": true
     },
     "us.amazon.nova-micro-v1:0": {
+        "display_name": "Amazon Nova Micro v1 US",
+        "model_vendor": "amazon",
         "input_cost_per_token": 3.5e-08,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -25882,6 +28923,8 @@
         "supports_response_schema": true
     },
     "us.amazon.nova-premier-v1:0": {
+        "display_name": "Amazon Nova Premier v1 US",
+        "model_vendor": "amazon",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 1000000,
@@ -25896,6 +28939,8 @@
         "supports_vision": true
     },
     "us.amazon.nova-pro-v1:0": {
+        "display_name": "Amazon Nova Pro v1 US",
+        "model_vendor": "amazon",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 300000,
@@ -25910,6 +28955,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 8e-08,
         "input_cost_per_token": 8e-07,
@@ -25927,6 +28975,9 @@
         "supports_tool_choice": true
     },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -25949,6 +29000,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240620",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -25963,6 +29017,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+        "display_name": "Claude 3.5 Sonnet v2",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -25982,6 +29039,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20250219",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -26002,6 +29062,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-haiku-20240307-v1:0": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20240307",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -26016,6 +29079,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-opus-20240229-v1:0": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -26029,6 +29095,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-3-sonnet-20240229-v1:0": {
+        "display_name": "Claude 3 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 200000,
@@ -26043,6 +29112,9 @@
         "supports_vision": true
     },
     "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
+        "model_version": "20250805",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -26069,6 +29141,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_read_input_token_cost": 3.3e-07,
         "input_cost_per_token": 3.3e-06,
@@ -26099,6 +29174,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -26120,6 +29198,9 @@
         "tool_use_system_prompt_tokens": 346
     },
     "us.anthropic.claude-opus-4-20250514-v1:0": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -26146,6 +29227,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251101",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -26172,6 +29256,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251101",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -26198,6 +29285,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+        "display_name": "Anthropic.claude Opus 4 5 20251101 V1:0",
+        "model_vendor": "anthropic",
+        "model_version": "0",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -26224,6 +29314,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -26254,6 +29347,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "us.deepseek.r1-v1:0": {
+        "display_name": "DeepSeek R1 v1 US",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.35e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -26266,6 +29361,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-1-405b-instruct-v1:0": {
+        "display_name": "Llama 3.1 405B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.32e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26277,6 +29374,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-1-70b-instruct-v1:0": {
+        "display_name": "Llama 3.1 70B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 9.9e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26288,6 +29387,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-1-8b-instruct-v1:0": {
+        "display_name": "Llama 3.1 8B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.2e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26299,6 +29400,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-2-11b-instruct-v1:0": {
+        "display_name": "Llama 3.2 11B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26311,6 +29414,8 @@
         "supports_vision": true
     },
     "us.meta.llama3-2-1b-instruct-v1:0": {
+        "display_name": "Llama 3.2 1B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26322,6 +29427,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-2-3b-instruct-v1:0": {
+        "display_name": "Llama 3.2 3B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26333,6 +29440,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama3-2-90b-instruct-v1:0": {
+        "display_name": "Llama 3.2 90B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock",
         "max_input_tokens": 128000,
@@ -26345,6 +29454,8 @@
         "supports_vision": true
     },
     "us.meta.llama3-3-70b-instruct-v1:0": {
+        "display_name": "Llama 3.3 70B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -26356,6 +29467,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama4-maverick-17b-instruct-v1:0": {
+        "display_name": "Llama 4 Maverick 17B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.4e-07,
         "input_cost_per_token_batches": 1.2e-07,
         "litellm_provider": "bedrock_converse",
@@ -26377,6 +29490,8 @@
         "supports_tool_choice": false
     },
     "us.meta.llama4-scout-17b-instruct-v1:0": {
+        "display_name": "Llama 4 Scout 17B Instruct v1 US",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.7e-07,
         "input_cost_per_token_batches": 8.5e-08,
         "litellm_provider": "bedrock_converse",
@@ -26398,6 +29513,9 @@
         "supports_tool_choice": false
     },
     "us.mistral.pixtral-large-2502-v1:0": {
+        "display_name": "Pixtral Large 2502 v1 US",
+        "model_vendor": "mistralai",
+        "model_version": "2502",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "bedrock_converse",
         "max_input_tokens": 128000,
@@ -26409,6 +29527,8 @@
         "supports_tool_choice": false
     },
     "v0/v0-1.0-md": {
+        "display_name": "V0 1.0 Medium",
+        "model_vendor": "vercel",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "v0",
         "max_input_tokens": 128000,
@@ -26423,6 +29543,8 @@
         "supports_vision": true
     },
     "v0/v0-1.5-lg": {
+        "display_name": "V0 1.5 Large",
+        "model_vendor": "vercel",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "v0",
         "max_input_tokens": 512000,
@@ -26437,6 +29559,8 @@
         "supports_vision": true
     },
     "v0/v0-1.5-md": {
+        "display_name": "V0 1.5 Medium",
+        "model_vendor": "vercel",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "v0",
         "max_input_tokens": 128000,
@@ -26451,6 +29575,8 @@
         "supports_vision": true
     },
     "vercel_ai_gateway/alibaba/qwen-3-14b": {
+        "display_name": "Qwen 3 14B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 40960,
@@ -26460,6 +29586,8 @@
         "output_cost_per_token": 2.4e-07
     },
     "vercel_ai_gateway/alibaba/qwen-3-235b": {
+        "display_name": "Qwen 3 235B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 40960,
@@ -26469,6 +29597,8 @@
         "output_cost_per_token": 6e-07
     },
     "vercel_ai_gateway/alibaba/qwen-3-30b": {
+        "display_name": "Qwen 3 30B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 40960,
@@ -26478,6 +29608,8 @@
         "output_cost_per_token": 3e-07
     },
     "vercel_ai_gateway/alibaba/qwen-3-32b": {
+        "display_name": "Qwen 3 32B",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 40960,
@@ -26487,6 +29619,8 @@
         "output_cost_per_token": 3e-07
     },
     "vercel_ai_gateway/alibaba/qwen3-coder": {
+        "display_name": "Qwen 3 Coder",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 262144,
@@ -26496,6 +29630,8 @@
         "output_cost_per_token": 1.6e-06
     },
     "vercel_ai_gateway/amazon/nova-lite": {
+        "display_name": "Amazon Nova Lite",
+        "model_vendor": "amazon",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 300000,
@@ -26505,6 +29641,8 @@
         "output_cost_per_token": 2.4e-07
     },
     "vercel_ai_gateway/amazon/nova-micro": {
+        "display_name": "Amazon Nova Micro",
+        "model_vendor": "amazon",
         "input_cost_per_token": 3.5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26514,6 +29652,8 @@
         "output_cost_per_token": 1.4e-07
     },
     "vercel_ai_gateway/amazon/nova-pro": {
+        "display_name": "Amazon Nova Pro",
+        "model_vendor": "amazon",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 300000,
@@ -26523,6 +29663,8 @@
         "output_cost_per_token": 3.2e-06
     },
     "vercel_ai_gateway/amazon/titan-embed-text-v2": {
+        "display_name": "Amazon Titan Embed Text v2",
+        "model_vendor": "amazon",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26532,6 +29674,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/anthropic/claude-3-haiku": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3e-07,
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_token": 2.5e-07,
@@ -26543,6 +29687,8 @@
         "output_cost_per_token": 1.25e-06
     },
     "vercel_ai_gateway/anthropic/claude-3-opus": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -26554,6 +29700,8 @@
         "output_cost_per_token": 7.5e-05
     },
     "vercel_ai_gateway/anthropic/claude-3.5-haiku": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1e-06,
         "cache_read_input_token_cost": 8e-08,
         "input_cost_per_token": 8e-07,
@@ -26565,6 +29713,8 @@
         "output_cost_per_token": 4e-06
     },
     "vercel_ai_gateway/anthropic/claude-3.5-sonnet": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -26576,6 +29726,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/anthropic/claude-3.7-sonnet": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -26587,6 +29739,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/anthropic/claude-4-opus": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -26598,6 +29752,8 @@
         "output_cost_per_token": 7.5e-05
     },
     "vercel_ai_gateway/anthropic/claude-4-sonnet": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -26609,6 +29765,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/cohere/command-a": {
+        "display_name": "Command A",
+        "model_vendor": "cohere",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 256000,
@@ -26618,6 +29776,8 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/cohere/command-r": {
+        "display_name": "Command R",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26627,6 +29787,8 @@
         "output_cost_per_token": 6e-07
     },
     "vercel_ai_gateway/cohere/command-r-plus": {
+        "display_name": "Command R Plus",
+        "model_vendor": "cohere",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26636,6 +29798,8 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/cohere/embed-v4.0": {
+        "display_name": "Embed v4.0",
+        "model_vendor": "cohere",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26645,6 +29809,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/deepseek/deepseek-r1": {
+        "display_name": "DeepSeek R1",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26654,6 +29820,8 @@
         "output_cost_per_token": 2.19e-06
     },
     "vercel_ai_gateway/deepseek/deepseek-r1-distill-llama-70b": {
+        "display_name": "DeepSeek R1 Distill Llama 70B",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 7.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -26663,6 +29831,8 @@
         "output_cost_per_token": 9.9e-07
     },
     "vercel_ai_gateway/deepseek/deepseek-v3": {
+        "display_name": "DeepSeek V3",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26672,6 +29842,8 @@
         "output_cost_per_token": 9e-07
     },
     "vercel_ai_gateway/google/gemini-2.0-flash": {
+        "display_name": "Gemini 2.0 Flash",
+        "model_vendor": "google",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1048576,
@@ -26681,6 +29853,8 @@
         "output_cost_per_token": 6e-07
     },
     "vercel_ai_gateway/google/gemini-2.0-flash-lite": {
+        "display_name": "Gemini 2.0 Flash Lite",
+        "model_vendor": "google",
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1048576,
@@ -26690,6 +29864,8 @@
         "output_cost_per_token": 3e-07
     },
     "vercel_ai_gateway/google/gemini-2.5-flash": {
+        "display_name": "Gemini 2.5 Flash",
+        "model_vendor": "google",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1000000,
@@ -26699,6 +29875,8 @@
         "output_cost_per_token": 2.5e-06
     },
     "vercel_ai_gateway/google/gemini-2.5-pro": {
+        "display_name": "Gemini 2.5 Pro",
+        "model_vendor": "google",
         "input_cost_per_token": 2.5e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 1048576,
@@ -26708,6 +29886,9 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/google/gemini-embedding-001": {
+        "display_name": "Gemini Embedding 001",
+        "model_vendor": "google",
+        "model_version": "001",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26717,6 +29898,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/google/gemma-2-9b": {
+        "display_name": "Gemma 2 9B",
+        "model_vendor": "google",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 8192,
@@ -26726,6 +29909,9 @@
         "output_cost_per_token": 2e-07
     },
     "vercel_ai_gateway/google/text-embedding-005": {
+        "display_name": "Text Embedding 005",
+        "model_vendor": "google",
+        "model_version": "005",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26735,6 +29921,9 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/google/text-multilingual-embedding-002": {
+        "display_name": "Text Multilingual Embedding 002",
+        "model_vendor": "google",
+        "model_version": "002",
         "input_cost_per_token": 2.5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26744,6 +29933,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/inception/mercury-coder-small": {
+        "display_name": "Mercury Coder Small",
+        "model_vendor": "inception",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32000,
@@ -26753,6 +29944,8 @@
         "output_cost_per_token": 1e-06
     },
     "vercel_ai_gateway/meta/llama-3-70b": {
+        "display_name": "Llama 3 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 5.9e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 8192,
@@ -26762,6 +29955,8 @@
         "output_cost_per_token": 7.9e-07
     },
     "vercel_ai_gateway/meta/llama-3-8b": {
+        "display_name": "Llama 3 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 8192,
@@ -26771,6 +29966,8 @@
         "output_cost_per_token": 8e-08
     },
     "vercel_ai_gateway/meta/llama-3.1-70b": {
+        "display_name": "Llama 3.1 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26780,6 +29977,8 @@
         "output_cost_per_token": 7.2e-07
     },
     "vercel_ai_gateway/meta/llama-3.1-8b": {
+        "display_name": "Llama 3.1 8B",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131000,
@@ -26789,6 +29988,8 @@
         "output_cost_per_token": 8e-08
     },
     "vercel_ai_gateway/meta/llama-3.2-11b": {
+        "display_name": "Llama 3.2 11B",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.6e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26798,6 +29999,8 @@
         "output_cost_per_token": 1.6e-07
     },
     "vercel_ai_gateway/meta/llama-3.2-1b": {
+        "display_name": "Llama 3.2 1B",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26807,6 +30010,8 @@
         "output_cost_per_token": 1e-07
     },
     "vercel_ai_gateway/meta/llama-3.2-3b": {
+        "display_name": "Llama 3.2 3B",
+        "model_vendor": "meta",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26816,6 +30021,8 @@
         "output_cost_per_token": 1.5e-07
     },
     "vercel_ai_gateway/meta/llama-3.2-90b": {
+        "display_name": "Llama 3.2 90B",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26825,6 +30032,8 @@
         "output_cost_per_token": 7.2e-07
     },
     "vercel_ai_gateway/meta/llama-3.3-70b": {
+        "display_name": "Llama 3.3 70B",
+        "model_vendor": "meta",
         "input_cost_per_token": 7.2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26834,6 +30043,8 @@
         "output_cost_per_token": 7.2e-07
     },
     "vercel_ai_gateway/meta/llama-4-maverick": {
+        "display_name": "Llama 4 Maverick",
+        "model_vendor": "meta",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -26843,6 +30054,8 @@
         "output_cost_per_token": 6e-07
     },
     "vercel_ai_gateway/meta/llama-4-scout": {
+        "display_name": "Llama 4 Scout",
+        "model_vendor": "meta",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -26852,6 +30065,8 @@
         "output_cost_per_token": 3e-07
     },
     "vercel_ai_gateway/mistral/codestral": {
+        "display_name": "Codestral",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 256000,
@@ -26861,6 +30076,8 @@
         "output_cost_per_token": 9e-07
     },
     "vercel_ai_gateway/mistral/codestral-embed": {
+        "display_name": "Codestral Embed",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26870,6 +30087,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/devstral-small": {
+        "display_name": "Devstral Small",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 7e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26879,6 +30098,8 @@
         "output_cost_per_token": 2.8e-07
     },
     "vercel_ai_gateway/mistral/magistral-medium": {
+        "display_name": "Magistral Medium",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26888,6 +30109,8 @@
         "output_cost_per_token": 5e-06
     },
     "vercel_ai_gateway/mistral/magistral-small": {
+        "display_name": "Magistral Small",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26897,6 +30120,8 @@
         "output_cost_per_token": 1.5e-06
     },
     "vercel_ai_gateway/mistral/ministral-3b": {
+        "display_name": "Ministral 3B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26906,6 +30131,8 @@
         "output_cost_per_token": 4e-08
     },
     "vercel_ai_gateway/mistral/ministral-8b": {
+        "display_name": "Ministral 8B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26915,6 +30142,8 @@
         "output_cost_per_token": 1e-07
     },
     "vercel_ai_gateway/mistral/mistral-embed": {
+        "display_name": "Mistral Embed",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -26924,6 +30153,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/mistral-large": {
+        "display_name": "Mistral Large",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32000,
@@ -26933,6 +30164,8 @@
         "output_cost_per_token": 6e-06
     },
     "vercel_ai_gateway/mistral/mistral-saba-24b": {
+        "display_name": "Mistral Saba 24B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 7.9e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32768,
@@ -26942,6 +30175,8 @@
         "output_cost_per_token": 7.9e-07
     },
     "vercel_ai_gateway/mistral/mistral-small": {
+        "display_name": "Mistral Small",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32000,
@@ -26951,6 +30186,8 @@
         "output_cost_per_token": 3e-07
     },
     "vercel_ai_gateway/mistral/mixtral-8x22b-instruct": {
+        "display_name": "Mixtral 8x22B Instruct",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 65536,
@@ -26960,6 +30197,8 @@
         "output_cost_per_token": 1.2e-06
     },
     "vercel_ai_gateway/mistral/pixtral-12b": {
+        "display_name": "Pixtral 12B",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26969,6 +30208,8 @@
         "output_cost_per_token": 1.5e-07
     },
     "vercel_ai_gateway/mistral/pixtral-large": {
+        "display_name": "Pixtral Large",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -26978,6 +30219,9 @@
         "output_cost_per_token": 6e-06
     },
     "vercel_ai_gateway/moonshotai/kimi-k2": {
+        "display_name": "Kimi K2",
+        "model_vendor": "moonshot",
+        "model_version": "k2",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -26987,6 +30231,8 @@
         "output_cost_per_token": 2.2e-06
     },
     "vercel_ai_gateway/morph/morph-v3-fast": {
+        "display_name": "Morph v3 Fast",
+        "model_vendor": "morph",
         "input_cost_per_token": 8e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32768,
@@ -26996,6 +30242,8 @@
         "output_cost_per_token": 1.2e-06
     },
     "vercel_ai_gateway/morph/morph-v3-large": {
+        "display_name": "Morph v3 Large",
+        "model_vendor": "morph",
         "input_cost_per_token": 9e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32768,
@@ -27005,6 +30253,8 @@
         "output_cost_per_token": 1.9e-06
     },
     "vercel_ai_gateway/openai/gpt-3.5-turbo": {
+        "display_name": "GPT-3.5 Turbo",
+        "model_vendor": "openai",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 16385,
@@ -27014,6 +30264,8 @@
         "output_cost_per_token": 1.5e-06
     },
     "vercel_ai_gateway/openai/gpt-3.5-turbo-instruct": {
+        "display_name": "GPT-3.5 Turbo Instruct",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 8192,
@@ -27023,6 +30275,8 @@
         "output_cost_per_token": 2e-06
     },
     "vercel_ai_gateway/openai/gpt-4-turbo": {
+        "display_name": "GPT-4 Turbo",
+        "model_vendor": "openai",
         "input_cost_per_token": 1e-05,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -27032,6 +30286,8 @@
         "output_cost_per_token": 3e-05
     },
     "vercel_ai_gateway/openai/gpt-4.1": {
+        "display_name": "GPT-4.1",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
@@ -27043,6 +30299,8 @@
         "output_cost_per_token": 8e-06
     },
     "vercel_ai_gateway/openai/gpt-4.1-mini": {
+        "display_name": "GPT-4.1 Mini",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 4e-07,
@@ -27054,6 +30312,8 @@
         "output_cost_per_token": 1.6e-06
     },
     "vercel_ai_gateway/openai/gpt-4.1-nano": {
+        "display_name": "GPT-4.1 Nano",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 1e-07,
@@ -27065,6 +30325,9 @@
         "output_cost_per_token": 4e-07
     },
     "vercel_ai_gateway/openai/gpt-4o": {
+        "display_name": "GPT-4o",
+        "model_vendor": "openai",
+        "model_version": "4o",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 1.25e-06,
         "input_cost_per_token": 2.5e-06,
@@ -27076,6 +30339,9 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/openai/gpt-4o-mini": {
+        "display_name": "GPT-4o Mini",
+        "model_vendor": "openai",
+        "model_version": "4o",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 1.5e-07,
@@ -27087,6 +30353,8 @@
         "output_cost_per_token": 6e-07
     },
     "vercel_ai_gateway/openai/o1": {
+        "display_name": "o1",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 7.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -27098,6 +30366,8 @@
         "output_cost_per_token": 6e-05
     },
     "vercel_ai_gateway/openai/o3": {
+        "display_name": "o3",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 2e-06,
@@ -27109,6 +30379,8 @@
         "output_cost_per_token": 8e-06
     },
     "vercel_ai_gateway/openai/o3-mini": {
+        "display_name": "o3 Mini",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 5.5e-07,
         "input_cost_per_token": 1.1e-06,
@@ -27120,6 +30392,8 @@
         "output_cost_per_token": 4.4e-06
     },
     "vercel_ai_gateway/openai/o4-mini": {
+        "display_name": "o4 Mini",
+        "model_vendor": "openai",
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 2.75e-07,
         "input_cost_per_token": 1.1e-06,
@@ -27131,6 +30405,8 @@
         "output_cost_per_token": 4.4e-06
     },
     "vercel_ai_gateway/openai/text-embedding-3-large": {
+        "display_name": "Text Embedding 3 Large",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.3e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -27140,6 +30416,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/openai/text-embedding-3-small": {
+        "display_name": "Text Embedding 3 Small",
+        "model_vendor": "openai",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -27149,6 +30427,9 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/openai/text-embedding-ada-002": {
+        "display_name": "Text Embedding Ada 002",
+        "model_vendor": "openai",
+        "model_version": "002",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 0,
@@ -27158,6 +30439,8 @@
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/perplexity/sonar": {
+        "display_name": "Sonar",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 127000,
@@ -27167,6 +30450,8 @@
         "output_cost_per_token": 1e-06
     },
     "vercel_ai_gateway/perplexity/sonar-pro": {
+        "display_name": "Sonar Pro",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 200000,
@@ -27176,6 +30461,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/perplexity/sonar-reasoning": {
+        "display_name": "Sonar Reasoning",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 127000,
@@ -27185,6 +30472,8 @@
         "output_cost_per_token": 5e-06
     },
     "vercel_ai_gateway/perplexity/sonar-reasoning-pro": {
+        "display_name": "Sonar Reasoning Pro",
+        "model_vendor": "perplexity",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 127000,
@@ -27194,6 +30483,8 @@
         "output_cost_per_token": 8e-06
     },
     "vercel_ai_gateway/vercel/v0-1.0-md": {
+        "display_name": "V0 1.0 MD",
+        "model_vendor": "vercel",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -27203,6 +30494,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/vercel/v0-1.5-md": {
+        "display_name": "V0 1.5 MD",
+        "model_vendor": "vercel",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -27212,6 +30505,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/xai/grok-2": {
+        "display_name": "Grok 2",
+        "model_vendor": "xai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27221,6 +30516,8 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/xai/grok-2-vision": {
+        "display_name": "Grok 2 Vision",
+        "model_vendor": "xai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 32768,
@@ -27230,6 +30527,8 @@
         "output_cost_per_token": 1e-05
     },
     "vercel_ai_gateway/xai/grok-3": {
+        "display_name": "Grok 3",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27239,6 +30538,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/xai/grok-3-fast": {
+        "display_name": "Grok 3 Fast",
+        "model_vendor": "xai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27248,6 +30549,8 @@
         "output_cost_per_token": 2.5e-05
     },
     "vercel_ai_gateway/xai/grok-3-mini": {
+        "display_name": "Grok 3 Mini",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27257,6 +30560,8 @@
         "output_cost_per_token": 5e-07
     },
     "vercel_ai_gateway/xai/grok-3-mini-fast": {
+        "display_name": "Grok 3 Mini Fast",
+        "model_vendor": "xai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27266,6 +30571,8 @@
         "output_cost_per_token": 4e-06
     },
     "vercel_ai_gateway/xai/grok-4": {
+        "display_name": "Grok 4",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 256000,
@@ -27275,6 +30582,8 @@
         "output_cost_per_token": 1.5e-05
     },
     "vercel_ai_gateway/zai/glm-4.5": {
+        "display_name": "GLM 4.5",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 131072,
@@ -27284,6 +30593,8 @@
         "output_cost_per_token": 2.2e-06
     },
     "vercel_ai_gateway/zai/glm-4.5-air": {
+        "display_name": "GLM 4.5 Air",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vercel_ai_gateway",
         "max_input_tokens": 128000,
@@ -27293,6 +30604,8 @@
         "output_cost_per_token": 1.1e-06
     },
     "vercel_ai_gateway/zai/glm-4.6": {
+        "display_name": "GLM 4.6",
+        "model_vendor": "zhipu",
         "litellm_provider": "vercel_ai_gateway",
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 4.5e-07,
@@ -27307,7 +30620,9 @@
         "supports_tool_choice": true
     },
     "vertex_ai/chirp": {
-        "input_cost_per_character": 30e-06,
+        "display_name": "Chirp",
+        "model_vendor": "google",
+        "input_cost_per_character": 3e-05,
         "litellm_provider": "vertex_ai",
         "mode": "audio_speech",
         "source": "https://cloud.google.com/text-to-speech/pricing",
@@ -27316,6 +30631,8 @@
         ]
     },
     "vertex_ai/claude-3-5-haiku": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27329,6 +30646,9 @@
         "supports_tool_choice": true
     },
     "vertex_ai/claude-3-5-haiku@20241022": {
+        "display_name": "Claude 3.5 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27342,6 +30662,9 @@
         "supports_tool_choice": true
     },
     "vertex_ai/claude-haiku-4-5@20251001": {
+        "display_name": "Claude Haiku 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251001",
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_read_input_token_cost": 1e-07,
         "input_cost_per_token": 1e-06,
@@ -27361,6 +30684,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/claude-3-5-sonnet": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27376,6 +30701,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-5-sonnet-v2": {
+        "display_name": "Claude 3.5 Sonnet v2",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27391,6 +30718,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-5-sonnet-v2@20241022": {
+        "display_name": "Claude 3.5 Sonnet v2",
+        "model_vendor": "anthropic",
+        "model_version": "20241022",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27406,6 +30736,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-5-sonnet@20240620": {
+        "display_name": "Claude 3.5 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240620",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27420,6 +30753,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-7-sonnet@20250219": {
+        "display_name": "Claude 3.7 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20250219",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "deprecation_date": "2025-06-01",
@@ -27442,6 +30778,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-3-haiku": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27455,6 +30793,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-haiku@20240307": {
+        "display_name": "Claude 3 Haiku",
+        "model_vendor": "anthropic",
+        "model_version": "20240307",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27468,6 +30809,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-opus": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27481,6 +30824,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-opus@20240229": {
+        "display_name": "Claude 3 Opus",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 1.5e-05,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27494,6 +30840,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-sonnet": {
+        "display_name": "Claude 3 Sonnet",
+        "model_vendor": "anthropic",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27507,6 +30855,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-3-sonnet@20240229": {
+        "display_name": "Claude 3 Sonnet",
+        "model_vendor": "anthropic",
+        "model_version": "20240229",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-anthropic_models",
         "max_input_tokens": 200000,
@@ -27520,6 +30871,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-opus-4": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -27546,6 +30899,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-opus-4-1": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -27563,6 +30918,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-opus-4-1@20250805": {
+        "display_name": "Claude Opus 4.1",
+        "model_vendor": "anthropic",
+        "model_version": "20250805",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -27580,6 +30938,8 @@
         "supports_vision": true
     },
     "vertex_ai/claude-opus-4-5": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -27606,6 +30966,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-opus-4-5@20251101": {
+        "display_name": "Claude Opus 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20251101",
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -27632,6 +30995,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-sonnet-4-5": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -27658,6 +31023,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4-5@20250929": {
+        "display_name": "Claude Sonnet 4.5",
+        "model_vendor": "anthropic",
+        "model_version": "20250929",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -27684,6 +31052,9 @@
         "supports_vision": true
     },
     "vertex_ai/claude-opus-4@20250514": {
+        "display_name": "Claude Opus 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 1.875e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "input_cost_per_token": 1.5e-05,
@@ -27710,6 +31081,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-sonnet-4": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -27740,6 +31113,9 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/claude-sonnet-4@20250514": {
+        "display_name": "Claude Sonnet 4",
+        "model_vendor": "anthropic",
+        "model_version": "20250514",
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
@@ -27770,6 +31146,8 @@
         "tool_use_system_prompt_tokens": 159
     },
     "vertex_ai/mistralai/codestral-2@001": {
+        "display_name": "Codestral 2",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27781,6 +31159,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/codestral-2": {
+        "display_name": "Codestral 2",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27792,6 +31172,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/codestral-2@001": {
+        "display_name": "Codestral 2 @001",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27803,6 +31185,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistralai/codestral-2": {
+        "display_name": "Codestral 2",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27814,6 +31198,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/codestral-2501": {
+        "display_name": "Codestral 2501",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27825,6 +31211,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/codestral@2405": {
+        "display_name": "Codestral 2405",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27836,6 +31224,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/codestral@latest": {
+        "display_name": "Codestral Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -27847,6 +31237,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/deepseek-ai/deepseek-v3.1-maas": {
+        "display_name": "DeepSeek V3.1 MaaS",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.35e-06,
         "litellm_provider": "vertex_ai-deepseek_models",
         "max_input_tokens": 163840,
@@ -27865,6 +31257,9 @@
         "supports_tool_choice": true
     },
     "vertex_ai/deepseek-ai/deepseek-v3.2-maas": {
+        "display_name": "Deepseek AI Deepseek V3.2 Maas",
+        "model_vendor": "deepseek",
+        "model_version": "3.2",
         "input_cost_per_token": 5.6e-07,
         "input_cost_per_token_batches": 2.8e-07,
         "litellm_provider": "vertex_ai-deepseek_models",
@@ -27885,6 +31280,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/deepseek-ai/deepseek-r1-0528-maas": {
+        "display_name": "DeepSeek R1 0528 MaaS",
+        "model_vendor": "deepseek",
         "input_cost_per_token": 1.35e-06,
         "litellm_provider": "vertex_ai-deepseek_models",
         "max_input_tokens": 65336,
@@ -27900,6 +31297,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/gemini-2.5-flash-image": {
+        "display_name": "Gemini 2.5 Flash Image",
+        "model_vendor": "google",
         "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -27915,7 +31314,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -27949,6 +31347,8 @@
         "tpm": 8000000
     },
     "vertex_ai/gemini-3-pro-image-preview": {
+        "display_name": "Gemini 3 Pro Image Preview",
+        "model_vendor": "google",
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
         "input_cost_per_token_batches": 1e-06,
@@ -27958,61 +31358,78 @@
         "max_tokens": 65536,
         "mode": "image_generation",
         "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 1.2e-04,
+        "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
     },
     "vertex_ai/imagegeneration@006": {
+        "display_name": "Image Generation 006",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-fast-generate-001": {
+        "display_name": "Imagen 3.0 Fast Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-generate-001": {
+        "display_name": "Imagen 3.0 Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-generate-002": {
-        "deprecation_date": "2025-11-10",
+        "display_name": "Imagen 3.0 Generate 002",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-3.0-capability-001": {
+        "display_name": "Imagen 3.0 Capability 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/image/edit-insert-objects"
     },
     "vertex_ai/imagen-4.0-fast-generate-001": {
+        "display_name": "Imagen 4.0 Fast Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.02,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-4.0-generate-001": {
+        "display_name": "Imagen 4.0 Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.04,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/imagen-4.0-ultra-generate-001": {
+        "display_name": "Imagen 4.0 Ultra Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-image-models",
         "mode": "image_generation",
         "output_cost_per_image": 0.06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
     "vertex_ai/jamba-1.5": {
+        "display_name": "Jamba 1.5",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-ai21_models",
         "max_input_tokens": 256000,
@@ -28023,6 +31440,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/jamba-1.5-large": {
+        "display_name": "Jamba 1.5 Large",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-ai21_models",
         "max_input_tokens": 256000,
@@ -28033,6 +31452,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/jamba-1.5-large@001": {
+        "display_name": "Jamba 1.5 Large @001",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-ai21_models",
         "max_input_tokens": 256000,
@@ -28043,6 +31464,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/jamba-1.5-mini": {
+        "display_name": "Jamba 1.5 Mini",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-ai21_models",
         "max_input_tokens": 256000,
@@ -28053,6 +31476,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/jamba-1.5-mini@001": {
+        "display_name": "Jamba 1.5 Mini @001",
+        "model_vendor": "ai21",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "vertex_ai-ai21_models",
         "max_input_tokens": 256000,
@@ -28063,6 +31488,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama-3.1-405b-instruct-maas": {
+        "display_name": "Llama 3.1 405B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 128000,
@@ -28076,6 +31503,8 @@
         "supports_vision": true
     },
     "vertex_ai/meta/llama-3.1-70b-instruct-maas": {
+        "display_name": "Llama 3.1 70B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 128000,
@@ -28089,6 +31518,8 @@
         "supports_vision": true
     },
     "vertex_ai/meta/llama-3.1-8b-instruct-maas": {
+        "display_name": "Llama 3.1 8B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 128000,
@@ -28105,6 +31536,8 @@
         "supports_vision": true
     },
     "vertex_ai/meta/llama-3.2-90b-vision-instruct-maas": {
+        "display_name": "Llama 3.2 90B Vision Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 128000,
@@ -28121,6 +31554,8 @@
         "supports_vision": true
     },
     "vertex_ai/meta/llama-4-maverick-17b-128e-instruct-maas": {
+        "display_name": "Llama 4 Maverick 17B 128E Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 1000000,
@@ -28141,6 +31576,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama-4-maverick-17b-16e-instruct-maas": {
+        "display_name": "Llama 4 Maverick 17B 16E Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 3.5e-07,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 1000000,
@@ -28161,6 +31598,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama-4-scout-17b-128e-instruct-maas": {
+        "display_name": "Llama 4 Scout 17B 128E Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 10000000,
@@ -28181,6 +31620,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama-4-scout-17b-16e-instruct-maas": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 10000000,
@@ -28201,6 +31642,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama3-405b-instruct-maas": {
+        "display_name": "Llama 3 405B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 32000,
@@ -28212,6 +31655,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama3-70b-instruct-maas": {
+        "display_name": "Llama 3 70B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 32000,
@@ -28223,6 +31668,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/meta/llama3-8b-instruct-maas": {
+        "display_name": "Llama 3 8B Instruct MaaS",
+        "model_vendor": "meta",
         "input_cost_per_token": 0.0,
         "litellm_provider": "vertex_ai-llama_models",
         "max_input_tokens": 32000,
@@ -28234,6 +31681,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/minimaxai/minimax-m2-maas": {
+        "display_name": "MiniMax M2 MaaS",
+        "model_vendor": "minimax",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-minimax_models",
         "max_input_tokens": 196608,
@@ -28246,6 +31695,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
+        "display_name": "Kimi K2 Thinking MaaS",
+        "model_vendor": "moonshot",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "vertex_ai-moonshot_models",
         "max_input_tokens": 256000,
@@ -28259,6 +31710,8 @@
         "supports_web_search": true
     },
     "vertex_ai/mistral-medium-3": {
+        "display_name": "Mistral Medium 3",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28270,6 +31723,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-medium-3@001": {
+        "display_name": "Mistral Medium 3 @001",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28281,6 +31736,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistralai/mistral-medium-3": {
+        "display_name": "Mistral Medium 3",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28292,6 +31749,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistralai/mistral-medium-3@001": {
+        "display_name": "Mistral Medium 3 @001",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28303,6 +31762,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-large-2411": {
+        "display_name": "Mistral Large 2411",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28314,6 +31775,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-large@2407": {
+        "display_name": "Mistral Large 2407",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28325,6 +31788,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-large@2411-001": {
+        "display_name": "Mistral Large 2411-001",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28336,6 +31801,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-large@latest": {
+        "display_name": "Mistral Large Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28347,6 +31814,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-nemo@2407": {
+        "display_name": "Mistral Nemo 2407",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28358,6 +31827,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-nemo@latest": {
+        "display_name": "Mistral Nemo Latest",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28369,6 +31840,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-small-2503": {
+        "display_name": "Mistral Small 2503",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 128000,
@@ -28381,6 +31854,8 @@
         "supports_vision": true
     },
     "vertex_ai/mistral-small-2503@001": {
+        "display_name": "Mistral Small 2503 @001",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-mistral_models",
         "max_input_tokens": 32000,
@@ -28392,23 +31867,19 @@
         "supports_tool_choice": true
     },
     "vertex_ai/mistral-ocr-2505": {
+        "display_name": "Mistral OCR 2505",
+        "model_vendor": "mistralai",
         "litellm_provider": "vertex_ai",
         "mode": "ocr",
-        "ocr_cost_per_page": 5e-4,
+        "ocr_cost_per_page": 0.0005,
         "supported_endpoints": [
             "/v1/ocr"
         ],
         "source": "https://cloud.google.com/generative-ai-app-builder/pricing"
     },
-    "vertex_ai/deepseek-ai/deepseek-ocr-maas": {
-        "litellm_provider": "vertex_ai",
-        "mode": "ocr",
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "ocr_cost_per_page": 3e-04,
-        "source": "https://cloud.google.com/vertex-ai/pricing"
-    },
     "vertex_ai/openai/gpt-oss-120b-maas": {
+        "display_name": "GPT-OSS 120B MaaS",
+        "model_vendor": "openai",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-openai_models",
         "max_input_tokens": 131072,
@@ -28420,6 +31891,8 @@
         "supports_reasoning": true
     },
     "vertex_ai/openai/gpt-oss-20b-maas": {
+        "display_name": "GPT-OSS 20B MaaS",
+        "model_vendor": "openai",
         "input_cost_per_token": 7.5e-08,
         "litellm_provider": "vertex_ai-openai_models",
         "max_input_tokens": 131072,
@@ -28431,6 +31904,8 @@
         "supports_reasoning": true
     },
     "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
+        "display_name": "Qwen 3 235B A22B Instruct 2507 MaaS",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
@@ -28443,6 +31918,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas": {
+        "display_name": "Qwen 3 Coder 480B A35B Instruct MaaS",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
@@ -28455,6 +31932,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas": {
+        "display_name": "Qwen 3 Next 80B A3B Instruct MaaS",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
@@ -28467,6 +31946,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas": {
+        "display_name": "Qwen 3 Next 80B A3B Thinking MaaS",
+        "model_vendor": "alibaba",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-qwen_models",
         "max_input_tokens": 262144,
@@ -28479,6 +31960,8 @@
         "supports_tool_choice": true
     },
     "vertex_ai/veo-2.0-generate-001": {
+        "display_name": "Veo 2.0 Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28493,7 +31976,8 @@
         ]
     },
     "vertex_ai/veo-3.0-fast-generate-preview": {
-        "deprecation_date": "2025-11-12",
+        "display_name": "Veo 3.0 Fast Generate Preview",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28508,7 +31992,8 @@
         ]
     },
     "vertex_ai/veo-3.0-generate-preview": {
-        "deprecation_date": "2025-11-12",
+        "display_name": "Veo 3.0 Generate Preview",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28523,6 +32008,8 @@
         ]
     },
     "vertex_ai/veo-3.0-fast-generate-001": {
+        "display_name": "Veo 3.0 Fast Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28537,6 +32024,8 @@
         ]
     },
     "vertex_ai/veo-3.0-generate-001": {
+        "display_name": "Veo 3.0 Generate 001",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28551,6 +32040,8 @@
         ]
     },
     "vertex_ai/veo-3.1-generate-preview": {
+        "display_name": "Veo 3.1 Generate Preview",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28565,34 +32056,8 @@
         ]
     },
     "vertex_ai/veo-3.1-fast-generate-preview": {
-        "litellm_provider": "vertex_ai-video-models",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "vertex_ai/veo-3.1-generate-001": {
-        "litellm_provider": "vertex_ai-video-models",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.4,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "vertex_ai/veo-3.1-fast-generate-001": {
+        "display_name": "Veo 3.1 Fast Generate Preview",
+        "model_vendor": "google",
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -28607,6 +32072,8 @@
         ]
     },
     "voyage/rerank-2": {
+        "display_name": "Rerank 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -28617,6 +32084,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/rerank-2-lite": {
+        "display_name": "Rerank 2 Lite",
+        "model_vendor": "voyage",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 8000,
@@ -28627,6 +32096,9 @@
         "output_cost_per_token": 0.0
     },
     "voyage/rerank-2.5": {
+        "display_name": "Rerank 2.5",
+        "model_vendor": "voyage",
+        "model_version": "2.5",
         "input_cost_per_token": 5e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28637,6 +32109,9 @@
         "output_cost_per_token": 0.0
     },
     "voyage/rerank-2.5-lite": {
+        "display_name": "Rerank 2.5 Lite",
+        "model_vendor": "voyage",
+        "model_version": "2.5",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28647,6 +32122,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-2": {
+        "display_name": "Voyage 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 4000,
@@ -28655,6 +32132,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-3": {
+        "display_name": "Voyage 3",
+        "model_vendor": "voyage",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28663,6 +32142,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-3-large": {
+        "display_name": "Voyage 3 Large",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28671,6 +32152,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-3-lite": {
+        "display_name": "Voyage 3 Lite",
+        "model_vendor": "voyage",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28679,6 +32162,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-3.5": {
+        "display_name": "Voyage 3.5",
+        "model_vendor": "voyage",
         "input_cost_per_token": 6e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28687,6 +32172,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-3.5-lite": {
+        "display_name": "Voyage 3.5 Lite",
+        "model_vendor": "voyage",
         "input_cost_per_token": 2e-08,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28695,6 +32182,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-code-2": {
+        "display_name": "Voyage Code 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -28703,6 +32192,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-code-3": {
+        "display_name": "Voyage Code 3",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28711,6 +32202,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-context-3": {
+        "display_name": "Voyage Context 3",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 120000,
@@ -28719,6 +32212,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-finance-2": {
+        "display_name": "Voyage Finance 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28727,6 +32222,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-large-2": {
+        "display_name": "Voyage Large 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -28735,6 +32232,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-law-2": {
+        "display_name": "Voyage Law 2",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 16000,
@@ -28743,6 +32242,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-lite-01": {
+        "display_name": "Voyage Lite 01",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 4096,
@@ -28751,6 +32252,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-lite-02-instruct": {
+        "display_name": "Voyage Lite 02 Instruct",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 4000,
@@ -28759,6 +32262,8 @@
         "output_cost_per_token": 0.0
     },
     "voyage/voyage-multimodal-3": {
+        "display_name": "Voyage Multimodal 3",
+        "model_vendor": "voyage",
         "input_cost_per_token": 1.2e-07,
         "litellm_provider": "voyage",
         "max_input_tokens": 32000,
@@ -28767,6 +32272,8 @@
         "output_cost_per_token": 0.0
     },
     "wandb/openai/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -28776,6 +32283,8 @@
         "mode": "chat"
     },
     "wandb/openai/gpt-oss-20b": {
+        "display_name": "GPT-OSS 20B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -28785,6 +32294,8 @@
         "mode": "chat"
     },
     "wandb/zai-org/GLM-4.5": {
+        "display_name": "GLM 4.5",
+        "model_vendor": "zhipu",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -28794,6 +32305,8 @@
         "mode": "chat"
     },
     "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "display_name": "Qwen 3 235B A22B Instruct 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -28803,6 +32316,8 @@
         "mode": "chat"
     },
     "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+        "display_name": "Qwen 3 Coder 480B A35B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -28812,6 +32327,8 @@
         "mode": "chat"
     },
     "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "display_name": "Qwen 3 235B A22B Thinking 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -28821,6 +32338,8 @@
         "mode": "chat"
     },
     "wandb/moonshotai/Kimi-K2-Instruct": {
+        "display_name": "Kimi K2 Instruct",
+        "model_vendor": "moonshot",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -28830,6 +32349,8 @@
         "mode": "chat"
     },
     "wandb/meta-llama/Llama-3.1-8B-Instruct": {
+        "display_name": "Llama 3.1 8B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -28839,6 +32360,8 @@
         "mode": "chat"
     },
     "wandb/deepseek-ai/DeepSeek-V3.1": {
+        "display_name": "DeepSeek V3.1",
+        "model_vendor": "deepseek",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -28848,6 +32371,8 @@
         "mode": "chat"
     },
     "wandb/deepseek-ai/DeepSeek-R1-0528": {
+        "display_name": "DeepSeek R1 0528",
+        "model_vendor": "deepseek",
         "max_tokens": 161000,
         "max_input_tokens": 161000,
         "max_output_tokens": 161000,
@@ -28857,6 +32382,8 @@
         "mode": "chat"
     },
     "wandb/deepseek-ai/DeepSeek-V3-0324": {
+        "display_name": "DeepSeek V3 0324",
+        "model_vendor": "deepseek",
         "max_tokens": 161000,
         "max_input_tokens": 161000,
         "max_output_tokens": 161000,
@@ -28866,6 +32393,8 @@
         "mode": "chat"
     },
     "wandb/meta-llama/Llama-3.3-70B-Instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -28875,6 +32404,8 @@
         "mode": "chat"
     },
     "wandb/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "display_name": "Llama 4 Scout 17B 16E Instruct",
+        "model_vendor": "meta",
         "max_tokens": 64000,
         "max_input_tokens": 64000,
         "max_output_tokens": 64000,
@@ -28884,6 +32415,8 @@
         "mode": "chat"
     },
     "wandb/microsoft/Phi-4-mini-instruct": {
+        "display_name": "Phi 4 Mini Instruct",
+        "model_vendor": "microsoft",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -28893,13 +32426,15 @@
         "mode": "chat"
     },
     "watsonx/ibm/granite-3-8b-instruct": {
-        "input_cost_per_token": 0.2e-06,
+        "display_name": "Granite 3 8B Instruct",
+        "model_vendor": "ibm",
+        "input_cost_per_token": 2e-07,
         "litellm_provider": "watsonx",
         "max_input_tokens": 8192,
         "max_output_tokens": 1024,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 0.2e-06,
+        "output_cost_per_token": 2e-07,
         "supports_audio_input": false,
         "supports_audio_output": false,
         "supports_function_calling": true,
@@ -28911,13 +32446,15 @@
         "supports_vision": false
     },
     "watsonx/mistralai/mistral-large": {
+        "display_name": "Mistral Large",
+        "model_vendor": "mistralai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "watsonx",
         "max_input_tokens": 131072,
         "max_output_tokens": 16384,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 10e-06,
+        "output_cost_per_token": 1e-05,
         "supports_audio_input": false,
         "supports_audio_output": false,
         "supports_function_calling": true,
@@ -28929,6 +32466,8 @@
         "supports_vision": false
     },
     "watsonx/bigscience/mt0-xxl-13b": {
+        "display_name": "MT0 XXL 13B",
+        "model_vendor": "bigscience",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -28941,6 +32480,8 @@
         "supports_vision": false
     },
     "watsonx/core42/jais-13b-chat": {
+        "display_name": "JAIS 13B Chat",
+        "model_vendor": "core42",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -28953,11 +32494,13 @@
         "supports_vision": false
     },
     "watsonx/google/flan-t5-xl-3b": {
+        "display_name": "Flan T5 XL 3B",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.6e-06,
-        "output_cost_per_token": 0.6e-06,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -28965,11 +32508,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-13b-chat-v2": {
+        "display_name": "Granite 13B Chat V2",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.6e-06,
-        "output_cost_per_token": 0.6e-06,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -28977,11 +32522,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-13b-instruct-v2": {
+        "display_name": "Granite 13B Instruct V2",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.6e-06,
-        "output_cost_per_token": 0.6e-06,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -28989,11 +32536,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-3-3-8b-instruct": {
+        "display_name": "Granite 3.3 8B Instruct",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.2e-06,
-        "output_cost_per_token": 0.2e-06,
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 2e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29001,11 +32550,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-4-h-small": {
+        "display_name": "Granite 4 H Small",
+        "model_vendor": "ibm",
         "max_tokens": 20480,
         "max_input_tokens": 20480,
         "max_output_tokens": 20480,
-        "input_cost_per_token": 0.06e-06,
-        "output_cost_per_token": 0.25e-06,
+        "input_cost_per_token": 6e-08,
+        "output_cost_per_token": 2.5e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29013,11 +32564,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-guardian-3-2-2b": {
+        "display_name": "Granite Guardian 3.2 2B",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.1e-06,
-        "output_cost_per_token": 0.1e-06,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29025,11 +32578,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-guardian-3-3-8b": {
+        "display_name": "Granite Guardian 3.3 8B",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.2e-06,
-        "output_cost_per_token": 0.2e-06,
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 2e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29037,11 +32592,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-ttm-1024-96-r2": {
+        "display_name": "Granite TTM 1024 96 R2",
+        "model_vendor": "ibm",
         "max_tokens": 512,
         "max_input_tokens": 512,
         "max_output_tokens": 512,
-        "input_cost_per_token": 0.38e-06,
-        "output_cost_per_token": 0.38e-06,
+        "input_cost_per_token": 3.8e-07,
+        "output_cost_per_token": 3.8e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29049,11 +32606,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-ttm-1536-96-r2": {
+        "display_name": "Granite TTM 1536 96 R2",
+        "model_vendor": "ibm",
         "max_tokens": 512,
         "max_input_tokens": 512,
         "max_output_tokens": 512,
-        "input_cost_per_token": 0.38e-06,
-        "output_cost_per_token": 0.38e-06,
+        "input_cost_per_token": 3.8e-07,
+        "output_cost_per_token": 3.8e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29061,11 +32620,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-ttm-512-96-r2": {
+        "display_name": "Granite TTM 512 96 R2",
+        "model_vendor": "ibm",
         "max_tokens": 512,
         "max_input_tokens": 512,
         "max_output_tokens": 512,
-        "input_cost_per_token": 0.38e-06,
-        "output_cost_per_token": 0.38e-06,
+        "input_cost_per_token": 3.8e-07,
+        "output_cost_per_token": 3.8e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29073,11 +32634,13 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-vision-3-2-2b": {
+        "display_name": "Granite Vision 3.2 2B",
+        "model_vendor": "ibm",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.1e-06,
-        "output_cost_per_token": 0.1e-06,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29085,11 +32648,13 @@
         "supports_vision": true
     },
     "watsonx/meta-llama/llama-3-2-11b-vision-instruct": {
+        "display_name": "Llama 3.2 11B Vision Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.35e-06,
-        "output_cost_per_token": 0.35e-06,
+        "input_cost_per_token": 3.5e-07,
+        "output_cost_per_token": 3.5e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29097,11 +32662,13 @@
         "supports_vision": true
     },
     "watsonx/meta-llama/llama-3-2-1b-instruct": {
+        "display_name": "Llama 3.2 1B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.1e-06,
-        "output_cost_per_token": 0.1e-06,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29109,11 +32676,13 @@
         "supports_vision": false
     },
     "watsonx/meta-llama/llama-3-2-3b-instruct": {
+        "display_name": "Llama 3.2 3B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.15e-06,
-        "output_cost_per_token": 0.15e-06,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 1.5e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29121,6 +32690,8 @@
         "supports_vision": false
     },
     "watsonx/meta-llama/llama-3-2-90b-vision-instruct": {
+        "display_name": "Llama 3.2 90B Vision Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -29133,11 +32704,13 @@
         "supports_vision": true
     },
     "watsonx/meta-llama/llama-3-3-70b-instruct": {
+        "display_name": "Llama 3.3 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.71e-06,
-        "output_cost_per_token": 0.71e-06,
+        "input_cost_per_token": 7.1e-07,
+        "output_cost_per_token": 7.1e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29145,10 +32718,12 @@
         "supports_vision": false
     },
     "watsonx/meta-llama/llama-4-maverick-17b": {
+        "display_name": "Llama 4 Maverick 17B",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.35e-06,
+        "input_cost_per_token": 3.5e-07,
         "output_cost_per_token": 1.4e-06,
         "litellm_provider": "watsonx",
         "mode": "chat",
@@ -29157,11 +32732,13 @@
         "supports_vision": false
     },
     "watsonx/meta-llama/llama-guard-3-11b-vision": {
+        "display_name": "Llama Guard 3 11B Vision",
+        "model_vendor": "meta",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.35e-06,
-        "output_cost_per_token": 0.35e-06,
+        "input_cost_per_token": 3.5e-07,
+        "output_cost_per_token": 3.5e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29169,11 +32746,13 @@
         "supports_vision": true
     },
     "watsonx/mistralai/mistral-medium-2505": {
+        "display_name": "Mistral Medium 2505",
+        "model_vendor": "mistralai",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
         "input_cost_per_token": 3e-06,
-        "output_cost_per_token": 10e-06,
+        "output_cost_per_token": 1e-05,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29181,11 +32760,13 @@
         "supports_vision": false
     },
     "watsonx/mistralai/mistral-small-2503": {
+        "display_name": "Mistral Small 2503",
+        "model_vendor": "mistralai",
         "max_tokens": 32000,
         "max_input_tokens": 32000,
         "max_output_tokens": 32000,
-        "input_cost_per_token": 0.1e-06,
-        "output_cost_per_token": 0.3e-06,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 3e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29193,11 +32774,13 @@
         "supports_vision": false
     },
     "watsonx/mistralai/mistral-small-3-1-24b-instruct-2503": {
+        "display_name": "Mistral Small 3.1 24B Instruct 2503",
+        "model_vendor": "mistralai",
         "max_tokens": 32000,
         "max_input_tokens": 32000,
         "max_output_tokens": 32000,
-        "input_cost_per_token": 0.1e-06,
-        "output_cost_per_token": 0.3e-06,
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 3e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": true,
@@ -29205,11 +32788,13 @@
         "supports_vision": false
     },
     "watsonx/mistralai/pixtral-12b-2409": {
+        "display_name": "Pixtral 12B 2409",
+        "model_vendor": "mistralai",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.35e-06,
-        "output_cost_per_token": 0.35e-06,
+        "input_cost_per_token": 3.5e-07,
+        "output_cost_per_token": 3.5e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29217,11 +32802,13 @@
         "supports_vision": true
     },
     "watsonx/openai/gpt-oss-120b": {
+        "display_name": "GPT-OSS 120B",
+        "model_vendor": "openai",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
-        "input_cost_per_token": 0.15e-06,
-        "output_cost_per_token": 0.6e-06,
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 6e-07,
         "litellm_provider": "watsonx",
         "mode": "chat",
         "supports_function_calling": false,
@@ -29229,6 +32816,8 @@
         "supports_vision": false
     },
     "watsonx/sdaia/allam-1-13b-instruct": {
+        "display_name": "ALLaM 1 13B Instruct",
+        "model_vendor": "sdaia",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -29241,6 +32830,8 @@
         "supports_vision": false
     },
     "watsonx/whisper-large-v3-turbo": {
+        "display_name": "Whisper Large v3 Turbo",
+        "model_vendor": "openai",
         "input_cost_per_second": 0.0001,
         "output_cost_per_second": 0.0001,
         "litellm_provider": "watsonx",
@@ -29250,6 +32841,8 @@
         ]
     },
     "whisper-1": {
+        "display_name": "Whisper 1",
+        "model_vendor": "openai",
         "input_cost_per_second": 0.0001,
         "litellm_provider": "openai",
         "mode": "audio_transcription",
@@ -29259,6 +32852,8 @@
         ]
     },
     "xai/grok-2": {
+        "display_name": "Grok 2",
+        "model_vendor": "xai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29271,6 +32866,8 @@
         "supports_web_search": true
     },
     "xai/grok-2-1212": {
+        "display_name": "Grok 2 1212",
+        "model_vendor": "xai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29283,6 +32880,8 @@
         "supports_web_search": true
     },
     "xai/grok-2-latest": {
+        "display_name": "Grok 2 Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29295,6 +32894,8 @@
         "supports_web_search": true
     },
     "xai/grok-2-vision": {
+        "display_name": "Grok 2 Vision",
+        "model_vendor": "xai",
         "input_cost_per_image": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
@@ -29309,6 +32910,8 @@
         "supports_web_search": true
     },
     "xai/grok-2-vision-1212": {
+        "display_name": "Grok 2 Vision 1212",
+        "model_vendor": "xai",
         "input_cost_per_image": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
@@ -29323,6 +32926,8 @@
         "supports_web_search": true
     },
     "xai/grok-2-vision-latest": {
+        "display_name": "Grok 2 Vision Latest",
+        "model_vendor": "xai",
         "input_cost_per_image": 2e-06,
         "input_cost_per_token": 2e-06,
         "litellm_provider": "xai",
@@ -29337,6 +32942,8 @@
         "supports_web_search": true
     },
     "xai/grok-3": {
+        "display_name": "Grok 3",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29351,6 +32958,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-beta": {
+        "display_name": "Grok 3 Beta",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29365,6 +32974,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-beta": {
+        "display_name": "Grok 3 Fast Beta",
+        "model_vendor": "xai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29379,6 +32990,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-fast-latest": {
+        "display_name": "Grok 3 Fast Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29393,6 +33006,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-latest": {
+        "display_name": "Grok 3 Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29407,6 +33022,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini": {
+        "display_name": "Grok 3 Mini",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29422,6 +33039,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-beta": {
+        "display_name": "Grok 3 Mini Beta",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29437,6 +33056,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast": {
+        "display_name": "Grok 3 Mini Fast",
+        "model_vendor": "xai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29452,6 +33073,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-beta": {
+        "display_name": "Grok 3 Mini Fast Beta",
+        "model_vendor": "xai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29467,6 +33090,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-fast-latest": {
+        "display_name": "Grok 3 Mini Fast Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29482,6 +33107,8 @@
         "supports_web_search": true
     },
     "xai/grok-3-mini-latest": {
+        "display_name": "Grok 3 Mini Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29497,6 +33124,8 @@
         "supports_web_search": true
     },
     "xai/grok-4": {
+        "display_name": "Grok 4",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 256000,
@@ -29510,31 +33139,35 @@
         "supports_web_search": true
     },
     "xai/grok-4-fast-reasoning": {
+        "display_name": "Grok 4 Fast Reasoning",
+        "model_vendor": "xai",
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
-        "output_cost_per_token": 0.5e-06,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
-        "cache_read_input_token_cost": 0.05e-06,
+        "cache_read_input_token_cost": 5e-08,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "xai/grok-4-fast-non-reasoning": {
+        "display_name": "Grok 4 Fast Non-Reasoning",
+        "model_vendor": "xai",
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "cache_read_input_token_cost": 0.05e-06,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "cache_read_input_token_cost": 5e-08,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
-        "output_cost_per_token": 0.5e-06,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
@@ -29542,6 +33175,8 @@
         "supports_web_search": true
     },
     "xai/grok-4-0709": {
+        "display_name": "Grok 4 0709",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_128k_tokens": 6e-06,
         "litellm_provider": "xai",
@@ -29550,13 +33185,15 @@
         "max_tokens": 256000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
-        "output_cost_per_token_above_128k_tokens": 30e-06,
+        "output_cost_per_token_above_128k_tokens": 3e-05,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "xai/grok-4-latest": {
+        "display_name": "Grok 4 Latest",
+        "model_vendor": "xai",
         "input_cost_per_token": 3e-06,
         "input_cost_per_token_above_128k_tokens": 6e-06,
         "litellm_provider": "xai",
@@ -29565,22 +33202,24 @@
         "max_tokens": 256000,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
-        "output_cost_per_token_above_128k_tokens": 30e-06,
+        "output_cost_per_token_above_128k_tokens": 3e-05,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_web_search": true
     },
     "xai/grok-4-1-fast": {
-        "cache_read_input_token_cost": 0.05e-06,
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
+        "display_name": "Grok 4.1 Fast",
+        "model_vendor": "xai",
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "output_cost_per_token": 0.5e-06,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models/grok-4-1-fast-reasoning",
         "supports_audio_input": true,
@@ -29592,15 +33231,17 @@
         "supports_web_search": true
     },
     "xai/grok-4-1-fast-reasoning": {
-        "cache_read_input_token_cost": 0.05e-06,
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
+        "display_name": "Grok 4.1 Fast Reasoning",
+        "model_vendor": "xai",
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "output_cost_per_token": 0.5e-06,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models/grok-4-1-fast-reasoning",
         "supports_audio_input": true,
@@ -29612,15 +33253,17 @@
         "supports_web_search": true
     },
     "xai/grok-4-1-fast-reasoning-latest": {
-        "cache_read_input_token_cost": 0.05e-06,
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
+        "display_name": "Grok 4.1 Fast Reasoning Latest",
+        "model_vendor": "xai",
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "output_cost_per_token": 0.5e-06,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models/grok-4-1-fast-reasoning",
         "supports_audio_input": true,
@@ -29632,15 +33275,17 @@
         "supports_web_search": true
     },
     "xai/grok-4-1-fast-non-reasoning": {
-        "cache_read_input_token_cost": 0.05e-06,
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
+        "display_name": "Grok 4.1 Fast Non-Reasoning",
+        "model_vendor": "xai",
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "output_cost_per_token": 0.5e-06,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models/grok-4-1-fast-non-reasoning",
         "supports_audio_input": true,
@@ -29651,15 +33296,17 @@
         "supports_web_search": true
     },
     "xai/grok-4-1-fast-non-reasoning-latest": {
-        "cache_read_input_token_cost": 0.05e-06,
-        "input_cost_per_token": 0.2e-06,
-        "input_cost_per_token_above_128k_tokens": 0.4e-06,
+        "display_name": "Grok 4.1 Fast Non-Reasoning Latest",
+        "model_vendor": "xai",
+        "cache_read_input_token_cost": 5e-08,
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_128k_tokens": 4e-07,
         "litellm_provider": "xai",
-        "max_input_tokens": 2e6,
-        "max_output_tokens": 2e6,
-        "max_tokens": 2e6,
+        "max_input_tokens": 2000000.0,
+        "max_output_tokens": 2000000.0,
+        "max_tokens": 2000000.0,
         "mode": "chat",
-        "output_cost_per_token": 0.5e-06,
+        "output_cost_per_token": 5e-07,
         "output_cost_per_token_above_128k_tokens": 1e-06,
         "source": "https://docs.x.ai/docs/models/grok-4-1-fast-non-reasoning",
         "supports_audio_input": true,
@@ -29670,6 +33317,8 @@
         "supports_web_search": true
     },
     "xai/grok-beta": {
+        "display_name": "Grok Beta",
+        "model_vendor": "xai",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
         "max_input_tokens": 131072,
@@ -29683,6 +33332,8 @@
         "supports_web_search": true
     },
     "xai/grok-code-fast": {
+        "display_name": "Grok Code Fast",
+        "model_vendor": "xai",
         "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "xai",
@@ -29697,6 +33348,8 @@
         "supports_tool_choice": true
     },
     "xai/grok-code-fast-1": {
+        "display_name": "Grok Code Fast 1",
+        "model_vendor": "xai",
         "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "xai",
@@ -29711,6 +33364,8 @@
         "supports_tool_choice": true
     },
     "xai/grok-code-fast-1-0825": {
+        "display_name": "Grok Code Fast 1 0825",
+        "model_vendor": "xai",
         "cache_read_input_token_cost": 2e-08,
         "input_cost_per_token": 2e-07,
         "litellm_provider": "xai",
@@ -29725,6 +33380,8 @@
         "supports_tool_choice": true
     },
     "xai/grok-vision-beta": {
+        "display_name": "Grok Vision Beta",
+        "model_vendor": "xai",
         "input_cost_per_image": 5e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "xai",
@@ -29738,21 +33395,9 @@
         "supports_vision": true,
         "supports_web_search": true
     },
-    "zai/glm-4.7": {
-        "cache_creation_input_token_cost": 0,
-        "cache_read_input_token_cost": 1.1e-07,
-        "input_cost_per_token": 6e-07,
-        "output_cost_per_token": 2.2e-06,
-        "litellm_provider": "zai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "source": "https://docs.z.ai/guides/overview/pricing"
-    },
     "zai/glm-4.6": {
+        "display_name": "GLM-4.6",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
         "litellm_provider": "zai",
@@ -29764,6 +33409,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5": {
+        "display_name": "GLM-4.5",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
         "litellm_provider": "zai",
@@ -29775,6 +33422,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5v": {
+        "display_name": "GLM-4.5V",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 1.8e-06,
         "litellm_provider": "zai",
@@ -29787,6 +33436,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-x": {
+        "display_name": "GLM-4.5X",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 2.2e-06,
         "output_cost_per_token": 8.9e-06,
         "litellm_provider": "zai",
@@ -29798,6 +33449,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-air": {
+        "display_name": "GLM-4.5 Air",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 1.1e-06,
         "litellm_provider": "zai",
@@ -29809,6 +33462,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-airx": {
+        "display_name": "GLM-4.5 AirX",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 1.1e-06,
         "output_cost_per_token": 4.5e-06,
         "litellm_provider": "zai",
@@ -29820,6 +33475,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4-32b-0414-128k": {
+        "display_name": "GLM-4 32B",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 1e-07,
         "litellm_provider": "zai",
@@ -29831,6 +33488,8 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "zai/glm-4.5-flash": {
+        "display_name": "GLM-4.5 Flash",
+        "model_vendor": "zhipu",
         "input_cost_per_token": 0,
         "output_cost_per_token": 0,
         "litellm_provider": "zai",
@@ -29842,19 +33501,25 @@
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
     "vertex_ai/search_api": {
-        "input_cost_per_query": 1.5e-03,
+        "display_name": "Search API",
+        "model_vendor": "google",
+        "input_cost_per_query": 0.0015,
         "litellm_provider": "vertex_ai",
         "mode": "vector_store"
     },
     "openai/container": {
+        "display_name": "Container",
+        "model_vendor": "openai",
         "code_interpreter_cost_per_session": 0.03,
         "litellm_provider": "openai",
         "mode": "chat"
     },
     "openai/sora-2": {
+        "display_name": "Sora 2",
+        "model_vendor": "openai",
         "litellm_provider": "openai",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.10,
+        "output_cost_per_video_per_second": 0.1,
         "source": "https://platform.openai.com/docs/api-reference/videos",
         "supported_modalities": [
             "text",
@@ -29869,9 +33534,11 @@
         ]
     },
     "openai/sora-2-pro": {
+        "display_name": "Sora 2 Pro",
+        "model_vendor": "openai",
         "litellm_provider": "openai",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.30,
+        "output_cost_per_video_per_second": 0.3,
         "source": "https://platform.openai.com/docs/api-reference/videos",
         "supported_modalities": [
             "text",
@@ -29886,9 +33553,11 @@
         ]
     },
     "azure/sora-2": {
+        "display_name": "Sora 2",
+        "model_vendor": "openai",
         "litellm_provider": "azure",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.10,
+        "output_cost_per_video_per_second": 0.1,
         "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
         "supported_modalities": [
             "text"
@@ -29902,9 +33571,11 @@
         ]
     },
     "azure/sora-2-pro": {
+        "display_name": "Sora 2 Pro",
+        "model_vendor": "openai",
         "litellm_provider": "azure",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.30,
+        "output_cost_per_video_per_second": 0.3,
         "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
         "supported_modalities": [
             "text"
@@ -29918,9 +33589,11 @@
         ]
     },
     "azure/sora-2-pro-high-res": {
+        "display_name": "Sora 2 Pro High Res",
+        "model_vendor": "openai",
         "litellm_provider": "azure",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.50,
+        "output_cost_per_video_per_second": 0.5,
         "source": "https://azure.microsoft.com/en-us/products/ai-services/video-generation",
         "supported_modalities": [
             "text"
@@ -29934,6 +33607,8 @@
         ]
     },
     "runwayml/gen4_turbo": {
+        "display_name": "Gen4 Turbo",
+        "model_vendor": "runwayml",
         "litellm_provider": "runwayml",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.05,
@@ -29954,6 +33629,8 @@
         }
     },
     "runwayml/gen4_aleph": {
+        "display_name": "Gen4 Aleph",
+        "model_vendor": "runwayml",
         "litellm_provider": "runwayml",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.15,
@@ -29974,6 +33651,9 @@
         }
     },
     "runwayml/gen3a_turbo": {
+        "display_name": "Gen3a Turbo",
+        "model_vendor": "runwayml",
+        "model_version": "3a",
         "litellm_provider": "runwayml",
         "mode": "video_generation",
         "output_cost_per_video_per_second": 0.05,
@@ -29994,6 +33674,8 @@
         }
     },
     "runwayml/gen4_image": {
+        "display_name": "Gen4 Image",
+        "model_vendor": "runwayml",
         "litellm_provider": "runwayml",
         "mode": "image_generation",
         "input_cost_per_image": 0.05,
@@ -30015,6 +33697,8 @@
         }
     },
     "runwayml/gen4_image_turbo": {
+        "display_name": "Gen4 Image Turbo",
+        "model_vendor": "runwayml",
         "litellm_provider": "runwayml",
         "mode": "image_generation",
         "input_cost_per_image": 0.02,
@@ -30036,6 +33720,8 @@
         }
     },
     "runwayml/eleven_multilingual_v2": {
+        "display_name": "Eleven Multilingual v2",
+        "model_vendor": "elevenlabs",
         "litellm_provider": "runwayml",
         "mode": "audio_speech",
         "input_cost_per_character": 3e-07,
@@ -30045,16 +33731,19 @@
         }
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+        "display_name": "Qwen3 Coder 480B A35b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
         "input_cost_per_token": 4.5e-07,
         "output_cost_per_token": 1.8e-06,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-kontext-pro": {
+        "display_name": "Flux Kontext Pro",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30064,6 +33753,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/SSD-1B": {
+        "display_name": "SSD 1B",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30073,6 +33764,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/chronos-hermes-13b-v2": {
+        "display_name": "Chronos Hermes 13B V2",
+        "model_vendor": "nousresearch",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30082,6 +33775,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-13b": {
+        "display_name": "Code Llama 13B",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30091,6 +33786,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-13b-instruct": {
+        "display_name": "Code Llama 13B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30100,6 +33797,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-13b-python": {
+        "display_name": "Code Llama 13B Python",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30109,6 +33808,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-34b": {
+        "display_name": "Code Llama 34B",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30118,6 +33819,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-34b-instruct": {
+        "display_name": "Code Llama 34B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30127,6 +33830,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-34b-python": {
+        "display_name": "Code Llama 34B Python",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30136,6 +33841,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-70b": {
+        "display_name": "Code Llama 70B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30145,6 +33852,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-70b-instruct": {
+        "display_name": "Code Llama 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30154,6 +33863,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-70b-python": {
+        "display_name": "Code Llama 70B Python",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30163,6 +33874,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-7b": {
+        "display_name": "Code Llama 7B",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30172,6 +33885,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-7b-instruct": {
+        "display_name": "Code Llama 7B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30181,6 +33896,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-llama-7b-python": {
+        "display_name": "Code Llama 7B Python",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30190,6 +33907,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/code-qwen-1p5-7b": {
+        "display_name": "Code Qwen 1p5 7B",
+        "model_vendor": "alibaba",
         "max_tokens": 65536,
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
@@ -30199,6 +33918,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/codegemma-2b": {
+        "display_name": "Codegemma 2B",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30208,6 +33929,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/codegemma-7b": {
+        "display_name": "Codegemma 7B",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30217,6 +33940,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-671b-v2-p1": {
+        "display_name": "Cogito 671B V2 P1",
+        "model_vendor": "cogito",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -30226,6 +33951,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+        "display_name": "Cogito V1 Preview Llama 3B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30235,6 +33962,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+        "display_name": "Cogito V1 Preview Llama 70B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30244,6 +33973,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+        "display_name": "Cogito V1 Preview Llama 8B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30253,6 +33984,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+        "display_name": "Cogito V1 Preview Qwen 14B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30262,6 +33995,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+        "display_name": "Cogito V1 Preview Qwen 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30271,6 +34006,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-kontext-max": {
+        "display_name": "Flux Kontext Max",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30280,6 +34017,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/dbrx-instruct": {
+        "display_name": "Dbrx Instruct",
+        "model_vendor": "databricks",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -30289,6 +34028,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-1b-base": {
+        "display_name": "Deepseek Coder 1B Base",
+        "model_vendor": "deepseek",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30298,6 +34039,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-33b-instruct": {
+        "display_name": "Deepseek Coder 33B Instruct",
+        "model_vendor": "deepseek",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30307,6 +34050,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base": {
+        "display_name": "Deepseek Coder 7B Base",
+        "model_vendor": "deepseek",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30316,6 +34061,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
+        "display_name": "Deepseek Coder 7B Base V1p5",
+        "model_vendor": "deepseek",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30325,6 +34072,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
+        "display_name": "Deepseek Coder 7B Instruct V1p5",
+        "model_vendor": "deepseek",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30334,6 +34083,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-base": {
+        "display_name": "Deepseek Coder V2 Lite Base",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -30343,6 +34094,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
+        "display_name": "Deepseek Coder V2 Lite Instruct",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -30352,6 +34105,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-prover-v2": {
+        "display_name": "Deepseek Prover V2",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -30361,6 +34116,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+        "display_name": "Deepseek R1 0528 Distill Qwen3 8B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30370,6 +34127,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
+        "display_name": "Deepseek R1 Distill Llama 70B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30379,6 +34138,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
+        "display_name": "Deepseek R1 Distill Llama 8B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30388,6 +34149,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
+        "display_name": "Deepseek R1 Distill Qwen 14B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30397,6 +34160,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
+        "display_name": "Deepseek R1 Distill Qwen 1p5b",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30406,6 +34171,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
+        "display_name": "Deepseek R1 Distill Qwen 32B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30415,6 +34182,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
+        "display_name": "Deepseek R1 Distill Qwen 7B",
+        "model_vendor": "deepseek",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30424,6 +34193,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v2-lite-chat": {
+        "display_name": "Deepseek V2 Lite Chat",
+        "model_vendor": "deepseek",
         "max_tokens": 163840,
         "max_input_tokens": 163840,
         "max_output_tokens": 163840,
@@ -30433,6 +34204,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/deepseek-v2p5": {
+        "display_name": "Deepseek V2p5",
+        "model_vendor": "deepseek",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -30442,6 +34215,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/devstral-small-2505": {
+        "display_name": "Devstral Small 2505",
+        "model_vendor": "mistral",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30451,6 +34226,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+        "display_name": "Dobby Mini Unhinged Plus Llama 3 1 8B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30460,6 +34237,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+        "display_name": "Dobby Unhinged Llama 3 3 70B New",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30469,6 +34248,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+        "display_name": "Dolphin 2 9 2 Qwen2 72B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30478,6 +34259,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+        "display_name": "Dolphin 2p6 Mixtral 8x7b",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -30487,6 +34270,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+        "display_name": "Ernie 4p5 21B A3b Pt",
+        "model_vendor": "baidu",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30496,6 +34281,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+        "display_name": "Ernie 4p5 300B A47b Pt",
+        "model_vendor": "baidu",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30505,6 +34292,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/fare-20b": {
+        "display_name": "Fare 20B",
+        "model_vendor": "fireworks",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30514,6 +34303,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/firefunction-v1": {
+        "display_name": "Firefunction V1",
+        "model_vendor": "fireworks",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -30523,6 +34314,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/firellava-13b": {
+        "display_name": "Firellava 13B",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30532,6 +34325,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/firesearch-ocr-v6": {
+        "display_name": "Firesearch OCR V6",
+        "model_vendor": "fireworks",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30541,6 +34336,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/fireworks-asr-large": {
+        "display_name": "Fireworks ASR Large",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30550,6 +34347,8 @@
         "mode": "audio_transcription"
     },
     "fireworks_ai/accounts/fireworks/models/fireworks-asr-v2": {
+        "display_name": "Fireworks ASR V2",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30559,6 +34358,8 @@
         "mode": "audio_transcription"
     },
     "fireworks_ai/accounts/fireworks/models/flux-1-dev": {
+        "display_name": "Flux 1 Dev",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30568,6 +34369,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-1-dev-controlnet-union": {
+        "display_name": "Flux 1 Dev Controlnet Union",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30577,6 +34380,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-1-dev-fp8": {
+        "display_name": "Flux 1 Dev FP8",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30586,6 +34391,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/flux-1-schnell": {
+        "display_name": "Flux 1 Schnell",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30595,6 +34402,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-1-schnell-fp8": {
+        "display_name": "Flux 1 Schnell FP8",
+        "model_vendor": "black_forest_labs",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30604,6 +34413,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/gemma-2b-it": {
+        "display_name": "Gemma 2B It",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30613,6 +34424,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/gemma-3-27b-it": {
+        "display_name": "Gemma 3 27B It",
+        "model_vendor": "google",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30622,6 +34435,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/gemma-7b": {
+        "display_name": "Gemma 7B",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30631,6 +34446,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/gemma-7b-it": {
+        "display_name": "Gemma 7B It",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30640,6 +34457,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/gemma2-9b-it": {
+        "display_name": "Gemma2 9B It",
+        "model_vendor": "google",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30649,6 +34468,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/glm-4p5v": {
+        "display_name": "Glm 4p5v",
+        "model_vendor": "zhipu",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30659,6 +34480,8 @@
         "supports_reasoning": true
     },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-120b": {
+        "display_name": "GPT Oss Safeguard 120B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30668,6 +34491,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-20b": {
+        "display_name": "GPT Oss Safeguard 20B",
+        "model_vendor": "openai",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30677,6 +34502,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+        "display_name": "Hermes 2 Pro Mistral 7B",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -30686,6 +34513,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/internvl3-38b": {
+        "display_name": "Internvl3 38B",
+        "model_vendor": "opengvlab",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30695,6 +34524,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/internvl3-78b": {
+        "display_name": "Internvl3 78B",
+        "model_vendor": "opengvlab",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30704,6 +34535,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/internvl3-8b": {
+        "display_name": "Internvl3 8B",
+        "model_vendor": "opengvlab",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -30713,6 +34546,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/japanese-stable-diffusion-xl": {
+        "display_name": "Japanese Stable Diffusion XL",
+        "model_vendor": "stability",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30722,6 +34557,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/kat-coder": {
+        "display_name": "Kat Coder",
+        "model_vendor": "fireworks",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -30731,6 +34568,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/kat-dev-32b": {
+        "display_name": "Kat Dev 32B",
+        "model_vendor": "fireworks",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30740,6 +34579,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/kat-dev-72b-exp": {
+        "display_name": "Kat Dev 72B Exp",
+        "model_vendor": "fireworks",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30749,6 +34590,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-guard-2-8b": {
+        "display_name": "Llama Guard 2 8B",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30758,6 +34601,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-guard-3-1b": {
+        "display_name": "Llama Guard 3 1B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30767,6 +34612,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-guard-3-8b": {
+        "display_name": "Llama Guard 3 8B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30776,6 +34623,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-13b": {
+        "display_name": "Llama V2 13B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30785,6 +34634,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-13b-chat": {
+        "display_name": "Llama V2 13B Chat",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30794,6 +34645,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-70b": {
+        "display_name": "Llama V2 70B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30803,6 +34656,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-70b-chat": {
+        "display_name": "Llama V2 70B Chat",
+        "model_vendor": "meta",
         "max_tokens": 2048,
         "max_input_tokens": 2048,
         "max_output_tokens": 2048,
@@ -30812,6 +34667,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-7b": {
+        "display_name": "Llama V2 7B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30821,6 +34678,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v2-7b-chat": {
+        "display_name": "Llama V2 7B Chat",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30830,6 +34689,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct": {
+        "display_name": "Llama V3 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30839,6 +34700,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct-hf": {
+        "display_name": "Llama V3 70B Instruct Hf",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30848,6 +34711,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3-8b": {
+        "display_name": "Llama V3 8B",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30857,6 +34722,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3-8b-instruct-hf": {
+        "display_name": "Llama V3 8B Instruct Hf",
+        "model_vendor": "meta",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -30866,6 +34733,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
+        "display_name": "Llama V3p1 405B Instruct Long",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30875,6 +34744,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct": {
+        "display_name": "Llama V3p1 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30884,6 +34755,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
+        "display_name": "Llama V3p1 70B Instruct 1B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30893,6 +34766,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
+        "display_name": "Llama V3p1 Nemotron 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30902,6 +34777,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-1b": {
+        "display_name": "Llama V3p2 1B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30911,6 +34788,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p2-3b": {
+        "display_name": "Llama V3p2 3B",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30920,6 +34799,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct": {
+        "display_name": "Llama V3p3 70B Instruct",
+        "model_vendor": "meta",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -30929,6 +34810,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llamaguard-7b": {
+        "display_name": "Llamaguard 7B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30938,6 +34821,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/llava-yi-34b": {
+        "display_name": "Llava Yi 34B",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30947,6 +34832,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/minimax-m1-80k": {
+        "display_name": "Minimax M1 80K",
+        "model_vendor": "minimax",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30956,6 +34843,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/minimax-m2": {
+        "display_name": "Minimax M2",
+        "model_vendor": "minimax",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -30965,6 +34854,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+        "display_name": "Ministral 3 14B Instruct 2512",
+        "model_vendor": "mistral",
         "max_tokens": 256000,
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
@@ -30974,6 +34865,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+        "display_name": "Ministral 3 3B Instruct 2512",
+        "model_vendor": "mistral",
         "max_tokens": 256000,
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
@@ -30983,6 +34876,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+        "display_name": "Ministral 3 8B Instruct 2512",
+        "model_vendor": "mistral",
         "max_tokens": 256000,
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
@@ -30992,6 +34887,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-7b": {
+        "display_name": "Mistral 7B",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31001,6 +34898,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-4k": {
+        "display_name": "Mistral 7B Instruct 4K",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31010,6 +34909,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+        "display_name": "Mistral 7B Instruct V0p2",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31019,6 +34920,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v3": {
+        "display_name": "Mistral 7B Instruct V3",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31028,6 +34931,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-7b-v0p2": {
+        "display_name": "Mistral 7B V0p2",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31037,6 +34942,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-large-3-fp8": {
+        "display_name": "Mistral Large 3 FP8",
+        "model_vendor": "mistral",
         "max_tokens": 256000,
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
@@ -31046,6 +34953,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-nemo-base-2407": {
+        "display_name": "Mistral Nemo Base 2407",
+        "model_vendor": "mistral",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31055,6 +34964,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-nemo-instruct-2407": {
+        "display_name": "Mistral Nemo Instruct 2407",
+        "model_vendor": "mistral",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31064,6 +34975,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mistral-small-24b-instruct-2501": {
+        "display_name": "Mistral Small 24B Instruct 2501",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31073,6 +34986,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b": {
+        "display_name": "Mixtral 8x22b",
+        "model_vendor": "mistral",
         "max_tokens": 65536,
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
@@ -31082,6 +34997,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct": {
+        "display_name": "Mixtral 8x22b Instruct",
+        "model_vendor": "mistral",
         "max_tokens": 65536,
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
@@ -31091,6 +35008,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x7b": {
+        "display_name": "Mixtral 8x7b",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31100,6 +35019,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct": {
+        "display_name": "Mixtral 8x7b Instruct",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31109,6 +35030,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+        "display_name": "Mixtral 8x7b Instruct Hf",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31118,6 +35041,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/mythomax-l2-13b": {
+        "display_name": "Mythomax L2 13B",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31127,6 +35052,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+        "display_name": "Nemotron Nano V2 12B VL",
+        "model_vendor": "nvidia",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31136,6 +35063,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-capybara-7b-v1p9": {
+        "display_name": "Nous Capybara 7B V1p9",
+        "model_vendor": "nousresearch",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31145,6 +35074,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+        "display_name": "Nous Hermes 2 Mixtral 8x7b DPO",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31154,6 +35085,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-hermes-2-yi-34b": {
+        "display_name": "Nous Hermes 2 Yi 34B",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31163,6 +35096,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-13b": {
+        "display_name": "Nous Hermes Llama2 13B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31172,6 +35107,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-70b": {
+        "display_name": "Nous Hermes Llama2 70B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31181,6 +35118,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-7b": {
+        "display_name": "Nous Hermes Llama2 7B",
+        "model_vendor": "meta",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31190,6 +35129,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+        "display_name": "Nvidia Nemotron Nano 12B V2",
+        "model_vendor": "nvidia",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31199,6 +35140,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+        "display_name": "Nvidia Nemotron Nano 9B V2",
+        "model_vendor": "nvidia",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31208,6 +35151,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/openchat-3p5-0106-7b": {
+        "display_name": "Openchat 3p5 0106 7B",
+        "model_vendor": "fireworks",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -31217,6 +35162,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/openhermes-2-mistral-7b": {
+        "display_name": "Openhermes 2 Mistral 7B",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31226,6 +35173,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+        "display_name": "Openhermes 2p5 Mistral 7B",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31235,6 +35184,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/openorca-7b": {
+        "display_name": "Openorca 7B",
+        "model_vendor": "fireworks",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31244,6 +35195,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phi-2-3b": {
+        "display_name": "Phi 2 3B",
+        "model_vendor": "microsoft",
         "max_tokens": 2048,
         "max_input_tokens": 2048,
         "max_output_tokens": 2048,
@@ -31253,6 +35206,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phi-3-mini-128k-instruct": {
+        "display_name": "Phi 3 Mini 128K Instruct",
+        "model_vendor": "microsoft",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31262,6 +35217,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phi-3-vision-128k-instruct": {
+        "display_name": "Phi 3 Vision 128K Instruct",
+        "model_vendor": "microsoft",
         "max_tokens": 32064,
         "max_input_tokens": 32064,
         "max_output_tokens": 32064,
@@ -31271,6 +35228,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+        "display_name": "Phind Code Llama 34B Python V1",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -31280,6 +35239,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v1": {
+        "display_name": "Phind Code Llama 34B V1",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -31289,6 +35250,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v2": {
+        "display_name": "Phind Code Llama 34B V2",
+        "model_vendor": "meta",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -31298,6 +35261,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/playground-v2-1024px-aesthetic": {
+        "display_name": "Playground V2 1024px Aesthetic",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31307,6 +35272,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
+        "display_name": "Playground V2 5 1024px Aesthetic",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31316,6 +35283,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/pythia-12b": {
+        "display_name": "Pythia 12B",
+        "model_vendor": "fireworks",
         "max_tokens": 2048,
         "max_input_tokens": 2048,
         "max_output_tokens": 2048,
@@ -31325,6 +35294,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen-qwq-32b-preview": {
+        "display_name": "Qwen Qwq 32B Preview",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31334,6 +35305,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen-v2p5-14b-instruct": {
+        "display_name": "Qwen V2p5 14B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31343,6 +35316,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen-v2p5-7b": {
+        "display_name": "Qwen V2p5 7B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31352,6 +35327,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen1p5-72b-chat": {
+        "display_name": "Qwen1p5 72B Chat",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31361,6 +35338,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2-7b-instruct": {
+        "display_name": "Qwen2 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31370,6 +35349,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2-vl-2b-instruct": {
+        "display_name": "Qwen2 VL 2B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31379,6 +35360,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2-vl-72b-instruct": {
+        "display_name": "Qwen2 VL 72B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31388,6 +35371,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2-vl-7b-instruct": {
+        "display_name": "Qwen2 VL 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31397,6 +35382,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-0p5b-instruct": {
+        "display_name": "Qwen2p5 0p5b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31406,6 +35393,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-14b": {
+        "display_name": "Qwen2p5 14B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31415,6 +35404,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-1p5b-instruct": {
+        "display_name": "Qwen2p5 1p5b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31424,6 +35415,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-32b": {
+        "display_name": "Qwen2p5 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31433,6 +35426,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-32b-instruct": {
+        "display_name": "Qwen2p5 32B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31442,6 +35437,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-72b": {
+        "display_name": "Qwen2p5 72B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31451,6 +35448,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-72b-instruct": {
+        "display_name": "Qwen2p5 72B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31460,6 +35459,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-7b-instruct": {
+        "display_name": "Qwen2p5 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31469,6 +35470,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b": {
+        "display_name": "Qwen2p5 Coder 0p5b",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31478,6 +35481,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b-instruct": {
+        "display_name": "Qwen2p5 Coder 0p5b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31487,6 +35492,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b": {
+        "display_name": "Qwen2p5 Coder 14B",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31496,6 +35503,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b-instruct": {
+        "display_name": "Qwen2p5 Coder 14B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31505,6 +35514,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b": {
+        "display_name": "Qwen2p5 Coder 1p5b",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31514,6 +35525,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b-instruct": {
+        "display_name": "Qwen2p5 Coder 1p5b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31523,6 +35536,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b": {
+        "display_name": "Qwen2p5 Coder 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31532,6 +35547,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
+        "display_name": "Qwen2p5 Coder 32B Instruct 128K",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31541,6 +35558,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-32k-rope": {
+        "display_name": "Qwen2p5 Coder 32B Instruct 32K Rope",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31550,6 +35569,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-64k": {
+        "display_name": "Qwen2p5 Coder 32B Instruct 64K",
+        "model_vendor": "alibaba",
         "max_tokens": 65536,
         "max_input_tokens": 65536,
         "max_output_tokens": 65536,
@@ -31559,6 +35580,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b": {
+        "display_name": "Qwen2p5 Coder 3B",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31568,6 +35591,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b-instruct": {
+        "display_name": "Qwen2p5 Coder 3B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31577,6 +35602,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b": {
+        "display_name": "Qwen2p5 Coder 7B",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31586,6 +35613,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b-instruct": {
+        "display_name": "Qwen2p5 Coder 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31595,6 +35624,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-math-72b-instruct": {
+        "display_name": "Qwen2p5 Math 72B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31604,6 +35635,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-32b-instruct": {
+        "display_name": "Qwen2p5 VL 32B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31613,6 +35646,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-3b-instruct": {
+        "display_name": "Qwen2p5 VL 3B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31622,6 +35657,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-72b-instruct": {
+        "display_name": "Qwen2p5 VL 72B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31631,6 +35668,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-7b-instruct": {
+        "display_name": "Qwen2p5 VL 7B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31640,6 +35679,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-0p6b": {
+        "display_name": "Qwen3 0p6b",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31649,6 +35690,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-14b": {
+        "display_name": "Qwen3 14B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31658,6 +35701,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-1p7b": {
+        "display_name": "Qwen3 1p7b",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31667,6 +35712,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft": {
+        "display_name": "Qwen3 1p7b FP8 Draft",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31676,6 +35723,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-131072": {
+        "display_name": "Qwen3 1p7b FP8 Draft 131072",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31685,6 +35734,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-40960": {
+        "display_name": "Qwen3 1p7b FP8 Draft 40960",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31694,6 +35745,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b": {
+        "display_name": "Qwen3 235B A22b",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31703,6 +35756,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+        "display_name": "Qwen3 235B A22b Instruct 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31712,6 +35767,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
+        "display_name": "Qwen3 235B A22b Thinking 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31721,6 +35778,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b": {
+        "display_name": "Qwen3 30B A3b",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31730,6 +35789,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-instruct-2507": {
+        "display_name": "Qwen3 30B A3b Instruct 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31739,6 +35800,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
+        "display_name": "Qwen3 30B A3b Thinking 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31748,16 +35811,19 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-32b": {
+        "display_name": "Qwen3 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "input_cost_per_token": 9e-07,
         "output_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-4b": {
+        "display_name": "Qwen3 4B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31767,6 +35833,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-4b-instruct-2507": {
+        "display_name": "Qwen3 4B Instruct 2507",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31776,16 +35844,19 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-8b": {
+        "display_name": "Qwen3 8B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 2e-07,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
+        "display_name": "Qwen3 Coder 30B A3b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31795,6 +35866,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
+        "display_name": "Qwen3 Coder 480B Instruct BF16",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31804,6 +35877,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-embedding-0p6b": {
+        "display_name": "Qwen3 Embedding 0p6b",
+        "model_vendor": "alibaba",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31813,6 +35888,8 @@
         "mode": "embedding"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-embedding-4b": {
+        "display_name": "Qwen3 Embedding 4B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31822,6 +35899,8 @@
         "mode": "embedding"
     },
     "fireworks_ai/accounts/fireworks/models/": {
+        "display_name": "",
+        "model_vendor": "fireworks",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31831,6 +35910,8 @@
         "mode": "embedding"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
+        "display_name": "Qwen3 Next 80B A3b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31840,6 +35921,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
+        "display_name": "Qwen3 Next 80B A3b Thinking",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31849,6 +35932,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-reranker-0p6b": {
+        "display_name": "Qwen3 Reranker 0p6b",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31858,6 +35943,8 @@
         "mode": "rerank"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-reranker-4b": {
+        "display_name": "Qwen3 Reranker 4B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31867,6 +35954,8 @@
         "mode": "rerank"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-reranker-8b": {
+        "display_name": "Qwen3 Reranker 8B",
+        "model_vendor": "alibaba",
         "max_tokens": 40960,
         "max_input_tokens": 40960,
         "max_output_tokens": 40960,
@@ -31876,6 +35965,8 @@
         "mode": "rerank"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
+        "display_name": "Qwen3 VL 235B A22b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31885,6 +35976,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
+        "display_name": "Qwen3 VL 235B A22b Thinking",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31894,6 +35987,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": {
+        "display_name": "Qwen3 VL 30B A3b Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31903,6 +35998,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
+        "display_name": "Qwen3 VL 30B A3b Thinking",
+        "model_vendor": "alibaba",
         "max_tokens": 262144,
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
@@ -31912,6 +36009,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-32b-instruct": {
+        "display_name": "Qwen3 VL 32B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31921,6 +36020,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-vl-8b-instruct": {
+        "display_name": "Qwen3 VL 8B Instruct",
+        "model_vendor": "alibaba",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31930,6 +36031,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwq-32b": {
+        "display_name": "Qwq 32B",
+        "model_vendor": "alibaba",
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
@@ -31939,6 +36042,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/rolm-ocr": {
+        "display_name": "Rolm OCR",
+        "model_vendor": "fireworks",
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -31948,6 +36053,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+        "display_name": "Snorkel Mistral 7B Pairrm DPO",
+        "model_vendor": "mistral",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -31957,6 +36064,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
+        "display_name": "Stable Diffusion XL 1024 V1 0",
+        "model_vendor": "stability",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31966,6 +36075,8 @@
         "mode": "image_generation"
     },
     "fireworks_ai/accounts/fireworks/models/stablecode-3b": {
+        "display_name": "Stablecode 3B",
+        "model_vendor": "fireworks",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -31975,6 +36086,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/starcoder-16b": {
+        "display_name": "Starcoder 16B",
+        "model_vendor": "bigcode",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -31984,6 +36097,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/starcoder-7b": {
+        "display_name": "Starcoder 7B",
+        "model_vendor": "bigcode",
         "max_tokens": 8192,
         "max_input_tokens": 8192,
         "max_output_tokens": 8192,
@@ -31993,6 +36108,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/starcoder2-15b": {
+        "display_name": "Starcoder2 15B",
+        "model_vendor": "bigcode",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -32002,6 +36119,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/starcoder2-3b": {
+        "display_name": "Starcoder2 3B",
+        "model_vendor": "bigcode",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -32011,6 +36130,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/starcoder2-7b": {
+        "display_name": "Starcoder2 7B",
+        "model_vendor": "bigcode",
         "max_tokens": 16384,
         "max_input_tokens": 16384,
         "max_output_tokens": 16384,
@@ -32020,6 +36141,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/toppy-m-7b": {
+        "display_name": "Toppy M 7B",
+        "model_vendor": "fireworks",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,
@@ -32029,6 +36152,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/whisper-v3": {
+        "display_name": "Whisper V3",
+        "model_vendor": "openai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -32038,6 +36163,8 @@
         "mode": "audio_transcription"
     },
     "fireworks_ai/accounts/fireworks/models/whisper-v3-turbo": {
+        "display_name": "Whisper V3 Turbo",
+        "model_vendor": "openai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -32047,6 +36174,8 @@
         "mode": "audio_transcription"
     },
     "fireworks_ai/accounts/fireworks/models/yi-34b": {
+        "display_name": "Yi 34B",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -32056,6 +36185,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/yi-34b-200k-capybara": {
+        "display_name": "Yi 34B 200K Capybara",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 200000,
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
@@ -32065,6 +36196,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/yi-34b-chat": {
+        "display_name": "Yi 34B Chat",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -32074,6 +36207,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/yi-6b": {
+        "display_name": "Yi 6B",
+        "model_vendor": "zero_one_ai",
         "max_tokens": 4096,
         "max_input_tokens": 4096,
         "max_output_tokens": 4096,
@@ -32083,6 +36218,8 @@
         "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/zephyr-7b-beta": {
+        "display_name": "Zephyr 7B Beta",
+        "model_vendor": "fireworks",
         "max_tokens": 32768,
         "max_input_tokens": 32768,
         "max_output_tokens": 32768,

--- a/tests/test_litellm/test_model_prices_metadata.py
+++ b/tests/test_litellm/test_model_prices_metadata.py
@@ -1,0 +1,57 @@
+"""
+Tests to validate model_prices_and_context_window.json metadata fields.
+
+Ensures all model entries have required metadata fields:
+- display_name: Human-readable name
+- model_vendor: Vendor/provider identifier (e.g., "openai", "anthropic", "meta")
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def model_prices_data():
+    """Load the model prices JSON file."""
+    possible_paths = [
+        Path(__file__).parent.parent.parent.parent / "model_prices_and_context_window.json",
+        Path("model_prices_and_context_window.json"),
+    ]
+
+    for path in possible_paths:
+        if path.exists():
+            with open(path, "r") as f:
+                return json.load(f)
+
+    pytest.fail("Could not find model_prices_and_context_window.json")
+
+
+class TestModelMetadataPresence:
+    """Test that required metadata fields are present."""
+
+    def test_all_models_have_display_name(self, model_prices_data):
+        """Every model entry should have a display_name."""
+        missing = []
+        for model_key, model_data in model_prices_data.items():
+            if "display_name" not in model_data:
+                missing.append(model_key)
+
+        if missing:
+            pytest.fail(
+                f"Missing display_name in {len(missing)} models. "
+                f"First 10: {missing[:10]}"
+            )
+
+    def test_all_models_have_model_vendor(self, model_prices_data):
+        """Every model entry should have a model_vendor."""
+        missing = []
+        for model_key, model_data in model_prices_data.items():
+            if "model_vendor" not in model_data:
+                missing.append(model_key)
+
+        if missing:
+            pytest.fail(
+                f"Missing model_vendor in {len(missing)} models. "
+                f"First 10: {missing[:10]}"
+            )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -507,6 +507,9 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
         "additionalProperties": {
             "type": "object",
             "properties": {
+                "display_name": {"type": "string"},
+                "model_vendor": {"type": "string"},
+                "model_version": {"type": "string"},
                 "supports_computer_use": {"type": "boolean"},
                 "cache_creation_input_audio_token_cost": {"type": "number"},
                 "cache_creation_input_token_cost": {"type": "number"},


### PR DESCRIPTION
## Title

Add display_name and model_vendor metadata to all models. Add model_version where relevant. These changes should not be breaking. They just add additional model info to the end user which provide a QoL boost. Parsing out the raw model name is painful as there is no standardized format.

some example updates:

```
    "512-x-512/dall-e-2": {
        "display_name": "DALL-E 2",
        "model_vendor": "openai",
        "input_cost_per_pixel": 6.86e-08,
        "litellm_provider": "openai",
        "mode": "image_generation",
        "output_cost_per_pixel": 0.0
    },
    "512-x-512/max-steps/stability.stable-diffusion-xl-v0": {
        "display_name": "Stable Diffusion XL",
        "litellm_provider": "bedrock",
        "max_input_tokens": 77,
        "max_tokens": 77,
        "mode": "image_generation",
        "model_vendor": "stability",
        "model_version": "v0",
        "output_cost_per_image": 0.036
    },
    "ai21.j2-mid-v1": {
        "display_name": "Jurassic-2 Mid",
        "input_cost_per_token": 1.25e-05,
        "litellm_provider": "bedrock",
        "max_input_tokens": 8191,
        "max_output_tokens": 8191,
        "max_tokens": 8191,
        "mode": "chat",
        "model_vendor": "ai21",
        "model_version": "v1",
        "output_cost_per_token": 1.25e-05
    },
    "ai21.j2-ultra-v1": {
        "display_name": "Jurassic-2 Ultra",
        "input_cost_per_token": 1.88e-05,
        "litellm_provider": "bedrock",
        "max_input_tokens": 8191,
        "max_output_tokens": 8191,
        "max_tokens": 8191,
        "mode": "chat",
        "model_vendor": "ai21",
        "model_version": "v1",
        "output_cost_per_token": 1.88e-05
    },

```


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] ~~My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)~~ failing tests are existing failures. see below
```
========================================================= short test summary info =========================================================
FAILED tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py::TestVertexGemmaCompletion::test_acompletion_basic_request - litellm.exceptions.BadRequestError: litellm.BadRequestError: Vertex_aiException BadRequestError - vertexai import failed please run `p...
FAILED tests/test_litellm/llms/cohere/rerank/test_rerank_guardrail_handler.py::TestContentFilteringScenario::test_content_filtering_query - TypeError: TestContentFilteringScenario.test_content_filtering_query.<locals>.ContentFilterGuardrail.apply_guardrail() got an unexpect...
FAILED tests/test_litellm/llms/openai/completion/test_text_completion_guardrail_handler.py::TestPIIMaskingScenario::test_batch_prompts_with_pii - TypeError: TestPIIMaskingScenario.test_batch_prompts_with_pii.<locals>.PIIMaskingGuardrail.apply_guardrail() got an unexpected keyword...
FAILED tests/test_litellm/llms/gemini/test_gemini_common_utils.py::TestGoogleAIStudioTokenCounter::test_clean_contents_for_gemini_api_preserves_other_fields - ModuleNotFoundError: No module named 'google.genai'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 4 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=================================== 4 failed, 656 passed, 13 skipped, 148 warnings in 68.25s (0:01:08) ====================================
```
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


<img width="990" height="354" alt="Screenshot 2025-12-02 at 4 44 19 PM" src="https://github.com/user-attachments/assets/bb55c9a0-3805-4191-b8d4-e9b4d10d3e69" />



## Type

🆕 New Feature

## Changes

This PR adds three new metadata fields to every model entry in `model_prices_and_context_window.json`:

- **`display_name`**: A human-readable name for the model (e.g., "Claude Sonnet 3.5", "GPT-4o", "Gemini 2.0 Flash")
- **`model_vendor`**: The organization that created the model (e.g., "anthropic", "openai", "google", "meta")

These fields enable better UI display and categorization of models in applications built on LiteLLM, making it easier to:
- Show user-friendly model names in dropdowns and selectors
- Filter and group models by vendor
- Build model selection interfaces with proper categorization

The metadata was generated using pattern matching against model keys and provider information to accurately detect vendors and families across 2000+ model entries.