### PR TITLE
[Fix] Change e2e test to look for Virtual Keys instead of API Keys

### DIFF
--- a/tests/proxy_admin_ui_tests/e2e_ui_tests/view_internal_user.spec.ts
+++ b/tests/proxy_admin_ui_tests/e2e_ui_tests/view_internal_user.spec.ts
@@ -34,10 +34,10 @@ test("view internal user page", async ({ page }) => {
   // The UI renders badges in each row - we just verify the column structure exists
   const rowCount = await page.locator("tbody tr").count();
   expect(rowCount).toBeGreaterThan(0);
-  
-  // Verify table headers are present (including API Keys column)
-  const apiKeysHeader = page.locator("th", { hasText: "API Keys" });
-  await expect(apiKeysHeader).toBeVisible();
+
+  // Verify table headers are present (including Virtual Keys column)
+  const virtualKeysHeader = page.locator("th", { hasText: "Virtual Keys" });
+  await expect(virtualKeysHeader).toBeVisible();
 
   // test pagination
   // Wait for pagination controls to be visible


### PR DESCRIPTION
## [Fix] Change e2e test to look for Virtual Keys instead of API Keys

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues
API Keys was renamed to Virtual Keys

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
✅ Test

## Changes


