### PR TITLE
fix(pricing): add missing Moonshot turbo models and fix incorrect pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18896,6 +18896,34 @@
         "supports_tool_choice": true,
         "supports_web_search": true
     },
+    "moonshot/kimi-k2-0905-preview": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
+    "moonshot/kimi-k2-turbo-preview": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.15e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "input_cost_per_token": 2e-06,
@@ -18953,14 +18981,15 @@
         "supports_vision": true
     },
     "moonshot/kimi-thinking-preview": {
-        "input_cost_per_token": 3e-05,
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 6e-07,
         "litellm_provider": "moonshot",
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 3e-05,
-        "source": "https://platform.moonshot.ai/docs/pricing",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_vision": true
     },
     "moonshot/kimi-k2-thinking": {
@@ -18972,6 +19001,20 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 2.5e-6,
+        "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_web_search": true
+    },
+    "moonshot/kimi-k2-thinking-turbo": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 1.15e-6,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8e-6,
         "source": "https://platform.moonshot.ai/docs/pricing/chat#generation-model-kimi-k2",
         "supports_function_calling": true,
         "supports_tool_choice": true,
@@ -26470,8 +26513,8 @@
         "max_tokens": 128000,
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
-        "input_cost_per_token": 0.135,
-        "output_cost_per_token": 0.4,
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.5e-06,
         "litellm_provider": "wandb",
         "mode": "chat"
     },


### PR DESCRIPTION
## Title

fix(pricing): add missing Moonshot turbo models and fix incorrect pricing

## Relevant issues

Fixes #17417

## Pre-Submission checklist

- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Added missing Moonshot turbo models:
| Model | Input/M | Output/M | Cache/M | Context |
|-------|---------|----------|---------|---------|
| `moonshot/kimi-k2-turbo-preview` | $1.15 | $8.00 | $0.15 | 262K |
| `moonshot/kimi-k2-thinking-turbo` | $1.15 | $8.00 | $0.15 | 262K |
| `moonshot/kimi-k2-0905-preview` | $0.60 | $2.50 | $0.15 | 262K |

### Fixed incorrect pricing:
| Model | Before | After |
|-------|--------|-------|
| `moonshot/kimi-thinking-preview` | $30/$30 (50x too high) | $0.60/$2.50 + cache |
| `wandb/moonshotai/Kimi-K2-Instruct` | $135,000/$400,000 (data entry error) | $0.60/$2.50 |

### Sources:
- [Artificial Analysis - Kimi K2 Thinking](https://artificialanalysis.ai/articles/kimi-k2-thinking-everything-you-need-to-know)
- [CostGoat - Kimi API Pricing](https://costgoat.com/pricing/kimi-api)