### PR TITLE
fix: resolve UI session MCP permissions across real teams

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1281,8 +1281,8 @@ async def test_list_tools_with_team_tool_permissions_inheritance():
     ):
         # Mock the team object permission retrieval
         with patch(
-            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_team_object_permission",
-            AsyncMock(return_value=team_object_permission),
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_team_object_permissions",
+            AsyncMock(return_value=[team_object_permission]),
         ):
             tools = await _get_tools_from_mcp_servers(
                 user_api_key_auth=user_api_key_auth,


### PR DESCRIPTION
## Title

fix: resolve UI session MCP permissions across real teams

## Relevant issues

#N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🐛 Bug Fix
✅ Test

## Changes

Addresses “Configured MCP servers are not visible anymore to internal users except proxy admin” by teaching the MCP auth layer to resolve UI-session tokens (team_id `litellm-dashboard`) back to each user’s real team memberships and union their object permissions.

https://www.loom.com/share/e788d3f695434d55967ffa6ce20a370c