### PR TITLE
[Bug Fix] Parallel Request Limiter with /messages 

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1343,19 +1343,19 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 "INSIDE parallel request limiter ASYNC SUCCESS LOGGING"
             )
 
-            # Get metadata from kwargs
-            litellm_metadata = kwargs["litellm_params"].get(
-                get_metadata_variable_name_from_kwargs(kwargs), {}
+            # Get metadata from standard_logging_object - this correctly handles both
+            # 'metadata' and 'litellm_metadata' fields from litellm_params
+            standard_logging_object = kwargs.get("standard_logging_object") or {}
+            standard_logging_metadata = standard_logging_object.get("metadata") or {}
+
+            # user_api_key_hash is the same as user_api_key (it's the hash)
+            user_api_key = standard_logging_metadata.get("user_api_key_hash")
+            user_api_key_user_id = standard_logging_metadata.get("user_api_key_user_id")
+            user_api_key_team_id = standard_logging_metadata.get("user_api_key_team_id")
+            user_api_key_organization_id = standard_logging_metadata.get(
+                "user_api_key_org_id"
             )
-            if litellm_metadata is None:
-                return
-            user_api_key = litellm_metadata.get("user_api_key")
-            user_api_key_user_id = litellm_metadata.get("user_api_key_user_id")
-            user_api_key_team_id = litellm_metadata.get("user_api_key_team_id")
-            user_api_key_organization_id = litellm_metadata.get(
-                "user_api_key_organization_id"
-            )
-            user_api_key_end_user_id = kwargs.get("user") or litellm_metadata.get(
+            user_api_key_end_user_id = kwargs.get("user") or standard_logging_metadata.get(
                 "user_api_key_end_user_id"
             )
             model_group = get_model_group_from_litellm_kwargs(kwargs)
@@ -1501,10 +1501,12 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             litellm_parent_otel_span: Union[
                 Span, None
             ] = _get_parent_otel_span_from_kwargs(kwargs)
-            litellm_metadata = kwargs["litellm_params"]["metadata"]
-            user_api_key = (
-                litellm_metadata.get("user_api_key") if litellm_metadata else None
-            )
+            # Get metadata from standard_logging_object - this correctly handles both
+            # 'metadata' and 'litellm_metadata' fields from litellm_params
+            standard_logging_object = kwargs.get("standard_logging_object") or {}
+            standard_logging_metadata = standard_logging_object.get("metadata") or {}
+            user_api_key = standard_logging_metadata.get("user_api_key_hash")
+
             pipeline_operations: List[RedisPipelineIncrementOperation] = []
 
             if user_api_key:

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -22,6 +22,7 @@ from litellm.proxy.hooks.parallel_request_limiter_v3 import (
 from litellm.proxy.utils import InternalUsageCache, ProxyLogging, hash_token
 from litellm.types.utils import ModelResponse, Usage
 
+
 class TimeController:
     def __init__(self):
         self._current = datetime.utcnow()
@@ -461,10 +462,11 @@ async def test_token_rate_limit_type_respected_v3(monkeypatch, token_rate_limit_
     )
 
     # Create mock kwargs for the success event
+    # Use standard_logging_object which is the canonical source for metadata
     mock_kwargs = {
-        "litellm_params": {
+        "standard_logging_object": {
             "metadata": {
-                "user_api_key": _api_key,
+                "user_api_key_hash": _api_key,
                 "user_api_key_user_id": None,
                 "user_api_key_team_id": None,
                 "user_api_key_end_user_id": None,
@@ -532,8 +534,8 @@ async def test_async_log_failure_event_v3():
         internal_usage_cache=InternalUsageCache(local_cache)
     )
 
-    # Mock kwargs with user_api_key
-    mock_kwargs = {"litellm_params": {"metadata": {"user_api_key": _api_key}}}
+    # Mock kwargs with user_api_key via standard_logging_object
+    mock_kwargs = {"standard_logging_object": {"metadata": {"user_api_key_hash": _api_key}}}
 
     # Capture pipeline operations
     captured_ops = []


### PR DESCRIPTION
## [Bug Fix] Parallel Request Limiter with /messages 

Fixes https://github.com/BerriAI/litellm/issues/17323

Manual testing, it functions as a parallel request limiter now

After 5 sequential requests, still works (before this would fail, for /messages it seemed to work as an all up counter)

<img width="1727" height="452" alt="Screenshot 2025-12-03 at 9 28 14 AM" src="https://github.com/user-attachments/assets/e096af1c-b95d-4b90-810a-64f01bbdd08c" />

After 5 parallel requests (here it should actually limit)

<img width="1728" height="271" alt="Screenshot 2025-12-03 at 9 37 42 AM" src="https://github.com/user-attachments/assets/d5b1d095-f9aa-4ca3-b9a9-633bbc934f0a" />

The issue was the parallel limiter should have been checking StandardLoggingPayload - that gets populated across /chat/completions, /responses, /messages etc 

For /messages it was noticing user api key = None so nothing we getting fixed around it 


<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix
✅ Test

## Changes


