### PR TITLE
Fix SCIM GET /Users error and enforce SCIM 2.0 compliance

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_transformations.py
+++ b/litellm/proxy/management_endpoints/scim/scim_transformations.py
@@ -40,7 +40,9 @@ class ScimTransformations:
         user_updated_at = user.updated_at.isoformat() if user.updated_at else None
 
         emails = []
-        if user.user_email:
+        # Only add email if it's a valid email address (contains @)
+        # user_email can be a UUID when users are created without an email
+        if user.user_email and "@" in user.user_email:
             emails.append(SCIMUserEmail(value=user.user_email, primary=True))
 
         return SCIMUser(
@@ -126,7 +128,7 @@ class ScimTransformations:
         for member in team.members_with_roles or []:
             if isinstance(member, dict):
                 member = Member(**member)
-            
+
             scim_members.append(
                 SCIMMember(
                     value=ScimTransformations._get_scim_member_value(member),
@@ -161,7 +163,7 @@ class ScimTransformations:
         elif hasattr(member, "user_id"):
             return member.user_id or ScimTransformations.DEFAULT_SCIM_MEMBER_VALUE
         return ScimTransformations.DEFAULT_SCIM_MEMBER_VALUE
-    
+
     @staticmethod
     def _get_scim_member_display(member: Member) -> str:
         """

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -310,7 +310,7 @@ async def _create_user_if_not_exists(
 
         new_user_request = NewUserRequest(
             user_id=user_id,
-            user_email=user_id,  # We don't have email from group membership
+            user_email=None,  # We don't have email from group membership
             user_alias=None,
             teams=[],  # Teams will be added separately
             metadata={"created_via": created_via},

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
@@ -1,14 +1,8 @@
-import asyncio
-import json
 import os
 import sys
-from litellm._uuid import uuid
-from typing import Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
-from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../../")
@@ -19,10 +13,7 @@ from litellm.proxy.management_endpoints.scim.scim_transformations import (
     ScimTransformations,
 )
 from litellm.types.proxy.management_endpoints.scim_v2 import (
-    SCIMGroup,
-    SCIMPatchOp,
     SCIMPatchOperation,
-    SCIMUser,
 )
 
 

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
@@ -229,6 +229,76 @@ class TestScimTransformations:
         result = ScimTransformations._get_scim_member_value(member_without_email)
         assert result == member_without_email.user_id
 
+    @pytest.mark.asyncio
+    async def test_transform_user_with_uuid_as_email(self, mock_prisma_client):
+        """
+        Test that users with UUID in user_email field (from old bug) 
+        don't cause validation errors when transforming to SCIM format.
+        This tests the defensive fix that validates email contains '@' before creating SCIMUserEmail.
+        """
+        mock_client, mock_find_unique = mock_prisma_client
+        
+        # Create a user with UUID in user_email (simulating the bug scenario)
+        user_with_uuid_email = LiteLLM_UserTable(
+            user_id="21df4e37-2f38-4f2e-a21b-c33cb939ff5b",
+            user_email="21df4e37-2f38-4f2e-a21b-c33cb939ff5b",  # UUID as email (bug scenario)
+            user_alias=None,
+            teams=[],
+            created_at=None,
+            updated_at=None,
+            metadata={},
+        )
+        
+        mock_find_unique.return_value = None  # No teams to look up
+        
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_client):
+            # This should not raise a validation error
+            scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(
+                user_with_uuid_email
+            )
+            
+            # Verify the user was transformed successfully
+            assert scim_user.id == user_with_uuid_email.user_id
+            # Email should not be in emails array since it's a UUID (no '@' sign)
+            assert scim_user.emails is None or len(scim_user.emails) == 0
+            # userName should fall back to default since email is invalid
+            assert scim_user.userName == ScimTransformations.DEFAULT_SCIM_DISPLAY_NAME
+
+    @pytest.mark.asyncio
+    async def test_transform_user_with_none_email(self, mock_prisma_client):
+        """
+        Test that users created via group membership (with user_email=None) 
+        are transformed correctly without errors.
+        This tests the root cause fix.
+        """
+        mock_client, mock_find_unique = mock_prisma_client
+        
+        # Create a user with None email (correct behavior after fix)
+        user_with_none_email = LiteLLM_UserTable(
+            user_id="user-from-group",
+            user_email=None,  # None instead of UUID (after fix)
+            user_alias=None,
+            teams=[],
+            created_at=None,
+            updated_at=None,
+            metadata={"created_via": "scim_group_membership"},
+        )
+        
+        mock_find_unique.return_value = None  # No teams to look up
+        
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_client):
+            # This should not raise any errors
+            scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(
+                user_with_none_email
+            )
+            
+            # Verify the user was transformed successfully
+            assert scim_user.id == user_with_none_email.user_id
+            # Email should not be in emails array
+            assert scim_user.emails is None or len(scim_user.emails) == 0
+            # userName should use default since no email
+            assert scim_user.userName == ScimTransformations.DEFAULT_SCIM_DISPLAY_NAME
+
 
 class TestSCIMPatchOperations:
     """Test SCIM PATCH operation validation and case-insensitive handling"""

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -915,10 +915,11 @@ async def test_update_group_e2e(mocker):
 
 
 @pytest.mark.asyncio
-async def test_create_group_with_nonexistent_users_creates_users(mocker):
+async def test_create_group_with_nonexistent_users_rejects(mocker):
     """
-    Test that creating a group with non-existent users creates those users.
-    This tests the scenario: Group Push ['new user', existing users...]
+    Test that creating a group with non-existent users is rejected.
+    Per SCIM 2.0 protocol, users must exist before being added to groups.
+    This prevents security issues where users not assigned to app get provisioned via group membership.
     """
     # Test data
     group_id = "test-group-123"
@@ -934,7 +935,7 @@ async def test_create_group_with_nonexistent_users_creates_users(mocker):
     )
 
     #########################################################
-    # We expect new-user-1 and new-user-2 to be created
+    # We expect the request to be rejected with 400 error
     #########################################################
     
     # Mock prisma client
@@ -963,95 +964,21 @@ async def test_create_group_with_nonexistent_users_creates_users(mocker):
         AsyncMock(return_value=mock_prisma_client)
     )
     
-    # Mock new_user function to track user creation
-    mock_new_user = mocker.patch(
-        "litellm.proxy.management_endpoints.internal_user_endpoints.new_user",
-        AsyncMock()
-    )
+    # Execute the create_group function - should raise HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await create_group(group=scim_group)
     
-    # Mock created users return values
-    def mock_new_user_side_effect(data):
-        from litellm.proxy._types import NewUserResponse
-        return NewUserResponse(
-            key="sk-test-key-" + data.user_id,  # Required field from GenerateKeyResponse
-            user_id=data.user_id,
-            user_email=data.user_email,
-            metadata=data.metadata,
-            teams=data.teams,
-            user_role=data.user_role
-        )
-    
-    mock_new_user.side_effect = mock_new_user_side_effect
-    
-    # Mock new_team function
-    mock_created_team = mocker.MagicMock()
-    mock_created_team.team_id = group_id
-    mock_created_team.team_alias = "Test Group"
-    
-    mock_new_team = mocker.patch(
-        "litellm.proxy.management_endpoints.scim.scim_v2.new_team",
-        AsyncMock(return_value=mock_created_team)
-    )
-    
-    # Mock SCIM transformation
-    expected_scim_response = SCIMGroup(
-        schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
-        id=group_id,
-        displayName="Test Group",
-        members=[
-            SCIMMember(value="existing-user", display="existing-user"),
-            SCIMMember(value="new-user-1", display="new-user-1"),
-            SCIMMember(value="new-user-2", display="new-user-2")
-        ]
-    )
-    mocker.patch(
-        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_team_to_scim_group",
-        AsyncMock(return_value=expected_scim_response)
-    )
-    
-    # Execute the create_group function
-    result = await create_group(group=scim_group)
-
-    #########################################################
-    # Assert that new-user-1 and new-user-2 were created
-    #########################################################
-    
-    # Verify that new_user was called exactly twice (for new-user-1 and new-user-2)
-    assert mock_new_user.call_count == 2
-    
-    # Check the user creation calls
-    created_user_ids = set()
-    for call in mock_new_user.call_args_list:
-        user_request = call.kwargs["data"]
-        created_user_ids.add(user_request.user_id)
-        assert user_request.metadata["created_via"] == "scim_group_membership"
-        assert user_request.user_role == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY
-        assert user_request.auto_create_key is False
-        assert user_request.teams == []  # Teams added separately
-    
-    assert created_user_ids == {"new-user-1", "new-user-2"}
-    
-    # Verify team creation was called with all members (existing + created)
-    mock_new_team.assert_called_once()
-    team_request = mock_new_team.call_args.kwargs["data"]
-    assert team_request.team_id == group_id
-    assert team_request.team_alias == "Test Group"
-    
-    # Verify all members are in the team (existing + newly created)
-    member_user_ids = {member.user_id for member in team_request.members_with_roles}
-    assert member_user_ids == {"existing-user", "new-user-1", "new-user-2"}
-    
-    # Verify response
-    assert result.id == group_id
-    assert result.displayName == "Test Group"
-    assert len(result.members) == 3
+    # Verify it's a 400 Bad Request
+    assert exc_info.value.status_code == 400
+    assert "does not exist" in str(exc_info.value.detail)
+    assert "new-user-1" in str(exc_info.value.detail) or "new-user-2" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
-async def test_update_group_with_nonexistent_users_creates_users(mocker):
+async def test_update_group_with_nonexistent_users_rejects(mocker):
     """
-    Test that updating a group with non-existent users creates those users.
-    This tests the scenario where a group is updated with members that don't exist in user table.
+    Test that updating a group with non-existent users is rejected.
+    Per SCIM 2.0 protocol, users must exist before being added to groups.
     """
     # Test data
     group_id = "existing-group-456"
@@ -1114,79 +1041,11 @@ async def test_update_group_with_nonexistent_users_creates_users(mocker):
         AsyncMock(return_value=mock_existing_team)
     )
     
-    # Mock new_user function to track user creation
-    mock_new_user = mocker.patch(
-        "litellm.proxy.management_endpoints.internal_user_endpoints.new_user",
-        AsyncMock()
-    )
+    # Execute the update_group function - should raise HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await update_group(group_id=group_id, group=scim_group_update)
     
-    # Mock created users return values
-    def mock_new_user_side_effect(data):
-        from litellm.proxy._types import NewUserResponse
-        return NewUserResponse(
-            key="sk-test-key-" + data.user_id,  # Required field from GenerateKeyResponse
-            user_id=data.user_id,
-            user_email=data.user_email,
-            metadata=data.metadata,
-            teams=data.teams,
-            user_role=data.user_role
-        )
-    
-    mock_new_user.side_effect = mock_new_user_side_effect
-    
-    # Mock group membership changes
-    mock_handle_group_membership_changes = mocker.patch(
-        "litellm.proxy.management_endpoints.scim.scim_v2._handle_group_membership_changes",
-        AsyncMock()
-    )
-    
-    # Mock SCIM transformation
-    expected_scim_response = SCIMGroup(
-        schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
-        id=group_id,
-        displayName="Updated Group Name",
-        members=[
-            SCIMMember(value="existing-user", display="existing-user"),
-            SCIMMember(value="new-user-3", display="new-user-3"),
-            SCIMMember(value="new-user-4", display="new-user-4")
-        ]
-    )
-    mocker.patch(
-        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_team_to_scim_group",
-        AsyncMock(return_value=expected_scim_response)
-    )
-    
-    # Execute the update_group function
-    result = await update_group(group_id=group_id, group=scim_group_update)
-    
-    # Verify that new_user was called exactly twice (for new-user-3 and new-user-4)
-    assert mock_new_user.call_count == 2
-    
-    # Check the user creation calls
-    created_user_ids = set()
-    for call in mock_new_user.call_args_list:
-        user_request = call.kwargs["data"]
-        created_user_ids.add(user_request.user_id)
-        assert user_request.metadata["created_via"] == "scim_group_membership"
-        assert user_request.user_role == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY
-        assert user_request.auto_create_key is False
-        assert user_request.teams == []  # Teams added separately
-    
-    assert created_user_ids == {"new-user-3", "new-user-4"}
-    
-    # Verify team update was called
-    mock_prisma_client.db.litellm_teamtable.update.assert_called_once()
-    update_call = mock_prisma_client.db.litellm_teamtable.update.call_args
-    assert update_call[1]["where"]["team_id"] == group_id
-    assert update_call[1]["data"]["team_alias"] == "Updated Group Name"
-    
-    # Verify group membership changes were handled with all members (existing + created)
-    mock_handle_group_membership_changes.assert_called_once()
-    membership_call = mock_handle_group_membership_changes.call_args
-    assert membership_call[1]["group_id"] == group_id
-    assert membership_call[1]["final_members"] == {"existing-user", "new-user-3", "new-user-4"}
-    
-    # Verify response
-    assert result.id == group_id
-    assert result.displayName == "Updated Group Name"
-    assert len(result.members) == 3
+    # Verify it's a 400 Bad Request
+    assert exc_info.value.status_code == 400
+    assert "does not exist" in str(exc_info.value.detail)
+    assert "new-user-3" in str(exc_info.value.detail) or "new-user-4" in str(exc_info.value.detail)

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -15,7 +15,6 @@ from litellm.proxy.management_endpoints.scim.scim_v2 import (
     update_user,
 )
 from litellm.types.proxy.management_endpoints.scim_v2 import (
-    SCIMFeature,
     SCIMGroup,
     SCIMMember,
     SCIMPatchOp,
@@ -428,7 +427,7 @@ async def test_update_user_success(mocker):
         "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
         AsyncMock()
     )
-    mock_transform = mocker.patch(
+    mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=response_scim_user)
     )
@@ -524,7 +523,7 @@ async def test_patch_user_success(mocker):
         "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
         AsyncMock()
     )
-    mock_transform = mocker.patch(
+    mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=response_scim_user)
     )
@@ -660,7 +659,7 @@ async def test_update_group_metadata_serialization_issue(mocker):
     )
     
     # Call the function that had the bug
-    result = await update_group(group_id=group_id, group=scim_group)
+    await update_group(group_id=group_id, group=scim_group)
     
     # Verify the team update was called
     mock_prisma_client.db.litellm_teamtable.update.assert_called_once()
@@ -696,7 +695,6 @@ async def test_team_membership_management(mocker):
     from litellm.proxy.management_endpoints.scim.scim_v2 import (
         _get_team_member_user_ids_from_team,
         _handle_group_membership_changes,
-        patch_team_membership,
     )
 
     # Mock team with members_with_roles as source of truth
@@ -772,7 +770,6 @@ async def test_update_group_e2e(mocker):
     from litellm.proxy.management_endpoints.scim.scim_transformations import (
         ScimTransformations,
     )
-    from litellm.proxy.utils import safe_dumps
 
     # Setup test data
     group_id = "test-team-123"


### PR DESCRIPTION
# Fix SCIM GET /Users error and enforce SCIM 2.0 compliance

## Core Issues

1. **Bug:** `GET /Users` returns 500 error when users have UUIDs in the `user_email` field
   - Root cause: When users were auto-created during SCIM group provisioning, `user_email` was incorrectly set to `user_id` (UUID) instead of `None`
   - This causes Pydantic `EmailStr` validation to fail

2. **Security Vulnerability:** SCIM auto-creates users when referenced in groups but not explicitly assigned
   - When aggregated groups from Sailpoint are synced to LiteLLM, users in those groups are auto-provisioned even if not assigned to the application
   - Violates principle of least privilege

## What This PR Does

### Bug Fix
- Set `user_email=None` instead of `user_email=user_id` when creating users without email
- Add defensive validation: only create `SCIMUserEmail` if email contains '@' (handles existing malformed data)

### Security Fix & SCIM 2.0 Compliance
- **Reject non-existent users in groups:** Group operations (POST, PUT, PATCH) now return `400 Bad Request` if referenced users don't exist
- **Per SCIM 2.0 protocol:** Users must be created via `POST /Users` before being added to groups
- Add validation for empty/None user IDs

## Breaking Change

⚠️ **Breaking:** SCIM no longer auto-creates users from group membership. Users must be created via `POST /Users` first, then added to groups. This is the correct SCIM 2.0 flow.

## Files Changed

- `scim_v2.py`: Fix user creation, reject non-existent users in groups
- `scim_transformations.py`: Add email validation
- Tests: Updated to verify new behavior
