### PR TITLE
fix: cyberark allow setting ssl verfiy to false

### DIFF
--- a/docs/my-website/docs/secret_managers/cyberark.md
+++ b/docs/my-website/docs/secret_managers/cyberark.md
@@ -41,6 +41,7 @@ CYBERARK_CLIENT_KEY="path/to/client.key"
 
 # OPTIONAL
 CYBERARK_REFRESH_INTERVAL="300" # defaults to 300 seconds (5 minutes), frequency of token refresh
+CYBERARK_SSL_VERIFY="true" # defaults to true, set to "false" to disable SSL verification (for self-signed certificates)
 ```
 
 **Step 2.** Add to proxy config.yaml
@@ -171,6 +172,24 @@ If these commands work successfully against your CyberArk instance, then CyberAr
 - Your environment variables are correctly set
 - The `CYBERARK_API_BASE` URL is accessible from your LiteLLM instance
 - Your API key or certificates have the necessary permissions in CyberArk
+
+### SSL Certificate Errors
+
+If you encounter SSL certificate verification errors like:
+
+```
+RuntimeError: Could not authenticate to CyberArk Conjur: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain
+```
+
+This typically occurs when your CyberArk Conjur instance uses a self-signed certificate. You can disable SSL verification by setting:
+
+```bash
+CYBERARK_SSL_VERIFY="false"
+```
+
+:::warning
+Disabling SSL verification is insecure and should only be used for testing or development environments with self-signed certificates. For production, configure your certificate chain properly or use certificate-based authentication with `CYBERARK_CLIENT_CERT` and `CYBERARK_CLIENT_KEY`.
+:::
 
 ## Video Walkthrough
 


### PR DESCRIPTION
## (fix: cyberark allow setting ssl verfiy to false)

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes


