### PR TITLE
Revert "Bump mcp from 1.10.1 to 1.23.0 in /.circleci"

### DIFF
--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -13,7 +13,7 @@ google-cloud-aiplatform==1.43.0
 google-cloud-iam==2.19.1
 fastapi-sso==0.16.0 
 uvloop==0.21.0
-mcp==1.23.0    # for MCP server  
+mcp==1.10.1    # for MCP server  
 semantic_router==0.1.10 # for auto-routing with litellm
 fastuuid==0.12.0
 responses==0.25.7  # for proxy client tests


### PR DESCRIPTION
Reverts BerriAI/litellm#17363