### PR TITLE
feat: Cancel LLM stream response on client disconnect

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -818,6 +818,7 @@ async def add_litellm_data_to_request(  # noqa: PLR0915
         "method": request.method,
         "headers": _headers,
         "body": copy.copy(data),  # use copy instead of deepcopy
+        "is_disconnected": request.state.is_disconnected if hasattr(request.state, "is_disconnected") else request.is_disconnected,
     }
 
     safe_add_api_version_from_query_params(data, request)

--- a/litellm/proxy/middleware/prometheus_auth_middleware.py
+++ b/litellm/proxy/middleware/prometheus_auth_middleware.py
@@ -25,8 +25,11 @@ class PrometheusAuthMiddleware(BaseHTTPMiddleware):
     """
 
     async def dispatch(self, request: Request, call_next):
-        # Check if this is a request to the metrics endpoint
+        # BaseHTTPMiddleware issue https://github.com/Kludex/starlette/discussions/2094#discussioncomment-9096047
+        if not hasattr(request.state, "is_disconnected"):
+            request.state.is_disconnected = request.is_disconnected
 
+        # Check if this is a request to the metrics endpoint
         if self._is_prometheus_metrics_endpoint(request):
             if self._should_run_auth_on_metrics_endpoint() is True:
                 try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8146,6 +8146,7 @@ async def async_queue_request(
             "method": request.method,
             "headers": dict(request.headers),
             "body": copy.copy(data),  # use copy instead of deepcopy
+            "is_disconnected": request.state.is_disconnected if hasattr(request.state, "is_disconnected") else request.is_disconnected,
         }
 
         verbose_proxy_logger.debug("receiving data: %s", data)

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -182,6 +182,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     organization: Optional[str] = None  # for openai orgs
     configurable_clientside_auth_params: CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS = None
     litellm_credential_name: Optional[str] = None
+    proxy_server_request: Optional[dict] = None
 
     ## LOGGING PARAMS ##
     litellm_trace_id: Optional[str] = None


### PR DESCRIPTION
## Title

Cancel LLM stream response on client disconnect

## Relevant issues

Feature https://github.com/BerriAI/litellm/issues/13774
Feature https://github.com/BerriAI/litellm/issues/17364

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

🆕 New Feature

## Changes

- Add `is_disconnected()` func to proxy_server_request
- Add `proxy_server_request` to CustomStreamWrapper
- break completion_stream on client disconnect


