### PR TITLE
fix(ocr): add missing ocr and aocr to CallTypes enum

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -341,6 +341,12 @@ class CallTypes(str, Enum):
     agenerate_content_stream = "agenerate_content_stream"
 
     #########################################################
+    # OCR Call Types
+    #########################################################
+    ocr = "ocr"
+    aocr = "aocr"
+
+    #########################################################
     # MCP Call Types
     #########################################################
     call_mcp_tool = "call_mcp_tool"

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1461,3 +1461,43 @@ async def test_async_mock_completion_stream_with_model_response():
             accumulated_content += chunk.choices[0].delta.content
 
     assert "This is an async test response" in accumulated_content or len(chunks) > 0
+
+
+class TestCallTypesOCR:
+    """Test that OCR call types are properly defined in CallTypes enum.
+
+    Fixes https://github.com/BerriAI/litellm/issues/17381
+    """
+
+    def test_ocr_call_type_exists(self):
+        """Test that CallTypes.ocr exists and has correct value."""
+        from litellm.types.utils import CallTypes
+
+        assert hasattr(CallTypes, "ocr")
+        assert CallTypes.ocr.value == "ocr"
+
+    def test_aocr_call_type_exists(self):
+        """Test that CallTypes.aocr exists and has correct value."""
+        from litellm.types.utils import CallTypes
+
+        assert hasattr(CallTypes, "aocr")
+        assert CallTypes.aocr.value == "aocr"
+
+    def test_ocr_call_type_from_string(self):
+        """Test that CallTypes can be constructed from 'ocr' string."""
+        from litellm.types.utils import CallTypes
+
+        call_type = CallTypes("ocr")
+        assert call_type == CallTypes.ocr
+
+    def test_aocr_call_type_from_string(self):
+        """Test that CallTypes can be constructed from 'aocr' string.
+
+        This is the actual use case that was failing - the OCR endpoint
+        uses route_type='aocr' and guardrails try to instantiate
+        CallTypes('aocr').
+        """
+        from litellm.types.utils import CallTypes
+
+        call_type = CallTypes("aocr")
+        assert call_type == CallTypes.aocr


### PR DESCRIPTION
## Title

fix(ocr): add missing ocr and aocr to CallTypes enum

## Relevant issues

Fixes #17381

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally 
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

Add `ocr` and `aocr` entries to the `CallTypes` enum in `litellm/types/utils.py`.

The OCR endpoint uses `route_type="aocr"` (in `litellm/proxy/ocr_endpoints/endpoints.py:76`), but the `CallTypes` enum was missing these values. When guardrail hooks tried to instantiate `CallTypes("aocr")`, it raised a `ValueError: 'aocr' is not a valid CallTypes`.

**Solution:** Added the missing enum members:
```python
#########################################################
# OCR Call Types
#########################################################
ocr = "ocr"
aocr = "aocr"
```

**Test output:**
```
tests/test_litellm/test_main.py::TestCallTypesOCR::test_aocr_call_type_exists PASSED [ 25%]
tests/test_litellm/test_main.py::TestCallTypesOCR::test_aocr_call_type_from_string PASSED [ 50%]
tests/test_litellm/test_main.py::TestCallTypesOCR::test_ocr_call_type_exists PASSED [ 75%]
tests/test_litellm/test_main.py::TestCallTypesOCR::test_ocr_call_type_from_string PASSED [100%]

======================== 4 passed, 4 warnings in 0.30s =========================
```