### PR TITLE
Add mistral 3 api support and docs

### DIFF
--- a/docs/my-website/docs/providers/mistral.md
+++ b/docs/my-website/docs/providers/mistral.md
@@ -147,7 +147,10 @@ All models listed here https://docs.mistral.ai/platform/endpoints are supported.
 | Model Name     | Function Call                                                | Reasoning Support |
 |----------------|--------------------------------------------------------------|-------------------|
 | Mistral Small  | `completion(model="mistral/mistral-small-latest", messages)` | No |
+| **Mistral Small 3.1**  | `completion(model="mistral/mistral-small-3-1-24b-instruct", messages)` | No |
+| **Mistral Small 3.2**  | `completion(model="mistral/mistral-small-3-2-24b-instruct", messages)` | No |
 | Mistral Medium | `completion(model="mistral/mistral-medium-latest", messages)`| No |
+| **Mistral Medium 3**  | `completion(model="mistral/mistral-medium-3", messages)`| No |
 | Mistral Large 2  | `completion(model="mistral/mistral-large-2407", messages)` | No |
 | Mistral Large Latest  | `completion(model="mistral/mistral-large-latest", messages)` | No |
 | **Magistral Small**  | `completion(model="mistral/magistral-small-2506", messages)` | Yes |

--- a/docs/my-website/docs/providers/mistral.md
+++ b/docs/my-website/docs/providers/mistral.md
@@ -146,6 +146,9 @@ All models listed here https://docs.mistral.ai/platform/endpoints are supported.
 
 | Model Name     | Function Call                                                | Reasoning Support |
 |----------------|--------------------------------------------------------------|-------------------|
+| **Ministral 3B** | `completion(model="mistral/ministral-3b-2512", messages)` | No |
+| **Ministral 8B** | `completion(model="mistral/ministral-8b-2512", messages)` | No |
+| **Ministral 14B** | `completion(model="mistral/ministral-14b-2512", messages)` | No |
 | Mistral Small  | `completion(model="mistral/mistral-small-latest", messages)` | No |
 | **Mistral Small 3.1**  | `completion(model="mistral/mistral-small-3-1-24b-instruct", messages)` | No |
 | **Mistral Small 3.2**  | `completion(model="mistral/mistral-small-3-2-24b-instruct", messages)` | No |
@@ -153,6 +156,7 @@ All models listed here https://docs.mistral.ai/platform/endpoints are supported.
 | **Mistral Medium 3**  | `completion(model="mistral/mistral-medium-3", messages)`| No |
 | Mistral Large 2  | `completion(model="mistral/mistral-large-2407", messages)` | No |
 | Mistral Large Latest  | `completion(model="mistral/mistral-large-latest", messages)` | No |
+| **Mistral Large 3** | `completion(model="mistral/mistral-large-3-2512", messages)` | No |
 | **Magistral Small**  | `completion(model="mistral/magistral-small-2506", messages)` | Yes |
 | **Magistral Medium** | `completion(model="mistral/magistral-medium-2506", messages)`| Yes |
 | Mistral 7B     | `completion(model="mistral/open-mistral-7b", messages)`      | No |

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18561,6 +18561,19 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "mistral/mistral-medium-3": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8191,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 2e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-small": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "mistral",
@@ -18580,6 +18593,32 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 8191,
         "max_tokens": 8191,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/mistral-small-3-1-24b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 8191,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/mistral-small-3-2-24b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
         "mode": "chat",
         "output_cost_per_token": 3e-07,
         "supports_assistant_prefill": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18511,6 +18511,19 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "mistral/mistral-large-3-2512": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "mistral/mistral-medium": {
         "input_cost_per_token": 2.7e-06,
         "litellm_provider": "mistral",
@@ -18635,6 +18648,45 @@
         "mode": "chat",
         "output_cost_per_token": 2.5e-07,
         "supports_assistant_prefill": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/ministral-3b-2512": {
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/ministral-8b-2512": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "mistral/ministral-14b-2512": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },


### PR DESCRIPTION
## Title

Add Mistral 3 models to cost map and documentation

## Relevant issues

<!-- No specific issue was provided in the conversation. -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Adds support for new Mistral 3 models by:
- Updating `model_prices_and_context_window.json` with pricing and context window details for `mistral/mistral-small-3-1-24b-instruct`, `mistral/mistral-small-3-2-24b-instruct`, and `mistral/mistral-medium-3`.
- Updating `docs/my-website/docs/providers/mistral.md` to include these new models in the supported models table.

---
[Slack Thread](https://berriaillm.slack.com/archives/C09MMPFRN7M/p1764718193118169?thread_ts=1764718193.118169&cid=C09MMPFRN7M)

<a href="https://cursor.com/background-agent?bcId=bc-114a54d7-c157-4a50-aa09-cc74bd685f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-114a54d7-c157-4a50-aa09-cc74bd685f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

