### PR TITLE
Fix/new org team validate against org

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -461,11 +461,38 @@ async def _check_org_team_limits(
     prisma_client: PrismaClient,
 ) -> None:
     """
-    Check if the organization team is allocating guaranteed throughput limits. If so, raise an error if we're overallocating.
-
-    Only runs check if tpm_limit_type or rpm_limit_type is "guaranteed_throughput"
+    Check organization team limits including:
+    - Team budget vs organization's max_budget
+    - Team models vs organization's allowed models
+    - Guaranteed throughput limits (tpm/rpm) if applicable
     """
 
+    # Validate team budget against organization's max_budget
+    if (
+        data.max_budget is not None
+        and org_table.litellm_budget_table is not None
+        and org_table.litellm_budget_table.max_budget is not None
+        and data.max_budget > org_table.litellm_budget_table.max_budget
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"Team max_budget ({data.max_budget}) exceeds organization's max_budget ({org_table.litellm_budget_table.max_budget}). Organization: {org_table.organization_id}"
+            },
+        )
+
+    # Validate team models against organization's allowed models
+    if data.models is not None and len(org_table.models) > 0:
+        for m in data.models:
+            if m not in org_table.models:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"Model '{m}' not in organization's allowed models. Organization allowed models={org_table.models}. Organization: {org_table.organization_id}"
+                    },
+                )
+
+    # Check guaranteed throughput limits (only if applicable)
     rpm_limit_type = getattr(data, "rpm_limit_type", None) or (
         data.metadata.get("rpm_limit_type", None) if data.metadata else None
     )
@@ -1154,168 +1181,211 @@ async def update_team(
     }'
     ```
     """
-    from litellm.proxy.auth.auth_checks import _cache_team_object
-    from litellm.proxy.proxy_server import (
-        litellm_proxy_admin_name,
-        llm_router,
-        prisma_client,
-        proxy_logging_obj,
-        user_api_key_cache,
-    )
-
-    if prisma_client is None:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": CommonProxyErrors.db_not_connected_error.value},
+    try:
+        from litellm.proxy.auth.auth_checks import _cache_team_object
+        from litellm.proxy.proxy_server import (
+            litellm_proxy_admin_name,
+            llm_router,
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
         )
 
-    if data.team_id is None:
-        raise HTTPException(status_code=400, detail={"error": "No team id passed in"})
-    verbose_proxy_logger.debug("/team/update - %s", data)
-
-    existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
-        where={"team_id": data.team_id}
-    )
-
-    if existing_team_row is None:
-        raise HTTPException(
-            status_code=404,
-            detail={"error": f"Team not found, passed team_id={data.team_id}"},
-        )
-
-    if (
-        data.organization_id is not None and len(data.organization_id) > 0
-    ):  # allow unsetting the organization_id
-        await fetch_and_validate_organization(
-            organization_id=data.organization_id,
-            existing_team_row=existing_team_row,
-            llm_router=llm_router,
-            prisma_client=prisma_client,
-        )
-    elif data.organization_id is not None and len(data.organization_id) == 0:
-        # unsetting the organization_id
-        data.organization_id = None
-
-    # check org team limits - if updating team that belongs to an org
-    org_id_to_check = (
-        data.organization_id
-        if data.organization_id is not None
-        else existing_team_row.organization_id
-    )
-    if (
-        org_id_to_check is not None
-        and isinstance(org_id_to_check, str)
-        and prisma_client is not None
-    ):
-        org_table = await get_org_object(
-            org_id=org_id_to_check,
-            user_api_key_cache=user_api_key_cache,
-            prisma_client=prisma_client,
-        )
-        if org_table is not None:
-            await _check_org_team_limits(
-                org_table=org_table,
-                data=data,
-                prisma_client=prisma_client,
+        if prisma_client is None:
+            raise HTTPException(
+                status_code=500,
+                detail={"error": CommonProxyErrors.db_not_connected_error.value},
             )
 
-    updated_kv = data.json(exclude_unset=True)
+        if data.team_id is None:
+            raise HTTPException(status_code=400, detail={"error": "No team id passed in"})
+        verbose_proxy_logger.debug("/team/update - %s", data)
 
-    # Check budget_duration and budget_reset_at
-    if data.budget_duration is not None:
-        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+        existing_team_row = await prisma_client.db.litellm_teamtable.find_unique(
+            where={"team_id": data.team_id}
+        )
 
-        reset_at = get_budget_reset_time(budget_duration=data.budget_duration)
+        if existing_team_row is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"error": f"Team not found, passed team_id={data.team_id}"},
+            )
 
-        # set the budget_reset_at in DB
-        updated_kv["budget_reset_at"] = reset_at
+        if (
+            data.organization_id is not None and len(data.organization_id) > 0
+        ):  # allow unsetting the organization_id
+            await fetch_and_validate_organization(
+                organization_id=data.organization_id,
+                existing_team_row=existing_team_row,
+                llm_router=llm_router,
+                prisma_client=prisma_client,
+            )
+        elif data.organization_id is not None and len(data.organization_id) == 0:
+            # unsetting the organization_id
+            data.organization_id = None
 
-    if TeamMemberBudgetHandler.should_create_budget(
-        team_member_budget=data.team_member_budget,
-        team_member_rpm_limit=data.team_member_rpm_limit,
-        team_member_tpm_limit=data.team_member_tpm_limit,
-    ):
-        updated_kv = await TeamMemberBudgetHandler.upsert_team_member_budget_table(
-            team_table=existing_team_row,
-            user_api_key_dict=user_api_key_dict,
-            updated_kv=updated_kv,
+        # check org team limits - if updating team that belongs to an org
+        org_id_to_check = (
+            data.organization_id
+            if data.organization_id is not None
+            else existing_team_row.organization_id
+        )
+        if (
+            org_id_to_check is not None
+            and isinstance(org_id_to_check, str)
+            and prisma_client is not None
+        ):
+            org_table = await get_org_object(
+                org_id=org_id_to_check,
+                user_api_key_cache=user_api_key_cache,
+                prisma_client=prisma_client,
+            )
+            if org_table is not None:
+                await _check_org_team_limits(
+                    org_table=org_table,
+                    data=data,
+                    prisma_client=prisma_client,
+                )
+
+        # Check user limits for standalone teams (not org-scoped)
+        # Skip for PROXY_ADMIN users
+        if (
+            user_api_key_dict.user_role is None
+            or user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN
+        ):
+            # Only validate user budget/models for standalone teams
+            # For org-scoped teams, validation is done by _check_org_team_limits() above
+            if org_id_to_check is None:
+                if data.max_budget is not None and user_api_key_dict.user_id is not None:
+                    # Fetch user object to get max_budget
+                    user_obj = await get_user_object(
+                        user_id=user_api_key_dict.user_id,
+                        prisma_client=prisma_client,
+                        user_api_key_cache=user_api_key_cache,
+                        user_id_upsert=False,
+                    )
+
+                    if (
+                        user_obj is not None
+                        and user_obj.max_budget is not None
+                        and data.max_budget > user_obj.max_budget
+                    ):
+                        raise HTTPException(
+                            status_code=400,
+                            detail={
+                                "error": f"max budget higher than user max. User max budget={user_obj.max_budget}. User role={user_api_key_dict.user_role}"
+                            },
+                        )
+
+                if data.models is not None and len(user_api_key_dict.models) > 0:
+                    for m in data.models:
+                        if m not in user_api_key_dict.models:
+                            raise HTTPException(
+                                status_code=400,
+                                detail={
+                                    "error": f"Model not in allowed user models. User allowed models={user_api_key_dict.models}. User id={user_api_key_dict.user_id}"
+                                },
+                            )
+
+        updated_kv = data.json(exclude_unset=True)
+
+        # Check budget_duration and budget_reset_at
+        if data.budget_duration is not None:
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+            reset_at = get_budget_reset_time(budget_duration=data.budget_duration)
+
+            # set the budget_reset_at in DB
+            updated_kv["budget_reset_at"] = reset_at
+
+        if TeamMemberBudgetHandler.should_create_budget(
             team_member_budget=data.team_member_budget,
             team_member_rpm_limit=data.team_member_rpm_limit,
             team_member_tpm_limit=data.team_member_tpm_limit,
-        )
-    else:
-        TeamMemberBudgetHandler._clean_team_member_fields(updated_kv)
-
-    # Check object permission
-    if data.object_permission is not None:
-        updated_kv = await handle_update_object_permission(
-            data_json=updated_kv,
-            existing_team_row=existing_team_row,
-        )
-
-    # update team metadata fields
-    _team_metadata_fields = LiteLLM_ManagementEndpoint_MetadataFields_Premium
-    for field in _team_metadata_fields:
-        if field in updated_kv and updated_kv[field] is not None:
-            _update_metadata_field(
+        ):
+            updated_kv = await TeamMemberBudgetHandler.upsert_team_member_budget_table(
+                team_table=existing_team_row,
+                user_api_key_dict=user_api_key_dict,
                 updated_kv=updated_kv,
-                field_name=field,
+                team_member_budget=data.team_member_budget,
+                team_member_rpm_limit=data.team_member_rpm_limit,
+                team_member_tpm_limit=data.team_member_tpm_limit,
+            )
+        else:
+            TeamMemberBudgetHandler._clean_team_member_fields(updated_kv)
+
+        # Check object permission
+        if data.object_permission is not None:
+            updated_kv = await handle_update_object_permission(
+                data_json=updated_kv,
+                existing_team_row=existing_team_row,
             )
 
-    for field in LiteLLM_ManagementEndpoint_MetadataFields:
-        if field in updated_kv and updated_kv[field] is not None:
-            _update_metadata_field(
-                updated_kv=updated_kv,
-                field_name=field,
+        # update team metadata fields
+        _team_metadata_fields = LiteLLM_ManagementEndpoint_MetadataFields_Premium
+        for field in _team_metadata_fields:
+            if field in updated_kv and updated_kv[field] is not None:
+                _update_metadata_field(
+                    updated_kv=updated_kv,
+                    field_name=field,
+                )
+
+        for field in LiteLLM_ManagementEndpoint_MetadataFields:
+            if field in updated_kv and updated_kv[field] is not None:
+                _update_metadata_field(
+                    updated_kv=updated_kv,
+                    field_name=field,
+                )
+
+        if "model_aliases" in updated_kv:
+            updated_kv.pop("model_aliases")
+            _model_id = await _update_model_table(
+                data=data,
+                model_id=existing_team_row.model_id,
+                prisma_client=prisma_client,
+                user_api_key_dict=user_api_key_dict,
+                litellm_proxy_admin_name=litellm_proxy_admin_name,
+            )
+            if _model_id is not None:
+                updated_kv["model_id"] = _model_id
+
+        updated_kv = prisma_client.jsonify_team_object(db_data=updated_kv)
+        team_row: Optional[LiteLLM_TeamTable] = (
+            await prisma_client.db.litellm_teamtable.update(
+                where={"team_id": data.team_id},
+                data=updated_kv,
+                include={"litellm_model_table": True},  # type: ignore
+            )
+        )
+
+        if team_row is None or team_row.team_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Team doesn't exist. Got={}".format(team_row)},
             )
 
-    if "model_aliases" in updated_kv:
-        updated_kv.pop("model_aliases")
-        _model_id = await _update_model_table(
-            data=data,
-            model_id=existing_team_row.model_id,
-            prisma_client=prisma_client,
-            user_api_key_dict=user_api_key_dict,
-            litellm_proxy_admin_name=litellm_proxy_admin_name,
-        )
-        if _model_id is not None:
-            updated_kv["model_id"] = _model_id
-
-    updated_kv = prisma_client.jsonify_team_object(db_data=updated_kv)
-    team_row: Optional[LiteLLM_TeamTable] = (
-        await prisma_client.db.litellm_teamtable.update(
-            where={"team_id": data.team_id},
-            data=updated_kv,
-            include={"litellm_model_table": True},  # type: ignore
-        )
-    )
-
-    if team_row is None or team_row.team_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Team doesn't exist. Got={}".format(team_row)},
+        verbose_proxy_logger.info("Successfully updated team - %s, info", team_row.team_id)
+        await _cache_team_object(
+            team_id=team_row.team_id,
+            team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
         )
 
-    verbose_proxy_logger.info("Successfully updated team - %s, info", team_row.team_id)
-    await _cache_team_object(
-        team_id=team_row.team_id,
-        team_table=LiteLLM_TeamTableCachedObj(**team_row.model_dump()),
-        user_api_key_cache=user_api_key_cache,
-        proxy_logging_obj=proxy_logging_obj,
-    )
+        # Enterprise Feature - Audit Logging. Enable with litellm.store_audit_logs = True
+        if litellm.store_audit_logs is True:
+            await _create_team_update_audit_log(
+                existing_team_row=existing_team_row,
+                updated_kv=updated_kv,
+                team_id=data.team_id,
+                litellm_changed_by=litellm_changed_by,
+                user_api_key_dict=user_api_key_dict,
+                litellm_proxy_admin_name=litellm_proxy_admin_name,
+            )
 
-    # Enterprise Feature - Audit Logging. Enable with litellm.store_audit_logs = True
-    if litellm.store_audit_logs is True:
-        await _create_team_update_audit_log(
-            existing_team_row=existing_team_row,
-            updated_kv=updated_kv,
-            team_id=data.team_id,
-            litellm_changed_by=litellm_changed_by,
-            user_api_key_dict=user_api_key_dict,
-            litellm_proxy_admin_name=litellm_proxy_admin_name,
-        )
-
-    return {"team_id": team_row.team_id, "data": team_row}
+        return {"team_id": team_row.team_id, "data": team_row}
+    except Exception as e:
+        raise handle_exception_on_proxy(e)
 
 
 async def handle_update_object_permission(


### PR DESCRIPTION
## Title

[new users are now automatically added to the associated SSO-synced teams](fix: org admin cannot create a Team due to budget and model checks against personal budget/models instead of org budget/models)

## Relevant issues

fixes https://github.com/BerriAI/litellm/issues/17059

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
🧹 Refactoring
✅ Test

## Changes

```
litellm/proxy/management_endpoints/team_endpoints.py
tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
```

  This PR fixes validation logic for team budget and rate limits, ensuring proper enforcement based on team scope:

  Key Changes:

  - Org-scoped teams (teams with organization_id) now validate TPM/RPM limits against the organization's limits instead of the creating user's personal limits
  - Standalone teams (teams without organization_id) continue to validate budget, models, TPM, and RPM against the user's limits
  - Added direct TPM/RPM comparison against organization limits in _check_org_team_limits()
  - Consolidated user limit validation into new _check_user_team_limits() helper function, reducing code duplication between new_team() and update_team()

  Bug Fixed:

  Previously, when creating/updating an org-scoped team, the user's personal TPM/RPM limits were incorrectly applied even though the team belongs to an organization with its own limits. This prevented org admins from creating teams with limits higher than their personal limits but within org limits.

  Test Coverage:

  Added 8 new tests covering:
  - Standalone team TPM/RPM validation against user limits
  - Org-scoped team TPM/RPM validation against org limits
  - Verification that org-scoped teams bypass user's personal limits when within org limits


## Unit test results

Note: the warning were there before
```
$ poetry run pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
======================================================================================================================== test session starts =========================================================================================================================
platform linux -- Python 3.13.9, pytest-7.4.4, pluggy-1.6.0
rootdir: /home/rioiart/workspace/litellm
configfile: pyproject.toml
plugins: asyncio-0.21.2, xdist-3.8.0, mock-3.15.1, retry-1.6.3, requests-mock-1.12.1, anyio-4.11.0, respx-0.22.0
asyncio: mode=Mode.AUTO
collected 56 items                                                                                                                                                                                                                                                   

tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py ........................................................                                                                                                                                  [100%]

========================================================================================================================== warnings summary ==========================================================================================================================
litellm/types/llms/anthropic.py:531
  /home/rioiart/workspace/litellm/litellm/types/llms/anthropic.py:531: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class AnthropicResponseContentBlockToolUse(BaseModel):

litellm/types/rag.py:181
  /home/rioiart/workspace/litellm/litellm/types/rag.py:181: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class RAGIngestRequest(BaseModel):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================================== 56 passed, 2 warnings in 2.87s ===================================================================================================================
```
