### PR TITLE
Fix sso users not added to entra synced team

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -435,9 +435,9 @@ async def add_missing_team_member(
     - Get missing teams (diff b/w user_info.team_ids and sso_teams)
     - Add missing user to missing teams
     """
-    if user_info.teams is None:
-        return
-    missing_teams = set(sso_teams) - set(user_info.teams)
+    # Handle None as empty list for new users
+    user_teams = user_info.teams if user_info.teams is not None else []
+    missing_teams = set(sso_teams) - set(user_teams)
     missing_teams_list = list(missing_teams)
     tasks = []
     tasks = [


### PR DESCRIPTION
## Title

new users are now automatically added to the associated SSO-synced teams

## Relevant issues

fixes https://github.com/BerriAI/litellm/issues/17051

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes
```
litellm/proxy/management_endpoints/ui_sso.py
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
```

## Unit test results

Note: the warning were there before
```
$ poetry run pytest tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
======================================================================================================================== test session starts =========================================================================================================================
platform linux -- Python 3.13.9, pytest-7.4.4, pluggy-1.6.0
rootdir: /home/rioiart/workspace/litellm
configfile: pyproject.toml
plugins: asyncio-0.21.2, xdist-3.8.0, mock-3.15.1, retry-1.6.3, requests-mock-1.12.1, anyio-4.11.0, respx-0.22.0
asyncio: mode=Mode.AUTO
collected 92 items                                                                                                                                                                                                                                                   

tests/test_litellm/proxy/management_endpoints/test_ui_sso.py ............................................................................................                                                                                                      [100%]

========================================================================================================================== warnings summary ==========================================================================================================================
litellm/types/llms/anthropic.py:531
  /home/rioiart/workspace/litellm/litellm/types/llms/anthropic.py:531: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class AnthropicResponseContentBlockToolUse(BaseModel):

litellm/types/rag.py:181
  /home/rioiart/workspace/litellm/litellm/types/rag.py:181: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class RAGIngestRequest(BaseModel):

tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_create_team_without_default_params
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_default_team_params[team_params0]
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_default_team_params[team_params1]
  /home/rioiart/workspace/litellm/litellm/proxy/management_endpoints/team_endpoints.py:1602: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    updated_users, updated_team_memberships = await _process_team_members(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_get_microsoft_callback_response
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_get_microsoft_callback_response_raw_sso_response
  /home/rioiart/.cache/pypoetry/virtualenvs/litellm-r8g_XKQW-py3.13/lib/python3.13/site-packages/fastapi_sso/sso/base.py:80: SecurityWarning: Please make sure you are using SSO provider in an async context (using 'async with provider:'). See https://github.com/tomasvotava/fastapi-sso/issues/186 for more information.
    warnings.warn(

tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_get_microsoft_callback_response
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_get_microsoft_callback_response_raw_sso_response
  /home/rioiart/.cache/pypoetry/virtualenvs/litellm-r8g_XKQW-py3.13/lib/python3.13/site-packages/aiohttp/connector.py:963: DeprecationWarning: enable_cleanup_closed ignored because https://github.com/python/cpython/pull/118960 is fixed in Python version sys.version_info(major=3, minor=13, micro=9, releaselevel='final', serial=0)
    super().__init__(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================================== 92 passed, 9 warnings in 1.95s ===================================================================================================================
```
