### PR TITLE
docs: add Microsoft Agent Lightning to projects

### DIFF
--- a/docs/my-website/docs/projects/Agent Lightning.md
+++ b/docs/my-website/docs/projects/Agent Lightning.md
@@ -1,0 +1,10 @@
+
+# Agent Lightning
+
+[Agent Lightning](https://github.com/microsoft/agent-lightning) is Microsoft's open-source framework for training and optimizing AI agents with Reinforcement Learning, Automatic Prompt Optimization, and Supervised Fine-tuning — with almost zero code changes.
+
+It works with any agent framework including LangChain, OpenAI Agents SDK, AutoGen, and CrewAI. Agent Lightning uses LiteLLM Proxy under the hood to route LLM requests and collect traces that power its training algorithms.
+
+- [GitHub](https://github.com/microsoft/agent-lightning)
+- [Docs](https://microsoft.github.io/agent-lightning/)
+- [arXiv Paper](https://arxiv.org/abs/2508.03680)

--- a/docs/my-website/sidebars.js
+++ b/docs/my-website/sidebars.js
@@ -826,6 +826,7 @@ const sidebars = {
             "projects/mini-swe-agent",
             "projects/openai-agents",
             "projects/Google ADK",
+            "projects/Agent Lightning",
             "projects/Harbor",
             "projects/Docq.AI",
             "projects/PDL",


### PR DESCRIPTION
## Title

Add Microsoft Agent Lightning to projects built on LiteLLM

## Relevant issues

Follow-up from https://github.com/BerriAI/litellm/pull/17352 - as requested by @krrishdholakia

## Pre-Submission checklist

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

📖 Documentation

## Changes

- Added Microsoft Agent Lightning to the "Projects built on LiteLLM" documentation ( Agent Lightning is Microsoft's open-source framework for training AI agents with RL, APO, and SFT, uses LiteLLM Proxy under the hood for LLM routing and trace collection )
- Updated sidebars.js to include the new project