### PR TITLE
[Fix] Remove second scrollbar when sidebar is expanded + tooltip z index

### DIFF
--- a/ui/litellm-dashboard/src/app/page.tsx
+++ b/ui/litellm-dashboard/src/app/page.tsx
@@ -328,7 +328,7 @@ export default function CreateKeyPage() {
                 sidebarCollapsed={sidebarCollapsed}
                 onToggleSidebar={toggleSidebar}
               />
-              <div className="flex flex-1 overflow-auto">
+              <div className="flex flex-1">
                 <div className="mt-2">
                   <SidebarProvider setPage={updatePage} defaultSelectedKey={page} sidebarCollapsed={sidebarCollapsed} />
                 </div>

--- a/ui/litellm-dashboard/src/components/model_dashboard/table.tsx
+++ b/ui/litellm-dashboard/src/components/model_dashboard/table.tsx
@@ -100,7 +100,7 @@ export function ModelDataTable<TData, TValue>({
                       key={header.id}
                       className={`py-1 h-8 relative ${
                         header.id === "actions"
-                          ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] z-20 w-[120px] ml-8"
+                          ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] w-[120px] ml-8"
                           : ""
                       } ${header.column.columnDef.meta?.className || ""}`}
                       style={{
@@ -160,7 +160,7 @@ export function ModelDataTable<TData, TValue>({
                         key={cell.id}
                         className={`py-0.5 ${
                           cell.column.id === "actions"
-                            ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] z-20 w-[120px] ml-8"
+                            ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)] w-[120px] ml-8"
                             : ""
                         } ${cell.column.columnDef.meta?.className || ""}`}
                         style={{


### PR DESCRIPTION
## [Fix] Remove second scrollbar when sidebar is expanded + tooltip z index

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
The overflow-auto was causing a 2nd scroll bar to appear when the sidebar expands past the screen's height. This change removes the the css, so the 2nd scrollbar does not appear. This PR also removes the z-index css from the action cell of the model table. See below for the issue it caused:
<img width="1244" height="264" alt="image" src="https://github.com/user-attachments/assets/c25f4411-10c7-4276-b64e-121e01360486" />


<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes


