### PR TITLE
docs: add Google ADK and Harbor to projects

### DIFF
--- a/docs/my-website/docs/projects/Google ADK.md
+++ b/docs/my-website/docs/projects/Google ADK.md
@@ -1,0 +1,21 @@
+
+# Google ADK (Agent Development Kit)
+
+[Google ADK](https://github.com/google/adk-python) is an open-source, code-first Python framework for building, evaluating, and deploying sophisticated AI agents. While optimized for Gemini, ADK is model-agnostic and supports LiteLLM for using 100+ providers.
+
+```python
+from google.adk.agents.llm_agent import Agent
+from google.adk.models.lite_llm import LiteLlm
+
+root_agent = Agent(
+    model=LiteLlm(model="openai/gpt-4o"),  # Or any LiteLLM-supported model
+    name="my_agent",
+    description="An agent using LiteLLM",
+    instruction="You are a helpful assistant.",
+    tools=[your_tools],
+)
+```
+
+- [GitHub](https://github.com/google/adk-python)
+- [Documentation](https://google.github.io/adk-docs)
+- [LiteLLM Samples](https://github.com/google/adk-python/tree/main/contributing/samples/hello_world_litellm)

--- a/docs/my-website/docs/projects/Harbor.md
+++ b/docs/my-website/docs/projects/Harbor.md
@@ -1,0 +1,24 @@
+
+# Harbor
+
+[Harbor](https://github.com/laude-institute/harbor) is a framework from the creators of Terminal-Bench for evaluating and optimizing agents and language models. It uses LiteLLM to call 100+ LLM providers.
+
+```bash
+# Install
+pip install harbor
+
+# Run a benchmark with any LiteLLM-supported model
+harbor run --dataset terminal-bench@2.0 \
+   --agent claude-code \
+   --model anthropic/claude-opus-4-1 \
+   --n-concurrent 4
+```
+
+Key features:
+- Evaluate agents like Claude Code, OpenHands, Codex CLI
+- Build and share benchmarks and environments
+- Run experiments in parallel across cloud providers (Daytona, Modal)
+- Generate rollouts for RL optimization
+
+- [GitHub](https://github.com/laude-institute/harbor)
+- [Documentation](https://harborframework.com/docs)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -816,10 +816,12 @@ const sidebars = {
               "Learn how to deploy + call models from different providers on LiteLLM",
             slug: "/project",
           },
-          items: [        
+          items: [
             "projects/smolagents",
             "projects/mini-swe-agent",
             "projects/openai-agents",
+            "projects/Google ADK",
+            "projects/Harbor",
             "projects/Docq.AI",
             "projects/PDL",
             "projects/OpenInterpreter",


### PR DESCRIPTION
## Title

Add Google ADK and Harbor to "Projects built on LiteLLM" documentation

## Relevant issues

N/A - documentation addition

## Pre-Submission checklist

- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

> Note: This is a docs-only change, no tests needed.

## Type

📖 Documentation

## Changes

Added two projects that integrate with LiteLLM:

- **Google ADK** - Google's Agent Development Kit, uses `LiteLlm` model class to support 100+ providers
- **Harbor** - Agent evaluation framework from Terminal-Bench creators, uses LiteLLM for multi-provider support

Files changed:
- `docs/my-website/docs/projects/Google ADK.md` (new)
- `docs/my-website/docs/projects/Harbor.md` (new)
- `docs/my-website/sidebars.js` (added to menu)