### PR TITLE
[Infra] Add Google Private API Endpoint to Vertex AI fields

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2608,6 +2608,16 @@
         "default_value": null
       },
       {
+        "key": "api_base",
+        "label": "Google Private API Endpoint",
+        "placeholder": null,
+        "tooltip": null,
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
         "key": "vertex_credentials",
         "label": "Vertex Credentials",
         "placeholder": null,


### PR DESCRIPTION
## [Fix] Add Google Private API Endpoint to Vertex AI fields

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
See screenshots for field being rendered in UI

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🚄 Infrastructure


## Changes

<img width="1186" height="783" alt="image" src="https://github.com/user-attachments/assets/cf4d9f60-a21c-4508-9407-7174b3d57737" />

