### PR TITLE
[Fix] UI - Change Edit Team Models Shown to Match Create Team

### DIFF
--- a/ui/litellm-dashboard/src/components/team/team_info.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/team_info.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/components/networking", () => ({
   getGuardrailsList: vi.fn(),
   fetchMCPAccessGroups: vi.fn(),
   getTeamPermissionsCall: vi.fn(),
+  organizationInfoCall: vi.fn(),
 }));
 
 describe("TeamInfoView", () => {
@@ -161,6 +162,116 @@ describe("TeamInfoView", () => {
 
     const allProxyModelsOption = screen.queryByText("All Proxy Models");
     expect(allProxyModelsOption).not.toBeInTheDocument();
-  }, // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
-  10000);
+  }, 10000); // This is a workaround to fix the flaky test issue. TODO: Remove this once we have a better solution.
+
+  it("should only show organization models in dropdown when team is in organization with limited models", async () => {
+    const organizationId = "org-123";
+    const organizationModels = ["gpt-4", "claude-3-opus"];
+    const userModels = ["gpt-4", "gpt-3.5-turbo", "claude-3-opus", "claude-2"];
+
+    vi.mocked(networking.teamInfoCall).mockResolvedValue({
+      team_id: "123",
+      team_info: {
+        team_alias: "Test Team",
+        team_id: "123",
+        organization_id: organizationId,
+        admins: ["admin@test.com"],
+        members: ["user1@test.com"],
+        members_with_roles: [
+          {
+            user_id: "user1@test.com",
+            user_email: "user1@test.com",
+            role: "member",
+            spend: 0,
+            budget_id: "budget1",
+          },
+        ],
+        metadata: {},
+        tpm_limit: null,
+        rpm_limit: null,
+        max_budget: null,
+        budget_duration: null,
+        models: ["gpt-4"],
+        blocked: false,
+        spend: 0,
+        max_parallel_requests: null,
+        budget_reset_at: null,
+        model_id: null,
+        litellm_model_table: null,
+        created_at: "2024-01-01T00:00:00Z",
+        team_member_budget_table: null,
+      },
+      keys: [],
+      team_memberships: [],
+    });
+
+    vi.mocked(networking.organizationInfoCall).mockResolvedValue({
+      organization_id: organizationId,
+      organization_name: "Test Organization",
+      spend: 0,
+      max_budget: null,
+      models: organizationModels,
+      tpm_limit: null,
+      rpm_limit: null,
+      members: null,
+    });
+
+    vi.mocked(networking.getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    vi.mocked(networking.fetchMCPAccessGroups).mockResolvedValue([]);
+
+    render(
+      <TeamInfoView
+        teamId="123"
+        onUpdate={() => {}}
+        onClose={() => {}}
+        accessToken="123"
+        is_team_admin={true}
+        is_proxy_admin={true}
+        userModels={userModels}
+        editTeam={false}
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Test Team")).not.toBeNull();
+    });
+
+    const settingsTab = screen.getByRole("tab", { name: "Settings" });
+    act(() => {
+      fireEvent.click(settingsTab);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Team Settings")).toBeInTheDocument();
+    });
+
+    const editButton = screen.getByRole("button", { name: "Edit Settings" });
+    act(() => {
+      fireEvent.click(editButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Models")).toBeInTheDocument();
+    });
+
+    const modelsSelect = screen.getByLabelText("Models");
+    act(() => {
+      fireEvent.mouseDown(modelsSelect);
+    });
+
+    await waitFor(() => {
+      const dropdownOptions = screen.getAllByRole("option");
+      const optionTexts = dropdownOptions.map((option) => option.textContent);
+
+      organizationModels.forEach((model) => {
+        expect(optionTexts).toContain(model);
+      });
+
+      const modelsNotInOrganization = userModels.filter((m) => !organizationModels.includes(m));
+      modelsNotInOrganization.forEach((model) => {
+        expect(optionTexts).not.toContain(model);
+      });
+    });
+  }, 10000);
 });


### PR DESCRIPTION
## [Fix] UI - Change Edit Team Models Shown to Match Create Team

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
In the create team flow, if an organization is selected, then the models drop down will take the organization's model into consideration. But the edit team flow is missing this logic. This PR makes it so that if the team is in an organization, then the organization's model list is only shown in the drop down. See screenshots for more information

Special cases: If the organization's model is [], it is treated as all proxy models

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

<img width="1204" height="619" alt="image" src="https://github.com/user-attachments/assets/c0b66aac-8b2e-4693-af48-e48e819b996e" />
<img width="439" height="247" alt="image" src="https://github.com/user-attachments/assets/ac801a91-6402-4070-8596-47e6305c36e3" />
<img width="1175" height="483" alt="image" src="https://github.com/user-attachments/assets/86a6ae08-8b93-462e-810e-35c7357f9311" />
<img width="805" height="192" alt="image" src="https://github.com/user-attachments/assets/de0b5a9c-3056-4a77-9b19-ad8cec2ee12d" />

