### PR TITLE
fix: conditionally pass enable_cleanup_closed to aiohttp TCPConnector

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -106,6 +106,7 @@ AIOHTTP_KEEPALIVE_TIMEOUT = int(os.getenv("AIOHTTP_KEEPALIVE_TIMEOUT", 120))
 AIOHTTP_TTL_DNS_CACHE = int(os.getenv("AIOHTTP_TTL_DNS_CACHE", 300))
 # enable_cleanup_closed is only needed for Python versions with the SSL leak bug
 # Fixed in Python 3.12.7+ and 3.13.1+ (see https://github.com/python/cpython/pull/118960)
+# Reference: https://github.com/aio-libs/aiohttp/blob/master/aiohttp/connector.py#L74-L78
 AIOHTTP_NEEDS_CLEANUP_CLOSED = (
     (3, 13, 0) <= sys.version_info < (3, 13, 1) or sys.version_info < (3, 12, 7)
 )

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Literal
 
 DEFAULT_HEALTH_CHECK_PROMPT = str(
@@ -103,6 +104,11 @@ _DEFAULT_TTL_FOR_HTTPX_CLIENTS = 3600  # 1 hour, re-use the same httpx client fo
 AIOHTTP_CONNECTOR_LIMIT = int(os.getenv("AIOHTTP_CONNECTOR_LIMIT", 0))
 AIOHTTP_KEEPALIVE_TIMEOUT = int(os.getenv("AIOHTTP_KEEPALIVE_TIMEOUT", 120))
 AIOHTTP_TTL_DNS_CACHE = int(os.getenv("AIOHTTP_TTL_DNS_CACHE", 300))
+# enable_cleanup_closed is only needed for Python versions with the SSL leak bug
+# Fixed in Python 3.12.7+ and 3.13.1+ (see https://github.com/python/cpython/pull/118960)
+AIOHTTP_NEEDS_CLEANUP_CLOSED = (
+    (3, 13, 0) <= sys.version_info < (3, 13, 1) or sys.version_info < (3, 12, 7)
+)
 
 # WebSocket constants
 # Default to None (unlimited) to match OpenAI's official agents SDK behavior

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -17,6 +17,7 @@ from litellm.constants import (
     _DEFAULT_TTL_FOR_HTTPX_CLIENTS,
     AIOHTTP_CONNECTOR_LIMIT,
     AIOHTTP_KEEPALIVE_TIMEOUT,
+    AIOHTTP_NEEDS_CLEANUP_CLOSED,
     AIOHTTP_TTL_DNS_CACHE,
     DEFAULT_SSL_CIPHERS,
 )
@@ -798,7 +799,7 @@ class AsyncHTTPHandler:
                     limit=AIOHTTP_CONNECTOR_LIMIT,
                     keepalive_timeout=AIOHTTP_KEEPALIVE_TIMEOUT,
                     ttl_dns_cache=AIOHTTP_TTL_DNS_CACHE,
-                    enable_cleanup_closed=True,
+                    enable_cleanup_closed=AIOHTTP_NEEDS_CLEANUP_CLOSED,
                     **connector_kwargs,
                 ),
                 trust_env=trust_env,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -32,6 +32,7 @@ from litellm._uuid import uuid
 from litellm.constants import (
     AIOHTTP_CONNECTOR_LIMIT,
     AIOHTTP_KEEPALIVE_TIMEOUT,
+    AIOHTTP_NEEDS_CLEANUP_CLOSED,
     AIOHTTP_TTL_DNS_CACHE,
     AUDIO_SPEECH_CHUNK_SIZE,
     BASE_MCP_ROUTE,
@@ -635,7 +636,7 @@ async def _initialize_shared_aiohttp_session():
             limit=AIOHTTP_CONNECTOR_LIMIT,
             keepalive_timeout=AIOHTTP_KEEPALIVE_TIMEOUT,
             ttl_dns_cache=AIOHTTP_TTL_DNS_CACHE,
-            enable_cleanup_closed=True,
+            enable_cleanup_closed=AIOHTTP_NEEDS_CLEANUP_CLOSED,
         )
 
         session = ClientSession(connector=connector)


### PR DESCRIPTION
## Title

fix: conditionally pass enable_cleanup_closed to aiohttp TCPConnector

## Relevant issues

N/A (addresses deprecation warning, no existing issue)

## Pre-Submission checklist

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement**

  Change is trivial and dependent on python versions, please let me know if still need to add tests.

- [x] I have added a screenshot of my new test passing locally - N/A
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code) - No new tests added; existing tests unaffected
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

To avoid warning:

```
.venv/lib/python3.13/site-packages/aiohttp/connector.py:963: DeprecationWarning: enable_cleanup_closed ignored because https://github.com/python/cpython/pull/118960 is fixed in Python version sys.version_info(major=3, minor=13, micro=5, releaselevel='final', serial=0)
```

Fixes deprecation warning on Python 3.12.7+ and 3.13.1+ where `enable_cleanup_closed` is no longer needed.

- Relevant CPython PR: https://github.com/python/cpython/pull/118960
- Added `AIOHTTP_NEEDS_CLEANUP_CLOSED` constant to `litellm/constants.py` that evaluates to `True` only on Python versions with the SSL leak bug (< 3.12.7 or exactly 3.13.0), aiohttp source: [`NEEDS_CLEANUP_CLOSED` in connector.py#L74-L78](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/connector.py#L74-L78)
- Updated `litellm/llms/custom_httpx/http_handler.py` to use the new constant
- Updated `litellm/proxy/proxy_server.py` to use the new constant