### PR TITLE
Support Deepseek 3.2 with Reasoning

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20487,6 +20487,21 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/deepseek/deepseek-v3.2": {
+        "input_cost_per_token": 2.8e-07,
+        "input_cost_per_token_cache_hit": 2.8e-08,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/deepseek/deepseek-v3.2-exp": {
         "input_cost_per_token": 2e-07,
         "input_cost_per_token_cache_hit": 2e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9564,6 +9564,21 @@
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
+    "deepseek/deepseek-v3.2": {
+        "input_cost_per_token": 2.8e-07,
+        "input_cost_per_token_cache_hit": 2.8e-08,
+        "litellm_provider": "deepseek",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "deepseek.v3-v1:0": {
         "input_cost_per_token": 5.8e-07,
         "litellm_provider": "bedrock_converse",

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -489,3 +489,30 @@ def test_openrouter_cost_tracking_streaming():
     # Verify cost field is preserved in the Usage object - this is the key data for cost tracking
     # The chunk_parser converts the dict to a Usage Pydantic model which includes the cost field
     assert result2.usage.cost == 0.0001
+
+
+def test_openrouter_reasoning_models_allow_reasoning_effort_param():
+    """
+    OpenRouter reasoning-capable models should accept the reasoning_effort param.
+    """
+    config = OpenrouterConfig()
+
+    supported_params = config.get_supported_openai_params(
+        model="openrouter/deepseek/deepseek-v3.2"
+    )
+
+    assert "reasoning_effort" in supported_params
+    assert supported_params.count("reasoning_effort") == 1
+
+
+def test_openrouter_non_reasoning_models_do_not_add_reasoning_effort():
+    """
+    Models without reasoning support should not gain reasoning-specific params.
+    """
+    config = OpenrouterConfig()
+
+    supported_params = config.get_supported_openai_params(
+        model="openrouter/anthropic/claude-3-5-haiku"
+    )
+
+    assert "reasoning_effort" not in supported_params


### PR DESCRIPTION
## Title

Add Deepseek 3.2 Thinking support and add reasoning_effort support for OpenRouter reasoning-capable models

Note that the test failures in this branch also occur in main.

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes
  - Allow OpenRouter reasoning-capable models to expose reasoning_effort via get_supported_openai_params.
  - Added tests to verify reasoning models get reasoning_effort while non-reasoning models do not (tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py).
  - Add Deepseek 3.2 to model_prices_and_context_window.json

<img width="943" height="501" alt="Screenshot 2025-12-02 at 3 43 31 PM" src="https://github.com/user-attachments/assets/5dd8e583-5f9d-446b-b454-926dc6b6e1b6" />

