### PR TITLE
fix(openai): add clear error message for empty LLM endpoint responses

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -444,6 +444,11 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             else:
                 headers = {}
             response = raw_response.parse()
+            if not hasattr(response, "model_dump"):
+                raise OpenAIError(
+                    status_code=500,
+                    message=f"Empty or invalid response from LLM endpoint. Received: {response!r}. Check the reverse proxy or model server configuration.",
+                )
             return headers, response
         except openai.APITimeoutError as e:
             end_time = time.time()
@@ -477,7 +482,14 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             else:
                 headers = {}
             response = raw_response.parse()
+            if not hasattr(response, "model_dump"):
+                raise OpenAIError(
+                    status_code=500,
+                    message=f"Empty or invalid response from LLM endpoint. Received: {response!r}. Check the reverse proxy or model server configuration.",
+                )
             return headers, response
+        except OpenAIError:
+            raise
         except Exception as e:
             if raw_response is not None:
                 raise Exception(

--- a/tests/test_litellm/llms/openai/test_openai_empty_response.py
+++ b/tests/test_litellm/llms/openai/test_openai_empty_response.py
@@ -1,0 +1,97 @@
+"""
+Test for issue #17209: Clearer error when LLM endpoint returns empty response
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+from litellm.llms.openai.common_utils import OpenAIError
+
+class TestEmptyResponseHandling:
+    """Test that empty/invalid responses from LLM endpoints produce clear error messages"""
+
+    def test_sync_empty_string_response_raises_clear_error(self):
+        """
+        Test that when an OpenAI-compatible endpoint returns an empty string,
+        we get a clear error instead of "'str' object has no attribute 'model_dump'"
+        """
+        openai_chat = OpenAIChatCompletion()
+
+        # Mock the raw response to return an empty string from parse()
+        mock_raw_response = MagicMock()
+        mock_raw_response.headers = {}
+        mock_raw_response.parse.return_value = ""  # Empty string response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.with_raw_response.create.return_value = (
+            mock_raw_response
+        )
+
+        with pytest.raises(OpenAIError) as exc_info:
+            openai_chat.make_sync_openai_chat_completion_request(
+                openai_client=mock_client,
+                data={"messages": [{"role": "user", "content": "test"}]},
+                timeout=30,
+                logging_obj=MagicMock(),
+            )
+
+        assert "Empty or invalid response from LLM endpoint" in str(exc_info.value)
+        assert "Check the reverse proxy or model server configuration" in str(
+            exc_info.value
+        )
+
+    def test_sync_none_response_raises_clear_error(self):
+        """Test that None response also produces a clear error"""
+        openai_chat = OpenAIChatCompletion()
+
+        mock_raw_response = MagicMock()
+        mock_raw_response.headers = {}
+        mock_raw_response.parse.return_value = None
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.with_raw_response.create.return_value = (
+            mock_raw_response
+        )
+
+        with pytest.raises(OpenAIError) as exc_info:
+            openai_chat.make_sync_openai_chat_completion_request(
+                openai_client=mock_client,
+                data={"messages": [{"role": "user", "content": "test"}]},
+                timeout=30,
+                logging_obj=MagicMock(),
+            )
+
+        assert "Empty or invalid response from LLM endpoint" in str(exc_info.value)
+
+    def test_valid_response_passes_through(self):
+        """Test that a valid response with model_dump passes through correctly"""
+        openai_chat = OpenAIChatCompletion()
+
+        # Create a mock response that has model_dump (like a real Pydantic model)
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"choices": []}
+
+        mock_raw_response = MagicMock()
+        mock_raw_response.headers = {"x-request-id": "123"}
+        mock_raw_response.parse.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.with_raw_response.create.return_value = (
+            mock_raw_response
+        )
+
+        headers, response = openai_chat.make_sync_openai_chat_completion_request(
+            openai_client=mock_client,
+            data={"messages": [{"role": "user", "content": "test"}]},
+            timeout=30,
+            logging_obj=MagicMock(),
+        )
+
+        assert response == mock_response
+        assert headers == {"x-request-id": "123"}


### PR DESCRIPTION
Fixes #17209

  ## Pre-Submission checklist

  - [x] I have Added testing in the tests/litellm/ directory
  - [x] I have added a screenshot of my new test passing locally
  - [x] My PR passes all unit tests on make test-unit
  - [x] My PR's scope is as isolated as possible

  ## Type

  🐛 Bug Fix
  ✅ Test

  ## Changes

  When a misconfigured reverse proxy or OpenAI-compatible endpoint returns an empty response, LiteLLM previously produced:
  OpenAIException - 'str' object has no attribute 'model_dump'

  Now produces a clear error:
  Empty or invalid response from LLM endpoint. Received: ''. Check the reverse proxy or model server configuration.


  **Test screenshot:**
<img width="1512" height="379" alt="Screenshot 2025-12-03 at 6 03 52 PM" src="https://github.com/user-attachments/assets/04c2b760-fdc6-49cb-a594-f163c68fba69" />
