### PR TITLE
Fix: Skip empty text blocks in Anthropic system messages

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -786,6 +786,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 valid_content: bool = False
                 system_message_block = ChatCompletionSystemMessage(**message)
                 if isinstance(system_message_block["content"], str):
+                    # Skip empty text blocks - Anthropic API raises errors for empty text
+                    if not system_message_block["content"]:
+                        continue
                     anthropic_system_message_content = AnthropicSystemMessageContent(
                         type="text",
                         text=system_message_block["content"],
@@ -800,10 +803,14 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     valid_content = True
                 elif isinstance(message["content"], list):
                     for _content in message["content"]:
+                        # Skip empty text blocks - Anthropic API raises errors for empty text
+                        text_value = _content.get("text")
+                        if _content.get("type") == "text" and not text_value:
+                            continue
                         anthropic_system_message_content = (
                             AnthropicSystemMessageContent(
                                 type=_content.get("type"),
-                                text=_content.get("text"),
+                                text=text_value,
                             )
                         )
                         if "cache_control" in _content:


### PR DESCRIPTION
## Summary
- Skip empty string content in system messages when translating to Anthropic API format
- Skip empty text blocks in list content to prevent API errors
- Fixes Vertex AI Anthropic API error: "messages: text content blocks must be non-empty"

## Error Details

When system messages contain empty text content blocks, the Vertex AI Anthropic API returns:

```
litellm.BadRequestError: Vertex_aiException BadRequestError - {
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "messages: text content blocks must be non-empty"
  }
}
```

This error occurs when using models like `claude-haiku-4-5` or `claude-sonnet-4-5` through Vertex AI, and causes all fallback attempts to fail as well since the root cause is the message format.

## Test plan
- [x] Added unit tests for empty string content
- [x] Added unit tests for empty text blocks in list content  
- [x] Added tests to verify valid content is preserved
- [x] Added tests to verify cache_control is preserved on valid content

🤖 Generated with [Claude Code](https://claude.com/claude-code)