### PR TITLE
Fix gemini 3 last chunk thinking block

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1091,6 +1091,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if "thoughtSignature" in part:
                 part_copy = part.copy()
                 part_copy.pop("thoughtSignature")
+
+                text_content = part_copy.get("text")
+                if isinstance(text_content, str) and text_content.strip() == "":
+                    continue
+
                 thinking_blocks.append(
                     ChatCompletionThinkingBlock(
                         type="thinking",

--- a/tests/local_testing/test_gemini_reasoning_content.py
+++ b/tests/local_testing/test_gemini_reasoning_content.py
@@ -1,0 +1,20 @@
+import json
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
+
+
+def test_empty_part_does_not_create_thinking_block():
+    parts = [{"text": "", "thoughtSignature": "sig-1"}]
+    config = VertexGeminiConfig()
+    thinking_blocks = config._extract_thinking_blocks_from_parts(parts)
+    assert thinking_blocks == []
+
+
+def test_non_empty_part_creates_thinking_block():
+    parts = [{"text": "Some thinking", "thoughtSignature": "sig-2"}]
+    config = VertexGeminiConfig()
+    thinking_blocks = config._extract_thinking_blocks_from_parts(parts)
+    assert len(thinking_blocks) == 1
+    block = thinking_blocks[0]
+    # thinking should be valid JSON containing the text
+    parsed = json.loads(block["thinking"]) if isinstance(block["thinking"], str) else None
+    assert parsed is not None and parsed.get("text") == "Some thinking"


### PR DESCRIPTION
## Title

Fix gemini 3 last chunk thinking block

## Relevant issues


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type
🐛 Bug Fix

## Changes
- Gemini 3 returns an empty text chunk with though_signature, which was making the code think that a thinking block was returned. Hence it was returning {"text":""} at the end of streaming, breaking streaming.
- Fixed the code to check if the text content is there, if it is, then only send the thinking block
<img width="1275" height="723" alt="image" src="https://github.com/user-attachments/assets/b5c7085e-ea27-410d-a115-6b6585ee406e" />


